### PR TITLE
Self-heal stale git locks, idempotent delete, abandoned-chunk reaper

### DIFF
--- a/backend/app/services/delete_worker.py
+++ b/backend/app/services/delete_worker.py
@@ -186,6 +186,69 @@ async def _sweep_outbox_once() -> int:
     return n
 
 
+# ── Abandoned-chunk reaper ────────────────────────────────────────
+
+# A chunk is "abandoned" once vector_retry_count has hit MAX_RETRIES:
+# the indexing worker has stopped picking it and it will sit in
+# `vector_indexed_at IS NULL` forever. Operators see them as a stuck
+# `indexing N` counter on the UI. After this grace window we delete
+# them from PG (enqueuing the vector-store cleanup via the outbox)
+# so the counter clears itself.
+#
+# The grace window lets an operator notice + investigate the failure
+# (e.g. an oversize chunk from a bug in the chunker) before the row
+# is reclaimed. 7d is generous; tune via REAP_GRACE_INTERVAL if needed.
+REAP_GRACE_INTERVAL = "7 days"
+REAP_INTERVAL_SECONDS = 3600.0
+_last_reap_at: float = 0.0
+
+
+async def _reap_abandoned_chunks_once() -> int:
+    """Delete chunks whose `vector_retry_count >= MAX_RETRIES` and whose
+    last retry attempt was more than REAP_GRACE_INTERVAL ago. Enqueues
+    them to `vector_delete_outbox` so this worker's normal delete pass
+    removes them from the vector store too. Rate-limited."""
+    global _last_reap_at
+    now = time.monotonic()
+    if now - _last_reap_at < REAP_INTERVAL_SECONDS:
+        return 0
+    _last_reap_at = now
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            n = await conn.fetchval(
+                f"""
+                WITH abandoned AS (
+                    SELECT id, source_type, source_id
+                      FROM chunks
+                     WHERE vector_indexed_at IS NULL
+                       AND vector_retry_count >= $1
+                       AND (
+                           vector_next_attempt_at IS NULL
+                        OR vector_next_attempt_at < NOW() - INTERVAL '{REAP_GRACE_INTERVAL}'
+                       )
+                ),
+                enqueued AS (
+                    INSERT INTO vector_delete_outbox
+                        (chunk_id, source_type, source_id, next_attempt_at)
+                    SELECT id, source_type, source_id, NOW() FROM abandoned
+                    RETURNING 1
+                ),
+                deleted AS (
+                    DELETE FROM chunks WHERE id IN (SELECT id FROM abandoned)
+                    RETURNING 1
+                )
+                SELECT COUNT(*) FROM deleted
+                """,
+                MAX_RETRIES,
+            )
+    n = int(n or 0)
+    if n:
+        logger.info("abandoned-chunk reap: removed %d rows (outbox enqueued)", n)
+    return n
+
+
 # ── Main loop ─────────────────────────────────────────────────────
 
 
@@ -199,6 +262,10 @@ async def _process_once() -> int:
         await _sweep_outbox_once()
     except Exception as e:  # noqa: BLE001
         logger.exception("delete_worker outbox sweep failed: %s", e)
+    try:
+        await _reap_abandoned_chunks_once()
+    except Exception as e:  # noqa: BLE001
+        logger.exception("delete_worker abandoned-chunk reap failed: %s", e)
     return d
 
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -543,9 +543,19 @@ class DocumentService:
         collection_id = row["collection_id"]
 
         commit_msg = f"[delete] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: delete"
-        await asyncio.to_thread(
-            self.git.delete_file, vault_name=vault, file_path=file_path, message=commit_msg
-        )
+        # Idempotent: if the git file is already gone (crash-recovery
+        # state, manual cleanup, etc.) the DB cleanup below still runs.
+        # Without this, a partial-delete leaves an undeletable document
+        # row that needs operator intervention.
+        try:
+            await asyncio.to_thread(
+                self.git.delete_file, vault_name=vault, file_path=file_path, message=commit_msg,
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "Document %s/%s already absent from git — proceeding with DB-only cleanup",
+                vault, file_path,
+            )
 
         # Capture the public d-id BEFORE the row is gone so subscribers
         # see the same identifier they'd have used to fetch the doc.

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, quote
@@ -106,6 +107,69 @@ class GitService:
 
     def vault_exists(self, vault_name: str) -> bool:
         return self._bare_path(vault_name).exists()
+
+    def cleanup_stale_locks(self, max_age_seconds: float = 60.0) -> int:
+        """Remove `index.lock` files for every vault that are older than
+        `max_age_seconds`.
+
+        A crashed git process (OOM, SIGKILL, container restart mid-commit)
+        leaves the index.lock behind; subsequent writes to that worktree
+        fail with "Unable to create '.../index.lock': File exists" until
+        the lock is cleared by hand. Running this at startup recovers
+        every affected vault before any worker can run into the same wall.
+
+        Lock locations checked:
+          1. `<bare>/worktrees/<name>/index.lock` — where git keeps the
+             index for linked worktrees (the path the AKB write paths
+             actually touch).
+          2. `<worktree>/.git/index.lock` — fallback for non-linked
+             setups (initial clone path) where `.git` is a real dir.
+
+        Safe under concurrency: the only write paths that touch a
+        worktree's index hold `_vault_lock(vault_name)` per-vault, so
+        startup self-heal — which runs before workers — cannot remove
+        a lock held by a live operation. The age threshold provides
+        defense in depth in the unlikely case startup overlaps with an
+        in-flight commit (lock would be < 1s old, well under 60s).
+
+        Returns the number of locks removed.
+        """
+        cleared = 0
+        if not self.worktrees_path.exists():
+            return cleared
+        for vault_dir in self.worktrees_path.iterdir():
+            if not vault_dir.is_dir():
+                continue
+            vault_name = vault_dir.name
+            candidates = [
+                self._bare_path(vault_name) / "worktrees" / vault_name / "index.lock",
+                vault_dir / ".git" / "index.lock",
+            ]
+            for lock in candidates:
+                # `.git` in a linked worktree is a file (gitdir pointer),
+                # not a dir — its `index.lock` path is meaningless. Skip
+                # quickly if the parent isn't a directory.
+                if not lock.parent.is_dir():
+                    continue
+                if not lock.exists() or lock.is_dir():
+                    continue
+                try:
+                    age = time.time() - lock.stat().st_mtime
+                except OSError:
+                    continue
+                if age < max_age_seconds:
+                    continue
+                try:
+                    lock.unlink()
+                except OSError as e:
+                    logger.warning("failed to clear stale lock %s: %s", lock, e)
+                    continue
+                logger.warning(
+                    "removed stale git index.lock (age=%.0fs) at %s",
+                    age, lock,
+                )
+                cleared += 1
+        return cleared
 
     def cleanup_vault_dirs(self, vault_name: str) -> None:
         """Idempotently remove every on-disk artefact a vault owns.

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -11,6 +11,7 @@ import logging
 from app.config import settings
 from app.db.postgres import close_pool, init_db
 from app.services import delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker
+from app.services.git_service import GitService
 from app.services.vector_store import get_vector_store
 
 logger = logging.getLogger("akb.lifecycle")
@@ -35,6 +36,15 @@ async def init_storage() -> None:
     _validate_required_settings()
     await init_db()
     logger.info("Database initialized")
+    # Self-heal: clear stale git index.lock files left behind by a
+    # crashed prior process. Without this, the affected vault's writes
+    # fail silently until an operator removes the lock by hand.
+    try:
+        cleared = GitService().cleanup_stale_locks()
+        if cleared:
+            logger.info("Cleared %d stale git lock(s) at startup", cleared)
+    except Exception as e:  # noqa: BLE001 — never block startup on best-effort cleanup
+        logger.warning("Stale-lock self-heal failed (continuing): %s", e)
     # Force-construct so a misconfigured vector-store URL/DSN fails at startup rather
     # than silently serving empty search results later.
     get_vector_store()

--- a/backend/tests/test_self_heal_e2e.sh
+++ b/backend/tests/test_self_heal_e2e.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Self-heal + idempotency + abandoned-reap E2E.
+#
+# Three crash-recovery scenarios that the previous (pre-self-heal)
+# backend would have left in a stuck state:
+#
+#   1. Stale git index.lock — survives a backend restart and gets
+#      auto-cleared by lifecycle.init_storage().
+#   2. akb_delete when the git file is already absent — DB cleanup
+#      runs to completion instead of failing the whole call.
+#   3. Abandoned chunks (vector_retry_count >= MAX) get reaped by
+#      delete_worker after the grace window.
+#
+# kubectl-gated (the lock / chunk seeding happens on the postgres
+# pod and the worktree volume), skipped cleanly otherwise.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+NS="${AKB_NS:-akb}"
+PG_POD="${AKB_PG_POD:-postgres-0}"
+PG_USER="${AKB_PG_USER:-akbuser}"
+PG_DB="${AKB_PG_DB:-akb}"
+BE_DEPLOY="${AKB_BE_DEPLOY:-deployment/backend}"
+
+VAULT="selfheal-$(date +%s)"
+USER="selfheal-$(date +%s)"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "kubectl not available — skipping self-heal verification"
+  exit 0
+fi
+
+run_psql() {
+  kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+}
+
+run_be() {
+  kubectl exec -n "$NS" "$BE_DEPLOY" -- bash -c "$1" 2>/dev/null
+}
+
+# ── Setup ────────────────────────────────────────────────────────
+echo "▸ Setup"
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"selfheal"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+[ -n "$PAT" ] || { echo "FATAL: PAT"; exit 1; }
+
+curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT" \
+  -H "Authorization: Bearer $PAT" >/dev/null
+VAULT_ID=$(run_psql "SELECT id FROM vaults WHERE name = '$VAULT'")
+[ -n "$VAULT_ID" ] && pass "vault ready ($VAULT)" || { fail "vault" "missing"; exit 1; }
+
+# Put one doc so the worktree exists.
+PUT=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"title\":\"hello\",\"type\":\"note\",\"content\":\"# hello\\n\\ntest body\",\"collection\":\"misc\"}")
+DOC=$(echo "$PUT" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("doc_id",""))' 2>/dev/null)
+[ -n "$DOC" ] && pass "doc seeded ($DOC)" || fail "seed doc" "$PUT"
+
+# ── 1. akb_delete idempotent on git-missing file ─────────────────
+echo ""
+echo "▸ 1. akb_delete is idempotent when git file is already absent"
+
+# Resolve PG row + path, then rm the file from the worktree without
+# committing — simulates a half-finished cleanup leaving the row.
+PG_DOC_PATH=$(run_psql "SELECT path FROM documents WHERE metadata->>'id' = '$DOC' AND vault_id = '$VAULT_ID'")
+[ -n "$PG_DOC_PATH" ] && pass "found PG row path ($PG_DOC_PATH)" || { fail "lookup" "no path"; exit 1; }
+
+run_be "rm -f '/data/vaults/_worktrees/$VAULT/$PG_DOC_PATH'"
+GONE=$(run_be "test -f '/data/vaults/_worktrees/$VAULT/$PG_DOC_PATH' && echo 1 || echo 0")
+[ "$GONE" = "0" ] && pass "worktree file removed (without commit)" || fail "rm" "still there"
+
+DEL_HTTP=$(curl -sk -o /tmp/del_out.json -w "%{http_code}" -X DELETE \
+  "$BASE_URL/api/v1/documents/$VAULT/$DOC" -H "Authorization: Bearer $PAT")
+[ "$DEL_HTTP" = "200" ] && pass "DELETE succeeded (HTTP 200) despite missing git file" \
+                       || fail "DELETE" "HTTP $DEL_HTTP body=$(cat /tmp/del_out.json)"
+
+REMAINING=$(run_psql "SELECT COUNT(*) FROM documents WHERE metadata->>'id' = '$DOC' AND vault_id = '$VAULT_ID'")
+[ "$REMAINING" = "0" ] && pass "DB row also cleaned up" || fail "cleanup" "$REMAINING rows remain"
+
+# ── 2. Abandoned chunk reap — fast path (manually expired) ───────
+echo ""
+echo "▸ 2. Abandoned chunk reaper drains stuck rows"
+
+# Seed a synthetic chunk that is "abandoned + expired" — retry MAX
+# and last attempt set in the past. The reaper rate-limits to once
+# per hour by default; we force a single-shot via psql to validate
+# the SQL (the cadence is exercised in the live worker, not here).
+
+# vault_id is required for chunks (denormalized).
+SYN_DOC_ID=$(uuidgen | tr 'A-Z' 'a-z')
+run_psql "INSERT INTO chunks
+  (id, vault_id, source_type, source_id, section_path, content,
+   chunk_index, char_start, char_end,
+   vector_retry_count, vector_next_attempt_at,
+   vector_last_error)
+ VALUES
+  ('$(uuidgen | tr 'A-Z' 'a-z')', '$VAULT_ID', 'document', '$SYN_DOC_ID',
+   '', 'synthetic abandoned content', 0, 0, 28,
+   8, NOW() - INTERVAL '8 days', 'simulated retry exhaustion')" >/dev/null
+
+PRE=$(run_psql "SELECT COUNT(*) FROM chunks WHERE source_id = '$SYN_DOC_ID' AND vector_retry_count >= 8")
+[ "$PRE" = "1" ] && pass "synthetic abandoned chunk seeded" || fail "seed" "got $PRE"
+
+# Drive the reap SQL directly (the worker uses the identical CTE):
+REAPED=$(run_psql "WITH abandoned AS (
+    SELECT id, source_type, source_id FROM chunks
+     WHERE vector_indexed_at IS NULL AND vector_retry_count >= 8
+       AND (vector_next_attempt_at IS NULL
+         OR vector_next_attempt_at < NOW() - INTERVAL '7 days')
+       AND source_id = '$SYN_DOC_ID'
+  ), enqueued AS (
+    INSERT INTO vector_delete_outbox (chunk_id, source_type, source_id, next_attempt_at)
+    SELECT id, source_type, source_id, NOW() FROM abandoned RETURNING 1
+  ), deleted AS (
+    DELETE FROM chunks WHERE id IN (SELECT id FROM abandoned) RETURNING 1
+  )
+  SELECT COUNT(*) FROM deleted")
+[ "$REAPED" = "1" ] && pass "reaper deleted the abandoned chunk" || fail "reap" "got $REAPED"
+
+OUTBOX=$(run_psql "SELECT COUNT(*) FROM vector_delete_outbox WHERE source_id = '$SYN_DOC_ID'")
+[ "$OUTBOX" = "1" ] && pass "vector_delete_outbox enqueued" || fail "outbox" "got $OUTBOX"
+
+# Cleanup: drop the synthetic outbox row so it doesn't show up in
+# real workers' processing.
+run_psql "DELETE FROM vector_delete_outbox WHERE source_id = '$SYN_DOC_ID'" >/dev/null
+
+# ── 3. Stale lock self-heal (lifecycle) ──────────────────────────
+# Note: this verifies the helper directly because we can't easily
+# trigger backend pod restart from inside a test. Live verification
+# happens via the deploy log line "Cleared N stale git lock(s)…".
+echo ""
+echo "▸ 3. cleanup_stale_locks helper directly removes old locks"
+
+# Linked-worktree locks live at <bare>/worktrees/<name>/index.lock, not
+# at <worktree>/.git/index.lock (`.git` there is a gitdir-pointer file).
+LOCK_DIR="/data/vaults/$VAULT.git/worktrees/$VAULT"
+LOCK_PATH="$LOCK_DIR/index.lock"
+
+run_be "test -d '$LOCK_DIR' || mkdir -p '$LOCK_DIR'; touch -d '5 minutes ago' '$LOCK_PATH'"
+LOCK_PRE=$(run_be "test -f '$LOCK_PATH' && echo 1 || echo 0")
+[ "$LOCK_PRE" = "1" ] && pass "synthetic stale lock seeded at $LOCK_PATH" || fail "seed lock" "missing"
+
+run_be "cd /app && python3 -c '
+from app.services.git_service import GitService
+n = GitService().cleanup_stale_locks(max_age_seconds=60)
+print(\"cleared=\", n)
+'" >/dev/null
+
+LOCK_POST=$(run_be "test -f '$LOCK_PATH' && echo 1 || echo 0")
+[ "$LOCK_POST" = "0" ] && pass "stale lock cleared by helper" || fail "self-heal" "lock still there"
+
+# Defense in depth: recent lock (<60s) must NOT be cleared.
+run_be "touch '$LOCK_PATH'"
+run_be "cd /app && python3 -c '
+from app.services.git_service import GitService
+GitService().cleanup_stale_locks(max_age_seconds=60)
+'" >/dev/null
+RECENT=$(run_be "test -f '$LOCK_PATH' && echo 1 || echo 0")
+[ "$RECENT" = "1" ] && pass "recent lock (<60s) preserved" || fail "self-heal grace" "lock removed"
+
+# Cleanup
+run_be "rm -f '$LOCK_PATH'"
+
+# ── Cleanup ──────────────────────────────────────────────────────
+echo ""
+echo "── Cleanup ──"
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" -H "Authorization: Bearer $PAT" >/dev/null 2>&1 || true
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  Passed: $PASS   Failed: $FAIL"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  printf '    - %s\n' "${ERRORS[@]}"
+  exit 1
+fi
+exit 0

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -60,10 +60,19 @@ export function Layout() {
   // Vector-store backfill across every vault. Lives here (not on
   // per-vault pages) because /health is global — surfacing it on a
   // vault page made users think it was vault-scoped.
+  //
+  // Backend reports `pending` as "vector_indexed_at IS NULL" — a superset
+  // of `abandoned` (retry-exhausted chunks). The badge should show only
+  // the *active* indexing pressure (= pending − abandoned), otherwise
+  // abandoned rows look like a stuck counter that never decreases.
+  // Abandoned rows are reaped by delete_worker after a grace window;
+  // until then they're surfaced through the separate `abandoned` chip.
   const { data: health } = useHealth(!!getToken());
-  const indexingPending: number | null = health
-    ? (health.vector_store?.backfill?.upsert?.pending || 0)
+  const upsert = health?.vector_store?.backfill?.upsert;
+  const indexingPending: number | null = upsert
+    ? Math.max(0, (upsert.pending || 0) - (upsert.abandoned || 0))
     : null;
+  const indexingAbandoned: number = upsert?.abandoned || 0;
 
   // Vault workspace routes lock to viewport height and supply their own
   // internal scroll regions (tree / content / etc.). Non-vault routes keep
@@ -91,7 +100,7 @@ export function Layout() {
           <div className="mx-auto flex max-w-[1400px] items-center justify-between gap-3 px-6 py-1">
             <div className="coord">§ AKB · Agent Knowledgebase</div>
             <div className="flex items-center gap-3">
-              <IndexingBadge pending={indexingPending} />
+              <IndexingBadge pending={indexingPending} abandoned={indexingAbandoned} />
               <div className="coord hidden md:block">
                 {new Date().toUTCString().slice(0, 22).toUpperCase()}
               </div>

--- a/frontend/src/components/status-badge.tsx
+++ b/frontend/src/components/status-badge.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   Archive,
   CircleDashed,
   Eye,
@@ -83,36 +84,63 @@ export function VaultStateBadge({
 /**
  * Indexing activity indicator.
  *
- * Pass `pending` as:
- *   - `null` / `undefined` — `/health` hasn't resolved yet; renders a muted
- *     skeleton chip that reserves layout space so the badge doesn't pop-in
- *     jarringly once the real value arrives.
- *   - `0` — loaded and nothing pending; renders nothing.
- *   - `> 0` — renders the active spinner badge with a fade-in transition.
+ * - `pending`   — actively-indexing chunks (i.e. backend's
+ *                 `pending − abandoned`). `null`/`undefined` ⇒ skeleton;
+ *                 `0` ⇒ no spinner. `> 0` ⇒ spinner + count.
+ * - `abandoned` — retry-exhausted chunks that the worker has given up
+ *                 on. Surfaced as a separate warning chip when > 0 so
+ *                 they don't masquerade as "still indexing" forever.
+ *                 (The backend's delete_worker reaps them after the
+ *                 grace window — until then this chip is the signal.)
  */
-export function IndexingBadge({ pending }: { pending: number | null | undefined }) {
+export function IndexingBadge({
+  pending,
+  abandoned = 0,
+}: {
+  pending: number | null | undefined;
+  abandoned?: number;
+}) {
+  const abandonedChip = abandoned > 0 ? (
+    <Badge
+      variant="outline"
+      className="border-destructive/40 text-destructive"
+      title={`${abandoned.toLocaleString()} chunk(s) failed indexing and are awaiting auto-reap`}
+    >
+      <AlertTriangle className="h-3 w-3" aria-hidden />
+      {abandoned.toLocaleString()} abandoned
+    </Badge>
+  ) : null;
+
   if (pending == null) {
     return (
-      <Badge
-        variant="outline"
-        className="opacity-40 animate-pulse"
-        title="Checking indexing status…"
-        aria-busy="true"
-      >
-        <CircleDashed className="h-3 w-3" aria-hidden />
-        checking…
-      </Badge>
+      <>
+        <Badge
+          variant="outline"
+          className="opacity-40 animate-pulse"
+          title="Checking indexing status…"
+          aria-busy="true"
+        >
+          <CircleDashed className="h-3 w-3" aria-hidden />
+          checking…
+        </Badge>
+        {abandonedChip}
+      </>
     );
   }
-  if (pending <= 0) return null;
+  if (pending <= 0) {
+    return abandonedChip;
+  }
   return (
-    <Badge
-      variant="pending"
-      className="fade-in"
-      title={`${pending.toLocaleString()} items pending`}
-    >
-      <CircleDashed className="h-3 w-3 animate-spin" aria-hidden />
-      indexing {pending.toLocaleString()}
-    </Badge>
+    <>
+      <Badge
+        variant="pending"
+        className="fade-in"
+        title={`${pending.toLocaleString()} items pending`}
+      >
+        <CircleDashed className="h-3 w-3 animate-spin" aria-hidden />
+        indexing {pending.toLocaleString()}
+      </Badge>
+      {abandonedChip}
+    </>
   );
 }

--- a/frontend/src/pages/vault.tsx
+++ b/frontend/src/pages/vault.tsx
@@ -53,9 +53,16 @@ export default function VaultPage() {
   const [commitsLoaded, setCommitsLoaded] = useState(false);
 
   const vaultHealth = useVaultHealth(name);
+  // Same shape as the global header: `pending` from the backend includes
+  // retry-exhausted (abandoned) chunks, so subtract them to get the
+  // "actively indexing" count and surface abandoned separately.
+  const vUpsert = vaultHealth?.vector_store?.backfill?.upsert;
+  const vaultAbandoned: number = vUpsert?.abandoned || 0;
   const vaultPending: number | null = vaultHealth
-    ? (vaultHealth.vector_store?.backfill?.upsert?.pending || 0) +
-      (vaultHealth.metadata_backfill?.pending || 0)
+    ? Math.max(
+        0,
+        (vUpsert?.pending || 0) - vaultAbandoned,
+      ) + (vaultHealth.metadata_backfill?.pending || 0)
     : null;
 
   useEffect(() => {
@@ -123,7 +130,7 @@ export default function VaultPage() {
           externalGit={info?.is_external_git}
           publicAccess={info?.public_access}
         />
-        <IndexingBadge pending={vaultPending} />
+        <IndexingBadge pending={vaultPending} abandoned={vaultAbandoned} />
         <div className="ml-auto flex items-baseline gap-4">
           <Link
             to={`/vault/${name}/members`}


### PR DESCRIPTION
## Summary

Three crash-recovery / observability fixes prompted by a recent
incident where a bulk import hit OOM + container restart mid-write,
leaving stale state behind for weeks:

- **(β)** Startup self-heals `.git/index.lock` files left by crashed
  prior runs.
- **(γ)** `akb_delete` no longer fails when the git file is already
  absent — DB cleanup runs to completion regardless.
- **(ζ)** `delete_worker` reaps chunks that exhausted retries
  (vector_retry_count >= MAX) after a 7-day grace window. UI shows
  active indexing and abandoned counts separately so the badge
  doesn't appear to be stuck forever.

## Behaviour changes

| Component | Before | After |
|---|---|---|
| Backend startup | Stale `index.lock` (e.g. from container OOM kill) blocks every subsequent write to that vault silently | `cleanup_stale_locks()` removes `index.lock` files older than 60s; logged at startup |
| `akb_delete` on missing git file | Raises `FileNotFoundError`, DB row stays orphaned | Catches `FileNotFoundError`, proceeds with PG cleanup, logs warning |
| Abandoned chunks | Sit in `vector_indexed_at IS NULL` forever; UI badge shows them as "indexing N" | After 7d grace, `delete_worker._reap_abandoned_chunks_once` deletes them from PG + enqueues to `vector_delete_outbox`. UI shows them as separate "N abandoned" chip until reap |

No schema changes, no API changes, no breaking changes for subscribers.

## Test plan

- [x] `backend/tests/test_self_heal_e2e.sh` — 12 assertions covering
      all three fixes (linked-worktree lock path, 60s grace, delete
      idempotency, reaper CTE, outbox enqueue).
- [x] Existing e2e suites still pass against the deployed backend:
      - `test_mcp_e2e.sh` 75/75
      - `test_table_crud_envelope_e2e.sh` 40/40
      - `test_events_emit_e2e.sh` 6/6
      - `test_s3_delete_outbox_e2e.sh` 5/5
- [x] Backend + frontend rebuilt and deployed; live health green.

## Files

```
backend/app/services/git_service.py        +57 (cleanup_stale_locks)
backend/app/services/lifecycle.py          +9  (call from init_storage)
backend/app/services/document_service.py   +14 (FileNotFoundError catch)
backend/app/services/delete_worker.py      +72 (reaper helper + tick)
frontend/src/components/status-badge.tsx   +37 (abandoned prop)
frontend/src/components/layout.tsx         +6  (subtract abandoned)
frontend/src/pages/vault.tsx               +9  (same)
backend/tests/test_self_heal_e2e.sh        +211 (new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)