### PR TITLE
Harden reaper + stale-lock self-heal (PR #5 follow-up)

### DIFF
--- a/backend/app/services/delete_worker.py
+++ b/backend/app/services/delete_worker.py
@@ -170,15 +170,16 @@ async def _sweep_outbox_once() -> int:
     pool = await get_pool()
     async with pool.acquire() as conn:
         n = await conn.fetchval(
-            f"""
+            """
             WITH d AS (
                 DELETE FROM vector_delete_outbox
                  WHERE processed_at IS NOT NULL
-                   AND processed_at < NOW() - INTERVAL '{SWEEP_GRACE_INTERVAL}'
+                   AND processed_at < NOW() - $1::interval
                 RETURNING 1
             )
             SELECT COUNT(*) FROM d
-            """
+            """,
+            SWEEP_GRACE_INTERVAL,
         )
     n = int(n or 0)
     if n:
@@ -218,7 +219,7 @@ async def _reap_abandoned_chunks_once() -> int:
     async with pool.acquire() as conn:
         async with conn.transaction():
             n = await conn.fetchval(
-                f"""
+                """
                 WITH abandoned AS (
                     SELECT id, source_type, source_id
                       FROM chunks
@@ -226,8 +227,9 @@ async def _reap_abandoned_chunks_once() -> int:
                        AND vector_retry_count >= $1
                        AND (
                            vector_next_attempt_at IS NULL
-                        OR vector_next_attempt_at < NOW() - INTERVAL '{REAP_GRACE_INTERVAL}'
+                        OR vector_next_attempt_at < NOW() - $2::interval
                        )
+                     FOR UPDATE SKIP LOCKED
                 ),
                 enqueued AS (
                     INSERT INTO vector_delete_outbox
@@ -241,7 +243,7 @@ async def _reap_abandoned_chunks_once() -> int:
                 )
                 SELECT COUNT(*) FROM deleted
                 """,
-                MAX_RETRIES,
+                MAX_RETRIES, REAP_GRACE_INTERVAL,
             )
     n = int(n or 0)
     if n:

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -118,7 +118,13 @@ class GitService:
         the lock is cleared by hand. Running this at startup recovers
         every affected vault before any worker can run into the same wall.
 
-        Lock locations checked:
+        Vault enumeration source: every `<storage>/<name>.git` bare repo
+        in `storage_path`. Iterating bare repos (rather than the linked
+        worktree dir) means we still find locks for vaults whose
+        `_worktrees/<name>` directory was wiped or never created — the
+        admin path inside the bare can hold an `index.lock` independently.
+
+        Lock locations checked per vault:
           1. `<bare>/worktrees/<name>/index.lock` — where git keeps the
              index for linked worktrees (the path the AKB write paths
              actually touch).
@@ -135,15 +141,17 @@ class GitService:
         Returns the number of locks removed.
         """
         cleared = 0
-        if not self.worktrees_path.exists():
+        if not self.storage_path.exists():
             return cleared
-        for vault_dir in self.worktrees_path.iterdir():
-            if not vault_dir.is_dir():
+        for bare in self.storage_path.iterdir():
+            if not bare.is_dir() or not bare.name.endswith(".git"):
                 continue
-            vault_name = vault_dir.name
+            vault_name = bare.name[: -len(".git")]
+            if not vault_name:
+                continue
             candidates = [
-                self._bare_path(vault_name) / "worktrees" / vault_name / "index.lock",
-                vault_dir / ".git" / "index.lock",
+                bare / "worktrees" / vault_name / "index.lock",
+                self._worktree_path(vault_name) / ".git" / "index.lock",
             ]
             for lock in candidates:
                 # `.git` in a linked worktree is a file (gitdir pointer),


### PR DESCRIPTION
## Summary

Three follow-ups from the self-review of PR #5:

1. `_sweep_outbox_once` + `_reap_abandoned_chunks_once` use `$N::interval`
   parameter binding instead of f-string interpolation of grace
   intervals. Consistency-only; values are constants we control.
2. Reaper's abandoned-chunk CTE acquires `FOR UPDATE SKIP LOCKED`, so
   two pods running concurrently no longer double-insert into
   `vector_delete_outbox` (harmless before due to idempotent S3 /
   vector deletes, but noisy).
3. `cleanup_stale_locks` enumerates vaults from `<storage>/<*>.git`
   bare-repo entries. Previously it only saw vaults that still had
   a linked `_worktrees/<name>` directory — a vault whose worktree
   was wiped but whose bare admin dir still carried an `index.lock`
   was invisible to the helper.

No behaviour change for the common path; failure-mode coverage strictly
stronger.

## Test plan

- [x] `test_self_heal_e2e.sh` 12/12 pass against redeployed backend
- [x] `test_mcp_e2e.sh` 75/75 pass (regression)
- [x] `test_s3_delete_outbox_e2e.sh` 5/5 pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)