### PR TITLE
fix(delete_worker): use timedelta for grace intervals

### DIFF
--- a/backend/app/services/delete_worker.py
+++ b/backend/app/services/delete_worker.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("akb.delete_worker")
 BATCH_SIZE = 16
 
 # Outbox sweep cadence + retention window.
-SWEEP_GRACE_INTERVAL = "1 day"
+SWEEP_GRACE_INTERVAL = timedelta(days=1)
 SWEEP_INTERVAL_SECONDS = 3600.0
 _last_sweep_at: float = 0.0
 
@@ -199,7 +199,7 @@ async def _sweep_outbox_once() -> int:
 # The grace window lets an operator notice + investigate the failure
 # (e.g. an oversize chunk from a bug in the chunker) before the row
 # is reclaimed. 7d is generous; tune via REAP_GRACE_INTERVAL if needed.
-REAP_GRACE_INTERVAL = "7 days"
+REAP_GRACE_INTERVAL = timedelta(days=7)
 REAP_INTERVAL_SECONDS = 3600.0
 _last_reap_at: float = 0.0
 


### PR DESCRIPTION
## Summary

Hotfix for the regression PR #6 introduced. Switching the sweep/reap
SQL to `\$N::interval` parameter binding broke the runtime because
asyncpg encodes the parameter natively and rejects the `str`
constants ('1 day' / '7 days'). Use `datetime.timedelta` instead;
asyncpg encodes that to interval out of the box.

Observed on the redeployed backend:
\`\`\`
delete_worker abandoned-chunk reap failed: invalid input for
query argument \$2: '7 days' ('str' object has no attribute 'days')
\`\`\`

Same issue applied to `SWEEP_GRACE_INTERVAL` — the 176-row outbox
backlog drained on the first sweep tick after this fix landed.

## Test plan

- [x] Direct invocation of `_reap_abandoned_chunks_once()` completes
      without exception on the deployed pod
- [x] `outbox sweep: purged N rows` log lines appear
- [x] `test_self_heal_e2e.sh` 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)