### PR TITLE
feat(frontend): collapsible auto-summary on document + publication pages

### DIFF
--- a/frontend/src/components/summary-fold.tsx
+++ b/frontend/src/components/summary-fold.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+/**
+ * SummaryFold — collapsed-by-default rendering of an auto-generated
+ * document summary.
+ *
+ * AKB's `documents.summary` is produced by `metadata_worker` for
+ * search relevance, not human readability — when shown at body-text
+ * weight it looks like the document's lead paragraph and obscures the
+ * real content beneath. This component demotes it visually (smaller,
+ * muted, italic) and clamps it to the first two lines, with an
+ * explicit toggle to read the rest.
+ *
+ * For short summaries (≤ FOLD_THRESHOLD chars, roughly two lines at
+ * typical column widths) the toggle is hidden — there's nothing to
+ * unfold and the chrome would be more noise than the text it sits next to.
+ */
+
+const FOLD_THRESHOLD = 140;
+
+interface Props {
+  summary?: string | null;
+  /** Slightly larger leading for the public-share page hero context. */
+  prominent?: boolean;
+  /** Outer spacing. Defaults to a small block; pass "" to flush against neighbors. */
+  className?: string;
+}
+
+export function SummaryFold({ summary, prominent = false, className = "my-4" }: Props) {
+  const [open, setOpen] = useState(false);
+  if (!summary) return null;
+  const needsFold = summary.length > FOLD_THRESHOLD;
+
+  const textCls = prominent
+    ? "font-serif-italic text-foreground-muted text-[15px] leading-[1.6] max-w-prose"
+    : "font-serif-italic text-foreground-muted text-sm leading-[1.55] max-w-prose";
+
+  if (!needsFold) {
+    return (
+      <p className={`${textCls} ${className}`}>
+        {summary}
+      </p>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <p className={`${textCls} ${open ? "" : "line-clamp-2"}`}>
+        {summary}
+      </p>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="mt-1 inline-flex items-center gap-1 coord text-foreground-muted hover:text-foreground transition-colors"
+      >
+        {open ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
+        {open ? "less" : "more"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -24,6 +24,7 @@ import {
 import { timeAgo } from "@/lib/utils";
 import { parseHeadings, slugify } from "@/lib/markdown";
 import { DocumentOutline } from "@/components/doc-outline";
+import { SummaryFold } from "@/components/summary-fold";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HistoryList } from "@/components/history-list";
@@ -201,11 +202,7 @@ export default function DocumentPage() {
         {/* Frontmatter card — mono metadata with semantic colors */}
         <FrontmatterCard doc={doc} />
 
-        {doc.summary && (
-          <p className="font-serif text-[17px] leading-[1.6] text-foreground mb-7 mt-6">
-            {doc.summary}
-          </p>
-        )}
+        <SummaryFold summary={doc.summary} className="mt-4 mb-7" />
 
         {publishError && (
           <div

--- a/frontend/src/pages/public-publication.tsx
+++ b/frontend/src/pages/public-publication.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api";
 import { formatDate } from "@/lib/utils";
 import { PasswordGate } from "@/components/password-gate";
+import { SummaryFold } from "@/components/summary-fold";
 import { TableViewer } from "@/components/table-viewer";
 import { FileViewer } from "@/components/file-viewer";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -189,11 +190,7 @@ function DocumentBody({ data }: { data: PublicationResponse }) {
           {data.title}
         </h1>
 
-        {data.summary && (
-          <p className="font-display-body text-lg text-foreground border-l-2 border-accent pl-4 mb-10 max-w-prose">
-            {data.summary}
-          </p>
-        )}
+        <SummaryFold summary={data.summary} prominent className="mt-4 mb-10" />
 
         {data.content_unavailable && (
           <div


### PR DESCRIPTION
## Summary

User feedback: `documents.summary` is auto-generated by
metadata_worker for search relevance — it reads like keyword soup
(title + tags inlined) but was rendered as if it were the document's
lead paragraph (17px serif, foreground color, prominent margin) and
obscured the real content beneath.

Demote it visually:

- New `SummaryFold` component: small italic muted text, 2-line clamp
  by default, chevron \"more / less\" toggle when the summary exceeds
  ~140 chars.
- Short summaries (≤ threshold) render inline without the toggle so
  there's no chrome noise.
- `prominent` variant for the public publication hero context keeps a
  slightly larger leading.

Applied at `pages/document.tsx` and `pages/public-publication.tsx`.
`pages/search.tsx` already uses the same line-clamp + muted style
and is left alone.

## Test plan

- [x] Frontend build + push + rollout against deployed cluster
- [ ] Visual smoke at `https://akb.agent.seahorse.dnotitia.com/vault/{v}/document/{id}` — long-summary doc shows the chevron, short-summary doc shows inline