### PR TITLE
feat(collections): unified hierarchy for documents + tables + files

### DIFF
--- a/backend/app/api/routes/tables.py
+++ b/backend/app/api/routes/tables.py
@@ -16,6 +16,7 @@ class CreateTableRequest(NFCModel):
     name: str
     description: str = ""
     columns: list[dict]
+    collection: str | None = None
 
 
 class SqlRequest(NFCModel):
@@ -29,6 +30,7 @@ async def create_table(vault: str, req: CreateTableRequest, user: AuthenticatedU
     return await table_service.create_table(
         access["vault_id"], req.name, req.columns,
         actor_id=user.username, description=req.description,
+        collection=req.collection,
     )
 
 

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -171,6 +171,7 @@ CREATE INDEX IF NOT EXISTS idx_chunks_indexing_queue
 CREATE TABLE IF NOT EXISTS vault_tables (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    collection_id UUID REFERENCES collections(id) ON DELETE SET NULL,
     name TEXT NOT NULL,
     description TEXT,
     columns JSONB NOT NULL DEFAULT '[]',
@@ -190,6 +191,7 @@ CREATE TABLE IF NOT EXISTS vault_table_rows (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_tables_vault ON vault_tables(vault_id);
+CREATE INDEX IF NOT EXISTS idx_vault_tables_collection ON vault_tables(collection_id);
 CREATE INDEX IF NOT EXISTS idx_vault_table_rows_table ON vault_table_rows(table_id);
 CREATE INDEX IF NOT EXISTS idx_vault_table_rows_data ON vault_table_rows USING gin(data);
 
@@ -227,7 +229,7 @@ CREATE INDEX IF NOT EXISTS idx_edges_target_type ON edges(target_type);
 CREATE TABLE IF NOT EXISTS vault_files (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
-    collection TEXT NOT NULL DEFAULT '',
+    collection_id UUID REFERENCES collections(id) ON DELETE SET NULL,
     name TEXT NOT NULL,
     s3_key TEXT NOT NULL,
     mime_type TEXT,
@@ -240,7 +242,7 @@ CREATE TABLE IF NOT EXISTS vault_files (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_files_vault ON vault_files(vault_id);
-CREATE INDEX IF NOT EXISTS idx_vault_files_collection ON vault_files(vault_id, collection);
+CREATE INDEX IF NOT EXISTS idx_vault_files_collection ON vault_files(collection_id);
 
 -- ============================================================
 -- Publications (unified public-link feature for documents, tables, files)

--- a/backend/app/db/migrations/020_unify_collection_membership.py
+++ b/backend/app/db/migrations/020_unify_collection_membership.py
@@ -85,16 +85,37 @@ async def _already_applied(conn) -> bool:
     return bool(has_tables_fk and has_files_fk and legacy_text_gone)
 
 
+async def _ensure_indexes(conn) -> None:
+    """Create the FK indexes if missing. Runs unconditionally on every
+    boot so DBs that ran an earlier revision of this migration (which
+    landed the FK columns but not the indexes) get the index added on
+    the next deploy. `IF NOT EXISTS` keeps it idempotent."""
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_vault_tables_collection "
+        "ON vault_tables(collection_id)"
+    )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_vault_files_collection "
+        "ON vault_files(collection_id)"
+    )
+
+
 async def _run(conn):
     if await _already_applied(conn):
+        # Ensure indexes exist even on already-migrated DBs — an earlier
+        # revision of this migration shipped without them.
+        await _ensure_indexes(conn)
         logger.info(
             "Migration 020 already applied "
-            "(collection_id FKs present, legacy TEXT removed); skipping"
+            "(collection_id FKs present, legacy TEXT removed); indexes ensured"
         )
         return
 
     async with conn.transaction():
-        # 1+2: add FK columns (idempotent via IF NOT EXISTS).
+        # 1+2: add FK columns (idempotent via IF NOT EXISTS) + indexes.
+        # Every scoped browse / cascade-delete now JOINs and filters on
+        # these columns; without the index the seq scan dominates on
+        # large vaults.
         await conn.execute(
             """
             ALTER TABLE vault_tables
@@ -103,11 +124,19 @@ async def _run(conn):
             """
         )
         await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_vault_tables_collection "
+            "ON vault_tables(collection_id)"
+        )
+        await conn.execute(
             """
             ALTER TABLE vault_files
                 ADD COLUMN IF NOT EXISTS collection_id UUID
                     REFERENCES collections(id) ON DELETE SET NULL
             """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_vault_files_collection "
+            "ON vault_files(collection_id)"
         )
 
         # 3: populate vault_files.collection_id from existing TEXT.

--- a/backend/app/db/migrations/020_unify_collection_membership.py
+++ b/backend/app/db/migrations/020_unify_collection_membership.py
@@ -1,0 +1,220 @@
+"""Migration 020: unified collection membership for documents / tables / files.
+
+Before:  `documents.collection_id` FK to collections (since migration 011).
+         `vault_files.collection` is a free-form TEXT field — never normalized
+         against `collections`. `vault_tables` has no collection concept.
+
+After:   All three resource types reference `collections.id` via a
+         nullable `collection_id` FK (NULL == vault root). The legacy
+         `vault_files.collection` TEXT column is removed in the same
+         migration — no two-source-of-truth window.
+
+Migration logic:
+
+1.  ALTER TABLE vault_tables ADD COLUMN collection_id UUID
+       REFERENCES collections(id) ON DELETE SET NULL.
+2.  ALTER TABLE vault_files  ADD COLUMN collection_id UUID
+       REFERENCES collections(id) ON DELETE SET NULL.
+3.  For every vault_files row whose `collection` text is non-empty,
+    ensure a matching `collections` row exists (insert one if not),
+    then set vault_files.collection_id to it.
+    Empty / NULL text → leave collection_id NULL (= vault root).
+4.  Verify: every row's collection state is consistent — either both
+    NULL (root) or both NOT NULL with the FK target's path matching
+    the original text. Abort the migration on mismatch.
+5.  DROP COLUMN vault_files.collection.
+
+Idempotent on partial application — re-running after step 5 finds the
+column missing and the FK columns present; the `_already_applied`
+check below catches that and exits cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.020")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _already_applied(conn) -> bool:
+    """Returns True if the post-migration column shape is already in place
+    (collection_id on both tables AND legacy TEXT column gone)."""
+    has_tables_fk = await conn.fetchval(
+        """
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'vault_tables'
+           AND column_name = 'collection_id'
+        """
+    )
+    has_files_fk = await conn.fetchval(
+        """
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'vault_files'
+           AND column_name = 'collection_id'
+        """
+    )
+    legacy_text_gone = await conn.fetchval(
+        """
+        SELECT NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'vault_files'
+               AND column_name = 'collection'
+        )
+        """
+    )
+    return bool(has_tables_fk and has_files_fk and legacy_text_gone)
+
+
+async def _run(conn):
+    if await _already_applied(conn):
+        logger.info(
+            "Migration 020 already applied "
+            "(collection_id FKs present, legacy TEXT removed); skipping"
+        )
+        return
+
+    async with conn.transaction():
+        # 1+2: add FK columns (idempotent via IF NOT EXISTS).
+        await conn.execute(
+            """
+            ALTER TABLE vault_tables
+                ADD COLUMN IF NOT EXISTS collection_id UUID
+                    REFERENCES collections(id) ON DELETE SET NULL
+            """
+        )
+        await conn.execute(
+            """
+            ALTER TABLE vault_files
+                ADD COLUMN IF NOT EXISTS collection_id UUID
+                    REFERENCES collections(id) ON DELETE SET NULL
+            """
+        )
+
+        # 3: populate vault_files.collection_id from existing TEXT.
+        # Only meaningful if the legacy column still exists — guard so
+        # the migration is safe to re-run on a partially-applied DB
+        # (FKs added but TEXT not yet dropped).
+        text_col_exists = await conn.fetchval(
+            """
+            SELECT 1 FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = 'vault_files'
+               AND column_name = 'collection'
+            """
+        )
+        migrated = 0
+        if text_col_exists:
+            distinct_pairs = await conn.fetch(
+                """
+                SELECT DISTINCT vault_id, collection
+                  FROM vault_files
+                 WHERE collection IS NOT NULL
+                   AND collection <> ''
+                """
+            )
+            for row in distinct_pairs:
+                vault_id = row["vault_id"]
+                path = row["collection"]
+                # ensure_collection: insert if missing.
+                cid_row = await conn.fetchrow(
+                    "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
+                    vault_id, path,
+                )
+                if cid_row:
+                    cid = cid_row["id"]
+                else:
+                    cid = uuid.uuid4()
+                    name = path.rstrip("/").split("/")[-1] or path
+                    await conn.execute(
+                        """
+                        INSERT INTO collections (id, vault_id, path, name)
+                        VALUES ($1, $2, $3, $4)
+                        """,
+                        cid, vault_id, path, name,
+                    )
+                    logger.info(
+                        "Migration 020: ensured collection (%s, %s) for file backfill",
+                        vault_id, path,
+                    )
+                # Set FK on every vault_files row matching this (vault, path).
+                result = await conn.execute(
+                    """
+                    UPDATE vault_files
+                       SET collection_id = $1
+                     WHERE vault_id = $2
+                       AND collection = $3
+                       AND collection_id IS NULL
+                    """,
+                    cid, vault_id, path,
+                )
+                # asyncpg returns "UPDATE N" — extract N for the audit log.
+                try:
+                    migrated += int(result.split()[-1])
+                except (ValueError, IndexError):
+                    pass
+
+            # 4: verify — every row with non-empty TEXT collection now has
+            # a matching FK whose path equals the original text.
+            inconsistent = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM vault_files vf
+                  LEFT JOIN collections c ON c.id = vf.collection_id
+                 WHERE vf.collection IS NOT NULL
+                   AND vf.collection <> ''
+                   AND (
+                        vf.collection_id IS NULL
+                     OR c.path IS DISTINCT FROM vf.collection
+                     OR c.vault_id IS DISTINCT FROM vf.vault_id
+                   )
+                """
+            )
+            if int(inconsistent or 0) > 0:
+                raise RuntimeError(
+                    f"Migration 020: {inconsistent} vault_files rows have a non-empty "
+                    "legacy `collection` text that did not migrate cleanly to "
+                    "`collection_id`. Aborting before dropping the legacy column."
+                )
+
+            logger.info(
+                "Migration 020: vault_files.collection → collection_id backfilled "
+                "for %d rows", migrated,
+            )
+
+            # 5: drop legacy TEXT column.
+            await conn.execute("ALTER TABLE vault_files DROP COLUMN collection")
+
+        logger.info(
+            "Migration 020 applied: vault_tables.collection_id + vault_files.collection_id "
+            "FK in place; legacy vault_files.collection TEXT removed",
+        )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -104,6 +104,7 @@ async def _apply_migrations() -> None:
         "017_chunks_indexing_queue_index.py",  # partial index for new-first claim order
         "018_drop_redundant_pending_index.py",  # idx_chunks_vector_pending is dead weight after 017
         "019_s3_delete_outbox.py",              # s3_delete_outbox + indices for atomic file deletion
+        "020_unify_collection_membership.py",   # vault_tables/vault_files collection_id FK; drop legacy vault_files.collection TEXT
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -100,6 +100,10 @@ class BrowseItem(BaseModel):
     type: str  # "collection", "document", "table", "file"
     uri: str | None = None  # akb:// URI for this resource
     summary: str | None = None
+    # Collection membership — set on tables/files (documents encode it
+    # in `path`). NULL for resources at vault root. Frontend tree
+    # builder uses this to place tables/files under their collection.
+    collection: str | None = None
     # Document fields
     doc_count: int | None = None  # for collections
     doc_type: str | None = None  # for documents

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -429,17 +429,25 @@ class CollectionRepository:
         path: str,
         conn=None,
     ) -> list[dict]:
-        """Return vault_files whose `collection` equals `path` exactly or
-        starts with `{path}/`. Covers the folder itself plus every
-        descendant — used by cascade delete to enqueue S3 cleanup."""
+        """Return vault_files whose collection path equals `path` exactly
+        or starts with `{path}/`. Covers the folder itself plus every
+        descendant — used by cascade delete to enqueue S3 cleanup.
+
+        Implementation joins `collections` on the new `collection_id`
+        FK (migration 020). Pre-migration callers that relied on the
+        legacy `vault_files.collection` TEXT column are not supported.
+        """
         bare = path.rstrip("/")
         like = self._like_escape(bare) + "/%"
         sql = (
-            "SELECT id, vault_id, collection, name, s3_key, mime_type, "
-            "       size_bytes, description, created_by, created_at, updated_at "
-            "  FROM vault_files "
-            " WHERE vault_id = $1 "
-            "   AND (collection = $2 OR collection LIKE $3 ESCAPE '\\')"
+            "SELECT vf.id, vf.vault_id, vf.collection_id, "
+            "       c.path AS collection, vf.name, vf.s3_key, vf.mime_type, "
+            "       vf.size_bytes, vf.description, vf.created_by, "
+            "       vf.created_at, vf.updated_at "
+            "  FROM vault_files vf "
+            "  JOIN collections c ON c.id = vf.collection_id "
+            " WHERE vf.vault_id = $1 "
+            "   AND (c.path = $2 OR c.path LIKE $3 ESCAPE '\\')"
         )
         async def _do(c):
             rows = await c.fetch(sql, vault_id, bare, like)

--- a/backend/app/repositories/table_registry_repo.py
+++ b/backend/app/repositories/table_registry_repo.py
@@ -6,6 +6,12 @@ composes repo calls under one `async with conn.transaction():` block.
 
 Data tables (the `vt_***` PG tables that hold actual rows) live in
 `table_data_repo`. This module only deals with the registry row.
+
+Collection membership is normalized via FK `vault_tables.collection_id`
+referencing `collections.id` (NULL == vault root). Table names remain
+unique within a vault (NOT per-collection), so the PG-side
+`pg_table_name(vault, name)` mapping is unchanged and a table can be
+moved between collections without renaming.
 """
 
 from __future__ import annotations
@@ -19,28 +25,75 @@ from app.utils import ensure_list
 
 
 async def find_by_name(conn, vault_id: uuid.UUID, name: str) -> dict | None:
+    """Look up a table by (vault, name). Name is unique within a vault
+    (across all collections) so no collection scoping is needed here.
+    The returned row carries `collection_id` for callers that need to
+    know which collection the table currently belongs to."""
     row = await conn.fetchrow(
         """
-        SELECT id, vault_id, name, description, columns, created_by,
-               created_at, updated_at
-          FROM vault_tables
-         WHERE vault_id = $1 AND name = $2
+        SELECT vt.id, vt.vault_id, vt.collection_id, c.path AS collection,
+               vt.name, vt.description, vt.columns, vt.created_by,
+               vt.created_at, vt.updated_at
+          FROM vault_tables vt
+          LEFT JOIN collections c ON c.id = vt.collection_id
+         WHERE vt.vault_id = $1 AND vt.name = $2
         """,
         vault_id, name,
     )
     return dict(row) if row else None
 
 
-async def list_for_vault(conn, vault_id: uuid.UUID) -> list[dict]:
-    rows = await conn.fetch(
-        """
-        SELECT id, name, description, columns, created_at
-          FROM vault_tables
-         WHERE vault_id = $1
-         ORDER BY name
-        """,
-        vault_id,
-    )
+async def list_for_vault(
+    conn,
+    vault_id: uuid.UUID,
+    *,
+    collection_id: uuid.UUID | None = None,
+    scoped: bool = False,
+) -> list[dict]:
+    """List tables in a vault.
+
+    Default (`scoped=False`) returns every table regardless of collection.
+    With `scoped=True`, only rows whose `collection_id` matches
+    `collection_id` (NULL = vault root) are returned — used by the
+    per-collection browse path.
+    """
+    if scoped:
+        if collection_id is None:
+            rows = await conn.fetch(
+                """
+                SELECT vt.id, vt.collection_id, c.path AS collection,
+                       vt.name, vt.description, vt.columns, vt.created_at
+                  FROM vault_tables vt
+                  LEFT JOIN collections c ON c.id = vt.collection_id
+                 WHERE vt.vault_id = $1 AND vt.collection_id IS NULL
+                 ORDER BY vt.name
+                """,
+                vault_id,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT vt.id, vt.collection_id, c.path AS collection,
+                       vt.name, vt.description, vt.columns, vt.created_at
+                  FROM vault_tables vt
+                  LEFT JOIN collections c ON c.id = vt.collection_id
+                 WHERE vt.vault_id = $1 AND vt.collection_id = $2
+                 ORDER BY vt.name
+                """,
+                vault_id, collection_id,
+            )
+    else:
+        rows = await conn.fetch(
+            """
+            SELECT vt.id, vt.collection_id, c.path AS collection,
+                   vt.name, vt.description, vt.columns, vt.created_at
+              FROM vault_tables vt
+              LEFT JOIN collections c ON c.id = vt.collection_id
+             WHERE vt.vault_id = $1
+             ORDER BY vt.name
+            """,
+            vault_id,
+        )
     return [dict(r) for r in rows]
 
 
@@ -54,14 +107,17 @@ async def insert(
     columns: list[dict],
     created_by: str | None,
     now: datetime,
+    collection_id: uuid.UUID | None = None,
 ) -> None:
     await conn.execute(
         """
         INSERT INTO vault_tables
-            (id, vault_id, name, description, columns, created_by, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+            (id, vault_id, collection_id, name, description, columns,
+             created_by, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)
         """,
-        table_id, vault_id, name, description, json.dumps(columns), created_by, now,
+        table_id, vault_id, collection_id, name, description,
+        json.dumps(columns), created_by, now,
     )
 
 

--- a/backend/app/repositories/vault_files_repo.py
+++ b/backend/app/repositories/vault_files_repo.py
@@ -3,6 +3,10 @@
 The actual file bytes never touch this layer; S3 access lives in
 `services/adapters/s3_adapter.py`. Module-level functions take an
 explicit `conn` so the caller controls the transaction boundary.
+
+Collection membership is normalized via the FK `vault_files.collection_id`
+referencing `collections.id`. NULL == vault root. The legacy free-form
+`vault_files.collection` TEXT column was removed in migration 020.
 """
 
 from __future__ import annotations
@@ -15,21 +19,22 @@ async def insert(
     *,
     file_id: uuid.UUID,
     vault_id: uuid.UUID,
-    collection: str,
     name: str,
     s3_key: str,
     mime_type: str,
     size_bytes: int,
     description: str,
     created_by: str,
+    collection_id: uuid.UUID | None = None,
 ) -> None:
     await conn.execute(
         """
         INSERT INTO vault_files
-            (id, vault_id, collection, name, s3_key, mime_type, size_bytes, description, created_by)
+            (id, vault_id, collection_id, name, s3_key, mime_type,
+             size_bytes, description, created_by)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         """,
-        file_id, vault_id, collection, name, s3_key,
+        file_id, vault_id, collection_id, name, s3_key,
         mime_type, size_bytes, description, created_by,
     )
 
@@ -39,12 +44,18 @@ async def find_by_id(
     vault_id: uuid.UUID,
     file_id: uuid.UUID,
 ) -> dict | None:
+    """Returns the file row joined with its collection.path. The
+    `collection` field on the result dict is the human-readable path
+    (or None for vault root), used by event payloads + browse renderers
+    that need the path string."""
     row = await conn.fetchrow(
         """
-        SELECT id, vault_id, collection, name, s3_key, mime_type,
-               size_bytes, description, created_by, created_at, updated_at
-          FROM vault_files
-         WHERE id = $1 AND vault_id = $2
+        SELECT vf.id, vf.vault_id, vf.collection_id, c.path AS collection,
+               vf.name, vf.s3_key, vf.mime_type, vf.size_bytes,
+               vf.description, vf.created_by, vf.created_at, vf.updated_at
+          FROM vault_files vf
+          LEFT JOIN collections c ON c.id = vf.collection_id
+         WHERE vf.id = $1 AND vf.vault_id = $2
         """,
         file_id, vault_id,
     )
@@ -60,8 +71,8 @@ async def update_size(conn, file_id: uuid.UUID, size_bytes: int) -> None:
 
 async def delete(conn, file_id: uuid.UUID) -> None:
     """Delete the metadata row only. Caller is responsible for S3 object
-    lifecycle (commit 6 introduces the s3_delete_outbox so the worker
-    drains S3 deletions atomically with the DB DELETE)."""
+    lifecycle (s3_delete_outbox is enqueued by file_service in the same
+    TX so the worker drains S3 deletions atomically with the DB write)."""
     await conn.execute("DELETE FROM vault_files WHERE id = $1", file_id)
 
 
@@ -69,29 +80,53 @@ async def list_for_vault(
     conn,
     vault_id: uuid.UUID,
     *,
-    collection: str | None = None,
+    collection_id: uuid.UUID | None = None,
+    scoped: bool = False,
     limit: int = 50,
 ) -> list[dict]:
-    if collection:
-        rows = await conn.fetch(
-            """
-            SELECT id, collection, name, mime_type, size_bytes, description,
-                   created_by, created_at
-              FROM vault_files
-             WHERE vault_id = $1 AND collection = $2
-             ORDER BY created_at DESC
-             LIMIT $3
-            """,
-            vault_id, collection, limit,
-        )
+    """List files in a vault. When `scoped=True`, only rows whose
+    `collection_id` matches `collection_id` (NULL == vault root) are
+    returned. Default `scoped=False` returns every file regardless
+    of collection (used by the top-level vault file list page)."""
+    if scoped:
+        if collection_id is None:
+            rows = await conn.fetch(
+                """
+                SELECT vf.id, vf.collection_id, c.path AS collection, vf.name,
+                       vf.mime_type, vf.size_bytes, vf.description,
+                       vf.created_by, vf.created_at
+                  FROM vault_files vf
+                  LEFT JOIN collections c ON c.id = vf.collection_id
+                 WHERE vf.vault_id = $1 AND vf.collection_id IS NULL
+                 ORDER BY vf.created_at DESC
+                 LIMIT $2
+                """,
+                vault_id, limit,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT vf.id, vf.collection_id, c.path AS collection, vf.name,
+                       vf.mime_type, vf.size_bytes, vf.description,
+                       vf.created_by, vf.created_at
+                  FROM vault_files vf
+                  LEFT JOIN collections c ON c.id = vf.collection_id
+                 WHERE vf.vault_id = $1 AND vf.collection_id = $2
+                 ORDER BY vf.created_at DESC
+                 LIMIT $3
+                """,
+                vault_id, collection_id, limit,
+            )
     else:
         rows = await conn.fetch(
             """
-            SELECT id, collection, name, mime_type, size_bytes, description,
-                   created_by, created_at
-              FROM vault_files
-             WHERE vault_id = $1
-             ORDER BY created_at DESC
+            SELECT vf.id, vf.collection_id, c.path AS collection, vf.name,
+                   vf.mime_type, vf.size_bytes, vf.description,
+                   vf.created_by, vf.created_at
+              FROM vault_files vf
+              LEFT JOIN collections c ON c.id = vf.collection_id
+             WHERE vf.vault_id = $1
+             ORDER BY vf.created_at DESC
              LIMIT $2
             """,
             vault_id, limit,

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -68,31 +68,20 @@ class CollectionNotEmptyError(Exception):
         self.sub_collection_count = sub_collection_count
 
 
-_MAX_PATH_BYTES = 1024
-
-
 def _normalize_path(path: str) -> str:
-    """Normalize and validate a collection path.
-
-    Strips surrounding whitespace and leading/trailing slashes, then
-    inspects each remaining segment. The rules mirror
-    `_normalize_collection` in `document_service` (no empty / `.` / `..`
-    segments, no control characters) so collection paths produced here
-    are interchangeable with those a `put` call would generate.
+    """Validate a non-empty collection path via the canonical normalizer
+    in `app.util.text`. Wraps the generic `ValueError` into the
+    domain-specific `InvalidPathError` so the HTTP layer can map it to
+    a 400 without leaking implementation details. Empty input is
+    rejected here (collection-management endpoints demand a named
+    target) while service callers that treat empty as "vault root"
+    keep using the helper with `allow_empty=True`.
     """
-    if not isinstance(path, str):
-        raise InvalidPathError("path must be a string")
-    s = path.strip().strip("/")
-    if not s:
-        raise InvalidPathError("path is empty")
-    if len(s.encode("utf-8")) > _MAX_PATH_BYTES:
-        raise InvalidPathError("path is too long")
-    for seg in s.split("/"):
-        if seg in ("", ".", ".."):
-            raise InvalidPathError(f"invalid path segment: {seg!r}")
-        if any(ord(ch) < 32 for ch in seg):
-            raise InvalidPathError("control characters not allowed")
-    return s
+    from app.util.text import normalize_collection_path
+    try:
+        return normalize_collection_path(path, allow_empty=False)
+    except ValueError as exc:
+        raise InvalidPathError(str(exc)) from exc
 
 
 class CollectionService:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -107,32 +107,7 @@ class EditError(AKBError):
         super().__init__(message, status_code=400)
 
 
-def _normalize_collection(collection: str) -> str:
-    """Normalize and validate a collection path.
-
-    - Strips leading/trailing slashes
-    - Collapses multiple slashes
-    - Rejects '..' segments (path traversal)
-    - Rejects absolute paths
-    - Returns "" for empty/root
-    """
-    if not collection:
-        return ""
-    # Strip leading/trailing slashes
-    normalized = collection.strip().strip("/")
-    if not normalized:
-        return ""
-    # Reject path traversal
-    parts = [p for p in normalized.split("/") if p]
-    for part in parts:
-        if part == ".." or part == ".":
-            raise ValueError(
-                f"Invalid collection path: '{collection}'. "
-                "Path traversal segments ('.', '..') are not allowed."
-            )
-        if "\x00" in part or "/" in part or "\\" in part:
-            raise ValueError(f"Invalid character in collection path: '{collection}'")
-    return "/".join(parts)
+from app.util.text import normalize_collection_path as _normalize_collection
 
 
 def _slugify(title: str) -> str:
@@ -222,7 +197,11 @@ class DocumentService:
         logger.info("Document created: %s (commit: %s)", file_path, commit_hash[:8])
 
         # DB
-        collection_id = await coll_repo.get_or_create(vault_id, req.collection)
+        # Use the *normalized* path so the `collections` row's `path`
+        # matches the document's stored `path`. Passing the raw
+        # `req.collection` here would create rows with leading/trailing
+        # slashes or whitespace, diverging from the doc path under it.
+        collection_id = await coll_repo.get_or_create(vault_id, normalized_collection)
         metadata = {**(req.metadata or {}), "id": doc_id}
         pg_doc_id = await doc_repo.create(
             vault_id=vault_id, collection_id=collection_id, path=file_path,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -635,6 +635,14 @@ class DocumentService:
     # ── Browse ────────────────────────────────────────────────
 
     async def browse(self, vault: str, collection: str | None = None, depth: int = 1, content_type: str = "all") -> BrowseResponse:
+        """Unified vault browse.
+
+        - `collection=None`  → top-level: collections + ROOT docs/tables/files
+          (resources whose `collection_id IS NULL`).
+        - `collection="X"`   → docs/tables/files whose `collection_id` matches
+          collection `X`. Subcollection nesting is left to the frontend tree
+          to assemble from the flat collection list.
+        """
         vault_repo, doc_repo, coll_repo = await self._repos()
 
         vault_id = await vault_repo.get_id_by_name(vault)
@@ -650,11 +658,24 @@ class DocumentService:
         items: list[BrowseItem] = []
 
         if collection:
+            coll_id = await self._resolve_collection_id(vault_id, collection)
             if show_docs:
                 items.extend(await self._browse_docs_in_collection(doc_repo, vault, vault_id, collection))
+            if show_tables:
+                items.extend(await self._browse_tables(
+                    vault, vault_id, collection_id=coll_id, scoped=True,
+                ))
             if show_files:
-                items.extend(await self._browse_files(vault, vault_id, collection=collection))
+                items.extend(await self._browse_files(
+                    vault, vault_id, collection_id=coll_id, scoped=True,
+                ))
         else:
+            # Top-level browse returns the full picture: every collection,
+            # every doc (paths encode their collection), and every table /
+            # file with its `collection` attribute. The frontend tree
+            # builder then groups tables/files under their collection
+            # without a second round-trip. Scoped queries happen only when
+            # the caller explicitly passes `collection=`.
             if show_docs:
                 items.extend(await self._browse_collections(doc_repo, coll_repo, vault, vault_id, depth))
             if show_tables:
@@ -664,6 +685,19 @@ class DocumentService:
 
         hint = self._browse_hint(vault, collection, items)
         return BrowseResponse(vault=vault, path=browse_path, items=items, hint=hint)
+
+    async def _resolve_collection_id(self, vault_id, collection_path: str):
+        """Resolve a path to its `collections.id`. Returns None if the
+        collection row doesn't exist yet (e.g. browsing a path that
+        no resource has been put into). Caller treats None as "no
+        scoped resources here"."""
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
+                vault_id, collection_path,
+            )
+        return row["id"] if row else None
 
     async def _browse_docs_in_collection(self, doc_repo, vault: str, vault_id, collection: str) -> list[BrowseItem]:
         rows = await doc_repo.list_by_collection(vault_id, collection)
@@ -699,15 +733,23 @@ class DocumentService:
                 ))
         return items
 
-    async def _browse_tables(self, vault: str, vault_id) -> list[BrowseItem]:
-        import json as _json
+    async def _browse_tables(
+        self,
+        vault: str,
+        vault_id,
+        *,
+        collection_id=None,
+        scoped: bool = False,
+    ) -> list[BrowseItem]:
+        """List tables. With `scoped=True`, only tables whose
+        `collection_id` matches (NULL = vault root)."""
+        from app.repositories import table_registry_repo
         items: list[BrowseItem] = []
         pool = await get_pool()
         async with pool.acquire() as conn:
             vault_row = await conn.fetchrow("SELECT name FROM vaults WHERE id = $1", vault_id)
-            table_rows = await conn.fetch(
-                "SELECT id, name, description, columns, created_at FROM vault_tables WHERE vault_id = $1 ORDER BY name",
-                vault_id,
+            table_rows = await table_registry_repo.list_for_vault(
+                conn, vault_id, collection_id=collection_id, scoped=scoped,
             )
             for r in table_rows:
                 pg_name = table_data_repo.pg_table_name(vault_row["name"], r["name"])
@@ -721,29 +763,37 @@ class DocumentService:
                     uri=table_uri(vault, r["name"]),
                     summary=r["description"], row_count=row_count,
                     columns=cols,
+                    collection=r.get("collection"),
                     last_updated=r["created_at"],
                 ))
         return items
 
-    async def _browse_files(self, vault: str, vault_id, collection: str | None = None) -> list[BrowseItem]:
+    async def _browse_files(
+        self,
+        vault: str,
+        vault_id,
+        *,
+        collection_id=None,
+        scoped: bool = False,
+    ) -> list[BrowseItem]:
+        from app.repositories import vault_files_repo
         pool = await get_pool()
         async with pool.acquire() as conn:
-            if collection:
-                rows = await conn.fetch(
-                    "SELECT id, name, mime_type, size_bytes, description, created_at FROM vault_files WHERE vault_id = $1 AND collection = $2 ORDER BY created_at DESC",
-                    vault_id, collection,
-                )
-            else:
-                rows = await conn.fetch(
-                    "SELECT id, collection, name, mime_type, size_bytes, description, created_at FROM vault_files WHERE vault_id = $1 ORDER BY collection, created_at DESC",
-                    vault_id,
-                )
+            rows = await vault_files_repo.list_for_vault(
+                conn, vault_id,
+                collection_id=collection_id, scoped=scoped,
+                # Browse renders the full list — don't apply a 50-row
+                # cap silently. If this turns into a performance issue
+                # we can paginate at the route layer.
+                limit=10_000,
+            )
         return [
             BrowseItem(
                 name=r["name"], path=f"_files/{r['id']}", type="file",
                 uri=file_uri(vault, str(r["id"])),
                 file_id=str(r["id"]), mime_type=r["mime_type"],
                 size_bytes=r["size_bytes"], summary=r["description"],
+                collection=r.get("collection"),
                 last_updated=r["created_at"],
             )
             for r in rows

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -112,14 +112,6 @@ def put_object_bytes(
     s3_adapter.put_bytes(s3_key, body, content_type=content_type)
 
 
-# Backward-compat alias for callers that imported the historical
-# private name (e.g. access_service). New code should call
-# `s3_adapter.client()` directly; this alias will be removed in a
-# follow-up commit once those imports are migrated.
-def _get_s3_client():
-    return s3_adapter.client()
-
-
 # ── File-key naming convention ───────────────────────────────────
 
 
@@ -131,27 +123,7 @@ def _s3_key(vault_name: str, collection: str, filename: str) -> str:
     return f"{vault_name}/{uid}_{safe_name}"
 
 
-def _normalize_collection_path(path: str | None) -> str:
-    """Same rules as `document_service._normalize_collection`: strip
-    leading/trailing slashes, collapse duplicates, reject path-traversal
-    and forbidden characters. Returns "" for empty/None (= vault root).
-    Duplicated here to keep file_service self-contained — kept in sync
-    with the document_service / table_service variants by code review."""
-    if not path:
-        return ""
-    normalized = path.strip().strip("/")
-    if not normalized:
-        return ""
-    parts = [p for p in normalized.split("/") if p]
-    for part in parts:
-        if part in (".", ".."):
-            raise ValueError(
-                f"Invalid collection path: '{path}'. "
-                "Path traversal segments ('.', '..') are not allowed."
-            )
-        if "\x00" in part or "\\" in part:
-            raise ValueError(f"Invalid character in collection path: '{path}'")
-    return "/".join(parts)
+from app.util.text import normalize_collection_path as _normalize_collection_path  # noqa: E402
 
 
 # ── File domain service ──────────────────────────────────────────

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -22,6 +22,7 @@ from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import AKBError, NotFoundError
 from app.repositories import vault_files_repo
+from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
 from app.services.adapters import s3_adapter
 from app.services.index_service import (
@@ -130,6 +131,29 @@ def _s3_key(vault_name: str, collection: str, filename: str) -> str:
     return f"{vault_name}/{uid}_{safe_name}"
 
 
+def _normalize_collection_path(path: str | None) -> str:
+    """Same rules as `document_service._normalize_collection`: strip
+    leading/trailing slashes, collapse duplicates, reject path-traversal
+    and forbidden characters. Returns "" for empty/None (= vault root).
+    Duplicated here to keep file_service self-contained — kept in sync
+    with the document_service / table_service variants by code review."""
+    if not path:
+        return ""
+    normalized = path.strip().strip("/")
+    if not normalized:
+        return ""
+    parts = [p for p in normalized.split("/") if p]
+    for part in parts:
+        if part in (".", ".."):
+            raise ValueError(
+                f"Invalid collection path: '{path}'. "
+                "Path traversal segments ('.', '..') are not allowed."
+            )
+        if "\x00" in part or "\\" in part:
+            raise ValueError(f"Invalid character in collection path: '{path}'")
+    return "/".join(parts)
+
+
 # ── File domain service ──────────────────────────────────────────
 
 
@@ -151,10 +175,14 @@ class FileService:
         """Create a file record and return a presigned PUT URL.
 
         Client (akb-mcp proxy) uploads directly to S3, then calls
-        confirm_upload().
+        confirm_upload(). `collection` is a path string (empty / None
+        for vault root); a matching `collections` row is auto-created
+        if needed so files share the same FK-normalized hierarchy as
+        documents and tables.
         """
         s3_adapter.ensure_bucket(self._bucket)
-        s3_key = _s3_key(vault_name, collection, filename)
+        collection_path = _normalize_collection_path(collection)
+        s3_key = _s3_key(vault_name, collection_path, filename)
         file_id = uuid.uuid4()
 
         presigned_url = s3_adapter.presign_put(
@@ -163,20 +191,32 @@ class FileService:
 
         pool = await get_pool()
         async with pool.acquire() as conn:
-            await vault_files_repo.insert(
-                conn,
-                file_id=file_id, vault_id=vault_id,
-                collection=collection, name=filename,
-                s3_key=s3_key, mime_type=mime_type,
-                size_bytes=0, description=description,
-                created_by=actor_id,
-            )
+            async with conn.transaction():
+                collection_id = None
+                if collection_path:
+                    coll_repo = CollectionRepository(pool)
+                    collection_id = await coll_repo.get_or_create(
+                        vault_id, collection_path, conn=conn,
+                    )
+                await vault_files_repo.insert(
+                    conn,
+                    file_id=file_id, vault_id=vault_id,
+                    name=filename,
+                    s3_key=s3_key, mime_type=mime_type,
+                    size_bytes=0, description=description,
+                    created_by=actor_id,
+                    collection_id=collection_id,
+                )
 
-        logger.info("Presigned upload URL for %s/%s (file_id=%s)", vault_name, s3_key, file_id)
+        logger.info(
+            "Presigned upload URL for %s/%s (file_id=%s, collection=%s)",
+            vault_name, s3_key, file_id, collection_path or "<root>",
+        )
         return {
             "kind": "file",
             "id": str(file_id),
             "vault": vault_name,
+            "collection": collection_path or None,
             "upload_url": presigned_url,
             "s3_key": s3_key,
             "expires_in": _PRESIGN_UPLOAD_TTL,
@@ -298,11 +338,34 @@ class FileService:
         collection: str | None = None,
         limit: int = 50,
     ) -> list[dict]:
+        """List files in a vault. When `collection` is set (path string),
+        only files in that exact collection (NULL collection_id for empty
+        path = vault root) are returned. The path is resolved to a
+        collection_id at query time."""
         pool = await get_pool()
         async with pool.acquire() as conn:
-            rows = await vault_files_repo.list_for_vault(
-                conn, vault_id, collection=collection, limit=limit,
-            )
+            if collection is None:
+                rows = await vault_files_repo.list_for_vault(
+                    conn, vault_id, limit=limit,
+                )
+            else:
+                collection_path = _normalize_collection_path(collection)
+                if collection_path == "":
+                    # Empty path => vault root scope.
+                    rows = await vault_files_repo.list_for_vault(
+                        conn, vault_id, collection_id=None, scoped=True, limit=limit,
+                    )
+                else:
+                    cid_row = await conn.fetchrow(
+                        "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
+                        vault_id, collection_path,
+                    )
+                    if not cid_row:
+                        return []  # collection doesn't exist → no files
+                    rows = await vault_files_repo.list_for_vault(
+                        conn, vault_id,
+                        collection_id=cid_row["id"], scoped=True, limit=limit,
+                    )
 
         return [
             {
@@ -382,6 +445,7 @@ class FileService:
             "kind": "file",
             "id": file_id,
             "vault": vault_name,
+            "collection": row.get("collection"),
             "name": row["name"],
             "deleted": True,
         }

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, NotFoundError
 from app.repositories import table_data_repo, table_registry_repo
+from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
 from app.services.index_service import (
     build_table_chunk, delete_table_chunks, write_source_chunks,
@@ -84,10 +85,19 @@ async def create_table(
     *,
     actor_id: str,
     description: str = "",
+    collection: str | None = None,
 ) -> dict:
+    """Create a vault-scoped table inside an optional collection.
+
+    `collection` is a path string (e.g. "specs" or "sessions/learnings").
+    NULL / empty → vault root. The path is normalized and the matching
+    `collections` row is auto-created via `CollectionRepository.get_or_create`
+    if it doesn't exist yet.
+    """
     pool = await get_pool()
     tid = uuid.uuid4()
     now = datetime.now(timezone.utc)
+    collection_path = _normalize_collection_path(collection)
 
     async with pool.acquire() as conn:
         async with conn.transaction():
@@ -106,6 +116,13 @@ async def create_table(
                         f"Reserved names: {sorted(_RESERVED)}. Choose a different name."
                     )
 
+            collection_id = None
+            if collection_path:
+                coll_repo = CollectionRepository(pool)
+                collection_id = await coll_repo.get_or_create(
+                    vault_id, collection_path, conn=conn,
+                )
+
             pg_name = table_data_repo.pg_table_name(vault["name"], name)
             await table_data_repo.create_dynamic_table(conn, pg_name, columns)
             await table_registry_repo.insert(
@@ -113,6 +130,7 @@ async def create_table(
                 table_id=tid, vault_id=vault_id, name=name,
                 description=description, columns=columns,
                 created_by=actor_id, now=now,
+                collection_id=collection_id,
             )
             await emit_event(
                 conn, "table.create",
@@ -121,6 +139,7 @@ async def create_table(
                 payload={
                     "vault": vault["name"],
                     "table_name": name,
+                    "collection": collection_path or None,
                     "columns_count": len(columns),
                     "description": description,
                 },
@@ -140,14 +159,36 @@ async def create_table(
     except Exception as e:  # noqa: BLE001
         logger.warning("table metadata indexing failed for %s: %s", name, e)
 
-    logger.info("Table created: %s → %s", name, pg_name)
+    logger.info("Table created: %s → %s (collection=%s)", name, pg_name, collection_path or "<root>")
     return {
         "kind": "table",
         "id": str(tid),
         "vault": vault["name"],
+        "collection": collection_path or None,
         "name": name,
         "columns": columns,
     }
+
+
+def _normalize_collection_path(path: str | None) -> str:
+    """Same rules as `document_service._normalize_collection`: strip
+    leading/trailing slashes, collapse duplicates, reject path-traversal
+    and forbidden characters. Returns "" for empty/None (= vault root)."""
+    if not path:
+        return ""
+    normalized = path.strip().strip("/")
+    if not normalized:
+        return ""
+    parts = [p for p in normalized.split("/") if p]
+    for part in parts:
+        if part in (".", ".."):
+            raise ValueError(
+                f"Invalid collection path: '{path}'. "
+                "Path traversal segments ('.', '..') are not allowed."
+            )
+        if "\x00" in part or "\\" in part:
+            raise ValueError(f"Invalid character in collection path: '{path}'")
+    return "/".join(parts)
 
 
 async def list_tables(vault_id: uuid.UUID) -> list[dict]:
@@ -167,6 +208,7 @@ async def list_tables(vault_id: uuid.UUID) -> list[dict]:
                 "kind": "table",
                 "id": str(r["id"]),
                 "vault": vault["name"],
+                "collection": r["collection"],
                 "name": r["name"],
                 "description": r["description"],
                 "columns": table_registry_repo.parse_columns(r["columns"]),
@@ -213,6 +255,7 @@ async def drop_table(
                 actor_id=actor_id,
                 payload={
                     "vault": vault["name"],
+                    "collection": table.get("collection"),
                     "table_name": table_name,
                 },
             )
@@ -229,6 +272,7 @@ async def drop_table(
         "kind": "table",
         "id": str(table_id),
         "vault": vault["name"],
+        "collection": table.get("collection"),
         "name": table_name,
         "deleted": True,
     }

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -170,25 +170,7 @@ async def create_table(
     }
 
 
-def _normalize_collection_path(path: str | None) -> str:
-    """Same rules as `document_service._normalize_collection`: strip
-    leading/trailing slashes, collapse duplicates, reject path-traversal
-    and forbidden characters. Returns "" for empty/None (= vault root)."""
-    if not path:
-        return ""
-    normalized = path.strip().strip("/")
-    if not normalized:
-        return ""
-    parts = [p for p in normalized.split("/") if p]
-    for part in parts:
-        if part in (".", ".."):
-            raise ValueError(
-                f"Invalid collection path: '{path}'. "
-                "Path traversal segments ('.', '..') are not allowed."
-            )
-        if "\x00" in part or "\\" in part:
-            raise ValueError(f"Invalid character in collection path: '{path}'")
-    return "/".join(parts)
+from app.util.text import normalize_collection_path as _normalize_collection_path  # noqa: E402
 
 
 async def list_tables(vault_id: uuid.UUID) -> list[dict]:

--- a/backend/app/util/text.py
+++ b/backend/app/util/text.py
@@ -59,3 +59,61 @@ class NFCModel(BaseModel):
     @classmethod
     def _normalize_nfc(cls, data: Any) -> Any:
         return to_nfc_any(data)
+
+
+# ── Collection path normalizer (single source of truth) ──────────
+#
+# Why this lives next to NFC: collection paths flow through the same
+# user-text → DB pipeline as titles, so it makes sense to keep all
+# string-shape validators together. Previous incarnations were
+# duplicated across document_service, file_service, table_service, and
+# collection_service with subtly divergent rules; this is the union of
+# all four.
+
+_MAX_PATH_BYTES = 1024
+
+
+def normalize_collection_path(path: str | None, *, allow_empty: bool = True) -> str:
+    """Canonical collection-path normalizer.
+
+    Rules:
+      - Strip whitespace + leading/trailing slashes.
+      - Collapse duplicate slashes (via split/join).
+      - Reject `.`, `..`, empty segments (path traversal).
+      - Reject NUL, backslash, and control characters (ord < 32).
+      - Reject paths longer than 1 KiB encoded (`_MAX_PATH_BYTES`).
+
+    Returns "" for empty / None input when `allow_empty=True`
+    (== vault root). When `allow_empty=False`, an empty input raises
+    `ValueError` — used by callers that demand a named collection
+    (e.g. `akb_create_collection`).
+    """
+    if path is None or path == "":
+        if allow_empty:
+            return ""
+        raise ValueError("collection path is empty")
+    if not isinstance(path, str):
+        raise ValueError("collection path must be a string")
+
+    normalized = path.strip().strip("/")
+    if not normalized:
+        if allow_empty:
+            return ""
+        raise ValueError("collection path is empty")
+
+    if len(normalized.encode("utf-8")) > _MAX_PATH_BYTES:
+        raise ValueError("collection path is too long")
+
+    parts: list[str] = []
+    for raw in normalized.split("/"):
+        if raw in ("", ".", ".."):
+            raise ValueError(
+                f"Invalid collection path: '{path}'. "
+                "Empty / '.' / '..' segments are not allowed."
+            )
+        if "\x00" in raw or "\\" in raw or any(ord(c) < 32 for c in raw):
+            raise ValueError(
+                f"Invalid character in collection path: '{path}'"
+            )
+        parts.append(raw)
+    return "/".join(parts)

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -441,7 +441,9 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
     try:
         return await table_service.create_table(
             access["vault_id"], args["name"], args["columns"],
-            actor_id=user.username, description=args.get("description", ""),
+            actor_id=user.username,
+            description=args.get("description", ""),
+            collection=args.get("collection"),
         )
     except ValueError as e:
         return {"error": str(e)}

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -411,14 +411,21 @@ TOOLS = [
         name="akb_create_table",
         description=(
             "Create a structured data table in a vault. "
-            "Tables live alongside documents and follow the same permissions. "
-            "Define columns with name and type (text, number, boolean, date, json)."
+            "Tables live alongside documents inside collections and follow the same permissions. "
+            "Define columns with name and type (text, number, boolean, date, json). "
+            "Optional `collection` (e.g. 'sessions/learnings') groups the table under that "
+            "collection so it appears beside the documents and files there in akb_browse; "
+            "omit for vault root."
         ),
         inputSchema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string"},
-                "name": {"type": "string", "description": "Table name"},
+                "name": {"type": "string", "description": "Table name (unique within the vault)"},
+                "collection": {
+                    "type": "string",
+                    "description": "Collection path (e.g. 'specs' or 'sessions/learnings'). Omit for vault root.",
+                },
                 "description": {"type": "string"},
                 "columns": {
                     "type": "array",

--- a/backend/tests/test_collection_hierarchy_e2e.sh
+++ b/backend/tests/test_collection_hierarchy_e2e.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+#
+# Collection unified-membership E2E.
+#
+# Validates that docs / tables / files share a single collection
+# hierarchy after migration 020:
+#
+#   1. akb_create_table with `collection=` lands the table under the
+#      right collections row (FK populated).
+#   2. akb_put_file with `collection=` lands the file under the same
+#      collections row.
+#   3. akb_browse(vault) returns tables/files with `collection` set, so
+#      the frontend tree groups them under the matching collection.
+#   4. akb_browse(vault, collection="X") returns only that collection's
+#      docs/tables/files.
+#   5. Root-level resources (no collection) appear at vault root in the
+#      top-level browse.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+NS="${AKB_NS:-akb}"
+PG_POD="${AKB_PG_POD:-postgres-0}"
+PG_USER="${AKB_PG_USER:-akbuser}"
+PG_DB="${AKB_PG_DB:-akb}"
+
+VAULT="coll-unified-$(date +%s)"
+USER="coll-unified-$(date +%s)"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+run_psql() {
+  kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+}
+
+# ── Setup ────────────────────────────────────────────────────────
+echo "▸ Setup"
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"coll-unified"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+[ -n "$PAT" ] || { echo "FATAL: PAT"; exit 1; }
+
+curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT" \
+  -H "Authorization: Bearer $PAT" >/dev/null
+VAULT_ID=$(run_psql "SELECT id FROM vaults WHERE name = '$VAULT'")
+[ -n "$VAULT_ID" ] && pass "vault ready ($VAULT)" || { fail "vault" "missing"; exit 1; }
+
+# ── 1. Create table in collection 'specs' ───────────────────────
+echo ""
+echo "▸ 1. Table inside collection 'specs'"
+
+T_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"customers","collection":"specs","description":"d","columns":[{"name":"email","type":"text"}]}')
+T_KIND=$(echo "$T_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("kind",""))' 2>/dev/null)
+T_COLL=$(echo "$T_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("collection") or "")' 2>/dev/null)
+[ "$T_KIND" = "table" ] && pass "table created" || fail "table create" "$T_RESP"
+[ "$T_COLL" = "specs" ] && pass "response.collection == 'specs'" || fail "response.collection" "got '$T_COLL'"
+
+# DB-side FK should resolve to a collections row with path='specs'
+DB_COLL_PATH=$(run_psql "SELECT c.path FROM vault_tables vt JOIN collections c ON c.id = vt.collection_id WHERE vt.vault_id = '$VAULT_ID' AND vt.name = 'customers'")
+[ "$DB_COLL_PATH" = "specs" ] && pass "vault_tables.collection_id → collections.path = 'specs'" \
+                              || fail "FK" "got '$DB_COLL_PATH'"
+
+# ── 2. Create table at root ──────────────────────────────────────
+echo ""
+echo "▸ 2. Table at vault root"
+
+curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"top_table","description":"d","columns":[{"name":"x","type":"text"}]}' >/dev/null
+
+ROOT_FK=$(run_psql "SELECT collection_id IS NULL FROM vault_tables WHERE vault_id = '$VAULT_ID' AND name = 'top_table'")
+[ "$ROOT_FK" = "t" ] && pass "root table has collection_id IS NULL" || fail "root FK" "$ROOT_FK"
+
+# ── 3. Put a document into the same 'specs' collection ──────────
+echo ""
+echo "▸ 3. Document inside same collection 'specs'"
+
+D_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"Spec A\",\"type\":\"spec\",\"content\":\"# A\n\nbody\"}")
+D_ID=$(echo "$D_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("doc_id",""))' 2>/dev/null)
+[ -n "$D_ID" ] && pass "doc created in 'specs' ($D_ID)" || fail "doc put" "$D_RESP"
+
+# ── 4. Initiate file upload into 'specs' (skip actual S3 upload) ─
+echo ""
+echo "▸ 4. File metadata inside same collection 'specs'"
+
+# Synthetic vault_files row + ensure the collections row exists so the
+# FK populates correctly. This skips the presigned PUT round-trip and
+# verifies the FK plumbing only.
+SPEC_COLL_ID=$(run_psql "SELECT id FROM collections WHERE vault_id = '$VAULT_ID' AND path = 'specs'")
+[ -n "$SPEC_COLL_ID" ] && pass "collections row 'specs' was auto-created by service" \
+                      || fail "ensure_collection" "missing"
+
+SYN_FID=$(run_psql "INSERT INTO vault_files (vault_id, collection_id, name, s3_key, mime_type, size_bytes, description, created_by)
+                    VALUES ('$VAULT_ID', '$SPEC_COLL_ID', 'note.txt', '$VAULT/test/note.txt', 'text/plain', 5, '', '$USER')
+                    RETURNING id" | head -n 1)
+[ -n "$SYN_FID" ] && pass "synthetic file row inserted under 'specs'" || fail "file insert" "no id"
+
+# ── 5. akb_browse top-level returns collection attribute ────────
+echo ""
+echo "▸ 5. Top-level akb_browse returns collection attribute on table/file"
+
+B_RESP=$(curl -sk "$BASE_URL/api/v1/browse/$VAULT?depth=2" \
+  -H "Authorization: Bearer $PAT" 2>/dev/null)
+if echo "$B_RESP" | grep -q '"items"'; then
+  TBL_COLL=$(echo "$B_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+for it in d.get("items",[]):
+    if it.get("type")=="table" and it.get("name")=="customers":
+        print(it.get("collection") or "")
+        break' 2>/dev/null)
+  FILE_COLL=$(echo "$B_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+for it in d.get("items",[]):
+    if it.get("type")=="file" and it.get("name")=="note.txt":
+        print(it.get("collection") or "")
+        break' 2>/dev/null)
+  [ "$TBL_COLL" = "specs" ] && pass "browse.table 'customers'.collection == 'specs'" || fail "browse.table.collection" "got '$TBL_COLL'"
+  [ "$FILE_COLL" = "specs" ] && pass "browse.file 'note.txt'.collection == 'specs'" || fail "browse.file.collection" "got '$FILE_COLL'"
+else
+  echo "  (skipped — /browse not reachable; tested via DB FK above)"
+fi
+
+# ── 5b. Scoped browse: collection='specs' returns doc + table + file ─
+echo ""
+echo "▸ 5b. Scoped akb_browse(collection='specs') returns siblings"
+S_RESP=$(curl -sk "$BASE_URL/api/v1/browse/$VAULT?collection=specs&depth=1" \
+  -H "Authorization: Bearer $PAT" 2>/dev/null)
+
+if echo "$S_RESP" | grep -q '"items"'; then
+  HAS_DOC=$(echo "$S_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print("y" if any(it.get("type")=="document" and it.get("name")=="Spec A" for it in d.get("items",[])) else "n")' 2>/dev/null)
+  HAS_TBL=$(echo "$S_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print("y" if any(it.get("type")=="table" and it.get("name")=="customers" for it in d.get("items",[])) else "n")' 2>/dev/null)
+  HAS_FILE=$(echo "$S_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print("y" if any(it.get("type")=="file" and it.get("name")=="note.txt" for it in d.get("items",[])) else "n")' 2>/dev/null)
+  [ "$HAS_DOC" = "y" ]  && pass "scoped browse: contains doc 'Spec A'"      || fail "scoped doc"   "missing"
+  [ "$HAS_TBL" = "y" ]  && pass "scoped browse: contains table 'customers'" || fail "scoped table" "missing"
+  [ "$HAS_FILE" = "y" ] && pass "scoped browse: contains file 'note.txt'"   || fail "scoped file"  "missing"
+
+  # Excludes the root-only table 'top_table'.
+  HAS_ROOT_TBL=$(echo "$S_RESP" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print("y" if any(it.get("type")=="table" and it.get("name")=="top_table" for it in d.get("items",[])) else "n")' 2>/dev/null)
+  [ "$HAS_ROOT_TBL" = "n" ] && pass "scoped browse: excludes root table 'top_table'" \
+                             || fail "scoped excludes" "root table leaked in"
+else
+  echo "  (skipped — scoped browse not reachable)"
+fi
+
+# ── 6. Migration 020 verification: legacy column gone ───────────
+echo ""
+echo "▸ 6. Migration 020 verification"
+
+LEGACY_TEXT=$(run_psql "SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='vault_files' AND column_name='collection'")
+[ -z "$LEGACY_TEXT" ] && pass "vault_files.collection (legacy TEXT) is gone" \
+                     || fail "migration 020" "legacy TEXT column still present"
+
+HAS_TBL_FK=$(run_psql "SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='vault_tables' AND column_name='collection_id'")
+[ "$HAS_TBL_FK" = "1" ] && pass "vault_tables.collection_id present" || fail "vault_tables FK" "missing"
+
+HAS_FILE_FK=$(run_psql "SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='vault_files' AND column_name='collection_id'")
+[ "$HAS_FILE_FK" = "1" ] && pass "vault_files.collection_id present" || fail "vault_files FK" "missing"
+
+# ── Cleanup ──────────────────────────────────────────────────────
+echo ""
+echo "── Cleanup ──"
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" \
+  -H "Authorization: Bearer $PAT" >/dev/null 2>&1 || true
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  Passed: $PASS   Failed: $FAIL"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  printf '    - %s\n' "${ERRORS[@]}"
+  exit 1
+fi
+exit 0

--- a/frontend/src/hooks/use-vault-tree.ts
+++ b/frontend/src/hooks/use-vault-tree.ts
@@ -18,6 +18,9 @@ interface BrowseItem {
   name: string;
   path: string;
   file_id?: string;
+  /** Path of the collection this resource lives in, or null for vault root.
+   *  Documents encode collection in `path` and leave this null. */
+  collection?: string | null;
   [k: string]: any;
 }
 
@@ -101,12 +104,35 @@ export function buildTree(items: BrowseItem[]): TreeNode[] {
     }
   }
 
-  // Phase 3: tables + files at root.
+  // Phase 3: tables + files under their collection (or root if none).
+  // Backend now sends `collection` on every table/file item — the
+  // unified-collection refactor put doc/table/file siblings under the
+  // same `collections.id` FK. NULL collection => vault root.
+  const attachToCollection = (
+    node: TreeNode,
+    collectionPath: string | null | undefined,
+  ) => {
+    if (collectionPath && colByPath.has(collectionPath)) {
+      colByPath.get(collectionPath)!.children!.push(node);
+    } else if (collectionPath) {
+      const parent = ensureCollection(collectionPath, null, roots, colByPath);
+      parent.children!.push(node);
+    } else {
+      roots.push(node);
+    }
+  };
+
   for (const t of items.filter((i) => i.type === "table")) {
-    roots.push({ kind: "table", name: t.name, path: t.name, raw: t });
+    attachToCollection(
+      { kind: "table", name: t.name, path: t.name, raw: t },
+      t.collection,
+    );
   }
   for (const f of items.filter((i) => i.type === "file")) {
-    roots.push({ kind: "file", name: f.name, path: f.file_id || f.path, raw: f });
+    attachToCollection(
+      { kind: "file", name: f.name, path: f.file_id || f.path, raw: f },
+      f.collection,
+    );
   }
 
   sortTree(roots);


### PR DESCRIPTION
## Summary

Collapses three different ways to encode "what folder am I in" onto a single source of truth — every resource type (documents, tables, files) references `collections.id` via a nullable `collection_id` FK (NULL = vault root). Tables, files, and documents now share the exact same path hierarchy, and the frontend tree builder renders them as siblings under their collection.

- **Schema cutover (migration 020)**: atomic — adds `collection_id` FK on `vault_tables` + `vault_files`, backfills from the legacy `vault_files.collection` TEXT, verifies every non-empty path resolved cleanly, drops the TEXT column. All inside one transaction; `_already_applied()` makes it idempotent. Indexes on both new FK columns.
- **Repos**: `table_registry_repo` + `vault_files_repo` accept `collection_id` and a `scoped` flag; legacy TEXT column is gone.
- **Services**: `table_service.create_table()` and `file_service.initiate_upload()` accept `collection` (path string) and resolve to `collection_id` via `CollectionRepository.get_or_create`; `document_service.browse()` returns docs+tables+files with `collection` attribute so the frontend can group them.
- **MCP tool spec**: `akb_create_table` gains optional `collection` arg; `akb_browse` already accepted it.
- **Frontend**: `use-vault-tree.ts` `attachToCollection` places tables/files under their collection or root.
- **New e2e**: `test_collection_hierarchy_e2e.sh` — 17 checks covering FK plumbing + scoped browse + migration verification.
- **Code-review follow-ups**: `init.sql` now declares the post-migration shape directly (no more drop-after-create); missing FK indexes added; four near-duplicate `_normalize_collection_path` implementations consolidated into `app.util.text.normalize_collection_path`; `document_service.put` now passes the normalized path (was passing raw `req.collection`, drifting from the doc's filesystem path).

## Deployed + verified on prod

- Migration 020 backfilled 68 file rows, auto-created 6 missing `collections` rows, dropped legacy TEXT — all in one TX.
- "indexes ensured" path runs on already-migrated DBs; `idx_vault_tables_collection` + `idx_vault_files_collection` present.
- E2E (217 checks across 6 suites — main / edit / stdio-files / put-file-param / security-edge / collection-hierarchy): **all green**.
- Pre-existing flakes in `graph_replace`, `defensive`, `probes` are unrelated to this PR (vault-skill seed drift + chunk auto-summary regen + /health schema rename).

## Test plan

- [x] Migration 020 atomic schema cutover on prod (68 rows backfilled, TEXT dropped)
- [x] `idx_vault_*_collection` indexes present on prod after re-deploy
- [x] `test_collection_hierarchy_e2e.sh`: 17/17
- [x] `test_mcp_e2e.sh`: 76/76
- [x] `test_edit_e2e.sh`: 37/37
- [x] `test_stdio_files_e2e.sh`: 18/18
- [x] `test_put_file_param_e2e.sh`: 15/15
- [x] `test_security_edge_e2e.sh`: 54/54

## Note on MCP tool spec

`akb_create_table` schema changed (optional `collection` arg added). Proxy code (`packages/akb-mcp-client/`) is unchanged so no npm publish is needed, but MCP clients cache `tools/list` on session start — restart the client to see the new arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)