### PR TITLE
feat(events): URI-canonical event stream — single resource handle end to end

### DIFF
--- a/backend/app/api/routes/knowledge.py
+++ b/backend/app/api/routes/knowledge.py
@@ -1,4 +1,10 @@
-"""REST API routes for knowledge graph, relations, and provenance."""
+"""REST API routes for knowledge graph, relations, and provenance.
+
+URI-canonical: every resource is addressed by its `uri` query param —
+the same `akb://{vault}/{doc|table|file}/{...}` handle MCP clients use.
+The frontend constructs the URI from `vault` + `path` (or file uuid)
+before calling these endpoints.
+"""
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -6,65 +12,90 @@ from app.api.deps import get_current_user
 from app.db.postgres import get_pool
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
-from app.services.kg_service import get_resource_relations, get_graph, get_provenance, resolve_doc_to_uri
+from app.services.kg_service import get_resource_relations, get_graph, get_provenance
+from app.services.uri_service import parse_uri
 
 router = APIRouter()
 
 
-@router.get("/relations/{vault}/{doc_id:path}", summary="Get resource relations (1-hop)")
-async def document_relations(
-    vault: str,
-    doc_id: str,
+def _parse_resource_uri(uri: str, expected_type: str | None = None) -> tuple[str, str, str]:
+    """Parse akb:// URI → (vault, type, identifier). Raise 400 on error.
+
+    `expected_type`, when given, must match the URI's scheme tag.
+    """
+    parsed = parse_uri(uri)
+    if parsed is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid AKB URI: {uri!r}. Expected akb://<vault>/<type>/<id>.",
+        )
+    vault, rtype, ident = parsed
+    if expected_type and rtype != expected_type:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Expected a {expected_type} URI; got {rtype}.",
+        )
+    return vault, rtype, ident
+
+
+@router.get("/relations", summary="Get resource relations (1-hop)")
+async def resource_relations(
+    uri: str = Query(..., description="Resource URI"),
     direction: str = Query("both", enum=["incoming", "outgoing", "both"]),
     type: str | None = Query(None),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
+    vault, _rtype, _ident = _parse_resource_uri(uri)
     access = await check_vault_access(user.user_id, vault, required_role="reader")
-    resource_uri = await resolve_doc_to_uri(vault, doc_id)
-    if not resource_uri:
-        raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
     relations = await get_resource_relations(
-        vault, resource_uri,
+        vault, uri,
         vault_id=access["vault_id"],
         direction=direction, relation_type=type,
     )
-    return {"doc_id": doc_id, "resource_uri": resource_uri, "relations": relations}
+    return {"uri": uri, "relations": relations}
 
 
-@router.get("/graph/{vault}", summary="Get knowledge graph (nodes + edges)")
+@router.get("/graph", summary="Get knowledge graph (nodes + edges)")
 async def vault_graph(
-    vault: str,
-    doc_id: str | None = Query(None, description="Center node (omit for full vault graph)"),
+    uri: str | None = Query(None, description="Center resource URI (omit + pass vault for full vault graph)"),
+    vault: str | None = Query(None, description="Vault name (only when uri is omitted)"),
     depth: int = Query(2, ge=1, le=5),
     limit: int = Query(50, ge=1, le=200),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    access = await check_vault_access(user.user_id, vault, required_role="reader")
-    resource_uri = None
-    if doc_id:
-        resource_uri = await resolve_doc_to_uri(vault, doc_id)
+    if uri:
+        center_vault, _rtype, _ident = _parse_resource_uri(uri)
+        vault_name = center_vault
+    else:
+        if not vault:
+            raise HTTPException(
+                status_code=400, detail="Either `uri` or `vault` is required",
+            )
+        vault_name = vault
+    access = await check_vault_access(user.user_id, vault_name, required_role="reader")
     return await get_graph(
-        vault, resource_uri=resource_uri, depth=depth, limit=limit,
+        vault_name, resource_uri=uri, depth=depth, limit=limit,
         vault_id=access["vault_id"],
     )
 
 
-@router.get("/provenance/{doc_id}", summary="Get document provenance")
+@router.get("/provenance", summary="Get document provenance")
 async def document_provenance(
-    doc_id: str,
+    uri: str = Query(..., description="Document URI"),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
+    vault, _rtype, doc_path = _parse_resource_uri(uri, expected_type="doc")
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT v.name AS vault_name, v.id AS vault_id
-            FROM documents d JOIN vaults v ON d.vault_id = v.id
-            WHERE d.id::text = $1 OR d.metadata->>'id' = $1
+            SELECT v.id AS vault_id, d.id AS doc_pk
+              FROM documents d JOIN vaults v ON d.vault_id = v.id
+             WHERE v.name = $1 AND d.path = $2
             """,
-            doc_id,
+            vault, doc_path,
         )
     if not row:
         raise HTTPException(status_code=404, detail="Document not found")
-    await check_vault_access(user.user_id, row["vault_name"], required_role="reader")
-    return await get_provenance(doc_id, vault_id=row["vault_id"])
+    await check_vault_access(user.user_id, vault, required_role="reader")
+    return await get_provenance(str(row["doc_pk"]), vault_id=row["vault_id"])

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -85,9 +85,16 @@ def _verify_token(slug: str, token: str) -> bool:
 # ============================================================
 
 class CreatePublicationRequest(NFCModel):
+    """Request body for `POST /publications/{vault}/create`.
+
+    URI-canonical: for document/file publications, pass the resource
+    `uri` (`akb://{vault}/doc/{path}` or `akb://{vault}/file/{id}`).
+    For table_query publications, pass `query_sql` plus optional
+    `query_vault_names`; no per-resource handle is needed since the
+    query is the publishable surface.
+    """
     resource_type: str = "document"  # 'document','table_query','file'
-    doc_id: str | None = None
-    file_id: str | None = None
+    uri: str | None = None
     query_sql: str | None = None
     query_vault_names: list[str] | None = None
     query_params: dict | None = None
@@ -123,12 +130,48 @@ async def create_publication_route(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     await check_vault_access(user.user_id, vault, required_role="writer")
+    # Split the canonical URI into the service-layer args
+    # (doc path / file uuid). Reject mismatches between resource_type
+    # and URI scheme so callers can't smuggle a doc URI into a file
+    # publication or vice versa.
+    doc_id: str | None = None
+    file_id: str | None = None
+    if req.resource_type in ("document", "file"):
+        if not req.uri:
+            raise HTTPException(
+                status_code=400,
+                detail=f"`uri` is required for resource_type={req.resource_type!r}",
+            )
+        from app.services.uri_service import parse_uri
+        parsed = parse_uri(req.uri)
+        if parsed is None:
+            raise HTTPException(status_code=400, detail=f"Invalid AKB URI: {req.uri!r}")
+        uri_vault, uri_type, uri_ident = parsed
+        if uri_vault != vault:
+            raise HTTPException(
+                status_code=400,
+                detail=f"URI vault {uri_vault!r} does not match route vault {vault!r}",
+            )
+        if req.resource_type == "document":
+            if uri_type != "doc":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"resource_type=document needs a doc URI, got {uri_type}",
+                )
+            doc_id = uri_ident
+        else:  # file
+            if uri_type != "file":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"resource_type=file needs a file URI, got {uri_type}",
+                )
+            file_id = uri_ident
     try:
-        return await publication_service.create_publication_for_vault(
+        result = await publication_service.create_publication_for_vault(
             vault_name=vault,
             resource_type=req.resource_type,
-            doc_id=req.doc_id,
-            file_id=req.file_id,
+            doc_id=doc_id,
+            file_id=file_id,
             query_sql=req.query_sql,
             query_vault_names=req.query_vault_names,
             query_params=req.query_params,
@@ -143,6 +186,7 @@ async def create_publication_route(
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    return publication_service.public_view(result)
 
 
 @router.delete("/publications/{vault}/{publication_id}", summary="Delete a public publication")
@@ -168,6 +212,7 @@ async def list_publications_route(
 ):
     access = await check_vault_access(user.user_id, vault, required_role="reader")
     publications = await publication_service.list_publications(access["vault_id"], resource_type)
+    publications = [publication_service.public_view(p) for p in publications]
     return {"publications": publications}
 
 

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -1,11 +1,12 @@
 """REST API routes for search."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.api.deps import get_current_user
 from app.models.document import SearchResponse
 from app.services.auth_service import AuthenticatedUser
 from app.services.search_service import SearchService
+from app.services.uri_service import parse_uri
 
 router = APIRouter()
 search_service = SearchService()
@@ -28,15 +29,18 @@ async def search_documents(
     )
 
 
-@router.get("/drill-down/{vault}/{doc_id:path}", summary="Drill down to document sections")
+@router.get("/drill-down", summary="Drill down to document sections")
 async def drill_down(
-    vault: str,
-    doc_id: str,
+    uri: str = Query(..., description="Document URI"),
     section: str | None = Query(None),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    sections = await search_service.drill_down(vault, doc_id, section)
-    return {"doc_id": doc_id, "vault": vault, "sections": sections}
+    parsed = parse_uri(uri)
+    if parsed is None or parsed[1] != "doc":
+        raise HTTPException(status_code=400, detail=f"Expected a doc URI, got {uri!r}")
+    vault, _rtype, doc_path = parsed
+    sections = await search_service.drill_down(vault, doc_path, section)
+    return {"uri": uri, "sections": sections}
 
 
 @router.get("/grep", summary="Literal substring / regex search across documents")

--- a/backend/app/db/migrations/015_events_outbox.py
+++ b/backend/app/db/migrations/015_events_outbox.py
@@ -38,6 +38,10 @@ async def migrate(conn=None):
 
 
 async def _run(conn):
+    # Fresh installs land on the post-021 shape directly: a single
+    # `resource_uri` column instead of the legacy (ref_type, ref_id) pair.
+    # Migration 021 contains the upgrade path from older databases that
+    # still carry the pair columns.
     await conn.execute(
         """
         CREATE TABLE IF NOT EXISTS events (
@@ -45,8 +49,7 @@ async def _run(conn):
             occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             vault_id        UUID,
             kind            TEXT NOT NULL,
-            ref_type        TEXT,
-            ref_id          TEXT,
+            resource_uri    TEXT,
             -- TEXT mirrors documents.created_by — `agent_id` flows in
             -- as a username string (not a UUID) on the MCP path.
             actor_id        TEXT,

--- a/backend/app/db/migrations/021_events_resource_uri.py
+++ b/backend/app/db/migrations/021_events_resource_uri.py
@@ -1,0 +1,211 @@
+"""Migration 021: collapse (events.ref_type, events.ref_id) → events.resource_uri.
+
+Before: every event row carried two columns identifying the resource —
+        `ref_type ∈ {document, table, file, collection, user}` plus
+        `ref_id` (a d-prefix id, UUID, or path string depending on type).
+        External Redis-stream consumers had to know that mapping to make
+        sense of an event.
+
+After:  a single `resource_uri` column holds the canonical akb:// URI
+        (or NULL for events that don't reference an in-vault resource —
+        e.g. user / collection / vault-level events). Stream consumers
+        see exactly what MCP clients see.
+
+Migration logic:
+
+1. ALTER TABLE events ADD COLUMN resource_uri TEXT (idempotent).
+2. Backfill resource_uri from existing rows per ref_type:
+     - document: JOIN documents on metadata->>'id' = ref_id → use doc.path
+     - table:    JOIN vault_tables on id::text = ref_id → use t.name
+     - file:     ref_id IS the UUID → use it directly
+     - collection / user / anything else → leave resource_uri NULL
+3. Verify: every row whose ref_type was document/table/file either has
+   a populated resource_uri or its ref_id has no matching row (orphan
+   history). Log the orphan count, do not fail — these are historical
+   rows downstream consumers haven't been able to address either.
+4. DROP COLUMN ref_type.
+5. DROP COLUMN ref_id.
+6. CREATE INDEX idx_events_resource_uri (partial, WHERE resource_uri
+   IS NOT NULL — keeps the index small since auth/collection events
+   are URI-less).
+
+Idempotent: re-running after step 6 finds ref_type/ref_id absent and
+resource_uri present; `_already_applied` returns True and skips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.021")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _column_exists(conn, table: str, column: str) -> bool:
+    return bool(await conn.fetchval(
+        """
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = $1
+           AND column_name = $2
+        """,
+        table, column,
+    ))
+
+
+async def _already_applied(conn) -> bool:
+    has_uri = await _column_exists(conn, "events", "resource_uri")
+    has_ref_type = await _column_exists(conn, "events", "ref_type")
+    has_ref_id = await _column_exists(conn, "events", "ref_id")
+    return bool(has_uri and not has_ref_type and not has_ref_id)
+
+
+async def _run(conn):
+    if await _already_applied(conn):
+        logger.info(
+            "Migration 021 already applied "
+            "(resource_uri present, ref_type/ref_id removed); skipping"
+        )
+        return
+
+    async with conn.transaction():
+        # Step 1: add resource_uri (idempotent).
+        await conn.execute(
+            "ALTER TABLE events ADD COLUMN IF NOT EXISTS resource_uri TEXT"
+        )
+
+        ref_type_present = await _column_exists(conn, "events", "ref_type")
+        ref_id_present = await _column_exists(conn, "events", "ref_id")
+
+        if ref_type_present and ref_id_present:
+            # Step 2a: documents — join on metadata->>'id' (the d-prefix
+            # id stored when the doc was first put), use documents.path
+            # for the URI.
+            doc_count = await conn.fetchval(
+                """
+                WITH updated AS (
+                    UPDATE events e
+                       SET resource_uri =
+                           'akb://' || v.name || '/doc/' || d.path
+                      FROM vaults v, documents d
+                     WHERE e.ref_type = 'document'
+                       AND e.resource_uri IS NULL
+                       AND v.id = e.vault_id
+                       AND d.vault_id = e.vault_id
+                       AND d.metadata->>'id' = e.ref_id
+                     RETURNING e.id
+                )
+                SELECT COUNT(*) FROM updated
+                """
+            )
+
+            # Step 2b: tables — ref_id is the vault_tables.id UUID;
+            # URI uses vault_tables.name.
+            table_count = await conn.fetchval(
+                """
+                WITH updated AS (
+                    UPDATE events e
+                       SET resource_uri =
+                           'akb://' || v.name || '/table/' || t.name
+                      FROM vaults v, vault_tables t
+                     WHERE e.ref_type = 'table'
+                       AND e.resource_uri IS NULL
+                       AND v.id = e.vault_id
+                       AND t.id::text = e.ref_id
+                     RETURNING e.id
+                )
+                SELECT COUNT(*) FROM updated
+                """
+            )
+
+            # Step 2c: files — ref_id is the vault_files.id UUID;
+            # URI is built directly from it (no name lookup needed).
+            file_count = await conn.fetchval(
+                """
+                WITH updated AS (
+                    UPDATE events e
+                       SET resource_uri =
+                           'akb://' || v.name || '/file/' || e.ref_id
+                      FROM vaults v
+                     WHERE e.ref_type = 'file'
+                       AND e.resource_uri IS NULL
+                       AND v.id = e.vault_id
+                     RETURNING e.id
+                )
+                SELECT COUNT(*) FROM updated
+                """
+            )
+
+            # Step 3: count orphan rows (doc/table whose ref_id no
+            # longer joins) — they remain NULL after backfill.
+            orphan_doc = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE ref_type = 'document' AND resource_uri IS NULL
+                """
+            )
+            orphan_table = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE ref_type = 'table' AND resource_uri IS NULL
+                """
+            )
+            url_less = await conn.fetchval(
+                """
+                SELECT COUNT(*) FROM events
+                 WHERE ref_type IS NOT NULL
+                   AND ref_type NOT IN ('document', 'table', 'file')
+                """
+            )
+
+            logger.info(
+                "Migration 021 backfilled events.resource_uri: "
+                "%d documents, %d tables, %d files (orphans: %d doc / %d table; "
+                "%d non-resource events left URI-less by design)",
+                doc_count or 0, table_count or 0, file_count or 0,
+                orphan_doc or 0, orphan_table or 0, url_less or 0,
+            )
+
+            # Step 4 + 5: drop the legacy columns.
+            await conn.execute("ALTER TABLE events DROP COLUMN ref_type")
+            await conn.execute("ALTER TABLE events DROP COLUMN ref_id")
+
+        # Step 6: partial index on the new column. Keeps the index
+        # small because most auth / collection events leave the column
+        # NULL by design.
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_events_resource_uri "
+            "ON events (resource_uri) "
+            "WHERE resource_uri IS NOT NULL"
+        )
+
+        logger.info(
+            "Migration 021 applied: events.resource_uri replaces "
+            "(ref_type, ref_id); index created"
+        )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -105,6 +105,7 @@ async def _apply_migrations() -> None:
         "018_drop_redundant_pending_index.py",  # idx_chunks_vector_pending is dead weight after 017
         "019_s3_delete_outbox.py",              # s3_delete_outbox + indices for atomic file deletion
         "020_unify_collection_membership.py",   # vault_tables/vault_files collection_id FK; drop legacy vault_files.collection TEXT
+        "021_events_resource_uri.py",           # collapse events (ref_type, ref_id) → events.resource_uri (URI canonical)
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/repositories/events_repo.py
+++ b/backend/app/repositories/events_repo.py
@@ -22,8 +22,7 @@ async def emit_event(
     kind: str,
     *,
     vault_id: uuid.UUID | str | None = None,
-    ref_type: str | None = None,
-    ref_id: str | None = None,
+    resource_uri: str | None = None,
     actor_id: str | None = None,
     payload: dict[str, Any] | None = None,
 ) -> int:
@@ -36,6 +35,13 @@ async def emit_event(
     (e.g. `document.put`, `document.update`, `document.delete`,
     `vault.grant`, `publication.publish`). Keep it short and stable;
     subscribers will filter on it.
+
+    `resource_uri` is the canonical akb:// handle for the resource the
+    event is about — same format MCP clients see. Use the doc_uri /
+    table_uri / file_uri helpers from `app.services.uri_service` to
+    build it. Pass None for events that don't reference an in-vault
+    resource (user / vault / collection — collections aren't URI-
+    addressable; their identity goes in `payload.path` if needed).
 
     `actor_id` is TEXT — mirrors `documents.created_by`. The MCP path
     passes a username, not a UUID, so we don't try to coerce.
@@ -50,11 +56,11 @@ async def emit_event(
     payload_json = json.dumps(payload or {})
     return await conn.fetchval(
         """
-        INSERT INTO events (vault_id, kind, ref_type, ref_id, actor_id, payload)
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+        INSERT INTO events (vault_id, kind, resource_uri, actor_id, payload)
+        VALUES ($1, $2, $3, $4, $5::jsonb)
         RETURNING id
         """,
-        vault_uuid, kind, ref_type, ref_id, actor_id, payload_json,
+        vault_uuid, kind, resource_uri, actor_id, payload_json,
     )
 
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -158,11 +158,13 @@ async def change_password(user_id: str, current: str, new: str) -> None:
                 hash_password(new),
                 uuid.UUID(user_id),
             )
+            # Users are not URI-addressable resources (the URI scheme
+            # covers in-vault resources only). Subscribers identify the
+            # user via `actor_id` + payload.user_id.
             await emit_event(
                 conn,
                 "auth.password_changed",
-                ref_type="user",
-                ref_id=user_id,
+                resource_uri=None,
                 actor_id=user_id,
                 payload={"user_id": user_id},
             )

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -141,12 +141,14 @@ class CollectionService:
         pool = await get_pool()
         async with pool.acquire() as conn:
             async with conn.transaction():
+                # Collections are not URI-addressable resources (the URI
+                # scheme is doc/table/file only), so resource_uri stays
+                # None. Subscribers reconstruct identity from payload.path.
                 await emit_event(
                     conn,
                     "collection.create",
                     vault_id=vault_id,
-                    ref_type="collection",
-                    ref_id=norm,
+                    resource_uri=None,
                     actor_id=agent_id,
                     payload={"vault": vault, "path": norm, "created": created},
                 )
@@ -336,8 +338,7 @@ class CollectionService:
                     conn,
                     "collection.delete",
                     vault_id=vault_id,
-                    ref_type="collection",
-                    ref_id=norm,
+                    resource_uri=None,
                     actor_id=agent_id,
                     payload={
                         "vault": vault,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -236,7 +236,8 @@ class DocumentService:
                 )
                 await emit_event(
                     conn, "document.put",
-                    vault_id=vault_id, ref_type="document", ref_id=doc_id,
+                    vault_id=vault_id,
+                    resource_uri=doc_uri(req.vault, file_path),
                     actor_id=agent_id,
                     payload={
                         "vault": req.vault,
@@ -403,17 +404,12 @@ class DocumentService:
                     new_body,
                 )
 
-        # ref_id uses the user-facing d-prefixed id from metadata when
-        # available (subscribers reference docs by that, not the PG UUID).
-        # Fall back to the PG UUID — same shape as delete() — instead of
-        # `doc_ref` which is whatever string the caller happened to pass.
-        meta = ensure_dict(row.get("metadata"))
-        public_doc_id = meta.get("id") or str(pg_doc_id)
         pool = await get_pool()
         async with pool.acquire() as conn:
             await emit_event(
                 conn, "document.update",
-                vault_id=vault_id, ref_type="document", ref_id=public_doc_id,
+                vault_id=vault_id,
+                resource_uri=doc_uri(vault, file_path),
                 actor_id=agent_id,
                 payload={
                     "vault": vault,
@@ -585,11 +581,6 @@ class DocumentService:
                 vault, file_path,
             )
 
-        # Capture the public d-id BEFORE the row is gone so subscribers
-        # see the same identifier they'd have used to fetch the doc.
-        meta = ensure_dict(row.get("metadata"))
-        public_doc_id = meta.get("id") or str(pg_doc_id)
-
         pool = await get_pool()
         async with pool.acquire() as conn:
             async with conn.transaction():
@@ -597,7 +588,8 @@ class DocumentService:
                 await delete_document_relations(conn, vault, file_path)
                 await emit_event(
                     conn, "document.delete",
-                    vault_id=vault_id, ref_type="document", ref_id=public_doc_id,
+                    vault_id=vault_id,
+                    resource_uri=doc_uri(vault, file_path),
                     actor_id=agent_id,
                     payload={
                         "vault": vault,
@@ -788,7 +780,7 @@ class DocumentService:
     @staticmethod
     def _browse_hint(vault: str, collection: str | None, items: list[BrowseItem]) -> str:
         if collection:
-            return f'Use akb_drill_down(vault="{vault}", doc_id="<doc_id>") to read sections, or akb_get() for full content.'
+            return 'Use akb_drill_down(uri=...) to read sections, or akb_get(uri=...) for full content. Pass the canonical `uri` from any item above.'
         if items:
             type_counts: dict[str, int] = {}
             for i in items:

--- a/backend/app/services/events_publisher.py
+++ b/backend/app/services/events_publisher.py
@@ -102,8 +102,8 @@ async def _claim_batch(conn) -> list[dict]:
            SET next_attempt_at = NOW() + INTERVAL '10 minutes'
           FROM pending p
          WHERE e.id = p.id
-        RETURNING e.id, e.occurred_at, e.vault_id, e.kind, e.ref_type,
-                  e.ref_id, e.actor_id, e.payload, e.attempts
+        RETURNING e.id, e.occurred_at, e.vault_id, e.kind,
+                  e.resource_uri, e.actor_id, e.payload, e.attempts
         """,
         BATCH_SIZE, MAX_RETRIES,
     )
@@ -157,10 +157,11 @@ def _xadd_fields(row: dict) -> dict[bytes, bytes]:
     }
     if row.get("vault_id") is not None:
         fields[b"vault_id"] = str(row["vault_id"]).encode()
-    if row.get("ref_type"):
-        fields[b"ref_type"] = row["ref_type"].encode()
-    if row.get("ref_id"):
-        fields[b"ref_id"] = str(row["ref_id"]).encode()
+    if row.get("resource_uri"):
+        # Canonical handle — same shape MCP clients see. Stream
+        # consumers parse it with the standard akb:// regex to recover
+        # vault + type + identifier.
+        fields[b"resource_uri"] = row["resource_uri"].encode()
     if row.get("actor_id") is not None:
         fields[b"actor_id"] = str(row["actor_id"]).encode()
     return fields

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -235,12 +235,17 @@ class FileService:
                 vault_row = await conn.fetchrow(
                     "SELECT name FROM vaults WHERE id = $1", vault_id,
                 )
+                vault_name_for_event = vault_row["name"] if vault_row else None
                 await emit_event(
                     conn, "file.put",
-                    vault_id=vault_id, ref_type="file", ref_id=file_id,
+                    vault_id=vault_id,
+                    resource_uri=(
+                        file_uri(vault_name_for_event, file_id)
+                        if vault_name_for_event else None
+                    ),
                     actor_id=actor_id,
                     payload={
-                        "vault": vault_row["name"] if vault_row else None,
+                        "vault": vault_name_for_event,
                         "collection": row["collection"],
                         "name": row["name"],
                         "mime_type": row["mime_type"],
@@ -408,7 +413,10 @@ class FileService:
 
                 await emit_event(
                     conn, "file.delete",
-                    vault_id=vault_id, ref_type="file", ref_id=file_id,
+                    vault_id=vault_id,
+                    resource_uri=(
+                        file_uri(vault_name, file_id) if vault_name else None
+                    ),
                     actor_id=actor_id,
                     payload={
                         "vault": vault_name,

--- a/backend/app/services/password_service.py
+++ b/backend/app/services/password_service.py
@@ -61,8 +61,7 @@ async def reset_password(
             await emit_event(
                 conn,
                 "auth.password_reset",
-                ref_type="user",
-                ref_id=str(row["id"]),
+                resource_uri=None,
                 actor_id=actor_id,
                 payload={
                     "user_id": str(row["id"]),

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -137,15 +137,24 @@ def _publication_row_to_dict(row) -> dict | None:
 
     Normalizations applied:
     - `id` is renamed to `publication_id` so callers never confuse it
-      with the underlying resource id (document_id / file_id).
+      with the underlying resource handle.
+    - `resource_uri` is built from the joined vault name + doc path /
+      file id (or left None for table_query publications, which have no
+      single addressable resource).
+    - Internal columns `document_id` / `file_id` and the join helpers
+      `_vault_name` / `_doc_path` are removed before the dict leaves
+      this function — clients see `uri` only.
     - `query_params` is parsed from JSON string into a dict.
     - UUID columns become strings.
     - Datetime columns become ISO strings.
 
     Returns None only if `row` is None. Otherwise the result is guaranteed
-    to contain `publication_id`, `slug`, and `resource_type`. Raises
-    PublicationError if `query_params` JSON is corrupted (data integrity).
+    to contain `publication_id`, `slug`, `resource_type`, and (where
+    applicable) `resource_uri`. Raises PublicationError if `query_params`
+    JSON is corrupted (data integrity).
     """
+    from app.services.uri_service import doc_uri, file_uri
+
     if row is None:
         return None
     d = dict(row)
@@ -165,7 +174,37 @@ def _publication_row_to_dict(row) -> dict | None:
             )
     if "id" in d:
         d["publication_id"] = d.pop("id")
+
+    # Build the canonical URI. We keep `document_id` and `file_id` in
+    # the internal dict so the resolution helpers (resolve_document_
+    # publication / resolve_file_publication) can fetch the underlying
+    # row without parsing the URI. The serialization layer
+    # (`_public_publication_view`) strips them before any client sees
+    # the dict.
+    vault_name = d.pop("_vault_name", None)
+    doc_path = d.pop("_doc_path", None)
+    resource_type = d.get("resource_type")
+    resource_uri: str | None = None
+    if vault_name:
+        if resource_type == "document" and doc_path:
+            resource_uri = doc_uri(vault_name, doc_path)
+        elif resource_type == "file" and d.get("file_id"):
+            resource_uri = file_uri(vault_name, d["file_id"])
+        # table_query: no single resource handle → resource_uri stays None.
+    d["resource_uri"] = resource_uri
     return d
+
+
+def public_view(d: dict | None) -> dict | None:
+    """Strip internal id columns from a publication dict before it
+    leaves the backend. Callers expose this view from MCP handlers and
+    REST routes that return publications to clients."""
+    if d is None:
+        return None
+    clean = dict(d)
+    clean.pop("document_id", None)
+    clean.pop("file_id", None)
+    return clean
 
 
 def to_uuid(value) -> uuid.UUID:
@@ -173,10 +212,6 @@ def to_uuid(value) -> uuid.UUID:
     if isinstance(value, uuid.UUID):
         return value
     return uuid.UUID(str(value))
-
-
-# Backwards-compat alias (private name removed in next pass)
-_to_uuid = to_uuid
 
 
 # ============================================================
@@ -252,17 +287,28 @@ async def create_publication(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO publications (
-                slug, vault_id, resource_type, document_id, file_id,
-                query_sql, query_vault_names, query_params,
-                password_hash, max_views, expires_at,
-                mode, section_filter, allow_embed, title, created_by
+            WITH inserted AS (
+              INSERT INTO publications (
+                  slug, vault_id, resource_type, document_id, file_id,
+                  query_sql, query_vault_names, query_params,
+                  password_hash, max_views, expires_at,
+                  mode, section_filter, allow_embed, title, created_by
+              )
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+              RETURNING id, slug, vault_id, resource_type, document_id, file_id,
+                        query_sql, query_vault_names, query_params, max_views,
+                        view_count, expires_at, mode, section_filter, allow_embed,
+                        title, created_at
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-            RETURNING id, slug, vault_id, resource_type, document_id, file_id,
-                      query_sql, query_vault_names, query_params, max_views,
-                      view_count, expires_at, mode, section_filter, allow_embed,
-                      title, created_at
+            SELECT i.id, i.slug, i.vault_id, i.resource_type, i.document_id, i.file_id,
+                   i.query_sql, i.query_vault_names, i.query_params, i.max_views,
+                   i.view_count, i.expires_at, i.mode, i.section_filter, i.allow_embed,
+                   i.title, i.created_at,
+                   v.name AS _vault_name,
+                   d.path AS _doc_path
+              FROM inserted i
+              JOIN vaults v ON v.id = i.vault_id
+              LEFT JOIN documents d ON d.id = i.document_id
             """,
             slug, vault_id, resource_type, document_id, file_id,
             query_sql, query_vault_names, json.dumps(query_params or {}),
@@ -383,13 +429,26 @@ async def delete_publications_for_document(document_id: uuid.UUID) -> int:
     return len(rows)
 
 
-# Columns selected for list/inspection queries (excludes large/sensitive fields).
+# SELECT clause used by every list/inspection query. Pulls the
+# publication row plus enough JOIN material (vault name, doc path, file
+# id) to build the canonical `resource_uri` in `_enrich_publication`.
+# Tables don't store a URI — they aren't publishable as single
+# resources (the table_query branch sets vault but no resource handle),
+# so we don't join `vault_tables` here.
 _PUBLICATION_LIST_COLUMNS = """
-    id, slug, vault_id, resource_type, document_id, file_id, title,
-    query_params, max_views, view_count, expires_at, mode, snapshot_at,
-    section_filter, allow_embed,
-    password_hash IS NOT NULL AS password_protected,
-    created_at
+    p.id, p.slug, p.vault_id, p.resource_type, p.document_id, p.file_id, p.title,
+    p.query_params, p.max_views, p.view_count, p.expires_at, p.mode, p.snapshot_at,
+    p.section_filter, p.allow_embed,
+    p.password_hash IS NOT NULL AS password_protected,
+    p.created_at,
+    v.name AS _vault_name,
+    d.path AS _doc_path
+"""
+
+_PUBLICATION_FROM_CLAUSE = """
+    publications p
+    JOIN vaults v ON v.id = p.vault_id
+    LEFT JOIN documents d ON d.id = p.document_id
 """
 
 
@@ -419,16 +478,16 @@ async def list_publications(vault_id: uuid.UUID, resource_type: str | None = Non
     async with pool.acquire() as conn:
         if resource_type:
             rows = await conn.fetch(
-                f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM publications "
-                "WHERE vault_id = $1 AND resource_type = $2 "
-                "ORDER BY created_at DESC",
+                f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM {_PUBLICATION_FROM_CLAUSE} "
+                "WHERE p.vault_id = $1 AND p.resource_type = $2 "
+                "ORDER BY p.created_at DESC",
                 vault_id, resource_type,
             )
         else:
             rows = await conn.fetch(
-                f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM publications "
-                "WHERE vault_id = $1 "
-                "ORDER BY created_at DESC",
+                f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM {_PUBLICATION_FROM_CLAUSE} "
+                "WHERE p.vault_id = $1 "
+                "ORDER BY p.created_at DESC",
                 vault_id,
             )
     return [_enrich_publication(_publication_row_to_dict(r)) for r in rows]
@@ -439,7 +498,8 @@ async def get_publication_by_slug(slug: str) -> dict | None:
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM publications WHERE slug = $1",
+            f"SELECT {_PUBLICATION_LIST_COLUMNS} FROM {_PUBLICATION_FROM_CLAUSE} "
+            "WHERE p.slug = $1",
             slug,
         )
     if row is None:
@@ -481,9 +541,12 @@ async def resolve_publication(
                    s.password_hash, s.max_views, s.view_count, s.expires_at,
                    s.mode, s.snapshot_s3_key, s.snapshot_at,
                    s.section_filter, s.allow_embed, s.title, s.created_at,
-                   v.name AS vault_name
+                   v.name AS vault_name,
+                   v.name AS _vault_name,
+                   d.path AS _doc_path
             FROM publications s
             JOIN vaults v ON s.vault_id = v.id
+            LEFT JOIN documents d ON d.id = s.document_id
             WHERE s.slug = $1
             """,
             slug,

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -273,7 +273,7 @@ class SearchService:
                         "tags": [],
                     }
 
-        from app.services.uri_service import make_uri
+        from app.services.uri_service import doc_uri, table_uri, file_uri
 
         results: list[SearchResult] = []
         for h in hits:
@@ -285,11 +285,11 @@ class SearchService:
             # the internal handle we use to fetch metadata; it never
             # leaves this function — the client only sees `uri`.
             if h.source_type == "document":
-                uri = make_uri(m["vault"], "doc", m["path"])
+                uri = doc_uri(m["vault"], m["path"])
             elif h.source_type == "table":
-                uri = make_uri(m["vault"], "table", m["title"])
+                uri = table_uri(m["vault"], m["title"])
             elif h.source_type == "file":
-                uri = make_uri(m["vault"], "file", h.source_id)
+                uri = file_uri(m["vault"], h.source_id)
             else:
                 continue
             results.append(
@@ -448,13 +448,17 @@ class SearchService:
                 *params,
             )
 
-        # Group by document and extract matching lines
+        # Group by document and extract matching lines. `_doc_pk` is
+        # the internal PG UUID — kept only as a dedup key while building
+        # results; stripped before the response leaves this function.
+        from app.services.uri_service import doc_uri as _doc_uri
         docs: dict[str, dict] = {}
         for r in rows:
             doc_key = r["doc_id"]
             if doc_key not in docs:
                 docs[doc_key] = {
-                    "doc_id": r["doc_id"],
+                    "_doc_pk": r["doc_id"],
+                    "uri": _doc_uri(r["vault"], r["path"]),
                     "vault": r["vault"],
                     "path": r["path"],
                     "title": r["title"],
@@ -482,20 +486,23 @@ class SearchService:
         result_docs = list(docs.values())[:limit]
         total_matches = sum(len(d["matches"]) for d in result_docs)
 
-        # Replace mode: apply find-and-replace on each matching document
+        # Replace mode: apply find-and-replace on each matching document.
+        # Service-layer `doc_service.update` still wants the doc path
+        # (which find_by_ref accepts) — we pass `path` rather than re-
+        # parsing the URI we just built.
         replaced: list[dict] = []
         if replace is not None and result_docs and doc_service:
             re_flags = 0 if case_sensitive else _re.IGNORECASE
 
             for doc_info in result_docs:
-                meta = ensure_dict(doc_info.get("metadata"))
-                doc_ref = meta.get("id") or doc_info["doc_id"]
                 doc_vault = doc_info["vault"]
+                doc_path = doc_info["path"]
+                doc_uri_str = doc_info["uri"]
 
                 try:
-                    doc = await doc_service.get(doc_vault, doc_ref)
+                    doc = await doc_service.get(doc_vault, doc_path)
                 except Exception:
-                    replaced.append({"doc_id": doc_ref, "vault": doc_vault, "error": "not found"})
+                    replaced.append({"uri": doc_uri_str, "error": "not found"})
                     continue
 
                 body = doc.content or ""
@@ -517,18 +524,18 @@ class SearchService:
                     content=new_body,
                     message=f"grep replace: '{pattern}' → '{replace}'",
                 )
-                result = await doc_service.update(doc_vault, doc_ref, req, agent_id=agent_id)
+                result = await doc_service.update(doc_vault, doc_path, req, agent_id=agent_id)
                 replaced.append({
-                    "doc_id": doc_ref,
-                    "vault": doc_vault,
-                    "path": doc_info["path"],
+                    "uri": doc_uri_str,
+                    "path": doc_path,
                     "title": doc_info["title"],
                     "commit": result.commit_hash,
                 })
 
-        # Build response — strip internal metadata before returning
+        # Build response — strip internal handles (`_doc_pk`, `metadata`)
+        # so the client only sees `uri`.
         clean_results = [
-            {k: v for k, v in d.items() if k != "metadata"}
+            {k: v for k, v in d.items() if k not in ("_doc_pk", "metadata")}
             for d in result_docs
         ]
 

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -135,7 +135,8 @@ async def create_table(
             )
             await emit_event(
                 conn, "table.create",
-                vault_id=vault_id, ref_type="table", ref_id=str(tid),
+                vault_id=vault_id,
+                resource_uri=table_uri(vault["name"], name),
                 actor_id=actor_id,
                 payload={
                     "vault": vault["name"],
@@ -234,7 +235,8 @@ async def drop_table(
 
             await emit_event(
                 conn, "table.drop",
-                vault_id=vault_id, ref_type="table", ref_id=str(table_id),
+                vault_id=vault_id,
+                resource_uri=table_uri(vault["name"], table_name),
                 actor_id=actor_id,
                 payload={
                     "vault": vault["name"],
@@ -327,7 +329,8 @@ async def alter_table(
 
             await emit_event(
                 conn, "table.alter",
-                vault_id=vault_id, ref_type="table", ref_id=str(table["id"]),
+                vault_id=vault_id,
+                resource_uri=table_uri(vault["name"], table_name),
                 actor_id=actor_id,
                 payload={
                     "vault": vault["name"],

--- a/backend/app/services/todo_service.py
+++ b/backend/app/services/todo_service.py
@@ -14,10 +14,15 @@ async def create_todo(
     title: str,
     note: str | None = None,
     vault_name: str | None = None,
-    ref_doc: str | None = None,
+    ref_uri: str | None = None,
     priority: str = "normal",
     due_date: str | None = None,
 ) -> dict:
+    """Create a todo. `ref_uri` (optional) is the canonical
+    `akb://{vault}/doc/{path}` handle for a related document — the
+    only resource type todos can link today. We resolve it to the
+    internal `ref_doc_id` for storage; the DB column name is
+    historical and stays as-is."""
     pool = await get_pool()
     async with pool.acquire() as conn:
         # Resolve vault
@@ -27,15 +32,22 @@ async def create_todo(
             if v:
                 vault_id = v["id"]
 
-        # Resolve ref doc
+        # Resolve ref doc from URI.
         ref_doc_id = None
-        if ref_doc:
-            d = await conn.fetchrow(
-                "SELECT id FROM documents WHERE id::text = $1 OR metadata->>'id' = $1",
-                ref_doc,
-            )
-            if d:
-                ref_doc_id = d["id"]
+        if ref_uri:
+            from app.services.uri_service import parse_uri
+            parsed = parse_uri(ref_uri)
+            if parsed is not None and parsed[1] == "doc":
+                ref_vault, _rtype, ref_path = parsed
+                d = await conn.fetchrow(
+                    """
+                    SELECT d.id FROM documents d JOIN vaults v ON d.vault_id = v.id
+                     WHERE v.name = $1 AND d.path = $2
+                    """,
+                    ref_vault, ref_path,
+                )
+                if d:
+                    ref_doc_id = d["id"]
 
         # Parse due date
         due = None
@@ -60,17 +72,23 @@ async def list_todos(
 ) -> dict:
     pool = await get_pool()
     async with pool.acquire() as conn:
+        # `ref_doc_vault` + `ref_doc_path` come from the LEFT JOIN; when
+        # the linked doc is in a different vault than the todo's own
+        # vault_id, the JOIN still works because documents carry their
+        # own vault_id. We build `ref_uri` from those two below.
         query = """
             SELECT t.id, t.title, t.note, t.priority, t.status, t.due_date,
                    t.created_at, t.completed_at,
                    u1.username as assignee, u2.username as created_by,
-                   v.name as vault, d.path as ref_doc_path,
-                   d.metadata->>'id' as ref_doc_id
+                   v.name as vault,
+                   dv.name as ref_doc_vault,
+                   d.path as ref_doc_path
             FROM todos t
             JOIN users u1 ON t.assignee_id = u1.id
             JOIN users u2 ON t.created_by = u2.id
             LEFT JOIN vaults v ON t.vault_id = v.id
             LEFT JOIN documents d ON t.ref_doc_id = d.id
+            LEFT JOIN vaults dv ON d.vault_id = dv.id
             WHERE t.assignee_id = $1
         """
         params: list = [uuid.UUID(assignee_id)]
@@ -105,8 +123,9 @@ async def list_todos(
                 todo["note"] = r["note"]
             if r["vault"]:
                 todo["vault"] = r["vault"]
-            if r["ref_doc_id"]:
-                todo["ref_doc"] = r["ref_doc_id"]
+            if r["ref_doc_vault"] and r["ref_doc_path"]:
+                from app.services.uri_service import doc_uri
+                todo["ref_uri"] = doc_uri(r["ref_doc_vault"], r["ref_doc_path"])
             if r["due_date"]:
                 todo["due_date"] = r["due_date"]
             if r["completed_at"]:

--- a/backend/app/services/uri_service.py
+++ b/backend/app/services/uri_service.py
@@ -44,3 +44,26 @@ def table_uri(vault: str, name: str) -> str:
 def file_uri(vault: str, file_id: str) -> str:
     """Shorthand for file URI."""
     return make_uri(vault, "file", file_id)
+
+
+def split_uri(uri: str, expected_type: str | None = None) -> tuple[str, str]:
+    """Parse an akb:// URI and return (vault, identifier).
+
+    `identifier` is the path for a doc URI, the table name for a table
+    URI, the file UUID for a file URI. Raises ValueError if the URI is
+    malformed or its type doesn't match `expected_type`.
+
+    Shared helper for MCP handlers and REST routes — both need the same
+    parse-and-validate flow before dispatching to the service layer.
+    """
+    parsed = parse_uri(uri)
+    if parsed is None:
+        raise ValueError(
+            f"Invalid AKB URI: '{uri}'. Expected akb://<vault>/<type>/<id>."
+        )
+    vault, rtype, ident = parsed
+    if expected_type and rtype != expected_type:
+        raise ValueError(
+            f"Expected a {expected_type} URI; got {rtype}: '{uri}'."
+        )
+    return vault, ident

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -33,7 +33,7 @@ from app.exceptions import NotFoundError
 from app.services.document_service import DocumentService, EditError
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources, resolve_doc_to_uri
-from app.services.uri_service import doc_uri, table_uri, file_uri, parse_uri
+from app.services.uri_service import doc_uri, table_uri, file_uri, parse_uri, split_uri
 from app.services.access_service import (
     check_vault_access, grant_access, revoke_access, list_vault_members,
     list_accessible_vaults, get_vault_info, search_users, transfer_ownership,
@@ -68,28 +68,9 @@ async def _find_doc(vault_name: str, doc_ref: str) -> dict | None:
         return await doc_repo.find_by_ref_with_conn(conn, vault["id"], doc_ref)
 
 
-def _split_uri(uri: str, expected_type: str | None = None) -> tuple[str, str]:
-    """Parse an akb:// URI and return (vault, identifier).
-
-    `identifier` is the path for a doc URI, the table name for a table
-    URI, the file UUID for a file URI. Raises ValueError if the URI is
-    malformed or its type doesn't match `expected_type`.
-
-    Handlers call this at entry so the rest of the body can stay
-    vault+identifier-shaped without the legacy `(vault, doc_id)` arg
-    pair leaking back in.
-    """
-    parsed = parse_uri(uri)
-    if parsed is None:
-        raise ValueError(
-            f"Invalid AKB URI: '{uri}'. Expected akb://<vault>/<type>/<id>."
-        )
-    vault, rtype, ident = parsed
-    if expected_type and rtype != expected_type:
-        raise ValueError(
-            f"Expected a {expected_type} URI; got {rtype}: '{uri}'."
-        )
-    return vault, ident
+# Re-export under the local name so the rest of this module stays
+# unchanged. The canonical implementation lives in `uri_service`.
+_split_uri = split_uri
 
 session_service = SessionService()
 
@@ -554,13 +535,10 @@ async def _handle_todo(args: dict, uid: str, user: _MCPUser) -> dict:
     else:
         assignee_id = uid
         assignee_username = user.username
-    # ref_uri is the canonical handle for a linked resource. We store it
-    # as-is in todos.ref_doc (legacy column name) so downstream stays
-    # untouched, but the client only ever sees `ref_uri`.
     result = await todo_service.create_todo(
         assignee_id=assignee_id, created_by=uid, title=args["title"],
         note=args.get("note"), vault_name=args.get("vault"),
-        ref_doc=args.get("ref_uri"), priority=args.get("priority", "normal"),
+        ref_uri=args.get("ref_uri"), priority=args.get("priority", "normal"),
         due_date=args.get("due_date"),
     )
     result["assignee"] = assignee_username
@@ -715,6 +693,7 @@ async def _handle_publications(args: dict, uid: str, user: _MCPUser) -> dict:
     publications = await publication_service.list_publications(
         access["vault_id"], args.get("resource_type"),
     )
+    publications = [publication_service.public_view(p) for p in publications]
     return {"publications": publications, "total": len(publications)}
 
 

--- a/backend/tests/test_auth_change_password.py
+++ b/backend/tests/test_auth_change_password.py
@@ -52,7 +52,9 @@ async def user(pool):
     yield uid, uname
     async with pool.acquire() as conn:
         await conn.execute("DELETE FROM users WHERE id = $1", uid)
-        await conn.execute("DELETE FROM events WHERE ref_id = $1", str(uid))
+        # User-scoped events live without a resource_uri (users are not
+        # URI-addressable); identify them via actor_id instead.
+        await conn.execute("DELETE FROM events WHERE actor_id = $1", str(uid))
 
 
 async def test_change_password_success(pool, user):
@@ -100,11 +102,12 @@ async def test_change_password_emits_event(pool, user):
     await change_password(str(uid), "orig-12345", "new-secret-67")
     async with pool.acquire() as conn:
         ev = await conn.fetchrow(
-            "SELECT kind, ref_type, ref_id, actor_id "
-            "FROM events WHERE ref_id = $1 ORDER BY id DESC LIMIT 1",
+            "SELECT kind, resource_uri, actor_id "
+            "FROM events WHERE actor_id = $1 ORDER BY id DESC LIMIT 1",
             str(uid),
         )
     assert ev is not None
     assert ev["kind"] == "auth.password_changed"
-    assert ev["ref_type"] == "user"
+    # Users have no URI scheme; resource_uri stays NULL.
+    assert ev["resource_uri"] is None
     assert ev["actor_id"] == str(uid)

--- a/backend/tests/test_collection_service.py
+++ b/backend/tests/test_collection_service.py
@@ -213,10 +213,10 @@ async def test_create_emits_event(service, vault_name, pool, vault_id):
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT kind, ref_type, ref_id, actor_id, payload
+            SELECT kind, resource_uri, actor_id, payload
               FROM events
              WHERE vault_id = $1 AND kind = 'collection.create'
-                   AND ref_id = $2
+                   AND payload->>'path' = $2
              ORDER BY id DESC
              LIMIT 1
             """,
@@ -224,8 +224,8 @@ async def test_create_emits_event(service, vault_name, pool, vault_id):
         )
     assert row is not None
     assert row["kind"] == "collection.create"
-    assert row["ref_type"] == "collection"
-    assert row["ref_id"] == "events/probe"
+    # Collections are not URI-addressable; identity lives in payload.path.
+    assert row["resource_uri"] is None
     assert row["actor_id"] == "bob"
 
 
@@ -439,10 +439,10 @@ async def test_delete_cascade_emits_event(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT kind, ref_type, ref_id, actor_id, payload
+            SELECT kind, resource_uri, actor_id, payload
               FROM events
              WHERE vault_id = $1 AND kind = 'collection.delete'
-                   AND ref_id = $2
+                   AND payload->>'path' = $2
              ORDER BY id DESC
              LIMIT 1
             """,
@@ -450,8 +450,7 @@ async def test_delete_cascade_emits_event(
         )
     assert row is not None
     assert row["kind"] == "collection.delete"
-    assert row["ref_type"] == "collection"
-    assert row["ref_id"] == "loud"
+    assert row["resource_uri"] is None
     assert row["actor_id"] == "bob"
     # Payload is JSON text on this column — decode and assert counts.
     import json

--- a/backend/tests/test_events_emit_e2e.sh
+++ b/backend/tests/test_events_emit_e2e.sh
@@ -2,9 +2,10 @@
 #
 # AKB Events Emit E2E
 # Verifies that each table/file write action emits the expected row
-# into the `events` outbox with the correct kind/ref_type/ref_id and
-# payload fields. Reads the events table directly via psql exec inside
-# the postgres pod (so this requires kubectl access — skip via env).
+# into the `events` outbox with the correct kind / resource_uri /
+# actor_id and payload fields. Reads the events table directly via
+# psql exec inside the postgres pod (so this requires kubectl access
+# — skip when kubectl is absent).
 #
 set -uo pipefail
 
@@ -70,17 +71,21 @@ CREATE_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
   -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$TABLE\",\"description\":\"d\",\"columns\":[{\"name\":\"sku\",\"type\":\"text\"}]}")
-TABLE_ID=$(echo "$CREATE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+TABLE_URI=$(echo "$CREATE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin)["uri"])')
+EXPECTED_TABLE_URI="akb://$VAULT/table/$TABLE"
 
 [ "$(events_for table.create)" = "1" ] && pass "table.create count=1" || fail "table.create" "expected 1, got $(events_for table.create)"
 
-# ref fields
-ROW=$(run_psql "SELECT ref_type || '|' || ref_id || '|' || actor_id FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'table.create'")
-[ "$ROW" = "table|$TABLE_ID|$USER" ] && pass "table.create ref+actor match" || fail "table.create ref" "got $ROW"
+# Canonical URI + actor match
+ROW=$(run_psql "SELECT resource_uri || '|' || actor_id FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'table.create'")
+[ "$ROW" = "$EXPECTED_TABLE_URI|$USER" ] && pass "table.create resource_uri+actor match" || fail "table.create uri" "got $ROW (expected $EXPECTED_TABLE_URI|$USER)"
 
 # payload includes table_name
 TBL_PAYLOAD=$(run_psql "SELECT payload->>'table_name' FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'table.create'")
 [ "$TBL_PAYLOAD" = "$TABLE" ] && pass "table.create payload.table_name" || fail "table.create payload" "got $TBL_PAYLOAD"
+
+# Same URI is what the create response advertises (contract check)
+[ "$TABLE_URI" = "$EXPECTED_TABLE_URI" ] && pass "table create response.uri matches event.resource_uri" || fail "uri parity" "resp=$TABLE_URI"
 
 echo ""
 echo "▸ 2. table.drop event"
@@ -89,8 +94,8 @@ curl -sk -X DELETE "$BASE_URL/api/v1/tables/$VAULT/$TABLE" -H "Authorization: Be
 
 [ "$(events_for table.drop)" = "1" ] && pass "table.drop count=1" || fail "table.drop" "expected 1, got $(events_for table.drop)"
 
-DROP_REF=$(run_psql "SELECT ref_id FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'table.drop'")
-[ "$DROP_REF" = "$TABLE_ID" ] && pass "table.drop ref_id matches created table_id" || fail "table.drop ref_id" "got $DROP_REF"
+DROP_URI=$(run_psql "SELECT resource_uri FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'table.drop'")
+[ "$DROP_URI" = "$EXPECTED_TABLE_URI" ] && pass "table.drop resource_uri matches" || fail "table.drop uri" "got $DROP_URI"
 
 echo ""
 echo "── Cleanup ──"

--- a/backend/tests/test_password_service.py
+++ b/backend/tests/test_password_service.py
@@ -55,7 +55,12 @@ async def user(pool):
     yield uid, uname
     async with pool.acquire() as conn:
         await conn.execute("DELETE FROM users WHERE id = $1", uid)
-        await conn.execute("DELETE FROM events WHERE ref_id = $1", str(uid))
+        # User events carry no resource_uri (users aren't vault
+        # resources); filter by the payload user_id instead.
+        await conn.execute(
+            "DELETE FROM events WHERE payload->>'user_id' = $1",
+            str(uid),
+        )
 
 
 def test_generate_temp_password_format():
@@ -91,13 +96,13 @@ async def test_reset_password_updates_hash_and_emits_event(pool, user):
 
     async with pool.acquire() as conn:
         ev = await conn.fetchrow(
-            "SELECT kind, ref_type, ref_id, actor_id, payload::text AS payload "
-            "FROM events WHERE ref_id = $1 ORDER BY id DESC LIMIT 1",
+            "SELECT kind, resource_uri, actor_id, payload::text AS payload "
+            "FROM events WHERE payload->>'user_id' = $1 ORDER BY id DESC LIMIT 1",
             str(uid),
         )
     assert ev is not None
     assert ev["kind"] == "auth.password_reset"
-    assert ev["ref_type"] == "user"
+    assert ev["resource_uri"] is None  # users have no URI scheme
     assert ev["actor_id"] == "admin-uuid"
     import json
     payload = json.loads(ev["payload"])
@@ -113,7 +118,7 @@ async def test_reset_password_cli_method_records_null_actor(pool, user):
     async with pool.acquire() as conn:
         ev = await conn.fetchrow(
             "SELECT actor_id, payload::text AS payload FROM events "
-            "WHERE ref_id = $1 ORDER BY id DESC LIMIT 1",
+            "WHERE payload->>'user_id' = $1 ORDER BY id DESC LIMIT 1",
             str(uid),
         )
     assert ev["actor_id"] is None

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -63,8 +63,8 @@ export function GraphDetailPanel({
     queryFn: () => getRelations(vault, docId),
   });
   const provQuery = useQuery({
-    queryKey: ["provenance", docId],
-    queryFn: () => getProvenance(docId),
+    queryKey: ["provenance", vault, docId],
+    queryFn: () => getProvenance(vault, docId),
     enabled: metaOpen,
   });
   const secQuery = useQuery({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -232,7 +232,7 @@ export interface GrepMatch {
   text: string;
 }
 export interface GrepDoc {
-  doc_id: string;
+  uri: string;
   vault: string;
   path: string;
   title: string;
@@ -261,17 +261,26 @@ export interface GraphApiEdge {
   target: string;
   relation?: string;
 }
-export const getGraph = (vault: string, docId?: string, depth = 2, limit = 50) => {
+// `docPath` is the doc filesystem path (e.g. `specs/api.md`). The
+// frontend currently routes by `:doc_id` segments — the helpers here
+// build the canonical URI from (vault, path) before calling REST so
+// every call site presents the unified shape to the backend.
+function _docUri(vault: string, docPath: string): string {
+  return `akb://${vault}/doc/${docPath}`;
+}
+
+export const getGraph = (vault: string, docPath?: string, depth = 2, limit = 50) => {
   const p = new URLSearchParams({ depth: String(depth), limit: String(limit) });
-  if (docId) p.set("doc_id", docId);
-  return api<{ nodes: GraphApiNode[]; edges: GraphApiEdge[] }>(`/graph/${vault}?${p}`);
+  if (docPath) p.set("uri", _docUri(vault, docPath));
+  else p.set("vault", vault);
+  return api<{ nodes: GraphApiNode[]; edges: GraphApiEdge[] }>(`/graph?${p}`);
 };
 
 // ── Drill Down ──
-export const drillDown = (vault: string, docId: string, section?: string) => {
-  const p = new URLSearchParams();
+export const drillDown = (vault: string, docPath: string, section?: string) => {
+  const p = new URLSearchParams({ uri: _docUri(vault, docPath) });
   if (section) p.set("section", section);
-  return api<{ sections: any[] }>(`/drill-down/${vault}/${docId}?${p}`);
+  return api<{ sections: any[] }>(`/drill-down?${p}`);
 };
 
 // ── Relations ──
@@ -282,10 +291,10 @@ export interface RelationRow {
   resource_type?: string;
   name?: string;
 }
-export const getRelations = (vault: string, docId: string) =>
-  api<{ doc_id: string; resource_uri: string; relations: RelationRow[] }>(
-    `/relations/${vault}/${encodeURIComponent(docId)}`,
-  );
+export const getRelations = (vault: string, docPath: string) => {
+  const p = new URLSearchParams({ uri: _docUri(vault, docPath) });
+  return api<{ uri: string; relations: RelationRow[] }>(`/relations?${p}`);
+};
 
 // ── Recent ──
 export const getRecent = (vault?: string, limit = 20) => {
@@ -316,20 +325,16 @@ export const getVaultActivity = (
   );
 };
 
-// ── Users ──
 // ── Document publish helpers (wrap createPublication/listPublications/deletePublication) ──
 //
-// publications.document_id is the underlying UUID. The user-facing doc_id can
-// be a UUID, a "d-XXXXXXXX" hash from metadata, or a path substring — we
-// resolve it via getDocument() once and then match exclusively by UUID.
-//
-// All publication objects use `publication_id` (not `id`) — backend normalizes
-// this in publication_service._row_to_dict so frontend can rely on it everywhere.
+// The user-facing `doc_id` in this module is the URL-shaped doc path
+// (e.g. `specs/api.md`). We resolve it via getDocument() to recover the
+// canonical `uri`, then match publications by `resource_uri` — the
+// single shape the backend now exposes for both documents and files.
 export const publishDoc = async (vault: string, doc_id: string) => {
-  // Idempotent: reuse the first existing publication for this doc, else create one.
   const doc = await getDocument(vault, doc_id);
   const { publications } = await listPublications(vault, "document");
-  const existing = publications.find((s: any) => s.document_id === doc.id);
+  const existing = publications.find((s: any) => s.resource_uri === doc.uri);
   if (existing) {
     return {
       published: true,
@@ -338,7 +343,7 @@ export const publishDoc = async (vault: string, doc_id: string) => {
       publication_id: existing.publication_id,
     };
   }
-  const result = await createPublication(vault, { resource_type: "document", doc_id });
+  const result = await createPublication(vault, { resource_type: "document", uri: doc.uri });
   return {
     published: true,
     public_url: result.public_url,
@@ -350,7 +355,7 @@ export const publishDoc = async (vault: string, doc_id: string) => {
 export const unpublishDoc = async (vault: string, doc_id: string) => {
   const doc = await getDocument(vault, doc_id);
   const { publications } = await listPublications(vault, "document");
-  const matches = publications.filter((s: any) => s.document_id === doc.id);
+  const matches = publications.filter((s: any) => s.resource_uri === doc.uri);
   let deleted = 0;
   for (const s of matches) {
     await deletePublication(vault, s.publication_id);
@@ -496,8 +501,10 @@ export function publicationCsvUrl(slug: string, params?: Record<string, string>)
 // ── Publications CRUD (authenticated) ──
 export interface CreatePublicationRequest {
   resource_type: "document" | "table_query" | "file";
-  doc_id?: string;
-  file_id?: string;
+  // For document/file publications, pass the canonical akb:// URI.
+  // table_query publications still scope by `vault` (route path) and
+  // use `query_sql`.
+  uri?: string;
   query_sql?: string;
   query_vault_names?: string[];
   query_params?: Record<string, { type?: string; default?: any; required?: boolean }>;
@@ -573,5 +580,9 @@ export const adminResetPassword = (userId: string) =>
   );
 
 // ── Provenance / drill-down ──
-export const getProvenance = (docId: string) =>
-  api<{ provenance: any }>(`/provenance/${encodeURIComponent(docId)}`);
+// Callers pass the doc path under its vault; the helper builds the
+// canonical URI before calling the URI-only REST endpoint.
+export const getProvenance = (vault: string, docPath: string) => {
+  const p = new URLSearchParams({ uri: _docUri(vault, docPath) });
+  return api<{ provenance: any }>(`/provenance?${p}`);
+};

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -21,8 +21,9 @@ interface Publication {
   publication_id: string;
   slug: string;
   resource_type: "document" | "file" | "table_query";
-  document_id?: string;
-  file_id?: string;
+  // Canonical handle (akb://{vault}/{doc|file}/{...}). Null for
+  // table_query publications, which have no single addressable resource.
+  resource_uri?: string | null;
   title?: string;
   created_at?: string;
   expires_at?: string | null;
@@ -108,15 +109,17 @@ export default function PublicationsPage() {
     setTimeout(() => setCopiedId(null), 1500);
   }
 
-  // Link back into the app for the underlying resource. Tables/files use
-  // their id; docs use the doc id since we don't have the path here.
+  // Link back into the app for the underlying resource. The canonical
+  // handle is `resource_uri` (akb://...) — we parse the tail to route.
   function resourceHref(pub: Publication): string {
-    if (!name) return "#";
-    if (pub.resource_type === "document" && pub.document_id) {
-      return `/vault/${name}/doc/${encodeURIComponent(pub.document_id)}`;
+    if (!name || !pub.resource_uri) return `/vault/${name ?? ""}`;
+    if (pub.resource_type === "document") {
+      const docPath = pub.resource_uri.split("/doc/")[1];
+      return docPath ? `/vault/${name}/doc/${docPath}` : `/vault/${name}`;
     }
-    if (pub.resource_type === "file" && pub.file_id) {
-      return `/vault/${name}/file/${encodeURIComponent(pub.file_id)}`;
+    if (pub.resource_type === "file") {
+      const fileId = pub.resource_uri.split("/file/")[1];
+      return fileId ? `/vault/${name}/file/${fileId}` : `/vault/${name}`;
     }
     return `/vault/${name}`;
   }

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -12,7 +12,10 @@ type SourceType = "document" | "table" | "file";
 
 interface DenseResult {
   source_type?: SourceType;
-  source_id: string;
+  // Canonical handle — `akb://{vault}/{doc|table|file}/{identifier}`.
+  // Backend dropped the legacy `source_id`/`doc_id`/`file_id` shape;
+  // routing decisions here parse the URI tail.
+  uri: string;
   vault: string;
   path: string;
   title: string;
@@ -24,15 +27,18 @@ interface DenseResult {
 
 function resultHref(r: DenseResult): string {
   const type = r.source_type || "document";
-  const id = r.source_id;
   if (type === "table") {
     const name = (r.path || "").replace(/^_tables\//, "") || r.title;
     return `/vault/${r.vault}/table/${encodeURIComponent(name)}`;
   }
   if (type === "file") {
-    return `/vault/${r.vault}/file/${id}`;
+    // file URI tail is the UUID.
+    const fileId = r.uri.split("/file/")[1] || "";
+    return `/vault/${r.vault}/file/${fileId}`;
   }
-  return `/vault/${r.vault}/doc/${id}`;
+  // document URI tail is the path.
+  const docPath = r.uri.split("/doc/")[1] || r.path;
+  return `/vault/${r.vault}/doc/${docPath}`;
 }
 
 const TYPE_META: Record<
@@ -363,9 +369,9 @@ export default function SearchPage() {
           </header>
           <ol className="divide-y divide-border">
             {literalResults.map((r, i) => (
-              <li key={r.doc_id}>
+              <li key={r.uri}>
                 <Link
-                  to={`/vault/${r.vault}/doc/${r.doc_id}`}
+                  to={`/vault/${r.vault}/doc/${r.uri.split("/doc/")[1] || r.path}`}
                   className="block px-5 py-4 group hover:bg-surface-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
                 >
                   <div className="grid grid-cols-[32px_1fr_60px] gap-4 items-baseline">
@@ -415,7 +421,7 @@ function DenseResultList({ items }: { items: DenseResult[] }) {
   return (
     <ol className="border border-border bg-surface divide-y divide-border">
       {items.map((r, i) => (
-        <li key={`${r.source_type || "document"}:${r.source_id}`}>
+        <li key={r.uri}>
           <Link
             to={resultHref(r)}
             className="block px-5 py-4 group hover:bg-surface-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"


### PR DESCRIPTION
## Summary

Closes the last gap from the MCP URI cutover: the events outbox + Redis stream payload now use the same `akb://{vault}/{type}/{id}` handle MCP clients see. External subscribers no longer have to reconcile two identifier shapes.

## DB migration 021

- Add `events.resource_uri TEXT` + partial index
- Backfill from `(ref_type, ref_id)` by joining `vaults` and the per-type resource table:
  - **document** → `akb://{vault.name}/doc/{documents.path}` (resolved via `documents.metadata->>'id' = ref_id`)
  - **table** → `akb://{vault.name}/table/{vault_tables.name}`
  - **file** → `akb://{vault.name}/file/{ref_id}`
  - **collection / user** → `resource_uri NULL` by design (not URI-addressable)
- Drop `ref_type` + `ref_id`. `init.sql` (migration 015) declares the post-021 shape so fresh installs skip 021

**Prod backfill (this deploy):** 7308 documents, 14 tables, 5 files migrated; 369 orphan rows (deleted resources, historical) left URI-less; 17 non-resource events (user/collection) URI-less by design.

## `emit_event` signature change

`(ref_type, ref_id)` → single `resource_uri`. All ~12 call sites updated to use `doc_uri`/`table_uri`/`file_uri` helpers. Four user-/collection-scoped emitters explicitly pass `resource_uri=None`.

## Redis stream payload

`_xadd_fields` drops the `ref_type`/`ref_id` bytes pairs, emits `resource_uri` only.

## Audit follow-ups bundled in

From the post-MCP-cutover review:

- `akb_grep` response no longer leaks `doc_id` (raw PG UUID) — builds `uri` from (vault, path) and strips the internal `_doc_pk` before returning
- `search_service` builds URIs via the doc/table/file helpers consistently
- **Frontend**: `pages/search.tsx` routes by `uri.tail` (was reading removed `source_id`); `pages/publications.tsx` routes by `resource_uri`; `lib/api.ts` publication helpers match by `resource_uri` instead of `document_id`
- **REST API URI parity**: `/relations`, `/graph`, `/provenance`, `/drill-down` all take `uri` query arg only. `/publications/{vault}/create` body accepts `uri` (no `doc_id`/`file_id`). Vault-name URI check prevents foreign-vault smuggling
- Publication dict surfaces `resource_uri`; new `public_view()` strips internal `document_id`/`file_id` at the serialization boundary. Internal resolvers still see them
- `todo_service.create_todo` takes `ref_uri` instead of `ref_doc`. List response surfaces `ref_uri`
- `_split_uri` moved to `app.services.uri_service` as the shared `split_uri()` helper — single source of truth for parse + type-validate
- Browse hint string updated to URI shape
- Dead backwards-compat alias `_to_uuid` in publication_service dropped

## Verification

- **Local docker-compose** (fresh DB → migrations on init): mcp_e2e 76/76, edit 37/37, security 54/54, unified_browse 70/70, collection_lifecycle 36/36, mcp_isolation 19/19 = **292 green**
- **Prod** (post-deploy): mcp_e2e 76/76, edit 37/37, security 54/54, unified_browse 70/70, events_emit 7/7 = **244 green**
- **events_emit** test directly checks the critical invariant: `event.resource_uri === MCP create_response.uri` for the same write

## No proxy / npm changes

File tool inputs/outputs were already URI-shaped from the prior cutover.

## Test plan

- [x] Migration 021 backfill on prod (7327 rows backfilled, 369 orphans flagged)
- [x] `events.resource_uri` present, `ref_type`/`ref_id` columns dropped
- [x] Full e2e green on local + prod
- [x] events_emit invariant: response.uri == event.resource_uri

🤖 Generated with [Claude Code](https://claude.com/claude-code)