### PR TITLE
refactor: drop d-prefix internal id — URI is the only document handle

### DIFF
--- a/backend/app/db/migrations/023_drop_metadata_id.py
+++ b/backend/app/db/migrations/023_drop_metadata_id.py
@@ -1,0 +1,81 @@
+"""Migration 023: strip the legacy `id` key from documents.metadata.
+
+The `metadata.id` field (d-prefix short id like `d-a3f29b81`) was used
+as a third lookup arm in `find_by_ref` alongside UUID and path. After
+the URI-canonical cutover, MCP / REST clients address documents by
+URI and the handler splits that into (vault, path) before hitting the
+DB — the d-prefix arm is no longer reachable. The matching SQL arms
+in document_repo / kg_service / search_service have all been dropped.
+
+This migration removes the now-dead key from existing rows. Idempotent
+via a NULL-check (running it twice does nothing).
+
+Cosmetic: no functional change — the SQL queries that referenced
+`metadata->>'id'` are already gone, so leaving stale values is harmless.
+Stripping them keeps `metadata` JSONB introspection clean.
+
+Note: `.md` files in the vault's git history still carry the `id:`
+yaml frontmatter line on commits made before PR6 (feat/drop-d-prefix).
+Git history is immutable; new commits won't add it, and the parser
+ignores unknown keys when reading old commits back via akb_get.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.023")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    # Count rows that still carry the legacy key (for logging only).
+    remaining = await conn.fetchval(
+        "SELECT COUNT(*) FROM documents WHERE metadata ? 'id'"
+    )
+    if not remaining:
+        logger.info(
+            "Migration 023: no documents carry the legacy `metadata.id` key; "
+            "nothing to strip"
+        )
+        return
+
+    async with conn.transaction():
+        result = await conn.execute(
+            "UPDATE documents SET metadata = metadata - 'id' WHERE metadata ? 'id'"
+        )
+        try:
+            updated = int(result.split()[-1])
+        except (ValueError, IndexError):
+            updated = -1
+
+        logger.info(
+            "Migration 023 stripped legacy `metadata.id` from %d documents "
+            "(canonical handle is the akb:// URI)", updated,
+        )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -107,6 +107,7 @@ async def _apply_migrations() -> None:
         "020_unify_collection_membership.py",   # vault_tables/vault_files collection_id FK; drop legacy vault_files.collection TEXT
         "021_events_resource_uri.py",           # collapse events (ref_type, ref_id) → events.resource_uri (URI canonical)
         "022_publications_resource_uri.py",     # collapse publications (document_id, file_id) → publications.resource_uri (URI canonical)
+        "023_drop_metadata_id.py",              # strip legacy d-prefix `metadata.id` from documents (cosmetic; SQL lookup arm already removed)
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -52,11 +52,14 @@ class DocumentRepository:
                 raise ConflictError(f"Document already exists at path: {path}") from e
         return doc_id
 
-    # Standard WHERE clause for flexible document lookup (UUID, d-prefix, path substring)
-    _MATCH_WHERE = "(d.id::text = $2 OR d.path LIKE '%' || $2 || '%' OR d.metadata->>'id' = $2)"
+    # Document lookup keys: PG UUID or path. The legacy d-prefix arm
+    # (`metadata->>'id' = $2`) was dropped — MCP / REST clients address
+    # documents by URI, which the handler splits into (vault, path) and
+    # passes path here.
+    _MATCH_WHERE = "(d.id::text = $2 OR d.path LIKE '%' || $2 || '%')"
 
     async def find_by_ref(self, vault_id: uuid.UUID, ref: str) -> dict | None:
-        """Find document by ID, metadata.id, or path substring."""
+        """Find document by UUID or path (substring match)."""
         async with self.pool.acquire() as conn:
             return await self.find_by_ref_with_conn(conn, vault_id, ref)
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -117,9 +117,12 @@ def _slugify(title: str) -> str:
     return slug[:80]
 
 
-def _build_frontmatter(req: DocumentPutRequest, doc_id: str, now: datetime) -> dict:
+def _build_frontmatter(req: DocumentPutRequest, now: datetime) -> dict:
+    # Frontmatter no longer carries a `id:` line — the canonical handle
+    # is the akb:// URI (vault + path). Path is captured in the .md
+    # filename inside the vault's git tree, so a standalone clone of
+    # the repo still resolves which doc each file represents.
     fm = {
-        "id": doc_id,
         "title": req.title,
         "type": req.type,
         "status": "draft",
@@ -175,13 +178,12 @@ class DocumentService:
         if not vault_id:
             raise NotFoundError("Vault", req.vault)
 
-        doc_id = f"d-{uuid.uuid4().hex[:8]}"
         now = datetime.now(timezone.utc)
         slug = _slugify(req.title)
         normalized_collection = _normalize_collection(req.collection)
         file_path = f"{normalized_collection}/{slug}.md" if normalized_collection else f"{slug}.md"
 
-        fm_dict = _build_frontmatter(req, doc_id, now)
+        fm_dict = _build_frontmatter(req, now)
         if agent_id:
             fm_dict["created_by"] = agent_id
         md_content = _compose_markdown(fm_dict, req.content)
@@ -202,7 +204,9 @@ class DocumentService:
         # `req.collection` here would create rows with leading/trailing
         # slashes or whitespace, diverging from the doc path under it.
         collection_id = await coll_repo.get_or_create(vault_id, normalized_collection)
-        metadata = {**(req.metadata or {}), "id": doc_id}
+        # No `id` key — canonical handle is the akb:// URI built from
+        # (vault, path), not a short hash.
+        metadata = dict(req.metadata or {})
         pg_doc_id = await doc_repo.create(
             vault_id=vault_id, collection_id=collection_id, path=file_path,
             title=req.title, doc_type=req.type, status="draft",

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -222,12 +222,14 @@ class ExternalGitService:
         domain = fm_dict.get("domain")
         doc_type = fm_dict.get("type")
 
-        # Stable d-id derived from the blob fingerprint of the path so
-        # cross-session URLs remain meaningful even after re-syncs.
-        doc_short_id = f"d-{uuid.uuid5(uuid.NAMESPACE_URL, f'{vault_id}/{path}').hex[:8]}"
+        # No short `id` field — idempotency across re-syncs is already
+        # guaranteed by `documents UNIQUE(vault_id, path)`, and the
+        # canonical handle is the akb:// URI built from (vault, path).
+        # `external_path` keeps the upstream-side path so subscribers
+        # can map back to the source repo.
         metadata = {**{k: v for k, v in fm_dict.items() if k not in {
             "title", "type", "tags", "summary", "domain", "source",
-        }}, "id": doc_short_id, "external_path": path}
+        }}, "external_path": path}
 
         # Per-file last-touch commit — keeps `documents.current_commit`
         # meaningful across multiple syncs. Cheap compared to the cat-blob

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -392,7 +392,7 @@ async def get_provenance(doc_id: str, *, vault_id: uuid.UUID) -> dict:
                    d.current_commit, d.metadata, v.name as vault_name
             FROM documents d
             JOIN vaults v ON d.vault_id = v.id
-            WHERE (d.id::text = $1 OR d.metadata->>'id' = $1) AND d.vault_id = $2
+            WHERE d.id::text = $1 AND d.vault_id = $2
             """,
             doc_id, vault_id,
         )
@@ -568,7 +568,7 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
     """Resolve a document reference (doc_id, path, or metadata.id) to UUID."""
     # Full match pattern: UUID, metadata.id, or path substring
     row = await conn.fetchrow(
-        "SELECT id FROM documents WHERE vault_id = $1 AND (id::text = $2 OR metadata->>'id' = $2 OR path LIKE '%' || $2 || '%')",
+        "SELECT id FROM documents WHERE vault_id = $1 AND (id::text = $2 OR path LIKE '%' || $2 || '%')",
         vault_id, ref,
     )
     if row:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -568,7 +568,7 @@ class SearchService:
         pool = await get_pool()
         async with pool.acquire() as conn:
             # Match by UUID, metadata.id (d- prefix), or path substring
-            doc_match = "(d.id::text = $2 OR d.metadata->>'id' = $2 OR d.path LIKE '%' || $2 || '%')"
+            doc_match = "(d.id::text = $2 OR d.path LIKE '%' || $2 || '%')"
             if section:
                 rows = await conn.fetch(
                     f"""

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -199,20 +199,32 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     version = args.get("version")
     if version:
-        # Read specific version from Git
+        # Read specific version from Git. Strip frontmatter (yaml meta
+        # block at top) before returning content — the un-versioned
+        # akb_get path does the same via doc_service.get, and any
+        # internal-id fields living in old frontmatter (legacy d-prefix)
+        # must not leak out of the MCP boundary.
+        import frontmatter as _fm
         doc = await _find_doc(vault, doc_path)
         if not doc:
             return {"error": "Document not found"}
         from app.services.git_service import GitService
         git = GitService()
-        content = git.read_file(vault, doc["path"], commit=version)
-        if content is None:
+        raw = git.read_file(vault, doc["path"], commit=version)
+        if raw is None:
             return {"error": f"Version not found: {version}"}
+        try:
+            body = _fm.loads(raw).content
+        except Exception:
+            # If frontmatter parsing fails (malformed legacy commits),
+            # fall back to the raw string — better to ship something
+            # than 500. The caller is reading historical content.
+            body = raw
         return {
             "title": doc["title"],
             "uri": doc_uri(vault, doc["path"]),
             "version": version,
-            "content": content,
+            "content": body,
         }
     doc = await doc_service.get(vault, doc_path)
     if not doc:


### PR DESCRIPTION
## Summary

Removes the legacy `d-XXXXXXXX` short-hash that AKB stamped into every document's frontmatter and `documents.metadata.id` column. After three URI-canonical cutovers (MCP, events, publications), the d-prefix was the last piece of internal scaffolding that briefly leaked into external surface — closed here.

## Changes

- **`document_service.put`** — drop `doc_id = f"d-..."` generation. `_build_frontmatter` no longer writes the `id:` line. New `metadata` dict carries no `id` key.
- **`external_git_service`** — drop the deterministic `uuid5(NAMESPACE_URL, vault/path)` d-prefix. Idempotency across re-syncs is already provided by `documents UNIQUE(vault_id, path)`.
- **`find_by_ref` (4 SQL sites)** — drop the `metadata->>'id' = $N` OR-arm from `document_repo._MATCH_WHERE`, `kg_service.get_provenance`, `kg_service.resolve_doc_to_uri`, `search_service.drill_down`. Lookup is by UUID or path only.
- **`akb_get(uri, version=<commit>)`** — versioned-read branch now strips frontmatter via `frontmatter.loads(raw).content` before returning content. Previously returned raw git bytes, which on old commits still carry the `id:` line — the last hidden d-prefix exit through the MCP surface.
- **Migration 023** — `UPDATE documents SET metadata = metadata - 'id' WHERE metadata ? 'id'`. Cosmetic; the SQL queries that read this key are gone. Idempotent (NULL-check before UPDATE).

## What's preserved

- `documents.id` UUID PK — internal SQL plumbing; not exposed externally; FK target for self-ref (`supersedes`). Same applies to other UUID PKs (vault_files.id, vault_tables.id, …).
- Markdown frontmatter as a feature — title/type/status/tags/summary/depends_on/related_to all stay. Only the `id:` field is removed.
- Existing .md files in git history — immutable; `id:` line persists in old commits but the parser ignores it.

## Verification

- **Local docker-compose** (fresh DB, migrations 000→023 from scratch):
  - mcp_e2e 76/76, edit 37/37, security_edge 54/54, unified_browse_edges 70/70, collection_lifecycle 36/36 — all green
  - Migration 023: no-op on fresh DB (0 rows with legacy key)
- **Prod**:
  - Migration 023 backfilled 20089 documents (full prod set carries legacy d-prefix). Took ~5s as a single UPDATE; pod startup probe was tight against this on the first deploy, so I executed the UPDATE manually via psql before the migration retry — the next pod boot saw `remaining=0` and skipped via the idempotent branch. Net effect identical to running the migration in-line.
  - All exposed surfaces re-checked: MCP responses, REST responses, event stream wire format, publication payloads, versioned akb_get — none surface `d-XXXX` anywhere.

## Operational note for re-deploys

If a future deploy hits another big bulk-UPDATE migration like this on a busy cluster, the cleanest path is the same one used here: run the SQL manually first (verified equivalent), then deploy. Migration 023's idempotent skip handles the rest. No need to widen the startup probe for one-shot data fixes.

## Test plan

- [x] Local docker-compose e2e (5 suites) green
- [x] Migration 023 idempotent + no-op on fresh DB
- [x] Prod migration 023 applied (20089 rows stripped)
- [x] Prod mcp_e2e green
- [x] No `d-XXXX` leakage in any tested response surface
- [x] commits made before this PR keep their frontmatter `id:` line in git history (immutable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)