### PR TITLE
fix(docs): scrub operator-specific prod host from plan docs

### DIFF
--- a/docs/superpowers/plans/2026-05-12-vault-template-selection.md
+++ b/docs/superpowers/plans/2026-05-12-vault-template-selection.md
@@ -1063,7 +1063,7 @@ Expected: all green.
 
 ```bash
 bash deploy/k8s/internal/deploy-internal.sh
-curl -sk https://akb.agent.seahorse.dnotitia.com/livez
+curl -sk <your-prod-host>/livez
 ```
 Expected: `{"status":"alive"}`.
 

--- a/docs/superpowers/plans/2026-05-13-frontend-ux-cleanup.md
+++ b/docs/superpowers/plans/2026-05-13-frontend-ux-cleanup.md
@@ -983,15 +983,15 @@ If Vite dev is running on `:5173`:
 ```bash
 git push origin main
 bash deploy/k8s/internal/deploy-internal.sh
-until curl -sf https://akb.agent.seahorse.dnotitia.com/livez >/dev/null 2>&1; do sleep 5; done
-curl -sk https://akb.agent.seahorse.dnotitia.com/livez
+until curl -sf <your-prod-host>/livez >/dev/null 2>&1; do sleep 5; done
+curl -sk <your-prod-host>/livez
 ```
 
 Expected: `{"status":"alive"}` from production.
 
 - [ ] **Step 5: Production smoke**
 
-Repeat Step 3's manual scenarios against `https://akb.agent.seahorse.dnotitia.com`.
+Repeat Step 3's manual scenarios against `<your-prod-host>`.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-13-password-recovery.md
+++ b/docs/superpowers/plans/2026-05-13-password-recovery.md
@@ -1539,7 +1539,7 @@ Expected: all green.
 - [ ] **Step 5: Manual smoke against production (if deploying)**
 
 After `deploy/k8s/internal/deploy-internal.sh`:
-- Log into `https://akb.agent.seahorse.dnotitia.com` as a test user.
+- Log into `<your-prod-host>` as a test user.
 - Settings → Profile → change password to a new value → success.
 - Log out, log back in with the new password.
 - As admin, Settings → Admin → click key icon on a user → Generate → confirm temp password renders + copy works.
@@ -1554,7 +1554,7 @@ After `deploy/k8s/internal/deploy-internal.sh`:
 ```bash
 git push origin main
 bash deploy/k8s/internal/deploy-internal.sh
-curl -sk https://akb.agent.seahorse.dnotitia.com/livez
+curl -sk <your-prod-host>/livez
 ```
 
 ---


### PR DESCRIPTION
## Summary

Three plan docs in `docs/superpowers/plans/` hard-coded an operator-specific prod URL. Per repo policy (no internal hosts / IPs / secrets in tracked OSS files; operator-specific config belongs in the gitignored `deploy/k8s/internal/` overlay), masked the host as `<your-prod-host>`.

## Files touched

- `docs/superpowers/plans/2026-05-12-vault-template-selection.md`
- `docs/superpowers/plans/2026-05-13-frontend-ux-cleanup.md`
- `docs/superpowers/plans/2026-05-13-password-recovery.md`

## How this slipped in

These plan docs were committed 2026-05-12 / 05-13 with the operator's actual prod host embedded in the test-plan and verification sections. The URI-canonical refactor audit caught it.

## Adjacent cleanup (already done outside this PR)

- PR #10 and #14 GitHub descriptions had the same string in their "Prod" verification sections — masked via `gh pr edit`. No code change needed.
- Confirmed clean: all 7 URI-cutover PRs introduced zero new secret / host / IP literals in tracked files. The internal registry IP (`192.168.110.11`), Seahorse tenant UUID, and DB / Redis / S3 / API-key credentials all remain in gitignored `config/*.yaml` and `deploy/k8s/internal/`.

## Test plan

- [x] `git grep akb.agent.seahorse.dnotitia.com` returns 0 matches after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)