### PR TITLE
fix: post-cutover bug sweep + chunk-header strip

### DIFF
--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -52,14 +52,18 @@ class DocumentRepository:
                 raise ConflictError(f"Document already exists at path: {path}") from e
         return doc_id
 
-    # Document lookup keys: PG UUID or path. The legacy d-prefix arm
-    # (`metadata->>'id' = $2`) was dropped — MCP / REST clients address
-    # documents by URI, which the handler splits into (vault, path) and
-    # passes path here.
-    _MATCH_WHERE = "(d.id::text = $2 OR d.path LIKE '%' || $2 || '%')"
+    # Document lookup keys: PG UUID or exact path. MCP / REST handlers
+    # all split the URI into (vault, path) before calling here, so the
+    # path is canonical. The earlier `path LIKE '%' || $2 || '%'` arm
+    # was a substring match that, after the URI cutover, could silently
+    # return the wrong doc when one path was a substring of another
+    # (`api.md` matching `api-v2.md`) — turning a benign-looking
+    # `akb_delete` into a wrong-resource delete. Exact match closes
+    # that class of bug.
+    _MATCH_WHERE = "(d.id::text = $2 OR d.path = $2)"
 
     async def find_by_ref(self, vault_id: uuid.UUID, ref: str) -> dict | None:
-        """Find document by UUID or path (substring match)."""
+        """Find document by UUID or exact path."""
         async with self.pool.acquire() as conn:
             return await self.find_by_ref_with_conn(conn, vault_id, ref)
 
@@ -119,8 +123,14 @@ class DocumentRepository:
                 title, doc_type, status, summary, domain, now, commit_hash, tags, doc_id,
             )
 
-    async def delete(self, doc_id: uuid.UUID) -> None:
-        async with self.pool.acquire() as conn:
+    async def delete(self, doc_id: uuid.UUID, *, conn=None) -> None:
+        """Delete the documents row. When `conn` is provided the DELETE
+        runs on the caller's connection (so it joins the same TX as the
+        cascade in `document_service.delete`)."""
+        if conn is None:
+            async with self.pool.acquire() as own_conn:
+                await own_conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
+        else:
             await conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
 
     async def list_by_collection(self, vault_id: uuid.UUID, collection_path: str) -> list[dict]:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -377,53 +377,54 @@ class DocumentService:
         )
 
         chunks_indexed = 0
-        if req.content is not None:
-            # Use the values that were actually persisted to DB, not the
-            # raw request — e.g. req.title may be None when caller kept
-            # the title unchanged.
-            meta_header = build_doc_metadata_header(
-                vault_name=vault, path=file_path,
-                title=req.title or row["title"],
-                summary=req.summary if req.summary is not None else row["summary"],
-                tags=req.tags if req.tags is not None else (list(row["tags"]) if row["tags"] else []),
-                doc_type=req.type or row["doc_type"],
-            )
-            chunks = chunk_markdown(new_body, metadata_header=meta_header)
-            pool = await get_pool()
-            async with pool.acquire() as conn:
-                chunks_indexed = await write_source_chunks(
-                    conn, "document", str(pg_doc_id),
-                    vault_id=vault_id,
-                    chunks=chunks,
-                )
-
-        # Re-extract edges when content or relations changed
-        if req.content is not None or req.depends_on is not None or req.related_to is not None:
-            depends = current_fm.get("depends_on", []) or []
-            related = current_fm.get("related_to", []) or []
-            implements = current_fm.get("implements", []) or []
-            pool = await get_pool()
-            async with pool.acquire() as conn:
-                await store_document_relations(
-                    conn, vault_id, vault, file_path,
-                    depends, related, implements,
-                    new_body,
-                )
-
+        # One transaction across chunks + relations + event so partial
+        # failure either commits all three or none — previously each
+        # was a separate connection, leaving git ahead of indices and
+        # subscribers missing the `document.update` signal when a
+        # mid-flight failure hit.
         pool = await get_pool()
         async with pool.acquire() as conn:
-            await emit_event(
-                conn, "document.update",
-                vault_id=vault_id,
-                resource_uri=doc_uri(vault, file_path),
-                actor_id=agent_id,
-                payload={
-                    "vault": vault,
-                    "path": file_path,
-                    "commit_hash": commit_hash,
-                    "content_changed": req.content is not None,
-                },
-            )
+            async with conn.transaction():
+                if req.content is not None:
+                    # Use the values that were actually persisted to DB, not the
+                    # raw request — e.g. req.title may be None when caller kept
+                    # the title unchanged.
+                    meta_header = build_doc_metadata_header(
+                        vault_name=vault, path=file_path,
+                        title=req.title or row["title"],
+                        summary=req.summary if req.summary is not None else row["summary"],
+                        tags=req.tags if req.tags is not None else (list(row["tags"]) if row["tags"] else []),
+                        doc_type=req.type or row["doc_type"],
+                    )
+                    chunks = chunk_markdown(new_body, metadata_header=meta_header)
+                    chunks_indexed = await write_source_chunks(
+                        conn, "document", str(pg_doc_id),
+                        vault_id=vault_id,
+                        chunks=chunks,
+                    )
+
+                if req.content is not None or req.depends_on is not None or req.related_to is not None:
+                    depends = current_fm.get("depends_on", []) or []
+                    related = current_fm.get("related_to", []) or []
+                    implements = current_fm.get("implements", []) or []
+                    await store_document_relations(
+                        conn, vault_id, vault, file_path,
+                        depends, related, implements,
+                        new_body,
+                    )
+
+                await emit_event(
+                    conn, "document.update",
+                    vault_id=vault_id,
+                    resource_uri=doc_uri(vault, file_path),
+                    actor_id=agent_id,
+                    payload={
+                        "vault": vault,
+                        "path": file_path,
+                        "commit_hash": commit_hash,
+                        "content_changed": req.content is not None,
+                    },
+                )
 
         return DocumentPutResponse(
             uri=doc_uri(vault, file_path),
@@ -611,8 +612,12 @@ class DocumentService:
                         "path": file_path,
                     },
                 )
-
-        await doc_repo.delete(pg_doc_id)
+                # Doc row delete inside the same TX. Previously this ran
+                # on a separate connection — a crash between the cascade
+                # commit and the row delete left an orphan documents row
+                # (no chunks/edges/publications). Recovery was possible
+                # via retry but the inconsistency was visible.
+                await doc_repo.delete(pg_doc_id, conn=conn)
 
         if collection_id:
             await coll_repo.decrement_count(collection_id, datetime.now(timezone.utc))

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -565,16 +565,26 @@ async def _store_edge(
 
 
 async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | None:
-    """Resolve a document reference (doc_id, path, or metadata.id) to UUID."""
-    # Full match pattern: UUID, metadata.id, or path substring
-    row = await conn.fetchrow(
-        "SELECT id FROM documents WHERE vault_id = $1 AND (id::text = $2 OR path LIKE '%' || $2 || '%')",
-        vault_id, ref,
-    )
-    if row:
-        return row["id"]
+    """Resolve a non-URI document reference to its PG UUID.
 
-    # By UUID
+    Used by `_store_edge` for the *legacy* path where a doc's frontmatter
+    `depends_on` / `related_to` list contains a bare string instead of
+    an `akb://` URI. New code is URI-first and bypasses this function
+    entirely (the URI path in `_store_edge` short-circuits before us).
+
+    Match arms (in order, each by exact / suffix / UUID — never by
+    substring; the legacy substring arm was a wrong-doc magnet after
+    the URI cutover):
+      1. UUID — `id = $2`
+      2. Exact path — `path = $2`
+      3. Trailing-segment match — `path LIKE '%/' || $2` (e.g. ref
+         `api.md` matches `notes/api.md` iff there is exactly one such
+         doc; the unique constraint on `(vault_id, path)` does NOT
+         dedupe across collections, so this can still return one of
+         several matches — but the suffix is anchored at `/`, so
+         `api.md` cannot match `funapi.md`).
+    """
+    # By UUID first — cheapest and unambiguous.
     try:
         uid = uuid.UUID(ref)
         row = await conn.fetchrow(
@@ -586,7 +596,7 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
     except ValueError:
         pass
 
-    # By path (exact or suffix match)
+    # Exact path.
     row = await conn.fetchrow(
         "SELECT id FROM documents WHERE vault_id = $1 AND path = $2",
         vault_id, ref,
@@ -594,7 +604,8 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
     if row:
         return row["id"]
 
-    # By path suffix
+    # Trailing-segment match: `api.md` ↔ `notes/api.md`. Anchored at
+    # `/` so it can't match arbitrary substrings.
     row = await conn.fetchrow(
         "SELECT id FROM documents WHERE vault_id = $1 AND path LIKE '%/' || $2",
         vault_id, ref,
@@ -699,17 +710,3 @@ async def _bfs_collect(
 
 # ── URI builder helpers for callers ──────────────────────────
 
-async def resolve_doc_to_uri(vault_name: str, doc_ref: str) -> str | None:
-    """Resolve a doc ref (doc_id, path, metadata.id) to its akb:// URI."""
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)
-        if not vault:
-            return None
-        doc_id = await _resolve_doc_ref(conn, vault["id"], doc_ref)
-        if not doc_id:
-            return None
-        path = await conn.fetchval("SELECT path FROM documents WHERE id = $1", doc_id)
-        if not path:
-            return None
-        return doc_uri(vault_name, path)

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -255,25 +255,66 @@ async def create_publication(
 
     pool = await get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            INSERT INTO publications (
+        async with conn.transaction():
+            # Re-check resource existence INSIDE the publish TX, against
+            # the canonical resource_uri the caller resolved. Closes the
+            # publish/delete race: without this, `document_service.delete`
+            # could cascade-clean publications (zero rows) before we
+            # INSERT below, leaving an orphan publication that points
+            # at a now-gone resource.
+            #
+            # The check holds the row in a snapshot for the duration of
+            # the TX. Concurrent delete blocks on the row lock until
+            # after our INSERT commits — meaning either the publication
+            # lands first and delete cleans it, or delete commits first
+            # and we abort with ResourceVanished.
+            if resource_type == ResourceType.DOCUMENT and resource_uri:
+                # Doc resource_uri form: akb://{vault}/doc/{path}
+                doc_path_for_check = resource_uri.split("/doc/", 1)[1] if "/doc/" in resource_uri else None
+                if doc_path_for_check is not None:
+                    found = await conn.fetchval(
+                        "SELECT 1 FROM documents WHERE vault_id = $1 AND path = $2 FOR SHARE",
+                        vault_id, doc_path_for_check,
+                    )
+                    if not found:
+                        raise ValueError(
+                            f"Document not found (resource was deleted concurrently): {resource_uri}"
+                        )
+            elif resource_type == ResourceType.FILE and resource_uri:
+                file_uuid_for_check = resource_uri.rsplit("/", 1)[-1]
+                try:
+                    file_uuid_obj = uuid.UUID(file_uuid_for_check)
+                except ValueError:
+                    file_uuid_obj = None
+                if file_uuid_obj is not None:
+                    found = await conn.fetchval(
+                        "SELECT 1 FROM vault_files WHERE id = $1 FOR SHARE",
+                        file_uuid_obj,
+                    )
+                    if not found:
+                        raise ValueError(
+                            f"File not found (resource was deleted concurrently): {resource_uri}"
+                        )
+
+            row = await conn.fetchrow(
+                """
+                INSERT INTO publications (
+                    slug, vault_id, resource_type, resource_uri,
+                    query_sql, query_vault_names, query_params,
+                    password_hash, max_views, expires_at,
+                    mode, section_filter, allow_embed, title, created_by
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                RETURNING id, slug, vault_id, resource_type, resource_uri,
+                          query_sql, query_vault_names, query_params, max_views,
+                          view_count, expires_at, mode, section_filter, allow_embed,
+                          title, created_at
+                """,
                 slug, vault_id, resource_type, resource_uri,
-                query_sql, query_vault_names, query_params,
-                password_hash, max_views, expires_at,
-                mode, section_filter, allow_embed, title, created_by
+                query_sql, query_vault_names, json.dumps(query_params or {}),
+                pwd_hash, max_views, expires_at,
+                mode, section_filter, allow_embed, title, created_by,
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-            RETURNING id, slug, vault_id, resource_type, resource_uri,
-                      query_sql, query_vault_names, query_params, max_views,
-                      view_count, expires_at, mode, section_filter, allow_embed,
-                      title, created_at
-            """,
-            slug, vault_id, resource_type, resource_uri,
-            query_sql, query_vault_names, json.dumps(query_params or {}),
-            pwd_hash, max_views, expires_at,
-            mode, section_filter, allow_embed, title, created_by,
-        )
 
     result = _enrich_publication(_publication_row_to_dict(row)) or {}
     result["password_protected"] = pwd_hash is not None

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -568,7 +568,10 @@ class SearchService:
         pool = await get_pool()
         async with pool.acquire() as conn:
             # Match by UUID, metadata.id (d- prefix), or path substring
-            doc_match = "(d.id::text = $2 OR d.path LIKE '%' || $2 || '%')"
+            # Exact path match — same reasoning as `find_by_ref`. The
+            # earlier substring `LIKE '%' || $2 || '%'` arm caused
+            # cross-doc section bleed when paths shared a substring.
+            doc_match = "(d.id::text = $2 OR d.path = $2)"
             if section:
                 rows = await conn.fetch(
                     f"""

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -12,6 +12,7 @@ Flow:
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 
 from app.config import settings
@@ -24,6 +25,31 @@ from app.services.rerank_service import RerankError, rerank
 from app.utils import ensure_dict
 
 logger = logging.getLogger("akb.search")
+
+# Strips the indexing-time enrichment block emitted by
+# `build_doc_metadata_header`. The block is `TITLE: ...\n` followed by
+# at least one more KEY: line and a `\n\n` separator before the body.
+# It rides along with every doc chunk so the BM25 and dense legs see
+# doc-level signals during retrieval — but it is noise when the chunk
+# content is shown to humans or agents. Requiring TWO header lines + a
+# `\n\n` body separator avoids stripping a user paragraph that happens
+# to start with `TITLE: foo`. Table/file chunks are pure-metadata (no
+# body separator) and intentionally do not match.
+_CHUNK_HEADER_KEYS = "TITLE|SUMMARY|TAGS|PATH|TYPE|VAULT|MIME|SIZE|DESCRIPTION"
+_CHUNK_HEADER_RE = re.compile(
+    rf"\ATITLE:[^\n]*\n(?:(?:{_CHUNK_HEADER_KEYS}):[^\n]*\n)+\n"
+)
+
+
+def strip_chunk_metadata_header(text: str | None) -> str | None:
+    """Strip the indexing-time TITLE/SUMMARY/TAGS/PATH/TYPE/... block
+    from a chunk's stored `content` before returning it to clients.
+    Leaves the body untouched if no such block is present (e.g. older
+    chunks indexed before the enrichment was added, or table/file
+    chunks that are pure-metadata with no body)."""
+    if not text:
+        return text
+    return _CHUNK_HEADER_RE.sub("", text, count=1)
 
 
 class SearchService:
@@ -299,7 +325,7 @@ class SearchService:
                     vault=m["vault"], path=m["path"], title=m["title"],
                     doc_type=m["doc_type"], summary=m["summary"],
                     tags=m["tags"], score=h.score,
-                    matched_section=h.content[:500] if h.content else None,
+                    matched_section=(strip_chunk_metadata_header(h.content) or "")[:500] or None,
                 )
             )
         return results
@@ -466,8 +492,13 @@ class SearchService:
                     "matches": [],
                 }
 
-            # Extract individual matching lines from chunk
-            chunk_lines = r["content"].split("\n")
+            # Extract individual matching lines from chunk. Strip the
+            # indexing-time TITLE/SUMMARY/... enrichment so a user
+            # grepping for a real body word doesn't get phantom hits
+            # against the doc-level signals that ride along with every
+            # chunk.
+            chunk_body = strip_chunk_metadata_header(r["content"]) or ""
+            chunk_lines = chunk_body.split("\n")
             for i, line in enumerate(chunk_lines):
                 if regex:
                     matched = bool(_re.search(pattern, line, 0 if case_sensitive else _re.IGNORECASE))
@@ -602,7 +633,7 @@ class SearchService:
             return [
                 {
                     "section_path": r["section_path"],
-                    "content": r["content"],
+                    "content": strip_chunk_metadata_header(r["content"]),
                     "chunk_index": r["chunk_index"],
                 }
                 for r in rows

--- a/backend/app/services/uri_service.py
+++ b/backend/app/services/uri_service.py
@@ -24,10 +24,25 @@ def make_uri(vault: str, resource_type: str, identifier: str) -> str:
 
 
 def parse_uri(uri: str) -> tuple[str, str, str] | None:
-    """Parse an AKB URI into (vault, type, identifier). Returns None if invalid."""
+    """Parse an AKB URI into (vault, type, identifier). Returns None if invalid.
+
+    A single trailing `/` on the identifier is stripped so URIs that
+    differ only by that slash (`akb://v/doc/x` vs `akb://v/doc/x/`)
+    resolve to the same canonical handle. Without this normalization a
+    hand-built URI in a frontmatter `depends_on` list could spawn a
+    separate edge row vs. server-generated callers — they'd index as
+    two distinct strings even though they refer to the same resource.
+    """
     m = _URI_RE.match(uri)
     if m:
-        return m.group(1), m.group(2), m.group(3)
+        ident = m.group(3)
+        if ident.endswith("/"):
+            ident = ident.rstrip("/")
+            # Defensive: if the entire identifier was slashes
+            # (`akb://v/doc//`) the strip leaves empty — reject.
+            if not ident:
+                return None
+        return m.group(1), m.group(2), ident
     return None
 
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -32,7 +32,7 @@ from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import NotFoundError
 from app.services.document_service import DocumentService, EditError
 from app.services.search_service import SearchService
-from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources, resolve_doc_to_uri
+from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
 from app.services.uri_service import doc_uri, table_uri, file_uri, parse_uri, split_uri
 from app.services.access_service import (
     check_vault_access, grant_access, revoke_access, list_vault_members,
@@ -216,10 +216,17 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
         try:
             body = _fm.loads(raw).content
         except Exception:
-            # If frontmatter parsing fails (malformed legacy commits),
-            # fall back to the raw string — better to ship something
-            # than 500. The caller is reading historical content.
-            body = raw
+            # YAML parser choked (rare — happens on historical commits
+            # with malformed frontmatter). Strip a leading `---\n…\n---`
+            # block by regex so the response body never leaks the yaml
+            # header verbatim (which on legacy commits still carries
+            # `id: d-XXXXXXXX`). If no `---` fence is present we ship
+            # the raw content — it has no frontmatter to leak.
+            import re as _re
+            stripped = _re.sub(
+                r"\A---\r?\n.*?\r?\n---\r?\n", "", raw, count=1, flags=_re.DOTALL,
+            )
+            body = stripped
         return {
             "title": doc["title"],
             "uri": doc_uri(vault, doc["path"]),

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -105,6 +105,11 @@ interface BfsExpandArgs {
 function rowToEdge(row: RelationRow, selfUri: string): GraphEdge | null {
   const relation = normalizeRelation(row.relation);
   if (!relation) return null;
+  // The relations endpoint can in principle emit an edge whose
+  // counter-party URI is null (unresolved forward ref). Skipping
+  // those keeps the graph free of `{source: "...", target: undefined}`
+  // shapes that would silently confuse the layout / viz layer.
+  if (!row.uri) return null;
   if (row.direction === "outgoing") {
     return { source: selfUri, target: row.uri, relation };
   }

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -73,9 +73,12 @@ export default function PublicationsPage() {
           if (p.title || p.resource_type !== "document" || !p.resource_uri) {
             return p;
           }
-          // Pull the doc path out of the canonical URI tail and look up
-          // the doc title for a friendlier list label.
-          const docPath = p.resource_uri.split("/doc/")[1];
+          // Pull the doc path out of the canonical URI by stripping the
+          // `akb://{vault}/doc/` prefix only — a plain `.split("/doc/")`
+          // would also split on any embedded `/doc/` segment inside the
+          // path (e.g. `archive/doc/legacy.md`), grabbing the wrong tail.
+          const match = p.resource_uri.match(/^akb:\/\/[^/]+\/doc\/(.+)$/);
+          const docPath = match ? match[1] : "";
           if (!docPath) return p;
           try {
             const doc = await getDocument(vault, docPath);


### PR DESCRIPTION
## Summary

Two-commit bundle finishing the URI-canonical refactor cleanup:

- **9-bug post-cutover sweep** — TX integrity, race fixes, URI normalization
- **Chunk-header strip** — UX fix for drill_down / search / grep output

## What's fixed

### Bug sweep (commit 8ec84e5)
1. `find_by_ref` + `drill_down` doc_match — exact `path = $2` instead of `path LIKE '%X%'`. Substring arm could match wrong doc (e.g. lookup `api.md` returning `api-v2.md`); after d-prefix removal the only legitimate caller of the substring fallback was gone.
2. Single-TX document update/delete — collapse chunks write, relations store, event emit, and cascade row delete into one connection scope so a mid-flight crash can't leave a half-updated document.
3. Publication create race — wrap existence check + insert in a TX with `FOR SHARE` on the document/file row; without it a concurrent delete could land an orphan publication.
4. URI trailing-slash normalization in `parse_uri` — strip a single trailing `/` so `akb://v/doc/x` and `akb://v/doc/x/` resolve to the same canonical handle. Confirmed live on prod via `akb_get` returning `Document not found` for the slash form.
5. Versioned `akb_get` frontmatter strip — when YAML parsing fails on a historical doc, regex-strip the `---\n...\n---\n` block instead of returning the raw body.
6. Frontend null-check `row.uri` in `rowToEdge` so the relations endpoint can't synthesize edges with undefined endpoints.
7. Publications page `resource_uri` parse — regex prefix strip so paths containing `/doc/` don't get sliced at the wrong segment.

### Chunk-header strip (commit d9ff52c)
Chunks store a `TITLE:/SUMMARY:/TAGS:/PATH:/TYPE:\n\n` enrichment block prepended at index time so the BM25 and dense legs both see doc-level signals on every chunk. It's meant for retrieval scoring — but `drill_down`'s `content`, `search`'s `matched_section`, and `grep`'s matching all leaked it through to the client, producing noisy output and phantom hits when a user grep'd for a word that only appears in the enrichment.

Strip it on the way out. Regex requires `TITLE:` plus at least one more KEY line followed by `\n\n`, so a user paragraph that coincidentally starts with `TITLE: foo` is left untouched, and table/file chunks (pure metadata, no body separator) are intentionally not matched.

## Test plan
- [x] Local mcp_e2e — 76 / 0
- [x] Local edit_e2e — 37 / 0
- [x] Local security_edge — 54 / 0
- [x] Local coll_lifecycle — 36 / 0
- [x] Local unified — 70 / 0
- [x] Local defensive — passed
- [x] Local graph_replace — 28 / 1 (+1 vs `main`'s 27/2; remaining failure is pre-existing Korean-BM25 issue, unrelated to PR8)
- [x] Local publications — 75 / 13 (13 failures pre-exist on `main`; require S3 which isn't in local docker-compose)
- [x] Frontend tests — 150 / 0
- [ ] Prod deploy + prod e2e (next)
- [ ] Verify `akb_get` with trailing-slash URI now resolves (was returning `Document not found` on prod)
- [ ] Verify `akb_drill_down` output no longer leaks `TITLE:/SUMMARY:/...` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)