### PR TITLE
fix(search): auto-refresh BM25 corpus stats

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -126,6 +126,13 @@ class Settings(BaseModel):
     # BM25 corpus tuning (driver-neutral; lives in main PG vocab).
     bm25_k1: float = 1.5
     bm25_b: float = 0.75
+    # How often to recompute `bm25_stats(total_docs, avgdl)` + per-term
+    # df from the live chunks corpus. The recompute also runs once at
+    # startup, so this controls the steady-state cadence. Lower = stats
+    # track new docs faster (better sparse ranking for fresh content);
+    # higher = less work on the DB. 30 min is a safe default for a
+    # mixed read/write workload.
+    bm25_recompute_interval_secs: int = 1800
 
     # Event stream — optional Redis Streams fanout. PG outbox (`events`
     # table) is always the source of truth; when redis_url is set the

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -184,9 +184,9 @@ async def health():
     except Exception as e:  # noqa: BLE001
         vs_info["backfill_error"] = str(e)
     try:
-        vs_info["bm25_vocab_size"] = await sparse_encoder.vocab_size()
+        vs_info["bm25"] = await sparse_encoder.stats_snapshot()
     except Exception as e:  # noqa: BLE001
-        vs_info["bm25_vocab_error"] = str(e)
+        vs_info["bm25_error"] = str(e)
 
     async def _safe(fn):
         try:

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -10,7 +10,7 @@ import logging
 
 from app.config import settings
 from app.db.postgres import close_pool, init_db
-from app.services import delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker
+from app.services import delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker, sparse_encoder
 from app.services.git_service import GitService
 from app.services.vector_store import get_vector_store
 
@@ -54,7 +54,13 @@ def start_workers() -> None:
     embed_worker.start()
     delete_worker.start()
     external_git_poller.start()
-    started = ["embed_worker", "delete_worker", "external_git_poller"]
+    # BM25 corpus stats (total_docs, avgdl, per-term df) only become
+    # non-degenerate after `recompute_stats()` runs. The refresher fires
+    # once at startup and then on a configurable cadence so the sparse
+    # leg of hybrid search isn't silently degraded on fresh installs or
+    # after long periods without manual init.
+    sparse_encoder.start_stats_refresher(settings.bm25_recompute_interval_secs)
+    started = ["embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher"]
     # s3_delete_worker drains s3_delete_outbox into S3 deletes. Only
     # makes sense when S3 is configured; otherwise file uploads are
     # disabled altogether and the outbox stays empty forever.
@@ -90,6 +96,7 @@ async def stop_workers() -> None:
     await s3_delete_worker.stop()
     await delete_worker.stop()
     await embed_worker.stop()
+    await sparse_encoder.stop_stats_refresher()
 
 
 async def shutdown_storage() -> None:

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -387,3 +387,97 @@ async def vocab_size() -> int:
     async with pool.acquire() as conn:
         n = await conn.fetchval("SELECT COUNT(*) FROM bm25_vocab")
     return int(n or 0)
+
+
+# ── Stats refresher background task ───────────────────────────────
+#
+# `recompute_stats()` rebuilds bm25_stats(total_docs, avgdl) and
+# bm25_vocab.df from the live chunks corpus. Without it the encoder
+# falls back to total_docs=0 (encode_query returns uniform 1.0 weights),
+# which degrades the sparse leg of hybrid search — silently. The
+# refresher runs the recompute on startup so a fresh install isn't
+# stuck at zero, then on a fixed cadence so a long-running deploy
+# stays in sync as docs are added/removed/updated.
+
+import asyncio  # noqa: E402  (placed here so the module's surface above stays import-light)
+
+_refresher_task: asyncio.Task | None = None
+_refresher_stop: asyncio.Event | None = None
+
+
+async def _refresher_loop(interval_secs: int) -> None:
+    """Run recompute_stats on startup, then every interval_secs."""
+    # First pass — fire as soon as we start. Fresh installs (and any
+    # deploy where recompute hasn't run) need stats populated before
+    # the first query lands.
+    try:
+        await recompute_stats()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("BM25 stats refresh failed at startup: %s", e)
+
+    while True:
+        try:
+            assert _refresher_stop is not None
+            await asyncio.wait_for(_refresher_stop.wait(), timeout=interval_secs)
+            return  # stop signalled
+        except asyncio.TimeoutError:
+            pass
+        try:
+            await recompute_stats()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("BM25 stats refresh failed: %s", e)
+
+
+def start_stats_refresher(interval_secs: int = 1800) -> None:
+    """Launch the periodic stats refresher. Idempotent."""
+    global _refresher_task, _refresher_stop
+    if _refresher_task and not _refresher_task.done():
+        return
+    _refresher_stop = asyncio.Event()
+    _refresher_task = asyncio.create_task(
+        _refresher_loop(interval_secs), name="bm25_stats_refresher",
+    )
+
+
+async def stop_stats_refresher() -> None:
+    """Signal stop and await the task. Safe to call when not started."""
+    global _refresher_task, _refresher_stop
+    if _refresher_stop is not None:
+        _refresher_stop.set()
+    if _refresher_task is not None:
+        try:
+            await _refresher_task
+        except asyncio.CancelledError:
+            pass
+    _refresher_task = None
+    _refresher_stop = None
+
+
+async def stats_snapshot() -> dict:
+    """Operator-facing snapshot of BM25 corpus stats. Surfaced by /health
+    so a stuck refresher (total_docs=0 while chunks exist) is visible."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT total_docs, avgdl, tokenizer_name, tokenizer_version, updated_at
+              FROM bm25_stats WHERE id = 1
+            """
+        )
+        vocab = await conn.fetchval("SELECT COUNT(*) FROM bm25_vocab")
+    if not row:
+        return {
+            "total_docs": 0, "avgdl": 0.0,
+            "tokenizer": "kiwi@0",
+            "vocab_size": int(vocab or 0),
+            "last_recomputed_at": None,
+        }
+    return {
+        "total_docs": int(row["total_docs"] or 0),
+        "avgdl": float(row["avgdl"] or 0.0),
+        "tokenizer": f"{row['tokenizer_name']}@{row['tokenizer_version']}",
+        "vocab_size": int(vocab or 0),
+        "last_recomputed_at": (
+            row["updated_at"].isoformat() if row["updated_at"] else None
+        ),
+    }


### PR DESCRIPTION
## Summary

`recompute_stats()` rebuilds `bm25_stats(total_docs, avgdl)` plus per-term `bm25_vocab.df` from the live chunks corpus. Until now it was only callable from a one-off init script — nothing in the runtime invoked it. On a fresh install or any deploy where the script hadn't been run, every search query hit `total_docs = 0` and the sparse leg of hybrid retrieval degenerated to uniform-weight nonsense.

## Changes

- `sparse_encoder.start_stats_refresher()` / `stop_stats_refresher()` — small refresher task; fires once at startup, then every `bm25_recompute_interval_secs` (default 30 min).
- `lifecycle.start_workers()` / `stop_workers()` — wire the refresher in alongside the other backfill workers.
- `config.bm25_recompute_interval_secs: 1800` — tunable cadence.
- `sparse_encoder.stats_snapshot()` — operator-facing snapshot.
- `/health` — new `vector_store.bm25` block: `{total_docs, avgdl, tokenizer, vocab_size, last_recomputed_at}`. Replaces the bare `bm25_vocab_size` reading which was misleading when stats hadn't been computed.

## Verification

Local (against a DB where `recompute_stats` had never run):
- before: `bm25_stats.total_docs = 0, avgdl = 0`, every `bm25_vocab.df = 0`
- after startup tick: `total_docs = 215, avgdl = 51.96, vocab_size = 305`
- backend log: `BM25 stats recomputed: total_docs=215 avgdl=51.96 vocab_size=262`

## Test plan
- [x] Local mcp_e2e (no regression on existing flow)
- [x] `/health` returns the new bm25 block with non-zero values once the refresher ticks
- [ ] Prod deploy + verify `/health` bm25 block populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)