### PR TITLE
fix(frontend): URL-encode doc path on search + publications result links

### DIFF
--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -122,7 +122,10 @@ export default function PublicationsPage() {
     if (!name || !pub.resource_uri) return `/vault/${name ?? ""}`;
     if (pub.resource_type === "document") {
       const docPath = pub.resource_uri.split("/doc/")[1];
-      return docPath ? `/vault/${name}/doc/${docPath}` : `/vault/${name}`;
+      // URL-encode the path so a hierarchical doc like
+      // `incidents/foo.md` survives as a single React Router param
+      // instead of being split at the embedded `/`.
+      return docPath ? `/vault/${name}/doc/${encodeURIComponent(docPath)}` : `/vault/${name}`;
     }
     if (pub.resource_type === "file") {
       const fileId = pub.resource_uri.split("/file/")[1];

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -36,9 +36,11 @@ function resultHref(r: DenseResult): string {
     const fileId = r.uri.split("/file/")[1] || "";
     return `/vault/${r.vault}/file/${fileId}`;
   }
-  // document URI tail is the path.
+  // document URI tail is the path. URL-encode it so a hierarchical
+  // doc path like `incidents/foo.md` survives as a single React Router
+  // param instead of being split at the embedded `/`.
   const docPath = r.uri.split("/doc/")[1] || r.path;
-  return `/vault/${r.vault}/doc/${docPath}`;
+  return `/vault/${r.vault}/doc/${encodeURIComponent(docPath)}`;
 }
 
 const TYPE_META: Record<
@@ -371,7 +373,7 @@ export default function SearchPage() {
             {literalResults.map((r, i) => (
               <li key={r.uri}>
                 <Link
-                  to={`/vault/${r.vault}/doc/${r.uri.split("/doc/")[1] || r.path}`}
+                  to={`/vault/${r.vault}/doc/${encodeURIComponent(r.uri.split("/doc/")[1] || r.path)}`}
                   className="block px-5 py-4 group hover:bg-surface-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
                 >
                   <div className="grid grid-cols-[32px_1fr_60px] gap-4 items-baseline">


### PR DESCRIPTION
## Summary

Search results and publications list both built \`/vault/<v>/doc/<path>\` URLs by splicing the doc path straight from the canonical URI tail. For a hierarchical path like \`incidents/foo.md\` the embedded \`/\` collided with React Router's segment delimiter, leaving the DocumentPage match short on segments and the page failing to load.

Reproducible from the user report: opening the same doc from the file tree (which already encoded the path) worked; opening it from a search hit landed at a broken URL.

## Changes
- \`frontend/src/pages/search.tsx\` — encode in \`resultHref()\` and in the inline literal-results link.
- \`frontend/src/pages/publications.tsx\` — encode in \`resourceHref()\` for the document case.

File links already use UUIDs so they were unaffected; table links are the table name and already encode (vault page, document inline links, tree-route helpers).

## Test plan
- [x] frontend build clean
- [x] frontend tests 150/150
- [ ] Verify in prod after deploy: search hit on a doc with \`/\` in the path lands at \`/vault/<v>/doc/<encoded>\` and renders, matching the working tree-click flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)