### PR TITLE
fix(git): make _commit_via_clone independent of process cwd

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -525,12 +525,28 @@ class GitService:
         """Legacy clone/push path, used only for the very first commit on
         an empty bare repo (before any branch exists — worktree add can't
         attach without a branch). One-shot cost at vault creation.
+
+        GitPython's ``Repo.clone_from`` calls ``os.getcwd()`` internally
+        to bootstrap the Git wrapper. If a previous call left the
+        process working directory pointing at a now-deleted
+        ``TemporaryDirectory``, that getcwd raises ``FileNotFoundError``
+        and every subsequent vault-creation request 500s. Use plain
+        ``subprocess`` with an explicit ``cwd`` so the call never reads
+        the process cwd.
         """
+        import subprocess
         import tempfile
         bare_path = self._bare_path(vault_name)
         author = Actor(author_name, author_email)
-        with tempfile.TemporaryDirectory() as tmp:
-            work_repo = Repo.clone_from(str(bare_path), tmp)
+        # Stable parent for the tmp dir so we don't depend on the
+        # process cwd to resolve a relative name. ``storage_path``
+        # always exists on a healthy deploy.
+        with tempfile.TemporaryDirectory(dir=str(self.storage_path)) as tmp:
+            subprocess.run(
+                ["git", "clone", "--quiet", str(bare_path), tmp],
+                check=True, cwd=tmp,
+            )
+            work_repo = Repo(tmp)
             full_path = Path(tmp) / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(content, encoding="utf-8")


### PR DESCRIPTION
## Summary

GitPython's `Repo.clone_from()` reads `os.getcwd()` internally to bootstrap its Git wrapper. If a previous `tempfile.TemporaryDirectory` session left the process cwd pointing at a now-deleted directory (a race we've hit in practice on backend cold starts and right after rollouts), every subsequent vault-creation request raises `FileNotFoundError: [Errno 2] No such file or directory`, and the backend stays broken until restart.

Replace the GitPython clone with a direct `subprocess.run(["git", "clone", ...], cwd=tmp)`, and anchor the TemporaryDirectory under `self.storage_path` instead of the OS default so even tmp-dir creation doesn't depend on the process cwd. The resulting work repo is still opened via GitPython for index ops, which read from the explicit work-tree path and don't touch cwd.

## Symptom in prod
First vault creation after rollout sometimes worked, then a later one tripped the cwd race; every vault create after that 500'd until the backend was rolled.

mcp_e2e showed up to 5 cascading failures (`Create lifecycle vault`, `akb_history`, `akb_diff`, `Writer write`, `Public write`) because the suite creates a fresh vault mid-test.

## Test plan
- [x] Local mcp_e2e — 76 / 0
- [ ] Prod deploy + prod mcp_e2e — confirm no cascading failures across consecutive vault creations

🤖 Generated with [Claude Code](https://claude.com/claude-code)