### PR TITLE
fix(security): enforce vault ACL on REST /drill-down

### DIFF
--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.api.deps import get_current_user
 from app.models.document import SearchResponse
+from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
 from app.services.search_service import SearchService
 from app.services.uri_service import parse_uri
@@ -39,6 +40,10 @@ async def drill_down(
     if parsed is None or parsed[1] != "doc":
         raise HTTPException(status_code=400, detail=f"Expected a doc URI, got {uri!r}")
     vault, _rtype, doc_path = parsed
+    # MCP `akb_drill_down` enforces vault ACL via check_vault_access; the
+    # REST entry-point used to skip it, letting any authenticated user
+    # read chunk content from any vault they don't belong to.
+    await check_vault_access(user.user_id, vault, required_role="reader")
     sections = await search_service.drill_down(vault, doc_path, section)
     return {"uri": uri, "sections": sections}
 


### PR DESCRIPTION
## Summary

The MCP \`akb_drill_down\` handler runs through \`check_vault_access\`, but the REST entry-point \`/api/v1/drill-down\` skipped that check. Any authenticated user could read full chunk content from any vault they didn't belong to, just by knowing the doc URI.

## Repro

Created two users (Alice, Bob); Alice put a private vault with a doc body containing a marker phrase; Bob (no role on that vault) called:

\`\`\`
GET /api/v1/drill-down?uri=akb://<alice-vault>/doc/<path>
Authorization: Bearer <bob's PAT>
\`\`\`

Response: full chunk content including the marker phrase.

Same call via MCP \`akb_drill_down\` correctly rejected with \`Requires 'reader' role\`.

## Fix

Call \`check_vault_access(user.user_id, vault, required_role="reader")\` in the REST handler before invoking \`search_service.drill_down\`. After fix, repro returns \`{"error": "Requires 'reader' role on vault '<vault>'"}\`.

## Test plan
- [x] Local repro confirms blocked after fix
- [x] MCP path still works for legitimate user
- [x] mcp_e2e 76/0
- [x] security_edge 54/0
- [ ] Prod deploy + post-deploy verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)