### PR TITLE
fix(frontend): match file by URI tail on the file page

### DIFF
--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -4,7 +4,7 @@ import { Download, File } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface FileInfo {
-  id: string;
+  uri: string;
   name: string;
   collection?: string;
   description?: string;
@@ -27,7 +27,13 @@ export default function FilePage() {
     fetch(`/api/v1/files/${vault}`, { headers: { Authorization: `Bearer ${t}` } })
       .then((r) => r.json())
       .then((d) => {
-        const found = (d.items || []).find((x: any) => x.id === fileId);
+        // Backend rows carry a canonical `uri` (akb://{vault}/file/{id}) and
+        // no separate `id` field after the URI-canonical refactor. Match by
+        // the tail of `/file/` so this page survives `id` ever being dropped.
+        const found = (d.items || []).find((x: any) => {
+          const tail = (x.uri ?? "").split("/file/")[1];
+          return tail === fileId;
+        });
         if (found) setInfo(found);
         else setError("File not found in vault");
       })


### PR DESCRIPTION
## Summary

\`/api/v1/files/{vault}\` carries each row's canonical \`uri\` (\`akb://{vault}/file/{id}\`) since the URI-canonical refactor, but \`FilePage\` was still doing \`x.id === fileId\`. The match always missed and the page showed "FILE NOT FOUND IN VAULT" even when the file existed and was downloadable.

## Repro

Open any vault containing a file, click into it from the sidebar — file page shows "File not found" but the Download button on the inline-preview-pending card still works (proof the file itself is fine, only the metadata lookup was broken).

## Fix

Extract the tail of \`/file/\` from the row's \`uri\` and compare that to the URL param. Survives \`id\` ever being dropped from the response too.

## Test plan
- [x] frontend build clean
- [x] frontend tests 150/150
- [ ] Verify in on-prem after deploy: open file page from sidebar — metadata renders + Download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)