### PR TITLE
refactor: review followups — shared helpers + BM25 cadence + dead-comment cleanup

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -128,11 +128,13 @@ class Settings(BaseModel):
     bm25_b: float = 0.75
     # How often to recompute `bm25_stats(total_docs, avgdl)` + per-term
     # df from the live chunks corpus. The recompute also runs once at
-    # startup, so this controls the steady-state cadence. Lower = stats
-    # track new docs faster (better sparse ranking for fresh content);
-    # higher = less work on the DB. 30 min is a safe default for a
-    # mixed read/write workload.
-    bm25_recompute_interval_secs: int = 1800
+    # startup, so this controls the steady-state cadence. recompute_stats
+    # tokenizes every chunk and gets expensive on large corpora; the
+    # refresher skips ticks when the chunk count hasn't moved (see
+    # `_should_recompute` in sparse_encoder), so an aggressive interval
+    # is cheap when nothing's changing. 6 h matches the slow drift of
+    # avgdl/df on a steady-state corpus.
+    bm25_recompute_interval_secs: int = 21600
 
     # Event stream — optional Redis Streams fanout. PG outbox (`events`
     # table) is always the source of truth; when redis_url is set the

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -62,6 +62,15 @@ class DocumentRepository:
     # that class of bug.
     _MATCH_WHERE = "(d.id::text = $2 OR d.path = $2)"
 
+    @staticmethod
+    def match_clause(param_index: int, alias: str = "d") -> str:
+        """Doc lookup predicate against `<alias>.id` OR `<alias>.path`,
+        parameter-positional so callers can compose the clause inside
+        a larger query with its own placeholder numbering. Mirrors
+        `_MATCH_WHERE` so a single source defines the substring-match
+        ban — adding new lookup arms here propagates to every caller."""
+        return f"({alias}.id::text = ${param_index} OR {alias}.path = ${param_index})"
+
     async def find_by_ref(self, vault_id: uuid.UUID, ref: str) -> dict | None:
         """Find document by UUID or exact path."""
         async with self.pool.acquire() as conn:

--- a/backend/app/services/_backfill.py
+++ b/backend/app/services/_backfill.py
@@ -42,9 +42,15 @@ class BackfillRunner:
     graceful stop.
     """
 
-    def __init__(self, name: str, process_once: Callable[[], Awaitable[int]]):
+    def __init__(
+        self,
+        name: str,
+        process_once: Callable[[], Awaitable[int]],
+        idle_secs: int = IDLE_INTERVAL_SECS,
+    ):
         self._name = name
         self._process_once = process_once
+        self._idle_secs = idle_secs
         self._task: Optional[asyncio.Task] = None
         self._stop_event: Optional[asyncio.Event] = None
         self._log = logging.getLogger(f"akb.{name}")
@@ -69,7 +75,7 @@ class BackfillRunner:
     async def _loop(self) -> None:
         assert self._stop_event is not None
         self._log.info("%s loop started (idle=%ds, max_retries=%d)",
-                       self._name, IDLE_INTERVAL_SECS, MAX_RETRIES)
+                       self._name, self._idle_secs, MAX_RETRIES)
         while not self._stop_event.is_set():
             try:
                 done = await self._process_once()
@@ -79,7 +85,7 @@ class BackfillRunner:
 
             if done == 0:
                 try:
-                    await asyncio.wait_for(self._stop_event.wait(), timeout=IDLE_INTERVAL_SECS)
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=self._idle_secs)
                 except asyncio.TimeoutError:
                     pass
             else:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -612,11 +612,9 @@ class DocumentService:
                         "path": file_path,
                     },
                 )
-                # Doc row delete inside the same TX. Previously this ran
-                # on a separate connection — a crash between the cascade
-                # commit and the row delete left an orphan documents row
-                # (no chunks/edges/publications). Recovery was possible
-                # via retry but the inconsistency was visible.
+                # Doc row delete must share the cascade TX so a crash
+                # between cascade commit and row delete can't leave an
+                # orphan `documents` row with no chunks/edges/publications.
                 await doc_repo.delete(pg_doc_id, conn=conn)
 
         if collection_id:

--- a/backend/app/services/index_service.py
+++ b/backend/app/services/index_service.py
@@ -49,6 +49,25 @@ OVERLAP = 200
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
 
+# Keys emitted by build_doc_metadata_header / build_table_chunk /
+# build_file_chunk. `strip_chunk_metadata_header` (search_service.py)
+# regex-matches the same set on the way out so the enrichment doesn't
+# leak into client-facing chunk content. Keep both in sync — adding a
+# new key here without updating the strip regex causes that key to
+# show up in drill_down / search / grep output.
+CHUNK_HEADER_KEYS: tuple[str, ...] = (
+    "TITLE",
+    "SUMMARY",
+    "TAGS",
+    "PATH",
+    "TYPE",
+    "VAULT",
+    "MIME",
+    "SIZE",
+    "DESCRIPTION",
+)
+
+
 def build_doc_metadata_header(
     *,
     vault_name: str,

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -584,21 +584,11 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
          several matches — but the suffix is anchored at `/`, so
          `api.md` cannot match `funapi.md`).
     """
-    # By UUID first — cheapest and unambiguous.
-    try:
-        uid = uuid.UUID(ref)
-        row = await conn.fetchrow(
-            "SELECT id FROM documents WHERE vault_id = $1 AND id = $2",
-            vault_id, uid,
-        )
-        if row:
-            return row["id"]
-    except ValueError:
-        pass
-
-    # Exact path.
+    # UUID + exact-path arms share the same predicate as `find_by_ref`
+    # / `drill_down` — keep the substring-match ban centralised.
+    from app.repositories.document_repo import DocumentRepository
     row = await conn.fetchrow(
-        "SELECT id FROM documents WHERE vault_id = $1 AND path = $2",
+        f"SELECT id FROM documents d WHERE vault_id = $1 AND {DocumentRepository.match_clause(2)}",
         vault_id, ref,
     )
     if row:

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -26,6 +26,7 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError, NotFoundError
 from app.services import file_service, table_service
 from app.services.document_service import DocumentService
+from app.services.uri_service import parse_uri
 
 logger = logging.getLogger("akb.publications")
 
@@ -269,8 +270,10 @@ async def create_publication(
             # lands first and delete cleans it, or delete commits first
             # and we abort with ResourceVanished.
             if resource_type == ResourceType.DOCUMENT and resource_uri:
-                # Doc resource_uri form: akb://{vault}/doc/{path}
-                doc_path_for_check = resource_uri.split("/doc/", 1)[1] if "/doc/" in resource_uri else None
+                parsed = parse_uri(resource_uri)
+                doc_path_for_check = (
+                    parsed[2] if parsed and parsed[1] == "doc" else None
+                )
                 if doc_path_for_check is not None:
                     found = await conn.fetchval(
                         "SELECT 1 FROM documents WHERE vault_id = $1 AND path = $2 FOR SHARE",

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -19,7 +19,7 @@ from app.config import settings
 from app.db.postgres import get_pool
 from app.models.document import SearchResponse, SearchResult
 from app.services import sparse_encoder
-from app.services.index_service import generate_embeddings
+from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.vector_store import get_vector_store
 from app.services.rerank_service import RerankError, rerank
 from app.utils import ensure_dict
@@ -34,10 +34,10 @@ logger = logging.getLogger("akb.search")
 # content is shown to humans or agents. Requiring TWO header lines + a
 # `\n\n` body separator avoids stripping a user paragraph that happens
 # to start with `TITLE: foo`. Table/file chunks are pure-metadata (no
-# body separator) and intentionally do not match.
-_CHUNK_HEADER_KEYS = "TITLE|SUMMARY|TAGS|PATH|TYPE|VAULT|MIME|SIZE|DESCRIPTION"
+# body separator) and intentionally do not match. Keys imported from
+# index_service so adding a new builder field can't silently drift.
 _CHUNK_HEADER_RE = re.compile(
-    rf"\ATITLE:[^\n]*\n(?:(?:{_CHUNK_HEADER_KEYS}):[^\n]*\n)+\n"
+    rf"\ATITLE:[^\n]*\n(?:(?:{'|'.join(CHUNK_HEADER_KEYS)}):[^\n]*\n)+\n"
 )
 
 
@@ -596,13 +596,10 @@ class SearchService:
 
     async def drill_down(self, vault: str, doc_id: str, section: str | None = None) -> list[dict]:
         """Get L3 section-level content for a document."""
+        from app.repositories.document_repo import DocumentRepository
         pool = await get_pool()
         async with pool.acquire() as conn:
-            # Match by UUID, metadata.id (d- prefix), or path substring
-            # Exact path match — same reasoning as `find_by_ref`. The
-            # earlier substring `LIKE '%' || $2 || '%'` arm caused
-            # cross-doc section bleed when paths shared a substring.
-            doc_match = "(d.id::text = $2 OR d.path = $2)"
+            doc_match = DocumentRepository.match_clause(2)
             if section:
                 rows = await conn.fetch(
                     f"""

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -399,58 +399,71 @@ async def vocab_size() -> int:
 # stuck at zero, then on a fixed cadence so a long-running deploy
 # stays in sync as docs are added/removed/updated.
 
-import asyncio  # noqa: E402  (placed here so the module's surface above stays import-light)
+# Skip a tick when the indexable chunk count hasn't moved by this many
+# rows since the last recompute. Tokenizing a 600k-row corpus through
+# Kiwi is minutes of CPU, so an unconditional cadence wastes work on a
+# steady-state vault.
+_BM25_RECOMPUTE_DELTA_THRESHOLD = 50
 
-_refresher_task: asyncio.Task | None = None
-_refresher_stop: asyncio.Event | None = None
+
+async def _should_recompute() -> bool:
+    """True if the chunk count has drifted enough from the stored
+    `total_docs` to warrant a fresh recompute. Cheap COUNT(*) probe."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        live = await conn.fetchval(
+            "SELECT COUNT(*) FROM chunks WHERE content IS NOT NULL"
+        )
+        stored = await conn.fetchval(
+            "SELECT total_docs FROM bm25_stats WHERE id = 1"
+        )
+    return abs(int(live or 0) - int(stored or 0)) >= _BM25_RECOMPUTE_DELTA_THRESHOLD
 
 
-async def _refresher_loop(interval_secs: int) -> None:
-    """Run recompute_stats on startup, then every interval_secs."""
-    # First pass — fire as soon as we start. Fresh installs (and any
-    # deploy where recompute hasn't run) need stats populated before
-    # the first query lands.
-    try:
+async def _refresh_tick() -> int:
+    """One refresher iteration. Returns 0 so `BackfillRunner` always
+    treats us as idle and respects the configured `idle_secs` cadence
+    rather than busy-looping."""
+    if await _should_recompute():
         await recompute_stats()
-    except Exception as e:  # noqa: BLE001
-        logger.warning("BM25 stats refresh failed at startup: %s", e)
+    return 0
 
-    while True:
-        try:
-            assert _refresher_stop is not None
-            await asyncio.wait_for(_refresher_stop.wait(), timeout=interval_secs)
-            return  # stop signalled
-        except asyncio.TimeoutError:
-            pass
-        try:
-            await recompute_stats()
-        except Exception as e:  # noqa: BLE001
-            logger.warning("BM25 stats refresh failed: %s", e)
+
+from app.services._backfill import BackfillRunner  # noqa: E402
+
+_refresher = BackfillRunner("bm25_stats_refresher", _refresh_tick, idle_secs=1)
 
 
 def start_stats_refresher(interval_secs: int = 1800) -> None:
-    """Launch the periodic stats refresher. Idempotent."""
-    global _refresher_task, _refresher_stop
-    if _refresher_task and not _refresher_task.done():
-        return
-    _refresher_stop = asyncio.Event()
-    _refresher_task = asyncio.create_task(
-        _refresher_loop(interval_secs), name="bm25_stats_refresher",
+    """Launch the periodic stats refresher. Idempotent.
+
+    Always fires `recompute_stats` once at startup (bypassing the delta
+    gate) so a fresh install isn't stuck at total_docs=0; subsequent
+    ticks honour the gate.
+    """
+    global _refresher
+    _refresher = BackfillRunner(
+        "bm25_stats_refresher", _refresh_tick, idle_secs=interval_secs,
     )
+    # Bootstrap: force one recompute on startup regardless of delta so
+    # a brand-new DB doesn't have to wait `interval_secs` for usable
+    # sparse weights. Wrapped in a task so startup isn't blocked.
+    import asyncio as _asyncio
+    _asyncio.create_task(_bootstrap_recompute(), name="bm25_stats_bootstrap")
+    _refresher.start()
+
+
+async def _bootstrap_recompute() -> None:
+    try:
+        await recompute_stats()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("BM25 bootstrap recompute failed: %s", e)
 
 
 async def stop_stats_refresher() -> None:
-    """Signal stop and await the task. Safe to call when not started."""
-    global _refresher_task, _refresher_stop
-    if _refresher_stop is not None:
-        _refresher_stop.set()
-    if _refresher_task is not None:
-        try:
-            await _refresher_task
-        except asyncio.CancelledError:
-            pass
-    _refresher_task = None
-    _refresher_stop = None
+    """Signal stop and await the runner. Safe to call when not started."""
+    if _refresher is not None:
+        await _refresher.stop()
 
 
 async def stats_snapshot() -> dict:

--- a/frontend/src/hooks/use-vault-tree.ts
+++ b/frontend/src/hooks/use-vault-tree.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { browseVault } from "@/lib/api";
+import { parseFileUri } from "@/lib/uri";
 
 export type NodeKind = "collection" | "document" | "table" | "file";
 
@@ -136,7 +137,7 @@ export function buildTree(items: BrowseItem[]): TreeNode[] {
     // File path uses the URI tail (the file UUID) — the legacy
     // `file_id` browse field is gone after the URI cutover. Fall back
     // to `path` for any defensive case where uri is missing.
-    const fileTail = f.uri ? f.uri.split("/file/")[1] : null;
+    const fileTail = parseFileUri(f.uri)?.id ?? null;
     attachToCollection(
       { kind: "file", name: f.name, path: fileTail || f.path, raw: f },
       f.collection,

--- a/frontend/src/lib/uri.ts
+++ b/frontend/src/lib/uri.ts
@@ -1,0 +1,34 @@
+// Parsing helpers for the canonical `akb://{vault}/{type}/{identifier}`
+// URI scheme. Backend `app/services/uri_service.py` has the matching
+// Python parser — keep both in sync.
+//
+// Why a regex instead of `.split("/doc/")`: plain split is wrong when
+// the doc path itself contains `/doc/` (e.g. an `archive/doc/...` doc
+// inside an `archive` collection). The regex anchors on the first
+// `/(doc|table|file)/` after the vault segment.
+
+const URI_RE = /^akb:\/\/([^/]+)\/(doc|table|file)\/(.+)$/;
+
+export interface ParsedUri {
+  vault: string;
+  kind: "doc" | "table" | "file";
+  /** Path for `doc`, table name for `table`, UUID for `file`. */
+  id: string;
+}
+
+export function parseUri(uri: string | null | undefined): ParsedUri | null {
+  if (!uri) return null;
+  const m = uri.match(URI_RE);
+  if (!m) return null;
+  return { vault: m[1], kind: m[2] as ParsedUri["kind"], id: m[3] };
+}
+
+export function parseDocUri(uri: string | null | undefined): ParsedUri | null {
+  const p = parseUri(uri);
+  return p && p.kind === "doc" ? p : null;
+}
+
+export function parseFileUri(uri: string | null | undefined): ParsedUri | null {
+  const p = parseUri(uri);
+  return p && p.kind === "file" ? p : null;
+}

--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Download, File } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { parseFileUri } from "@/lib/uri";
 
 interface FileInfo {
   uri: string;
@@ -28,12 +29,10 @@ export default function FilePage() {
       .then((r) => r.json())
       .then((d) => {
         // Backend rows carry a canonical `uri` (akb://{vault}/file/{id}) and
-        // no separate `id` field after the URI-canonical refactor. Match by
-        // the tail of `/file/` so this page survives `id` ever being dropped.
-        const found = (d.items || []).find((x: any) => {
-          const tail = (x.uri ?? "").split("/file/")[1];
-          return tail === fileId;
-        });
+        // no separate `id` field after the URI-canonical refactor.
+        const found = (d.items || []).find(
+          (x: any) => parseFileUri(x.uri)?.id === fileId,
+        );
         if (found) setInfo(found);
         else setError("File not found in vault");
       })

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -13,6 +13,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { listPublications, deletePublication, getDocument } from "@/lib/api";
+import { parseDocUri, parseFileUri } from "@/lib/uri";
 import { timeAgo } from "@/lib/utils";
 import { EmptyState } from "@/components/empty-state";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -73,12 +74,7 @@ export default function PublicationsPage() {
           if (p.title || p.resource_type !== "document" || !p.resource_uri) {
             return p;
           }
-          // Pull the doc path out of the canonical URI by stripping the
-          // `akb://{vault}/doc/` prefix only — a plain `.split("/doc/")`
-          // would also split on any embedded `/doc/` segment inside the
-          // path (e.g. `archive/doc/legacy.md`), grabbing the wrong tail.
-          const match = p.resource_uri.match(/^akb:\/\/[^/]+\/doc\/(.+)$/);
-          const docPath = match ? match[1] : "";
+          const docPath = parseDocUri(p.resource_uri)?.id;
           if (!docPath) return p;
           try {
             const doc = await getDocument(vault, docPath);
@@ -121,14 +117,13 @@ export default function PublicationsPage() {
   function resourceHref(pub: Publication): string {
     if (!name || !pub.resource_uri) return `/vault/${name ?? ""}`;
     if (pub.resource_type === "document") {
-      const docPath = pub.resource_uri.split("/doc/")[1];
       // URL-encode the path so a hierarchical doc like
-      // `incidents/foo.md` survives as a single React Router param
-      // instead of being split at the embedded `/`.
+      // `incidents/foo.md` survives as a single React Router param.
+      const docPath = parseDocUri(pub.resource_uri)?.id;
       return docPath ? `/vault/${name}/doc/${encodeURIComponent(docPath)}` : `/vault/${name}`;
     }
     if (pub.resource_type === "file") {
-      const fileId = pub.resource_uri.split("/file/")[1];
+      const fileId = parseFileUri(pub.resource_uri)?.id;
       return fileId ? `/vault/${name}/file/${fileId}` : `/vault/${name}`;
     }
     return `/vault/${name}`;

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/empty-state";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { parseUri } from "@/lib/uri";
 
 type Mode = "dense" | "literal";
 type SourceType = "document" | "table" | "file";
@@ -31,15 +32,13 @@ function resultHref(r: DenseResult): string {
     const name = (r.path || "").replace(/^_tables\//, "") || r.title;
     return `/vault/${r.vault}/table/${encodeURIComponent(name)}`;
   }
+  const parsed = parseUri(r.uri);
   if (type === "file") {
-    // file URI tail is the UUID.
-    const fileId = r.uri.split("/file/")[1] || "";
-    return `/vault/${r.vault}/file/${fileId}`;
+    return `/vault/${r.vault}/file/${parsed?.id ?? ""}`;
   }
-  // document URI tail is the path. URL-encode it so a hierarchical
-  // doc path like `incidents/foo.md` survives as a single React Router
-  // param instead of being split at the embedded `/`.
-  const docPath = r.uri.split("/doc/")[1] || r.path;
+  // URL-encode the doc path so a hierarchical id like `incidents/foo.md`
+  // survives as a single React Router param.
+  const docPath = parsed?.id ?? r.path;
   return `/vault/${r.vault}/doc/${encodeURIComponent(docPath)}`;
 }
 
@@ -373,7 +372,7 @@ export default function SearchPage() {
             {literalResults.map((r, i) => (
               <li key={r.uri}>
                 <Link
-                  to={`/vault/${r.vault}/doc/${encodeURIComponent(r.uri.split("/doc/")[1] || r.path)}`}
+                  to={`/vault/${r.vault}/doc/${encodeURIComponent(parseUri(r.uri)?.id ?? r.path)}`}
                   className="block px-5 py-4 group hover:bg-surface-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
                 >
                   <div className="grid grid-cols-[32px_1fr_60px] gap-4 items-baseline">


### PR DESCRIPTION
Six items from the code review of PRs #16–#22:

1. **CHUNK_HEADER_KEYS** — single source of truth for the keys emitted by every chunk builder; strip regex now imports the tuple from `index_service.py`. Adding a new key in one place can't silently break the strip on the other.

2. **\`DocumentRepository.match_clause(param_index, alias='d')\`** — shared SQL predicate. The "id::text = \$X OR path = \$X" doc-lookup predicate was duplicated across \`document_repo._MATCH_WHERE\`, \`search_service.drill_down\`, and \`kg_service._resolve_doc_ref\`. Centralising prevents the substring-match ban (PR #16) from being reintroduced by a fourth caller.

3. **\`parseUri\` / \`parseDocUri\` / \`parseFileUri\`** (\`frontend/src/lib/uri.ts\`) — the \`.split("/doc/")[1]\` / \`.split("/file/")[1]\` pattern was in 5 call sites and one already had a regex fix while a sibling function still used raw split. Migrated \`file.tsx\`, \`search.tsx\` (×2), \`publications.tsx\` (×2), \`use-vault-tree.ts\`. Same fix backend-side in \`publication_service.py\` via the existing \`uri_service.parse_uri\`.

4. **BM25 recompute cadence + delta-skip guard** — 30 min on a 605k-row corpus was tokenising the whole corpus through Kiwi every cycle. Default raised to 21600s (6 h); each tick gated on \`abs(chunks_count - stored_total_docs) >= 50\` so a steady-state vault stops re-tokenising. Bootstrap recompute on startup still fires regardless.

5. **\`BackfillRunner.idle_secs\`** — sparse-stats refresher reimplemented the worker loop pattern. Added an optional \`idle_secs\` parameter (default \`IDLE_INTERVAL_SECS\` — backward-compatible) and routed the refresher through it.

6. **Dead comment narrate** — \`document_service.py\`'s "Previously this ran on a separate connection" comment described the change rather than the invariant; replaced with the actual reason.

## Out of scope
- publications.tsx N+1 (needs backend \`list_publications\` JOIN — separate work)
- file.tsx single-fetch endpoint (vault file counts low enough that list-then-find is cheaper than a new route)
- \`delete_with_conn\` sibling pattern (cosmetic)

## Test plan
- [x] frontend build clean
- [x] frontend tests 150/150
- [x] backend mcp_e2e 76/0
- [x] backend security_e2e 54/0
- [x] BM25 refresher starts with idle=21600s and bootstraps on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)