### PR TITLE
test(e2e): cover the recent backend behavior changes + fix two broken probes

### DIFF
--- a/backend/tests/test_hybrid_chaos_e2e.sh
+++ b/backend/tests/test_hybrid_chaos_e2e.sh
@@ -63,7 +63,7 @@ search() {
 echo ""
 echo "▸ C1. Vocab write race (20 parallel new terms)"
 
-V_BEFORE=$(rcurl "$BASE/health" | jget "d['vector_store']['bm25_vocab_size']")
+V_BEFORE=$(rcurl "$BASE/health" | jget "d['vector_store']['bm25']['vocab_size']")
 for i in $(seq 1 20); do
   HEX=$(python3 -c "import secrets; print(''.join(secrets.choice('abcdef') for _ in range(10)))")
   ( put "Race$i" "RaceTerm$HEX content for race test." >/dev/null ) &
@@ -71,7 +71,7 @@ done
 wait
 sleep "$WAIT"
 
-V_AFTER=$(rcurl "$BASE/health" | jget "d['vector_store']['bm25_vocab_size']")
+V_AFTER=$(rcurl "$BASE/health" | jget "d['vector_store']['bm25']['vocab_size']")
 DIFF=$((V_AFTER - V_BEFORE))
 # Each put adds at least 2 new terms (racetermXXX + content-ish). 20 puts → ~20-40 new terms.
 [ "$DIFF" -ge 20 ] 2>/dev/null && pass "vocab grew by $DIFF under parallel writes" || fail "C1" "only grew by $DIFF"

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -164,6 +164,43 @@ R=$(mcp_call akb_drill_down "{\"uri\":\"$DOC_URI\"}" | mcp_result)
 SECT_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['sections']))" 2>/dev/null)
 [ "$SECT_COUNT" -ge 1 ] 2>/dev/null && pass "akb_drill_down: $SECT_COUNT sections" || fail "akb_drill_down" "expected >=1"
 
+# Chunk header strip — drill_down content must not leak the
+# indexing-time enrichment header (TITLE:/SUMMARY:/TAGS:/PATH:/TYPE:).
+HEADER_LEAKED=$(echo "$R" | python3 -c "
+import sys, json, re
+d = json.load(sys.stdin)
+leaked = any(re.match(r'^(TITLE|SUMMARY|TAGS|PATH|TYPE):', (s.get('content') or ''))
+             for s in d.get('sections', []))
+print(leaked)
+" 2>/dev/null)
+[ "$HEADER_LEAKED" = "False" ] && pass "drill_down strips chunk header" || fail "drill_down header leak" "TITLE:/SUMMARY: visible in response"
+
+# URI trailing-slash normalization — akb_get must resolve the same
+# doc whether the URI has a trailing slash or not.
+R=$(mcp_call akb_get "{\"uri\":\"${DOC_URI}/\"}" | mcp_result)
+GOT_PATH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('path','MISSING'))" 2>/dev/null)
+[ "$GOT_PATH" = "specs/mcp-created-spec.md" ] && pass "akb_get tolerates trailing slash on URI" || fail "trailing slash" "got path: $GOT_PATH"
+
+# find_by_ref must not return a wrong doc when one path is a prefix
+# of another. Create two docs whose paths differ only by suffix and
+# verify each get returns its own content.
+mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"api\",\"content\":\"## v1\\n\\nFIRST_ONLY_TAG\"}" >/dev/null
+mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"api v2\",\"content\":\"## v2\\n\\nSECOND_ONLY_TAG\"}" >/dev/null
+R=$(mcp_call akb_get "{\"uri\":\"akb://$VAULT/doc/specs/api.md\"}" | mcp_result)
+HAS_FIRST=$(echo "$R" | python3 -c "import sys,json; print('FIRST_ONLY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+NO_SECOND=$(echo "$R" | python3 -c "import sys,json; print('SECOND_ONLY_TAG' not in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+[ "$HAS_FIRST" = "True" ] && [ "$NO_SECOND" = "True" ] && pass "find_by_ref: exact path match (api.md ≠ api-v2.md)" || fail "find_by_ref bleed" "wrong-doc match on prefix overlap"
+
+# Versioned akb_get must strip YAML frontmatter from the historical
+# body — older commits stored the `---\n…\n---` block inline.
+HISTORY=$(mcp_call akb_history "{\"uri\":\"$DOC_URI\",\"limit\":1}" | mcp_result)
+COMMIT=$(echo "$HISTORY" | python3 -c "import sys,json; h=json.load(sys.stdin).get('history',[]); print(h[0]['hash'] if h else '')" 2>/dev/null)
+if [ -n "$COMMIT" ]; then
+  R=$(mcp_call akb_get "{\"uri\":\"$DOC_URI\",\"version\":\"$COMMIT\"}" | mcp_result)
+  CLEAN=$(echo "$R" | python3 -c "import sys,json; c=json.load(sys.stdin).get('content',''); print(not c.lstrip().startswith('---'))" 2>/dev/null)
+  [ "$CLEAN" = "True" ] && pass "akb_get(version=…) strips frontmatter" || fail "versioned frontmatter leak" "content starts with ---"
+fi
+
 # ── 6. Relations & Graph ─────────────────────────────────────
 echo ""
 echo "▸ 6. Relations & Graph via MCP"

--- a/backend/tests/test_probes_e2e.sh
+++ b/backend/tests/test_probes_e2e.sh
@@ -50,9 +50,24 @@ echo ""
 echo "▸ 3. /health"
 
 body=$(curl -sk "$BASE_URL/health")
-echo "$body" | grep -q '"embed_backfill"' && pass "embed_backfill present" || fail "embed_backfill" "$body"
 echo "$body" | grep -q '"vector_store"' && pass "vector_store section present" || fail "vector_store section" "$body"
-echo "$body" | grep -q '"bm25_vocab_size"' && pass "bm25_vocab_size present" || fail "bm25_vocab_size" "$body"
+# Indexing queue stats live under `vector_store.backfill` after the
+# embed+sparse+upsert single-stage refactor (no more standalone
+# `embed_backfill` top-level key).
+echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'upsert' in d['vector_store']['backfill'] else 1)" \
+  && pass "vector_store.backfill.upsert present" \
+  || fail "backfill stats" "$body"
+# BM25 stats block — added by the auto-refresh refactor; replaces
+# the flat `bm25_vocab_size` key.
+echo "$body" | python3 -c "
+import sys, json
+bm25 = json.load(sys.stdin)['vector_store'].get('bm25', {})
+required = {'total_docs', 'avgdl', 'tokenizer', 'vocab_size', 'last_recomputed_at'}
+missing = required - set(bm25.keys())
+sys.exit(0 if not missing else 1)
+" && pass "vector_store.bm25 has required keys" || fail "bm25 keys" "$body"
+echo "$body" | grep -q '"metadata_backfill"' && pass "metadata_backfill present" || fail "metadata_backfill" "$body"
+echo "$body" | grep -q '"external_git"' && pass "external_git present" || fail "external_git" "$body"
 
 # ── 4. /livez under concurrent load ──────────────────────────
 # The whole point of splitting /livez out of /health is that it must

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -134,6 +134,17 @@ HAS_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print
 R=$(mcp_as "$PAT1" "$SID1" "akb_graph" "{\"vault\":\"$VAULT1\"}" | mr)
 echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'nodes' in d and 'edges' in d" 2>/dev/null && pass "User1 can call akb_graph on own vault" || fail "Graph self" "$R"
 
+# REST /drill-down — the MCP handler runs through check_vault_access,
+# the REST entry-point used to skip it. Regression guard: any
+# authenticated user (here: user2) must be blocked from a private
+# vault's drill-down even though they have a valid PAT.
+DOC1_TAIL=$(echo "$DOC1_URI" | python3 -c "import sys; u=sys.stdin.read().strip(); print(u.split('/doc/',1)[1] if '/doc/' in u else '')")
+HTTP=$(curl -sS -k -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $PAT2" \
+  --get --data-urlencode "uri=$DOC1_URI" \
+  "$BASE_URL/api/v1/drill-down")
+[ "$HTTP" = "403" ] && pass "User2 blocked from REST /drill-down (403)" || fail "REST drill-down ACL" "got HTTP $HTTP"
+
 # ── 1c. Vault-scoped health ACL ──────────────────────────────
 echo ""
 echo "▸ 1c. Vault-scoped health ACL"


### PR DESCRIPTION
Audit of e2e assertions vs PRs #16–#23 surfaced six behaviors with no regression guard plus two broken probes that still referenced removed fields. Net +6 new assertions and 2 fixes.

## Added (regression guards)

| PR | Assertion |
|---|---|
| #16 | mcp: \`akb_drill_down\` content never leaks the indexing-time \`TITLE:/SUMMARY:/TAGS:/PATH:/TYPE:\` header |
| #16 | mcp: \`akb_get\` resolves URIs with trailing slash (\`…/path.md/\`) |
| #16 | mcp: \`find_by_ref\` returns exact path, never a substring overlap — \`api.md\` + \`api-v2.md\` coexistence check |
| #16 | mcp: versioned \`akb_get(uri, version=…)\` strips YAML frontmatter |
| #20 | security: REST \`/api/v1/drill-down\` returns 403 for a user without vault access |
| #17 | probes: \`/health.vector_store.bm25\` has \`total_docs / avgdl / tokenizer / vocab_size / last_recomputed_at\` |

## Fixed (already broken)
- **probes**: \`embed_backfill\` + \`bm25_vocab_size\` are gone (PR #16/#17 schema flattening). Replaced with the current paths (\`vector_store.backfill.*\`, \`vector_store.bm25.*\`).
- **hybrid_chaos**: same \`bm25_vocab_size\` lookup → \`bm25.vocab_size\`.

## Counts after
- \`mcp_e2e\`:        76 → **80**
- \`security_edge\`:  54 → **55**
- \`probes\`:         11 → **13**

## Test plan
- [x] mcp_e2e — 80/0
- [x] security_edge — 55/0
- [x] probes — 13/0
- [ ] prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)