### PR TITLE
fix(security): reader SQL must be SELECT/WITH only, not just non-mutating

### DIFF
--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -373,6 +373,15 @@ async def execute_sql(
 
         is_select = rewritten.strip().upper().startswith(("SELECT", "WITH"))
 
+        # Read-only access must reject anything that isn't a SELECT or
+        # WITH query. PG's `SET TRANSACTION READ ONLY` blocks data
+        # mutations (INSERT/UPDATE/DELETE/DDL) but transaction-control
+        # statements (SET/BEGIN/RESET/COMMIT/ROLLBACK/SAVEPOINT) and
+        # informational statements (SHOW/EXPLAIN) slip through. None of
+        # them are useful to a reader and several change session state.
+        if read_only and not is_select:
+            return {"error": "Read-only access: only SELECT / WITH queries are allowed."}
+
         try:
             async with conn.transaction():
                 # PostgreSQL enforces read-only: blocks INSERT/UPDATE/DELETE/

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -344,6 +344,17 @@ R=$(mcp_as "$PAT2" "$SID2" "akb_sql" "{\"vault\":\"$VAULT1\",\"sql\":\"DELETE FR
 READER_DELETE_DENIED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d or 'denied' in str(d).lower() or 'Access' in str(d))" 2>/dev/null)
 [ "$READER_DELETE_DENIED" = "True" ] && pass "Reader DELETE blocked" || fail "Reader DELETE" "should be denied: $R"
 
+# Reader must not be able to slip non-SELECT statements past
+# `SET TRANSACTION READ ONLY`. Transaction-control (SET, BEGIN,
+# RESET, ROLLBACK, SAVEPOINT) and informational (SHOW, EXPLAIN)
+# statements all return success at PG level even inside a read-only
+# TX — the service must reject them based on statement type.
+for KW in 'SET TRANSACTION READ WRITE' 'RESET SESSION AUTHORIZATION' 'BEGIN'; do
+  R=$(mcp_as "$PAT2" "$SID2" "akb_sql" "{\"vault\":\"$VAULT1\",\"sql\":\"$KW\"}" | mr)
+  BLOCKED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d)" 2>/dev/null)
+  [ "$BLOCKED" = "True" ] && pass "Reader '$KW' blocked" || fail "Reader '$KW' leak" "$R"
+done
+
 # Upgrade to writer
 mcp_as "$PAT1" "$SID1" "akb_grant" "{\"vault\":\"$VAULT1\",\"user\":\"$USER2\",\"role\":\"writer\"}" >/dev/null 2>&1
 


### PR DESCRIPTION
\`akb_sql\` for a reader wrapped the query in \`SET TRANSACTION READ ONLY\` and relied on PG to reject writes. PG blocks data mutations but does NOT block:

- **transaction control**: \`SET\`, \`BEGIN\`, \`COMMIT\`, \`ROLLBACK\`, \`SAVEPOINT\`, \`RESET\`
- **informational**:       \`SHOW\`, \`EXPLAIN\`

So a reader could fire e.g. \`RESET SESSION AUTHORIZATION\` and the service returned \`{"kind":"table_sql","result":"RESET"}\`.

Exploitability is low (asyncpg hands out a fresh connection per call so the session change doesn't persist), but a reader firing arbitrary non-SELECT statements violates the contract.

## Fix
In read-only mode, reject anything whose first keyword isn't SELECT/WITH before opening the TX. Multi-statement gate unchanged.

## e2e (security_edge: 55 → 58)
Three new assertions — \`SET TRANSACTION READ WRITE\`, \`RESET SESSION AUTHORIZATION\`, \`BEGIN\` all blocked for reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)