### PR TITLE
docs(readme): state the no-built-in-augmentation design philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ explicit relations, and full version history. AKB gives agents a single set of
 tools (`akb_put`, `akb_search`, `akb_browse`, `akb_relations`, …) over a
 backing store of Git bare repos and a PostgreSQL hybrid index.
 
+## Design philosophy
+
+**Core stays small; flexibility comes from extension, not built-in
+automation.** AKB does not ship its own consolidator, summariser, or
+"knowledge gardener" — instead every write emits a structured event to a
+Redis Stream (`akb:events`). Operators wire any external consumer
+(periodic synthesis bot, doc-rot reaper, weekly-digest agent, audit
+trail, …) on top, with no patches to the core. The base contract is a
+read/write store; opinions about *what to do with* the knowledge live
+outside.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Adds a short \"Design philosophy\" section right after \"Why AKB\".

Surfaces an intentional design choice that's currently invisible to new readers: AKB's core is small and does NOT ship a built-in consolidator / summariser / \"knowledge gardener\". Instead every write emits a structured event to a Redis Stream (\`akb:events\`); external bots wire any synthesis / decay / audit behaviour on top, with no core patches.

Positive differentiator vs tools that bundle a consolidator inside the engine — AKB stays as a clean read/write store, opinions about *what to do with* the knowledge live outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)