### PR TITLE
chore: add glama.json (Glama directory claim)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "byongjohnhan-oss"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds top-level `glama.json` so the GitHub OAuth on https://glama.ai/mcp/servers/dnotitia/akb can verify ownership of this org repo.
- Lists `byongjohnhan-oss` as the maintainer; once claimed we'll be able to configure Docker build instructions (point at `deploy/all-in-one/Dockerfile`) and surface review notifications.

## Test plan
- [x] schema validated against https://glama.ai/mcp/schemas/server.json
- [ ] After merge, click "Login with GitHub to claim" on the Glama page and verify the OAuth flow recognises the maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)