### PR TITLE
chore: rename Docker Hub references to dnseahorse/akb

### DIFF
--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -16,16 +16,16 @@
 # Boot flow is supervisord-managed. See entrypoint.sh + supervisord.conf.
 #
 # Build:
-#   docker build -f deploy/all-in-one/Dockerfile -t dnotitia/akb .
+#   docker build -f deploy/all-in-one/Dockerfile -t dnseahorse/akb .
 # Run (MCP introspection works without any external API key):
-#   docker run --rm -p 8080:8080 dnotitia/akb
+#   docker run --rm -p 8080:8080 dnseahorse/akb
 # Run with embeddings/search enabled:
 #   docker run --rm -p 8080:8080 \
 #       -e EMBED_API_KEY=sk-... \
 #       -e EMBED_BASE_URL=https://api.openai.com/v1 \
 #       -e EMBED_MODEL=text-embedding-3-small \
 #       -e EMBED_DIMENSIONS=1536 \
-#       dnotitia/akb
+#       dnseahorse/akb
 
 # ---------- frontend build ----------
 FROM node:22-slim AS frontend-builder

--- a/deploy/all-in-one/README.md
+++ b/deploy/all-in-one/README.md
@@ -10,7 +10,7 @@ backend + frontend behind nginx). Use cases:
 ## Quick start (pre-built image)
 
 ```bash
-docker run --rm -p 8080:8080 dnotitia/akb
+docker run --rm -p 8080:8080 dnseahorse/akb
 ```
 
 | What                   | URL                                                 |
@@ -27,8 +27,8 @@ The container prints the demo `DEMO_PAT` on first boot — grep
 ## Build locally
 
 ```bash
-docker build -f deploy/all-in-one/Dockerfile -t dnotitia/akb .
-docker run --rm -p 8080:8080 dnotitia/akb
+docker build -f deploy/all-in-one/Dockerfile -t dnseahorse/akb .
+docker run --rm -p 8080:8080 dnseahorse/akb
 ```
 
 ## With embeddings + search enabled
@@ -41,7 +41,7 @@ docker run --rm -p 8080:8080 \
     -e EMBED_API_KEY=sk-... \
     -v akb-data:/data \
     -v akb-state:/var/lib/akb \
-    dnotitia/akb
+    dnseahorse/akb
 ```
 
 Mounting `/data` and `/var/lib/akb` makes the demo state (PG cluster,
@@ -54,7 +54,7 @@ Pin the PAT (handy when registering the container as a Glama Connector):
 ```bash
 docker run --rm -p 8080:8080 \
     -e DEMO_PAT=akb_my-fixed-token-for-glama \
-    dnotitia/akb
+    dnseahorse/akb
 ```
 
 Any of `DEMO_USERNAME`, `DEMO_EMAIL`, `DEMO_PASSWORD`, `DEMO_VAULT`,


### PR DESCRIPTION
## Summary
- README / Dockerfile inside `deploy/all-in-one/` previously referenced `dnotitia/akb`, but only `dnseahorse` is reachable from our Docker Hub credentials.
- Renaming so the published image (`dnseahorse/akb:latest` / `:0.1.0`, multi-arch amd64+arm64) and the docs agree.

Image now live: https://hub.docker.com/r/dnseahorse/akb

🤖 Generated with [Claude Code](https://claude.com/claude-code)