### PR TITLE
chore: gitignore /config/*.bak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 
 # AKB config (yaml — single source of runtime config; only .example is tracked)
 /config/*.yaml
+/config/*.bak
 !/config/*.yaml.example
 # Test-bootstrap copy of app.yaml — materialised by backend/tests/conftest.py
 # so `app.config` can import when pytest runs from `backend/` (CWD-relative


### PR DESCRIPTION
## Summary
Pre-cutover left `config/app.yaml.bak` and `config/secret.yaml.bak` in the working tree. Both are local backups of the active runtime config and should never be committed — adding the pattern keeps them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)