### PR TITLE
fix(search): hybrid requires sparse signal — no dense-only fallback for OOV (closes #3)

### DIFF
--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -366,6 +366,15 @@ class SearchService:
             logger.warning("sparse encode_query failed (%s); dense-only path", e)
             sparse_idx, sparse_vals = [], []
 
+        # Hybrid requires a sparse signal. If encode_query succeeded but
+        # returned no vocab terms (OOV / nonsense query) AND the embedding
+        # API succeeded (query_embedding not None), the right answer is [].
+        # Dense-only is a degraded mode for embedding-API outage, not for
+        # OOV — Qwen3-style embeddings sit at ~0.4-0.5 cosine for unrelated
+        # text and would return plausible-looking distractor neighbours.
+        if not sparse_idx and query_embedding is not None:
+            return []
+
         # max(limit*3, 50): same heuristic the legacy native-fusion path used.
         # Driver-agnostic now, but the value transfers cleanly — RRF
         # fusion benefits from generous prefetch in either driver.


### PR DESCRIPTION
## Summary
Restores the gate originally added by `5ede82e` and lost in a later refactor — when `sparse_encoder.encode_query` returns empty (vocab-empty / OOV query) but the embedding API succeeded, return `[]` instead of falling through to dense-only.

Without this gate, Qwen3-style embeddings at ~0.4–0.5 cosine for unrelated text return plausible-looking distractor neighbours for nonsense queries. Particularly bad for agents — hallucinated tool calls would get false-positive distractor chunks instead of cleanly empty back.

## Why one-line caller-side guard
Issue #3 lists two layers; the caller-side guard (preferred, single source of truth) is what's added here. The driver-side defensive guard for the dense+sparse branch (when sparse leg returns 0 against candidates) remains a follow-up if we ever observe the failure mode in practice.

## Test plan
- [x] `test_hybrid_search_e2e.sh` — **16/16 pass** with the guard applied
  - test #8 "Blarghnizophorpquix\$RANDOM" → returns 0 (was returning 2 on main)
  - tests #3 (dense), #4 (BM25 en/ko), #6 (reindex), #7 (delete) — all still pass; sparse signal is present and the guard is skipped

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)