### PR TITLE
feat(search): separate returned vs total_matches (closes #35)

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -153,8 +153,21 @@ class SearchResult(BaseModel):
 
 
 class SearchResponse(BaseModel):
-    """Response for akb_search."""
+    """Response for akb_search.
+
+    `returned` is the number of items in `results` (post-limit / post-rerank).
+    `total_matches` is how many unique hits the prefetch window saw before
+    the limit was applied — gives callers a way to distinguish "this is
+    the full set" from "first N of more". When `total_matches > returned`
+    the agent should re-issue with a larger `limit` rather than treating
+    `returned` as the population.
+
+    `total` is kept as a deprecated alias of `returned` for backward
+    compatibility with existing UI / agent prompts.
+    """
 
     query: str
     total: int
+    returned: int = 0
+    total_matches: int = 0
     results: list[SearchResult]

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -180,7 +180,7 @@ class SearchService:
                     candidate_source_ids.extend(str(r["id"]) for r in frows)
 
                 if not candidate_source_ids:
-                    return SearchResponse(query=query, total=0, results=[])
+                    return SearchResponse(query=query, total=0, returned=0, total_matches=0, results=[])
 
         target_unique = (
             max(settings.rerank_prefetch, limit) if settings.rerank_enabled else limit
@@ -212,6 +212,11 @@ class SearchService:
             if len(unique_hits) >= target_unique:
                 break
 
+        # Capture pre-limit count so callers can tell "this is the full
+        # set" from "first N of more" — the limit-as-count confusion was
+        # observed in the KISA RAG PoC (issue #35).
+        total_matches = len(unique_hits)
+
         if settings.rerank_enabled and len(unique_hits) > 1:
             unique_hits = await self._apply_rerank(query, unique_hits)
 
@@ -221,7 +226,14 @@ class SearchService:
         # in the driver-returned order. Keeps document results fully
         # backward-compatible (doc_id == source_id) while adding table/file.
         results = await self._hydrate_hits(unique_hits)
-        return SearchResponse(query=query, total=len(results), results=results)
+        returned = len(results)
+        return SearchResponse(
+            query=query,
+            total=returned,  # deprecated alias of `returned`
+            returned=returned,
+            total_matches=total_matches,
+            results=results,
+        )
 
     async def _hydrate_hits(self, hits: list) -> list[SearchResult]:
         from app.services.index_service import SOURCE_TYPES

--- a/backend/tests/test_hybrid_search_e2e.sh
+++ b/backend/tests/test_hybrid_search_e2e.sh
@@ -20,7 +20,7 @@ VAULT_A="hybrid-a-$(date +%s)"
 VAULT_B="hybrid-b-$(date +%s)"
 # Background workers (embedding + vector indexer) are async; tune this upward
 # if the embedding API is slow.
-INDEX_WAIT="${AKB_HYBRID_INDEX_WAIT:-20}"
+INDEX_WAIT="${AKB_HYBRID_INDEX_WAIT:-40}"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -118,6 +118,11 @@ pass "4 docs seeded"
 
 echo "    waiting ${INDEX_WAIT}s for async embedding + vector-store indexing…"
 sleep "$INDEX_WAIT"
+# Force BM25 stats recompute so the freshly-indexed chunks are reflected
+# in `bm25_stats` (the background refresher only fires when delta >= 50
+# chunks — small-corpus tests never clear that threshold).
+${AKB_RECOMPUTE_CMD:-docker compose exec -T backend python -m scripts.init_bm25_vocab} \
+  >/dev/null 2>&1 || true
 
 search_total() {
   local q=$1 vault=$2
@@ -193,6 +198,8 @@ if [ -n "$GQL_DOC_URI" ]; then
   mcp_call akb_update "{\"uri\":\"$GQL_DOC_URI\",\"content\":\"## Intro\\n\\nGraphQL is a query language. Updated content now mentions Apollo and Relay clients. Federation allows composing services.\",\"message\":\"test re-index\"}" >/dev/null
   echo "    waiting ${INDEX_WAIT}s for re-index…"
   sleep "$INDEX_WAIT"
+  curl -sk -X POST "$BASE_URL/api/v1/search/bm25/recompute" \
+    -H "Authorization: Bearer $JWT" >/dev/null 2>&1
 
   TITLES=$(search_titles "Apollo" "$VAULT_A")
   if echo "$TITLES" | grep -q "GraphQL"; then
@@ -219,6 +226,18 @@ if [ -n "$GQL_DOC_URI" ]; then
     pass "deleted doc is no longer returned"
   fi
 fi
+
+# ── 7b. Response shape: returned vs total_matches (#35) ──────
+# `total` alias kept for back-compat; `returned`/`total_matches` are new.
+R=$(mcp_call akb_search "{\"query\":\"PostgreSQL\",\"vault\":\"$VAULT_A\",\"limit\":2}" | mcp_result)
+RETURNED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('returned'))")
+TOTAL_M=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_matches'))")
+TOTAL=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total'))")
+[ "$RETURNED" = "$TOTAL" ] && pass "returned == legacy total ($RETURNED)" || fail "returned" "returned=$RETURNED total=$TOTAL"
+# total_matches must always be ≥ returned (limit-as-count guarantee).
+[ -n "$TOTAL_M" ] && [ "$TOTAL_M" -ge "$RETURNED" ] 2>/dev/null \
+  && pass "total_matches ($TOTAL_M) >= returned ($RETURNED)" \
+  || fail "total_matches" "got total_matches=$TOTAL_M returned=$RETURNED"
 
 # ── 8. Nonsense query returns 0 ──────────────────────────────
 # Queries with no vocab overlap (random strings, fully OOV tokens) are


### PR DESCRIPTION
## Summary
`akb_search` now distinguishes:
- **`returned`** — items actually in \`results\` after limit + rerank
- **`total_matches`** — unique hits the prefetch window saw before the limit was applied
- **`total`** — deprecated alias of `returned`, kept so existing UI / agent prompts keep working

When `total_matches > returned` the agent should request a larger `limit` instead of treating `returned` as the population (root cause of the KISA RAG PoC q602 "총 10건" answer when 14 existed).

## E2E
`test_hybrid_search_e2e.sh` — 18/18 pass after this change. Three e2e improvements bundled (without them the long-standing BM25 stale-vocab race against the 30-min / 50-chunk background refresher meant the suite was flaky 11/16 on small-corpus runs):
- New assertions verify shape + invariant `total_matches >= returned`
- Setup wait raised 20s → 40s for embed_worker headroom
- After seed + reindex, force BM25 vocab/stats recompute via `docker compose exec backend python -m scripts.init_bm25_vocab` (override with `AKB_RECOMPUTE_CMD=...` for non-compose envs)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)