### PR TITLE
feat(vault_info): embed table schema + sample row + jsonb hint (closes #34)

### DIFF
--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -317,6 +317,8 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
         _q("SELECT 1 FROM vault_external_git WHERE vault_id = $1", vid),
     )
 
+    tables = await _list_tables_with_schema(vault_name, vid) if table_count else []
+
     return {
         "name": vault["name"],
         "description": vault["description"],
@@ -333,10 +335,90 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
         "table_count": table_count,
         "file_count": file_count,
         "edge_count": edge_count,
+        "tables": tables,
         "last_activity": last_doc["updated_at"].isoformat() if last_doc else None,
         "last_active_user": last_doc["created_by"] if last_doc else None,
         "created_at": vault["created_at"].isoformat(),
     }
+
+
+async def _list_tables_with_schema(vault_name: str, vault_id) -> list[dict]:
+    """Return [{name, row_count, columns: [{name, type, example?}]}, …]
+    for every table in `vault_id`.
+
+    Pre-loads schema + sample so agents don't have to run mid-flow
+    `information_schema.columns` lookups (issue #34 KISA RAG PoC pattern —
+    122 such calls observed across 107 queries).
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        registry = await conn.fetch(
+            "SELECT id, name FROM vault_tables WHERE vault_id = $1 ORDER BY name",
+            vault_id,
+        )
+        if not registry:
+            return []
+
+        # All columns for the vault's vt_* tables in one query — use the
+        # canonical sanitizer so hyphenated vault names map to the actual
+        # `vt_<sanitised>__<sanitised>` PG identifiers.
+        from app.repositories.table_data_repo import pg_table_name
+        pg_names = [pg_table_name(vault_name, r["name"]) for r in registry]
+        # Map back PG name → registry short name for output.
+        short_by_pg = {pg_table_name(vault_name, r["name"]): r["name"] for r in registry}
+        col_rows = await conn.fetch(
+            """
+            SELECT c.relname AS table_name, a.attname AS name,
+                   format_type(a.atttypid, a.atttypmod) AS type, a.attnum
+              FROM pg_attribute a
+              JOIN pg_class c ON c.oid = a.attrelid
+             WHERE c.relname = ANY($1::text[])
+               AND a.attnum > 0
+               AND NOT a.attisdropped
+             ORDER BY c.relname, a.attnum
+            """,
+            pg_names,
+        )
+        by_table: dict[str, list[dict]] = {}
+        for row in col_rows:
+            col: dict = {"name": row["name"], "type": row["type"]}
+            if row["type"] == "jsonb":
+                col["search_hint"] = f"{row['name']}::text ILIKE '%X%'"
+            by_table.setdefault(row["table_name"], []).append(col)
+
+        # Row counts + one-row sample (only when row_count > 0).
+        out: list[dict] = []
+        for r in registry:
+            pg_name = pg_table_name(vault_name, r["name"])
+            # Identifier is built from validated vault + table names —
+            # vault_tables.name is constrained by `akb_create_table`
+            # validation, so direct interpolation is safe.
+            row_count = await conn.fetchval(f'SELECT COUNT(*) FROM "{pg_name}"')
+            columns = by_table.get(pg_name, [])
+            if row_count and columns:
+                sample = await conn.fetchrow(f'SELECT * FROM "{pg_name}" LIMIT 1')
+                example_map = dict(sample) if sample else {}
+                for col in columns:
+                    val = example_map.get(col["name"])
+                    if val is not None:
+                        col["example"] = _coerce_example(val)
+            out.append({
+                "name": r["name"],
+                "row_count": row_count,
+                "columns": columns,
+            })
+        return out
+
+
+def _coerce_example(v):
+    """JSON-safe coercion for sample values (UUIDs, dates, jsonb, …)."""
+    if isinstance(v, uuid.UUID):
+        return str(v)
+    if hasattr(v, "isoformat"):
+        return v.isoformat()
+    if isinstance(v, (int, float, str, bool, list, dict)):
+        return v
+    return str(v)
 
 
 # ── Transfer ownership ──────────────────────────────────────

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -338,6 +338,25 @@ R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT SUM(qty) as total_q
 SUM=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['items'][0]['total_qty'])" 2>/dev/null)
 [ "$SUM" = "150" ] && pass "akb_sql SUM=150" || pass "Aggregate responded ($SUM)"
 
+# vault_info now embeds table schema (#34) so agents don't run mid-flow
+# information_schema lookups. Verify columns + row_count + jsonb hint.
+R=$(mcp_call akb_vault_info "{\"vault\":\"$VAULT\"}" | mcp_result)
+TBLS=$(echo "$R" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+tables = d.get('tables') or []
+print(len(tables))
+" 2>/dev/null)
+[ "$TBLS" -ge 1 ] 2>/dev/null && pass "vault_info has tables[] ($TBLS)" || fail "vault_info tables" "got $TBLS"
+
+HAS_COLS=$(echo "$R" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+t = next((x for x in (d.get('tables') or []) if x.get('name') == 'mcp_items'), None)
+print('yes' if t and any(c.get('name')=='product' for c in t.get('columns', [])) else 'no')
+" 2>/dev/null)
+[ "$HAS_COLS" = "yes" ] && pass "vault_info.tables.columns include 'product'" || fail "vault_info columns" "got=$HAS_COLS"
+
 # Wrong column name → fuzzy hint (issue #36)
 R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT * FROM mcp_items WHERE producct = 'Widget'\"}" | mcp_result)
 HINT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hint',''))" 2>/dev/null)


### PR DESCRIPTION
## Summary
`akb_vault_info` now returns a `tables[]` payload — each entry has `row_count`, `columns[]` (name + PG type), and a first-row example value per column. JSONB columns surface a `search_hint` (`<col>::text ILIKE '%X%'`) so agents don't have to guess the cast pattern.

## Why
KISA RAG PoC benchmark recorded **122 mid-flow `information_schema.columns` lookups across 107 queries** (~20% of SQL, ~26% of queries). Each affected query paid ~1700 tokens + 3 round-trips just to discover the column shapes it should have known up front. Embedding the schema in `vault_info` removes that loop at no extra agent-side round-trip.

## Implementation
- One query fetches all columns for the vault's `vt_*` tables via `pg_attribute` / `pg_class` (backend-role read; the `akb_sql` regex sandbox only applies to user-supplied SQL).
- One `COUNT(*) + LIMIT 1` per table for cardinality + sample.
- PG identifiers built via the existing `pg_table_name()` sanitiser so vaults with hyphens (`mcp-e2e-…` → `vt_mcp_e2e_…__t`) resolve.

## E2E
- New assertions in `test_mcp_e2e.sh` (after table create + insert):
  - ✓ `vault_info has tables[]`
  - ✓ `vault_info.tables.columns include 'product'`
- 85/85 pass.

## Sample response (excerpt)
```json
{
  "name": "sqltestvault",
  "tables": [
    {
      "name": "events",
      "row_count": 0,
      "columns": [
        {"name": "event_type", "type": "text"},
        {"name": "payload", "type": "jsonb",
         "search_hint": "payload::text ILIKE '%X%'"}
      ]
    },
    {
      "name": "incidents",
      "row_count": 1,
      "columns": [
        {"name": "ir_number", "type": "text", "example": "IR-001"},
        {"name": "attack_groups", "type": "text", "example": "[\"ShadowNexus\"]"}
      ]
    }
  ]
}
```

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)