### PR TITLE
chore(ci): static-analysis CI (ruff + tsc) + zero-out backend baseline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,44 @@
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-flight runs on the same ref — only the latest PR push matters.
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static:
+    name: Static analysis (ruff + tsc)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Python ─────────────────────────────────────────────────
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          # No cache — the only python dep we need here is ruff,
+          # installed in the next step.
+      - name: Install ruff
+        run: pip install 'ruff>=0.6.0'
+
+      # ── Node / pnpm (for `tsc --noEmit` in scripts/check.sh) ───
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install frontend deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      # ── Single entry point so CI and local pre-commit stay in sync ──
+      - name: Run scripts/check.sh
+        run: bash scripts/check.sh

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -1,7 +1,6 @@
 """REST API routes for vault access management."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.services.auth_service import AuthenticatedUser

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,7 +1,6 @@
 """REST API routes for auth — register, login, PAT management."""
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.exceptions import NotFoundError

--- a/backend/app/api/routes/memory.py
+++ b/backend/app/api/routes/memory.py
@@ -1,7 +1,6 @@
 """REST API routes for agent memory."""
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.services.auth_service import AuthenticatedUser

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -28,7 +28,6 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, Response, StreamingResponse
-from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.config import settings

--- a/backend/app/api/routes/tables.py
+++ b/backend/app/api/routes/tables.py
@@ -1,7 +1,6 @@
 """REST API routes for vault tables (structured data)."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends
 
 from app.api.deps import get_current_user
 from app.services.access_service import check_vault_access

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from app.api.deps import get_current_user
 from app.db.postgres import get_pool
 from app.exceptions import AKBError
 from app.api.routes import access, auth, documents, files, memory, public, search, collections, knowledge, sessions, tables
-from app.services import delete_worker, embed_worker, events_publisher, external_git_poller, metadata_worker
+from app.services import embed_worker, events_publisher, external_git_poller, metadata_worker
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
 from app.services.health import vault_health

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from datetime import datetime
 from typing import Any
 

--- a/backend/app/repositories/vault_repo.py
+++ b/backend/app/repositories/vault_repo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 import asyncpg
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -168,7 +168,7 @@ async def revoke_access(revoker_id: str, vault_name: str, target_username: str) 
         if vault["owner_id"] == target["id"]:
             raise ForbiddenError("Cannot revoke owner's access. Use transfer_ownership instead.")
 
-        result = await conn.execute(
+        await conn.execute(
             "DELETE FROM vault_access WHERE vault_id = $1 AND user_id = $2",
             vault["id"], target["id"],
         )
@@ -364,8 +364,6 @@ async def _list_tables_with_schema(vault_name: str, vault_id) -> list[dict]:
         # `vt_<sanitised>__<sanitised>` PG identifiers.
         from app.repositories.table_data_repo import pg_table_name
         pg_names = [pg_table_name(vault_name, r["name"]) for r in registry]
-        # Map back PG name → registry short name for output.
-        short_by_pg = {pg_table_name(vault_name, r["name"]): r["name"] for r in registry}
         col_rows = await conn.fetch(
             """
             SELECT c.relname AS table_name, a.attname AS name,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -95,7 +95,7 @@ from app.services.index_service import (
 from app.services.kg_service import delete_document_relations, store_document_relations
 from app.services.uri_service import doc_uri, table_uri, file_uri
 from app.repositories import table_data_repo
-from app.utils import ensure_dict, ensure_list
+from app.utils import ensure_list
 
 logger = logging.getLogger("akb.documents")
 
@@ -960,14 +960,13 @@ class DocumentService:
             logger.warning("Template not found: %s", template)
             return
 
-        now = datetime.now(timezone.utc)
         for coll in tmpl.get("collections", []):
             path = coll["path"]
             coll_name = coll.get("name", path)
             guide = coll.get("guide", "")
 
             # Create collection
-            coll_id = await coll_repo.get_or_create(vault_id, path)
+            await coll_repo.get_or_create(vault_id, path)
 
             # Create _guide.md in collection
             if guide:

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -597,7 +597,7 @@ class GitService:
             # Parse commit message for action/summary
             lines = c.message.strip().split("\n")
             subject = lines[0] if lines else ""
-            body_lines = [l.strip() for l in lines[1:] if l.strip()]
+            body_lines = [line.strip() for line in lines[1:] if line.strip()]
 
             meta = {}
             for bl in body_lines:

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import uuid
 
-from app.services import delete_worker, embed_worker, metadata_worker
+from app.services import embed_worker, metadata_worker
 
 
 async def vault_health(vault_id: uuid.UUID) -> dict:

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -19,7 +19,7 @@ import re
 import uuid
 
 from app.db.postgres import get_pool
-from app.services.uri_service import parse_uri, doc_uri, table_uri, file_uri
+from app.services.uri_service import parse_uri, doc_uri
 
 logger = logging.getLogger("akb.graph")
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -12,7 +12,6 @@ import json
 import logging
 from typing import Any
 
-import httpx
 
 from app.config import settings
 from app.services import http_pool

--- a/backend/app/services/metadata_worker.py
+++ b/backend/app/services/metadata_worker.py
@@ -19,8 +19,8 @@ identical contract to `embed_worker`.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
+import uuid  # noqa: F401  — referenced in PEP 563 string annotation
 from datetime import datetime, timedelta, timezone
 
 from app.db.postgres import get_pool

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -22,7 +22,6 @@ from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.vector_store import get_vector_store
 from app.services.rerank_service import RerankError, rerank
-from app.utils import ensure_dict
 
 logger = logging.getLogger("akb.search")
 

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -218,7 +218,8 @@ async def encode_document(text: str) -> tuple[list[int], list[float]]:
     vocab = await get_or_create_term_ids(term_counts.keys())
 
     stats = await load_stats()
-    total_docs = int(stats.get("total_docs") or 0)
+    # total_docs is only needed for query-side IDF (see encode_query); doc
+    # encoding works on TF saturation + dl normalization only.
     avgdl_raw = float(stats.get("avgdl") or 0)
     avgdl = avgdl_raw if avgdl_raw > 0 else 1.0
     k1 = float(stats.get("k1") or settings.bm25_k1)

--- a/backend/mcp_server/http_app.py
+++ b/backend/mcp_server/http_app.py
@@ -14,7 +14,7 @@ import uuid
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import Receive, Scope, Send
 
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -24,15 +24,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import TextContent
 
-from app.config import settings
 from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import NotFoundError
 from app.services.document_service import DocumentService, EditError
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
-from app.services.uri_service import doc_uri, table_uri, file_uri, parse_uri, split_uri
+from app.services.uri_service import doc_uri, parse_uri, split_uri
 from app.services.access_service import (
     check_vault_access, grant_access, revoke_access, list_vault_members,
     list_accessible_vaults, get_vault_info, search_users, transfer_ownership,
@@ -41,12 +40,11 @@ from app.services.access_service import (
 from app.services.auth_service import resolve_token
 from app.services.memory_service import remember, recall, forget
 from app.services import publication_service, table_service
-from app.services.publication_service import parse_expires_in
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.document_repo import DocumentRepository
 
 from mcp_server.tools import TOOLS
-from mcp_server.help import HELP, _resolve_help
+from mcp_server.help import _resolve_help
 from mcp_server.instructions import INSTRUCTIONS
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,5 +41,15 @@ build-backend = "hatchling.build"
 target-version = "py311"
 line-length = 120
 
+[tool.ruff.lint]
+# Default ruleset is `[E, F]`. The three style rules below are routinely
+# the wrong call for this codebase:
+#   E402 — lazy/conditional imports (heavy ML/Kiwi/embedding modules) are
+#          deliberately deferred past the file top to keep import-time
+#          fast and side-effect-free.
+#   E701/E702 — single-line `if x: do_y` and `x = …; y = …` are kept for
+#          tight setup blocks; splitting hurts readability more than it helps.
+ignore = ["E402", "E701", "E702"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/tests/bench/sparse_shape_bench.py
+++ b/backend/tests/bench/sparse_shape_bench.py
@@ -30,7 +30,6 @@ import os
 import random
 import sys
 import time
-import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 from statistics import median

--- a/backend/tests/test_indexable_e2e.py
+++ b/backend/tests/test_indexable_e2e.py
@@ -27,11 +27,10 @@ import uuid
 
 sys.path.insert(0, "/app")
 
-from app.config import settings  # noqa: E402
 from app.db.postgres import get_pool, init_db, close_pool  # noqa: E402
 from app.services.index_service import (  # noqa: E402
-    build_doc_metadata_header, build_table_chunk, build_file_chunk,
-    chunk_markdown, generate_embeddings, write_source_chunks,
+    build_table_chunk, build_file_chunk,
+    generate_embeddings, write_source_chunks,
     delete_table_chunks, delete_file_chunks,
 )
 from app.services.search_service import SearchService  # noqa: E402
@@ -253,12 +252,13 @@ async def t12_delete_table_chunk():
     fake_id = uuid.uuid4()
     # Insert synthetic table chunk then delete, verify
     pool = await get_pool()
-    from app.services.index_service import build_table_chunk, write_source_chunks, delete_table_chunks
+    from app.services.index_service import write_source_chunks
     chunk = build_table_chunk(
         vault_name="_test", name="_e2e_fake_table_",
         description="e2e fake", columns=[{"name": "x", "type": "text"}],
     )
-    embs = await generate_embeddings([chunk.content])
+    # Side-effect call to verify embedding API still answers — discard.
+    await generate_embeddings([chunk.content])
     async with pool.acquire() as conn:
         vault_id = await _get_or_create_test_vault(conn)
         await write_source_chunks(
@@ -293,7 +293,8 @@ async def t13_delete_file_chunk():
         mime_type="application/pdf", size_bytes=100,
         description="e2e fake file",
     )
-    embs = await generate_embeddings([chunk.content])
+    # Side-effect call to verify embedding API still answers — discard.
+    await generate_embeddings([chunk.content])
     async with pool.acquire() as conn:
         vault_id = await _get_or_create_test_vault(conn)
         await write_source_chunks(

--- a/backend/tests/test_mcp_init_unit.py
+++ b/backend/tests/test_mcp_init_unit.py
@@ -11,7 +11,6 @@ We verify:
      server chain which requires kiwipiepy / psycopg / /data/ filesystem).
 """
 import ast
-import textwrap
 from pathlib import Path
 
 from mcp_server.instructions import INSTRUCTIONS

--- a/backend/tests/test_vault_skill_seed_unit.py
+++ b/backend/tests/test_vault_skill_seed_unit.py
@@ -1,8 +1,7 @@
 """Unit test: create_vault seeds overview/vault-skill.md with type=skill."""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.services.document_service import DocumentService, VAULT_SKILL_SEED_TEMPLATE
+from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE
 
 
 def test_seed_template_constant_exists():

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Static-analysis check entry point. Run locally (pre-commit) and from
+# CI on every push / PR. Fails on the first violation so the diff is
+# small enough to fix in one round.
+#
+# Adding a check? Pick the smallest tool that fits and slot it here.
+# Resist adding "warnings-only" steps — they always rot into noise.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+step() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+
+# ─── backend: ruff (lint) ──────────────────────────────────────────
+step "ruff (backend)"
+ruff check backend/
+
+# ─── frontend: tsc --noEmit (type) ────────────────────────────────
+# `frontend/` has its own tsconfig; running tsc from inside the dir
+# picks it up automatically. node_modules must already be installed —
+# CI does `pnpm install --frozen-lockfile` upstream of this script.
+step "tsc (frontend)"
+(cd frontend && npx --no-install tsc --noEmit)
+
+printf '\n\033[1;32mAll checks passed.\033[0m\n'


### PR DESCRIPTION
## Why

Static analysis was effectively un-enforced — `pyproject.toml` had a `[tool.ruff]` stub but no CI invocation, frontend had no linter, no `.github/workflows`, no pre-commit. Code-quality drift slipped past human review.

## What

- **`scripts/check.sh`** — single entry point. `ruff check backend/` + `tsc --noEmit` in frontend. Run locally and from CI.
- **`.github/workflows/check.yml`** — runs `scripts/check.sh` on every push to main + every PR. Cancel-in-flight on the same ref.
- **`backend/pyproject.toml`** — `[tool.ruff.lint] ignore = ["E402","E701","E702"]` (deferred imports + tight one-liners — both deliberate in this codebase).
- **Baseline zero-out** — ruff caught 70 violations. Auto-fix took 38. Remaining handled:
  - F841 × 7 dead locals removed (`result`, `now`, `coll_id`, `total_docs`, `short_by_pg`, `embs` × 2)
  - E741 `l` → `line` in `git_service`
  - F821 missing `import uuid` in `metadata_worker` (quoted PEP 563 annotation under `from __future__ import annotations`)

## Verification
- `ruff check backend/` → 0
- `tsc --noEmit` (frontend) → clean
- `test_mcp_e2e.sh` → 75/75 (auto-fix didn't break runtime)
- `scripts/check.sh` end-to-end → all green

## Deferred (separate follow-ups)
- ESLint / Prettier on the frontend — lock-file change + flat-config setup, its own PR
- E2E in CI — docker-compose runtime; separate workflow
- pre-commit hooks — optional local layer on top of the same script

🤖 Generated with [Claude Code](https://claude.com/claude-code)