### PR TITLE
ci: backend pytest workflow (#49)

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -1,0 +1,41 @@
+name: backend-pytest
+
+# Closes the gap that `check.yml` couldn't: unit tests under
+# `backend/tests/test_*.py` import asyncpg, kiwipiepy, etc., so they
+# need backend runtime deps installed. Lives in its own workflow so
+# the heavy install doesn't slow down the lint/type/vitest gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: backend-pytest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: backend unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install backend (runtime + dev)
+        working-directory: backend
+        run: |
+          pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Run unit tests
+        working-directory: backend
+        # `-k 'not _e2e'` excludes the two e2e files that need a live
+        # backend pod (test_indexable_e2e.py, test_rerank_e2e.py).
+        # Shell e2e suites under tests/*.sh aren't picked up by pytest.
+        run: pytest tests/ -k 'not _e2e' -v --tb=short


### PR DESCRIPTION
## Summary
Closes second half of the test-gate gap. PR #47 added vitest + detect-secrets to `check.yml`, but backend pytest was still uncovered — most tests under `backend/tests/test_*.py` import `asyncpg`/`kiwipiepy`/etc., so they need the full backend runtime.

Separate workflow keeps the heavier pip install + ~2-3min cache miss out of the lint/type gate path.

## Scope
- `pytest tests/ -k 'not _e2e'`
- Excludes `test_indexable_e2e.py` and `test_rerank_e2e.py` (need live backend pod).
- Shell `*_e2e.sh` suites aren't picked up by pytest at all.

## Verification
Local: 21 passed, 40 skipped. Skipped = needs a live PG, which is correct for a unit gate. Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)