### PR TITLE
test(frontend): Playwright selectors + SearchPage + AuthPage coverage

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,14 +1,18 @@
 // SPA smoke E2E. Runs against the docker-compose stack — frontend on
 // :3000, backend on :8000. Covers the happy-path the previous bug
-// classes lived in: signup → vault create → doc put → search hit.
+// classes lived in: signup → land in shell → profile edit round-trip.
 //
-// Failure modes we deliberately want this to catch:
+// Failure modes this should catch:
 //   - Build/serve regression (white page, hydration crash, console errors)
-//   - Layout auth-gate broken (logged-out gets the SPA shell instead of /auth)
+//   - Layout auth-gate broken (logged-out gets SPA shell instead of /auth)
 //   - Profile edit form / save round-trip (PR #43 — settings tab)
-//   - akb_search wired to the backend response (PR #39 — total_matches in UI)
 //
-// Slow tests are out of scope here — fine-grained UX checks live in vitest+RTL.
+// Selector notes (from frontend/src/pages/auth.tsx, settings.tsx):
+//   - Tabs render "Log in" / "Register" — NOT "Sign in/up".
+//   - Submit button text is "Create Account" (register) or
+//     "Enter the Base" (login). During submit it flips to "Signing in…".
+//   - Profile labels are uppercase ("DISPLAY NAME", "EMAIL").
+//   - Save confirmation is the literal string "Saved" (not "saved").
 //
 // Run locally:
 //   docker compose up -d
@@ -21,29 +25,36 @@ const PASS = "test-pass-1234";
 
 test.describe.configure({ mode: "serial" });
 
-test("signup → vault create → put doc → search round-trip", async ({ page }) => {
-  // 1. signup
+test("signup → land in shell → profile edit round-trip", async ({ page }) => {
+  // ── 1. Register ────────────────────────────────────────────
   await page.goto("/auth");
-  await page.getByRole("tab", { name: /sign up/i }).click().catch(() => {});
-  await page.getByLabel(/username/i).fill(USER);
-  await page.getByLabel(/email/i).fill(`${USER}@e2e.test`);
-  await page.getByLabel(/password/i).first().fill(PASS);
-  await page.getByRole("button", { name: /sign up|create account/i }).click();
+  await page.getByRole("tab", { name: /^register$/i }).click();
+  await page.getByLabel("Username").fill(USER);
+  await page.getByLabel("Email").fill(`${USER}@e2e.test`);
+  await page.getByLabel("Password").fill(PASS);
+  await page.getByRole("button", { name: /create account/i }).click();
 
-  // Land in the authenticated shell — the home page link should appear.
-  await expect(page.getByRole("link", { name: /home|new chat|browse/i }).first())
-    .toBeVisible({ timeout: 10_000 });
+  // The authenticated shell sets up nav links — "Home" is the
+  // first NavLink in components/layout.tsx.
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible({
+    timeout: 10_000,
+  });
 
-  // 2. profile tab is editable (PR #43)
+  // ── 2. Profile edit (PR #43 regression guard) ──────────────
   await page.goto("/settings?tab=profile");
-  const displayName = page.getByLabel(/display name/i);
+  const displayName = page.getByLabel("DISPLAY NAME");
   await expect(displayName).toBeEditable();
   await displayName.fill(`${USER} Renamed`);
   await page.getByRole("button", { name: /save profile/i }).click();
-  await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible({
+    timeout: 5_000,
+  });
 });
 
-test("logged-out user redirects to /auth (layout auth gate)", async ({ page, context }) => {
+test("logged-out user redirects to /auth (layout auth gate)", async ({
+  page,
+  context,
+}) => {
   await context.clearCookies();
   await page.addInitScript(() => localStorage.removeItem("akb_token"));
   await page.goto("/settings");

--- a/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
+++ b/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
@@ -1,0 +1,133 @@
+// RTL coverage for AuthPage. Auth is the single funnel — every user
+// arrives via /auth — yet shipped with zero UI tests for the most
+// common failure modes.
+//
+// Guards:
+//   - register submits the right fields to authRegister + then logs in
+//   - login submits to authLogin + stores the token + navigates
+//   - server errors render in the role=alert region
+//   - switching tabs clears the previous error message
+//
+// We mock @/lib/api at the module boundary; the wire-level fetch
+// contract lives in lib/__tests__/api-search-contract.test.ts (and a
+// similar pattern for auth could be added there as it grows).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import AuthPage from "../auth";
+import { authLogin, authRegister, setToken } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  authLogin: vi.fn(),
+  authRegister: vi.fn(),
+  setToken: vi.fn(),
+}));
+
+const mockedLogin = vi.mocked(authLogin);
+const mockedRegister = vi.mocked(authRegister);
+const mockedSetToken = vi.mocked(setToken);
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+afterEach(cleanup);
+beforeEach(() => {
+  mockedLogin.mockReset();
+  mockedRegister.mockReset();
+  mockedSetToken.mockReset();
+  navigate.mockReset();
+});
+
+function renderAuth() {
+  return render(
+    <MemoryRouter initialEntries={["/auth"]}>
+      <AuthPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthPage · login happy path", () => {
+  it("submits username+password, stores token, and navigates to /", async () => {
+    mockedLogin.mockResolvedValue({ token: "tok-xyz" });
+    const u = userEvent.setup();
+    renderAuth();
+    await u.type(screen.getByLabelText("Username"), "alice");
+    await u.type(screen.getByLabelText("Password"), "pw-1234");
+    await u.click(screen.getByRole("button", { name: /enter the base/i }));
+    await waitFor(() =>
+      expect(mockedLogin).toHaveBeenCalledWith("alice", "pw-1234"),
+    );
+    expect(mockedSetToken).toHaveBeenCalledWith("tok-xyz");
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("AuthPage · register flow", () => {
+  it("calls authRegister with (username, email, password, displayName), then logs in", async () => {
+    mockedRegister.mockResolvedValue({});
+    mockedLogin.mockResolvedValue({ token: "tok-new" });
+    const u = userEvent.setup();
+    renderAuth();
+    // Radix TabsTrigger renders as a button — getByText is the
+    // narrowest selector that works in jsdom (Radix's tab role
+    // assignment doesn't surface here consistently).
+    await u.click(screen.getByText("Register"));
+    await u.type(screen.getByLabelText("Username"), "bob");
+    await u.type(screen.getByLabelText("Email"), "bob@x.test");
+    await u.type(screen.getByLabelText("Password"), "pw-1234");
+    await u.click(screen.getByRole("button", { name: /create account/i }));
+    await waitFor(() =>
+      expect(mockedRegister).toHaveBeenCalledWith(
+        "bob",
+        "bob@x.test",
+        "pw-1234",
+        undefined,
+      ),
+    );
+    await waitFor(() =>
+      expect(mockedLogin).toHaveBeenCalledWith("bob", "pw-1234"),
+    );
+    expect(mockedSetToken).toHaveBeenCalledWith("tok-new");
+  });
+});
+
+describe("AuthPage · error surface", () => {
+  it("renders server error in the role=alert region", async () => {
+    mockedLogin.mockResolvedValue({ error: "Bad credentials" });
+    const u = userEvent.setup();
+    renderAuth();
+    await u.type(screen.getByLabelText("Username"), "alice");
+    await u.type(screen.getByLabelText("Password"), "wrong");
+    await u.click(screen.getByRole("button", { name: /enter the base/i }));
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/Bad credentials/);
+    expect(mockedSetToken).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("clears the error message when switching tabs", async () => {
+    mockedLogin.mockResolvedValue({ error: "Bad credentials" });
+    const u = userEvent.setup();
+    renderAuth();
+    await u.type(screen.getByLabelText("Username"), "alice");
+    await u.type(screen.getByLabelText("Password"), "wrong");
+    await u.click(screen.getByRole("button", { name: /enter the base/i }));
+    await screen.findByRole("alert");
+    // Radix TabsTrigger renders as a button — getByText is the
+    // narrowest selector that works in jsdom (Radix's tab role
+    // assignment doesn't surface here consistently).
+    await u.click(screen.getByText("Register"));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
+++ b/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
@@ -1,0 +1,127 @@
+// RTL coverage for SearchPage.
+//
+// Why this file: search.tsx wires the URL (?q / ?mode / ?v) into two
+// different API calls (searchDocs vs grepDocs) and renders two
+// different shapes — and we shipped the returned/total_matches change
+// in PR #39 without any UI-level test for it. These cases catch:
+//   - mode toggle issues a fresh API call and the right shape lands
+//   - literal results render the `[N docs · M matches]` header
+//     (regression guard for total_matches drift)
+//   - an empty query never fires a search
+//
+// Module-level vi.mock of @/lib/api keeps the test fast (no MSW spin-up
+// cost) and lets us assert call args directly. The MSW-level contract
+// test already lives in lib/__tests__/api-search-contract.test.ts.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import SearchPage from "../search";
+import { searchDocs, grepDocs, listVaults } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  searchDocs: vi.fn(),
+  grepDocs: vi.fn(),
+  listVaults: vi.fn(),
+}));
+
+const mockedSearch = vi.mocked(searchDocs);
+const mockedGrep = vi.mocked(grepDocs);
+const mockedListVaults = vi.mocked(listVaults);
+
+afterEach(cleanup);
+beforeEach(() => {
+  mockedSearch.mockReset();
+  mockedGrep.mockReset();
+  mockedListVaults.mockReset();
+  mockedListVaults.mockResolvedValue({ vaults: [] });
+});
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <SearchPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("SearchPage · semantic (dense) mode", () => {
+  it("calls searchDocs on initial render with ?q and renders a hit", async () => {
+    mockedSearch.mockResolvedValue({
+      query: "postgres",
+      total: 1,
+      returned: 1,
+      total_matches: 1,
+      results: [
+        {
+          source_type: "document",
+          uri: "akb://akb/document/abc",
+          vault: "akb",
+          path: "notes/postgres.md",
+          title: "PostgreSQL tuning",
+          score: 0.91,
+        },
+      ],
+    });
+    renderAt("/search?q=postgres");
+    await waitFor(() => expect(mockedSearch).toHaveBeenCalledWith("postgres", undefined));
+    expect(await screen.findByText("PostgreSQL tuning")).toBeTruthy();
+    expect(mockedGrep).not.toHaveBeenCalled();
+  });
+
+  it("does not search when ?q is missing", async () => {
+    renderAt("/search");
+    // Give the effect a tick to misfire.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockedSearch).not.toHaveBeenCalled();
+    expect(mockedGrep).not.toHaveBeenCalled();
+  });
+});
+
+describe("SearchPage · literal mode + counter header (PR #39 regression)", () => {
+  it("renders [N docs · M matches] from grepDocs response", async () => {
+    mockedGrep.mockResolvedValue({
+      query: "TODO",
+      total_docs: 2,
+      total_matches: 7,
+      results: [
+        { uri: "akb://akb/document/a", vault: "akb", path: "a.md", title: "A", matches: [] },
+        { uri: "akb://akb/document/b", vault: "akb", path: "b.md", title: "B", matches: [] },
+      ],
+    });
+    renderAt("/search?q=TODO&mode=literal");
+    expect(await screen.findByText(/2 docs · 7 matches/)).toBeTruthy();
+    expect(mockedSearch).not.toHaveBeenCalled();
+  });
+});
+
+describe("SearchPage · mode toggle re-issues the correct call", () => {
+  it("switches from semantic to literal on button click", async () => {
+    mockedSearch.mockResolvedValue({
+      query: "k8s",
+      total: 0,
+      returned: 0,
+      total_matches: 0,
+      results: [],
+    });
+    mockedGrep.mockResolvedValue({
+      query: "k8s",
+      total_docs: 0,
+      total_matches: 0,
+      results: [],
+    });
+    renderAt("/search?q=k8s");
+    await waitFor(() => expect(mockedSearch).toHaveBeenCalledTimes(1));
+    const u = userEvent.setup();
+    // Two buttons render with text "LITERAL": the mode toggle (with
+    // aria-pressed) and the short-query hint link below. The toggle
+    // is the only one with aria-pressed set.
+    const toggle = screen
+      .getAllByRole("button", { name: "LITERAL" })
+      .find((b) => b.hasAttribute("aria-pressed"));
+    if (!toggle) throw new Error("LITERAL toggle button not found");
+    await u.click(toggle);
+    await waitFor(() => expect(mockedGrep).toHaveBeenCalledWith("k8s", undefined));
+  });
+});


### PR DESCRIPTION
## Summary
Three follow-ups on PR #46.

**1. Playwright smoke selectors**
Sample skeleton in PR #46 had wrong selectors (used "Sign up" / generic labels). Tuned to the real SPA: tabs are "Log in" / "Register", submit is "Create Account" / "Enter the Base", profile labels are uppercase, save toast is literal "Saved".

**2. SearchPage RTL** (`search-mode-and-counters.test.tsx`, 4 cases)
PR #39 shipped the `returned`/`total_matches` split but no UI test exercised it. Now covers:
- semantic search call on initial render with `?q`
- no-search when `?q` is missing
- literal mode `[N docs · M matches]` header
- mode toggle re-issuing the correct API call

**3. AuthPage RTL** (`auth-form-submit-and-error.test.tsx`, 4 cases)
`/auth` is the only entry funnel and had zero tests. Now covers:
- login happy path (token store + navigate)
- register chained into login
- server error rendered in `role=alert`
- tab switch clears the previous error

## Test plan
- [x] `cd frontend && npx vitest run` → 28 files / 169 tests pass
- [ ] `npm run test:e2e` against `docker compose up -d` — selector validation pending live verification

Targets `validate/local-stack-and-frontend-tests` so it merges with PR #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)