### PR TITLE
fix(docker): pnpm --ignore-scripts in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,11 @@ RUN npm install -g pnpm@latest
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+# `--ignore-scripts` skips devDependency postinstall hooks (e.g. msw's
+# service-worker bundle registration). The image only runs the built
+# SPA via nginx — none of those hooks are needed at runtime, and pnpm
+# 10+ otherwise exits non-zero when it sees them.
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
 RUN npx vite build


### PR DESCRIPTION
## Summary
Same root cause as the CI fix in #47, this time inside `frontend/Dockerfile`. pnpm 10+ refuses msw's postinstall and the image build exits non-zero — breaking every deploy (caught when re-deploying to AWS demo just now).

Runtime is just nginx serving the built SPA; no install hooks needed.

## Test plan
- [ ] `docker build frontend/` succeeds locally
- [ ] AWS demo redeploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)