### PR TITLE
fix(grep,graph): drop limit*N prefetch caps that drifted user-facing counts

### DIFF
--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -338,10 +338,20 @@ async def get_graph(
         if resource_uri:
             await _bfs_collect(conn, vault_id, vault, resource_uri, depth, limit, nodes, edge_list)
         else:
+            # Vault-scope full graph. The cap is a visualization safety net
+            # — large graphs are unrenderable client-side — but the old code
+            # used `LIMIT (limit * 3)` *without* an ORDER BY, so PG returned
+            # an arbitrary subset and the result was non-deterministic across
+            # callers and across runs. Pin to `created_at DESC` so the cap
+            # consistently keeps the most recent edges (better UX than
+            # whatever order the heap happened to produce). The same anti-
+            # pattern that bit `grep` (count drifts with WHERE clause because
+            # the cap is tied to `limit`).
             edge_rows = await conn.fetch(
                 """
                 SELECT source_uri, target_uri, source_type, target_type, relation_type
                 FROM edges WHERE vault_id = $1
+                ORDER BY created_at DESC
                 LIMIT $2
                 """,
                 vault_id, limit * 3,

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -501,6 +501,23 @@ class SearchService:
                 idx += 1
 
             where_sql = " AND ".join(conditions)
+            # No prefetch cap. The old `LIMIT (limit * 5)` cap was inherited
+            # from a score-ordered hybrid search path, but `grep` matches with
+            # ILIKE — there is no score, so ORDER + LIMIT was just chopping the
+            # corpus alphabetically. Symptoms reported by users:
+            #   - vault filter gave 13 hits, no filter gave 11 (cap consumed
+            #     by vaults sorted before the real one).
+            #   - within a single vault, adding a `collection` filter raised
+            #     the count (the tighter WHERE shrank the population below
+            #     the cap, so all rows fit again).
+            # Both are the same anti-pattern: a user-facing count (total_docs /
+            # total_matches) that drifted with the WHERE clause because the
+            # cap was tied to `limit`. ILIKE is a full scan either way; the
+            # only thing the cap was buying was a memory safety net. The PG
+            # planner happily streams millions of rows back through asyncpg,
+            # and our largest vault has tens of thousands of chunks — well
+            # within budget. Drop the cap; if a pathological corpus ever
+            # becomes a real concern, gate it on `EXPLAIN` cost instead.
             rows = await conn.fetch(
                 f"""
                 SELECT d.id::text as doc_id, v.name as vault, d.path, d.title,
@@ -511,7 +528,6 @@ class SearchService:
                 JOIN vaults v ON d.vault_id = v.id
                 WHERE {where_sql}
                 ORDER BY v.name, d.path, c.chunk_index
-                LIMIT {int(limit) * 5}
                 """,
                 *params,
             )


### PR DESCRIPTION
## Summary
Same anti-pattern in two places: a user-facing count drifted with the WHERE clause because the SQL prefetch cap was tied to `limit` (a *response* knob, not a *truth* knob).

## grep — `search_service.py`
User reported:
- vault filter → 13 hits, no filter → 11.
- within a single vault, adding `collection` → count went **up**.

Both because `LIMIT (limit * 5) ORDER BY v.name, d.path, c.chunk_index` chopped the corpus alphabetically. Vaults that sorted before the one with the real matches ate the prefetch budget; narrowing WHERE shrank the population below the cap so all rows fit again. ILIKE is a full scan either way — the cap was only a memory net.

**Drop entirely.** PG streams fine; our largest vault has ~tens of thousands of chunks.

## graph — `kg_service.py`
`vault_graph(vault=X)` did `LIMIT (limit * 3)` with **no ORDER BY** → PG returned an arbitrary subset of edges (non-deterministic across calls). Same family of bug.

Kept the cap as a visualization safety net (large graphs are unrenderable client-side) but pinned order to `created_at DESC` so the most recent edges land in the response.

## Test plan
- [x] `bash scripts/check.sh` → all green
- [ ] After deploy: same grep with/without `vault=` returns the same `total_matches`. Adding `collection=` only ever lowers `total_matches`.
- [ ] `akb_graph(vault=X)` returns deterministic edges across calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)