### PR TITLE
feat(eval): add LongMemEval benchmark runner for akb_search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ htmlcov/
 /deploy/k8s/aws-internal/
 /deploy/k8s/aws-demo-internal/
 
+# Benchmark runtime artifacts (NDJSON shards, per-worker logs, smoke
+# outputs). The runner writes here at execution time; nothing under
+# /eval/reports/ belongs in source control.
+/eval/reports/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/eval/longmemeval/.gitignore
+++ b/eval/longmemeval/.gitignore
@@ -1,0 +1,6 @@
+# Local secrets — copy from secret.yaml.example and fill in.
+config/secret.yaml
+
+# Downloaded datasets and NDJSON outputs land elsewhere by default
+# (~/datasets, eval/reports). Add patterns here only if a local
+# convention places them inside this directory.

--- a/eval/longmemeval/README.md
+++ b/eval/longmemeval/README.md
@@ -1,0 +1,407 @@
+# LongMemEval benchmark — AKB runner
+
+Measures `akb_search` retrieval recall on the public
+[`xiaowu0162/longmemeval`](https://huggingface.co/datasets/xiaowu0162/longmemeval)
+`_s` split (500 questions). The goal is to put one honest line —
+`akb-hybrid+rerank` — next to [gbrain-evals](https://github.com/garrytan/gbrain-evals)
+and MemPalace on the same dataset.
+
+Reference lines as of 2026-05-07:
+
+| System                          | R@5    | k | n   | LLM in retrieval | Source |
+|---------------------------------|--------|---|-----|-------------------|--------|
+| gbrain-hybrid                   | 97.60% | 5 | 500 | no  | [gbrain-evals](https://github.com/garrytan/gbrain-evals/blob/main/docs/benchmarks/2026-05-07-longmemeval-s.md) |
+| gbrain-vector                   | 97.40% | 5 | 500 | no  | same |
+| MemPal hybrid+rerank (held-out) | 98.4%  | 5 | 450 | yes | MemPalace |
+| MemPal raw (ChromaDB)           | 96.6%  | 5 | 500 | no  | MemPalace headline |
+| gbrain-keyword (BM25)           | 19.80% | 5 | 500 | no  | gbrain-evals |
+
+AKB posts its own line. The embedding model differs (see
+[Comparability notes](#comparability-notes)), so this is a **stack-level**
+comparison rather than apples-to-apples; the result still pins where AKB's
+production default lands on the same dataset.
+
+---
+
+## Dataset
+
+- **Source**: HuggingFace [`xiaowu0162/longmemeval`](https://huggingface.co/datasets/xiaowu0162/longmemeval),
+  `_s` split — same as gbrain-evals.  The dataset is HF-deprecated but the
+  raw file at `resolve/main/longmemeval_s` is still served and is what
+  gbrain's published numbers were computed against.
+- **Splits**: `_s` (500 questions, ~50 sessions per haystack). `_oracle`
+  (3 sessions/Q) and `_m` (200 sessions/Q) are out of scope here.
+- **Format**: single JSON file (~278MB). Each question has
+  `{question_id, question, question_type, question_date, haystack_dates,
+   haystack_session_ids, haystack_sessions, answer_session_ids, answer}`.
+- **Download**:
+  ```bash
+  mkdir -p ~/datasets/longmemeval
+  curl -Lo ~/datasets/longmemeval/longmemeval_s.json \
+    https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/main/longmemeval_s
+  ```
+
+The cleaned variant ([`xiaowu0162/longmemeval-cleaned`](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned))
+exists but is reserved for a v2 round so first-round numbers stay
+comparable with gbrain.
+
+### Question types (per-type recall reported)
+
+| Type | What it stresses |
+|---|---|
+| `single-session-user` | Answer lives in user turns of one session |
+| `single-session-assistant` | Answer is in assistant turns — user vocabulary ≠ answer vocabulary (BM25 stress) |
+| `single-session-preference` | Indirect statements ("I usually prefer X") |
+| `multi-session` | Evidence spread across multiple sessions |
+| `temporal-reasoning` | Requires "first time", "last time", date comparison |
+| `knowledge-update` | A fact changes over time |
+
+`temporal-reasoning` + `knowledge-update` = 211/500 (42%) need date
+signals; the runner therefore prefixes each rendered session with
+`[Session date: ...]` (see [Adapter mapping](#adapter-mapping)).
+
+### Metrics
+
+- **Primary**: `Recall@K` — top-K results contain at least one of
+  `answer_session_ids`. No LLM judge; cleanly comparable.
+- **Secondary**: per-type Recall@K, p50/p99 client-side query latency,
+  per-question ingest wall-clock.
+- **Abstention (`_abs` suffix, 30/500)**: included in the denominator.
+  All `_abs` questions still have ground truth (`answer_xxx_abs`
+  patterns present in the haystack), so retrieval-side measurement is
+  the same shape as any other question.  The NDJSON `is_abstention`
+  flag lets you re-aggregate excluding `_abs` after the fact.
+- **Non-goal**: QA accuracy. LongMemEval's `evaluate_qa.py` (generation
+  judge) is out of scope; a separate `akb-rag-qa` adapter would address
+  it later.
+
+---
+
+## Stack
+
+Self-contained `docker-compose.yaml`. Coexists with the main `akb` dev
+stack — ports are shifted (`18000`/`19000`/`19001`) and the compose
+project name (`longmemeval`, taken from this directory) keeps volumes
+isolated. `docker compose down -v` resets only `longmemeval_*` volumes;
+your main dev data is untouched.
+
+### Effective config (pinned from the cluster's `akb-app-config`)
+
+| Setting | Value | Note |
+|---|---|---|
+| `vector_store_driver` | `pgvector` | same PG instance, separate `vector_index` schema; visibility lag = 0 |
+| `vector_store_sparse_shape` | `posting` | production-recommended |
+| `embed_model` / `embed_dimensions` | `baai/bge-m3` / `1024` | multilingual, within pgvector HNSW 2000-dim limit |
+| `embed_base_url` | `https://openrouter.ai/api/v1` | |
+| `rerank_enabled` / `rerank_model` | `true` / `cohere/rerank-v3.5` | production default ON |
+| `rerank_base_url` | `https://openrouter.ai/api/v1` | explicit — see [run #3](#known-issues) |
+| `rerank_prefetch` | `30` | RRF top-30 → rerank → top-K |
+| `bm25_k1` / `bm25_b` | `1.5` / `0.75` | standard Lucene values |
+
+`config/app.yaml` is committed because it's part of the benchmark
+definition.  Anything sensitive lives in `config/secret.yaml`
+(gitignored).
+
+### Secrets
+
+Copy `config/secret.yaml.example` → `config/secret.yaml` and fill in:
+
+```yaml
+db_password: akb                            # matches docker-compose hardcoded value
+jwt_secret: <local-only dev string>
+embed_api_key: ${OPENROUTER_API_KEY}        # bge-m3 embedding
+llm_api_key:   ${OPENROUTER_API_KEY}        # SAME key — rerank fallback target
+rerank_api_key: ""                          # leave blank; rerank_service falls back to llm_api_key
+```
+
+**One OpenRouter key is enough.** [rerank_service.py:56](../../backend/app/services/rerank_service.py:56)
+resolves the rerank URL from `rerank_base_url or llm_base_url` and the key
+from `rerank_api_key or llm_api_key`.  OpenRouter routes `/v1/rerank`
+calls to `cohere/rerank-v3.5` — verified live against the cluster's
+backend pod.  Putting a Cohere key under `rerank_api_key` would send a
+Cohere credential to the OpenRouter URL → 401 → backend silently falls
+back to RRF-only output, making the `akb-hybrid+rerank` label a lie.
+
+---
+
+## Setup and smoke test
+
+```bash
+cd eval/longmemeval
+cp config/secret.yaml.example config/secret.yaml
+# edit config/secret.yaml — fill embed_api_key and llm_api_key with the same OpenRouter key
+docker compose up -d --build                  # first run takes a few minutes for backend build
+curl http://localhost:18000/livez             # {"status":"alive"}
+curl http://localhost:18000/readyz            # {"status":"ready", ...}
+
+cd ../..
+python3 eval/longmemeval/run.py \
+  --dataset ~/datasets/longmemeval/longmemeval_s.json \
+  --ndjson eval/reports/smoke.ndjson \
+  --limit 5
+```
+
+Expected smoke output (current baseline): 5/5 OK, ~4 hits, R@5 ≈ 80%,
+~45s per question of indexing wait.
+
+### Reset between full runs
+
+```bash
+cd eval/longmemeval
+docker compose down -v
+docker compose up -d
+```
+
+---
+
+## Adapter mapping
+
+| gbrain-evals abstraction | AKB mapping |
+|---|---|
+| `PGLiteEngine` instance | Per-question temp vault `lme-{normalize(qid)}-{wid}` |
+| `TRUNCATE` between questions | `DELETE /api/v1/vaults/{vault}` → re-create |
+| `importFromContent(slug, body)` | `POST /api/v1/documents` body=`{vault, collection:"chat", title:session_id, content:rendered}` |
+| Rendered session body | `[Session date: ...]\n\nUSER: ...\n\nASSISTANT: ...` (date prefix matters for `temporal-reasoning`/`knowledge-update`) |
+| `slug = "chat/{session_id}"` | `path = "chat/{slugify(session_id)}.md"` — backend `_slugify` lowercases and appends `.md` |
+| `hybridSearch(q, limit)` | `GET /api/v1/search?q=...&vault=...&limit=K` (rerank ON via config) |
+| `uniqSessionIds(results)` | `[r.path.removeprefix("chat/").removesuffix(".md") for r in results]` (path is stabler than title under backend normalization) |
+| Wait for indexing | `GET /health/vault/{vault}` poll until `vector_store.backfill.upsert.pending == 0` (vault-scoped, not global) |
+
+### Adapter scope
+
+Only `akb-hybrid+rerank` (production default) is wired up.  Ablations
+(`akb-hybrid` rerank-off, `akb-keyword` BM25-only, `akb-vector`
+vector-only) are deferred — turning rerank off requires editing
+`app.yaml` and restarting the backend, which we'd only pay for once the
+first numbers say it's worth it.
+
+---
+
+## Runner
+
+### `run.py`
+
+Stdlib-only single file.  No external dependencies — `python3` is
+enough.
+
+```bash
+python3 eval/longmemeval/run.py \
+  --dataset ~/datasets/longmemeval/longmemeval_s.json \
+  --ndjson eval/reports/longmemeval-akb.ndjson \
+  --adapter akb-hybrid+rerank \
+  --top-k 5 \
+  --worker-id 0 --total-workers 1 \
+  [--limit N | --stratify N] [--max-wall-seconds N]
+```
+
+Environment variables:
+
+| Name | Default | Purpose |
+|---|---|---|
+| `AKB_URL` | `http://localhost:18000` | benchmark stack backend (main dev is on `:8000`) |
+| `LONGMEMEVAL_PATH` | — | fallback when `--dataset` is omitted |
+
+### Per-question lifecycle
+
+```
+for q in questions:
+    if (adapter, q.question_id) in resume_set: continue
+
+    vault = f"lme-{normalize(q.question_id)}-{worker_id}"
+    DELETE /vaults/{vault}                  # 404 OK — clear stale state
+    POST /vaults?name={vault}&public_access=none
+
+    try:
+        for s in dedup(q.sessions):         # ~50 sessions, render with date header
+            POST /documents body={vault, collection:"chat", title:s.id, content:s.body, ...}
+    except HTTPError:                       # skip on partial fail
+        DELETE /vaults/{vault}; append_ndjson(status="ingest_error"); continue
+
+    wait_for_indexing(vault)                # poll GET /health/vault/{vault}, pending==0
+    res = GET /search?q=q.question&vault=vault&limit=K
+    retrieved = [strip(r.path) for r in res.results]
+    hit = bool(set(retrieved) & set(q.answer_session_ids))
+    append_ndjson(status="ok", hit_at_k=hit, ...)
+    DELETE /vaults/{vault}
+```
+
+Per-question vault isolation is what lets the runner write to the same
+backend without cross-question interference.
+
+### Auth and cleanup
+
+On startup: `POST /auth/register` → `POST /auth/login` → JWT (no PAT —
+JWT lifetime of 24h covers even the slow full run).
+
+On exit (normal, exception, SIGINT, SIGTERM): `DELETE /my/account`
+cascades through all per-question vaults.  `finally` block plus signal
+handlers — no orphan vaults on Ctrl-C.
+
+### NDJSON output
+
+First line is a `run_meta_start` header (backend git sha, app.yaml sha,
+embed/rerank config) for post-hoc reproducibility.  Each subsequent
+line is one question:
+
+```json
+{"adapter":"akb-hybrid+rerank","question_id":"e47becba",
+ "question_type":"single-session-user","status":"ok",
+ "is_abstention":false,"num_haystack":54,
+ "ground_truth":["answer_280352e9"],
+ "retrieved":["answer_280352e9","sharegpt_xxx_0","ultrachat_yyy", ...],
+ "hit_at_k":true,
+ "ingest_ms":601,"index_wait_ms":43549,"query_ms":964}
+```
+
+Resume key is `(adapter, question_id)` — re-running with the same
+`--ndjson` skips completed questions.
+
+---
+
+## Multi-worker (`batch.sh`)
+
+```bash
+WORKERS=3 LIMIT=10 ./eval/longmemeval/batch.sh         # 3 shards, 10 Q each
+WORKERS=1 WALL=600 ./eval/longmemeval/batch.sh         # 1 worker, 10-min cap
+STRATIFY=5 ./eval/longmemeval/batch.sh                 # 5 per question_type
+```
+
+Each worker writes its own NDJSON shard
+(`reports/longmemeval-akb.shard-{i}of{N}.ndjson`); questions are
+partitioned by `hash(qid) mod N` so a worker always sees the same
+subset across reruns (resume works per-shard).  After workers finish,
+the script aggregates totals + per-type breakdown.  Any non-zero shard
+exit code propagates as `exit 1` so CI sees the failure.
+
+> **Multi-worker (WORKERS > 1) is currently blocked** by a cross-vault
+> race condition in the backend's GitService — concurrent PUTs to
+> different vaults trigger `FileNotFoundError` from a process-global
+> `os.chdir` inside GitPython.  See [Backend follow-ups](#backend-follow-ups).
+> Until that's fixed, run with `WORKERS=1`.
+
+Merge shards for analysis:
+
+```bash
+cat eval/reports/longmemeval-akb.shard-*.ndjson > eval/reports/longmemeval-akb.ndjson
+```
+
+---
+
+## Performance and cost
+
+Measured on a 5Q smoke (one worker, M-series Mac talking to OpenRouter):
+
+| Stage | Per question | Per 500 (1 worker) |
+|---|---|---|
+| Vault create/delete | ~50ms × 2 | ~50s |
+| Session PUTs (~50/Q) | ~600ms total (backend chunks asynchronously) | ~5 min |
+| Indexing wait | **~45s** (~486 chunks/Q ÷ ~32-batch × ~1.7s embedding + per-chunk upsert) | **~6.25 h** |
+| Search (rerank ON) | ~1000ms | ~8 min |
+| **Total wall-clock** | **~48s** | **~6.5 h** |
+
+**Cost estimate** (`bge-m3` + `cohere/rerank-v3.5` via OpenRouter):
+
+| Item | Unit | Per full run |
+|---|---|---|
+| Embedding (ingest) | $0.01–0.04 / M tokens | ~$0.40 |
+| Rerank | ~$2 / 1000 queries | ~$1.00 |
+| **Total** | | **~$1.40** |
+
+OpenRouter is the rate-limit boundary (account-balance based), not
+Cohere's trial 10 req/min cap.  3-worker concurrency would cut wall
+time to ~2.5h, but requires the backend follow-ups below first.
+
+---
+
+## Comparability notes
+
+- **Embedding model differs.** gbrain uses OpenAI
+  `text-embedding-3-large@1536`; AKB uses `bge-m3@1024`.  Score
+  differences mix model effect with system effect.  AKB posts as its
+  own line, framed as stack-level comparison.
+- **Reranker default ON.** gbrain's 97.6% is hybrid-only.  AKB's
+  default has rerank on; posting them side by side isn't fair until
+  the rerank-off ablation runs.  First-round number is the production
+  default; ablation is a follow-up if the gap warrants it.
+- **Abstention handling unverified across systems.** §1 includes `_abs`
+  in the denominator (the only consistent choice when ground truth
+  exists).  If gbrain excluded them, the comparison drifts slightly;
+  the `is_abstention` flag lets readers re-aggregate either way.
+
+---
+
+## Known issues
+
+1. **bge-m3 absolute performance on English-only data is uncertain.**
+   Multilingual models typically trail English-only models slightly.
+   First-run number is the answer.
+2. **Indexing worker throughput is the bottleneck** (~45s/Q for 486
+   chunks).  See [Backend follow-ups](#backend-follow-ups).
+3. **`SearchResult.path` round-trip stability.** Backend `_slugify`
+   currently lowercases and appends `.md`.  If that normalization
+   changes, ground-truth matching breaks silently.  Worth a single
+   PUT→GET sanity check before each round.
+4. **Source-aware boost may interact poorly.** Everything is in the
+   `chat/` collection, so any collection-weighting becomes noise.
+   First-run numbers will tell whether it matters.
+5. **OpenRouter → Cohere rerank latency is two hops, not one.** p99
+   query latency could exceed 500ms.  Time estimate uses ~150ms; update
+   after first measurement.
+6. **HF deprecated label on the dataset.** Raw file is still served,
+   but if HF removes it, the `curl` command breaks.  Save a local
+   SHA256 of the downloaded JSON for reproducibility.
+
+---
+
+## Backend follow-ups
+
+Four backend issues were discovered while building the runner.  None
+are fixed in this directory; they live as separate tasks because each
+needs an independent backend PR.
+
+1. **`rerank_service` fallback chain produces a cryptic httpx error**
+   when both `rerank_base_url` and `llm_base_url` are blank.  Should
+   fail fast at startup with a clear config error.
+2. **`backend/app/db/init.sql` is missing `CREATE EXTENSION IF NOT EXISTS
+   vector`.**  The cluster's `akb-init-sql` ConfigMap papers over this;
+   a fresh `docker compose up` against repo root would otherwise leave
+   every chunk in a `vector_last_error = 'unknown type: public.vector'`
+   loop.  Worked around here via `postgres-init/01-pgvector.sql`.
+3. **`embed_worker` runs as a single asyncio task.**  Per-chunk upsert
+   in a separate transaction dominates after the embed call (~50ms ×
+   N).  Adding N concurrent runners + a batched upsert would drop
+   45s/Q to <5s/Q.
+4. **`GitService` has a cross-vault `os.chdir` race condition.**
+   GitPython mutates process-global cwd inside `index.add`, so
+   concurrent PUTs to different vaults race.  Per-vault `threading.Lock`
+   doesn't help.  Blocks `WORKERS > 1` in `batch.sh`.
+
+---
+
+## Success criteria
+
+- **Smoke (`--limit 5`)**: 5/5 OK, `hit_at_k` neither 0/5 nor 5/5 — a
+  plausible non-degenerate number.  Current: 4/5 at R@5=80%.
+- **First report**: 500Q full-run R@5 + per-type table + latency
+  distribution + comparison table including gbrain/MemPal lines.  One
+  `akb-hybrid+rerank` row.
+- **Honesty bar**: publish the number whatever it is.  Footnote the
+  embedding-model and rerank-default differences explicitly so readers
+  can interpret.
+
+---
+
+## References
+
+- gbrain-evals repo: https://github.com/garrytan/gbrain-evals
+- gbrain LongMemEval report: `docs/benchmarks/2026-05-07-longmemeval-s.md` in that repo
+- LongMemEval original (used here): https://huggingface.co/datasets/xiaowu0162/longmemeval
+- LongMemEval cleaned (v2 option): https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned
+- LongMemEval paper + eval code: https://github.com/xiaowu0162/LongMemEval
+- AKB internal regression harness (small, different purpose): `backend/tests/eval/`
+- Cluster effective config: `kubectl -n akb get configmap akb-app-config -o yaml`
+- AKB config loader (justifies "yaml only, no env vars"): [backend/app/config.py:12](../../backend/app/config.py:12)
+- SearchResult schema (path-based mapping rationale): [backend/app/models/document.py:137](../../backend/app/models/document.py:137)
+- Vault-scoped health endpoint: [backend/app/main.py:207](../../backend/app/main.py:207)
+- Vault name regex: [backend/app/services/document_service.py:845](../../backend/app/services/document_service.py:845)
+- rerank dispatch: [backend/app/services/rerank_service.py:56](../../backend/app/services/rerank_service.py:56)

--- a/eval/longmemeval/batch.sh
+++ b/eval/longmemeval/batch.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# LongMemEval benchmark batch runner.
+#
+# Spawns N workers concurrently, each writing to its own NDJSON shard.
+# Resume works across reruns because run.py keys dedup on
+# (adapter, question_id) per shard, and shards are partitioned by
+# hash(qid) mod N -- a worker always sees the same subset across runs.
+#
+# Wall budget caps each worker's runtime, not the batch as a whole.
+# That's a feature: bumping LIMIT or rerunning after fixing indexing
+# picks up where you left off without re-running completed questions.
+#
+# Usage:
+#   ./batch.sh                                  # 3 workers, no wall cap
+#   WORKERS=5 WALL=600 ./batch.sh               # 5 workers, 10-min cap each
+#   DATASET=/path/to/longmemeval_s.json LIMIT=10 ./batch.sh
+#   STRATIFY=5 ./batch.sh                       # 5 per question_type
+#
+# After a partial run, just re-invoke the same command -- shards resume.
+# Merge for analysis:
+#   cat reports/longmemeval-akb.shard-*.ndjson > reports/longmemeval-akb.ndjson
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+WORKERS=${WORKERS:-3}
+WALL=${WALL:-}
+DATASET=${DATASET:-$HOME/datasets/longmemeval/longmemeval_s.json}
+ADAPTER=${ADAPTER:-akb-hybrid+rerank}
+TOPK=${TOPK:-5}
+REPORTS_DIR=${REPORTS_DIR:-"$REPO_ROOT/eval/reports"}
+NDJSON_PREFIX=${NDJSON_PREFIX:-longmemeval-akb}
+AKB_URL=${AKB_URL:-http://localhost:18000}
+LIMIT=${LIMIT:-}
+STRATIFY=${STRATIFY:-}
+MAX_INDEX_WAIT=${MAX_INDEX_WAIT:-300}
+
+mkdir -p "$REPORTS_DIR"
+
+if [[ ! -f "$DATASET" ]]; then
+  echo "error: dataset not found: $DATASET" >&2
+  echo "       download with: curl -Lo $DATASET https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/main/longmemeval_s" >&2
+  exit 2
+fi
+
+echo "batch: workers=$WORKERS wall=${WALL:-unbounded}s adapter=$ADAPTER topk=$TOPK"
+echo "       dataset=$DATASET"
+echo "       reports=$REPORTS_DIR  prefix=$NDJSON_PREFIX"
+[[ -n "$LIMIT" ]] && echo "       limit=$LIMIT (per worker, applied after shard)"
+[[ -n "$STRATIFY" ]] && echo "       stratify=$STRATIFY per question_type"
+echo
+
+declare -a PIDS=()
+declare -a LOGS=()
+declare -a SHARDS=()
+for ((i=0; i<WORKERS; i++)); do
+  SHARD="$REPORTS_DIR/$NDJSON_PREFIX.shard-${i}of${WORKERS}.ndjson"
+  LOG="$REPORTS_DIR/$NDJSON_PREFIX.shard-${i}of${WORKERS}.log"
+  SHARDS+=("$SHARD")
+  LOGS+=("$LOG")
+  ARGS=(
+    --dataset "$DATASET"
+    --ndjson "$SHARD"
+    --adapter "$ADAPTER"
+    --top-k "$TOPK"
+    --worker-id "$i"
+    --total-workers "$WORKERS"
+    --akb-url "$AKB_URL"
+    --max-index-wait-seconds "$MAX_INDEX_WAIT"
+  )
+  [[ -n "$WALL" ]] && ARGS+=(--max-wall-seconds "$WALL")
+  [[ -n "$LIMIT" ]] && ARGS+=(--limit "$LIMIT")
+  [[ -n "$STRATIFY" ]] && ARGS+=(--stratify "$STRATIFY")
+  python3 "$SCRIPT_DIR/run.py" "${ARGS[@]}" >"$LOG" 2>&1 &
+  PIDS+=($!)
+  echo "  worker $i started (pid=${PIDS[$i]}, log=$LOG)"
+done
+echo
+
+# Propagate signals so each run.py runs its DELETE /my/account cleanup.
+cleanup() {
+  echo
+  echo "received signal — propagating SIGTERM to all workers"
+  for pid in "${PIDS[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup INT TERM
+
+# Wait individually so we can capture each exit code.
+declare -a EXIT_CODES=()
+for i in "${!PIDS[@]}"; do
+  if wait "${PIDS[$i]}"; then
+    EXIT_CODES+=(0)
+  else
+    EXIT_CODES+=($?)
+  fi
+done
+echo
+
+# Aggregate.
+echo "=== summary ==="
+TOTAL=0; HITS=0; OK=0; INGEST_ERR=0; WAIT_ERR=0; SEARCH_ERR=0
+for ((i=0; i<WORKERS; i++)); do
+  SHARD="${SHARDS[$i]}"
+  STATS=$(python3 - "$SHARD" <<'PY'
+import json, sys
+ok = hits = ie = we = se = total = 0
+try:
+    for line in open(sys.argv[1]):
+        r = json.loads(line)
+        if r.get("type") == "run_meta_start":
+            continue
+        total += 1
+        s = r.get("status")
+        if s == "ok":
+            ok += 1
+            if r.get("hit_at_k"):
+                hits += 1
+        elif s == "ingest_error":
+            ie += 1
+        elif s == "index_wait_timeout":
+            we += 1
+        elif s == "search_error":
+            se += 1
+except FileNotFoundError:
+    pass
+print(total, ok, hits, ie, we, se)
+PY
+  )
+  read -r T O H IE WE SE <<< "$STATS"
+  printf "  shard %d/%d (exit %s): %d processed, %d ok, %d hits, errors=(ingest=%d wait=%d search=%d)\n" \
+    "$i" "$WORKERS" "${EXIT_CODES[$i]}" "$T" "$O" "$H" "$IE" "$WE" "$SE"
+  TOTAL=$((TOTAL + T))
+  HITS=$((HITS + H))
+  OK=$((OK + O))
+  INGEST_ERR=$((INGEST_ERR + IE))
+  WAIT_ERR=$((WAIT_ERR + WE))
+  SEARCH_ERR=$((SEARCH_ERR + SE))
+done
+echo "  ─────"
+if [[ $OK -gt 0 ]]; then
+  RECALL=$(python3 -c "print(f'{$HITS/$OK:.1%}')")
+else
+  RECALL="n/a"
+fi
+echo "  TOTAL: $TOTAL processed, $OK ok, $HITS hits, R@$TOPK=$RECALL, errors=(ingest=$INGEST_ERR wait=$WAIT_ERR search=$SEARCH_ERR)"
+echo
+echo "Per-type breakdown:"
+python3 - "${SHARDS[@]}" <<'PY'
+import json, sys
+from collections import defaultdict
+by_type = defaultdict(lambda: {"total": 0, "ok": 0, "hits": 0, "abs": 0})
+for path in sys.argv[1:]:
+    try:
+        f = open(path)
+    except FileNotFoundError:
+        continue
+    for line in f:
+        r = json.loads(line)
+        if r.get("type") == "run_meta_start":
+            continue
+        t = r.get("question_type", "?")
+        by_type[t]["total"] += 1
+        if r.get("is_abstention"):
+            by_type[t]["abs"] += 1
+        if r.get("status") == "ok":
+            by_type[t]["ok"] += 1
+            if r.get("hit_at_k"):
+                by_type[t]["hits"] += 1
+for t, c in sorted(by_type.items()):
+    eff_ok = c["ok"]
+    recall = (c["hits"] / eff_ok * 100) if eff_ok else 0.0
+    print(f"  {t:30s} total={c['total']:4d} ok={c['ok']:4d} hits={c['hits']:4d} R@K={recall:5.1f}%  abstention={c['abs']}")
+PY
+
+echo
+echo "Merge shards for analysis:"
+echo "  cat $REPORTS_DIR/$NDJSON_PREFIX.shard-*.ndjson > $REPORTS_DIR/$NDJSON_PREFIX.ndjson"
+
+# Propagate worker failure -- CI / automation must not treat a partial
+# benchmark with non-zero shards as a successful run.
+ANY_FAIL=0
+for code in "${EXIT_CODES[@]}"; do
+  if [[ "$code" -ne 0 ]]; then
+    ANY_FAIL=1
+  fi
+done
+if [[ $ANY_FAIL -ne 0 ]]; then
+  echo
+  echo "ERROR: at least one worker exited non-zero (see per-shard exit codes above)" >&2
+  exit 1
+fi

--- a/eval/longmemeval/config/app.yaml
+++ b/eval/longmemeval/config/app.yaml
@@ -1,0 +1,79 @@
+# LongMemEval benchmark runtime config — pinned to the cluster's
+# effective `akb-app-config` (bge-m3 + cohere/rerank-v3.5 + pgvector).
+#
+# Differences vs cluster yaml:
+#   - db_user: akb            (cluster: akbuser — local compose hard-codes 'akb')
+#   - s3_endpoint_url: http://minio:9000  (cluster: in-cluster IP)
+#   - s3_public_url: ""       (benchmark doesn't return presigned URLs to a browser)
+#   - public_base_url: ""     (no publication snapshots in benchmark)
+#   - llm_*: ""               (metadata_worker disabled — irrelevant to retrieval)
+#   - redis_url: ""           (no redis container in this stack — events outbox stays in PG)
+#
+# Keep this file committed: it's part of the benchmark definition.
+# Anything sensitive lives in config/secret.yaml (gitignored).
+
+# === Database ===
+db_host: postgres
+db_port: 5432
+db_name: akb
+db_user: akb
+
+# === Git storage ===
+git_storage_path: /data/vaults
+
+# === Embedding (bge-m3@1024 via OpenRouter) ===
+embed_base_url: https://openrouter.ai/api/v1
+embed_model: baai/bge-m3
+embed_dimensions: 1024
+
+# === LLM (disabled — metadata_worker unused for retrieval benchmark) ===
+# llm_base_url stays "" so metadata_worker doesn't start.  Rerank can't
+# share this fallback when it's blank, so rerank_base_url below is set
+# explicitly.
+llm_base_url: ""
+llm_model: ""
+
+# === Reranker (Cohere via OpenRouter routing) ===
+# rerank_base_url MUST be explicit here because llm_base_url is "" (the
+# default fallback path produces a bare "/rerank" without a scheme,
+# which httpx rejects).  rerank_api_key in secret.yaml is "" — service
+# falls back to llm_api_key, which holds the OpenRouter key.
+rerank_enabled: true
+rerank_provider: cohere
+rerank_model: cohere/rerank-v3.5
+rerank_base_url: https://openrouter.ai/api/v1
+rerank_prefetch: 30
+rerank_timeout_seconds: 3.0
+
+# === S3 (in-stack MinIO — required for backend to boot cleanly) ===
+s3_endpoint_url: http://minio:9000
+s3_public_url: ""
+s3_bucket: akb-files
+s3_region: ""
+
+# === Auth ===
+jwt_algorithm: HS256
+jwt_expire_hours: 24
+
+# === Server ===
+host: 0.0.0.0
+port: 8000
+public_base_url: ""
+
+# === Vector store (pgvector, same-instance same-PG, posting sparse shape) ===
+vector_store_driver: pgvector
+vector_store_dsn: ""
+vector_store_schema: vector_index
+vector_store_sparse_shape: posting
+
+# === Indexing worker tuning ===
+indexing_batch_size: 16
+
+# === BM25 ===
+bm25_k1: 1.5
+bm25_b: 0.75
+
+# === Events (no redis in this stack) ===
+redis_url: ""
+redis_event_stream: akb:events
+redis_stream_maxlen: 100000

--- a/eval/longmemeval/config/secret.yaml.example
+++ b/eval/longmemeval/config/secret.yaml.example
@@ -1,0 +1,40 @@
+# LongMemEval benchmark secrets. Copy to `secret.yaml` and fill in.
+# `secret.yaml` is gitignored.
+
+# === Database (matches POSTGRES_PASSWORD in docker-compose.yaml) ===
+db_password: akb
+
+# === JWT — local-dev only; benchmark issues a temp user per run. ===
+jwt_secret: longmemeval-bench-dev-only-change-if-you-keep-this-stack-running
+
+# === Embedding API key — REQUIRED ===
+# Same OpenRouter key powers BOTH embedding (bge-m3) and rerank
+# (cohere/rerank-v3.5 via OpenRouter routing — see app.yaml).
+# Without this, indexing fails and the runner stalls.
+embed_api_key: ""
+
+# === LLM API key — REQUIRED (rerank fallback target) ===
+# app.yaml has llm_base_url="" so metadata_worker stays off, but
+# rerank_service uses llm_api_key as the fallback credential when
+# rerank_api_key is blank.  Set this to the SAME OpenRouter key
+# as embed_api_key above.  Leaving it blank silently disables
+# reranking (RRF-only output) -- the "akb-hybrid+rerank" label would
+# be a lie.
+llm_api_key: ""
+
+# === Reranker API key — leave blank ===
+# This stack routes rerank through OpenRouter (app.yaml:
+# rerank_base_url: https://openrouter.ai/api/v1).  Setting a Cohere
+# key here would send a Cohere credential to the OpenRouter URL and
+# get a 401 -- backend then silently falls back to RRF-only output.
+# Leave this blank; rerank_service falls back to llm_api_key.
+rerank_api_key: ""
+
+# === S3 (in-stack MinIO) ===
+s3_access_key: akb-local
+s3_secret_key: akb-local-secret
+
+# === Vector store / Seahorse / Redis — unused in this stack. ===
+vector_api_key: ""
+seahorse_token: ""
+redis_password: ""

--- a/eval/longmemeval/docker-compose.yaml
+++ b/eval/longmemeval/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       POSTGRES_DB: akb
       POSTGRES_USER: akb
-      POSTGRES_PASSWORD: akb
+      POSTGRES_PASSWORD: akb  # pragma: allowlist secret -- local-dev hardcoded, matches secret.yaml
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # Install pgvector extension on first boot.  Without this, the
@@ -50,7 +50,7 @@ services:
     command: server /data --address :9000 --console-address :9001
     environment:
       MINIO_ROOT_USER: akb-local
-      MINIO_ROOT_PASSWORD: akb-local-secret
+      MINIO_ROOT_PASSWORD: akb-local-secret  # pragma: allowlist secret -- local-dev hardcoded
     volumes:
       - minio_data:/data
     ports:

--- a/eval/longmemeval/docker-compose.yaml
+++ b/eval/longmemeval/docker-compose.yaml
@@ -1,0 +1,93 @@
+# LongMemEval benchmark stack — self-contained, isolated from local dev.
+#
+# Why a separate stack:
+#   - Pins the runtime config to the cluster's effective `akb-app-config`
+#     (bge-m3 + cohere/rerank-v3.5 + pgvector) regardless of what the
+#     dev `config/app.yaml` at repo root says.
+#   - `down -v` between full runs starts from a clean baseline without
+#     touching the main dev volumes.
+#   - Ports shifted (18000/19000/19001) so it can coexist with the main
+#     `akb` stack on `:8000`/`:9000`/`:9001`.
+#
+# Project name comes from this directory: `longmemeval`. Volumes and
+# containers are auto-prefixed (e.g. `longmemeval_postgres_data`).
+#
+# Usage:
+#   cd eval/longmemeval
+#   cp config/secret.yaml.example config/secret.yaml
+#   # edit config/secret.yaml — fill embed_api_key (OpenRouter) and
+#   # rerank_api_key (Cohere production)
+#   docker compose up -d
+#   curl http://localhost:18000/livez
+#
+# Reset for a clean run:
+#   docker compose down -v && docker compose up -d
+#
+# Frontend is intentionally omitted — benchmark runner talks REST only.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: akb
+      POSTGRES_USER: akb
+      POSTGRES_PASSWORD: akb
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      # Install pgvector extension on first boot.  Without this, the
+      # backend's pgvector driver hits a chicken-and-egg failure
+      # (register_vector() needs the type, ensure_collection() creates
+      # it but never gets called).  See postgres-init/01-pgvector.sql.
+      - ./postgres-init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U akb -d akb"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --address :9000 --console-address :9001
+    environment:
+      MINIO_ROOT_USER: akb-local
+      MINIO_ROOT_PASSWORD: akb-local-secret
+    volumes:
+      - minio_data:/data
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio-bootstrap:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 akb-local akb-local-secret &&
+      mc mb -p local/akb-files &&
+      echo 'akb-files bucket ready'
+      "
+
+  backend:
+    build: ../../backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-bootstrap:
+        condition: service_completed_successfully
+    volumes:
+      - ./config:/etc/akb:ro
+      - vault_data:/data/vaults
+    ports:
+      - "18000:8000"
+
+volumes:
+  postgres_data:
+  vault_data:
+  minio_data:

--- a/eval/longmemeval/postgres-init/01-pgvector.sql
+++ b/eval/longmemeval/postgres-init/01-pgvector.sql
@@ -1,0 +1,10 @@
+-- PG first-boot init: install pgvector extension before backend boots.
+-- The backend's bundled init.sql doesn't include this line, and the
+-- pgvector driver's `register_vector(conn)` call fails ("unknown type:
+-- public.vector") before it ever reaches the CREATE EXTENSION inside
+-- ensure_collection -- causing a circular dependency that leaves every
+-- chunk stuck retrying with vector_last_error = 'unknown type: public.vector'.
+--
+-- The cluster's akb-init-sql ConfigMap already contains this line; this
+-- file is the docker-compose equivalent.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/eval/longmemeval/run.py
+++ b/eval/longmemeval/run.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""LongMemEval benchmark runner for AKB — single-file, stdlib-only CLI.
+
+See README.md (next to this file) for the full plan, design decisions,
+and known risks.
+
+Quick start (after `docker compose up -d` in this directory):
+
+    python eval/longmemeval/run.py \\
+        --dataset ~/datasets/longmemeval/longmemeval_s.json \\
+        --ndjson eval/reports/longmemeval-akb.ndjson \\
+        --limit 5
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import secrets
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_AKB_URL = "http://localhost:18000"
+DEFAULT_ADAPTER = "akb-hybrid+rerank"
+DEFAULT_TOP_K = 5
+DEFAULT_MAX_INDEX_WAIT = 300
+POLL_INTERVAL_S = 1.0
+
+
+# ── HTTP ──────────────────────────────────────────────────────────────────
+
+class HTTPError(Exception):
+    def __init__(self, status: int, body: str, url: str):
+        super().__init__(f"HTTP {status} on {url}: {body[:200]}")
+        self.status = status
+        self.body = body
+        self.url = url
+
+
+def http_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    data = json.dumps(body).encode() if body is not None else None
+    req_headers = {"Accept": "application/json"}
+    if body is not None:
+        req_headers["Content-Type"] = "application/json"
+    if headers:
+        req_headers.update(headers)
+    req = urllib.request.Request(url, data=data, method=method, headers=req_headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        raise HTTPError(e.code, body_text, url) from e
+
+
+# ── AKB client ────────────────────────────────────────────────────────────
+
+class AKBClient:
+    def __init__(self, base_url: str, token: str | None = None):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def _auth(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"} if self.token else {}
+
+    def register(self, username: str, password: str) -> None:
+        http_request(
+            "POST",
+            f"{self.base_url}/api/v1/auth/register",
+            body={
+                "username": username,
+                "password": password,
+                "email": f"{username}@example.invalid",
+            },
+        )
+
+    def login(self, username: str, password: str) -> str:
+        r = http_request(
+            "POST",
+            f"{self.base_url}/api/v1/auth/login",
+            body={"username": username, "password": password},
+        )
+        self.token = r["token"]
+        return self.token
+
+    def delete_account(self) -> dict:
+        return http_request(
+            "DELETE", f"{self.base_url}/api/v1/my/account", headers=self._auth()
+        )
+
+    def create_vault(self, name: str, description: str = "lme") -> dict:
+        qs = urllib.parse.urlencode(
+            {"name": name, "description": description, "public_access": "none"}
+        )
+        return http_request(
+            "POST", f"{self.base_url}/api/v1/vaults?{qs}", headers=self._auth()
+        )
+
+    def delete_vault(self, name: str) -> None:
+        try:
+            http_request(
+                "DELETE", f"{self.base_url}/api/v1/vaults/{name}", headers=self._auth()
+            )
+        except HTTPError as e:
+            if e.status != 404:
+                raise
+
+    def put_document(
+        self,
+        vault: str,
+        collection: str,
+        title: str,
+        content: str,
+        tags: list[str] | None = None,
+    ) -> dict:
+        return http_request(
+            "POST",
+            f"{self.base_url}/api/v1/documents",
+            headers=self._auth(),
+            body={
+                "vault": vault,
+                "collection": collection,
+                "title": title,
+                "content": content,
+                "type": "note",
+                "tags": tags or [],
+            },
+        )
+
+    def health_vault(self, vault: str) -> dict:
+        return http_request(
+            "GET", f"{self.base_url}/health/vault/{vault}", headers=self._auth()
+        )
+
+    def search(self, q: str, vault: str, limit: int) -> dict:
+        qs = urllib.parse.urlencode({"q": q, "vault": vault, "limit": limit})
+        return http_request(
+            "GET", f"{self.base_url}/api/v1/search?{qs}", headers=self._auth()
+        )
+
+
+# ── Dataset normalization ─────────────────────────────────────────────────
+
+@dataclass
+class Session:
+    session_id: str
+    rendered: str
+
+
+@dataclass
+class Question:
+    question_id: str
+    question: str
+    question_type: str
+    sessions: list[Session]
+    answer_session_ids: list[str]
+    is_abstention: bool
+
+
+def render_session(session_date: str | None, turns: list[dict]) -> str:
+    """Plain explicit format with session date header.
+
+    LongMemEval's `temporal-reasoning` (133/500) and `knowledge-update`
+    (78/500) question types depend on per-session timestamps -- 42% of
+    the benchmark.  Without the date in the document body, those
+    questions can't be answered from retrieval alone.
+    """
+    lines = []
+    if session_date:
+        lines.append(f"[Session date: {session_date}]")
+    for t in turns:
+        role = (t.get("role") or "?").upper()
+        content = t.get("content") or ""
+        lines.append(f"{role}: {content}")
+    return "\n\n".join(lines)
+
+
+def normalize_question(raw: dict) -> Question:
+    # Each question has three parallel arrays: haystack_session_ids[i]
+    # is the id for haystack_sessions[i] (turns), and haystack_dates[i]
+    # is the per-session timestamp (string, formatted like
+    # "2023/05/30 (Tue) 23:40").
+    sids = raw.get("haystack_session_ids") or []
+    bodies = raw.get("haystack_sessions") or []
+    dates = raw.get("haystack_dates") or [None] * len(sids)
+    if len(sids) != len(bodies):
+        raise ValueError(
+            f"question {raw.get('question_id')}: haystack length mismatch "
+            f"{len(sids)} vs {len(bodies)}"
+        )
+    if len(dates) != len(sids):
+        # Don't fail -- pad with None so render_session just omits the
+        # date header for those sessions.
+        dates = list(dates) + [None] * (len(sids) - len(dates))
+    # Some LongMemEval questions list the same session id twice in
+    # haystack_session_ids (15/500 in the _s split).  Posting the same
+    # title twice into one vault returns 409 Conflict, so keep the
+    # first occurrence and drop the rest -- preserving the implicit
+    # ordering the dataset chose.
+    sessions: list[Session] = []
+    seen: set[str] = set()
+    for sid, turns, date in zip(sids, bodies, dates):
+        if sid in seen:
+            continue
+        seen.add(sid)
+        sessions.append(Session(session_id=sid, rendered=render_session(date, turns)))
+    qid = raw["question_id"]
+    return Question(
+        question_id=qid,
+        question=raw["question"],
+        question_type=raw["question_type"],
+        sessions=sessions,
+        answer_session_ids=list(raw.get("answer_session_ids") or []),
+        is_abstention=qid.endswith("_abs"),
+    )
+
+
+def normalize_vault_name(qid: str) -> str:
+    # Vault name regex: ^[a-z0-9][a-z0-9-]*$.  LongMemEval qids are 8-char
+    # hex (already legal); only the `_abs` suffix needs translation.
+    return qid.replace("_", "-").lower()
+
+
+def session_id_from_path(path: str) -> str:
+    # Backend _slugify lowercases the title, preserves underscores, and
+    # appends `.md`.  Reverse: 'chat/sharegpt_xxx_0.md' → 'sharegpt_xxx_0'.
+    return path.removeprefix("chat/").removesuffix(".md")
+
+
+def lowered(ids: list[str]) -> set[str]:
+    return {s.lower() for s in ids}
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+def sha8(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()[:8]
+
+
+def shard_for(qid: str, total_workers: int) -> int:
+    if total_workers <= 1:
+        return 0
+    return hashlib.sha256(qid.encode()).digest()[0] % total_workers
+
+
+def load_completed(ndjson_path: Path, adapter: str) -> set[str]:
+    if not ndjson_path.exists():
+        return set()
+    completed: set[str] = set()
+    with ndjson_path.open() as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("type") == "run_meta_start":
+                continue
+            if rec.get("adapter") == adapter and "question_id" in rec:
+                completed.add(rec["question_id"])
+    return completed
+
+
+def append_ndjson(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        f.flush()
+
+
+def wait_for_indexing(
+    client: AKBClient, vault: str, max_seconds: int
+) -> tuple[bool, int]:
+    """Poll /health/vault until backfill.upsert.pending == 0.
+
+    Returns (success, elapsed_ms).
+    """
+    start = time.monotonic()
+    deadline = start + max_seconds
+    while time.monotonic() < deadline:
+        try:
+            h = client.health_vault(vault)
+            # Response shape: {"vault", "metadata_backfill", "vector_store": {"backfill": {"upsert": {pending, retrying, abandoned, indexed}}}}
+            upsert = (
+                ((h.get("vector_store") or {}).get("backfill") or {}).get("upsert")
+                or {}
+            )
+            if int(upsert.get("pending", 0)) == 0:
+                return True, int((time.monotonic() - start) * 1000)
+        except HTTPError:
+            pass
+        time.sleep(POLL_INTERVAL_S)
+    return False, int(max_seconds * 1000)
+
+
+def collect_run_meta(adapter: str, akb_url: str) -> dict:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    try:
+        backend_sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=repo_root,
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        backend_sha = "unknown"
+
+    app_yaml = Path(__file__).resolve().parent / "config" / "app.yaml"
+    app_yaml_sha = (
+        hashlib.sha256(app_yaml.read_bytes()).hexdigest()[:12]
+        if app_yaml.exists()
+        else "unknown"
+    )
+
+    # Lightweight YAML scrape (avoid a pyyaml dep).  Pulls keys we care
+    # about for retrieval-side reproducibility.
+    snapshot: dict[str, str] = {}
+    if app_yaml.exists():
+        for raw_line in app_yaml.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or ":" not in line:
+                continue
+            k, _, v = line.partition(":")
+            snapshot[k.strip()] = v.strip().strip('"').strip("'")
+
+    interesting = (
+        "embed_model embed_dimensions embed_base_url rerank_enabled "
+        "rerank_model rerank_base_url rerank_prefetch vector_store_driver "
+        "vector_store_sparse_shape bm25_k1 bm25_b indexing_batch_size"
+    ).split()
+    cfg = {k: snapshot.get(k) for k in interesting}
+
+    return {
+        "type": "run_meta_start",
+        "adapter": adapter,
+        "akb_url": akb_url,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "backend_sha": backend_sha,
+        "app_yaml_sha": app_yaml_sha,
+        "config": cfg,
+    }
+
+
+# ── Per-question pipeline ─────────────────────────────────────────────────
+
+def run_question(
+    client: AKBClient,
+    q: Question,
+    worker_id: int,
+    top_k: int,
+    max_index_wait: int,
+    adapter: str,
+) -> dict:
+    base = {
+        "adapter": adapter,
+        "question_id": q.question_id,
+        "question_type": q.question_type,
+        "is_abstention": q.is_abstention,
+        "num_haystack": len(q.sessions),
+        "ground_truth": q.answer_session_ids,
+    }
+    vault = f"lme-{normalize_vault_name(q.question_id)}-{worker_id}"
+
+    client.delete_vault(vault)  # 404 OK — clear stale state from a prior crash
+    client.create_vault(vault)
+
+    # ── ingest ──
+    ingest_start = time.monotonic()
+    try:
+        for s in q.sessions:
+            client.put_document(vault, "chat", s.session_id, s.rendered, tags=["lme"])
+    except HTTPError as e:
+        client.delete_vault(vault)
+        return {
+            **base,
+            "status": "ingest_error",
+            "error": str(e),
+            "ingest_ms": int((time.monotonic() - ingest_start) * 1000),
+            "index_wait_ms": None,
+            "query_ms": None,
+            "retrieved": None,
+            "hit_at_k": None,
+        }
+    ingest_ms = int((time.monotonic() - ingest_start) * 1000)
+
+    # ── indexing wait ──
+    ok, wait_ms = wait_for_indexing(client, vault, max_index_wait)
+    if not ok:
+        client.delete_vault(vault)
+        return {
+            **base,
+            "status": "index_wait_timeout",
+            "ingest_ms": ingest_ms,
+            "index_wait_ms": wait_ms,
+            "query_ms": None,
+            "retrieved": None,
+            "hit_at_k": None,
+        }
+
+    # ── search ──
+    query_start = time.monotonic()
+    try:
+        resp = client.search(q.question, vault, top_k)
+    except HTTPError as e:
+        client.delete_vault(vault)
+        return {
+            **base,
+            "status": "search_error",
+            "error": str(e),
+            "ingest_ms": ingest_ms,
+            "index_wait_ms": wait_ms,
+            "query_ms": int((time.monotonic() - query_start) * 1000),
+            "retrieved": None,
+            "hit_at_k": None,
+        }
+    query_ms = int((time.monotonic() - query_start) * 1000)
+
+    retrieved = [session_id_from_path(r["path"]) for r in resp.get("results", [])]
+    hit = bool(lowered(retrieved).intersection(lowered(q.answer_session_ids)))
+
+    client.delete_vault(vault)
+    return {
+        **base,
+        "status": "ok",
+        "ingest_ms": ingest_ms,
+        "index_wait_ms": wait_ms,
+        "query_ms": query_ms,
+        "retrieved": retrieved,
+        "hit_at_k": hit,
+    }
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dataset", type=Path, default=os.environ.get("LONGMEMEVAL_PATH"))
+    p.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    p.add_argument("--adapter", default=DEFAULT_ADAPTER)
+    p.add_argument("--ndjson", type=Path, required=True)
+    p.add_argument("--max-wall-seconds", type=int, default=None)
+    p.add_argument("--worker-id", type=int, default=0)
+    p.add_argument("--total-workers", type=int, default=1)
+    p.add_argument("--limit", type=int, default=None, help="cap to first N questions (after shard/stratify)")
+    p.add_argument("--stratify", type=int, default=None, help="sample N per question_type (seed=0)")
+    p.add_argument("--akb-url", default=os.environ.get("AKB_URL", DEFAULT_AKB_URL))
+    p.add_argument("--max-index-wait-seconds", type=int, default=DEFAULT_MAX_INDEX_WAIT)
+    args = p.parse_args()
+    if not args.dataset:
+        p.error("--dataset (or env LONGMEMEVAL_PATH) is required")
+    if not args.dataset.exists():
+        p.error(f"dataset not found: {args.dataset}")
+    if args.worker_id >= args.total_workers:
+        p.error(f"--worker-id must be < --total-workers ({args.worker_id} >= {args.total_workers})")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+
+    print(f"loading dataset: {args.dataset}", file=sys.stderr)
+    raw = json.loads(args.dataset.read_text())
+    questions = [normalize_question(q) for q in raw]
+    print(f"  loaded {len(questions)} questions", file=sys.stderr)
+
+    # stratify before shard so each worker gets a balanced slice
+    if args.stratify:
+        rng = random.Random(0)
+        by_type: dict[str, list[Question]] = {}
+        for q in questions:
+            by_type.setdefault(q.question_type, []).append(q)
+        sample: list[Question] = []
+        for qs in by_type.values():
+            rng.shuffle(qs)
+            sample.extend(qs[: args.stratify])
+        questions = sample
+        print(f"  stratified: {len(questions)} questions across {len(by_type)} types", file=sys.stderr)
+
+    # shard
+    questions = [q for q in questions if shard_for(q.question_id, args.total_workers) == args.worker_id]
+
+    # resume — drop already-completed
+    completed = load_completed(args.ndjson, args.adapter)
+    if completed:
+        before = len(questions)
+        questions = [q for q in questions if q.question_id not in completed]
+        print(f"  resume: skipping {before - len(questions)} already-completed", file=sys.stderr)
+
+    # limit applies last (testing convenience)
+    if args.limit:
+        questions = questions[: args.limit]
+
+    print(
+        f"worker_id={args.worker_id}/{args.total_workers} todo={len(questions)} "
+        f"adapter={args.adapter} akb_url={args.akb_url}",
+        file=sys.stderr,
+    )
+    if not questions:
+        print("nothing to do", file=sys.stderr)
+        return 0
+
+    # auth — ephemeral user per run
+    ts = int(time.time())
+    username = f"lme-eval-{args.worker_id}-{ts}"
+    password = secrets.token_urlsafe(24)
+    client = AKBClient(args.akb_url)
+    client.register(username, password)
+    client.login(username, password)
+    print(f"auth: {username}", file=sys.stderr)
+
+    # cleanup hooks — SIGINT/SIGTERM call the same path as the finally block
+    _cleaned = {"done": False}
+
+    def _cleanup() -> None:
+        if _cleaned["done"]:
+            return
+        _cleaned["done"] = True
+        print("cleanup: DELETE /my/account", file=sys.stderr)
+        try:
+            r = client.delete_account()
+            print(f"  deleted vaults: {r.get('vaults_deleted', [])}", file=sys.stderr)
+        except Exception as e:
+            print(f"  cleanup failed: {e}", file=sys.stderr)
+
+    def _sigexit(*_):
+        _cleanup()
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, _sigexit)
+    signal.signal(signal.SIGTERM, _sigexit)
+
+    # run_meta header — once per file
+    if not args.ndjson.exists() or args.ndjson.stat().st_size == 0:
+        append_ndjson(args.ndjson, collect_run_meta(args.adapter, args.akb_url))
+
+    wall_start = time.monotonic()
+    counts = {"ok": 0, "hit": 0, "ingest_error": 0, "index_wait_timeout": 0, "search_error": 0}
+
+    try:
+        for i, q in enumerate(questions, 1):
+            if args.max_wall_seconds and (time.monotonic() - wall_start) > args.max_wall_seconds:
+                print(f"wall budget exhausted ({args.max_wall_seconds}s)", file=sys.stderr)
+                break
+            rec = run_question(
+                client,
+                q,
+                args.worker_id,
+                args.top_k,
+                args.max_index_wait_seconds,
+                args.adapter,
+            )
+            append_ndjson(args.ndjson, rec)
+            status = rec["status"]
+            counts[status] = counts.get(status, 0) + 1
+            if status == "ok" and rec.get("hit_at_k"):
+                counts["hit"] += 1
+            elapsed = int((time.monotonic() - wall_start))
+            print(
+                f"  [{i}/{len(questions)} t+{elapsed}s] {q.question_id} "
+                f"{q.question_type:24s} {status:18s} "
+                f"hit={rec.get('hit_at_k')!s:5s} "
+                f"ingest={rec.get('ingest_ms')}ms wait={rec.get('index_wait_ms')}ms "
+                f"query={rec.get('query_ms')}ms",
+                file=sys.stderr,
+            )
+    finally:
+        _cleanup()
+
+    n_ok = counts["ok"]
+    recall = (counts["hit"] / n_ok) if n_ok else 0.0
+    print(
+        f"\nsummary: ok={n_ok} hits={counts['hit']} R@{args.top_k}={recall:.1%} "
+        f"errors=(ingest={counts.get('ingest_error', 0)} "
+        f"wait={counts.get('index_wait_timeout', 0)} "
+        f"search={counts.get('search_error', 0)})",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Self-contained `eval/longmemeval/` directory: docker-compose stack (pinned config matching cluster's `akb-app-config`), single-file stdlib runner, multi-worker shard wrapper, README with full plan & known issues.
- Measures retrieval `Recall@K` on the public `xiaowu0162/longmemeval` `_s` split (500 questions) — same dataset as gbrain-evals, so the resulting line is comparable as a stack-level number.
- 5-question smoke validated end-to-end: **R@5 = 80% (4/5)**, ~48s/Q wall-clock under a single worker.

## Why a separate stack

The benchmark needs a known-good config (bge-m3@1024 + cohere/rerank-v3.5 via OpenRouter + pgvector, exactly matching the cluster's effective `akb-app-config`). Reusing the main `akb` dev stack would (a) silently inherit whatever's in repo-root `config/app.yaml` and (b) nuke dev data on every `down -v`.

`eval/longmemeval/docker-compose.yaml` runs under the compose project name `longmemeval`, shifts ports (`18000` / `19000` / `19001`), and keeps volumes auto-prefixed. Coexists with the main stack on the same host.

## Highlights

- **One OpenRouter key covers both embedding and rerank.** Validated live against the cluster's backend pod (`rerank_service` falls back from `rerank_api_key` to `llm_api_key`, and OpenRouter routes `/v1/rerank` to `cohere/rerank-v3.5`).
- **Per-question vault isolation** (`lme-{normalize(qid)}-{wid}`) prevents cross-question interference without needing PG cleanup between questions.
- **Vault-scoped polling** (`GET /health/vault/{vault}`, `backfill.upsert.pending == 0`) — no false positives from other workers' activity.
- **NDJSON resume** keyed on `(adapter, question_id)`; first line is a `run_meta_start` header with backend git sha + app.yaml sha for reproducibility.
- **Cleanup on exit / SIGINT / SIGTERM**: `DELETE /my/account` cascades through all per-question vaults via `finally` block plus signal handlers.

## Backend follow-ups (filed separately, not in this PR)

The runner is self-contained, but four backend issues surfaced and are documented in `eval/longmemeval/README.md` §Backend follow-ups:

1. `rerank_service` fallback produces a cryptic httpx error when both URLs are blank — needs fail-fast at startup.
2. `backend/app/db/init.sql` is missing `CREATE EXTENSION IF NOT EXISTS vector`. The cluster's `akb-init-sql` ConfigMap papers over this in prod; fresh docker-compose volumes need it. Workaround in `postgres-init/01-pgvector.sql` ships with this PR.
3. `embed_worker` runs as a single asyncio task with per-chunk upsert in a fresh transaction — dominates wall time. N concurrent runners + batched upsert would drop ~45s/Q to <5s/Q.
4. `GitService` has a cross-vault `os.chdir` race (GitPython mutates process-global cwd inside `index.add`). Per-vault `threading.Lock` doesn't help. Blocks `WORKERS > 1` in `batch.sh`.

## Test plan

- [x] `cd eval/longmemeval && docker compose up -d --build` brings the stack up; `/livez`, `/readyz`, `/health` all 200.
- [x] `rerank_service.rerank(...)` exec'd inside the local backend container returns the expected ranking (parity with cluster pod).
- [x] 5Q smoke completes end-to-end: 5 ok, 4 hit, R@5=80%; NDJSON has `run_meta_start` header + 5 records.
- [x] Re-running with the same `--ndjson` skips the 5 already-completed questions (resume).
- [x] `batch.sh` with `WORKERS=1 LIMIT=3` produces 3 ok records; rerun adds 3 more on top.
- [x] `batch.sh` with a bad `AKB_URL` exits 1 (CI-friendly failure propagation).
- [ ] 500Q single-worker full run (~6.5h) — deferred until embed_worker throughput follow-up lands.
- [ ] Multi-worker validation — blocked on cross-vault git race fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)