### PR TITLE
chore(frontend): block protocol-relative URLs + lint cleanup

### DIFF
--- a/frontend/src/components/document-view.tsx
+++ b/frontend/src/components/document-view.tsx
@@ -181,7 +181,7 @@ function TabStrip({ view, isSkill, onSelect, extraTab }: TabStripProps) {
   }
 
   function onKey(e: React.KeyboardEvent<HTMLButtonElement>, idx: number) {
-    let next = idx;
+    let next: number;
     if (e.key === "ArrowRight") next = (idx + 1) % tabs.length;
     else if (e.key === "ArrowLeft") next = (idx - 1 + tabs.length) % tabs.length;
     else if (e.key === "Home") next = 0;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -24,6 +24,10 @@ export function sanitizeLinkUrl(raw: string | null | undefined): string {
   if (!raw) return "#";
   const trimmed = raw.trim();
   if (!trimmed) return "#";
+  // Protocol-relative URLs (`//evil.com/x`) inherit the current page
+  // scheme and act like a redirect to an arbitrary origin. Treat them
+  // as untrusted and refuse before the absolute-path check below.
+  if (trimmed.startsWith("//")) return "#";
   if (trimmed.startsWith("/") || trimmed.startsWith("#") || trimmed.startsWith("?")) {
     return trimmed;
   }

--- a/frontend/src/pages/document-new.tsx
+++ b/frontend/src/pages/document-new.tsx
@@ -84,7 +84,7 @@ export default function DocumentNewPage() {
     // separators, absolute paths, and trailing slashes before the backend
     // ever sees the value. The backend should still validate, but a clear
     // client-side rejection produces a much better error message.
-    if (!/^[a-z0-9_\-]+(?:\/[a-z0-9_\-]+)*$/.test(c)) {
+    if (!/^[a-z0-9_-]+(?:\/[a-z0-9_-]+)*$/.test(c)) {
       setError(
         "Collection must use lowercase letters, digits, hyphens, underscores, and `/` only.",
       );


### PR DESCRIPTION
Three small post-merge fixes surfaced by the 3rd review pass.

## sanitizeLinkUrl — protocol-relative URL fix
Browsers inherit the current page scheme for `//evil.com/x` style URLs, so the previous \`startsWith(\"/\")\` allowance let a markdown link act as an open redirect / phishing vector. Adds an explicit \`//\` rejection before the absolute-path passthrough.

## Lint (3 errors → 0)
- \`document-new.tsx\`: collection regex \`[a-z0-9_\\-]\` → \`[a-z0-9_-]\` (eslint no-useless-escape, 2)
- \`document-view.tsx\`: TabStrip onKey drops unused \`let next = idx\` initializer (no-useless-assignment) — every branch assigns or early-returns, the seed was dead.

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` (0 errors) / \`pnpm build\` pass
- [x] sanitizeLinkUrl behavior:
  - \`//evil.com/x\` → \`#\` (new)
  - \`/local/path\` → unchanged ✓
  - \`https://example.com\` → unchanged ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)