### PR TITLE
chore(frontend): editor follow-up — tests, dead-import cleanup, edit-tab a11y, README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,89 @@
+# AKB Frontend
+
+React 19 + TypeScript + Vite + Radix UI + Tailwind CSS v4. The web UI for
+[AKB](../README.md), the agent knowledgebase.
+
+## Scripts
+
+```sh
+pnpm install          # install deps
+pnpm dev              # vite dev server on :5173 (proxies /api to :8000)
+pnpm typecheck        # tsc --noEmit
+pnpm lint             # eslint src
+pnpm test             # vitest run
+pnpm build            # tsc && vite build
+pnpm preview          # serve dist locally
+pnpm test:e2e         # playwright (requires backend reachable at AKB_URL)
+```
+
+## Editing documents
+
+Two write surfaces live in the SPA — both reuse the same lazy-loaded
+[Plate](https://platejs.org)-based `MarkdownEditor`:
+
+- **New document** — `+ NEW DOC` link on the vault page, or
+  `/vault/:name/doc/new`. Visible to writers/admins/owners. The form
+  asks for title, collection (lowercase path, `engineering/specs`-style),
+  optional type/domain/tags/summary, and a body in markdown. New
+  collections are created on the fly by the backend.
+- **Edit body** — `EDIT` tab on the document page (writers and above,
+  hidden in historical view). The editor reclaims the full outlet width
+  while open (right rail hides). Saves go through
+  `PATCH /documents/:vault/:id` with only the `content` field; metadata
+  is preserved by the backend's frontmatter merge logic. Use the
+  `Edit details` button in the right rail for title/type/tags/etc.
+
+Both flows guard against accidental data loss:
+
+- `beforeunload` warning while the editor is dirty.
+- Confirmation when switching tabs from `EDIT` with unsaved changes.
+- `EDIT*` star marker + a `UNSAVED CHANGES` line while dirty.
+- Cancel resets the editor to the last server state.
+
+Link URLs in user-authored markdown pass through `sanitizeLinkUrl()`
+on both the editor and the rendered view — `javascript:`, `data:`,
+`vbscript:`, and protocol-relative `//host` schemes round-trip to
+`#` so a malicious doc can't embed a clickable XSS.
+
+## Architecture quick map
+
+```
+src/
+  pages/                       route components
+    document.tsx               read + edit body (Rendered / Raw / Agent / Edit)
+    document-new.tsx           create page with form + Plate body
+    vault.tsx                  vault home; `+ NEW DOC` entry point
+    ...
+  components/
+    markdown-editor.tsx        Plate editor (lazy chunk)
+    markdown-editor-fallback.tsx  Suspense placeholder (main bundle)
+    document-view.tsx          Rendered/Raw/Agent + WAI-ARIA tab strip
+    frontmatter-edit-dialog.tsx  metadata + optional body edit
+    ui/tag-input.tsx           shared tag chip input
+    ui/...
+  lib/
+    api.ts                     fetch helpers + ApiError
+    utils.ts                   `cn`, `timeAgo`, `sanitizeLinkUrl`, ...
+    doc-constants.ts           DOC_TYPES / DOC_STATUSES
+    markdown.ts                heading parsing for the outline
+```
+
+The Plate chunk is ~260 KB gzipped and only loads when the user enters
+`EDIT` or `/doc/new`, so the read-only path is unaffected.
+
+## Testing
+
+Unit tests live under `src/**/__tests__/`. Vitest runs against jsdom +
+`@testing-library/react`. Critical security helpers (link sanitizing)
+and interactive components (`TagInput`) have explicit coverage. Add a
+test alongside any change to those code paths.
+
+Playwright e2e specs live in `e2e/`. `pnpm test:e2e` expects the AKB
+backend reachable at `AKB_URL` (defaults to `http://localhost:8000`).
+
+## Adding routes
+
+Routes are declared in `src/main.tsx` inside the `<Routes>` block.
+Doc routes are nested under `VaultShell`; the doc-create route
+(`/vault/:name/doc/new`) sits *before* `/vault/:name/doc/:id` so the
+literal `new` segment matches first.

--- a/frontend/src/components/__tests__/tag-input.test.tsx
+++ b/frontend/src/components/__tests__/tag-input.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TagInput } from "@/components/ui/tag-input";
+
+describe("TagInput", () => {
+  it("commits a tag on Enter and clears the draft", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={[]} onChange={onChange} />);
+    const input = screen.getByRole("textbox");
+    await user.type(input, "release{Enter}");
+    expect(onChange).toHaveBeenCalledWith(["release"]);
+    expect(input).toHaveValue("");
+  });
+
+  it("commits a tag on comma", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={[]} onChange={onChange} />);
+    await user.type(screen.getByRole("textbox"), "alpha,");
+    expect(onChange).toHaveBeenCalledWith(["alpha"]);
+  });
+
+  it("strips a leading # and de-dupes existing tags", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={["alpha"]} onChange={onChange} />);
+    await user.type(screen.getByRole("textbox"), "#alpha{Enter}");
+    // Already in value — onChange should not be called with a duplicate.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("backspace on an empty draft pops the last tag", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={["alpha", "beta"]} onChange={onChange} />);
+    await user.click(screen.getByRole("textbox"));
+    await user.keyboard("{Backspace}");
+    expect(onChange).toHaveBeenCalledWith(["alpha"]);
+  });
+
+  it("caps individual tags at maxTagLength", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={[]} onChange={onChange} maxTagLength={5} />);
+    await user.type(screen.getByRole("textbox"), "supercalifragilistic{Enter}");
+    expect(onChange).toHaveBeenCalledWith(["super"]);
+  });
+
+  it("refuses to add tags once maxTags is reached", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={["a", "b"]} onChange={onChange} maxTags={2} />);
+    await user.type(screen.getByRole("textbox"), "c{Enter}");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("renders an X button per existing tag and removes via click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TagInput value={["alpha", "beta"]} onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: /Remove tag alpha/ }));
+    expect(onChange).toHaveBeenCalledWith(["beta"]);
+  });
+});

--- a/frontend/src/lib/__tests__/sanitize-link-url.test.ts
+++ b/frontend/src/lib/__tests__/sanitize-link-url.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeLinkUrl } from "@/lib/utils";
+
+// sanitizeLinkUrl is the only thing standing between user-written markdown
+// links and the user's clipboard / clicks. The actual XSS vectors we care
+// about — `javascript:`, `data:`, `vbscript:`, and protocol-relative
+// `//host` redirects — must round-trip to `#`, while every reasonable
+// navigation scheme must pass through unchanged. Lock both halves down so
+// a well-meaning refactor can't reintroduce the hole.
+describe("sanitizeLinkUrl", () => {
+  it("strips javascript: links", () => {
+    expect(sanitizeLinkUrl("javascript:alert(1)")).toBe("#");
+    expect(sanitizeLinkUrl("JavaScript:alert(1)")).toBe("#");
+    expect(sanitizeLinkUrl("  javascript:alert(1)  ")).toBe("#");
+  });
+
+  it("strips data: links", () => {
+    expect(sanitizeLinkUrl("data:text/html,<script>alert(1)</script>")).toBe("#");
+  });
+
+  it("strips vbscript: and other unknown schemes", () => {
+    expect(sanitizeLinkUrl("vbscript:msgbox(1)")).toBe("#");
+    expect(sanitizeLinkUrl("file:///etc/passwd")).toBe("#");
+    expect(sanitizeLinkUrl("intent://evil")).toBe("#");
+  });
+
+  it("blocks protocol-relative URLs that inherit the page scheme", () => {
+    // Browsers expand `//evil.example/x` to `https://evil.example/x` —
+    // treat the implicit scheme as untrusted.
+    expect(sanitizeLinkUrl("//evil.example/x")).toBe("#");
+    expect(sanitizeLinkUrl("  //evil.example/x  ")).toBe("#");
+  });
+
+  it("passes through http / https / mailto / tel", () => {
+    expect(sanitizeLinkUrl("https://example.com")).toBe("https://example.com");
+    expect(sanitizeLinkUrl("http://example.com")).toBe("http://example.com");
+    expect(sanitizeLinkUrl("HTTPS://Example.COM")).toBe("HTTPS://Example.COM");
+    expect(sanitizeLinkUrl("mailto:a@example.com")).toBe("mailto:a@example.com");
+    expect(sanitizeLinkUrl("tel:+1-555-0100")).toBe("tel:+1-555-0100");
+  });
+
+  it("passes through same-origin paths, fragments, queries", () => {
+    expect(sanitizeLinkUrl("/local/path")).toBe("/local/path");
+    expect(sanitizeLinkUrl("#anchor")).toBe("#anchor");
+    expect(sanitizeLinkUrl("?q=x")).toBe("?q=x");
+  });
+
+  it("returns `#` for empty, whitespace, null, or undefined input", () => {
+    expect(sanitizeLinkUrl("")).toBe("#");
+    expect(sanitizeLinkUrl("   ")).toBe("#");
+    expect(sanitizeLinkUrl(null)).toBe("#");
+    expect(sanitizeLinkUrl(undefined)).toBe("#");
+  });
+});

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -19,7 +19,6 @@ import {
   getDocument,
   getRelations,
   getVaultInfo,
-  publishDoc,
   unpublishDoc,
   updateDocument,
 } from "@/lib/api";
@@ -409,10 +408,32 @@ export default function DocumentPage() {
                 role="tablist"
                 aria-label="Document view"
                 className="inline-flex border border-border"
+                onKeyDown={(e) => {
+                  // Roving tabindex within the strip — Arrow keys move
+                  // focus, Enter/Space (handled by the button itself)
+                  // activates. Matches the WAI-ARIA tabs pattern used in
+                  // DocumentView's TabStrip.
+                  const buttons = Array.from(
+                    e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+                  );
+                  const idx = buttons.indexOf(document.activeElement as HTMLButtonElement);
+                  if (idx < 0) return;
+                  let next: number;
+                  if (e.key === "ArrowRight") next = (idx + 1) % buttons.length;
+                  else if (e.key === "ArrowLeft") next = (idx - 1 + buttons.length) % buttons.length;
+                  else if (e.key === "Home") next = 0;
+                  else if (e.key === "End") next = buttons.length - 1;
+                  else return;
+                  e.preventDefault();
+                  buttons[next]?.focus();
+                }}
               >
                 <button
                   role="tab"
+                  id="doc-tab-rendered"
                   aria-selected={false}
+                  aria-controls="doc-panel-rendered"
+                  tabIndex={-1}
                   onClick={() => setView("rendered")}
                   className="px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider transition-colors cursor-pointer text-foreground-muted hover:text-foreground hover:bg-surface-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
@@ -420,7 +441,10 @@ export default function DocumentPage() {
                 </button>
                 <button
                   role="tab"
+                  id="doc-tab-raw"
                   aria-selected={false}
+                  aria-controls="doc-panel-raw"
+                  tabIndex={-1}
                   onClick={() => setView("raw")}
                   className="px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider border-l border-border transition-colors cursor-pointer text-foreground-muted hover:text-foreground hover:bg-surface-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
@@ -428,14 +452,22 @@ export default function DocumentPage() {
                 </button>
                 <button
                   role="tab"
+                  id="doc-tab-edit"
                   aria-selected={true}
+                  aria-controls="doc-panel-edit"
+                  tabIndex={0}
                   className="px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider border-l border-border bg-foreground text-background cursor-default"
                 >
                   EDIT{isDirty ? "*" : ""}
                 </button>
               </div>
             </div>
-            <div className="space-y-3">
+            <div
+              id="doc-panel-edit"
+              role="tabpanel"
+              aria-labelledby="doc-tab-edit"
+              className="space-y-3"
+            >
               <div className="coord flex items-center justify-between">
                 <span>EDITING BODY</span>
                 <span className="text-foreground-muted normal-case tracking-normal font-sans">


### PR DESCRIPTION
Remaining follow-ups identified after the editor PRs (#58, #59, #60) went live on production. No behavior change for happy-path users; new tests guard against regressions and screen-reader users gain full arrow-key navigation on the editor tab strip too.

## Tests
- \`frontend/src/lib/__tests__/sanitize-link-url.test.ts\` — 7 cases locking in \`javascript:\` / \`data:\` / \`vbscript:\` rejection, protocol-relative \`//host\` rejection (the 3rd-pass regression), \`http\` / \`https\` / \`mailto\` / \`tel\` passthrough, and empty-input → \`#\` behavior.
- \`frontend/src/components/__tests__/tag-input.test.tsx\` — 7 cases covering Enter / comma commit, leading \`#\` strip + de-dupe, Backspace pop, per-tag length cap, max-tags refusal, per-tag remove.

Total: **\`pnpm test\`** = 44 files / 222 tests, all green.

## document.tsx
- Drop the unused \`publishDoc\` import (carry-over from main; \`unpublishDoc\` is the only call site).
- Edit-mode inline tab strip now follows the WAI-ARIA tabs pattern, matching DocumentView's TabStrip: roving \`tabindex\`, ArrowLeft / ArrowRight / Home / End keyboard navigation, \`aria-controls\` / \`aria-labelledby\` wiring the EDIT button to the body editor panel id.

## Docs
- \`frontend/README.md\` added — scripts, the two write surfaces (new doc + edit body), data-loss guards, sanitize behavior, an architecture quick map pointing at the lazy Plate chunk, test layout, and the literal-route-before-dynamic-route rule for adding routes.

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` (0 errors) / \`pnpm test\` (222/222) / \`pnpm build\` pass
- [x] Yatap production smoke (before this PR): \`//evil.example\` link → \`href=#\`, full WAI-ARIA tabs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)