### PR TITLE
Remove GitPython index lock from GitService writes

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -28,7 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, quote
 
-from git import Repo, Actor, cmd as git_cmd
+from git import Repo, cmd as git_cmd
 from git.exc import GitError
 
 from app.config import settings
@@ -53,15 +53,6 @@ def _vault_lock(vault_name: str) -> threading.Lock:
         return lock
 
 
-# GitPython's IndexFile ops (`add`/`commit`/`remove`) are decorated
-# with `@git_working_dir`, which `os.chdir`s into the worktree and
-# restores cwd in a finally. `os.chdir` is process-global — concurrent
-# writes on DIFFERENT vault worktrees leak cwd across threads, and a
-# cleanup of the leaked dir makes the next `os.getcwd()` raise ENOENT
-# (request 500s). Per-vault `_vault_lock` is not enough; serialize
-# globally. Always acquired INSIDE `_vault_lock`.
-_GITPY_INDEX_LOCK = threading.Lock()
-
 
 class GitService:
     def __init__(self, storage_path: str | None = None):
@@ -81,6 +72,48 @@ class GitService:
         if not bare_path.exists():
             raise FileNotFoundError(f"Vault repo not found: {vault_name}")
         return Repo(str(bare_path))
+
+    @staticmethod
+    def _git_author_env(author_name: str, author_email: str) -> dict[str, str]:
+        return {
+            "GIT_AUTHOR_NAME": author_name,
+            "GIT_AUTHOR_EMAIL": author_email,
+            "GIT_COMMITTER_NAME": author_name,
+            "GIT_COMMITTER_EMAIL": author_email,
+        }
+
+    def _stage_and_commit(
+        self,
+        work_repo: Repo,
+        message: str,
+        author_name: str,
+        author_email: str,
+        *,
+        parent_required: bool,
+    ) -> str:
+        """Commit the already-staged index without GitPython IndexFile ops.
+
+        GitPython's IndexFile add/remove/commit path mutates process cwd.
+        The `repo.git.*` command interface launches git with an explicit
+        working directory instead, so writes remain safe across thread-pool
+        workers and vaults.
+        """
+        tree_sha = work_repo.git.write_tree()
+        parent_args: list[str] = []
+        if parent_required:
+            work_repo.git.rev_parse("--verify", "HEAD")
+            parent_args = ["-p", "HEAD"]
+
+        with work_repo.git.custom_environment(**self._git_author_env(author_name, author_email)):
+            commit_sha = work_repo.git.commit_tree(
+                "--no-gpg-sign",
+                tree_sha,
+                *parent_args,
+                "-m",
+                message,
+            ).strip()
+        work_repo.git.update_ref("HEAD", commit_sha)
+        return work_repo.git.rev_parse("HEAD").strip()
 
     def _ensure_worktree(self, vault_name: str) -> Path | None:
         """Create a persistent worktree for this vault if one doesn't exist.
@@ -492,11 +525,14 @@ class GitService:
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(content, encoding="utf-8")
 
-            author = Actor(author_name, author_email)
-            with _GITPY_INDEX_LOCK:
-                work_repo.index.add([file_path])
-                commit = work_repo.index.commit(message, author=author, committer=author)
-            return commit.hexsha
+            work_repo.git.add("--", file_path)
+            return self._stage_and_commit(
+                work_repo,
+                message,
+                author_name,
+                author_email,
+                parent_required=True,
+            )
 
     def delete_file(
         self,
@@ -519,11 +555,14 @@ class GitService:
             if not full_path.exists():
                 raise FileNotFoundError(f"File not found in vault: {file_path}")
 
-            author = Actor(author_name, author_email)
-            with _GITPY_INDEX_LOCK:
-                work_repo.index.remove([file_path], working_tree=True)
-                commit = work_repo.index.commit(message, author=author, committer=author)
-            return commit.hexsha
+            work_repo.git.rm("--", file_path)
+            return self._stage_and_commit(
+                work_repo,
+                message,
+                author_name,
+                author_email,
+                parent_required=True,
+            )
 
     def delete_paths_bulk(
         self,
@@ -541,7 +580,7 @@ class GitService:
         every requested path is already absent, no commit is made and
         this returns `None`. Duplicates in `file_paths` are deduplicated
         (order-preserving) before the presence check so a doubled path
-        doesn't trip `index.remove` on its second occurrence.
+        doesn't trip `git rm` on its second occurrence.
 
         Mirrors `delete_file`'s lock + worktree-prep + commit shape.
         Returns the new commit's hex SHA, or `None` when no commit was made.
@@ -556,7 +595,7 @@ class GitService:
             work_repo.git.reset("--hard", "HEAD")
 
             # Dedupe while preserving caller order so log output is stable
-            # and so a doubled path doesn't make `index.remove` fail on
+            # and so a doubled path doesn't make `git rm` fail on
             # the second occurrence.
             unique_paths = list(dict.fromkeys(file_paths))
             present = [p for p in unique_paths if (wt / p).exists()]
@@ -567,11 +606,14 @@ class GitService:
                 )
                 return None
 
-            author = Actor(author_name, author_email)
-            with _GITPY_INDEX_LOCK:
-                work_repo.index.remove(present, working_tree=True)
-                commit = work_repo.index.commit(message, author=author, committer=author)
-            return commit.hexsha
+            work_repo.git.rm("--", *present)
+            return self._stage_and_commit(
+                work_repo,
+                message,
+                author_name,
+                author_email,
+                parent_required=True,
+            )
 
     def _commit_via_clone(
         self,
@@ -606,7 +648,6 @@ class GitService:
         import subprocess
         import tempfile
         bare_path = self._bare_path(vault_name)
-        author = Actor(author_name, author_email)
         # Stable parent for the tmp dir so we don't depend on the
         # process cwd to resolve a relative name. ``storage_path``
         # always exists on a healthy deploy.
@@ -624,13 +665,14 @@ class GitService:
             full_path = Path(tmp) / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(content, encoding="utf-8")
-            # IndexFile add/commit mutate process-global cwd via GitPython's
-            # @git_working_dir decorator — serialize them so concurrent commits
-            # to other vaults can't leak cwd. The push below uses the cwd-safe
-            # repo.git.* interface and stays outside the lock.
-            with _GITPY_INDEX_LOCK:
-                work_repo.index.add([file_path])
-                commit = work_repo.index.commit(message, author=author, committer=author)
+            work_repo.git.add("--", file_path)
+            commit_hash = self._stage_and_commit(
+                work_repo,
+                message,
+                author_name,
+                author_email,
+                parent_required=False,
+            )
             # Push is local-to-local (bare repo on the same disk), so
             # 60s is generous; if it hangs the timeout still releases
             # the vault lock for the next caller.
@@ -640,7 +682,7 @@ class GitService:
                 raise GitError(
                     f"git push failed for vault {vault_name}: {e}"
                 ) from e
-        return commit.hexsha
+        return commit_hash
 
     # ── History operations ───────────────────────────────────
 

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1,16 +1,13 @@
-"""Unit tests for GitService bulk-delete behaviour.
+"""Unit tests for GitService write behaviour.
 
 GitService writes to `git_storage_path` from settings. Passing a tmp
 `storage_path` to the constructor bypasses that entirely, so these
 tests never touch the real `/data/vaults` directory.
-
-The full write path requires a non-empty bare repo (otherwise
-`_ensure_worktree` returns None and writes fall back to the clone
-path). We seed each vault with one `commit_file` to get past that.
 """
 
 from __future__ import annotations
 
+import os
 import uuid
 
 import pytest
@@ -29,7 +26,7 @@ def vault(git_service):
     """Initialise a vault with one seed commit so the worktree exists.
 
     Returns the vault name. The seed commit is on a single throwaway
-    file ('seed.md') the bulk-delete tests do not touch.
+    file ('seed.md') the write tests do not touch.
     """
     name = f"test_vault_{uuid.uuid4().hex[:8]}"
     git_service.init_vault(name)
@@ -44,6 +41,122 @@ def vault(git_service):
 
 def _vault_commit_count(git_service: GitService, vault_name: str) -> int:
     return len(git_service.vault_log(vault_name, max_count=1000))
+
+
+def _block_chdir(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_chdir(path: str) -> None:
+        raise AssertionError(f"os.chdir must not be used by GitService writes: {path}")
+
+    monkeypatch.setattr(os, "chdir", fail_chdir)
+
+
+def test_commit_file_creates_initial_commit(git_service: GitService) -> None:
+    name = f"test_vault_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+
+    sha = git_service.commit_file(
+        vault_name=name,
+        file_path="first.md",
+        content="first\n",
+        message="initial document",
+        author_name="Ada Lovelace",
+        author_email="ada@example.dev",
+    )
+
+    assert len(sha) == 40
+    assert git_service.read_file(name, "first.md") == "first\n"
+    assert _vault_commit_count(git_service, name) == 1
+
+
+def test_commit_file_existing_worktree_preserves_author_and_message(git_service: GitService, vault: str) -> None:
+    before = _vault_commit_count(git_service, vault)
+
+    sha = git_service.commit_file(
+        vault_name=vault,
+        file_path="authored.md",
+        content="body\n",
+        message="custom subject\n\nbody line",
+        author_name="Ada Lovelace",
+        author_email="ada@example.dev",
+    )
+
+    after = _vault_commit_count(git_service, vault)
+    latest = git_service.vault_log(vault, max_count=1)[0]
+
+    assert len(sha) == 40
+    assert after == before + 1
+    assert latest["hash"] == sha[:12]
+    assert latest["subject"] == "custom subject"
+    assert latest["author"] == "Ada Lovelace"
+    assert git_service.read_file(vault, "authored.md") == "body\n"
+
+
+def test_delete_file_removes_file_and_creates_commit(git_service: GitService, vault: str) -> None:
+    git_service.commit_file(
+        vault_name=vault,
+        file_path="delete-me.md",
+        content="delete me",
+        message="add delete-me",
+    )
+    before = _vault_commit_count(git_service, vault)
+
+    sha = git_service.delete_file(
+        vault_name=vault,
+        file_path="delete-me.md",
+        message="delete delete-me",
+    )
+
+    after = _vault_commit_count(git_service, vault)
+    latest = git_service.vault_log(vault, max_count=1)[0]
+
+    assert len(sha) == 40
+    assert after == before + 1
+    assert latest["hash"] == sha[:12]
+    assert latest["subject"] == "delete delete-me"
+    assert git_service.read_file(vault, "delete-me.md") is None
+
+
+def test_write_paths_do_not_call_os_chdir(
+    git_service: GitService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = f"test_vault_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+
+    _block_chdir(monkeypatch)
+
+    git_service.commit_file(
+        vault_name=name,
+        file_path="seed.md",
+        content="seed\n",
+        message="seed",
+    )
+    git_service.commit_file(
+        vault_name=name,
+        file_path="delete-me.md",
+        content="delete me",
+        message="add delete-me",
+    )
+    git_service.delete_file(
+        vault_name=name,
+        file_path="delete-me.md",
+        message="delete delete-me",
+    )
+    for path in ("bulk-a.md", "bulk-b.md"):
+        git_service.commit_file(
+            vault_name=name,
+            file_path=path,
+            content=path,
+            message=f"add {path}",
+        )
+
+    sha = git_service.delete_paths_bulk(
+        vault_name=name,
+        file_paths=["bulk-a.md", "bulk-b.md"],
+        message="bulk delete",
+    )
+
+    assert sha is not None
 
 
 def test_delete_paths_bulk_removes_files_and_creates_one_commit(git_service, vault):


### PR DESCRIPTION
## Summary
- Replaced `GitPython` index-based write operations with `repo.git.*`-driven staging and commit flow in `GitService`.
- Removed the global `_GITPY_INDEX_LOCK` and kept per-vault serialization via `_vault_lock`.
- Added regression tests covering initial commit, existing worktree writes, delete flows, and a guard that fails if `os.chdir` is used during writes.

## Testing
- `pytest tests/test_git_service.py` passed
- `ruff check app/services/git_service.py tests/test_git_service.py` passed
- `git diff --check` passed
- Verified the new write path no longer references `work_repo.index` / `_GITPY_INDEX_LOCK`