### PR TITLE
perf(proxy): reuse HTTP connections with keep-alive agent

### DIFF
--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -9,12 +9,21 @@
  * - Zero dependencies (Node.js built-in only)
  */
 
-import { request as httpsRequest } from "node:https";
-import { request as httpRequest } from "node:http";
+import { request as httpsRequest, Agent as httpsAgent } from "node:https";
+import { request as httpRequest, Agent as httpAgent } from "node:http";
 import { createInterface } from "node:readline";
 import { createReadStream, createWriteStream, readFileSync, statSync } from "node:fs";
 import { mkdir, stat as fsStat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+
+// ── Connection reuse ───────────────────────────────────────
+// Without keepAlive agents, every MCP tool call (search, browse, put,
+// update, relations, …) triggers a fresh TCP+TLS handshake to the backend.
+// A typical agent session chains 5–15 tool calls; reusing connections
+// saves one round-trip per call (40–100 ms on a nearby cloud backend,
+// more across regions or with slow TLS termination).
+const httpKeepAlive = new httpAgent({ keepAlive: true });
+const httpsKeepAlive = new httpsAgent({ keepAlive: true });
 
 // ── MIME type inference ────────────────────────────────────
 // Covers common file types. Unknown extensions fall back to octet-stream.
@@ -546,6 +555,7 @@ export class AKBProxy {
         path,
         method,
         headers,
+        agent: isHttps ? httpsKeepAlive : httpKeepAlive,
       };
       if (isHttps && this.insecure) opts.rejectUnauthorized = false;
 


### PR DESCRIPTION
## What

The `akb-mcp` proxy creates a new TCP+TLS connection for every MCP tool call because Node.js default HTTP agent has `keepAlive: false`. A typical agent session chains 5–15 tool calls (initialize → search → browse → put → update → relations → …) — each one pays the handshake cost.

## Fix

Two module-level agents with `keepAlive: true` shared across all `_http` calls to the same backend host:

```diff
+ import { Agent as httpAgent } from "node:http";
+ import { Agent as httpsAgent } from "node:https";
+
+ const httpKeepAlive = new httpAgent({ keepAlive: true });
+ const httpsKeepAlive = new httpsAgent({ keepAlive: true });
```

Passed via `agent:` in the `_http` opts. Zero config, zero dependencies (Node built-in since v0.x).

## Impact

| Call | Before | After |
|---|---|---|
| 1st tool call | TCP + TLS handshake (~50 ms) | TCP + TLS handshake (~50 ms) |
| 2nd tool call | TCP + TLS handshake (~50 ms) | **Reuses connection (0 ms)** |
| 3rd+ | Same | **Reuses connection (0 ms)** |

Per-session savings: ~200–500 ms for a typical 5–10 call session (more across regions).

## Verification

- Contract test: 5/5 pass
- Module loads without error
- MCP JSON-RPC semantics unchanged
- S3 presigned-URL methods (`_uploadToS3`, `_downloadFromS3`) are unaffected — they connect to MinIO/S3 hosts, not the AKB backend

## Alternatives considered

- **Single-request agent per call**: More isolation but defeats the purpose — each call still gets its own connection.
- **Keep-alive on S3 methods too**: The S3 upload/download methods go to presigned URLs that may point to different hosts — marginal benefit, left out to keep this PR surgical.

Happy to iterate.