### PR TITLE
fix: enforce ACLs for MCP search

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -310,6 +310,8 @@ async def _handle_browse(args: dict, uid: str, user: _MCPUser) -> dict:
 
 @_h("akb_search")
 async def _handle_search(args: dict, uid: str, user: _MCPUser) -> dict:
+    if args.get("vault"):
+        await check_vault_access(uid, args["vault"], required_role="reader")
     result = await search_service.search(
         query=args["query"],
         vault=args.get("vault"),
@@ -317,6 +319,7 @@ async def _handle_search(args: dict, uid: str, user: _MCPUser) -> dict:
         doc_type=args.get("type"),
         tags=args.get("tags"),
         limit=args.get("limit", 10),
+        user_id=uid,
     )
     return result.model_dump()
 

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -471,6 +471,11 @@ R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
 DENIED_AGAIN=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
 [ "$DENIED_AGAIN" = "True" ] && pass "User2 denied after revoke" || fail "Post-revoke check" "still has access"
 
+# User2 cannot search again after revoke
+R=$(mcp_call2 akb_search "{\"query\":\"test\",\"vault\":\"$VAULT\"}" | mcp_result2)
+SEARCH_DENIED_AGAIN=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
+[ "$SEARCH_DENIED_AGAIN" = "True" ] && pass "User2 denied search after revoke" || fail "Post-revoke search" "still returned search access"
+
 # ── 16. Public Access Levels ─────────────────────────────────
 echo ""
 echo "▸ 16. Public Access Levels"


### PR DESCRIPTION
## Summary
- pass the authenticated `uid` into `SearchService.search()` from the MCP `akb_search` handler
- fail closed with `check_vault_access(..., required_role="reader")` when a vault is explicitly targeted
- extend the MCP e2e flow to assert search is denied again after revoke

## Why
Issue #66: the MCP path was bypassing the ACL-aware `user_id` prefilter in `SearchService.search()`, which created a risk of unauthorized search results.

## Verification
- `python3 -m py_compile backend/mcp_server/server.py`
- `bash -n backend/tests/test_mcp_e2e.sh`