### PR TITLE
test(security): assert no cross-vault leak in akb_search

### DIFF
--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -113,6 +113,47 @@ R=$(mcp_as "$PAT2" "$SID2" "akb_grep" "{\"pattern\":\"XYZZY-SECRET\"}" | mr)
 LEAK_DOCS=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total_docs',0))" 2>/dev/null)
 [ "$LEAK_DOCS" = "0" ] && pass "Cross-vault grep leak prevented (0 docs)" || fail "Grep leak" "User2 found $LEAK_DOCS docs without vault access"
 
+# ── 1a. Search Access Control (issue #66) ────────────────────
+# Mirrors the grep cases above. The leak path closed by PR #67 was:
+# `akb_search` ran service-layer ACL prefiltering only when `user_id`
+# was supplied — the MCP handler wasn't forwarding it. Test 3 below
+# asserts on the actual `vault` field in results so a hit from a
+# legitimately-readable public vault is NOT mistaken for a leak.
+#
+# akb_search uses BM25 + vector store, both of which are populated by
+# the embed_worker after akb_put returns. Grep above hits git-stored
+# content directly so it doesn't need this wait; search does.
+echo ""
+echo "▸ 1a. Search Access Control"
+# embed_worker default idle is 10s; we need TWO loops worth in the worst
+# case (drain the chunks queue + actually index). 20s is conservative
+# for local pgvector.
+sleep 20
+
+# 1a-1: explicit vault arg → fail-closed at the handler gate.
+R=$(mcp_as "$PAT2" "$SID2" "akb_search" "{\"query\":\"XYZZY-SECRET\",\"vault\":\"$VAULT1\"}" | mr)
+HAS_ERROR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d or 'Access denied' in str(d) or 'role' in str(d).lower())" 2>/dev/null)
+[ "$HAS_ERROR" = "True" ] && pass "User2 blocked from search on private vault (explicit arg)" || fail "Search explicit-vault" "$R"
+
+# 1a-2: owner can find their own doc.
+R=$(mcp_as "$PAT1" "$SID1" "akb_search" "{\"query\":\"XYZZY-SECRET\",\"vault\":\"$VAULT1\"}" | mr)
+RES=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
+[ "$RES" -ge 1 ] 2>/dev/null && pass "User1 search own vault ($RES hits)" || fail "Search own vault" "expected >=1, got $RES"
+
+# 1a-3: no vault arg → ACL prefilter must scope results to vaults
+# User2 can read. Hits from public vaults are FINE; the only thing
+# that constitutes a leak is a hit whose `vault` field is User1's
+# private vault. Naive total-count checks false-positive on prods
+# that have public vaults whose content loosely matches the query.
+R=$(mcp_as "$PAT2" "$SID2" "akb_search" "{\"query\":\"XYZZY-SECRET\"}" | mr)
+LEAK_FROM_V1=$(echo "$R" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+leaks = [r for r in d.get('results', []) if r.get('vault') == '$VAULT1']
+print(len(leaks))
+" 2>/dev/null)
+[ "$LEAK_FROM_V1" = "0" ] && pass "Cross-vault search leak prevented (0 results from $VAULT1)" || fail "Search leak" "User2 saw $LEAK_FROM_V1 result(s) from User1's private vault"
+
 # ── 1b. Knowledge graph access control (issue #3) ────────────
 echo ""
 echo "▸ 1b. Knowledge graph access control"


### PR DESCRIPTION
## Summary

Follow-up to #67 — adds the e2e case that should have caught the
original leak. PR #67 closed the explicit-vault path with
\`check_vault_access\` and added a single post-revoke regression
test, but the no-vault-arg path (the actual leak source per
issue #66) stayed un-asserted.

Three cases in \`test_security_edge_e2e.sh\` section **1a**, mirroring
the existing \`akb_grep\` cross-vault coverage:

1. User2 search with explicit \`vault\` arg → fail-closed (\`check_vault_access\`)
2. User1 search own vault → finds the secret doc
3. **User2 search WITHOUT vault arg** → asserts on the \`vault\`
   field of each result; only a hit whose \`vault\` equals User1's
   private vault counts as a leak. Hits from legitimate public
   vaults don't false-positive.

## Why the vault-field check matters

When my reproduction of #66 against prod returned hits, my first-
pass repro script flagged it as a leak — but the hits were from
public vaults (\`legalize-kr-external-ro\`, \`agent-notes\`) that
Bob can legitimately read. The hybrid search matched loose tokens.
Naive \"total > 0 = leak\" assertions false-positive on any DB with
public-readable content. The only honest signal is whether a
private-vault URI appears in the result list.

## Test plan
- [x] \`backend/tests/test_security_edge_e2e.sh\` — 65/65 (was
  62/62, +3 cases).
- [x] All other suites unaffected (no shared state changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)