### PR TITLE
fix(search): require vault or user_id on SearchService.search

### DIFF
--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -116,6 +116,15 @@ class SearchService:
         user_id: str | None = None,
     ) -> SearchResponse:
         """Hybrid search across documents. See module docstring for flow."""
+        # ACL guard mirroring `grep` below: when neither vault nor
+        # user_id scopes the query, the prefilter block ends up
+        # skipped (has_filters=False) and `_run_vector_search` runs
+        # unscoped — a cross-vault scan. The MCP and REST handlers
+        # both forward user_id today (see issue #66 / PR #67), but
+        # this self-defends against any future caller that forgets.
+        if vault is None and user_id is None:
+            raise ValidationError("vault or user_id required")
+
         pool = await get_pool()
 
         # Generate query embedding. When the embedding API is down we still

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.exceptions import ValidationError
 from app.services.search_service import (
+    SearchService,
     fuse_original_and_reranked_hits,
     resolve_first_stage_unique_limit,
 )
@@ -66,3 +68,28 @@ def test_first_stage_unique_limit_keeps_legacy_rerank_off_default():
         rerank_prefetch=30,
         search_prefetch=0,
     ) == 5
+
+
+@pytest.mark.asyncio
+async def test_search_requires_vault_or_user_id():
+    """Mirror of the same guard in `grep`: a caller that forwards
+    neither `vault` nor `user_id` would otherwise fall through to an
+    unscoped cross-vault scan. All current callers (REST /search, MCP
+    akb_search) forward `user_id`, so this is defense-in-depth for
+    any future caller that forgets."""
+    svc = SearchService()
+    with pytest.raises(ValidationError):
+        await svc.search(query="anything")
+    with pytest.raises(ValidationError):
+        await svc.search(query="anything", vault=None, user_id=None)
+    # Either argument present is enough — no raise.
+    # (Don't actually run the search; just verify the guard returns
+    # control flow back so something further can happen. Catching
+    # downstream errors keeps this a pure-guard unit test that
+    # doesn't need a DB.)
+    try:
+        await svc.search(query="x", vault="v")
+    except ValidationError:
+        pytest.fail("Should not raise ValidationError when vault is set")
+    except Exception:
+        pass  # downstream (DB / embedding) is fine to fail; we only assert the guard


### PR DESCRIPTION
## Summary

Adds the same ACL guard `SearchService.grep` already has (search_service.py:521) to its sibling `SearchService.search`. Closes #70.

## Why

Pre-PR #67, the MCP `akb_search` handler didn't forward `user_id` to the service. Inside the service, `has_filters = any([vault, collection, doc_type, tags, user_id])` evaluated False on that path, the prefilter block was skipped, `candidate_source_ids` stayed None, and `_run_vector_search(..., candidate_source_ids=None)` ran unscoped — a cross-vault scan. That's the exact leak issue #66 / PR #67 closed.

PR #67 fixed it at the **handler**. This commit fixes it at the **service**, so the next caller that forgets `user_id` (a new REST endpoint, an internal worker, a future MCP tool) fails closed with `ValidationError` instead of silently scanning every vault.

## Test plan

- [x] New unit test `test_search_requires_vault_or_user_id` in `test_search_rerank_fusion.py` — asserts the guard raises with no scope args, doesn't raise when `vault` is supplied. Runs pure-function (no DB needed, the guard runs before `get_pool()`).
- [x] All other test_search_rerank_fusion tests still pass (6/6).

## Scope

This commit doesn't change any current behavior:
- `/api/v1/search` route: already forwards `user.user_id`
- MCP `akb_search`: already forwards `uid` (post PR #67)
- No internal callers exist (grep'd)

So it's a strict defense-in-depth addition. Two lines of code (guard) + one unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)