### PR TITLE
fix(proxy): configurable request timeout, default 5 min (2.0.2)

### DIFF
--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.0.2 — bump default request timeout (30s → 5min)
+
+Bug fix: the proxy's per-request timeout was hardcoded to 30s, which
+aborted any operation slower than that on the client side — most
+visibly `akb_delete_vault` against a large vault (7K+ docs), where the
+backend cascade (chunks delete + vector outbox + git cleanup) easily
+runs past 30s. The operator would see `Request timeout (30s)` even
+though the backend kept processing and eventually completed; this
+produced the misleading impression that the delete had failed when in
+fact it had succeeded after the client gave up.
+
+The default is now 5 minutes (300_000 ms). For very large vaults or
+slow links, set `AKB_MCP_REQUEST_TIMEOUT_MS` to override. S3
+upload/download paths remain at 10 min (unchanged).
+
+Longer-term fix (separate backend PR): make `akb_delete_vault` an
+async background job that returns immediately and exposes a status
+endpoint, so client timeout becomes irrelevant.
+
 ## 2.0.1 — keep-alive proxy connections
 
 Performance fix: the stdio ↔ HTTP proxy now reuses TCP+TLS connections to

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -573,7 +573,14 @@ export class AKBProxy {
       });
 
       req.on("error", reject);
-      req.setTimeout(30000, () => req.destroy(new Error("Request timeout (30s)")));
+      // Default 5 min — destructive ops like `akb_delete_vault` on
+      // large vaults (7K+ docs) take well over 30s for the backend
+      // cascade (chunks + vector outbox + git cleanup). Hardcoding
+      // 30s caused the client to abort while the backend continued
+      // processing, leaving the operator with a misleading timeout
+      // error. Override via `AKB_MCP_REQUEST_TIMEOUT_MS`.
+      const reqTimeoutMs = Number(process.env.AKB_MCP_REQUEST_TIMEOUT_MS) || 300000;
+      req.setTimeout(reqTimeoutMs, () => req.destroy(new Error(`Request timeout (${Math.round(reqTimeoutMs / 1000)}s)`)));
       if (body) req.write(body);
       req.end();
     });

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {
     "akb-mcp": "./bin/akb-mcp.mjs"


### PR DESCRIPTION
## Summary

The stdio ↔ HTTP proxy hardcoded a 30-second per-request timeout on
non-S3 calls. Long backend operations — most visibly
`akb_delete_vault` on a 7k-document vault — take well over 30s to
cascade (chunks delete + vector outbox drain + git cleanup), and the
client side aborted while the backend kept processing. The operator
saw a misleading `Request timeout (30s)` error and would typically
retry, leaving the impression that the delete had failed when it had
actually succeeded after the client gave up.

- Default raised to **5 minutes (300_000 ms)**.
- New env override **`AKB_MCP_REQUEST_TIMEOUT_MS`** for very large vaults or slow links.
- S3 upload/download paths remain at 10 min (unchanged).

## Why this is the right size of fix

A longer-term fix is to make `akb_delete_vault` an async background
job that returns immediately and exposes a status endpoint — that
makes client timeout structurally irrelevant. Tracked separately.
The default bump and env override unblock the operator today without
touching backend contracts.

## Test plan

- [x] Verified `akb_delete_vault` on a 7k-doc vault completes through the proxy without timeout
- [x] Normal short tool calls still return well within the default 5-min window
- [x] `AKB_MCP_REQUEST_TIMEOUT_MS=600000` env override honored

After merge: bump in `packages/akb-mcp-client/package.json` triggers
the publish step (operator-only, see CLAUDE.md release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)