### PR TITLE
feat(eval): add agentic-bench harness

### DIFF
--- a/eval/agentic-bench/.gitignore
+++ b/eval/agentic-bench/.gitignore
@@ -1,0 +1,26 @@
+# Dataset and raw results stay out of the OSS repo — they're
+# domain-specific (Korean legal text, internal vault contents) and
+# the ground-truth answers are hand-written. Form/result tracking
+# lives in a separate private repo per project; OSS publishes only
+# the runner/judge code so other teams can fork it for their own
+# corpora.
+
+evalset/
+runs/
+runs_*/
+batches/
+verdicts/
+metrics.json
+vault_snapshot.json
+report_*.md
+runner*.log
+log_*.log
+
+# Build artefacts
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# One-off helpers from earlier iterations — not part of the
+# released runner. Kept out so the public surface stays tight.
+judge_local.py

--- a/eval/agentic-bench/README.md
+++ b/eval/agentic-bench/README.md
@@ -92,6 +92,52 @@ path on `akb_drill_down`. Earlier backends will run but the tree
 arm will look much worse than it should — the early-version
 benchmarks in our own history demonstrate exactly that failure mode.
 
+## Findings from the seed run
+
+The dataset we shipped this harness against was a 100-question
+single-vault corpus with ≈ 5 700 documents, a deep section
+hierarchy, and a long-form domain text style. Eight backend
+iterations measured against the same evalset and agent model
+(`qwen3.6-plus`), changing only the search-tool surface between
+runs:
+
+| Run | Backend change | A1 search | A2 grep | A3 tree | A4 all |
+|---|---|---|---|---|---|
+| Early | baseline | 73 % | 33 % | **4 %** | 63 % |
+| Mid | `akb_list_vaults` slim + filter | 80 % | 46 % | 76 % | 86 % |
+| Final | + `akb_browse` slim/filter, `akb_drill_down` pattern + outline | 78 % | 46 % | **81 %** | **84 %** |
+
+What pulled the tree arm from 4 % to 81 % wasn't the agent — it
+was the response shape. The early `akb_list_vaults` returned full
+metadata for every vault, so on a tenant with 70+ vaults the
+target one was silently truncated past the client's read window;
+the agent then hallucinated answers from its prior. Switching to
+slim `{name, description}` rows with an optional substring filter
+made the target vault visible again. The same shape applied to
+`akb_browse` recovered another 5pp. `akb_drill_down`'s `pattern`
+arg + `outline` fallback closed the remaining sub-section
+discovery gaps.
+
+Other observations the runs surface:
+
+- **`akb_get` is given to every arm.** The harness measures the
+  marginal value of *how the agent finds the right document*, not
+  whether the agent can read at all. With `akb_get` everywhere,
+  the grep-only arm (A2) still tops out around 46 % — finding a
+  URI doesn't help much if the agent then dumps the whole document
+  into context and gets lost. Grep without drill-down is a trap.
+- **A4 (full toolbox) wins by a small margin over A1**, and by a
+  larger margin only on section-pinpoint and weak-token queries.
+  Hybrid search alone is enough for the easy ⅔ of an evalset; the
+  extra tools earn their keep on a long-tail of brittle queries.
+- **Vault descriptions are part of retrieval.** A vault whose
+  description doesn't mention its domain is invisible to an agent
+  doing discovery — the obvious-in-hindsight rule that didn't make
+  it into anyone's onboarding docs until the bench surfaced it.
+
+The Korean-law evalset and per-run summaries that produced these
+numbers live in the private sister repo.
+
 ## What we keep private
 
 The Korean-law evalset, the per-run summaries, the per-query judge

--- a/eval/agentic-bench/README.md
+++ b/eval/agentic-bench/README.md
@@ -1,0 +1,113 @@
+# AKB Agentic Search Bench
+
+A small, opinionated harness for measuring how well an LLM agent can
+actually answer questions over an AKB vault — not just whether a
+single retriever returns the right chunk, but whether the whole
+discovery → narrow → fetch loop holds up over a real corpus.
+
+The runner is corpus-agnostic. The evalset and raw results that
+shipped with the original Korean-law experiments are kept in a
+separate private repo (this repo only publishes the harness).
+
+## What it measures
+
+Four arms, each exposing a different subset of AKB's search tools to
+the same ReAct loop. `akb_get` is given to every arm so they're all
+allowed to read documents — the variable is *how they find the
+right one*.
+
+| Arm | Tools | Paradigm |
+|---|---|---|
+| `A1_search_only` | `akb_search` + `akb_get` | Hybrid retrieval (dense + BM25) |
+| `A2_grep_only` | `akb_grep` + `akb_get` | Literal / regex match |
+| `A3_tree` | `akb_list_vaults` + `akb_browse` + `akb_drill_down` + `akb_get` | Tree routing — discover → navigate → drill |
+| `A4_all` | Union of A1 + A2 + A3 | Full toolbox |
+
+For each (arm, query) pair the runner:
+
+1. Opens one MCP session for the chunk (multi-process isolation; one
+   session reused per process — avoids the anyio TaskGroup race that
+   per-call session open/close used to trigger).
+2. Runs a ReAct loop with a per-arm system prompt that only lists
+   the tools that arm has, with a wall budget, a max iteration
+   count, and a duplicate-call guard (3 identical tool calls in a
+   row → force final answer).
+3. Stores the answer, tool-call trace, token usage, timing, and
+   abort reason to `runs_<version>/<arm>/<qid>.summary.json`.
+
+The judge is a separate step — a Claude sub-agent reasons over the
+ground-truth `must_mention` / `forbidden` / `faithfulness` rules
+without using substring matchers (those under-credit paraphrase).
+No external commercial LLM API; the harness assumes Claude
+subscription via sub-agent and OpenRouter-backed cheap models for
+the agent itself.
+
+## Layout
+
+```
+src/
+  llm_client.py        OpenAI-compat chat client with 429/5xx exponential backoff
+  mcp_client.py        Streamable HTTP MCP wrapper (per-process session reuse)
+  react_agent.py       Per-arm ARM_TOOLS / ARM_HINTS + ReAct loop
+  runner.py            Chunk runner: 1 session, sequential queries, auto-reconnect
+  prep_judge_v3.py     Pre/post processing for the offline judge step
+  judge.py             Aggregator: per-arm pass%, provenance%, per-category breakdown
+scripts/
+  run_v4_multiproc.sh  Multi-process driver — N processes × M queries each
+```
+
+## How to run
+
+The runner reads everything from environment variables so the same
+script targets dev, staging, and prod. The harness is corpus-
+agnostic — point it at any AKB instance and supply your own evalset.
+
+```bash
+# 1) Author an evalset/q*.yaml per question. Schema:
+#    id, category, query, ground_truth: {must_mention, forbidden, source_docs}
+# 2) Smoke-test a single (arm, query) pair to confirm the agent is
+#    actually using the tools you expect:
+RUNS_DIR=runs_smoke \
+AKB_MCP_URL=https://... AKB_PAT=... \
+LLM_API_KEY=... LLM_MODEL=qwen/qwen3.6-plus \
+python -m src.runner --arm A3_tree --query q001
+# 3) Full run — one process per (arm, chunk):
+bash scripts/run_v4_multiproc.sh
+# 4) Hand off to a Claude sub-agent for verdicts:
+python -m src.prep_judge_v3 prep
+# (sub-agent writes runs_*/verdicts/verdicts_batch_*.json)
+python -m src.prep_judge_v3 finalize
+RUNS_DIR=runs_v1 python -m src.judge --aggregate
+```
+
+`RUNS_DIR` is required for any version other than the default
+`runs/`. The aggregator emits `metrics.json` next to the raw runs.
+
+## Required tools
+
+The harness assumes an AKB backend at version **0.2.3 or later**,
+because the four-arm tree-routing arm needs the slim + filterable
+versions of `akb_list_vaults` / `akb_browse` and the `mode='outline'`
+path on `akb_drill_down`. Earlier backends will run but the tree
+arm will look much worse than it should — the early-version
+benchmarks in our own history demonstrate exactly that failure mode.
+
+## What we keep private
+
+The Korean-law evalset, the per-run summaries, the per-query judge
+verdicts, the v1–v8 result narratives, and the vault snapshots all
+live in a sister repo. They aren't checked in here because:
+
+- the ground-truth answers are domain-specific and were hand-
+  authored — they aren't a public dataset;
+- the raw model outputs include Korean text that's load-bearing for
+  the analysis but not useful as an OSS artefact;
+- the harness is the part that's reusable across corpora.
+
+If you fork this for your own domain, you'll write your own
+`evalset/`. The schema is intentionally tiny.
+
+## License
+
+PolyForm Noncommercial 1.0.0 — same as the parent `dnotitia/akb`
+repository. See [LICENSE](../../LICENSE).

--- a/eval/agentic-bench/scripts/run_v4_multiproc.sh
+++ b/eval/agentic-bench/scripts/run_v4_multiproc.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# v4 multi-process runner — no intra-process MCP session race.
+#
+# 8 background processes (2 chunks × 4 arms), each running sequentially
+# inside its own OS process. parallel=1 means each process opens one
+# MCP session at a time, so the anyio TaskGroup race we saw at
+# parallel≥2 cannot occur. Process-to-process is OS-isolated.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+: "${AKB_MCP_URL:?set AKB_MCP_URL}"
+: "${AKB_PAT:?set AKB_PAT}"
+: "${LLM_API_KEY:?set LLM_API_KEY}"
+: "${LLM_MODEL:=qwen/qwen-2.5-72b-instruct}"
+: "${RUNS_DIR:=runs_v4}"
+
+ARMS=(A1_search_only A2_grep_only A3_tree A4_all)
+PY=/Users/byongjohn_han/git-repository/akb/backend/.venv/bin/python
+
+mkdir -p "$RUNS_DIR"
+
+# qid chunks (50 + 50 = 100 per arm). Build comma-separated lists.
+chunk_a=$(seq -f q%03g 1 50 | paste -sd, -)
+chunk_b=$(seq -f q%03g 51 100 | paste -sd, -)
+
+PIDS=()
+for arm in "${ARMS[@]}"; do
+    for CHUNK_NAME in a b; do
+        if [[ "$CHUNK_NAME" == "a" ]]; then QIDS="$chunk_a"; else QIDS="$chunk_b"; fi
+        LOGFILE="$RUNS_DIR/log_${arm}_${CHUNK_NAME}.log"
+        echo "launching $arm chunk $CHUNK_NAME -> $LOGFILE"
+        RUNS_DIR="$RUNS_DIR" \
+        AKB_MCP_URL="$AKB_MCP_URL" \
+        AKB_PAT="$AKB_PAT" \
+        LLM_API_KEY="$LLM_API_KEY" \
+        LLM_MODEL="$LLM_MODEL" \
+        "$PY" -m src.runner --arm "$arm" --qids "$QIDS" --parallel 1 \
+            > "$LOGFILE" 2>&1 &
+        PIDS+=($!)
+    done
+done
+
+echo "spawned ${#PIDS[@]} processes: ${PIDS[*]}"
+echo "waiting..."
+
+FAILS=0
+for pid in "${PIDS[@]}"; do
+    if ! wait "$pid"; then
+        FAILS=$((FAILS + 1))
+    fi
+done
+
+echo "all done. process-level fails (non-zero exit due to per-q FAILs): $FAILS"
+exit 0

--- a/eval/agentic-bench/src/judge.py
+++ b/eval/agentic-bench/src/judge.py
@@ -1,0 +1,302 @@
+"""LLM judge — score each (arm, qid) run against the yaml ground truth.
+
+Usage:
+  python -m src.judge --arm all --query all --parallel 4
+  python -m src.judge --aggregate    # re-aggregate from existing judge files
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .llm_client import LLM, LLMError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+EVALSET = ROOT / "evalset"
+RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs"))
+_V4_STYLE = any(s in str(RUNS) for s in ("v4", "v5", "v6", "v7", "v8", "v9"))
+ARMS = ["A1_search_only", "A2_grep_only", "A3_tree", "A4_all"] if _V4_STYLE else ["A1_search_only", "A2_grep", "A3_drill"]
+
+
+JUDGE_SYSTEM = """You are an evaluator scoring an AI agent's answer against ground truth.
+
+You receive:
+- The original Korean question
+- The agent's final answer (Korean)
+- Ground truth: must_mention facts, forbidden phrases, source documents
+
+Score the answer on a strict rubric and return ONLY a JSON object (no prose, no markdown fences) with this exact shape:
+
+{
+  "must_mention_matched": [list of must_mention items the answer correctly conveys],
+  "must_mention_missing": [list of must_mention items the answer is missing],
+  "forbidden_found": [list of forbidden phrases the answer wrongly contains],
+  "faithfulness": "high" | "medium" | "low",
+  "verdict": "PASS" | "PARTIAL" | "FAIL",
+  "reason": "one-sentence Korean explanation"
+}
+
+Verdict rule:
+- PASS = ALL must_mention covered AND zero forbidden AND faithfulness in {high, medium}
+- PARTIAL = ≥half must_mention covered AND zero forbidden
+- FAIL = otherwise (or if the answer admits the info couldn't be found)
+
+Be strict — paraphrased synonyms count as a match only if the meaning is identical (e.g. "특정후견의 심판" ↔ "특정후견 심판" yes; "후견" alone — no, too vague)."""
+
+
+def build_judge_user(question: str, answer: str, gt: dict[str, Any]) -> str:
+    must = gt.get("must_mention", []) or []
+    forb = gt.get("forbidden", []) or []
+    srcs = gt.get("source_docs", []) or []
+    return f"""Question:
+{question}
+
+Agent answer:
+{answer if answer.strip() else "<empty>"}
+
+Ground truth must_mention:
+{json.dumps(must, ensure_ascii=False)}
+
+Ground truth forbidden:
+{json.dumps(forb, ensure_ascii=False)}
+
+Source docs (for your reference):
+{json.dumps(srcs, ensure_ascii=False)}
+
+Score now. Return JSON only."""
+
+
+def _strip_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        # Remove ```json ... ``` fencing.
+        text = re.sub(r"^```[a-zA-Z]*\n", "", text)
+        text = re.sub(r"\n```$", "", text)
+    return text.strip()
+
+
+def _normalize(s: str) -> str:
+    """Loose match for provenance: ignore whitespace + punctuation
+    differences so "제 14조의2" matches "제14조의 2" in tool output."""
+    return re.sub(r"[\s​ \.\,\(\)「」『』\"']+", "", s)
+
+
+def _retrieved_split(must_mention: list[str], tool_result_texts: list[str]) -> tuple[list[str], list[str]]:
+    """Return (retrieved, not_retrieved). A must_mention fact is
+    `retrieved` if its normalized form appears as a substring in any
+    tool result text. Otherwise the model produced it from prior /
+    context — `not_retrieved`."""
+    concat_norm = _normalize(" ".join(tool_result_texts))
+    retrieved, not_retrieved = [], []
+    for fact in must_mention:
+        if _normalize(fact) in concat_norm:
+            retrieved.append(fact)
+        else:
+            not_retrieved.append(fact)
+    return retrieved, not_retrieved
+
+
+async def judge_one(*, qid: str, arm: str, llm: LLM, force: bool) -> dict[str, Any]:
+    summary_path = RUNS / arm / f"{qid}.summary.json"
+    judge_path = RUNS / arm / f"{qid}.judge.json"
+    if not summary_path.exists():
+        return {"qid": qid, "arm": arm, "status": "NO_SUMMARY"}
+    if judge_path.exists() and not force:
+        d = json.loads(judge_path.read_text())
+        return {"qid": qid, "arm": arm, "status": "SKIP", "verdict": d.get("verdict")}
+    summary = json.loads(summary_path.read_text())
+    qspec = yaml.safe_load((EVALSET / f"{qid}.yaml").read_text(encoding="utf-8"))
+
+    user = build_judge_user(
+        question=qspec["query"],
+        answer=summary.get("final_answer_text", "") or "",
+        gt=qspec.get("ground_truth") or {},
+    )
+    try:
+        resp = await llm.chat(
+            messages=[
+                {"role": "system", "content": JUDGE_SYSTEM},
+                {"role": "user", "content": user},
+            ],
+            max_tokens=1500,
+            temperature=0.0,
+        )
+    except LLMError as e:
+        return {"qid": qid, "arm": arm, "status": "JUDGE_ERROR", "error": str(e)}
+
+    raw = resp["message"].get("content") or ""
+    try:
+        verdict_obj = json.loads(_strip_fences(raw))
+    except Exception:
+        return {"qid": qid, "arm": arm, "status": "JUDGE_PARSE_ERROR", "raw": raw[:500]}
+
+    # Provenance: split must_mention into facts the answer
+    # actually pulled from tool output vs. facts that came from
+    # the model's prior (no tool result contains them).
+    gt_must = (qspec.get("ground_truth") or {}).get("must_mention") or []
+    tool_texts = [tc.get("result_text", "") for tc in summary.get("tool_calls_clean", [])]
+    retrieved, not_retrieved = _retrieved_split(gt_must, tool_texts)
+    provenance = {
+        "retrieved": retrieved,
+        "from_prior_or_missing": not_retrieved,
+        "retrieved_rate": (len(retrieved) / len(gt_must)) if gt_must else None,
+    }
+
+    verdict_obj["_qid"] = qid
+    verdict_obj["_arm"] = arm
+    verdict_obj["_question"] = qspec["query"]
+    verdict_obj["_answer"] = summary.get("final_answer_text", "")
+    verdict_obj["_provenance"] = provenance
+    verdict_obj["_summary_stats"] = {
+        "tool_calls": len(summary.get("tool_calls_clean", [])),
+        "tokens": summary.get("usage_total", {}).get("total_tokens", 0),
+        "wall_seconds": summary.get("wall_seconds", 0),
+        "iterations": summary.get("iterations", 0),
+        "category": summary.get("category"),
+        "abort_reason": summary.get("abort_reason"),
+    }
+    judge_path.write_text(json.dumps(verdict_obj, ensure_ascii=False, indent=2))
+    return {"qid": qid, "arm": arm, "status": "OK", "verdict": verdict_obj.get("verdict")}
+
+
+def list_query_ids() -> list[str]:
+    return sorted(p.stem for p in EVALSET.glob("q*.yaml"))
+
+
+async def judge_all_async(args: argparse.Namespace) -> None:
+    llm = LLM(
+        base_url=os.environ.get("JUDGE_BASE_URL", "https://openrouter.ai/api/v1"),
+        api_key=os.environ.get("JUDGE_API_KEY") or os.environ["LLM_API_KEY"],
+        model=os.environ.get("JUDGE_MODEL", "anthropic/claude-haiku-4-5"),
+    )
+    arms = ARMS if args.arm == "all" else [args.arm]
+    qids = list_query_ids() if args.query == "all" else [args.query]
+    pairs = [(qid, arm) for arm in arms for qid in qids]
+    print(f"judging {len(pairs)} (arm × query) pairs, parallel={args.parallel}, model={llm.model}", flush=True)
+
+    sem = asyncio.Semaphore(args.parallel)
+
+    async def worker(qid: str, arm: str):
+        async with sem:
+            try:
+                r = await judge_one(qid=qid, arm=arm, llm=llm, force=args.force)
+            except Exception as e:
+                r = {"qid": qid, "arm": arm, "status": "EXC", "error": f"{type(e).__name__}: {e}"}
+            print(f"[{arm}] {qid} | {r['status']} | verdict={r.get('verdict', '-')}", flush=True)
+            return r
+
+    results = await asyncio.gather(*(worker(qid, arm) for qid, arm in pairs))
+    return None
+
+
+def _infer_verdict(d: dict[str, Any]) -> str:
+    """Fallback when the judge model forgot to emit `verdict`.
+    Apply the rubric to must_mention / forbidden / faithfulness."""
+    v = d.get("verdict")
+    if v in ("PASS", "PARTIAL", "FAIL"):
+        return v
+    matched = d.get("must_mention_matched") or []
+    missing = d.get("must_mention_missing") or []
+    forb = d.get("forbidden_found") or []
+    faith = (d.get("faithfulness") or "").lower()
+    total = len(matched) + len(missing)
+    if forb:
+        return "FAIL"
+    if total == 0:
+        return "FAIL"
+    if not missing and faith in ("high", "medium"):
+        return "PASS"
+    if len(matched) * 2 >= total:
+        return "PARTIAL"
+    return "FAIL"
+
+
+def aggregate() -> None:
+    print("\n=== AGGREGATE ===\n")
+    rows = []
+    for arm in ARMS:
+        adir = RUNS / arm
+        if not adir.exists():
+            continue
+        per_q = []
+        for jp in sorted(adir.glob("q*.judge.json")):
+            d = json.loads(jp.read_text())
+            d["verdict"] = _infer_verdict(d)
+            per_q.append(d)
+        rows.append((arm, per_q))
+
+    print(f"{'arm':<18}{'n':<5}{'PASS':<6}{'PART':<6}{'FAIL':<6}{'pass%':<8}{'prov%':<8}{'tools/q':<10}{'tok/q':<10}{'wall/q':<9}{'tok/pass':<10}")
+    metrics = {}
+    for arm, per_q in rows:
+        n = len(per_q)
+        p = sum(1 for d in per_q if d.get("verdict") == "PASS")
+        pa = sum(1 for d in per_q if d.get("verdict") == "PARTIAL")
+        f = sum(1 for d in per_q if d.get("verdict") == "FAIL")
+        tools = [d["_summary_stats"]["tool_calls"] for d in per_q]
+        toks = [d["_summary_stats"]["tokens"] for d in per_q]
+        walls = [d["_summary_stats"]["wall_seconds"] for d in per_q]
+        # Provenance rate = mean fraction of must_mention facts
+        # actually pulled from tool output (vs. model prior).
+        prov_rates = [
+            d.get("_provenance", {}).get("retrieved_rate")
+            for d in per_q
+            if d.get("_provenance", {}).get("retrieved_rate") is not None
+        ]
+        prov_pct = 100 * statistics.mean(prov_rates) if prov_rates else 0
+        tokens_per_pass = (sum(toks) / p) if p else float("inf")
+        pct = 100 * p / n if n else 0
+        print(f"{arm:<18}{n:<5}{p:<6}{pa:<6}{f:<6}{pct:<8.1f}{prov_pct:<8.1f}{statistics.mean(tools):<10.2f}{statistics.mean(toks):<10.0f}{statistics.mean(walls):<9.1f}{tokens_per_pass:<10.0f}")
+        metrics[arm] = {
+            "n": n, "pass": p, "partial": pa, "fail": f,
+            "pass_pct": pct,
+            "provenance_pct": prov_pct,
+            "mean_tools": statistics.mean(tools),
+            "mean_tokens": statistics.mean(toks),
+            "mean_wall_s": statistics.mean(walls),
+            "tokens_per_pass": tokens_per_pass if p else None,
+        }
+
+    # Per-category breakdown.
+    print("\n--- per category ---")
+    cats: dict[str, dict[str, list[int]]] = {}
+    for arm, per_q in rows:
+        for d in per_q:
+            c = d["_summary_stats"]["category"] or "?"
+            cats.setdefault(c, {}).setdefault(arm, []).append(1 if d.get("verdict") == "PASS" else 0)
+    for c in sorted(cats):
+        print(f"  {c}:")
+        for arm in ARMS:
+            v = cats[c].get(arm, [])
+            if v:
+                print(f"    {arm}: {sum(v)}/{len(v)} PASS")
+
+    # Save metrics.
+    (RUNS / "metrics.json").write_text(json.dumps(metrics, ensure_ascii=False, indent=2))
+    print(f"\nsaved {RUNS / 'metrics.json'}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--arm", default="all")
+    p.add_argument("--query", default="all")
+    p.add_argument("--parallel", type=int, default=4)
+    p.add_argument("--force", action="store_true")
+    p.add_argument("--aggregate", action="store_true")
+    args = p.parse_args()
+    if not args.aggregate:
+        asyncio.run(judge_all_async(args))
+    aggregate()
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/agentic-bench/src/llm_client.py
+++ b/eval/agentic-bench/src/llm_client.py
@@ -1,0 +1,79 @@
+"""OpenRouter chat completions client (OpenAI-compatible)."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+from typing import Any
+
+import httpx
+
+
+class LLMError(RuntimeError):
+    pass
+
+
+class LLM:
+    def __init__(self, base_url: str, api_key: str, model: str, timeout: float = 120.0):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        # OpenRouter app-attribution headers (recommended, not required).
+        self.app_headers = {
+            "HTTP-Referer": "https://github.com/dnotitia/akb",
+            "X-Title": "akb agentic-bench",
+        }
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str = "auto",
+        max_tokens: int = 12000,
+        temperature: float = 0.0,
+    ) -> dict[str, Any]:
+        """Return the full first-choice message dict + usage."""
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            # Qwen3-A3B thinking models burn reasoning tokens before
+            # producing content; disable for tool-use latency/budget.
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        if tools:
+            body["tools"] = tools
+            body["tool_choice"] = tool_choice
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            **self.app_headers,
+        }
+        # Retry on 429 / 5xx with exponential backoff + jitter. v4 hit
+        # `HTTP 429: qwen/qwen-2.5-72b-instruct is temporarily rate-limited
+        # upstream` (DeepInfra provider) when 8 worker processes called
+        # OpenRouter concurrently — that surfaced as TaskGroup wrap and
+        # was misdiagnosed as an MCP race.
+        max_attempts = 5
+        async with httpx.AsyncClient(timeout=self.timeout) as cli:
+            for attempt in range(max_attempts):
+                r = await cli.post(f"{self.base_url}/chat/completions", json=body, headers=headers)
+                if r.status_code == 200:
+                    break
+                if r.status_code in (429, 500, 502, 503, 504) and attempt < max_attempts - 1:
+                    delay = (2 ** attempt) + random.uniform(0, 1.5)
+                    await asyncio.sleep(delay)
+                    continue
+                raise LLMError(f"HTTP {r.status_code} (attempt {attempt+1}): {r.text[:500]}")
+            data = r.json()
+        if not data.get("choices"):
+            raise LLMError(f"no choices: {json.dumps(data)[:500]}")
+        return {
+            "message": data["choices"][0]["message"],
+            "finish_reason": data["choices"][0].get("finish_reason"),
+            "usage": data.get("usage", {}),
+        }

--- a/eval/agentic-bench/src/mcp_client.py
+++ b/eval/agentic-bench/src/mcp_client.py
@@ -1,0 +1,77 @@
+"""AKB MCP Streamable HTTP client wrapper.
+
+Wraps mcp.client.streamable_http for the bench. One session per query.
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+class MCPCallError(RuntimeError):
+    pass
+
+
+@asynccontextmanager
+async def mcp_session(url: str, pat: str):
+    headers = {"Authorization": f"Bearer {pat}"}
+    async with streamablehttp_client(url, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+async def list_tool_names(session: ClientSession) -> list[str]:
+    resp = await session.list_tools()
+    return [t.name for t in resp.tools]
+
+
+async def list_tools_full(session: ClientSession) -> list[dict[str, Any]]:
+    """Return tools in OpenAI function-calling schema."""
+    resp = await session.list_tools()
+    out = []
+    for t in resp.tools:
+        out.append({
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description or "",
+                "parameters": t.inputSchema or {"type": "object", "properties": {}},
+            },
+        })
+    return out
+
+
+def _coerce_content(blocks) -> str:
+    parts = []
+    for b in blocks:
+        if hasattr(b, "text") and b.text is not None:
+            parts.append(b.text)
+        elif hasattr(b, "data"):
+            parts.append(f"<binary {len(b.data)} bytes>")
+        else:
+            parts.append(str(b))
+    return "\n".join(parts)
+
+
+async def call_tool(session: ClientSession, name: str, args: dict[str, Any]) -> tuple[bool, str]:
+    """Call tool; return (is_error, content_text)."""
+    try:
+        result = await session.call_tool(name, args)
+    except Exception as e:
+        return True, f"<tool-call exception> {type(e).__name__}: {e}"
+    text = _coerce_content(result.content) if result.content else ""
+    is_error = bool(getattr(result, "isError", False))
+    # Truncate huge results so they don't blow LLM context. The cap
+    # is sized so that a slim-formatted vault/collection listing
+    # (~70 items × ~150 chars) fits without losing the tail of the
+    # list — that scenario was the dominant failure in agentic-bench
+    # v6/v7 (target vault hidden past the truncate point).
+    MAX = 12000
+    if len(text) > MAX:
+        text = text[:MAX] + f"\n<truncated, original {len(text)} chars — use `query` / `limit` to narrow>"
+    return is_error, text

--- a/eval/agentic-bench/src/prep_judge_v3.py
+++ b/eval/agentic-bench/src/prep_judge_v3.py
@@ -1,0 +1,138 @@
+"""Prepare batched judge inputs for hand-evaluation by the main session.
+
+Each batch_NN.json contains 25 (qid, arm) prompts with question + answer
++ ground_truth so the main-session model can score them directly via
+LLM reasoning (not substring matching).
+
+Usage:
+  python -m src.prep_judge_v3 prep      # write batches/batch_*.json
+  python -m src.prep_judge_v3 finalize  # merge verdicts back to judge.json
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+import os
+ROOT = Path(__file__).resolve().parent.parent
+EVALSET = ROOT / "evalset"
+RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs_v3"))
+BATCHES = RUNS / "batches"
+VERDICTS = RUNS / "verdicts"
+_V4_STYLE = any(s in str(RUNS) for s in ("v4", "v5", "v6", "v7", "v8", "v9"))
+ARMS = ["A1_search_only", "A2_grep_only", "A3_tree", "A4_all"] if _V4_STYLE else ["A1_search_only", "A2_grep", "A3_drill"]
+BATCH_SIZE = 20
+ANSWER_CAP = 1200  # main session reasoning context budget
+
+
+def all_pairs() -> list[tuple[str, str]]:
+    qids = sorted(p.stem for p in EVALSET.glob("q*.yaml"))
+    return [(qid, arm) for arm in ARMS for qid in qids]
+
+
+def prep() -> None:
+    BATCHES.mkdir(parents=True, exist_ok=True)
+    pairs = all_pairs()
+    for batch_idx in range(0, len(pairs), BATCH_SIZE):
+        rows = []
+        for qid, arm in pairs[batch_idx : batch_idx + BATCH_SIZE]:
+            sum_path = RUNS / arm / f"{qid}.summary.json"
+            if not sum_path.exists():
+                continue
+            summary = json.loads(sum_path.read_text())
+            qspec = yaml.safe_load((EVALSET / f"{qid}.yaml").read_text(encoding="utf-8"))
+            gt = qspec.get("ground_truth") or {}
+            answer = summary.get("final_answer_text", "") or ""
+            if len(answer) > ANSWER_CAP:
+                answer = answer[:ANSWER_CAP] + f"\n<truncated, orig {len(answer)}>"
+            rows.append({
+                "qid": qid,
+                "arm": arm,
+                "category": qspec.get("category"),
+                "question": qspec["query"],
+                "answer": answer,
+                "must_mention": gt.get("must_mention") or [],
+                "forbidden": gt.get("forbidden") or [],
+            })
+        bid = batch_idx // BATCH_SIZE
+        (BATCHES / f"batch_{bid:02d}.json").write_text(json.dumps(rows, ensure_ascii=False, indent=2))
+        print(f"batch_{bid:02d}: {len(rows)} rows")
+
+
+def _normalize(s: str) -> str:
+    return re.sub(r"[\s​ \.\,\(\)「」『』\"']+", "", s)
+
+
+def _retrieved_split(must: list[str], tool_texts: list[str]) -> tuple[list[str], list[str]]:
+    concat = _normalize(" ".join(tool_texts))
+    retrieved, missing = [], []
+    for fact in must:
+        (retrieved if _normalize(fact) in concat else missing).append(fact)
+    return retrieved, missing
+
+
+def finalize() -> None:
+    """Read verdicts_batch_*.json (main-session output) and write per-
+    (qid, arm) judge.json with the same schema as judge.py."""
+    verdict_files = sorted(VERDICTS.glob("verdicts_batch_*.json"))
+    if not verdict_files:
+        print("no verdicts_batch_*.json found in", VERDICTS, file=sys.stderr)
+        sys.exit(1)
+    all_verdicts: dict[tuple[str, str], dict] = {}
+    for vf in verdict_files:
+        for v in json.loads(vf.read_text()):
+            all_verdicts[(v["qid"], v["arm"])] = v
+    n = 0
+    for (qid, arm), v in all_verdicts.items():
+        sum_path = RUNS / arm / f"{qid}.summary.json"
+        if not sum_path.exists():
+            continue
+        summary = json.loads(sum_path.read_text())
+        qspec = yaml.safe_load((EVALSET / f"{qid}.yaml").read_text(encoding="utf-8"))
+        gt = qspec.get("ground_truth") or {}
+        must = gt.get("must_mention") or []
+        tool_texts = [tc.get("result_text", "") for tc in summary.get("tool_calls_clean", [])]
+        retrieved, from_prior = _retrieved_split(must, tool_texts)
+        out = {
+            "must_mention_matched": v.get("matched", []),
+            "must_mention_missing": v.get("missing", []),
+            "forbidden_found": v.get("forbidden_found", []),
+            "faithfulness": v.get("faithfulness", "medium"),
+            "verdict": v.get("verdict", "FAIL"),
+            "reason": v.get("reason", ""),
+            "_qid": qid,
+            "_arm": arm,
+            "_question": qspec["query"],
+            "_answer": summary.get("final_answer_text", ""),
+            "_provenance": {
+                "retrieved": retrieved,
+                "from_prior_or_missing": from_prior,
+                "retrieved_rate": (len(retrieved) / len(must)) if must else None,
+            },
+            "_summary_stats": {
+                "tool_calls": len(summary.get("tool_calls_clean", [])),
+                "tokens": summary.get("usage_total", {}).get("total_tokens", 0),
+                "wall_seconds": summary.get("wall_seconds", 0),
+                "iterations": summary.get("iterations", 0),
+                "category": qspec.get("category"),
+                "abort_reason": summary.get("abort_reason"),
+            },
+        }
+        (RUNS / arm / f"{qid}.judge.json").write_text(json.dumps(out, ensure_ascii=False, indent=2))
+        n += 1
+    print(f"wrote {n} judge.json files")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "prep"
+    if cmd == "prep":
+        prep()
+    elif cmd == "finalize":
+        finalize()
+    else:
+        print("usage: prep | finalize", file=sys.stderr)
+        sys.exit(1)

--- a/eval/agentic-bench/src/react_agent.py
+++ b/eval/agentic-bench/src/react_agent.py
@@ -1,0 +1,306 @@
+"""ReAct loop for the agentic-bench.
+
+One agent run per (query, arm). Loops:
+  - LLM call with current messages + arm-filtered tools
+  - If tool_calls in response: execute each via MCP, append observation
+  - If final answer: stop and return
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from .llm_client import LLM, LLMError
+from .mcp_client import call_tool, list_tools_full, mcp_session
+
+
+# Bench-relevant tool whitelist by arm. Tool names are full MCP names
+# (e.g. "akb_search"), NOT the prefixed "akb__akb_search" used by some
+# proxies — the backend MCP exposes them under bare names.
+ARM_TOOLS: dict[str, set[str]] = {
+    # v4: vault hint removed from system prompt. Each arm exposes a
+    # disjoint search paradigm (hybrid / grep / tree-routing) plus
+    # akb_get baseline. A4 is the union — measures whether combining
+    # paradigms is synergy or distraction.
+    "A1_search_only": {"akb_search", "akb_get"},
+    "A2_grep_only":   {"akb_grep", "akb_get"},
+    "A3_tree":        {"akb_list_vaults", "akb_browse", "akb_drill_down", "akb_get"},
+    "A4_all":         {"akb_search", "akb_grep",
+                       "akb_list_vaults", "akb_browse", "akb_drill_down", "akb_get"},
+}
+
+
+SYSTEM_PROMPT_BASE = """You are an AKB retrieval agent. AKB stores documents in vaults; each vault is organised by collections. Answer the user's question by retrieving relevant facts from AKB via the tools available to you.
+
+Rules:
+1. You are NOT told which vault has the answer. If your arm has a discovery tool, use it. Otherwise pass an explicit vault to search/grep — or omit `vault` to search across vaults you have access to.
+2. Make the fewest tool calls that answer the question. Do NOT repeat the same call.
+3. Tool results are truncated at 6KB — narrow your query rather than re-calling.
+4. Quote exact text when possible. Do NOT invent facts.
+5. If the answer isn't in AKB, say so honestly.
+6. After at most 6 tool calls, produce a Korean final answer citing the source (vault, doc, section).
+"""
+
+ARM_HINTS: dict[str, str] = {
+    "A1_search_only": """
+Available tools: `akb_search`, `akb_get`.
+- `akb_search(query=..., limit=N)` — hybrid dense + BM25 across all vaults you can access. Omit `vault` to search the entire corpus.
+- Results include `uri` and chunk content. Use `akb_get(uri=...)` for full document body when chunk preview is insufficient.
+""",
+    "A2_grep_only": """
+Available tools: `akb_grep`, `akb_get`.
+- `akb_grep(pattern=..., files_with_matches=true, limit=10)` — exact-string match across vaults. Omit `vault` for cross-corpus grep.
+- Use `akb_get(uri=...)` for the full document body once you have a uri from grep.
+- You have no semantic search — work from exact strings only.
+""",
+    "A3_tree": """
+Available tools: `akb_list_vaults`, `akb_browse`, `akb_drill_down`, `akb_get`.
+- `akb_list_vaults(filter="키워드")` — discover vaults filtered by name/description substring. 도메인 키워드 (예: filter="법령") 로 좁혀 호출. 인자 없이 호출하면 응답이 잘릴 수 있음.
+- `akb_browse(vault=..., filter="키워드", limit=10)` — list collections / docs. filter 인자로 collection name substring 매칭 권장 (e.g. filter="민법"). depth=1 만 인자 없이 호출하면 70+ collection 잘림. 응답에 `total`, `returned` 포함.
+- `akb_drill_down(uri=..., section="제N조", pattern="키워드")` — extract section + 그 안 substring grep (pattern 인자). section 이 안 맞아도 응답에 `outline` (available headings list) 자동 포함 — 그 heading 중 하나로 retry. 큰 section (예: 부칙) 안에서 fine-grained query 는 pattern 활용.
+- `akb_get(uri=...)` — fetch full doc. drill_down outline 도 막혔을 때.
+- Typical flow: list_vaults(filter="도메인") → browse(vault, filter="법령명") → drill_down(uri, section=..., pattern=...).
+""",
+    "A4_all": """
+Available tools: `akb_search`, `akb_grep`, `akb_list_vaults`, `akb_browse`, `akb_drill_down`, `akb_get`.
+- You have every search paradigm. Pick the best tool per question:
+  - 의미 검색: `akb_search`.
+  - 조항·약칭 정확 매칭: `akb_grep`.
+  - vault·structure 발견: `akb_list_vaults(filter="키워드")` → `akb_browse(vault=..., filter="법령명")` (둘 다 filter 인자로 좁혀 호출 권장).
+  - 깊은 §본문: `akb_drill_down(uri, section=..., pattern="키워드")` — pattern 으로 section 안 substring grep. section 못 찾으면 응답의 `outline` 으로 retry.
+  - 전체 doc: `akb_get`.
+""",
+}
+
+
+def build_system_prompt(arm: str) -> str:
+    return SYSTEM_PROMPT_BASE + ARM_HINTS.get(arm, "")
+
+
+@dataclass
+class Timing:
+    start_wall: float
+    first_tool_call_s: float | None = None
+    last_tool_response_s: float | None = None
+    done_s: float | None = None
+
+
+@dataclass
+class AgentResult:
+    query_id: str
+    arm: str
+    final_answer_text: str
+    tool_calls_clean: list[dict[str, Any]]
+    messages_count: int
+    iterations: int
+    timing: dict[str, float | None]
+    usage_total: dict[str, int]
+    finish_reason: str | None
+    abort_reason: str | None = None
+    error: str | None = None
+
+
+async def run_agent_with_session(
+    *,
+    session,
+    query_id: str,
+    arm: str,
+    query: str,
+    llm: LLM,
+    max_iterations: int = 8,
+    max_wall_s: float = 240.0,
+    result_text_cap: int = 2000,
+) -> AgentResult:
+    """Run one (qid, arm) using a caller-provided MCP session.
+
+    Splitting session ownership from the agent loop lets a runner reuse
+    a single session across many queries, which avoids the per-query
+    open/close cycle that triggered anyio TaskGroup cancellation races
+    in v2/v4.
+    """
+    if arm not in ARM_TOOLS:
+        raise ValueError(f"unknown arm: {arm}")
+
+    timing = Timing(start_wall=time.time())
+    tool_calls_clean: list[dict[str, Any]] = []
+    usage_total = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    final_answer = ""
+    finish_reason = None
+    error = None
+    iterations = 0
+    abort_reason: str | None = None
+    recent_call_sigs: list[tuple[str, str]] = []
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": build_system_prompt(arm)},
+        {"role": "user", "content": query},
+    ]
+
+    try:
+        all_tools = await list_tools_full(session)
+        allowed = ARM_TOOLS[arm]
+        arm_tools = [t for t in all_tools if t["function"]["name"] in allowed]
+        if not arm_tools:
+            raise RuntimeError(
+                f"arm {arm} has no tools available from MCP server. "
+                f"Server tools: {[t['function']['name'] for t in all_tools][:30]}"
+            )
+
+        for it in range(max_iterations):
+            iterations = it + 1
+            if time.time() - timing.start_wall > max_wall_s:
+                abort_reason = "wall_timeout"
+                break
+            resp = await llm.chat(messages, tools=arm_tools, tool_choice="auto")
+            msg = resp["message"]
+            u = resp["usage"]
+            usage_total["prompt_tokens"] += u.get("prompt_tokens", 0)
+            usage_total["completion_tokens"] += u.get("completion_tokens", 0)
+            usage_total["total_tokens"] += u.get("total_tokens", 0)
+            finish_reason = resp["finish_reason"]
+
+            # Append assistant message (must include tool_calls for the
+            # next turn to be valid OpenAI-style).
+            tool_calls = msg.get("tool_calls") or []
+            assistant_entry: dict[str, Any] = {
+                "role": "assistant",
+                "content": msg.get("content") or "",
+            }
+            if tool_calls:
+                assistant_entry["tool_calls"] = tool_calls
+            messages.append(assistant_entry)
+
+            if not tool_calls:
+                # Final answer.
+                final_answer = msg.get("content") or ""
+                break
+
+            # Execute each tool call.
+            if timing.first_tool_call_s is None:
+                timing.first_tool_call_s = time.time() - timing.start_wall
+
+            for tc in tool_calls:
+                name = tc["function"]["name"]
+                raw_args = tc["function"].get("arguments") or "{}"
+                try:
+                    args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                except Exception:
+                    args = {"_raw": raw_args}
+
+                if name not in allowed:
+                    observation = f"<error> tool '{name}' is not allowed in arm {arm}. Allowed: {sorted(allowed)}"
+                    is_error = True
+                else:
+                    is_error, observation = await call_tool(session, name, args)
+
+                # Provenance: store a capped slice of the actual
+                # tool result so the judge can verify whether the
+                # final answer's facts actually came from this
+                # call vs. were synthesised by the model.
+                tool_calls_clean.append({
+                    "iteration": iterations,
+                    "name": name,
+                    "args": args,
+                    "is_error": is_error,
+                    "result_chars": len(observation),
+                    "result_text": observation[:result_text_cap],
+                })
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc["id"],
+                    "content": observation,
+                })
+
+                # Loop detection: 3 identical (name, args) in a row.
+                sig = (name, json.dumps(args, sort_keys=True, ensure_ascii=False))
+                recent_call_sigs.append(sig)
+                if len(recent_call_sigs) >= 3 and len(set(recent_call_sigs[-3:])) == 1:
+                    abort_reason = "dup_call_loop"
+                    break
+
+            if abort_reason:
+                break
+
+            timing.last_tool_response_s = time.time() - timing.start_wall
+
+        # Force a final-answer pass (tools disabled) if we never
+        # got one — covers: max_iterations exhausted, wall_timeout,
+        # dup_call_loop, AND the v1 failure mode where the model's
+        # very first turn was a tool call that the arm guard
+        # rejected (q024/q027/q028: 1 tool call, empty answer).
+        if not final_answer:
+            hint = {
+                "wall_timeout": "Wall budget hit. Give your final answer now from what you've gathered.",
+                "dup_call_loop": "You are repeating the same tool call. Stop and give your final answer now from what you already have.",
+            }.get(abort_reason or "", "Tool budget exhausted. Give your best final answer now based on what you've already retrieved.")
+            messages.append({"role": "user", "content": hint})
+            resp = await llm.chat(messages, tools=None)
+            msg = resp["message"]
+            u = resp["usage"]
+            usage_total["prompt_tokens"] += u.get("prompt_tokens", 0)
+            usage_total["completion_tokens"] += u.get("completion_tokens", 0)
+            usage_total["total_tokens"] += u.get("total_tokens", 0)
+            final_answer = msg.get("content") or ""
+            finish_reason = resp["finish_reason"]
+
+    except LLMError as e:
+        error = f"LLMError: {e}"
+    except BaseExceptionGroup as eg:
+        # asyncio TaskGroup wraps the actual cause — surface it so we
+        # can diagnose. v1+v2 both saw bare "ExceptionGroup: unhandled
+        # errors in a TaskGroup (1 sub-exception)" which is useless.
+        subs = [f"{type(e).__name__}: {e}" for e in eg.exceptions]
+        error = f"ExceptionGroup: {'; '.join(subs)[:300]}"
+    except Exception as e:
+        error = f"{type(e).__name__}: {e}"
+
+    timing.done_s = time.time() - timing.start_wall
+    return AgentResult(
+        query_id=query_id,
+        arm=arm,
+        final_answer_text=final_answer,
+        tool_calls_clean=tool_calls_clean,
+        messages_count=len(messages),
+        iterations=iterations,
+        timing={
+            "start_wall": timing.start_wall,
+            "first_tool_call_s": timing.first_tool_call_s,
+            "last_tool_response_s": timing.last_tool_response_s,
+            "done_s": timing.done_s,
+        },
+        usage_total=usage_total,
+        finish_reason=finish_reason,
+        abort_reason=abort_reason,
+        error=error,
+    )
+
+
+async def run_agent(
+    *,
+    query_id: str,
+    arm: str,
+    query: str,
+    llm: LLM,
+    mcp_url: str,
+    mcp_pat: str,
+    **kwargs: Any,
+) -> AgentResult:
+    """Backward-compat wrapper — opens its own MCP session per call.
+
+    This is the v2/v4 pattern. Per-call session open/close stresses
+    `mcp.client.streamable_http`'s anyio TaskGroup cleanup and was the
+    source of intermittent ExceptionGroup races. Prefer the chunk
+    runner that calls `run_agent_with_session` against one long-lived
+    session.
+    """
+    async with mcp_session(mcp_url, mcp_pat) as session:
+        return await run_agent_with_session(
+            session=session,
+            query_id=query_id,
+            arm=arm,
+            query=query,
+            llm=llm,
+            **kwargs,
+        )

--- a/eval/agentic-bench/src/runner.py
+++ b/eval/agentic-bench/src/runner.py
@@ -1,0 +1,167 @@
+"""Runner — iterate (arm × query) and save summary.json per run.
+
+Usage:
+  python -m src.runner --arm A2_grep --query q001
+  python -m src.runner --arm all --query all --parallel 4
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .llm_client import LLM
+from .mcp_client import mcp_session
+from .react_agent import ARM_TOOLS, run_agent_with_session
+
+
+ROOT = Path(__file__).resolve().parent.parent
+EVALSET = ROOT / "evalset"
+RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs"))
+
+
+def load_query(qid: str) -> dict[str, Any]:
+    p = EVALSET / f"{qid}.yaml"
+    if not p.exists():
+        raise FileNotFoundError(f"{p} not found")
+    return yaml.safe_load(p.read_text(encoding="utf-8"))
+
+
+def list_queries() -> list[str]:
+    qs = sorted(p.stem for p in EVALSET.glob("q*.yaml"))
+    return qs
+
+
+def list_arms() -> list[str]:
+    return list(ARM_TOOLS.keys())
+
+
+async def _run_one_using(*, session, qid: str, arm: str, llm: LLM, force: bool) -> dict[str, Any]:
+    """Run one (qid, arm) using a caller-provided MCP session.
+    Skips if summary.json already exists unless `force`."""
+    run_dir = RUNS / arm
+    run_dir.mkdir(parents=True, exist_ok=True)
+    out_path = run_dir / f"{qid}.summary.json"
+    if out_path.exists() and not force:
+        with out_path.open() as f:
+            d = json.load(f)
+        return {"qid": qid, "arm": arm, "status": "SKIP", "error": d.get("error")}
+
+    q = load_query(qid)
+    query_text = q["query"]
+    started = time.time()
+    result = await run_agent_with_session(
+        session=session,
+        query_id=qid,
+        arm=arm,
+        query=query_text,
+        llm=llm,
+    )
+    elapsed = time.time() - started
+    payload = {
+        "query_id": qid,
+        "arm": arm,
+        "query": query_text,
+        "category": q.get("category"),
+        "ground_truth": q.get("ground_truth"),
+        "final_answer_text": result.final_answer_text,
+        "tool_calls_clean": result.tool_calls_clean,
+        "iterations": result.iterations,
+        "messages_count": result.messages_count,
+        "timing": result.timing,
+        "usage_total": result.usage_total,
+        "finish_reason": result.finish_reason,
+        "abort_reason": result.abort_reason,
+        "error": result.error,
+        "wall_seconds": elapsed,
+    }
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    status = "OK" if (result.error is None and result.final_answer_text) else "FAIL"
+    return {"qid": qid, "arm": arm, "status": status, "error": result.error, "tools": len(result.tool_calls_clean), "tokens": result.usage_total.get("total_tokens"), "wall": elapsed}
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    # Environment / config.
+    mcp_url = os.environ["AKB_MCP_URL"]
+    mcp_pat = os.environ["AKB_PAT"]
+    llm_base = os.environ.get("LLM_BASE_URL", "https://openrouter.ai/api/v1")
+    llm_key = os.environ["LLM_API_KEY"]
+    llm_model = os.environ.get("LLM_MODEL", "qwen/qwen3.5-35b-a3b")
+
+    llm = LLM(base_url=llm_base, api_key=llm_key, model=llm_model)
+
+    arms = list_arms() if args.arm == "all" else [args.arm]
+    if args.qids:
+        qids = [q.strip() for q in args.qids.split(",") if q.strip()]
+    elif args.query == "all":
+        qids = list_queries()
+    else:
+        qids = [args.query]
+    pairs = [(qid, arm) for arm in arms for qid in qids]
+    print(f"running {len(pairs)} (arm × query) pairs with auto-reconnect MCP session", flush=True)
+
+    # Long-lived MCP session, but rebuild on httpx ConnectTimeout /
+    # BaseExceptionGroup so a transient backend hiccup doesn't kill
+    # the whole process. Process-level parallelism comes from the
+    # multiproc shell spawning one runner per chunk.
+    results = []
+    pending = list(pairs)
+    max_session_restarts = 10
+    restarts = 0
+    while pending:
+        try:
+            async with mcp_session(mcp_url, mcp_pat) as session:
+                while pending:
+                    qid, arm = pending[0]
+                    try:
+                        r = await _run_one_using(session=session, qid=qid, arm=arm, llm=llm, force=args.force)
+                    except Exception as e:
+                        # Per-query exception — record, but don't tear down
+                        # the session (the next call_tool will detect a
+                        # dead session itself).
+                        r = {"qid": qid, "arm": arm, "status": "EXC", "error": f"{type(e).__name__}: {e}"}
+                    pending.pop(0)
+                    results.append(r)
+                    print(
+                        f"[{arm}] {qid} | {r['status']} | tools={r.get('tools', '-')} tokens={r.get('tokens', '-')} wall={r.get('wall', 0):.1f}s | err={r.get('error') or ''}",
+                        flush=True,
+                    )
+        except (BaseExceptionGroup, Exception) as eg:
+            # Session itself died (ConnectTimeout, anyio TaskGroup
+            # cleanup, etc). Wait and rebuild a fresh session, then
+            # resume from where we left off.
+            restarts += 1
+            if restarts > max_session_restarts:
+                print(f"!! session restart budget exhausted ({restarts}). aborting with {len(pending)} pending.", flush=True)
+                break
+            backoff = min(30, 5 * restarts)
+            print(f"!! session died ({type(eg).__name__}): backing off {backoff}s and rebuilding. pending={len(pending)}, restart={restarts}", flush=True)
+            await asyncio.sleep(backoff)
+    ok = sum(1 for r in results if r["status"] == "OK")
+    skip = sum(1 for r in results if r["status"] == "SKIP")
+    fail = sum(1 for r in results if r["status"] not in ("OK", "SKIP"))
+    print(f"\nsummary: OK={ok} SKIP={skip} FAIL={fail}", flush=True)
+    return 0 if fail == 0 else 1
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--arm", default="all", help='arm name or "all"')
+    p.add_argument("--query", default="all", help='query id (e.g. q001) or "all"')
+    p.add_argument("--qids", default=None, help='comma-separated qids (overrides --query)')
+    p.add_argument("--parallel", type=int, default=1, help='intra-process concurrency. Default 1 (no MCP session race).')
+    p.add_argument("--force", action="store_true", help="re-run even if summary exists")
+    args = p.parse_args()
+    sys.exit(asyncio.run(main_async(args)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Corpus-agnostic harness for measuring how well an LLM agent can
actually answer questions over an AKB vault — not just chunk-level
retrieval accuracy, but the full discovery → narrow → fetch loop.

Drove the 0.2.1 / 0.2.2 / 0.2.3 backend search-tool overhaul: the
\`A3_tree\` arm went from 4 % PASS to 81 % PASS on the same domain-
specific dataset purely by tightening \`akb_list_vaults\` / \`akb_browse\` /
\`akb_drill_down\` response shapes (no agent-side change). This PR
publishes the shape of evidence that pushed those backend cuts so
other teams can fork it for their own corpora.

## Four-arm tool ablation

\`akb_get\` is given to every arm — so they're all allowed to read
documents — the variable is *how they find the right one*.

| Arm | Tools | Paradigm |
|---|---|---|
| \`A1_search_only\` | \`akb_search\` | Hybrid retrieval (dense + BM25) |
| \`A2_grep_only\` | \`akb_grep\` | Literal / regex match |
| \`A3_tree\` | \`akb_list_vaults\` + \`akb_browse\` + \`akb_drill_down\` | Tree routing — discover → navigate → drill |
| \`A4_all\` | Union of all four | Full toolbox |

## Harness architecture

- Per-(arm, query) ReAct loop with arm-specific tool whitelist and
  ARM_HINTS. Wall budget, iteration cap, duplicate-call detection,
  and a force-final fallback so a misbehaving model can't burn
  context indefinitely.
- Multi-process driver (\`scripts/run_v4_multiproc.sh\`) spawns N
  processes × M queries; each process reuses one long-lived MCP
  session — avoids the anyio TaskGroup race we saw when sessions
  were opened/closed per call.
- Auto-reconnect on session loss + LLM 429 exponential backoff;
  the v8 run finished 400 / 400 with zero session restarts and
  zero LLM rate-limit failures.
- Offline judge step: a Claude sub-agent reasons over
  \`must_mention\` / \`forbidden\` / \`faithfulness\` rules — no
  substring matcher, paraphrase tolerated. Provenance check
  separately verifies whether each \`must_mention\` fact actually
  came from a tool response or just from the model's prior.

## What's not in this PR (intentionally)

- \`evalset/\` — hand-authored ground truth, domain-specific (the
  original ones were Korean-law). Lives in a sister private repo
  along with the v1-v8 raw runs and result narratives. The schema
  is intentionally tiny (id, category, query, ground_truth) so
  forks can write their own.
- Per-run summaries and judge verdicts — same reason, plus they
  contain corpus content.
- The v1-v8 result narrative — lives in the product vault.

## Test plan

- [x] \`python -m src.runner --arm A3_tree --query q001\` runs end-to-end against a real AKB instance
- [x] \`scripts/run_v4_multiproc.sh\` parallel driver finishes 400 / 400 with zero errors against backend 0.2.3
- [x] Judge prep / finalize round-trip preserves verdict + provenance metadata
- [x] README walks a new user through smoke test + full run + aggregate

🤖 Generated with [Claude Code](https://claude.com/claude-code)