### PR TITLE
fix(grep): default-mode total_* reflects full corpus (0.2.4)

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,37 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.2.4 — 2026-05-24
+
+`akb_grep` default response now reports the true corpus-wide totals
+even when the line snippets get truncated under `limit`. The old
+shape aggregated `total_docs` / `total_matches` over the post-limit
+slice — agents that read those as "how many hits exist in the corpus"
+got false-low counts and made early-termination mistakes. Symptom:
+"the pattern only appears in N docs" when the actual count was much
+higher.
+
+New default-mode fields:
+
+- `returned_docs` / `returned_matches` — what fit under `limit`
+- `total_docs` / `total_matches` — full ILIKE scan (no cap)
+- `truncated` (bool) + `hint` — set when there's more than `limit`
+  could hold, recommending `count_only=true` or
+  `files_with_matches=true` instead of bumping `limit`
+
+This aligns `akb_grep` with the `returned` vs `total_matches`
+contract that `akb_search` already follows (issue #35). The
+`count_only=true` and `files_with_matches=true` response shapes are
+unchanged — they always reported full-scan counts and are now also
+the official escape hatch when the default shape reports
+`truncated=true`.
+
+One small correctness side-effect: chunk hits that produced no
+line-level matches after `strip_chunk_metadata_header` (header /
+summary metadata artifacts riding along with every chunk) no longer
+appear as zero-match docs in the response. They were never real
+grep hits.
+
 ## 0.2.3 — 2026-05-23
 
 Agent-facing polish on the search tools introduced in 0.2.1 / 0.2.2.

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -670,9 +670,18 @@ class SearchService:
                 "files": files,
             }
 
-        # Apply document limit (default response shape only)
-        result_docs = list(docs.values())[:limit]
-        total_matches = sum(len(d["matches"]) for d in result_docs)
+        # Default response shape: separate "what fit under limit"
+        # (`returned_*`) from "what the full scan actually matched"
+        # (`total_*`). Aligning with the hybrid-search response shape
+        # established by issue #35 (`total_matches` MUST always be ≥
+        # `returned`). Filter out chunk-level ILIKE hits that produced
+        # no line-level matches after `strip_chunk_metadata_header` —
+        # those are not real grep hits.
+        matched_docs = [d for d in docs.values() if d["matches"]]
+        total_docs = len(matched_docs)
+        total_matches = sum(len(d["matches"]) for d in matched_docs)
+        result_docs = matched_docs[:limit]
+        returned_matches = sum(len(d["matches"]) for d in result_docs)
 
         # Replace mode: apply find-and-replace on each matching document.
         # Service-layer `doc_service.update` still wants the doc path
@@ -730,10 +739,20 @@ class SearchService:
         resp = {
             "pattern": pattern,
             "regex": regex,
-            "total_docs": len(clean_results),
+            "returned_docs": len(clean_results),
+            "returned_matches": returned_matches,
+            "total_docs": total_docs,
             "total_matches": total_matches,
+            "truncated": total_docs > len(clean_results),
             "results": clean_results,
         }
+        if resp["truncated"]:
+            resp["hint"] = (
+                f"Showing {len(clean_results)} of {total_docs} matching docs "
+                f"(limit={limit}, {returned_matches} of {total_matches} line matches). "
+                f"For full counts use count_only=true; for the full URI list use "
+                f"files_with_matches=true."
+            )
 
         if total_matches == 0 and not regex:
             metachars = set("|.*+?()[]{}^$\\")

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -275,7 +275,10 @@ TOOLS = [
             "Optionally pass `replace` to find-and-replace across all matching documents. "
             "Three response shapes (mutually exclusive): default lines, `count_only=true` "
             "(grep -c — per-doc counts + total, no snippets), `files_with_matches=true` "
-            "(grep -l — just the URIs that contain the pattern)."
+            "(grep -l — just the URIs that contain the pattern). "
+            "The default shape always reports BOTH `returned_*` (what fit under `limit`) "
+            "and `total_*` (full corpus matches) plus a `truncated` flag — if truncated, "
+            "switch to count_only/files_with_matches for the full picture instead of bumping `limit`."
         ),
         inputSchema={
             "type": "object",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.2.3"
+version = "0.2.4"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_hybrid_search_e2e.sh
+++ b/backend/tests/test_hybrid_search_e2e.sh
@@ -334,6 +334,55 @@ case "$ERR" in
   *) fail "grep mutual excl" "got err=$ERR" ;;
 esac
 
+# ── 10. Default-mode truncation: total_* MUST reflect full scan ──
+# Pre-patch bug: when more docs matched than `limit` allowed in the
+# default snippet response, `total_docs`/`total_matches` aggregated
+# only the post-limit slice. Agents reading those fields as "corpus
+# total" got false-low counts and made early-termination mistakes.
+# Now: `returned_*` = post-limit, `total_*` = full scan, plus a
+# `truncated` flag + hint so the agent can switch to count_only.
+echo ""
+echo "▸ 10. akb_grep default-mode truncation reports full corpus totals"
+
+TRUNC="TruncMarker${RANDOM}${RANDOM}"
+for i in 1 2 3; do
+  mcp_call akb_put \
+    "{\"vault\":\"$VAULT_A\",\"collection\":\"grep-trunc\",\"title\":\"trunc-$i\",\"content\":\"$TRUNC hit ${i}\"}" \
+    >/dev/null
+done
+wait_for_indexing "$INDEX_WAIT"
+
+# limit=1 → 1 doc returned, but full scan must surface total_docs=3.
+R=$(mcp_call akb_grep "{\"pattern\":\"$TRUNC\",\"vault\":\"$VAULT_A\",\"limit\":1}" | mcp_result)
+RD=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('returned_docs',-1))")
+RM=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('returned_matches',-1))")
+TD=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_docs',-1))")
+TM=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_matches',-1))")
+TR=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('truncated',False))")
+HH=$(echo  "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('hint') else 'no')")
+[ "$RD" = "1" ] && [ "$RM" = "1" ] && [ "$TD" = "3" ] && [ "$TM" = "3" ] \
+  && [ "$TR" = "True" ] && [ "$HH" = "yes" ] \
+  && pass "truncated default returned=($RD,$RM) total=($TD,$TM) truncated+hint" \
+  || fail "grep truncated" "returned=($RD,$RM) total=($TD,$TM) truncated=$TR hint=$HH"
+
+# count_only on the same scope must agree with default's total_*.
+R=$(mcp_call akb_grep "{\"pattern\":\"$TRUNC\",\"vault\":\"$VAULT_A\",\"count_only\":true}" | mcp_result)
+CO_TD=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_docs',-1))")
+CO_TM=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_matches',-1))")
+[ "$CO_TD" = "$TD" ] && [ "$CO_TM" = "$TM" ] \
+  && pass "count_only total_* parity ($CO_TD docs, $CO_TM matches)" \
+  || fail "grep count_only parity" "count_only=($CO_TD,$CO_TM) default=($TD,$TM)"
+
+# When everything fits, returned == total, truncated=false, no hint.
+R=$(mcp_call akb_grep "{\"pattern\":\"$TRUNC\",\"vault\":\"$VAULT_A\",\"limit\":50}" | mcp_result)
+RD2=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('returned_docs',-1))")
+TD2=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_docs',-1))")
+TR2=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('truncated',True))")
+HH2=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('hint') else 'no')")
+[ "$RD2" = "3" ] && [ "$TD2" = "3" ] && [ "$TR2" = "False" ] && [ "$HH2" = "no" ] \
+  && pass "no truncation when all fit (returned=$RD2 total=$TD2 truncated=$TR2 hint=$HH2)" \
+  || fail "grep untruncated" "returned=$RD2 total=$TD2 truncated=$TR2 hint=$HH2"
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"


### PR DESCRIPTION
## Summary

`akb_grep` default response was aggregating `total_docs` /
`total_matches` over the post-`limit` slice — so an agent reading
those as "corpus-wide hit count" got false-low numbers and could
early-terminate. Likely contributor to the A2 grep-only arm
weakness observed in agentic-bench v7/v8.

Now matches the `returned` vs `total_matches` contract already in
place for `akb_search` (issue #35):

- `returned_docs` / `returned_matches` — post-limit slice
- `total_docs` / `total_matches` — full ILIKE scan (no cap)
- `truncated` (bool) + `hint` — set when the corpus exceeds `limit`,
  pointing the agent at `count_only=true` /
  `files_with_matches=true` instead of bumping `limit`

`count_only` and `files_with_matches` shapes were already correct
(full-scan counts) and are now also the documented escape hatch
when `truncated=true`.

One small correctness side-effect: chunk hits that produced no
line-level matches after `strip_chunk_metadata_header` (header /
summary metadata artifacts that ride along with every chunk) no
longer appear as zero-match docs in the response. They were never
real grep hits.

`backend/pyproject.toml` bumped to **0.2.4**, CHANGELOG entry added.

## Test plan

- [x] `bash backend/tests/test_hybrid_search_e2e.sh` — 24/24 pass
  locally against `docker compose`. §10 extends with three new
  assertions: limit-truncated case (returned/total/truncated/hint),
  count_only parity with default `total_*`, untruncated case
  (returned == total, truncated=false, no hint).
- [x] `bash backend/tests/test_graph_replace_e2e.sh` — 29/29 pass
  (grep-related regression coverage).
- [x] `bash backend/tests/test_hybrid_integration_e2e.sh` — 15/17
  pass; INT1 (collection prefix filter) flakes the same way on
  `main` against local pgvector before this PR. Not caused by this
  change; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)