### PR TITLE
fix(search): expose prefetch-pool ceiling as truncated+hint (0.2.5)

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,33 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.2.5 — 2026-05-24
+
+`akb_search` response now carries a `truncated` boolean and an
+optional `hint`, mirroring the contract that `akb_grep` got in 0.2.4.
+The motivation: `total_matches` in hybrid search was always the
+size of the source-deduped *prefetch pool*, not a corpus-wide hit
+count — vector ANN is fundamentally top-K. When the pool fills to
+the `rerank_prefetch` ceiling (default 30), the corpus may hold
+many more hits than ever reach the response, but the existing
+contract (`total_matches >= returned`) made it look like the
+caller had seen the truth.
+
+Now:
+
+- `truncated=true` iff `total_matches >= target_unique` (the
+  prefetch ceiling computed from `rerank_prefetch` /
+  `search_prefetch` / `limit`). Treats "pool filled" as "there may
+  be more in the corpus."
+- `hint` set when `truncated=true`, recommending `akb_grep` with
+  `count_only=true` for an exact literal-substring count and noting
+  that semantic queries can't be exhaustively enumerated.
+- Model docstring on `SearchResponse` rewritten to call out the
+  pool-depth semantics explicitly.
+
+The `total_matches` value itself is unchanged — same number,
+honest framing. `total` (deprecated alias of `returned`) stays.
+
 ## 0.2.4 — 2026-05-24
 
 `akb_grep` default response now reports the true corpus-wide totals

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -181,11 +181,20 @@ class SearchResponse(BaseModel):
     """Response for akb_search.
 
     `returned` is the number of items in `results` (post-limit / post-rerank).
-    `total_matches` is how many unique hits the prefetch window saw before
-    the limit was applied — gives callers a way to distinguish "this is
-    the full set" from "first N of more". When `total_matches > returned`
-    the agent should re-issue with a larger `limit` rather than treating
-    `returned` as the population.
+
+    `total_matches` is how many unique sources the prefetch window saw
+    before the limit was applied. **It is NOT a corpus-wide hit count.**
+    Vector ANN is fundamentally top-K; the backend pulls a fixed-size
+    pool (driven by `rerank_prefetch`, default 30) and dedupes
+    source-level. When `total_matches` equals that pool ceiling the
+    corpus may contain many more hits — see `truncated` / `hint`. For
+    an exact corpus-wide count, use `akb_grep` with `count_only=true`
+    (literal substrings only — semantic queries can't be exhaustively
+    enumerated).
+
+    `truncated` is true when `total_matches` hit the prefetch ceiling
+    (i.e. the pool was filled and there might be more in the corpus).
+    `hint` carries a one-line follow-up suggestion when truncated.
 
     `total` is kept as a deprecated alias of `returned` for backward
     compatibility with existing UI / agent prompts.
@@ -195,4 +204,6 @@ class SearchResponse(BaseModel):
     total: int
     returned: int = 0
     total_matches: int = 0
+    truncated: bool = False
+    hint: str | None = None
     results: list[SearchResult]

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -275,10 +275,14 @@ class SearchService:
             if len(unique_hits) >= target_unique:
                 break
 
-        # Capture pre-limit count so callers can tell "this is the full
-        # set" from "first N of more" — the limit-as-count confusion was
-        # observed in the KISA RAG PoC (issue #35).
+        # `total_matches` here is the size of the *prefetch pool* after
+        # source-level dedup, NOT a corpus-wide hit count — vector ANN is
+        # fundamentally top-K. When the pool fills to `target_unique` the
+        # corpus may contain many more hits than we ever fetched, and the
+        # caller deserves an explicit signal (the limit-as-count confusion
+        # this guards against was observed in the KISA RAG PoC, issue #35).
         total_matches = len(unique_hits)
+        prefetch_capped = total_matches >= target_unique
 
         if settings.rerank_enabled and len(unique_hits) > 1:
             unique_hits = await self._apply_rerank(query, unique_hits)
@@ -290,11 +294,19 @@ class SearchService:
         # backward-compatible (doc_id == source_id) while adding table/file.
         results = await self._hydrate_hits(unique_hits)
         returned = len(results)
+        hint = (
+            "Prefetch pool was capped; the corpus may contain more matches than reported. "
+            "For an exact corpus-wide count of a literal substring use akb_grep with "
+            "count_only=true. Semantic queries are inherently top-K and cannot be "
+            "exhaustively enumerated."
+        ) if prefetch_capped else None
         return SearchResponse(
             query=query,
             total=returned,  # deprecated alias of `returned`
             returned=returned,
             total_matches=total_matches,
+            truncated=prefetch_capped,
+            hint=hint,
             results=results,
         )
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -246,7 +246,12 @@ TOOLS = [
             "BM25 sparse (keyword) via Reciprocal Rank Fusion. Handles both natural-language "
             "questions and short keyword queries well. For exact string / regex matches "
             "(code, URLs, version numbers) prefer akb_grep. Returns each hit's `uri`; "
-            "use akb_drill_down or akb_get with that URI for full content."
+            "use akb_drill_down or akb_get with that URI for full content. "
+            "Response reports `returned` (in `results`) and `total_matches` (size of the "
+            "deduped prefetch pool — NOT a corpus-wide hit count; vector ANN is top-K only). "
+            "When `truncated=true` the prefetch pool was capped, meaning the corpus may hold "
+            "more hits than reported — switch to akb_grep with count_only=true for an exact "
+            "literal-substring count, or refine the query."
         ),
         inputSchema={
             "type": "object",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.2.4"
+version = "0.2.5"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_hybrid_search_e2e.sh
+++ b/backend/tests/test_hybrid_search_e2e.sh
@@ -293,6 +293,18 @@ TOTAL=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d
   && pass "total_matches ($TOTAL_M) >= returned ($RETURNED)" \
   || fail "total_matches" "got total_matches=$TOTAL_M returned=$RETURNED"
 
+# ── 7c. truncated + hint signal (prefetch-pool honesty) ──────
+# A small corpus that fits entirely under the prefetch ceiling must
+# report truncated=false / hint=null. Adding the truncated field is
+# what lets agents tell "this is the whole set" from "tip of a deep
+# pool" — `total_matches` alone is a pool-depth read, not a corpus
+# count, since vector ANN is fundamentally top-K (see model docstring).
+TR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('truncated', False))")
+HH=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('hint') else 'no')")
+[ "$TR" = "False" ] && [ "$HH" = "no" ] \
+  && pass "small corpus → truncated=false, hint=null" \
+  || fail "truncated false" "truncated=$TR hint=$HH"
+
 # ── 8. Nonsense query returns 0 ──────────────────────────────
 # Queries with no vocab overlap (random strings, fully OOV tokens) are
 # treated as "no signal" — no dense-only fallback, so total must be 0.

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.exceptions import ValidationError
+from app.models.document import SearchResponse
 from app.services.search_service import (
     SearchService,
     fuse_original_and_reranked_hits,
@@ -68,6 +69,30 @@ def test_first_stage_unique_limit_keeps_legacy_rerank_off_default():
         rerank_prefetch=30,
         search_prefetch=0,
     ) == 5
+
+
+def test_search_response_defaults_truncated_false_no_hint():
+    """A response built without explicit truncated/hint must default to
+    'not truncated, no hint' — the most common case (small corpus or
+    prefetch pool not filled). Mirrors how the empty-result paths in
+    search_service.py:243 / :262 still construct SearchResponse."""
+    r = SearchResponse(query="x", total=0, returned=0, total_matches=0, results=[])
+    assert r.truncated is False
+    assert r.hint is None
+
+
+def test_search_response_carries_truncated_signal():
+    r = SearchResponse(
+        query="x",
+        total=2,
+        returned=2,
+        total_matches=30,
+        truncated=True,
+        hint="Prefetch pool was capped...",
+        results=[],
+    )
+    assert r.truncated is True
+    assert r.hint and "Prefetch pool" in r.hint
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`akb_search.total_matches` has always been the size of the
source-deduped *prefetch pool*, not a corpus-wide hit count — vector
ANN is fundamentally top-K. The pool fills to `target_unique`
(driven by `rerank_prefetch`, default 30) and that's it. In large
tenants, agents reading `total_matches` as "docs in the corpus that
matched my query" were getting a number that capped silently at 30,
which looked authoritative but wasn't. Caught in review while
landing the sibling fix #76 for `akb_grep`.

Same contract that `akb_grep` got in 0.2.4:

- `truncated=True` iff `total_matches >= target_unique`. Treats
  "pool filled" as "there may be more in the corpus."
- `hint` recommends `akb_grep(count_only=true)` for exact
  literal-substring counts, and notes semantic queries can't be
  exhaustively enumerated.
- `SearchResponse` docstring rewritten — no more "limit-as-count"
  framing.
- MCP tool description spells out the prefetch-pool caveat.

`total_matches` numeric value unchanged. `total` (deprecated alias
of `returned`) stays. Additive shape change — older clients keep
working.

## Test plan

- [x] `bash backend/tests/test_hybrid_search_e2e.sh` — 25/25 local
  (24 previous + new §7c truncated=false / hint=null assertion).
- [x] Unit tests in `test_search_rerank_fusion.py` for the
  `SearchResponse` defaults + truncated-signal paths.
- [ ] CI: backend-pytest + check
- The `truncated=True` integration path is naturally exercised on
  production tenants where `total_matches` saturates the
  `rerank_prefetch` ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)