### PR TITLE
feat(frontend): surface truncated signal + honest counts in search UI

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -248,14 +248,17 @@ export const browseVault = (vault: string, collection?: string, depth = 1) => {
 // `total` is the legacy alias of `returned` (kept until the SPA / agent
 // prompts stop reading it). New fields per backend PR #39:
 //   - returned: items in `results` after limit + rerank
-//   - total_matches: unique hits seen in the prefetch window before limit
-// When `total_matches > returned`, surface "first N of more" rather than
-// treating `returned` as the population.
+//   - total_matches: deduped prefetch-pool size, NOT a corpus-wide count
+//     (vector ANN is top-K; see backend SearchResponse docstring)
+//   - truncated / hint: set when the prefetch pool filled, meaning the
+//     corpus may contain more hits than the response surfaces (#77 / 0.2.5).
 export interface SearchResponse {
   query: string;
   total: number;
   returned: number;
   total_matches: number;
+  truncated?: boolean;
+  hint?: string | null;
   results: any[];
 }
 export const searchDocs = (query: string, vault?: string, limit = 10) => {
@@ -275,17 +278,28 @@ export interface GrepDoc {
   title: string;
   matches: GrepMatch[];
 }
-export const grepDocs = (query: string, vault?: string, limit = 20) => {
-  const p = new URLSearchParams({ q: query, limit: String(limit) });
-  if (vault) p.set("vault", vault);
-  return api<{
-    pattern: string;
-    regex: boolean;
-    total_docs: number;
-    total_matches: number;
-    results: GrepDoc[];
-  }>(`/grep?${p}`);
-};
+// Grep response (default mode). `total_*` reflect the full ILIKE scan
+// across the corpus; `returned_*` reflect what fit under `limit` in
+// `results`. `truncated=true` + `hint` are set when the corpus has more
+// matches than the response surfaces — switch to count_only or
+// files_with_matches at the agent / caller level (backend #76 / 0.2.4).
+export interface GrepResponse {
+  pattern: string;
+  regex: boolean;
+  returned_docs?: number;
+  returned_matches?: number;
+  total_docs: number;
+  total_matches: number;
+  truncated?: boolean;
+  hint?: string | null;
+  results: GrepDoc[];
+}
+export const grepDocs = (query: string, vault?: string, limit = 20) =>
+  api<GrepResponse>(`/grep?${(() => {
+    const p = new URLSearchParams({ q: query, limit: String(limit) });
+    if (vault) p.set("vault", vault);
+    return p;
+  })()}`);
 
 // ── Graph ──
 export interface GraphApiNode {

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -81,6 +81,15 @@ export default function SearchPage() {
   const [literalResults, setLiteralResults] = useState<GrepDoc[]>([]);
   const [total, setTotal] = useState(0);
   const [totalMatches, setTotalMatches] = useState(0);
+  // grep returns both doc-count and line-count; track the "what was
+  // shown" side separately so the header can honestly say "N of M
+  // docs · K of L matches" instead of pretending the response is the
+  // whole population. Defaults to total* when the backend doesn't
+  // distinguish (older grep, or pre-0.2.4 servers).
+  const [returnedDocs, setReturnedDocs] = useState(0);
+  const [returnedMatches, setReturnedMatches] = useState(0);
+  const [truncated, setTruncated] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
   const [vaults, setVaults] = useState<{ name: string }[]>([]);
@@ -122,19 +131,33 @@ export default function SearchPage() {
         setDenseResults(d.results);
         setLiteralResults([]);
         setTotal(d.total);
-        setTotalMatches(0);
+        setTotalMatches(d.total_matches);
+        setReturnedDocs(d.returned);
+        setReturnedMatches(0);
+        setTruncated(Boolean(d.truncated));
+        setHint(d.hint ?? null);
       } else {
         const d = await grepDocs(s, v || undefined);
         setLiteralResults(d.results);
         setDenseResults([]);
         setTotal(d.total_docs);
         setTotalMatches(d.total_matches);
+        // Older servers (< 0.2.4) don't ship returned_*; fall back to
+        // total_* so the header still renders a sensible single count.
+        setReturnedDocs(d.returned_docs ?? d.total_docs);
+        setReturnedMatches(d.returned_matches ?? d.total_matches);
+        setTruncated(Boolean(d.truncated));
+        setHint(d.hint ?? null);
       }
     } catch {
       setDenseResults([]);
       setLiteralResults([]);
       setTotal(0);
       setTotalMatches(0);
+      setReturnedDocs(0);
+      setReturnedMatches(0);
+      setTruncated(false);
+      setHint(null);
     }
     setLoading(false);
   }
@@ -386,6 +409,17 @@ export default function SearchPage() {
         />
       )}
 
+      {truncated && hint && total > 0 && !loading && (
+        <div
+          role="note"
+          className="mt-6 border border-warning/40 bg-warning/5 px-4 py-2.5 coord text-xs leading-relaxed"
+          aria-label="Result set may be incomplete"
+        >
+          <span className="coord-ink mr-2">▲ TRUNCATED</span>
+          {hint}
+        </div>
+      )}
+
       {total > 0 && mode === "dense" && (
         <Tabs defaultValue="all" className="mt-6">
           <TabsList>
@@ -428,7 +462,9 @@ export default function SearchPage() {
           <header className="border-b border-border px-4 py-2 flex items-baseline justify-between">
             <span className="coord-ink">§ RESULTS · LITERAL</span>
             <span className="coord tabular-nums">
-              [{total} docs · {totalMatches} matches]
+              {returnedDocs !== total || returnedMatches !== totalMatches
+                ? `[${returnedDocs} of ${total} docs · ${returnedMatches} of ${totalMatches} matches]`
+                : `[${total} docs · ${totalMatches} matches]`}
             </span>
           </header>
           <ol className="divide-y divide-border">


### PR DESCRIPTION
## Summary

Follow-up to backend 0.2.4 (#76) and 0.2.5 (#77). After those PRs,
`akb_search` and `akb_grep` responses ship `truncated` / `hint`
when the response isn't the full picture — but the SPA was still
reading only `total_*` and rendering it as ground truth, defeating
the honest-counts work in the backend.

### `frontend/src/lib/api.ts`

- `SearchResponse` gets optional `truncated`, `hint`
- `GrepResponse` is split out into a named interface with the new
  optional `returned_docs`, `returned_matches`, `truncated`, `hint`
- Older servers omitting these fields keep working — fallbacks
  use `total_*`

### `frontend/src/pages/search.tsx`

- `doSearch` threads `returned_*` / `truncated` / `hint` into
  component state
- A warning-tinted "▲ TRUNCATED" banner renders above results when
  the backend says the response is incomplete, carrying the hint
  verbatim (count_only / files_with_matches / refine query)
- Literal-mode header switches to "N of M docs · K of L matches"
  when returned != total; single-count form preserved when the
  corpus fits under `limit`

### Behaviour preserved

- Untruncated case (small corpus / response fits under `limit`):
  no banner, same single-count header. Pre-PR UI parity.
- Dense (semantic) mode pre-existing tabs / type filters
  untouched.

## Test plan

- [x] `npx tsc --noEmit` — typecheck pass
- [x] `npm run build` — production build pass
- [x] vite dev server boots; SPA renders auth page without console
  errors (the one 401 is the failed login attempt, expected for
  a fresh local docker compose stack with no pre-seeded user)
- [x] Backend e2e from #76 / #77 still green against the docker
  compose stack (truncated flag end-to-end correctness was already
  covered there)
- The `truncated=true` UI case requires a corpus large enough to
  exceed the prefetch ceiling (≥30 matching docs for search, or
  ≥limit docs for grep) — naturally exercised on production tenants
  rather than the local fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)