### PR TITLE
fix(all-in-one): repair docker image — pnpm scripts gate + config dir leak

### DIFF
--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /src
 RUN npm install -g pnpm@latest
 
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY frontend/ ./
 RUN npx vite build
@@ -72,6 +72,11 @@ RUN pip install --no-cache-dir /tmp/akb-backend && rm -rf /tmp/akb-backend
 
 # Backend source (used at runtime — venv only carries dependencies).
 COPY backend /app/backend
+# Drop any locally-rendered backend/config/ that leaked into the build
+# context. The all-in-one image must use /etc/akb/{app,secret}.yaml,
+# rendered by entrypoint.sh — a stray ./config/app.yaml short-circuits
+# `config.py:_CONFIG_CANDIDATES` and starves backend of secret.yaml.
+RUN rm -rf /app/backend/config
 
 # Frontend static bundle.
 COPY --from=frontend-builder /src/dist /var/www/akb


### PR DESCRIPTION
## Summary
Two regressions in `deploy/all-in-one/Dockerfile` made `dnseahorse/akb:latest` (and any fresh build off main) fail to boot the backend. Both fixed in one Dockerfile change.

- **pnpm 10+ build-scripts gate** — `RUN pnpm install --frozen-lockfile` aborts when any transitive dep declares a postinstall (msw@2.x) that isn't on the allow-list. `.github/workflows/check.yml` already passes `--ignore-scripts` for the same reason; the Dockerfile was the missing pair.
- **`backend/config/` leak** — `backend/config/` is gitignored (operator-local config). With no `.dockerignore`, `COPY backend /app/backend` pulls those local files into the image. Backend's `_CONFIG_CANDIDATES = [./config, /etc/akb]` then short-circuits at `/app/backend/config/app.yaml` and never loads `/etc/akb/secret.yaml` rendered by `entrypoint.sh` — so `jwt_secret` / `db_password` stay empty and the lifecycle validator fast-fails. Fix: `RUN rm -rf /app/backend/config` right after the COPY.

## Test plan
- [x] Multi-arch rebuild (`linux/amd64,linux/arm64`) succeeds
- [x] `docker run -p 8080:8080 dnseahorse/akb:latest` boots cleanly
- [x] `/livez`, `/readyz`, `/health` → 200
- [x] `supervisorctl status` shows postgres / redis / minio / backend / nginx all RUNNING
- [x] MCP `initialize` with seeded demo PAT → `serverInfo{name:"akb",version:"1.27.1"}`
- [x] `/mcp/` without auth → 401 (as expected)

`dnseahorse/akb:latest` already rebuilt + pushed at 2026-05-26 03:11 UTC (digest `sha256:fec610d38a48b614e60b362cc4894235ce9438b49270ef03385e5d591322482b`). Image is currently working — this PR just lands the Dockerfile change so the next fresh build off main keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)