### PR TITLE
refactor(documents): remove free-form metadata escape hatch from write API

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -40,7 +39,6 @@ class DocumentPutRequest(NFCModel):
     summary: str | None = None
     depends_on: list[str] = Field(default_factory=list)
     related_to: list[str] = Field(default_factory=list)
-    metadata: dict[str, Any] = Field(default_factory=dict)
     # Optional explicit slug for the file path under the collection.
     # When omitted, the slug is derived from `title`. The seed flow and
     # frontend "Create from template" both pass an explicit slug so the
@@ -61,7 +59,6 @@ class DocumentUpdateRequest(NFCModel):
     summary: str | None = None
     depends_on: list[str] | None = None
     related_to: list[str] | None = None
-    metadata: dict[str, Any] | None = None
     message: str | None = None  # commit message
     # Optimistic concurrency: when provided, the update is rejected with
     # 409 unless the document's current_commit matches. Use to detect a

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -185,8 +185,6 @@ def _build_frontmatter(req: DocumentPutRequest, now: datetime) -> dict:
         fm["depends_on"] = req.depends_on
     if req.related_to:
         fm["related_to"] = req.related_to
-    if req.metadata:
-        fm.update(req.metadata)
     return fm
 
 
@@ -284,13 +282,14 @@ class DocumentService:
         # slashes or whitespace, diverging from the doc path under it.
         collection_id = await coll_repo.get_or_create(vault_id, normalized_collection)
         # No `id` key — canonical handle is the akb:// URI built from
-        # (vault, path), not a short hash.
-        metadata = dict(req.metadata or {})
+        # (vault, path), not a short hash. The `metadata` JSONB column is
+        # reserved for internal writers (external-git import, LLM auto-tagging)
+        # — user document writes never populate it.
         pg_doc_id = await doc_repo.create(
             vault_id=vault_id, collection_id=collection_id, path=file_path,
             title=req.title, doc_type=req.type, status="draft",
             summary=fm_dict.get("summary") or req.summary, domain=req.domain, created_by=agent_id,
-            now=now, commit_hash=commit_hash, tags=req.tags, metadata=metadata,
+            now=now, commit_hash=commit_hash, tags=req.tags, metadata={},
         )
 
         # Index: write chunks into PG (truth) + best-effort vector-store upsert.
@@ -518,8 +517,6 @@ class DocumentService:
             current_fm["depends_on"] = req.depends_on
         if req.related_to is not None:
             current_fm["related_to"] = req.related_to
-        if req.metadata:
-            current_fm.update(req.metadata)
         current_fm["updated_at"] = now.isoformat()
 
         new_body = req.content if req.content is not None else current_body


### PR DESCRIPTION
## What

Removes the free-form `metadata: dict[str, Any]` input field from `DocumentPutRequest` / `DocumentUpdateRequest` and the three sites in `document_service.py` that merged it into git frontmatter.

- Drop `metadata` from both request models (+ now-unused `Any` import) — `backend/app/models/document.py`
- Remove `fm.update(req.metadata)` in `_build_frontmatter` (put) and `current_fm.update(req.metadata)` in the update path; drop the put metadata-extraction site and pass `metadata={}` to `doc_repo.create` — `backend/app/services/document_service.py`

## Why

The `metadata` field accepted arbitrary keys and merged them verbatim into a document's git frontmatter **with no schema validation**. It was the *only* path by which non-AKB keys could land in frontmatter (top-level unknown keys are already dropped by Pydantic's default `extra="ignore"`). This surfaced when an app built on the AKB API accidentally wrote application-schema fields into frontmatter. Removing the field makes frontmatter **type-safe** — it now only ever carries AKB-native fields.

## Scope / what is NOT changed

- The `documents.metadata` **JSONB column stays**, along with its internal writers (external-git import, LLM auto-tagging via `mark_llm_metadata_filled`) and readers (`search_service`, `kg_service`, `sessions` route). Only the user-facing input field + frontmatter merge are removed.
- No `extra="forbid"` added (out of scope — Pydantic default is `ignore`, and the pollution vector is closed by removing the field alone).
- Read-side symmetry (`depends_on`/`related_to` on `DocumentResponse`) deferred.
- Existing stored data left as-is — this only prevents *future* writes.

## Reviewer notes

- **No runtime break**: no current consumer sends `metadata` (verified across the AKB frontend, `reef`, and the MCP handlers — none forward it). With `extra="ignore"`, a stray `metadata` payload is a silent no-op, not a 422.
- `doc_repo.create`'s only caller is `put`; signature unchanged, now passed `{}`. The separate `doc_repo.upsert` (external-git) is untouched.
- OpenAPI at `/docs` regenerates from the models automatically — `metadata` disappears from the documented bodies with no manual edit.

## Verification

- `test_edit_e2e.sh` → 37/37 green (document put/update/edit fully exercised)
- Model/frontmatter sanity: `metadata` absent from both request models; `_build_frontmatter` emits only AKB-native keys; stray `metadata`/unknown fields silently ignored (no 422)
- `test_mcp_e2e.sh` document CRUD all pass (search-dependent failures in this run trace to a stalled local indexing pipeline — `vector_store.backfill.upsert.indexed=0` — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)