### PR TITLE
fix(browse): surface root-level docs + drop phantom path='' collection (#81, #82)

### DIFF
--- a/backend/app/db/migrations/025_drop_phantom_root_collection.py
+++ b/backend/app/db/migrations/025_drop_phantom_root_collection.py
@@ -1,0 +1,129 @@
+"""Migration 025: drop phantom ``path=''`` collection rows.
+
+Pre-fix, ``document_service.put()`` called
+``coll_repo.get_or_create(vault_id, "")`` whenever a user put a doc
+without specifying a collection. That inserted a phantom row with
+``path=''`` and ``name=''`` per affected vault, and every "vault-root"
+doc/file/table pointed its ``collection_id`` FK at it.
+
+Two visible bugs followed (issues #81, #82):
+  * ``akb_browse`` emitted an empty-name collection marker — every
+    rendering client had to special-case it out of the response.
+  * Root-level docs lived under a phantom collection rather than
+    ``collection_id IS NULL``, so the unified browse couldn't surface
+    them at ``depth=1`` (which is the symmetric behaviour we want with
+    root-level tables/files).
+
+The fix landed at the call site
+(``document_service.py`` — only call ``get_or_create`` when the
+normalized collection path is non-empty, matching the peer pattern in
+``file_service``, ``table_service``, ``external_git_service``). This
+migration cleans up the data already in production:
+
+  1. Re-NULL the FK on documents / vault_files / vault_tables that
+     pointed at any phantom collection.
+  2. DELETE the phantom rows themselves.
+
+The FKs already declare ``ON DELETE SET NULL`` (init.sql:100/180/238),
+so step 1 is technically redundant — but explicit is clearer in the
+audit log and removes the brief window where the cascade hasn't
+finished. Idempotent: re-running after the prod DB is clean is a no-op
+(`UPDATE` over an empty set, `DELETE` over an empty set).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.025")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        # FK is ON DELETE SET NULL, so the explicit UPDATEs below are
+        # belt-and-braces — they fire even on a schema variant that lost
+        # the cascade, and they leave a clear audit trail.
+        doc_count = await conn.fetchval(
+            """
+            WITH updated AS (
+                UPDATE documents
+                   SET collection_id = NULL
+                 WHERE collection_id IN (
+                     SELECT id FROM collections WHERE path = ''
+                 )
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM updated
+            """
+        )
+        file_count = await conn.fetchval(
+            """
+            WITH updated AS (
+                UPDATE vault_files
+                   SET collection_id = NULL
+                 WHERE collection_id IN (
+                     SELECT id FROM collections WHERE path = ''
+                 )
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM updated
+            """
+        )
+        table_count = await conn.fetchval(
+            """
+            WITH updated AS (
+                UPDATE vault_tables
+                   SET collection_id = NULL
+                 WHERE collection_id IN (
+                     SELECT id FROM collections WHERE path = ''
+                 )
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM updated
+            """
+        )
+        phantom_count = await conn.fetchval(
+            """
+            WITH deleted AS (
+                DELETE FROM collections WHERE path = ''
+                RETURNING 1
+            )
+            SELECT COUNT(*) FROM deleted
+            """
+        )
+
+    if phantom_count:
+        logger.info(
+            "Migration 025: cleared %d phantom path='' collection(s); "
+            "re-NULLed FK on %d documents, %d files, %d tables",
+            phantom_count, doc_count, file_count, table_count,
+        )
+    else:
+        logger.info("Migration 025: no phantom collections found; nothing to clean up")
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -109,6 +109,7 @@ async def _apply_migrations() -> None:
         "022_publications_resource_uri.py",     # collapse publications (document_id, file_id) → publications.resource_uri (URI canonical)
         "023_drop_metadata_id.py",              # strip legacy d-prefix `metadata.id` from documents (cosmetic; SQL lookup arm already removed)
         "024_tokens_revoked_before.py",         # users.tokens_revoked_before for JWT revocation (default epoch — pre-existing JWTs unaffected)
+        "025_drop_phantom_root_collection.py",  # drop path='' collection rows that legacy put() created when collection was omitted (issues #81/#82)
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -193,6 +193,26 @@ class DocumentRepository:
             )
             return [dict(r) for r in rows]
 
+    async def list_root_docs(self, vault_id: uuid.UUID) -> list[dict]:
+        """Documents living at the vault root (collection_id IS NULL).
+
+        Distinct from `list_by_vault`: this is the slice that the unified
+        browse needs at depth=1 — sibling to root-level tables/files —
+        so users who put docs without a collection can still find them
+        without paying the depth=2 cost of unspooling every sub-collection.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT path, title, doc_type, status, summary, tags, updated_at
+                FROM documents
+                WHERE vault_id = $1 AND collection_id IS NULL
+                ORDER BY updated_at DESC
+                """,
+                vault_id,
+            )
+            return [dict(r) for r in rows]
+
     # ── External-git mirror helpers ──────────────────────────
 
     async def list_external_blobs(self, vault_id: uuid.UUID) -> dict[str, dict]:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -282,7 +282,14 @@ class DocumentService:
         # matches the document's stored `path`. Passing the raw
         # `req.collection` here would create rows with leading/trailing
         # slashes or whitespace, diverging from the doc path under it.
-        collection_id = await coll_repo.get_or_create(vault_id, normalized_collection)
+        # Empty (== vault root) maps to NULL FK, matching the convention
+        # used by file_service / table_service / external_git_service —
+        # never insert a `path=""` phantom collection row.
+        collection_id = (
+            await coll_repo.get_or_create(vault_id, normalized_collection)
+            if normalized_collection
+            else None
+        )
         # No `id` key — canonical handle is the akb:// URI built from
         # (vault, path), not a short hash.
         metadata = dict(req.metadata or {})
@@ -929,16 +936,24 @@ class DocumentService:
                 summary=r["summary"], doc_count=r["doc_count"],
                 last_updated=r["last_updated"],
             ))
+        # Documents:
+        #   depth=1 → root-level docs only (collection_id IS NULL), so users
+        #     who put a doc without a collection can find it from the default
+        #     browse — symmetric with tables/files which already surface at root.
+        #   depth=2 → every doc in the vault, root + inside collections (used
+        #     by exporters / bulk-context loaders / the AKB frontend tree).
         if depth >= 2:
             doc_rows = await doc_repo.list_by_vault(vault_id)
-            for r in doc_rows:
-                items.append(BrowseItem(
-                    name=r["title"], path=r["path"], type="document",
-                    uri=doc_uri(vault, r["path"]),
-                    summary=r["summary"], doc_type=r["doc_type"], status=r["status"],
-                    tags=list(r["tags"]) if r["tags"] else [],
-                    last_updated=r["updated_at"],
-                ))
+        else:
+            doc_rows = await doc_repo.list_root_docs(vault_id)
+        for r in doc_rows:
+            items.append(BrowseItem(
+                name=r["title"], path=r["path"], type="document",
+                uri=doc_uri(vault, r["path"]),
+                summary=r["summary"], doc_type=r["doc_type"], status=r["status"],
+                tags=list(r["tags"]) if r["tags"] else [],
+                last_updated=r["updated_at"],
+            ))
         return items
 
     async def _browse_tables(

--- a/backend/tests/test_unified_browse_edges_e2e.sh
+++ b/backend/tests/test_unified_browse_edges_e2e.sh
@@ -472,6 +472,73 @@ R=$(mcp_call akb_list_tables "{\"vault\":\"$VAULT\"}" | mcp_result)
 UNKNOWN=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin) or 'Unknown' in json.load(sys.stdin).get('error',''))" 2>/dev/null)
 [ "$UNKNOWN" = "True" ] && pass "akb_list_tables returns error (removed)" || pass "akb_list_tables may still work (graceful deprecation)"
 
+# ── 18. Root-level browse visibility (issues #81/#82) ────────
+# Two paired bugs fixed together:
+#   #82: put-without-collection used to insert a phantom path='' row
+#        which then appeared in browse as {name:'', path:'', uri:null}.
+#   #81: depth=1 default browse used to skip documents entirely, even
+#        the root-level ones, so users who put docs without collections
+#        had no way to find them via browse.
+echo ""
+echo "▸ 18. Root-Level Browse Visibility (issues #81/#82)"
+
+# Put a doc directly at vault root via explicit empty-string collection.
+# (`collection` is marked required at the MCP layer; an empty string passes
+# validation but normalises to "" — which is the exact path that used to
+# trigger the phantom row before this fix.)
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"\",\"title\":\"Root-Level Doc\",\"content\":\"# Lives at vault root\",\"type\":\"note\"}" | mcp_result)
+ROOT_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+ROOT_DOC_PATH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])" 2>/dev/null)
+[ -n "$ROOT_DOC_URI" ] && pass "Root doc put (uri=$ROOT_DOC_URI, path=$ROOT_DOC_PATH)" || fail "Root doc put" "no uri"
+
+# Path must be flat (no slash) — confirms collection_id is NULL, not a phantom row
+case "$ROOT_DOC_PATH" in
+  */*) fail "Root doc path" "path '$ROOT_DOC_PATH' contains a slash; root docs must be flat" ;;
+  *)   pass "Root doc path is flat (no slash)" ;;
+esac
+
+# Default browse (depth=1) — must include root doc, no empty marker
+R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result)
+EMPTY_MARKER=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+empties=[i for i in d['items']
+         if i.get('type')=='collection' and not i.get('path') and not i.get('name')]
+print(len(empties))
+" 2>/dev/null)
+[ "$EMPTY_MARKER" = "0" ] && pass "browse(default): no empty-name collection marker" || fail "Empty marker" "found $EMPTY_MARKER empty marker(s) in default browse"
+
+ROOT_DOC_VISIBLE=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+hits=[i for i in d['items']
+      if i.get('type')=='document' and i.get('path')=='$ROOT_DOC_PATH']
+print(len(hits))
+" 2>/dev/null)
+[ "$ROOT_DOC_VISIBLE" = "1" ] && pass "browse(default): root doc is visible" || fail "Root doc visibility" "root doc not in default browse response"
+
+# Default browse must NOT include sub-collection docs (depth=1 root-only contract)
+SUBCOLL_LEAK=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+leaks=[i for i in d['items']
+       if i.get('type')=='document' and i.get('path') and '/' in i['path']]
+print(len(leaks))
+" 2>/dev/null)
+[ "$SUBCOLL_LEAK" = "0" ] && pass "browse(default): sub-collection docs not leaked at depth=1" || fail "Sub-collection leak" "$SUBCOLL_LEAK sub-collection doc(s) leaked into depth=1 browse"
+
+# depth=2 — must show every doc (root + sub-collection). Regression check.
+R2=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"depth\":2}" | mcp_result)
+ALL_DOCS=$(echo "$R2" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+docs=[i for i in d['items'] if i.get('type')=='document']
+print(len(docs))
+" 2>/dev/null)
+# Expect at least 3 docs: root + specs/api-spec-v2 + designs/system-design.
+# (Other earlier sections may have created more — only assert the minimum.)
+[ "$ALL_DOCS" -ge 3 ] 2>/dev/null && pass "browse(depth=2): all docs surfaced ($ALL_DOCS docs)" || fail "depth=2 regression" "only $ALL_DOCS docs (expected >=3)"
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"


### PR DESCRIPTION
## Summary

Two paired bugs in `akb_browse` with one root cause. `document_service.put()` was the only caller of `coll_repo.get_or_create` that didn't guard the empty-string case — every peer (file_service, table_service, external_git_service) already maps empty collection → `collection_id=NULL`. The missing guard let a put without a collection insert a phantom row with `path=''` and `name=''`, which then surfaced two visible symptoms.

- **#82** — `akb_browse` emitted that row as `{type:"collection", name:"", path:"", uri:null}`; every client had to special-case it out (e.g. seahorse-mcp-agent-server PR #134's literal `if !path && !name continue`).
- **#81** — Root-level docs lived under the phantom collection rather than `collection_id IS NULL`, so the unified browse at depth=1 hid them — a real asymmetry, since root-level tables/files DID appear at depth=1. Search/get/grep saw them; only browse silently hid them.

## Changes

- `document_service.py:put` — guard `get_or_create` so empty collection maps to `collection_id=NULL`, matching the peer pattern. Comment cites the bug class.
- `document_repo.py` — new `list_root_docs(vault_id)` (collection_id IS NULL). Mirrors `list_by_vault` shape.
- `document_service.py:_browse_collections` — at depth=1 emit `list_root_docs`; at depth=2 keep emitting all docs. depth=2 behavior preserved (AKB frontend tree builder uses depth=2 — `use-vault-tree.ts:64`).
- `025_drop_phantom_root_collection.py` — idempotent migration: re-NULL FK on docs/files/tables pointing at phantom rows, then delete the phantom rows. Logs counts. Silent no-op on clean DBs. Registered in `postgres.py`.

## Test plan
- [x] `test_mcp_e2e.sh` — 76/76 (regression sweep)
- [x] `test_unified_browse_edges_e2e.sh` — 76/76 (incl. new §18: 6 cases)
- [x] `test_defensive_e2e.sh` — 3 pre-existing failures unchanged from main (caused by auto-`overview` collection on vault create; unrelated)
- [x] Migration ran clean on local DB (`no phantom collections found`)

## New test cases (§18)
1. Put with explicit `collection: ""` succeeds; path has no slash.
2. Default browse has no empty-name collection marker.
3. Default browse (depth=1) includes the root doc as `type:"document"`.
4. Default browse does NOT include sub-collection docs (depth=1 contract preserved).
5. depth=2 still surfaces every doc.
6. Root doc path has no slash (defensive).

## Client impact

- **AKB frontend** — no change. Already calls depth=2; tree builder already routes root docs to roots. Side effect: empty-card placeholder disappears.
- **MCP clients with strict depth=1 allow-lists** — will receive `type:"document"` items. Pattern was already established at depth=1 (tables/files), so it's consistent, but a strict client may need a one-line update.
- **seahorse-mcp-agent-server PR #134's empty-marker filter** — becomes dead code. Harmless.

Closes #81
Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)