### PR TITLE
fix(edges): filter coll/vault URIs at extraction + reject template placeholders

### DIFF
--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -138,13 +138,31 @@ async def link_resources(
     created_by: str | None = None,
     metadata: dict | None = None,
 ) -> dict:
-    """Create an explicit edge between any two resources."""
+    """Create an explicit edge between any two resources.
+
+    Only doc / table / file are linkable. ``coll`` and vault URIs are
+    rejected — collections are navigation aids, not edge endpoints.
+    The ``edges.target_type`` CHECK constraint enforces the same
+    invariant at the DB layer; this surface-level reject gives the
+    caller a clear error instead of a Postgres failure.
+    """
     source_parsed = parse_uri(source_uri)
     target_parsed = parse_uri(target_uri)
     if not source_parsed:
         return {"error": f"Invalid source URI: {source_uri}"}
     if not target_parsed:
         return {"error": f"Invalid target URI: {target_uri}"}
+    _LINKABLE = ("doc", "table", "file")
+    if source_parsed.kind not in _LINKABLE:
+        return {"error": (
+            f"Cannot link from a {source_parsed.kind} URI ({source_uri}). "
+            f"Linkable kinds: {_LINKABLE}."
+        )}
+    if target_parsed.kind not in _LINKABLE:
+        return {"error": (
+            f"Cannot link to a {target_parsed.kind} URI ({target_uri}). "
+            f"Linkable kinds: {_LINKABLE}."
+        )}
 
     source_vault_name = source_parsed.vault
     source_type = source_parsed.kind
@@ -550,10 +568,30 @@ async def _store_edge(
     source_uri: str, source_type: str,
     target_ref: str, relation_type: str,
 ) -> bool:
-    """Resolve target reference and insert edge. Returns True if stored."""
+    """Resolve target reference and insert edge. Returns True if stored.
+
+    Only doc / table / file are linkable resources. ``coll`` and the
+    vault-only form ``akb://{vault}`` are navigation handles — semantically
+    a "link to a collection" doesn't have a clear meaning (is it a link
+    to every doc inside? to the folder concept itself?), and the
+    ``edges.target_type`` CHECK constraint enforces the same invariant
+    at the DB layer. This filter is what keeps body-text mentions of
+    coll URIs (e.g. "see ``akb://V/coll/X`` for the spec") from
+    silently failing at INSERT.
+    """
     # If target is already an akb:// URI, parse it directly
     parsed = parse_uri(target_ref)
     if parsed:
+        if parsed.kind not in ("doc", "table", "file"):
+            # `coll` / `vault` URIs are navigation aids, not link
+            # targets — skip silently. Logged at DEBUG so an
+            # operator running noisy edge-extraction can still see
+            # how many got filtered.
+            logger.debug(
+                "Skipping edge target %r: %s URIs are not linkable",
+                target_ref, parsed.kind,
+            )
+            return False
         target_type = parsed.kind
         target_uri = target_ref
     else:

--- a/backend/app/services/uri_service.py
+++ b/backend/app/services/uri_service.py
@@ -115,12 +115,24 @@ def parse_uri(uri: str) -> ParsedUri | None:
     resolve identically (defense against hand-typed URIs in
     frontmatter `depends_on` lists).
 
+    Also rejects URIs containing ``{`` or ``}`` — those are template
+    placeholders (e.g. ``akb://{vault}/coll/{path}/doc/{filename}``
+    written into a markdown body as documentation) that the bare-URI
+    scanner in ``kg_service.extract_markdown_links`` would otherwise
+    pick up and try to insert as edges. Real AKB URIs never contain
+    braces, so this is a safe + cheap pre-flight check.
+
     Try-order matters: the typed-in-collection pattern must run before
     the typed-root pattern, otherwise something like
     ``akb://V/coll/X/doc/Y.md`` would mis-match the root form with
     ``type=coll`` and an identifier starting with ``X/doc/Y.md``.
     """
     if not isinstance(uri, str):
+        return None
+    if "{" in uri or "}" in uri:
+        # Template placeholder — not a real URI. Reject before regex
+        # so neither `parse_uri` nor `split_uri` ever produces a row
+        # the edges table won't accept.
         return None
 
     m = _URI_TYPED_IN_COLL_RE.match(uri)

--- a/backend/tests/test_unified_browse_edges_e2e.sh
+++ b/backend/tests/test_unified_browse_edges_e2e.sh
@@ -894,6 +894,79 @@ print(hit.get('path','') if hit else '')
 
 mcp_call akb_drop_table "{\"vault\":\"$VAULT\",\"name\":\"path_check\"}" >/dev/null 2>&1
 
+# ── 28. Edge-extraction safety: placeholders + coll URIs ───────
+#
+# 0.3.0 introduced `coll` as a URI kind, but the edges table's
+# `target_type` CHECK only allows doc / table / file (collections are
+# navigation aids, not link targets). Two scenarios this section
+# locks down so they don't surface as CHECK violations:
+#
+#  (a) `parse_uri` rejects URIs containing template placeholders
+#      (`{...}`) — caught at edge extraction so a markdown body
+#      describing the URI scheme as documentation doesn't trip
+#      kg_service into trying to insert an edge whose target_uri is
+#      literally `akb://{vault}/doc/{path}`.
+#  (b) `_store_edge` filters out coll / vault URIs as link targets —
+#      a doc whose `depends_on` mentions a coll URI by mistake
+#      silently skips that entry instead of throwing.
+echo ""
+echo "▸ 28. Edge-extraction safety (placeholders + coll URIs)"
+
+# (a) Doc body containing a placeholder URI — should be put cleanly,
+# no edge created from the placeholder, no CHECK constraint failure.
+PH_CONTENT='# Placeholder safety\n\nThis doc explains the URI scheme: `akb://{vault}/coll/{path}/doc/{filename}`. The bare-URI extractor must NOT treat that template string as a real edge target.'
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"safety\",\"title\":\"Placeholder safety\",\"content\":\"$PH_CONTENT\",\"type\":\"note\"}" | mcp_result)
+PH_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+[ -n "$PH_URI" ] && pass "akb_put with placeholder-URI body succeeded (no constraint failure)" || fail "Placeholder put" "$R"
+
+# Verify no orphan edges were inserted for the placeholder.
+R=$(mcp_call akb_relations "{\"uri\":\"$PH_URI\"}" | mcp_result)
+PLACEHOLDER_EDGE_COUNT=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+# Count any edge whose URI mentions '{' — that'd be the smoking gun.
+n=sum(1 for r in d.get('relations',[]) if '{' in (r.get('uri') or ''))
+print(n)
+" 2>/dev/null)
+[ "$PLACEHOLDER_EDGE_COUNT" = "0" ] && pass "No edges emitted for placeholder URIs" || fail "Placeholder edges" "$PLACEHOLDER_EDGE_COUNT placeholder edges leaked"
+
+# (b) Doc with `depends_on` pointing at a coll URI — silent skip.
+# Without the kg_service filter this would either succeed (if the
+# constraint were relaxed) or fail with a Postgres CHECK error. The
+# right behavior is "doc put succeeds, that entry is just ignored
+# at edge extraction with a debug log".
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"safety\",\"title\":\"Coll-URI depends_on\",\"content\":\"# coll dep\",\"type\":\"note\",\"depends_on\":[\"akb://$VAULT/coll/safety\"]}" | mcp_result)
+COLL_DEP_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+[ -n "$COLL_DEP_URI" ] && pass "akb_put with coll-URI depends_on succeeded (constraint-safe)" || fail "Coll-URI dep put" "$R"
+
+R=$(mcp_call akb_relations "{\"uri\":\"$COLL_DEP_URI\"}" | mcp_result)
+COLL_EDGE_COUNT=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+# coll URI must not appear as a target of any extracted edge.
+n=sum(1 for r in d.get('relations',[]) if '/coll/' in (r.get('uri') or '') and '/doc/' not in (r.get('uri') or '') and '/table/' not in (r.get('uri') or '') and '/file/' not in (r.get('uri') or ''))
+print(n)
+" 2>/dev/null)
+[ "$COLL_EDGE_COUNT" = "0" ] && pass "Coll URIs filtered out at edge extraction" || fail "Coll URI edge leak" "$COLL_EDGE_COUNT coll edges"
+
+# (c) Explicit akb_link to a coll URI — must error out, not try the
+# DB and crash on the constraint.
+R=$(mcp_call akb_link "{\"source\":\"$PH_URI\",\"target\":\"akb://$VAULT/coll/safety\",\"relation\":\"related_to\"}" | mcp_result)
+LINK_REJECTED=$(echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+# Either explicit error or 'not linkable' message — both are valid
+# rejections; what we don't want is a Postgres constraint violation
+# bubbling up unwrapped.
+ok = 'error' in d and 'Linkable' in d.get('error','') or 'coll' in d.get('error','')
+print(int(ok))
+" 2>/dev/null)
+[ "$LINK_REJECTED" = "1" ] && pass "akb_link rejects coll URI target with friendly error" || fail "Coll URI link rejection" "$R"
+
+# Cleanup
+mcp_call akb_delete "{\"uri\":\"$PH_URI\"}" >/dev/null 2>&1
+mcp_call akb_delete "{\"uri\":\"$COLL_DEP_URI\"}" >/dev/null 2>&1
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"


### PR DESCRIPTION
## Summary

Two paired contract gaps surfaced during the 0.3.0 on-prem verification. Both manifest as a Postgres `edges_target_type_check` violation when something the new URI scheme considers parseable makes it past `kg_service` into the INSERT.

- **Markdown body with URI placeholders** — a doc whose body documents the URI scheme (`akb://{vault}/coll/{path}/doc/{filename}`) trips `extract_markdown_links` into treating the template string as a real edge target.
- **Doc with `depends_on: [coll-URI]`** — 0.3.0 made `coll` a first-class URI kind; agents writing docs that mention a coll URI as a dependency now produce `target_type='coll'` which the CHECK constraint rejects.
- **`akb_link(target=coll-URI)`** — same hole; `link_resources` had no surface filter.

## Fix

- `uri_service.parse_uri`: reject any URI containing `{` or `}`. Real AKB URIs never contain braces.
- `kg_service._store_edge`: explicit `parsed.kind in ('doc','table','file')` check; coll/vault URIs are navigation aids, not link endpoints. Silent skip with DEBUG log.
- `kg_service.link_resources`: friendly user-facing error for coll/vault URIs at either endpoint.

## Test plan
- [x] New §28 of `test_unified_browse_edges_e2e.sh` — 5 cases covering placeholder body, coll-URI depends_on, akb_link rejection
- [x] Full local sweep — 401 e2e cases (mcp 76 + unified_browse_edges 108 + collection_lifecycle 36 + security_edge 65 + pg_rbac 50 + edit 37 + graph_replace 29) all green

## Context

Found this dogfooding during the 0.3.0 on-prem verification — the operations report writing into `product/akb/architecture/` failed at edge insertion because its body documented the URI scheme with placeholders. The doc itself landed (put commits before edges), but the gap is what this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)