### PR TITLE
chore(0.3.0): README URI scheme + search UI collection field

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,21 @@ The full tool catalogue is exposed via `akb_help()` from any MCP client.
 
 ## Document Format
 
-Documents are addressed by URI — `akb://{vault}/{path}` is the canonical
-handle used by every tool and stored in relations.
+Every vault resource has a location-aware AKB URI — the canonical handle
+used by every tool and stored in relations. As of 0.3.0:
+
+```
+akb://{vault}                                          vault root (browse target)
+akb://{vault}/coll/{coll_path}                         collection (browse target)
+akb://{vault}[/coll/{coll_path}]/doc/{filename}        document
+akb://{vault}[/coll/{coll_path}]/table/{name}          table
+akb://{vault}[/coll/{coll_path}]/file/{uuid}           file
+```
+
+The `/coll/{coll_path}` segment is omitted for resources at the vault
+root. Walking up a URI to its parent collection is a pure string
+operation — paste the parent into `akb_browse(uri=...)` to list
+siblings without an extra lookup.
 
 ```yaml
 ---
@@ -136,8 +149,8 @@ status: active          # draft | active | archived | superseded
 tags: [payments, api]
 domain: engineering
 summary: "REST → gRPC transition plan."
-depends_on: ["akb://eng/specs/payment-api-v2"]
-related_to: ["akb://eng/meetings/2026-05-01-payments"]
+depends_on: ["akb://eng/coll/specs/doc/payment-api-v2.md"]
+related_to: ["akb://eng/coll/meetings/doc/2026-05-01-payments.md"]
 ---
 
 # Payment API v2 migration plan

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -27,13 +27,17 @@ type DocTypeFilter = (typeof ALL_TYPES)[number];
 
 interface DenseResult {
   source_type?: SourceType;
-  // Canonical handle — `akb://{vault}/{doc|table|file}/{identifier}`.
-  // Backend dropped the legacy `source_id`/`doc_id`/`file_id` shape;
+  // Canonical handle. As of backend 0.3.0 the form is
+  // `akb://{vault}[/coll/{coll_path}]/{doc|table|file}/{identifier}` —
   // routing decisions here parse the URI tail.
   uri: string;
   vault: string;
   path: string;
   title: string;
+  // Containing-collection path (null at vault root). Surfaced
+  // explicitly by backend 0.3.0 so clients group/filter hits
+  // without parsing the URI themselves.
+  collection?: string | null;
   doc_type?: string;
   summary?: string;
   matched_section?: string;
@@ -543,7 +547,9 @@ function DenseResultList({ items }: { items: DenseResult[] }) {
                   {r.doc_type && <Badge variant="outline">{r.doc_type}</Badge>}
                 </div>
                 <div className="coord mt-0.5">
-                  {r.vault} / {r.path}
+                  {r.vault}
+                  {r.collection && <> · <span className="text-accent/80">{r.collection}</span></>}
+                  {" / "}{r.path}
                 </div>
                 {r.summary && (
                   <p className="text-sm text-foreground-muted mt-2 line-clamp-2">


### PR DESCRIPTION
## Summary
Non-functional tail-end follow-ups from the 0.3.0 audit.

- `README.md`: doc-format section updated to the location-aware URI grammar (5 forms) and frontmatter examples switched to new shape.
- `frontend/src/pages/search.tsx`: dense-result rows surface the new `collection` field (backend 0.3.0). `DenseResult` interface widened.

## Test plan
- [x] tsc EXIT=0
- [x] vitest 223/223

🤖 Generated with [Claude Code](https://claude.com/claude-code)