### PR TITLE
fix(coll-path): reject 'coll'/'doc'/'table'/'file' as collection segments

### DIFF
--- a/backend/app/db/migrations/027_collection_path_reserved_segments.py
+++ b/backend/app/db/migrations/027_collection_path_reserved_segments.py
@@ -1,0 +1,102 @@
+"""Migration 027: warn about collection paths whose segments collide
+with URI structural markers.
+
+The 0.3.0 URI grammar is ``akb://V/coll/<coll_path>/<type>/<id>``
+with ``<type>`` in ``{doc, table, file}``. A collection whose path
+contains ``coll`` / ``doc`` / ``table`` / ``file`` as a segment
+(not at the leaf — leaves are safe) can produce a URI that
+``parse_uri`` mis-classifies as a typed-resource URI:
+
+    coll path "frontend/file/X"
+      → coll URI  "akb://V/coll/frontend/file/X"
+      → parsed as file URI (coll="frontend", id="X")
+
+Going forward the input layer (``normalize_collection_path``)
+refuses these segments at create time. This migration scans the
+existing ``collections`` table for any pre-0.3.0 row that already
+has the issue, logs them, and lets the operator decide whether to
+rename — we do **not** auto-mutate paths because that would also
+need a cascading rewrite of every URI that references them
+(documents.path, edges, publications, events, …) which is too
+risky for a passive startup migration.
+
+Reads the table, never writes — strictly informational. Idempotent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+from app.util.text import RESERVED_COLLECTION_SEGMENTS
+
+logger = logging.getLogger("akb.migration.027")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    # Pull every collection path; client-side segment check keeps the
+    # SQL simple and works regardless of which reserved words we
+    # decide to add in the future. The collections table is small
+    # (one row per logical folder; usually < 100 per vault), so the
+    # full scan cost is negligible.
+    rows = await conn.fetch(
+        """
+        SELECT c.id, c.path, v.name AS vault_name
+          FROM collections c
+          JOIN vaults v ON v.id = c.vault_id
+         ORDER BY v.name, c.path
+        """
+    )
+
+    offending: list[tuple[str, str]] = []
+    for r in rows:
+        path = r["path"] or ""
+        if not path:
+            continue
+        segments = path.split("/")
+        if any(seg in RESERVED_COLLECTION_SEGMENTS for seg in segments):
+            offending.append((r["vault_name"], path))
+
+    if not offending:
+        logger.info(
+            "Migration 027: scanned %d collection rows; no segments collide "
+            "with URI structural markers (%s). New input is also rejected "
+            "by normalize_collection_path.",
+            len(rows), sorted(RESERVED_COLLECTION_SEGMENTS),
+        )
+        return
+
+    logger.warning(
+        "Migration 027: found %d collection(s) with reserved-word segments. "
+        "URIs for these may round-trip ambiguously — rename via "
+        "akb_create_collection (new name) + manual move, or accept the "
+        "navigation quirk. Affected:",
+        len(offending),
+    )
+    for vault, path in offending:
+        logger.warning("  vault=%s  path=%s", vault, path)
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -111,6 +111,7 @@ async def _apply_migrations() -> None:
         "024_tokens_revoked_before.py",         # users.tokens_revoked_before for JWT revocation (default epoch — pre-existing JWTs unaffected)
         "025_drop_phantom_root_collection.py",  # drop path='' collection rows that legacy put() created when collection was omitted (issues #81/#82)
         "026_uri_collection_prefix.py",         # rewrite edges/publications/events URIs to 0.3.0 canonical (akb://V[/coll/<path>]/<type>/<id>)
+        "027_collection_path_reserved_segments.py",  # WARN about pre-existing collection paths whose segments collide with URI structural markers (coll/doc/table/file)
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/util/text.py
+++ b/backend/app/util/text.py
@@ -73,6 +73,17 @@ class NFCModel(BaseModel):
 _MAX_PATH_BYTES = 1024
 
 
+# URI structural markers — using these as collection-path segments
+# creates a round-trip ambiguity in the 0.3.0 URI grammar
+# (`akb://V/coll/<coll_path>/<type>/<id>`). Example: a collection
+# at path ``frontend/file/X`` would emit URI
+# ``akb://V/coll/frontend/file/X``, which the parser then mis-classifies
+# as a file URI (coll="frontend", type="file", id="X"). Banning them
+# at create time keeps the grammar unambiguous and matches the
+# existing ``_RESERVED`` column-name guard in ``table_data_repo``.
+RESERVED_COLLECTION_SEGMENTS = frozenset({"coll", "doc", "table", "file"})
+
+
 def normalize_collection_path(path: str | None, *, allow_empty: bool = True) -> str:
     """Canonical collection-path normalizer.
 
@@ -82,6 +93,10 @@ def normalize_collection_path(path: str | None, *, allow_empty: bool = True) -> 
       - Reject `.`, `..`, empty segments (path traversal).
       - Reject NUL, backslash, and control characters (ord < 32).
       - Reject paths longer than 1 KiB encoded (`_MAX_PATH_BYTES`).
+      - Reject the URI structural markers ``coll`` / ``doc`` /
+        ``table`` / ``file`` as any segment. They round-trip
+        ambiguously in the URI grammar (see
+        ``RESERVED_COLLECTION_SEGMENTS`` above).
 
     Returns "" for empty / None input when `allow_empty=True`
     (== vault root). When `allow_empty=False`, an empty input raises
@@ -114,6 +129,15 @@ def normalize_collection_path(path: str | None, *, allow_empty: bool = True) -> 
         if "\x00" in raw or "\\" in raw or any(ord(c) < 32 for c in raw):
             raise ValueError(
                 f"Invalid character in collection path: '{path}'"
+            )
+        if raw in RESERVED_COLLECTION_SEGMENTS:
+            raise ValueError(
+                f"Invalid collection path: '{path}'. Segment '{raw}' is a "
+                f"URI structural marker; using it as a collection name "
+                f"creates ambiguity in the canonical URI form "
+                f"(akb://V/coll/<path>/<type>/<id>). Choose a different "
+                f"name. Reserved segments: "
+                f"{sorted(RESERVED_COLLECTION_SEGMENTS)}."
             )
         parts.append(raw)
     return "/".join(parts)

--- a/backend/tests/test_unified_browse_edges_e2e.sh
+++ b/backend/tests/test_unified_browse_edges_e2e.sh
@@ -967,6 +967,46 @@ print(int(ok))
 mcp_call akb_delete "{\"uri\":\"$PH_URI\"}" >/dev/null 2>&1
 mcp_call akb_delete "{\"uri\":\"$COLL_DEP_URI\"}" >/dev/null 2>&1
 
+# ── 29. Reserved collection segments (URI grammar safety) ──────
+#
+# The 0.3.0 URI grammar `akb://V/coll/<coll_path>/<type>/<id>` puts the
+# four type words (coll / doc / table / file) in fixed structural
+# positions. A collection whose path contains one of those words as a
+# MIDDLE segment produces a URI the parser then mis-classifies as a
+# typed-resource URI — e.g. coll path "frontend/file/X" emits
+# `akb://V/coll/frontend/file/X` which `parse_uri` reads as
+# (coll="frontend", type=file, id="X"). Round-trip broken.
+#
+# Fix: `normalize_collection_path` rejects reserved segments at the
+# input layer. These cases lock that down.
+echo ""
+echo "▸ 29. Reserved collection segments (URI grammar safety)"
+
+for seg in coll doc table file; do
+  # As the only segment
+  R=$(mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":\"$seg\"}" | mcp_result)
+  REJECTED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d or 'reserved' in d.get('error','').lower() or 'Invalid' in d.get('error',''))" 2>/dev/null)
+  [ "$REJECTED" = "True" ] && pass "akb_create_collection(path='$seg'): rejected" || fail "Reserved '$seg' alone" "$R"
+
+  # As a middle segment — the case that actually breaks URI round-trip
+  R=$(mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":\"frontend/$seg/X\"}" | mcp_result)
+  REJECTED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d or 'reserved' in d.get('error','').lower() or 'Invalid' in d.get('error',''))" 2>/dev/null)
+  [ "$REJECTED" = "True" ] && pass "akb_create_collection(path='frontend/$seg/X'): rejected" || fail "Reserved '$seg' middle" "$R"
+done
+
+# akb_put with a reserved segment in its collection arg also blocked
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"X/doc/y\",\"title\":\"x\",\"content\":\"y\",\"type\":\"note\"}" | mcp_result)
+PUT_REJECT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d or 'reserved' in d.get('error','').lower() or 'Invalid' in d.get('error',''))" 2>/dev/null)
+[ "$PUT_REJECT" = "True" ] && pass "akb_put(collection='X/doc/y'): rejected (same normalizer)" || fail "Put with reserved coll" "$R"
+
+# Sanity — paths that look similar but are NOT reserved still succeed
+# ("docs" plural, etc.). Confirms exact-segment match.
+R=$(mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":\"docs/api\"}" | mcp_result)
+CREATED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' not in d)" 2>/dev/null)
+[ "$CREATED" = "True" ] && pass "akb_create_collection(path='docs/api'): allowed (plural — not reserved)" || fail "Plural docs" "$R"
+mcp_call akb_delete_collection "{\"vault\":\"$VAULT\",\"path\":\"docs/api\"}" >/dev/null 2>&1
+mcp_call akb_delete_collection "{\"vault\":\"$VAULT\",\"path\":\"docs\"}" >/dev/null 2>&1
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"


### PR DESCRIPTION
## Summary

0.3.0 URI grammar `akb://V/coll/<coll_path>/<type>/<id>` puts the four type words (`coll`/`doc`/`table`/`file`) in fixed structural positions. A collection whose path contains one of those words as a MIDDLE segment causes a URI round-trip ambiguity — `coll_uri("V", "frontend/file/X")` emits `akb://V/coll/frontend/file/X` which `parse_uri` then reads as a file URI (`coll="frontend"`, `kind=file`, `id="X"`).

## Fix

`normalize_collection_path` now rejects any segment matching the new `RESERVED_COLLECTION_SEGMENTS = {coll, doc, table, file}` set. Applies wherever user-supplied collection paths are normalized (`akb_create_collection`, `akb_put`, `akb_create_table`, `akb_put_file`).

Migration 027 scans `collections` at startup and WARNs for pre-existing offenders. No auto-rename — cascading URI rewrite would be too risky for a passive migration; surface for operator decision.

## Test plan
- [x] §29 of `test_unified_browse_edges_e2e.sh` — 9 cases (4 reserved words × {alone, middle} + put-with-reserved + plural sanity)
- [x] Full local sweep: 411 e2e cases passing
- [x] Migration 027 ran on local DB: 426 rows scanned, 0 offending

## Context

Dogfooding the 0.3.0 design exposed this — user asked "are these reserved words like /coll/ /doc/ etc.?" and the answer is yes plus an actual round-trip bug demoed in console. This PR closes it before any operator hits it in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)