### PR TITLE
fix(0.3.1): concurrency audit v2 — Tier 0/1 + /simplify

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,138 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.1 — 2026-05-27
+
+Second-round concurrency/atomicity audit. 54 findings across six
+domains were narrowed by a meta-review pass to a Tier 0 (HIGH,
+deterministic data loss / surface bypass) and a Tier 1 (TX + advisory
+lock + canonical URI hardening) cut, then reproduced in a Docker
+desktop isolation environment before fix. The shape of every fix is
+"narrow the surface or hold the right lock", not new feature.
+
+### Tier 0 — HIGH severity
+
+- **`edges.kind` discriminator (migration 028).** Before, every
+  `akb_update` ran `DELETE FROM edges WHERE source_uri = X` and
+  re-extracted from frontmatter + body. That wiped explicit edges
+  created via `akb_link` — deterministic, not a race. New
+  `kind ∈ {implicit, explicit}` column; rewrite DELETE is scoped to
+  `kind = 'implicit'`, `akb_link` writes `kind = 'explicit'`. Existing
+  rows default to implicit so current behaviour is preserved.
+- **Token-aware SQL rewriter for `table_query`.** Pre-fix
+  `table_data_repo.rewrite_table_names` used a regex substring
+  substitution, so a publication that mapped table name `name` would
+  silently corrupt a `WHERE label = 'foo_name_bar'` literal. New scan
+  tokenises (single/double quoted strings, line + block comments,
+  dollar-quoted strings, identifiers) and rewrites only `ident` tokens.
+- **`file_uri` collection prefix.** `document_service.delete` was
+  emitting the root-form URI for collection-resident files, so the
+  same file appeared under two URIs across event payloads / responses.
+- **MCP `version` parameter hex validation.** REST already rejected
+  non-hex refs (`HEAD~1`, `refs/...`, `@~5`) for `?version=`, but the
+  MCP `akb_get` / `akb_diff` handlers passed the string straight to
+  GitPython — letting a caller bypass the lifecycle to read historical
+  content the REST trust boundary refused. Now both handlers validate
+  with the same `^[0-9a-f]{7,64}$` regex (shared via
+  `app/util/git_refs.py`).
+
+### Tier 1 — TX / advisory-lock / canonical URI hardening
+
+- **`link_resources` runs in one TX with `acquire_path_lock`.**
+  Doc-endpoint locks are taken in `(vault_id, identifier)`-sorted
+  order so two `akb_link` calls touching overlapping endpoints never
+  deadlock. Both vault and endpoint reads are inside the snapshot.
+- **`unlink_resources(*, vault_id=...)`.** Without a vault scope the
+  delete matched purely on `(source_uri, target_uri)`, so a caller
+  could erase another vault's edge by spelling its URIs. MCP now
+  threads `access["vault_id"]` through.
+- **BFS edge dedup in `_bfs_collect`.** An `emitted: set[tuple[str,
+  str, str]]` removes duplicate edges that surfaced when both
+  endpoints sat in the same wave.
+- **`create_table` / `drop_table` / `alter_table` fully transactional.**
+  Includes new `RoleSync.grant_table_in_conn(...)` that propagates
+  errors (vs `on_table_create` which swallows) — the grant commits
+  atomically with the CREATE TABLE, eliminating the "exists but 42501"
+  window callers used to see. `alter_table` holds `FOR UPDATE` on the
+  registry row so two concurrent alters can't last-write-wins the
+  column list. Table-name validator is now `[a-z][a-z0-9_]*` —
+  rejecting hyphens because `pg_table_name`'s `[^a-z0-9] → _`
+  sanitiser is otherwise non-injective.
+- **`delete_vault` per-table chunk cleanup.** `chunks.source_id` has
+  no FK to `vault_tables` (polymorphic source), so the prior
+  vault-scoped chunk DELETE missed `source_type = 'table'` rows and
+  orphaned their vector-store entries. Now iterates `vault_tables`,
+  routes each through `_drop_source_chunks_with_outbox`, then drops
+  the dynamic PG table — all inside the outer TX.
+- **`external_git` reconciler hardening.**
+  - `last_commit_for_path` takes the synced tip sha so attribution
+    can't drift past the tree we're writing.
+  - `mark_llm_metadata_filled(..., expected_blob=...)` gates the
+    UPDATE on `external_blob = expected_blob` — a reconciler that
+    superseded the row mid-LLM-call no longer overwrites with stale
+    output. The worker clears `llm_next_attempt_at` on the dropped
+    result so the next tick reprocesses immediately.
+  - Emits `document.put` / `document.update` / `document.delete`
+    events so mirror writes have the same subscriber surface as
+    user PUTs. `_delete_external_path` also calls
+    `delete_document_relations` to drop implicit edges with the doc.
+- **Session / publication concurrency.**
+  - `SessionService.end_session` wraps the row read in a transaction
+    with `SELECT ... FOR UPDATE`; concurrent ends no longer both run
+    the `auto_summarize_session` side effect.
+  - `publication_service.create_snapshot` holds a session-scoped
+    advisory lock keyed on `publication_id` so two concurrent
+    snapshot calls don't both execute the SQL, both upload to S3,
+    and race on the final UPDATE.
+  - `resolve_publication` folds `expires_at` into the atomic view
+    UPDATE — pre-fix a publication that expired between the SELECT
+    and the UPDATE would still record a view.
+- **BM25 `recompute_stats` holds `pg_try_advisory_lock` for the full
+  scan + write.** A second replica that arrives mid-rebuild bails
+  out cheaply with a log line instead of redoing the whole tokenise
+  pass on top of the leader.
+- **Abandoned-chunk reaper outbox dedup.** Reaper INSERT into
+  `vector_delete_outbox` now guards with `NOT EXISTS (... WHERE
+  chunk_id = a.id AND processed_at IS NULL)` so concurrent
+  `_drop_source_chunks_with_outbox` calls don't enqueue the same
+  chunk twice. New `idx_vector_outbox_chunk_pending` partial index
+  (migration 029) so the guard is O(1) instead of a filtered seq scan.
+- **Edge URI canonicalisation in `_store_edge`.** Parsed URIs are
+  rebuilt through `doc_uri` / `table_uri` / `file_uri` before INSERT
+  so two surface variants (trailing slash, coll-prefix shape) of the
+  same target collapse onto one row — the `ON CONFLICT DO NOTHING`
+  dedup is no longer defeated by string variance.
+- **`external_git` paths run through `normalize_collection_path`.**
+  Mirror docs whose upstream directory contained reserved segments
+  (`coll`/`doc`/`table`/`file`) now fail at reindex time instead of
+  smuggling unparseable URIs into the edges table.
+
+### Schema
+
+- Migration **028**: `edges.kind TEXT NOT NULL DEFAULT 'implicit'
+  CHECK(kind IN ('implicit', 'explicit'))` + partial index
+  `idx_edges_source_kind ON edges(source_uri, kind)`.
+- Migration **029**: partial index
+  `idx_vector_outbox_chunk_pending ON vector_delete_outbox(chunk_id)
+  WHERE processed_at IS NULL`.
+
+Both migrations are idempotent ADD COLUMN / CREATE INDEX IF NOT
+EXISTS; PG 11+ runs the column add as a metadata-only ALTER (no
+table rewrite).
+
+### Notes for operators
+
+- Existing edges are preserved as `kind = 'implicit'`. Explicit
+  edges that were destroyed by prior `akb_update` rewrites are
+  recovered by re-running `akb_link` — the new row lands as
+  `kind = 'explicit'` and now survives.
+- MCP clients that previously passed `version="HEAD~1"` (or any
+  symbolic ref) to `akb_get` / `akb_diff` will start receiving a
+  clear error. Switch to a hex commit hash from `akb_history`.
+- `external_git` mirror vaults now emit `document.*` events on each
+  reindex pass. Existing subscribers will see throughput proportional
+  to the upstream change rate.
+
 ## 0.3.0 — 2026-05-27
 
 ### Follow-up patch: edge-extraction safety (PR #85, 2026-05-26)

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,7 +1,5 @@
 """REST API routes for document CRUD."""
 
-import re
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
@@ -16,6 +14,7 @@ from app.models.document import (
 )
 from app.services.auth_service import AuthenticatedUser
 from app.services.document_service import DocumentService
+from app.util.git_refs import HEX_COMMIT_RE
 from app.util.text import to_nfc
 
 
@@ -81,9 +80,6 @@ async def put_document(req: DocumentPutRequest, user: AuthenticatedUser = Depend
     return await doc_service.put(req, agent_id=user.username)
 
 
-_HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$")
-
-
 @router.get("/documents/{vault}/{doc_id:path}", response_model=DocumentResponse, summary="Get a document")
 async def get_document(
     vault: str,
@@ -93,10 +89,7 @@ async def get_document(
 ):
     await check_vault_access(user.user_id, vault, required_role="reader")
     if version:
-        # Reject symbolic refs (HEAD~N, refs/...), special-name commits,
-        # and any non-hex input. Without this guard, a user could read
-        # arbitrary refs (refs/stash, FETCH_HEAD, ...) via GitPython.
-        if not _HEX_COMMIT_RE.fullmatch(version):
+        if not HEX_COMMIT_RE.fullmatch(version):
             raise HTTPException(
                 status_code=400,
                 detail="version must be a 7-64 char lowercase hex commit hash",

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -219,6 +219,12 @@ CREATE TABLE IF NOT EXISTS edges (
     metadata JSONB DEFAULT '{}',
     created_by TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- 'implicit' = derived from frontmatter / body markdown links (rewritten on
+    -- every document write). 'explicit' = created via akb_link and durable
+    -- across document writes. Without this discriminator,
+    -- store_document_relations' DELETE-then-reinsert pattern silently destroys
+    -- every akb_link-created edge on the next akb_update of the source doc.
+    kind TEXT NOT NULL DEFAULT 'implicit' CHECK(kind IN ('implicit', 'explicit')),
     UNIQUE(source_uri, target_uri, relation_type)
 );
 

--- a/backend/app/db/migrations/028_edges_kind.py
+++ b/backend/app/db/migrations/028_edges_kind.py
@@ -1,0 +1,97 @@
+"""Migration 028: add `edges.kind` to distinguish implicit from explicit edges.
+
+`store_document_relations` rewrites a doc's outgoing edges by
+DELETE-then-INSERT on every put/update/edit — the model is "frontmatter
++ body markdown links are the source of truth for this doc's edges."
+That model is fine in isolation, but the explicit `akb_link` /
+`akb_unlink` API writes into the same `edges` table without any
+discriminator, so every routine `akb_update` silently destroys every
+explicit edge the user created.
+
+Adding `kind`:
+
+  - 'implicit' (default) — derived from the doc; rewritten by
+    store_document_relations on every write.
+  - 'explicit' — created by akb_link; persists across doc writes.
+
+After this migration:
+
+  - store_document_relations DELETE is filtered to kind='implicit'.
+  - link_resources INSERT sets kind='explicit'.
+
+Existing rows default to 'implicit' (current behaviour), so an
+already-deployed instance sees no change in semantics — only future
+`akb_link` calls produce durable edges. Re-running `akb_link` for any
+edge that was previously erased restores it as explicit.
+
+Idempotent: ADD COLUMN IF NOT EXISTS + DEFAULT 'implicit'. PG 11+ does
+this as a metadata-only ALTER (no table rewrite).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.028")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    existing = await conn.fetchval(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_name = 'edges'
+           AND column_name = 'kind'
+        """
+    )
+    if existing:
+        logger.info("Migration 028: edges.kind already present; skipping")
+        return
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE edges
+              ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'implicit'
+                CHECK (kind IN ('implicit', 'explicit'))
+            """
+        )
+        # Helpful filter for the rewrite DELETE — predicate match.
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_edges_source_kind
+                ON edges(source_uri, kind)
+            """
+        )
+
+    logger.info(
+        "Migration 028 added edges.kind (default 'implicit'). "
+        "Existing edges are preserved; future akb_link writes mark explicit."
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/migrations/029_outbox_chunk_id_index.py
+++ b/backend/app/db/migrations/029_outbox_chunk_id_index.py
@@ -1,0 +1,61 @@
+"""Migration 029: partial index on vector_delete_outbox(chunk_id).
+
+The abandoned-chunk reaper (delete_worker._reap_abandoned_chunks_once)
+guards its outbox INSERT with `WHERE NOT EXISTS (SELECT 1 FROM
+vector_delete_outbox o WHERE o.chunk_id = a.id AND o.processed_at IS NULL)`
+to avoid duplicating rows for chunks already enqueued by an explicit
+delete. The only existing index on the outbox is on `next_attempt_at`
+filtered to unprocessed rows, so the chunk_id lookup falls through to a
+filtered seq scan — fine for a fresh queue, O(pending) for a backed-up
+one.
+
+This partial index also speeds up future ON CONFLICT or NOT EXISTS
+guards in `_drop_source_chunks_with_outbox` and `delete_vault_chunks`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.029")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    await conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_vector_outbox_chunk_pending
+            ON vector_delete_outbox(chunk_id)
+         WHERE processed_at IS NULL
+        """
+    )
+    logger.info(
+        "Migration 029 added idx_vector_outbox_chunk_pending "
+        "(partial index on chunk_id for reaper dedup)."
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -112,6 +112,7 @@ async def _apply_migrations() -> None:
         "025_drop_phantom_root_collection.py",  # drop path='' collection rows that legacy put() created when collection was omitted (issues #81/#82)
         "026_uri_collection_prefix.py",         # rewrite edges/publications/events URIs to 0.3.0 canonical (akb://V[/coll/<path>]/<type>/<id>)
         "027_collection_path_reserved_segments.py",  # WARN about pre-existing collection paths whose segments collide with URI structural markers (coll/doc/table/file)
+        "028_edges_kind.py",                    # edges.kind ('implicit' rewriteable | 'explicit' akb_link-created) so akb_link edges survive akb_update rewrites
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -113,6 +113,7 @@ async def _apply_migrations() -> None:
         "026_uri_collection_prefix.py",         # rewrite edges/publications/events URIs to 0.3.0 canonical (akb://V[/coll/<path>]/<type>/<id>)
         "027_collection_path_reserved_segments.py",  # WARN about pre-existing collection paths whose segments collide with URI structural markers (coll/doc/table/file)
         "028_edges_kind.py",                    # edges.kind ('implicit' rewriteable | 'explicit' akb_link-created) so akb_link edges survive akb_update rewrites
+        "029_outbox_chunk_id_index.py",         # partial index on vector_delete_outbox(chunk_id) WHERE processed_at IS NULL for reaper dedup lookups
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -364,13 +364,19 @@ class DocumentRepository:
         doc_type: str | None,
         domain: str | None,
         now: datetime,
-    ) -> None:
+        expected_blob: str | None = None,
+    ) -> bool:
         """Apply LLM-generated metadata, but only into NULL/empty fields
         so that frontmatter-provided values always win.
+
+        When `expected_blob` is passed, the UPDATE is gated on
+        `external_blob = expected_blob`. The external_git reconciler can
+        reindex a path between worker claim and worker write — without
+        the predicate the worker would stamp stale LLM output onto a row
+        whose body is already newer. Returns True iff the row matched.
         """
         async with self.pool.acquire() as conn:
-            await conn.execute(
-                """
+            sql = """
                 UPDATE documents SET
                     summary  = COALESCE(NULLIF(summary, ''), $2, summary),
                     tags     = CASE
@@ -382,9 +388,13 @@ class DocumentRepository:
                     llm_metadata_at = $6,
                     updated_at = $6
                 WHERE id = $1
-                """,
-                doc_id, summary, tags, doc_type, domain, now,
-            )
+            """
+            args: list = [doc_id, summary, tags, doc_type, domain, now]
+            if expected_blob is not None:
+                sql += " AND external_blob = $7"
+                args.append(expected_blob)
+            status = await conn.execute(sql, *args)
+        return status.endswith(" 1")
 
 
 class CollectionRepository:
@@ -413,6 +423,32 @@ class CollectionRepository:
                 "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
                 vault_id, path,
             )
+            if existing is None:
+                # ON CONFLICT DO NOTHING returned no row, AND the SELECT
+                # also finds nothing — the conflict winner committed and
+                # then deleted the row before our SELECT ran. Retry the
+                # full insert+select cycle once; if that also fails we
+                # surface the underlying state to the caller.
+                row = await c.fetchrow(
+                    """
+                    INSERT INTO collections (id, vault_id, path, name)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (vault_id, path) DO NOTHING
+                    RETURNING id
+                    """,
+                    uuid.uuid4(), vault_id, path, name,
+                )
+                if row:
+                    return row["id"]
+                existing = await c.fetchrow(
+                    "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
+                    vault_id, path,
+                )
+                if existing is None:
+                    raise RuntimeError(
+                        f"collection {path!r} could not be created or found "
+                        "(concurrent delete race in vault {vault_id})"
+                    )
             return existing["id"]
         if conn is not None:
             return await _do(conn)

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -404,9 +404,7 @@ class CollectionRepository:
     async def get_or_create(self, vault_id: uuid.UUID, path: str, conn=None) -> uuid.UUID:
         async def _do(c):
             # ON CONFLICT handles the SELECT-then-INSERT race where two
-            # concurrent PUTs both find no row and both INSERT. Pre-fix
-            # the loser raised UniqueViolationError → 500.
-            cid = uuid.uuid4()
+            # concurrent PUTs both find no row and both INSERT.
             name = path.rstrip("/").split("/")[-1]
             row = await c.fetchrow(
                 """
@@ -415,7 +413,7 @@ class CollectionRepository:
                 ON CONFLICT (vault_id, path) DO NOTHING
                 RETURNING id
                 """,
-                cid, vault_id, path, name,
+                uuid.uuid4(), vault_id, path, name,
             )
             if row:
                 return row["id"]
@@ -424,31 +422,10 @@ class CollectionRepository:
                 vault_id, path,
             )
             if existing is None:
-                # ON CONFLICT DO NOTHING returned no row, AND the SELECT
-                # also finds nothing — the conflict winner committed and
-                # then deleted the row before our SELECT ran. Retry the
-                # full insert+select cycle once; if that also fails we
-                # surface the underlying state to the caller.
-                row = await c.fetchrow(
-                    """
-                    INSERT INTO collections (id, vault_id, path, name)
-                    VALUES ($1, $2, $3, $4)
-                    ON CONFLICT (vault_id, path) DO NOTHING
-                    RETURNING id
-                    """,
-                    uuid.uuid4(), vault_id, path, name,
+                raise RuntimeError(
+                    f"collection {path!r} could not be created or found "
+                    f"in vault {vault_id} (concurrent delete?)"
                 )
-                if row:
-                    return row["id"]
-                existing = await c.fetchrow(
-                    "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
-                    vault_id, path,
-                )
-                if existing is None:
-                    raise RuntimeError(
-                        f"collection {path!r} could not be created or found "
-                        "(concurrent delete race in vault {vault_id})"
-                    )
             return existing["id"]
         if conn is not None:
             return await _do(conn)

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -134,7 +134,7 @@ async def build_table_name_map(conn, vault_names: list[str]) -> dict[str, str]:
 # Naive regex rewriting (`re.sub(r"\bname\b", ..., flags=IGNORECASE)`)
 # matched inside single-quoted strings, double-quoted identifiers,
 # comments, and column aliases — silently corrupting query results
-# (audit-v2 B-F9). The tokenizer makes the rewrite scope-aware:
+#. The tokenizer makes the rewrite scope-aware:
 # strings/comments/quoted-idents pass through untouched.
 _SQL_TOKEN_RE = re.compile(
     r"""

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -127,17 +127,90 @@ async def build_table_name_map(conn, vault_names: list[str]) -> dict[str, str]:
     return table_map
 
 
+# Token kinds emitted by `_tokenize_sql`. Only ``id`` tokens are eligible
+# for rewriting; everything else (literals, comments, punctuation) is
+# emitted verbatim so the rewriter cannot corrupt string contents.
+#
+# Naive regex rewriting (`re.sub(r"\bname\b", ..., flags=IGNORECASE)`)
+# matched inside single-quoted strings, double-quoted identifiers,
+# comments, and column aliases — silently corrupting query results
+# (audit-v2 B-F9). The tokenizer makes the rewrite scope-aware:
+# strings/comments/quoted-idents pass through untouched.
+_SQL_TOKEN_RE = re.compile(
+    r"""
+      (?P<str>'(?:[^']|'')*')                # single-quoted string (PG escapes '' inside)
+    | (?P<qid>"(?:[^"]|"")+")                # double-quoted identifier
+    | (?P<line_comment>--[^\n]*)             # line comment
+    | (?P<block_comment>/\*[\s\S]*?\*/)      # block comment (non-greedy)
+    | (?P<num>[0-9]+(?:\.[0-9]+)?)           # numeric literal
+    | (?P<ident>[A-Za-z_][A-Za-z0-9_]*)      # bare identifier or keyword
+    | (?P<ws>\s+)                            # whitespace
+    | (?P<sym>.)                             # any other single char
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _scan_dollar_quote(sql: str, start: int) -> int | None:
+    """If sql[start:] begins with a PG dollar-quote `$tag$ ... $tag$`,
+    return the index just past the closing tag. Otherwise None.
+    """
+    if sql[start] != "$":
+        return None
+    m = re.match(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$", sql[start:])
+    if not m:
+        return None
+    tag = m.group(0)
+    end = sql.find(tag, start + len(tag))
+    if end == -1:
+        return None
+    return end + len(tag)
+
+
 def rewrite_table_names(sql: str, table_map: dict[str, str]) -> str:
-    """Replace short table names in `sql` with their pg-qualified names.
-    Longest match first to avoid partial collisions (e.g. 'sales' vs
-    'sales_v2')."""
-    rewritten = sql
-    for short_name in sorted(table_map.keys(), key=len, reverse=True):
-        pg_name = table_map[short_name]
-        rewritten = re.sub(
-            rf"\b{re.escape(short_name)}\b",
-            pg_name,
-            rewritten,
-            flags=re.IGNORECASE,
-        )
-    return rewritten
+    """Replace short table names in ``sql`` with their pg-qualified
+    names, but ONLY for bare identifiers — never inside string literals,
+    quoted identifiers, or comments.
+
+    The map is matched case-insensitively (PG identifiers are
+    case-folded for unquoted refs), so ``SELECT * FROM PIPELINE`` and
+    ``FROM pipeline`` both rewrite. A quoted identifier ``"Pipeline"``
+    is left alone because PG treats it as case-sensitive — rewriting it
+    would change semantics.
+
+    Longest key first so ``"sales_v2"`` doesn't get partially clobbered
+    by a shorter ``"sales"`` entry.
+    """
+    if not table_map:
+        return sql
+
+    # Pre-sort once so each lookup is deterministic. Lower-case the keys
+    # for the case-insensitive match.
+    lowered = {k.lower(): v for k, v in table_map.items()}
+
+    out: list[str] = []
+    pos = 0
+    n = len(sql)
+    while pos < n:
+        # Manual dollar-quote scan first; the regex below can't match
+        # arbitrary tags with backreferences via a single alternation.
+        end = _scan_dollar_quote(sql, pos)
+        if end is not None:
+            out.append(sql[pos:end])
+            pos = end
+            continue
+        m = _SQL_TOKEN_RE.match(sql, pos)
+        if not m:
+            # Should not happen — `sym` catches any character. Safety net.
+            out.append(sql[pos])
+            pos += 1
+            continue
+        kind = m.lastgroup
+        text = m.group()
+        if kind == "ident":
+            replacement = lowered.get(text.lower())
+            out.append(replacement if replacement is not None else text)
+        else:
+            out.append(text)
+        pos = m.end()
+    return "".join(out)

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -788,7 +788,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
         # narrow "S3 gone but DB rolled back" recovery window. Everything
         # PG-side runs inside the transaction below so a mid-flight crash
         # never leaves the vault with phantom vt_* tables or registry
-        # rows pointing at dropped physical tables (audit-v2 B-F3).
+        # rows pointing at dropped physical tables.
         file_rows = await conn.fetch("SELECT s3_key FROM vault_files WHERE vault_id = $1", vault_id)
         if file_rows and settings.s3_endpoint_url:
             from app.services.adapters import s3_adapter
@@ -810,12 +810,10 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
             await delete_vault_chunks(conn, vault_id)
 
             # Drop table metadata chunks BEFORE the registry DELETE so the
-            # chunk outbox is enqueued against the still-extant source_id.
-            # `delete_vault_chunks` only handles source_type='document';
-            # tables (and files) need explicit per-source cleanup because
-            # chunks.source_id has no PG FK (polymorphic source) — pre-fix
-            # this left orphan vector entries for every dropped table
-            # (audit-v2 B-F8).
+            # outbox is enqueued against the still-extant source_id.
+            # delete_vault_chunks only handles source_type='document';
+            # tables/files need explicit cleanup because chunks.source_id
+            # has no FK (polymorphic source) and would orphan otherwise.
             from app.services.index_service import _drop_source_chunks_with_outbox
             vtables = await conn.fetch(
                 "SELECT id, name FROM vault_tables WHERE vault_id = $1",

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -783,7 +783,12 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
             return {"error": f"Vault not found: {vault_name}"}
         vault_id = vault["id"]
 
-        # Delete S3 files before DB cascade removes vault_files records.
+        # Delete S3 files BEFORE the DB cascade — this part cannot be
+        # transactional with PG (S3 is out-of-band), so we accept the
+        # narrow "S3 gone but DB rolled back" recovery window. Everything
+        # PG-side runs inside the transaction below so a mid-flight crash
+        # never leaves the vault with phantom vt_* tables or registry
+        # rows pointing at dropped physical tables (audit-v2 B-F3).
         file_rows = await conn.fetch("SELECT s3_key FROM vault_files WHERE vault_id = $1", vault_id)
         if file_rows and settings.s3_endpoint_url:
             from app.services.adapters import s3_adapter
@@ -796,23 +801,40 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                     logger.warning("Failed to delete S3 object %s: %s", fr["s3_key"], e)
             if failed:
                 logger.error("Vault %s: %d/%d S3 files failed to delete", vault_name, len(failed), len(file_rows))
-            await conn.execute("DELETE FROM vault_files WHERE vault_id = $1", vault_id)
 
-        await conn.execute("DELETE FROM edges WHERE vault_id = $1", vault_id)
-        await delete_vault_chunks(conn, vault_id)
+        async with conn.transaction():
+            if file_rows and settings.s3_endpoint_url:
+                await conn.execute("DELETE FROM vault_files WHERE vault_id = $1", vault_id)
 
-        vtables = await conn.fetch("SELECT name FROM vault_tables WHERE vault_id = $1", vault_id)
-        for vt in vtables:
-            pg_name = table_data_repo.pg_table_name(vault_name, vt["name"])
-            await conn.execute(f"DROP TABLE IF EXISTS {pg_name}")
-        await conn.execute("DELETE FROM vault_tables WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM edges WHERE vault_id = $1", vault_id)
+            await delete_vault_chunks(conn, vault_id)
 
-        await conn.execute("DELETE FROM todos WHERE vault_id = $1", vault_id)
-        await conn.execute("DELETE FROM sessions WHERE vault_id = $1", vault_id)
-        await conn.execute("DELETE FROM documents WHERE vault_id = $1", vault_id)
-        await conn.execute("DELETE FROM collections WHERE vault_id = $1", vault_id)
-        await conn.execute("DELETE FROM vault_access WHERE vault_id = $1", vault_id)
-        await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+            # Drop table metadata chunks BEFORE the registry DELETE so the
+            # chunk outbox is enqueued against the still-extant source_id.
+            # `delete_vault_chunks` only handles source_type='document';
+            # tables (and files) need explicit per-source cleanup because
+            # chunks.source_id has no PG FK (polymorphic source) — pre-fix
+            # this left orphan vector entries for every dropped table
+            # (audit-v2 B-F8).
+            from app.services.index_service import _drop_source_chunks_with_outbox
+            vtables = await conn.fetch(
+                "SELECT id, name FROM vault_tables WHERE vault_id = $1",
+                vault_id,
+            )
+            for vt in vtables:
+                await _drop_source_chunks_with_outbox(
+                    conn, "table", str(vt["id"]),
+                )
+                pg_name = table_data_repo.pg_table_name(vault_name, vt["name"])
+                await conn.execute(f"DROP TABLE IF EXISTS {pg_name}")
+            await conn.execute("DELETE FROM vault_tables WHERE vault_id = $1", vault_id)
+
+            await conn.execute("DELETE FROM todos WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM sessions WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM documents WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM collections WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM vault_access WHERE vault_id = $1", vault_id)
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
 
     # On-disk cleanup: bare repo + persistent worktree. Both must go,
     # otherwise a same-named recreate hits stale state on its second

--- a/backend/app/services/delete_worker.py
+++ b/backend/app/services/delete_worker.py
@@ -237,9 +237,21 @@ async def _reap_abandoned_chunks_once() -> int:
                      FOR UPDATE SKIP LOCKED
                 ),
                 enqueued AS (
+                    -- Guard against duplicate outbox rows for the same
+                    -- chunk_id. `_drop_source_chunks_with_outbox` can run
+                    -- concurrently with reap on the same chunk_id (e.g.
+                    -- an explicit doc delete arrives while we're reaping
+                    -- abandoned chunks); the FOR UPDATE serializes the
+                    -- chunks DELETE but does not serialize the outbox
+                    -- INSERT, so both would otherwise enqueue the same
+                    -- chunk_id.
                     INSERT INTO vector_delete_outbox
                         (chunk_id, source_type, source_id, next_attempt_at)
-                    SELECT id, source_type, source_id, NOW() FROM abandoned
+                    SELECT a.id, a.source_type, a.source_id, NOW() FROM abandoned a
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM vector_delete_outbox o
+                         WHERE o.chunk_id = a.id AND o.processed_at IS NULL
+                    )
                     RETURNING 1
                 ),
                 deleted AS (

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -1027,7 +1027,12 @@ class DocumentService:
                 # display string and must not embed the file UUID.
                 path=(f"{r.get('collection')}/{r['name']}" if r.get("collection") else r["name"]),
                 type="file",
-                uri=file_uri(vault, str(r["id"])),
+                # Pass collection so the URI takes 0.3.0 canonical form
+                # akb://V/coll/<path>/file/<uuid> instead of root-form
+                # akb://V/file/<uuid>. Without this, browse → akb_link
+                # round-trips re-pollute the edges table with non-canonical
+                # URIs that migration 026 already cleaned up.
+                uri=file_uri(vault, str(r["id"]), collection=r.get("collection")),
                 mime_type=r["mime_type"],
                 size_bytes=r["size_bytes"], summary=r["description"],
                 collection=r.get("collection"),

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -34,6 +34,7 @@ from urllib.parse import urlsplit
 
 from app.db.postgres import get_pool
 from app.repositories.document_repo import CollectionRepository, DocumentRepository
+from app.repositories.events_repo import emit_event
 from app.repositories.vault_external_git_repo import VaultExternalGitRepository
 from app.services.git_service import GitService
 from app.services.index_service import (
@@ -42,7 +43,8 @@ from app.services.index_service import (
     delete_document_chunks,
     write_source_chunks,
 )
-from app.util.text import to_nfc, to_nfc_any
+from app.services.uri_service import doc_uri
+from app.util.text import normalize_collection_path, to_nfc, to_nfc_any
 
 logger = logging.getLogger("akb.external_git")
 
@@ -144,6 +146,7 @@ class ExternalGitService:
                 await self._reindex_file(
                     vault_id=vault_id, vault_name=vault_name,
                     path=path, blob_sha=blob_sha, remote_url=cfg["remote_url"],
+                    tip_sha=new_sha,
                 )
                 if existing:
                     updated += 1
@@ -158,7 +161,9 @@ class ExternalGitService:
 
         for path in local.keys() - remote_tree.keys():
             try:
-                await self._delete_external_path(vault_id=vault_id, path=path)
+                await self._delete_external_path(
+                    vault_id=vault_id, vault_name=vault_name, path=path
+                )
                 deleted += 1
             except Exception as e:  # noqa: BLE001
                 errors += 1
@@ -200,6 +205,7 @@ class ExternalGitService:
         path: str,
         blob_sha: str,
         remote_url: str,
+        tip_sha: str,
     ) -> None:
         raw = await asyncio.to_thread(self.git.cat_blob, vault_name, blob_sha)
         try:
@@ -235,13 +241,24 @@ class ExternalGitService:
         # meaningful across multiple syncs. Cheap compared to the cat-blob
         # / chunking work we're already doing for this path.
         last_commit = await asyncio.to_thread(
-            self.git.last_commit_for_path, vault_name, path
+            self.git.last_commit_for_path, vault_name, path, tip_sha
         )
         created_by = _created_by_for(remote_url)
         now = datetime.now(timezone.utc)
 
         parent = str(PurePosixPath(path).parent)
-        coll_path = "" if parent in (".", "") else parent
+        raw_coll = "" if parent in (".", "") else parent
+        try:
+            # Same validator the user-write path uses (rejects reserved
+            # segments `coll`/`doc`/`table`/`file`). External mirrors
+            # otherwise smuggle them in via upstream directory names,
+            # and the corresponding `akb://` URIs would be unparseable.
+            coll_path = normalize_collection_path(raw_coll, allow_empty=True)
+        except ValueError as e:
+            raise ValueError(
+                f"external_git path {path!r} maps to invalid collection "
+                f"{raw_coll!r}: {e}"
+            )
 
         meta_header = build_doc_metadata_header(
             vault_name=vault_name, path=path, title=title,
@@ -288,17 +305,40 @@ class ExternalGitService:
                     vault_id=vault_id,
                     chunks=chunks,
                 )
+                # Subscribers (search reindex, audit) need to see external
+                # mirror writes the same as user PUTs. Emitted inside the
+                # same TX so rollback drops the event too.
+                await emit_event(
+                    conn,
+                    "document.put" if inserted else "document.update",
+                    vault_id=vault_id,
+                    resource_uri=doc_uri(vault_name, path),
+                    actor_id=created_by,
+                    payload={
+                        "path": path,
+                        "title": title,
+                        "doc_type": doc_type,
+                        "external_blob": blob_sha,
+                        "commit": last_commit,
+                    },
+                )
 
-    async def _delete_external_path(self, *, vault_id: uuid.UUID, path: str) -> None:
+    async def _delete_external_path(
+        self, *, vault_id: uuid.UUID, vault_name: str, path: str
+    ) -> None:
         pool = await get_pool()
         doc_repo = DocumentRepository(pool)
         coll_repo = CollectionRepository(pool)
         existing = await doc_repo.find_by_external_path(vault_id, path)
         if not existing:
             return
+        from app.services.kg_service import delete_document_relations
         async with pool.acquire() as conn:
             async with conn.transaction():
                 await delete_document_chunks(conn, str(existing["id"]))
+                # Remove implicit edges anchored on this doc — otherwise
+                # they survive the delete and dangle on the next BFS.
+                await delete_document_relations(conn, vault_name, path)
                 await conn.execute("DELETE FROM documents WHERE id = $1", existing["id"])
                 if existing.get("collection_id"):
                     await coll_repo.decrement_count(
@@ -306,6 +346,14 @@ class ExternalGitService:
                         datetime.now(timezone.utc),
                         conn=conn,
                     )
+                await emit_event(
+                    conn,
+                    "document.delete",
+                    vault_id=vault_id,
+                    resource_uri=doc_uri(vault_name, path),
+                    actor_id=existing.get("created_by"),
+                    payload={"path": path, "source": "external_git"},
+                )
 
 
 # ── Helpers ──────────────────────────────────────────────────

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -399,16 +399,29 @@ class GitService:
                 out[item.path] = item.hexsha
         return out
 
-    def last_commit_for_path(self, vault_name: str, path: str) -> str | None:
+    def last_commit_for_path(
+        self, vault_name: str, path: str, rev: str | None = None
+    ) -> str | None:
         """Hex sha of the most recent commit that touched `path`. Used to
         stamp `documents.current_commit` per-file so mirror docs don't
         all share the reconcile-time HEAD sha. Returns None when the
         path has no commits (should not happen for a path we just
         read from the tree).
+
+        `rev` pins the walk to a specific tip. The external_git reconciler
+        passes the tree-sha it just synced so attribution can't drift past
+        the snapshot it's writing — without it a concurrent fetch can
+        return a commit not yet reflected in `documents.current_commit`,
+        and that commit may not even contain `path` on the new tip.
         """
         repo = self._get_repo(vault_name)
         try:
-            commits = list(repo.iter_commits(paths=path, max_count=1))
+            kwargs = {"paths": path, "max_count": 1}
+            commits = (
+                list(repo.iter_commits(rev, **kwargs))
+                if rev is not None
+                else list(repo.iter_commits(**kwargs))
+            )
         except (ValueError, GitError):
             return None
         return commits[0].hexsha if commits else None
@@ -785,9 +798,24 @@ class GitService:
         """Get diff for a specific file at a specific commit.
 
         Returns the unified diff patch for the file.
+
+        Mirrors read_file's defensive `BadName/BadObject` catch so an
+        unknown / malformed commit hash surfaces as a clean
+        ``{"type":"unknown"}`` response rather than propagating as an
+        unhandled 500 (audit-v2 F-F2).
         """
+        from git.exc import BadName, BadObject
         repo = self._get_repo(vault_name)
-        commit = repo.commit(commit_hash)
+        try:
+            commit = repo.commit(commit_hash)
+        except (ValueError, BadName, BadObject):
+            return {
+                "file": file_path,
+                "commit": commit_hash,
+                "type": "unknown",
+                "diff": "",
+                "error": "commit not found",
+            }
 
         if not commit.parents:
             # Initial commit — show full content as addition

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -802,7 +802,7 @@ class GitService:
         Mirrors read_file's defensive `BadName/BadObject` catch so an
         unknown / malformed commit hash surfaces as a clean
         ``{"type":"unknown"}`` response rather than propagating as an
-        unhandled 500 (audit-v2 F-F2).
+        unhandled 500.
         """
         from git.exc import BadName, BadObject
         repo = self._get_repo(vault_name)

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -19,7 +19,7 @@ import re
 import uuid
 
 from app.db.postgres import get_pool
-from app.services.uri_service import parse_uri, doc_uri
+from app.services.uri_service import parse_uri, doc_uri, table_uri, file_uri
 
 logger = logging.getLogger("akb.graph")
 
@@ -85,11 +85,9 @@ async def store_document_relations(
     """
     source = doc_uri(vault_name, doc_path)
 
-    # Delete old IMPLICIT edges from this source — frontmatter+body markdown
-    # links are the source of truth for the implicit set, but explicit edges
-    # created via akb_link must survive this rewrite. Without the kind filter,
-    # every akb_update silently destroys every explicit edge from the doc
-    # (audit-v2 A-F1 — deterministic data loss, not a race).
+    # Delete only IMPLICIT edges — frontmatter+body links are the source
+    # of truth for those, but explicit (akb_link) edges must survive a
+    # rewrite. Without the kind filter every akb_update destroys them.
     await conn.execute(
         "DELETE FROM edges WHERE source_uri = $1 AND kind = 'implicit'",
         source,
@@ -185,7 +183,7 @@ async def link_resources(
     async with pool.acquire() as conn:
         async with conn.transaction():
             # All reads + INSERT inside one TX so a concurrent delete on
-            # either endpoint cannot leave a dangling edge (audit-v2 A-F2).
+            # either endpoint cannot leave a dangling edge.
             vault = await conn.fetchrow(
                 "SELECT id FROM vaults WHERE name = $1", vault_name,
             )
@@ -255,7 +253,7 @@ async def unlink_resources(
     """Remove an edge between two resources.
 
     ``vault_id`` scopes the DELETE so a future caller can't accidentally
-    delete an edge from another vault by spelling its URIs (audit-v2 A-F9).
+    delete an edge from another vault by spelling its URIs.
     The MCP handler already gates by vault access, but the service-level
     interface now enforces it too.
     """
@@ -636,21 +634,16 @@ async def _store_edge(
             )
             return False
         target_type = parsed.kind
-        # Rebuild the URI from its parsed parts so two surface
-        # variants of the same target (extra slash, mixed-case vault,
-        # NFC vs NFD identifier) collapse to a single canonical row
-        # under the (vault_id, source_uri, target_uri, relation_type)
-        # uniqueness convention. Without this, dedup via
-        # ON CONFLICT DO NOTHING is defeated by string variance.
+        # Rebuild from parsed parts so surface variants (extra slash,
+        # coll prefix shape) of the same target collapse under the
+        # edges uniqueness convention — otherwise ON CONFLICT can't dedupe.
+        ident = parsed.identifier or ""
         if parsed.kind == "doc":
-            target_uri = doc_uri(parsed.vault, parsed.identifier or "")
+            target_uri = doc_uri(parsed.vault, ident)
+        elif parsed.kind == "table":
+            target_uri = table_uri(parsed.vault, ident, parsed.coll_path)
         else:
-            # table / file URIs already round-trip; use the parsed form
-            # so coll prefix and trailing slash variations collapse.
-            from app.services.uri_service import table_uri as _table_uri
-            from app.services.uri_service import file_uri as _file_uri
-            builder = _table_uri if parsed.kind == "table" else _file_uri
-            target_uri = builder(parsed.vault, parsed.identifier or "", parsed.coll_path)
+            target_uri = file_uri(parsed.vault, ident, parsed.coll_path)
     else:
         # Legacy: resolve as doc ref within the same vault
         target_id = await _resolve_doc_ref(conn, vault_id, target_ref)
@@ -736,7 +729,7 @@ async def _bfs_collect(
     queue = [start_uri]
     visited: set[str] = set()
     # Track emitted edges so an edge A→B doesn't appear twice when both
-    # A and B are processed in the same BFS wave (audit-v2 A-F7).
+    # A and B are processed in the same BFS wave.
     emitted: set[tuple[str, str, str]] = set()
 
     for current_depth in range(depth + 1):

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -85,8 +85,15 @@ async def store_document_relations(
     """
     source = doc_uri(vault_name, doc_path)
 
-    # Delete old edges from this source
-    await conn.execute("DELETE FROM edges WHERE source_uri = $1", source)
+    # Delete old IMPLICIT edges from this source — frontmatter+body markdown
+    # links are the source of truth for the implicit set, but explicit edges
+    # created via akb_link must survive this rewrite. Without the kind filter,
+    # every akb_update silently destroys every explicit edge from the doc
+    # (audit-v2 A-F1 — deterministic data loss, not a race).
+    await conn.execute(
+        "DELETE FROM edges WHERE source_uri = $1 AND kind = 'implicit'",
+        source,
+    )
 
     count = 0
 
@@ -176,36 +183,63 @@ async def link_resources(
 
     pool = await get_pool()
     async with pool.acquire() as conn:
-        # The edge is owned by the caller-specified vault (source convention),
-        # but each endpoint is validated against its own vault from the URI.
-        vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)
-        if not vault:
-            return {"error": f"Vault not found: {vault_name}"}
-        vault_id = vault["id"]
+        async with conn.transaction():
+            # All reads + INSERT inside one TX so a concurrent delete on
+            # either endpoint cannot leave a dangling edge (audit-v2 A-F2).
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1", vault_name,
+            )
+            if not vault:
+                return {"error": f"Vault not found: {vault_name}"}
+            vault_id = vault["id"]
 
-        source_vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", source_vault_name)
-        if not source_vault:
-            return {"error": f"Source vault not found: {source_vault_name}"}
-        target_vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", target_vault_name)
-        if not target_vault:
-            return {"error": f"Target vault not found: {target_vault_name}"}
+            source_vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1", source_vault_name,
+            )
+            if not source_vault:
+                return {"error": f"Source vault not found: {source_vault_name}"}
+            target_vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1", target_vault_name,
+            )
+            if not target_vault:
+                return {"error": f"Target vault not found: {target_vault_name}"}
 
-        if not await _resource_exists(conn, source_vault["id"], source_type, source_id):
-            return {"error": f"Source resource not found: {source_uri}"}
-        if not await _resource_exists(conn, target_vault["id"], target_type, target_id):
-            return {"error": f"Target resource not found: {target_uri}"}
+            # Acquire the same path advisory lock the doc write paths use so
+            # akb_link serialises with akb_delete / akb_update on either
+            # endpoint. Doc endpoints only — table/file lifecycle is keyed by
+            # UUID and doesn't go through path_lock. Sort by (vault_id, id) to
+            # impose a deadlock-free lock-acquisition order.
+            from app.repositories.document_repo import acquire_path_lock
+            doc_endpoints: list[tuple[uuid.UUID, str]] = []
+            if source_type == "doc":
+                doc_endpoints.append((source_vault["id"], source_id))
+            if target_type == "doc":
+                doc_endpoints.append((target_vault["id"], target_id))
+            for vid, ident in sorted(
+                doc_endpoints, key=lambda x: (str(x[0]), x[1]),
+            ):
+                await acquire_path_lock(conn, vid, ident)
 
-        await conn.execute(
-            """
-            INSERT INTO edges (id, vault_id, source_uri, target_uri, relation_type,
-                               source_type, target_type, metadata, created_by)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            ON CONFLICT (source_uri, target_uri, relation_type) DO UPDATE
-            SET metadata = $8, created_by = $9
-            """,
-            uuid.uuid4(), vault_id, source_uri, target_uri, relation_type,
-            source_type, target_type, json.dumps(metadata or {}), created_by,
-        )
+            if not await _resource_exists(
+                conn, source_vault["id"], source_type, source_id,
+            ):
+                return {"error": f"Source resource not found: {source_uri}"}
+            if not await _resource_exists(
+                conn, target_vault["id"], target_type, target_id,
+            ):
+                return {"error": f"Target resource not found: {target_uri}"}
+
+            await conn.execute(
+                """
+                INSERT INTO edges (id, vault_id, source_uri, target_uri, relation_type,
+                                   source_type, target_type, metadata, created_by, kind)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'explicit')
+                ON CONFLICT (source_uri, target_uri, relation_type) DO UPDATE
+                SET metadata = $8, created_by = $9, kind = 'explicit'
+                """,
+                uuid.uuid4(), vault_id, source_uri, target_uri, relation_type,
+                source_type, target_type, json.dumps(metadata or {}), created_by,
+            )
 
     logger.info("Linked %s → %s (%s)", source_uri, target_uri, relation_type)
     return {"linked": True, "source": source_uri, "target": target_uri, "relation": relation_type}
@@ -215,20 +249,29 @@ async def unlink_resources(
     source_uri: str,
     target_uri: str,
     relation_type: str | None = None,
+    *,
+    vault_id: uuid.UUID | None = None,
 ) -> dict:
-    """Remove an edge between two resources."""
+    """Remove an edge between two resources.
+
+    ``vault_id`` scopes the DELETE so a future caller can't accidentally
+    delete an edge from another vault by spelling its URIs (audit-v2 A-F9).
+    The MCP handler already gates by vault access, but the service-level
+    interface now enforces it too.
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
+        params: list = [source_uri, target_uri]
+        where = "source_uri = $1 AND target_uri = $2"
         if relation_type:
-            result = await conn.execute(
-                "DELETE FROM edges WHERE source_uri = $1 AND target_uri = $2 AND relation_type = $3",
-                source_uri, target_uri, relation_type,
-            )
-        else:
-            result = await conn.execute(
-                "DELETE FROM edges WHERE source_uri = $1 AND target_uri = $2",
-                source_uri, target_uri,
-            )
+            where += " AND relation_type = $3"
+            params.append(relation_type)
+        if vault_id is not None:
+            where += f" AND vault_id = ${len(params) + 1}"
+            params.append(vault_id)
+        result = await conn.execute(
+            f"DELETE FROM edges WHERE {where}", *params,
+        )
 
     count = int(result.split(" ")[1]) if " " in result else 0
     logger.info("Unlinked %s → %s (%d removed)", source_uri, target_uri, count)
@@ -593,7 +636,21 @@ async def _store_edge(
             )
             return False
         target_type = parsed.kind
-        target_uri = target_ref
+        # Rebuild the URI from its parsed parts so two surface
+        # variants of the same target (extra slash, mixed-case vault,
+        # NFC vs NFD identifier) collapse to a single canonical row
+        # under the (vault_id, source_uri, target_uri, relation_type)
+        # uniqueness convention. Without this, dedup via
+        # ON CONFLICT DO NOTHING is defeated by string variance.
+        if parsed.kind == "doc":
+            target_uri = doc_uri(parsed.vault, parsed.identifier or "")
+        else:
+            # table / file URIs already round-trip; use the parsed form
+            # so coll prefix and trailing slash variations collapse.
+            from app.services.uri_service import table_uri as _table_uri
+            from app.services.uri_service import file_uri as _file_uri
+            builder = _table_uri if parsed.kind == "table" else _file_uri
+            target_uri = builder(parsed.vault, parsed.identifier or "", parsed.coll_path)
     else:
         # Legacy: resolve as doc ref within the same vault
         target_id = await _resolve_doc_ref(conn, vault_id, target_ref)
@@ -678,6 +735,9 @@ async def _bfs_collect(
     """
     queue = [start_uri]
     visited: set[str] = set()
+    # Track emitted edges so an edge A→B doesn't appear twice when both
+    # A and B are processed in the same BFS wave (audit-v2 A-F7).
+    emitted: set[tuple[str, str, str]] = set()
 
     for current_depth in range(depth + 1):
         if not queue or len(nodes) >= limit:
@@ -730,20 +790,26 @@ async def _bfs_collect(
                 continue
 
             for r in out_by_uri.get(uri, []):
-                edges.append({
-                    "source": uri,
-                    "target": r["target_uri"],
-                    "relation": r["relation_type"],
-                })
+                key = (uri, r["target_uri"], r["relation_type"])
+                if key not in emitted:
+                    emitted.add(key)
+                    edges.append({
+                        "source": uri,
+                        "target": r["target_uri"],
+                        "relation": r["relation_type"],
+                    })
                 if r["target_uri"] not in visited:
                     next_queue.append(r["target_uri"])
 
             for r in in_by_uri.get(uri, []):
-                edges.append({
-                    "source": r["source_uri"],
-                    "target": uri,
-                    "relation": r["relation_type"],
-                })
+                key = (r["source_uri"], uri, r["relation_type"])
+                if key not in emitted:
+                    emitted.add(key)
+                    edges.append({
+                        "source": r["source_uri"],
+                        "target": uri,
+                        "relation": r["relation_type"],
+                    })
                 if r["source_uri"] not in visited:
                     next_queue.append(r["source_uri"])
 

--- a/backend/app/services/metadata_worker.py
+++ b/backend/app/services/metadata_worker.py
@@ -197,13 +197,18 @@ async def _process_once() -> int:
         )
         if applied:
             succeeded += 1
-        else:
-            # external_git reconciler superseded the row while the LLM
-            # call was in flight. Drop the stale result; the next claim
-            # cycle re-fetches body for the new blob.
-            logger.info(
-                "metadata_worker: dropping stale result for doc=%s "
-                "(external_blob changed since claim)", doc_id,
+            continue
+        # external_git superseded the blob mid-call. Drop the stale
+        # output and clear the lookahead so the next tick reprocesses
+        # immediately instead of waiting external_git_claim_lookahead_secs.
+        logger.info(
+            "metadata_worker: dropping stale result for doc=%s "
+            "(external_blob changed since claim)", doc_id,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET llm_next_attempt_at = NULL WHERE id = $1",
+                doc_id,
             )
 
     return succeeded

--- a/backend/app/services/metadata_worker.py
+++ b/backend/app/services/metadata_worker.py
@@ -186,15 +186,25 @@ async def _process_once() -> int:
                 await _mark_failure(conn, doc_id, row["llm_retry_count"], str(e))
             continue
 
-        await doc_repo.mark_llm_metadata_filled(
+        applied = await doc_repo.mark_llm_metadata_filled(
             doc_id=doc_id,
             summary=fields["summary"],
             tags=fields["tags"],
             doc_type=fields["doc_type"],
             domain=fields["domain"],
             now=datetime.now(timezone.utc),
+            expected_blob=blob_sha,
         )
-        succeeded += 1
+        if applied:
+            succeeded += 1
+        else:
+            # external_git reconciler superseded the row while the LLM
+            # call was in flight. Drop the stale result; the next claim
+            # cycle re-fetches body for the new blob.
+            logger.info(
+                "metadata_worker: dropping stale result for doc=%s "
+                "(external_blob changed since claim)", doc_id,
+            )
 
     return succeeded
 

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -627,19 +627,35 @@ async def resolve_publication(
             # separate statements with no row lock, so N concurrent
             # readers all saw view_count < max_views and all incremented,
             # overshooting max_views by up to N-1 (06-F8 / 04-F7).
+            #
+            # Re-check expires_at inside the UPDATE too — between the
+            # SELECT above and this UPDATE another caller could
+            # post-date `expires_at` via an admin edit, and we don't
+            # want to record a view against a publication that became
+            # expired in the gap.
             updated = await conn.fetchrow(
                 """
                 UPDATE publications
                    SET view_count = view_count + 1
                  WHERE id = $1
                    AND (max_views IS NULL OR view_count < max_views)
-                 RETURNING view_count, max_views
+                   AND (expires_at IS NULL OR expires_at > NOW())
+                 RETURNING view_count, max_views, expires_at
                 """,
                 row["id"],
             )
             if updated is None:
-                # The row exists but max_views was already reached at the
-                # moment the UPDATE ran — concurrent reader beat us.
+                # Either max_views was reached or expires_at lapsed
+                # between the SELECT and the UPDATE. Re-resolve which
+                # one to surface so the caller sees the same error class
+                # they would have seen with stale data.
+                cur = await conn.fetchrow(
+                    "SELECT expires_at, view_count, max_views FROM publications WHERE id = $1",
+                    row["id"],
+                )
+                if cur is not None and cur["expires_at"] is not None and \
+                        cur["expires_at"] <= datetime.now(timezone.utc):
+                    raise PublicationExpired()
                 raise PublicationViewLimitReached()
             # Reflect the post-increment counter back so the response is
             # consistent with the value that just landed in PG.
@@ -1027,49 +1043,59 @@ async def create_snapshot(publication_id: uuid.UUID) -> dict:
     return the cached result instead of re-running the query.
     """
     pool = await get_pool()
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT s.id, s.slug, s.vault_id, s.resource_type, s.query_sql,
-                   s.query_vault_names, s.query_params, s.title,
-                   v.name AS vault_name
-            FROM publications s JOIN vaults v ON s.vault_id = v.id
-            WHERE s.id = $1
-            """,
-            publication_id,
-        )
-        if row is None:
-            raise PublicationNotFound(str(publication_id))
+    # Session-scoped advisory lock keyed on the publication id so two
+    # concurrent /snapshot calls on the same publication don't both run
+    # the (potentially slow) table query, upload to S3 twice, and race
+    # on the final UPDATE. Released on connection close.
+    lock_key = int.from_bytes(publication_id.bytes[:8], "big", signed=True)
+    async with pool.acquire() as lock_conn:
+        async with lock_conn.transaction():
+            await lock_conn.execute("SELECT pg_advisory_xact_lock($1)", lock_key)
 
-    publication = _publication_row_to_dict(row)
-    assert publication is not None  # row is non-None
-    if publication["resource_type"] != ResourceType.TABLE_QUERY:
-        raise PublicationError("Snapshots only supported for table_query publications", status_code=400)
+            row = await lock_conn.fetchrow(
+                """
+                SELECT s.id, s.slug, s.vault_id, s.resource_type, s.query_sql,
+                       s.query_vault_names, s.query_params, s.title,
+                       v.name AS vault_name
+                FROM publications s JOIN vaults v ON s.vault_id = v.id
+                WHERE s.id = $1
+                """,
+                publication_id,
+            )
+            if row is None:
+                raise PublicationNotFound(str(publication_id))
 
-    # Force live execution for the snapshot (regardless of current mode)
-    publication_for_exec = {**publication, "mode": Mode.LIVE}
-    result = await resolve_table_query_publication(publication_for_exec, {})
+            publication = _publication_row_to_dict(row)
+            assert publication is not None  # row is non-None
+            if publication["resource_type"] != ResourceType.TABLE_QUERY:
+                raise PublicationError(
+                    "Snapshots only supported for table_query publications",
+                    status_code=400,
+                )
 
-    s3_key = f"snapshots/{publication_id}.json"
-    try:
-        file_service.put_object_bytes(
-            s3_key,
-            json.dumps(result, ensure_ascii=False).encode("utf-8"),
-            content_type="application/json",
-        )
-    except (file_service.StorageError, IOError) as e:
-        raise PublicationError(f"Failed to upload snapshot: {e}", status_code=502)
+            # Force live execution for the snapshot (regardless of current mode)
+            publication_for_exec = {**publication, "mode": Mode.LIVE}
+            result = await resolve_table_query_publication(publication_for_exec, {})
 
-    now = datetime.now(timezone.utc)
-    async with pool.acquire() as conn:
-        await conn.execute(
-            """
-            UPDATE publications
-            SET snapshot_s3_key = $1, snapshot_at = $2, mode = 'snapshot', updated_at = $2
-            WHERE id = $3
-            """,
-            s3_key, now, publication_id,
-        )
+            s3_key = f"snapshots/{publication_id}.json"
+            try:
+                file_service.put_object_bytes(
+                    s3_key,
+                    json.dumps(result, ensure_ascii=False).encode("utf-8"),
+                    content_type="application/json",
+                )
+            except (file_service.StorageError, IOError) as e:
+                raise PublicationError(f"Failed to upload snapshot: {e}", status_code=502)
+
+            now = datetime.now(timezone.utc)
+            await lock_conn.execute(
+                """
+                UPDATE publications
+                SET snapshot_s3_key = $1, snapshot_at = $2, mode = 'snapshot', updated_at = $2
+                WHERE id = $3
+                """,
+                s3_key, now, publication_id,
+            )
 
     return {
         "snapshot_s3_key": s3_key,

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -472,7 +472,13 @@ class RoleSync:
         pg_table_name: str,
     ) -> None:
         """Grant SELECT/INSERT/UPDATE/DELETE/ALL on the new table to the
-        vault's reader/writer/admin group roles, matching their scope."""
+        vault's reader/writer/admin group roles, matching their scope.
+
+        Reconciler path (acquires own connection). Prefer
+        :meth:`grant_table_in_conn` from inside the caller's TX so the
+        grant commits atomically with the CREATE TABLE — pre-fix, this
+        path ran post-commit and left a window where the table existed
+        but akb_sql callers got 42501 (audit-v2 B-F7)."""
         if not _is_safe_pg_table_name(pg_table_name):
             logger.error("on_table_create: unsafe pg_table_name %r — refusing", pg_table_name)
             self.metrics.record_failure("on_table_create")
@@ -482,6 +488,24 @@ class RoleSync:
                 await self._grant_table(conn, vault_id, pg_table_name)
         except Exception as e:  # noqa: BLE001
             self._record_failure("on_table_create", e, vault_id, pg_table_name)
+
+    async def grant_table_in_conn(
+        self,
+        conn,
+        vault_id: uuid.UUID | str,
+        pg_table_name: str,
+    ) -> None:
+        """In-TX variant: grant runs on the caller's connection so it
+        commits atomically with the CREATE TABLE that preceded it.
+
+        Errors propagate — the create_table TX rolls back rather than
+        leaving an ungranted table (intentional; the reconciler path
+        above swallows for self-healing, this path does not)."""
+        if not _is_safe_pg_table_name(pg_table_name):
+            raise ValueError(
+                f"unsafe pg_table_name {pg_table_name!r} — refusing grant"
+            )
+        await self._grant_table(conn, vault_id, pg_table_name)
 
     async def on_table_drop(
         self,

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -478,7 +478,7 @@ class RoleSync:
         :meth:`grant_table_in_conn` from inside the caller's TX so the
         grant commits atomically with the CREATE TABLE — pre-fix, this
         path ran post-commit and left a window where the table existed
-        but akb_sql callers got 42501 (audit-v2 B-F7)."""
+        but akb_sql callers got 42501."""
         if not _is_safe_pg_table_name(pg_table_name):
             logger.error("on_table_create: unsafe pg_table_name %r — refusing", pg_table_name)
             self.metrics.record_failure("on_table_create")

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -49,36 +49,46 @@ class SessionService:
         now = datetime.now(timezone.utc)
 
         async with pool.acquire() as conn:
-            row = await conn.fetchrow(
-                "SELECT s.id, s.agent_id, s.started_at, s.ended_at, s.doc_ids, v.name as vault_name FROM sessions s JOIN vaults v ON s.vault_id = v.id WHERE s.id = $1",
-                sid,
-            )
-            if not row:
-                return {"error": "Session not found"}
+            # Single TX with FOR UPDATE so two concurrent end_session
+            # calls can't both see ended_at = NULL and both fire the
+            # auto-summarize side effect.
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT s.id, s.agent_id, s.started_at, s.ended_at, s.doc_ids, "
+                    "v.name as vault_name "
+                    "FROM sessions s JOIN vaults v ON s.vault_id = v.id "
+                    "WHERE s.id = $1 FOR UPDATE OF s",
+                    sid,
+                )
+                if not row:
+                    return {"error": "Session not found"}
 
-            if row["ended_at"] is not None:
-                return {
-                    "error": "Session already ended",
-                    "session_id": session_id,
-                    "ended_at": row["ended_at"].isoformat(),
-                }
+                if row["ended_at"] is not None:
+                    return {
+                        "error": "Session already ended",
+                        "session_id": session_id,
+                        "ended_at": row["ended_at"].isoformat(),
+                    }
 
-            await conn.execute(
-                "UPDATE sessions SET ended_at = $1, summary = $2 WHERE id = $3",
-                now, summary, sid,
-            )
+                await conn.execute(
+                    "UPDATE sessions SET ended_at = $1, summary = $2 WHERE id = $3",
+                    now, summary, sid,
+                )
 
-            # Auto-store work memory
-            if user_id and summary:
-                from app.services.memory_service import auto_summarize_session
-                doc_titles = []
-                if row["doc_ids"]:
+                doc_titles: list[str] = []
+                if user_id and summary and row["doc_ids"]:
                     title_rows = await conn.fetch(
                         "SELECT title FROM documents WHERE id = ANY($1)",
                         row["doc_ids"],
                     )
                     doc_titles = [r["title"] for r in title_rows]
 
+            # auto_summarize_session takes its own pool connections and
+            # writes a memory doc; keep it outside the session TX so it
+            # can't escalate into a multi-resource deadlock. The
+            # FOR UPDATE check above already prevents double-fire.
+            if user_id and summary:
+                from app.services.memory_service import auto_summarize_session
                 await auto_summarize_session(
                     user_id=user_id,
                     session_id=session_id,

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -437,110 +437,131 @@ async def encode_query(text: str) -> tuple[list[int], list[float]]:
 # ── Corpus stats recompute ────────────────────────────────────────
 
 
+_BM25_RECOMPUTE_LOCK_KEY = 987654321
+
+
 async def recompute_stats(batch_size: int = 500) -> dict:
     """Rebuild df (per term) and (total_docs, avgdl). Safe to run repeatedly.
 
     Streams chunks in keyset-paginated batches to keep memory bounded even
     on large corpora.
+
+    Held under a session-scoped PG advisory lock for the duration of the
+    scan AND write. Without this, two replicas would each spend minutes
+    tokenizing the corpus and then race on the final UPDATE — wasting
+    CPU and letting the loser overwrite newer counts with older ones.
+    `pg_try_advisory_lock` makes the loser bail out cheaply instead of
+    waiting for the leader to finish.
     """
     pool = await get_pool()
     tname, tver = tokenizer_info()
 
-    total_docs = 0
-    total_length = 0
-    df_counts: Counter[str] = Counter()
-
-    last_id = None
-    while True:
-        async with pool.acquire() as conn:
-            if last_id is None:
-                rows = await conn.fetch(
-                    "SELECT id, content FROM chunks WHERE content IS NOT NULL "
-                    "ORDER BY id LIMIT $1",
-                    batch_size,
-                )
-            else:
-                rows = await conn.fetch(
-                    "SELECT id, content FROM chunks WHERE content IS NOT NULL AND id > $1 "
-                    "ORDER BY id LIMIT $2",
-                    last_id, batch_size,
-                )
-        if not rows:
-            break
-        for r in rows:
-            last_id = r["id"]
-            toks = await tokenize(r["content"] or "")
-            if not toks:
-                continue
-            total_docs += 1
-            total_length += len(toks)
-            for term in set(toks):
-                df_counts[term] += 1
-
-    avgdl = (total_length / total_docs) if total_docs else 0.0
-
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            # Cross-pod serialization. Two replicas (or a manual operator
-            # invocation racing the periodic refresher) running recompute
-            # in parallel would both zero `bm25_vocab.df` and then race on
-            # the UPDATE — whichever commits last wins, but the corpus
-            # they each scanned may have drifted, so the loser overwrites
-            # newer counts with older ones. A transaction-scoped
-            # PG advisory lock serializes the rebuild; the key is an
-            # arbitrary constant unique to this routine.
-            await conn.execute("SELECT pg_advisory_xact_lock(987654321)")
-            # Ensure all encountered terms have vocab ids. Assign in one batch.
-            if df_counts:
-                await conn.execute(
-                    """
-                    INSERT INTO bm25_vocab (term, term_id)
-                    SELECT t, nextval('bm25_term_id_seq')
-                      FROM unnest($1::text[]) AS t
-                    ON CONFLICT (term) DO NOTHING
-                    """,
-                    list(df_counts.keys()),
-                )
-
-            # Two-step reset: (1) zero every row, (2) set counts for present
-            # terms from a single unnest. Replaces a full-table UPDATE + N
-            # executemany (one round-trip per term) with exactly two queries.
-            await conn.execute("UPDATE bm25_vocab SET df = 0, updated_at = NOW()")
-            if df_counts:
-                terms, counts = zip(*df_counts.items())
-                await conn.execute(
-                    """
-                    UPDATE bm25_vocab v
-                       SET df = c.cnt,
-                           updated_at = NOW()
-                      FROM unnest($1::text[], $2::bigint[]) AS c(term, cnt)
-                     WHERE v.term = c.term
-                    """,
-                    list(terms), list(counts),
-                )
-
-            await conn.execute(
-                """
-                UPDATE bm25_stats
-                   SET total_docs = $1,
-                       avgdl = $2,
-                       tokenizer_name = $3,
-                       tokenizer_version = $4,
-                       updated_at = NOW()
-                 WHERE id = 1
-                """,
-                total_docs, avgdl, tname, tver,
+    # Hold one connection for the whole call so the session-scoped
+    # advisory lock outlives every batch SELECT. Releasing on conn close.
+    async with pool.acquire() as lock_conn:
+        got = await lock_conn.fetchval(
+            "SELECT pg_try_advisory_lock($1)", _BM25_RECOMPUTE_LOCK_KEY
+        )
+        if not got:
+            logger.info(
+                "BM25 recompute skipped: another replica holds the lock"
             )
+            return {
+                "total_docs": None,
+                "avgdl": None,
+                "vocab_size": None,
+                "tokenizer": f"{tname}@{tver}",
+                "skipped": True,
+            }
+        try:
+            total_docs = 0
+            total_length = 0
+            df_counts: Counter[str] = Counter()
 
-    _invalidate_stats_cache()
-    logger.info("BM25 stats recomputed: total_docs=%d avgdl=%.2f vocab_size=%d",
-                total_docs, avgdl, len(df_counts))
-    return {
-        "total_docs": total_docs,
-        "avgdl": avgdl,
-        "vocab_size": len(df_counts),
-        "tokenizer": f"{tname}@{tver}",
-    }
+            last_id = None
+            while True:
+                if last_id is None:
+                    rows = await lock_conn.fetch(
+                        "SELECT id, content FROM chunks WHERE content IS NOT NULL "
+                        "ORDER BY id LIMIT $1",
+                        batch_size,
+                    )
+                else:
+                    rows = await lock_conn.fetch(
+                        "SELECT id, content FROM chunks WHERE content IS NOT NULL AND id > $1 "
+                        "ORDER BY id LIMIT $2",
+                        last_id, batch_size,
+                    )
+                if not rows:
+                    break
+                for r in rows:
+                    last_id = r["id"]
+                    toks = await tokenize(r["content"] or "")
+                    if not toks:
+                        continue
+                    total_docs += 1
+                    total_length += len(toks)
+                    for term in set(toks):
+                        df_counts[term] += 1
+
+            avgdl = (total_length / total_docs) if total_docs else 0.0
+
+            async with lock_conn.transaction():
+                # Ensure all encountered terms have vocab ids. Assign in one batch.
+                if df_counts:
+                    await lock_conn.execute(
+                        """
+                        INSERT INTO bm25_vocab (term, term_id)
+                        SELECT t, nextval('bm25_term_id_seq')
+                          FROM unnest($1::text[]) AS t
+                        ON CONFLICT (term) DO NOTHING
+                        """,
+                        list(df_counts.keys()),
+                    )
+
+                # Two-step reset: (1) zero every row, (2) set counts for present
+                # terms from a single unnest. Replaces a full-table UPDATE + N
+                # executemany (one round-trip per term) with exactly two queries.
+                await lock_conn.execute("UPDATE bm25_vocab SET df = 0, updated_at = NOW()")
+                if df_counts:
+                    terms, counts = zip(*df_counts.items())
+                    await lock_conn.execute(
+                        """
+                        UPDATE bm25_vocab v
+                           SET df = c.cnt,
+                               updated_at = NOW()
+                          FROM unnest($1::text[], $2::bigint[]) AS c(term, cnt)
+                         WHERE v.term = c.term
+                        """,
+                        list(terms), list(counts),
+                    )
+
+                await lock_conn.execute(
+                    """
+                    UPDATE bm25_stats
+                       SET total_docs = $1,
+                           avgdl = $2,
+                           tokenizer_name = $3,
+                           tokenizer_version = $4,
+                           updated_at = NOW()
+                     WHERE id = 1
+                    """,
+                    total_docs, avgdl, tname, tver,
+                )
+
+            _invalidate_stats_cache()
+            logger.info("BM25 stats recomputed: total_docs=%d avgdl=%.2f vocab_size=%d",
+                        total_docs, avgdl, len(df_counts))
+            return {
+                "total_docs": total_docs,
+                "avgdl": avgdl,
+                "vocab_size": len(df_counts),
+                "tokenizer": f"{tname}@{tver}",
+            }
+        finally:
+            await lock_conn.execute(
+                "SELECT pg_advisory_unlock($1)", _BM25_RECOMPUTE_LOCK_KEY
+            )
 
 
 async def vocab_size() -> int:

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -15,9 +15,12 @@ names.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from difflib import get_close_matches
+
+import asyncpg
 
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, NotFoundError
@@ -98,6 +101,16 @@ async def create_table(
     `collections` row is auto-created via `CollectionRepository.get_or_create`
     if it doesn't exist yet.
     """
+    # Tables surface directly in akb_sql, so the user-visible name needs
+    # to be a clean PG identifier shape. The sanitiser in pg_table_name
+    # maps hyphens AND any other punctuation to underscores, so accepting
+    # both `mcp-items` and `mcp_items` would collide on the PG side.
+    # Allow only `[a-z0-9_]+` (underscore is the PG-native separator) to
+    # keep the sanitiser injective for valid inputs (audit-v2 B-F5).
+    if not _TABLE_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid table name {name!r}: must match {_TABLE_NAME_RE.pattern}"
+        )
     pool = await get_pool()
     tid = uuid.uuid4()
     now = datetime.now(timezone.utc)
@@ -128,14 +141,27 @@ async def create_table(
                 )
 
             pg_name = table_data_repo.pg_table_name(vault["name"], name)
-            await table_data_repo.create_dynamic_table(conn, pg_name, columns)
-            await table_registry_repo.insert(
-                conn,
-                table_id=tid, vault_id=vault_id, name=name,
-                description=description, columns=columns,
-                created_by=actor_id, now=now,
-                collection_id=collection_id,
-            )
+            try:
+                await table_data_repo.create_dynamic_table(conn, pg_name, columns)
+                await table_registry_repo.insert(
+                    conn,
+                    table_id=tid, vault_id=vault_id, name=name,
+                    description=description, columns=columns,
+                    created_by=actor_id, now=now,
+                    collection_id=collection_id,
+                )
+            except asyncpg.UniqueViolationError as e:
+                # Two concurrent create_table calls past the find_by_name
+                # check both hit the UNIQUE constraint (vault_tables) or
+                # the pg_type sysid for the dynamic table. Surface as a
+                # clean 409 rather than leaking raw PG error text to the
+                # caller (audit-v2 B-F1).
+                raise ConflictError(f"Table already exists: {name}") from e
+            # Grant PG RBAC inside the same TX so the table is callable
+            # via akb_sql the instant the create commits — pre-fix, the
+            # grant ran in a separate connection after the TX commit,
+            # leaving an "exists but 42501" window (audit-v2 B-F7).
+            await get_role_sync().grant_table_in_conn(conn, vault_id, pg_name)
             await emit_event(
                 conn, "table.create",
                 vault_id=vault_id,
@@ -164,12 +190,6 @@ async def create_table(
     except Exception as e:  # noqa: BLE001
         logger.warning("table metadata indexing failed for %s: %s", name, e)
 
-    # PG-native RBAC: grant SELECT/INSERT/UPDATE/DELETE/ALL on the new
-    # vt_* table to the vault's reader/writer/admin group roles. Tables
-    # without these grants are invisible to akb_user_<uid> roles (PG
-    # returns "relation does not exist" or 42501).
-    await get_role_sync().on_table_create(vault_id, pg_name)
-
     logger.info("Table created: %s → %s (collection=%s)", name, pg_name, collection_path or "<root>")
     return {
         "kind": "table",
@@ -182,6 +202,11 @@ async def create_table(
 
 
 from app.util.text import normalize_collection_path as _normalize_collection_path  # noqa: E402
+
+# Table name shape — PG-native identifier grammar. Underscores only
+# (no hyphens) so `pg_table_name`'s `[^a-z0-9] → _` sanitiser doesn't
+# collapse two distinct user-visible names onto the same PG identifier.
+_TABLE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 async def list_tables(vault_id: uuid.UUID) -> list[dict]:
@@ -233,6 +258,13 @@ async def drop_table(
             table_id = table["id"]
             pg_name = table_data_repo.pg_table_name(vault["name"], table_name)
             await table_data_repo.drop_dynamic_table(conn, pg_name)
+            # Drop chunks + enqueue vector-store outbox in the SAME TX as
+            # the DDL/registry delete. Pre-fix this ran on a separate
+            # connection after the TX committed, so a crash between the
+            # two steps left orphan chunks (audit-v2 B-F2). Now it's
+            # atomic — the table either disappears completely or not at all.
+            from app.services.index_service import delete_table_chunks
+            await delete_table_chunks(conn, str(table_id))
             await table_registry_repo.delete(conn, table_id)
 
             # Clean up edges referencing this table — use the canonical
@@ -255,13 +287,6 @@ async def drop_table(
                     "table_name": table_name,
                 },
             )
-
-    # Outside the TX: drop the metadata chunk via the vector-store
-    # outbox (same pattern as file deletion).
-    try:
-        await delete_table_index(str(table_id))
-    except Exception as e:  # noqa: BLE001
-        logger.warning("table chunk delete failed for %s: %s", table_name, e)
 
     # PG-native RBAC: DROP TABLE has already cascaded the GRANTs;
     # this hook exists for symmetry + audit (logs at DEBUG).
@@ -302,7 +327,18 @@ async def alter_table(
             if not vault:
                 raise NotFoundError("Vault", str(vault_id))
 
-            table = await table_registry_repo.find_by_name(conn, vault_id, table_name)
+            # FOR UPDATE on the registry row so two concurrent alter_table
+            # calls serialise their read-modify-write of vault_tables.columns
+            # (audit-v2 B-F4). Without this, concurrent alters could
+            # silently last-write-wins one of them.
+            table = await conn.fetchrow(
+                """
+                SELECT * FROM vault_tables
+                 WHERE vault_id = $1 AND name = $2
+                 FOR UPDATE
+                """,
+                vault_id, table_name,
+            )
             if not table:
                 raise NotFoundError("Table", table_name)
 
@@ -356,6 +392,21 @@ async def alter_table(
                     "renamed": renamed,
                 },
             )
+
+    # Refresh the metadata chunk so search reflects the new schema
+    # (audit-v2 B-F4: pre-fix the chunk drifted permanently from the
+    # ALTER until the table was dropped and recreated).
+    try:
+        await index_table_metadata(
+            str(table["id"]),
+            vault_id=vault_id,
+            vault_name=vault["name"],
+            name=table_name,
+            description=table["description"] or "",
+            columns=columns,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("alter_table chunk reindex failed for %s: %s", table_name, e)
 
     return {
         "kind": "table",

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -101,12 +101,8 @@ async def create_table(
     `collections` row is auto-created via `CollectionRepository.get_or_create`
     if it doesn't exist yet.
     """
-    # Tables surface directly in akb_sql, so the user-visible name needs
-    # to be a clean PG identifier shape. The sanitiser in pg_table_name
-    # maps hyphens AND any other punctuation to underscores, so accepting
-    # both `mcp-items` and `mcp_items` would collide on the PG side.
-    # Allow only `[a-z0-9_]+` (underscore is the PG-native separator) to
-    # keep the sanitiser injective for valid inputs (audit-v2 B-F5).
+    # pg_table_name maps any punctuation to underscore — allowing hyphens
+    # would let `mcp-items` and `mcp_items` collide on the PG side.
     if not _TABLE_NAME_RE.fullmatch(name):
         raise ValueError(
             f"Invalid table name {name!r}: must match {_TABLE_NAME_RE.pattern}"
@@ -151,16 +147,11 @@ async def create_table(
                     collection_id=collection_id,
                 )
             except asyncpg.UniqueViolationError as e:
-                # Two concurrent create_table calls past the find_by_name
-                # check both hit the UNIQUE constraint (vault_tables) or
-                # the pg_type sysid for the dynamic table. Surface as a
-                # clean 409 rather than leaking raw PG error text to the
-                # caller (audit-v2 B-F1).
+                # Concurrent create past the find_by_name check races on
+                # UNIQUE(vault_tables) or pg_type. Surface as 409.
                 raise ConflictError(f"Table already exists: {name}") from e
-            # Grant PG RBAC inside the same TX so the table is callable
-            # via akb_sql the instant the create commits — pre-fix, the
-            # grant ran in a separate connection after the TX commit,
-            # leaving an "exists but 42501" window (audit-v2 B-F7).
+            # Grant inside the TX so akb_sql can address the table the
+            # instant the create commits (no "exists but 42501" window).
             await get_role_sync().grant_table_in_conn(conn, vault_id, pg_name)
             await emit_event(
                 conn, "table.create",
@@ -258,18 +249,12 @@ async def drop_table(
             table_id = table["id"]
             pg_name = table_data_repo.pg_table_name(vault["name"], table_name)
             await table_data_repo.drop_dynamic_table(conn, pg_name)
-            # Drop chunks + enqueue vector-store outbox in the SAME TX as
-            # the DDL/registry delete. Pre-fix this ran on a separate
-            # connection after the TX committed, so a crash between the
-            # two steps left orphan chunks (audit-v2 B-F2). Now it's
-            # atomic — the table either disappears completely or not at all.
+            # Chunks + vector outbox enqueue must commit with the DDL/registry
+            # delete so a crash mid-drop can't leave orphan chunks.
             from app.services.index_service import delete_table_chunks
             await delete_table_chunks(conn, str(table_id))
             await table_registry_repo.delete(conn, table_id)
 
-            # Clean up edges referencing this table — use the canonical
-            # URI helper so the location prefix matches what every
-            # other write site produces.
             t_uri = table_uri(vault["name"], table_name, collection=table.get("collection"))
             await conn.execute(
                 "DELETE FROM edges WHERE source_uri = $1 OR target_uri = $1",
@@ -327,10 +312,8 @@ async def alter_table(
             if not vault:
                 raise NotFoundError("Vault", str(vault_id))
 
-            # FOR UPDATE on the registry row so two concurrent alter_table
-            # calls serialise their read-modify-write of vault_tables.columns
-            # (audit-v2 B-F4). Without this, concurrent alters could
-            # silently last-write-wins one of them.
+            # FOR UPDATE serialises concurrent alters' read-modify-write
+            # of vault_tables.columns — without it they last-write-wins.
             table = await conn.fetchrow(
                 """
                 SELECT * FROM vault_tables
@@ -393,9 +376,8 @@ async def alter_table(
                 },
             )
 
-    # Refresh the metadata chunk so search reflects the new schema
-    # (audit-v2 B-F4: pre-fix the chunk drifted permanently from the
-    # ALTER until the table was dropped and recreated).
+    # Refresh the metadata chunk so search reflects the new schema —
+    # otherwise the chunk drifts from the ALTER until the table is dropped.
     try:
         await index_table_metadata(
             str(table["id"]),

--- a/backend/app/util/git_refs.py
+++ b/backend/app/util/git_refs.py
@@ -1,0 +1,15 @@
+"""Shared validators for git references surfaced through public APIs.
+
+Both the REST layer (`api/routes/documents.py`) and the MCP layer
+(`mcp_server/server.py`) accept a `version` parameter for fetching
+historical content. Anything other than a literal commit hash is
+rejected — symbolic refs like `HEAD~1`, `refs/...`, or branch names
+would let a caller bypass the document's lifecycle (e.g. read a
+deleted revision via the branch tip) and break audit trails.
+"""
+
+from __future__ import annotations
+
+import re
+
+HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$")

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -14,10 +14,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sys
 import uuid
 from pathlib import Path
 from typing import Any
+
+# Git commit hashes only — same regex the REST layer (documents.py)
+# applies to ?version=. MCP must validate too: pre-fix, an MCP caller
+# could send version="HEAD~1" / "refs/heads/main" / "@~5" and have it
+# resolved by GitPython, leaking historical content the REST trust
+# boundary rejects (audit-v2 F-F2).
+_HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$")
 
 # Add backend to path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -298,6 +306,13 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     version = args.get("version")
     if version:
+        if not _HEX_COMMIT_RE.fullmatch(version):
+            return {
+                "error": (
+                    "version must be a 7-64 char lowercase hex commit hash; "
+                    "symbolic refs (HEAD~N, refs/heads/main, ...) are not accepted"
+                )
+            }
         # Read specific version from Git. Strip frontmatter (yaml meta
         # block at top) before returning content — the un-versioned
         # akb_get path does the same via doc_service.get, and any
@@ -655,12 +670,20 @@ async def _handle_activity(args: dict, uid: str, user: _MCPUser) -> dict:
 async def _handle_diff(args: dict, uid: str, user: _MCPUser) -> dict:
     vault, doc_path = split_uri(args["uri"], expected_type="doc")
     await check_vault_access(uid, vault, required_role="reader")
+    commit = args.get("commit", "")
+    if not _HEX_COMMIT_RE.fullmatch(commit):
+        return {
+            "error": (
+                "commit must be a 7-64 char lowercase hex hash; "
+                "symbolic refs are not accepted"
+            )
+        }
     doc = await _find_doc(vault, doc_path)
     if not doc:
         return {"error": f"Document not found: {args['uri']}"}
     from app.services.git_service import GitService
     git = GitService()
-    return git.file_diff(vault, doc["path"], args["commit"])
+    return git.file_diff(vault, doc["path"], commit)
 
 
 @_h("akb_relations")
@@ -736,10 +759,11 @@ async def _handle_unlink(args: dict, uid: str, user: _MCPUser) -> dict:
     if src_parsed.vault != tgt_parsed.vault:
         return {"error": "source and target must belong to the same vault"}
     vault = src_parsed.vault
-    await check_vault_access(uid, vault, required_role="writer")
+    access = await check_vault_access(uid, vault, required_role="writer")
     return await unlink_resources(
         args["source"], args["target"],
         relation_type=args.get("relation"),
+        vault_id=access["vault_id"],
     )
 
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -14,18 +14,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import sys
 import uuid
 from pathlib import Path
 from typing import Any
 
-# Git commit hashes only — same regex the REST layer (documents.py)
-# applies to ?version=. MCP must validate too: pre-fix, an MCP caller
-# could send version="HEAD~1" / "refs/heads/main" / "@~5" and have it
-# resolved by GitPython, leaking historical content the REST trust
-# boundary rejects (audit-v2 F-F2).
-_HEX_COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$")
+from app.util.git_refs import HEX_COMMIT_RE
 
 # Add backend to path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -306,7 +300,7 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     version = args.get("version")
     if version:
-        if not _HEX_COMMIT_RE.fullmatch(version):
+        if not HEX_COMMIT_RE.fullmatch(version):
             return {
                 "error": (
                     "version must be a 7-64 char lowercase hex commit hash; "
@@ -671,7 +665,7 @@ async def _handle_diff(args: dict, uid: str, user: _MCPUser) -> dict:
     vault, doc_path = split_uri(args["uri"], expected_type="doc")
     await check_vault_access(uid, vault, required_role="reader")
     commit = args.get("commit", "")
-    if not _HEX_COMMIT_RE.fullmatch(commit):
+    if not HEX_COMMIT_RE.fullmatch(commit):
         return {
             "error": (
                 "commit must be a 7-64 char lowercase hex hash; "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.0"
+version = "0.3.1"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Second-round concurrency/atomicity audit. 54 findings across six domains were narrowed by a meta-review pass to a Tier 0 (HIGH, deterministic data loss / surface bypass) and a Tier 1 (TX + advisory lock + canonical URI hardening) cut, then reproduced in a Docker desktop isolation environment before fix, then simplified.

### Tier 0 — HIGH
- `edges.kind` discriminator (migration 028) — every `akb_update` was wiping `akb_link`'s explicit edges. Deterministic, not a race.
- Token-aware SQL rewriter for `table_query` — silent corruption of string literals containing column-name substrings.
- `file_uri` collection prefix in `document_service.delete` response.
- MCP `version` parameter accepts only hex commit hashes — pre-fix a caller could read historical content via `HEAD~1` / `refs/...` even though REST refused.

### Tier 1
- `link_resources` TX + `acquire_path_lock` (deadlock-free order); `unlink_resources(*, vault_id=...)`; BFS edge dedup.
- `create_table`/`drop_table`/`alter_table` fully transactional + in-TX `RoleSync.grant_table_in_conn` (no "exists but 42501" window); `[a-z][a-z0-9_]*` table-name validator keeps `pg_table_name` injective; `delete_vault` runs per-table chunk cleanup inside the outer TX.
- `external_git` last_commit_for_path pinned to synced tip sha; `mark_llm_metadata_filled(expected_blob=...)` stale guard; emits `document.put`/`update`/`delete` events.
- `SessionService.end_session` FOR UPDATE; `create_snapshot` session-scoped advisory lock; `resolve_publication` folds expires_at into atomic view UPDATE.
- BM25 `recompute_stats` holds `pg_try_advisory_lock` for scan+write (cross-replica race + duplicate work prevented); reaper outbox INSERT guarded with NOT EXISTS, `idx_vector_outbox_chunk_pending` partial index (migration 029).
- `_store_edge` rebuilds canonical URI before INSERT; `external_git` paths through `normalize_collection_path`; `CollectionRepository.get_or_create` handles concurrent-delete race.

### /simplify pass
- `HEX_COMMIT_RE` extracted to `util/git_refs.py` (was duplicated in REST + MCP).
- `_store_edge` hoists `table_uri`/`file_uri` to module-level imports.
- `CollectionRepository.get_or_create` over-defensive retry simplified (also fixes a missing f-prefix that would have rendered `{vault_id}` literally).
- `metadata_worker` clears `llm_next_attempt_at` on stale-result drop so the next tick reprocesses immediately.
- 15 `(audit-v2 X-Fn)` parenthetical references + multi-paragraph pre-fix narratives stripped — keep the WHY, drop change-tracking metadata that rots.

### Schema
- Migration 028: `edges.kind` + `idx_edges_source_kind`.
- Migration 029: `idx_vector_outbox_chunk_pending`.
Both idempotent ADD COLUMN / CREATE INDEX IF NOT EXISTS.

### Notes for operators
- Existing edges preserved as `kind='implicit'`. Re-run `akb_link` to recover any explicit edge that prior `akb_update`s destroyed.
- MCP `akb_get(version="HEAD~1")` etc. now returns a clear error — switch to a hex commit from `akb_history`.
- `external_git` mirror vaults now emit `document.*` events on reindex.

## Test plan
- [x] `test_mcp_e2e.sh` 76/76 (Docker desktop)
- [x] `test_edit_e2e.sh` 37/37
- [x] Migration 028 + 029 apply cleanly on existing data
- [x] A-F1 / F-F2 / B-F1 repro scripts confirm fix
- [ ] Production K8s rollout
- [ ] Production E2E (`AKB_URL=<prod>` test_mcp_e2e.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)