### PR TITLE
chore: rename 'Agent Knowledgebase' → 'Agent Knowledge Base' (typography)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/akb-hero.png" alt="AKB — agents reading and writing into a permissioned knowledge vault of docs, tables, and files, linked by a URI graph" width="100%">
 </p>
 
-# AKB — Agent Knowledgebase
+# AKB — Agent Knowledge Base
 
 > **Organizational memory for AI agents.** Git-backed knowledge base served
 > over the **Model Context Protocol (MCP)** — agents read and write directly

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-"""AKB — Agent Knowledgebase API Server."""
+"""AKB — Agent Knowledge Base API Server."""
 
 import asyncio
 import logging
@@ -42,7 +42,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="AKB — Agent Knowledgebase",
+    title="AKB — Agent Knowledge Base",
     description="Organizational Memory for Agents. Git-backed, MCP-native knowledge base.",
     version="0.1.0",
     lifespan=lifespan,

--- a/backend/tests/test_rerank_e2e.py
+++ b/backend/tests/test_rerank_e2e.py
@@ -75,7 +75,7 @@ async def test_rerank_raw_call():
         results = await rerank(
             "AKB 검색 파이프라인 설계",
             [
-                "AKB는 agent knowledgebase 플랫폼입니다.",
+                "AKB는 agent knowledge base 플랫폼입니다.",
                 "오늘 점심은 김치찌개입니다.",
                 "AKB 검색은 하이브리드와 RRF 융합을 씁니다.",
             ],

--- a/design-system/MASTER.md
+++ b/design-system/MASTER.md
@@ -136,7 +136,7 @@ Use for any page chrome bar:
 ```jsx
 <div className="border-b border-border">
   <div className="mx-auto flex max-w-[1400px] justify-between px-6 py-1">
-    <div className="coord">§ AKB · Agent Knowledgebase</div>
+    <div className="coord">§ AKB · Agent Knowledge Base</div>
     <div className="coord">v1.0</div>
   </div>
 </div>

--- a/docs/frontend-redesign-brief.md
+++ b/docs/frontend-redesign-brief.md
@@ -28,7 +28,7 @@
 
 ## 0. 한눈에 보기
 
-**AKB (Agent Knowledgebase)** — Confluence/Notion을 대체하는 **Git 네이티브 + RAG + MCP 퍼스트** 조직 메모리.
+**AKB (Agent Knowledge Base)** — Confluence/Notion을 대체하는 **Git 네이티브 + RAG + MCP 퍼스트** 조직 메모리.
 
 - **두 종류 사용자**: (1) **사람** — 웹 UI / (2) **AI 에이전트** — MCP 스트리밍 HTTP
 - **세 종류 콘텐츠**: **Document (Markdown)**, **Table (구조화 데이터, 실제 PG 테이블)**, **File (바이너리, S3)** — 모두 하나의 검색 인덱스에 공존

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,7 @@
 # AKB Frontend
 
 React 19 + TypeScript + Vite + Radix UI + Tailwind CSS v4. The web UI for
-[AKB](../README.md), the agent knowledgebase.
+[AKB](../README.md), the agent knowledge base.
 
 ## Scripts
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AKB — Agent Knowledgebase</title>
+    <title>AKB — Agent Knowledge Base</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect x='10' y='10' width='80' height='80' fill='none' stroke='%230a0908' stroke-width='6'/><text x='50' y='68' text-anchor='middle' font-family='ui-monospace,monospace' font-size='38' font-weight='700' fill='%23ff4d12'>AKB</text></svg>" />
     <script>
       (function () {

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -102,7 +102,7 @@ export function Layout() {
         {/* Coordinate strip */}
         <div className="border-b border-border">
           <div className="mx-auto flex max-w-[1400px] items-center justify-between gap-3 px-6 py-1">
-            <div className="coord">§ AKB · Agent Knowledgebase</div>
+            <div className="coord">§ AKB · Agent Knowledge Base</div>
             <div className="flex items-center gap-3">
               <IndexingBadge pending={indexingPending} abandoned={indexingAbandoned} />
               <div className="coord hidden md:block">
@@ -222,7 +222,7 @@ export function Layout() {
         <footer className="border-t border-border mt-16">
           <div className="mx-auto flex max-w-[1400px] items-center justify-between px-6 py-2">
             <div className="coord">© Dnotitia / Seahorse</div>
-            <div className="coord hidden md:block">AGENT KNOWLEDGEBASE</div>
+            <div className="coord hidden md:block">AGENT KNOWLEDGE BASE</div>
             <div className="coord">v1.0</div>
           </div>
         </footer>

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -123,7 +123,7 @@ export default function AuthPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const title = useTyped("Agent Knowledgebase", 60);
+  const title = useTyped("Agent Knowledge Base", 60);
   const subText =
     "A unified base for AI agents — documents, tables, and files under one structured root.";
   const sub = useTypingLoop(subText, {
@@ -250,7 +250,7 @@ export default function AuthPage() {
         <div className="tw-marquee-track py-1.5 coord">
           {Array.from({ length: 16 }).map((_, i) => (
             <span key={i} className="px-6">
-              § AKB · A knowledgebase for agents · Documents / Tables / Files · MCP · Git · Dnotitia · Seahorse ·
+              § AKB · A knowledge base for agents · Documents / Tables / Files · MCP · Git · Dnotitia · Seahorse ·
             </span>
           ))}
         </div>

--- a/frontend/src/pages/public-publication.tsx
+++ b/frontend/src/pages/public-publication.tsx
@@ -93,7 +93,7 @@ export default function PublicationPage() {
             <span className="font-display text-3xl leading-none tracking-tight group-hover:text-accent transition-colors">
               AKB
             </span>
-            <span className="coord hidden sm:inline">/ knowledgebase</span>
+            <span className="coord hidden sm:inline">/ knowledge base</span>
           </a>
           <div className="flex items-center gap-3">
             <Badge variant="spark">PUBLIC</Badge>


### PR DESCRIPTION
## Summary

Per feedback from 노홍찬 (Nathan, agent team): "knowledge base" is the standard English spelling (two words), and the capitalised "Base" matches the "B" in the AKB acronym.

Touched every user-visible surface (README, frontend titles, layout headers, auth typed animation, page footers, design docs, backend FastAPI title + docstring, design system MASTER, test fixture body).

Preserved the doc slug `akb-agent-knowledgebase-제품-개요` — that's an immutable identifier for an actual product-vault document.

## Test plan
- [x] ruff All checks passed
- [x] tsc EXIT=0
- [x] vitest 223/223

🤖 Generated with [Claude Code](https://claude.com/claude-code)