### PR TITLE
test(concurrency): invariant suite (shell + unit) + delete_vault file outbox fix

### DIFF
--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -827,6 +827,19 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                 await conn.execute(f"DROP TABLE IF EXISTS {pg_name}")
             await conn.execute("DELETE FROM vault_tables WHERE vault_id = $1", vault_id)
 
+            # File chunks need the same explicit outbox enqueue as table
+            # chunks — chunks.vault_id CASCADE removes the rows from PG,
+            # but vector_delete_outbox doesn't ride the cascade and the
+            # vector-store points would otherwise orphan.
+            vfiles = await conn.fetch(
+                "SELECT id FROM vault_files WHERE vault_id = $1",
+                vault_id,
+            )
+            for vf in vfiles:
+                await _drop_source_chunks_with_outbox(
+                    conn, "file", str(vf["id"]),
+                )
+
             await conn.execute("DELETE FROM todos WHERE vault_id = $1", vault_id)
             await conn.execute("DELETE FROM sessions WHERE vault_id = $1", vault_id)
             await conn.execute("DELETE FROM documents WHERE vault_id = $1", vault_id)

--- a/backend/tests/concurrency/test_invariants.sh
+++ b/backend/tests/concurrency/test_invariants.sh
@@ -116,21 +116,26 @@ mcp_classify() {
 python3 -c '
 import sys, json
 raw = sys.stdin.read()
+if not raw.strip():
+    print("ERR:empty-response"); sys.exit(0)
 try:
     d = json.loads(raw)
 except Exception:
-    print("ERR:non-json"); sys.exit(0)
-if d.get("error"):
-    print(f"ERR:{d[\"error\"].get(\"message\",\"jsonrpc-error\")}"); sys.exit(0)
+    snippet = raw[:120]
+    print("ERR:non-json:" + repr(snippet)); sys.exit(0)
+err = d.get("error")
+if err:
+    msg = err.get("message", "jsonrpc-error") if isinstance(err, dict) else str(err)
+    print("ERR:" + str(msg)); sys.exit(0)
 res = d.get("result") or {}
 if res.get("isError"):
-    print(f"ERR:{res}"); sys.exit(0)
+    print("ERR:" + str(res)); sys.exit(0)
 # tools/call wraps the actual return in result.content[0].text (json string)
 try:
     txt = res["content"][0]["text"]
     obj = json.loads(txt)
     if isinstance(obj, dict) and "error" in obj:
-        print(f"ERR:{obj[\"error\"]}"); sys.exit(0)
+        print("ERR:" + str(obj["error"])); sys.exit(0)
 except Exception:
     pass
 print("OK")

--- a/backend/tests/concurrency/test_invariants.sh
+++ b/backend/tests/concurrency/test_invariants.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Concurrency invariant tests for AKB (audit-v2 Tier 0/1 verification).
+#
+# Hits prod-shaped state with N concurrent clients (curl) and asserts the
+# post-condition in the response or directly in PG.
+#
+# Defaults to the audit Docker stack on :8001 with PG container
+# akb-v2-postgres-1. Override AKB_URL / PG_CONTAINER if needed.
+
+set -uo pipefail
+
+AKB_URL="${AKB_URL:-http://localhost:8001}"
+PG_CONTAINER="${PG_CONTAINER:-akb-v2-postgres-1}"
+N_PARALLEL="${N_PARALLEL:-20}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-30}"
+LABELS=("$@")
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ✗ $1: $2"; FAIL=$((FAIL+1)); FAILURES+=("$1: $2"); }
+
+run_inv() {
+  local id="$1"
+  if [ ${#LABELS[@]} -gt 0 ]; then
+    local found=0
+    for w in "${LABELS[@]}"; do [ "$w" = "$id" ] && found=1 && break; done
+    [ $found -eq 0 ] && return 1
+  fi
+  return 0
+}
+
+pg() {
+  docker exec "$PG_CONTAINER" bash -c "psql -U \$POSTGRES_USER -d \$POSTGRES_DB -tAc \"$1\""
+}
+
+# ── Setup: user + vault + PAT ─────────────────────────────────────────
+TS=$(date +%s)
+USER="inv-$TS"
+EMAIL="inv-$TS@test.local"
+PW="testtest1234"
+VAULT="inv-vault-$TS"
+
+echo "▸ Setup"
+curl -sf --max-time $CURL_TIMEOUT -X POST "$AKB_URL/api/v1/auth/register" -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USER\",\"email\":\"$EMAIL\",\"password\":\"$PW\"}" > /dev/null \
+  || { echo "register failed"; exit 1; }
+
+JWT=$(curl -sf --max-time $CURL_TIMEOUT -X POST "$AKB_URL/api/v1/auth/login" -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USER\",\"password\":\"$PW\"}" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+[ -z "$JWT" ] && { echo "login failed"; exit 1; }
+
+PAT=$(curl -sf --max-time $CURL_TIMEOUT -X POST "$AKB_URL/api/v1/auth/tokens" -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" -d '{"name":"inv-test"}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+[ -z "$PAT" ] && { echo "PAT mint failed"; exit 1; }
+
+curl -sf --max-time $CURL_TIMEOUT -X POST "$AKB_URL/api/v1/vaults?name=$VAULT&description=invariants" \
+  -H "Authorization: Bearer $PAT" > /dev/null || { echo "vault create failed"; exit 1; }
+
+cleanup() {
+  curl -s --max-time 10 -X DELETE "$AKB_URL/api/v1/vaults/$VAULT" -H "Authorization: Bearer $PAT" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+VID=$(pg "SELECT id FROM vaults WHERE name='$VAULT'")
+echo "  ✓ user=$USER vault=$VAULT (id=$VID)"
+echo ""
+
+# ── MCP helpers ───────────────────────────────────────────────────────
+mcp_init() {
+  local sid
+  sid=$(curl -s --max-time $CURL_TIMEOUT -i -X POST "$AKB_URL/mcp/" \
+    -H "Authorization: Bearer $PAT" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"inv","version":"1"}}}' 2>&1 \
+    | grep -i 'mcp-session-id' | head -1 | awk -F': ' '{print $2}' | tr -d '\r\n')
+  curl -s --max-time $CURL_TIMEOUT -X POST "$AKB_URL/mcp/" \
+    -H "Authorization: Bearer $PAT" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "mcp-session-id: $sid" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' > /dev/null
+  echo "$sid"
+}
+
+mcp_call() {
+  local sid="$1" name="$2" args="$3"
+  curl -s --max-time $CURL_TIMEOUT -X POST "$AKB_URL/mcp/" \
+    -H "Authorization: Bearer $PAT" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "mcp-session-id: $sid" \
+    -H "Content-Type: application/json" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}"
+}
+
+mcp_result_text() {
+  python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    txt = d["result"]["content"][0]["text"]
+    print(txt)
+except Exception as e:
+    print(f"PARSE_ERR: {e}", file=sys.stderr)
+    sys.exit(1)
+'
+}
+
+# Classify an MCP tools/call response body: "OK" / "ERR:<msg>"
+mcp_classify() {
+python3 -c '
+import sys, json
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print("ERR:non-json"); sys.exit(0)
+if d.get("error"):
+    print(f"ERR:{d[\"error\"].get(\"message\",\"jsonrpc-error\")}"); sys.exit(0)
+res = d.get("result") or {}
+if res.get("isError"):
+    print(f"ERR:{res}"); sys.exit(0)
+# tools/call wraps the actual return in result.content[0].text (json string)
+try:
+    txt = res["content"][0]["text"]
+    obj = json.loads(txt)
+    if isinstance(obj, dict) and "error" in obj:
+        print(f"ERR:{obj[\"error\"]}"); sys.exit(0)
+except Exception:
+    pass
+print("OK")
+'
+}
+
+SID=$(mcp_init)
+[ -z "$SID" ] && { echo "MCP init failed"; exit 1; }
+echo "▸ MCP session: $SID"
+echo ""
+
+# ── INV-1: edges.kind — explicit edge survives concurrent akb_update ──
+if run_inv "INV-1"; then
+  echo "▸ INV-1: edges.kind — explicit edge survives $N_PARALLEL concurrent akb_update"
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv1\",\"title\":\"src\",\"content\":\"# src\",\"type\":\"note\"}" | mcp_result_text)
+  SRC=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv1\",\"title\":\"tgt\",\"content\":\"# tgt\",\"type\":\"note\"}" | mcp_result_text)
+  TGT=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  LR=$(mcp_call "$SID" "akb_link" "{\"source\":\"$SRC\",\"target\":\"$TGT\",\"relation\":\"depends_on\"}")
+  CLS=$(echo "$LR" | mcp_classify)
+  [ "$CLS" != "OK" ] && fail "INV-1 link" "$CLS"
+
+  PRE=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$SRC' AND kind='explicit'")
+  if [ "$PRE" != "1" ]; then
+    fail "INV-1 setup" "explicit edge not created (got $PRE)"
+  else
+    for i in $(seq 1 $N_PARALLEL); do
+      (curl -s --max-time $CURL_TIMEOUT -X POST "$AKB_URL/mcp/" \
+        -H "Authorization: Bearer $PAT" \
+        -H "Accept: application/json, text/event-stream" \
+        -H "mcp-session-id: $SID" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1000$i,\"method\":\"tools/call\",\"params\":{\"name\":\"akb_update\",\"arguments\":{\"uri\":\"$SRC\",\"content\":\"# src v$i\"}}}" > /dev/null) &
+    done
+    wait
+    POST=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$SRC' AND kind='explicit'")
+    if [ "$POST" = "1" ]; then
+      pass "INV-1 explicit edge survived $N_PARALLEL concurrent updates"
+    else
+      fail "INV-1" "explicit edge count after updates = $POST (expected 1)"
+    fi
+  fi
+fi
+
+# ── INV-2: concurrent create_table — exactly 1 success ────────────────
+if run_inv "INV-2"; then
+  echo "▸ INV-2: concurrent akb_create_table same name — exactly 1 wins"
+  NAME="inv2_t"
+  RESULTS=$(mktemp -d)
+  for i in $(seq 1 10); do
+    (curl -s --max-time $CURL_TIMEOUT -X POST "$AKB_URL/mcp/" \
+      -H "Authorization: Bearer $PAT" \
+      -H "Accept: application/json, text/event-stream" \
+      -H "mcp-session-id: $SID" \
+      -H "Content-Type: application/json" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":2000$i,\"method\":\"tools/call\",\"params\":{\"name\":\"akb_create_table\",\"arguments\":{\"vault\":\"$VAULT\",\"name\":\"$NAME\",\"columns\":[{\"name\":\"v\",\"type\":\"text\"}]}}}" \
+      > "$RESULTS/$i.json") &
+  done
+  wait
+  OK=0; CONFLICT=0; OTHER=0
+  for f in "$RESULTS"/*.json; do
+    cls=$(cat "$f" | mcp_classify)
+    case "$cls" in
+      OK) OK=$((OK+1)) ;;
+      ERR:*already*exist*|ERR:*Conflict*|ERR:*already*) CONFLICT=$((CONFLICT+1)) ;;
+      *) OTHER=$((OTHER+1)); echo "    other: $cls" ;;
+    esac
+  done
+  rm -rf "$RESULTS"
+  PG_CNT=$(pg "SELECT COUNT(*) FROM vault_tables WHERE vault_id='$VID' AND name='$NAME'")
+  if [ "$OK" = "1" ] && [ "$CONFLICT" = "9" ] && [ "$PG_CNT" = "1" ]; then
+    pass "INV-2 1 OK / 9 conflict / pg_rows=1"
+  else
+    fail "INV-2" "OK=$OK conflict=$CONFLICT other=$OTHER pg_rows=$PG_CNT"
+  fi
+fi
+
+# ── INV-4: publication view_count + expires atomic ────────────────────
+if run_inv "INV-4"; then
+  echo "▸ INV-4: max_views=5 publication, N=$N_PARALLEL concurrent resolve → view_count ≤ 5"
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv4\",\"title\":\"pub\",\"content\":\"# pub\",\"type\":\"note\"}" | mcp_result_text)
+  PUB_URI=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  R=$(mcp_call "$SID" "akb_publish" "{\"uri\":\"$PUB_URI\",\"max_views\":5}" | mcp_result_text)
+  SLUG=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["slug"])')
+  for i in $(seq 1 $N_PARALLEL); do
+    (curl -s --max-time $CURL_TIMEOUT "$AKB_URL/api/v1/public/$SLUG" > /dev/null) &
+  done
+  wait
+  VC=$(pg "SELECT view_count FROM publications WHERE slug='$SLUG'")
+  if [ "$VC" -le 5 ] && [ "$VC" -ge 1 ]; then
+    pass "INV-4 view_count=$VC (≤5, no overshoot)"
+  else
+    fail "INV-4" "view_count=$VC (expected 1..5)"
+  fi
+fi
+
+# ── INV-8: MCP version hex validation ─────────────────────────────────
+if run_inv "INV-8"; then
+  echo "▸ INV-8: MCP akb_get version=HEAD~1 rejected"
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv8\",\"title\":\"v\",\"content\":\"# a\",\"type\":\"note\"}" | mcp_result_text)
+  URI8=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  RAW=$(mcp_call "$SID" "akb_get" "{\"uri\":\"$URI8\",\"version\":\"HEAD~1\"}")
+  if echo "$RAW" | grep -qE '7-64.*hex|version must be'; then
+    pass "INV-8 HEAD~1 rejected with hex error"
+  else
+    fail "INV-8" "HEAD~1 was accepted: $(echo $RAW | head -c 200)"
+  fi
+fi
+
+# ── INV-9: get_or_create concurrent same collection ───────────────────
+if run_inv "INV-9"; then
+  echo "▸ INV-9: N=$N_PARALLEL concurrent akb_put new collection → exactly 1 collection row"
+  COLL="inv9-$(date +%s)"
+  for i in $(seq 1 $N_PARALLEL); do
+    (curl -s --max-time $CURL_TIMEOUT -X POST "$AKB_URL/mcp/" \
+      -H "Authorization: Bearer $PAT" \
+      -H "Accept: application/json, text/event-stream" \
+      -H "mcp-session-id: $SID" \
+      -H "Content-Type: application/json" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":9000$i,\"method\":\"tools/call\",\"params\":{\"name\":\"akb_put\",\"arguments\":{\"vault\":\"$VAULT\",\"collection\":\"$COLL\",\"title\":\"doc$i\",\"content\":\"# d$i\",\"type\":\"note\"}}}" > /dev/null) &
+  done
+  wait
+  CNT=$(pg "SELECT COUNT(*) FROM collections WHERE vault_id='$VID' AND path='$COLL'")
+  DOC_CNT=$(pg "SELECT COUNT(*) FROM documents WHERE vault_id='$VID' AND path LIKE '$COLL/%'")
+  if [ "$CNT" = "1" ] && [ "$DOC_CNT" = "$N_PARALLEL" ]; then
+    pass "INV-9 1 collection / $DOC_CNT docs (no duplicate collection rows)"
+  else
+    fail "INV-9" "collections=$CNT docs=$DOC_CNT (expected 1/$N_PARALLEL)"
+  fi
+fi
+
+# ── INV-10: unlink_resources is same-vault only at MCP surface ────────
+if run_inv "INV-10"; then
+  echo "▸ INV-10: MCP akb_unlink validates source/target same vault (URI-derived)"
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv10\",\"title\":\"a\",\"content\":\"# a\",\"type\":\"note\"}" | mcp_result_text)
+  A=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv10\",\"title\":\"b\",\"content\":\"# b\",\"type\":\"note\"}" | mcp_result_text)
+  B=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  LR=$(mcp_call "$SID" "akb_link" "{\"source\":\"$A\",\"target\":\"$B\",\"relation\":\"related_to\"}")
+  CLS=$(echo "$LR" | mcp_classify)
+  [ "$CLS" != "OK" ] && { fail "INV-10 link" "$CLS"; }
+
+  PRE=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$A' AND target_uri='$B' AND kind='explicit'")
+  if [ "$PRE" != "1" ]; then
+    fail "INV-10 setup" "edge missing (got $PRE)"
+  else
+    # Cross-vault unlink: forge target URI in a DIFFERENT vault — MCP should reject
+    B_FAKE="akb://different-vault/coll/inv10/doc/b.md"
+    UR=$(mcp_call "$SID" "akb_unlink" "{\"source\":\"$A\",\"target\":\"$B_FAKE\",\"relation\":\"related_to\"}")
+    CLS=$(echo "$UR" | mcp_classify)
+    POST=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$A' AND target_uri='$B' AND kind='explicit'")
+    if [ "$POST" = "1" ] && case "$CLS" in ERR:*same\ vault*|ERR:*belong*to*the*same*) true ;; *) false ;; esac; then
+      pass "INV-10 cross-vault unlink rejected; edge preserved"
+    else
+      fail "INV-10" "cls=$CLS post_edge=$POST"
+    fi
+    # Same-vault unlink works
+    mcp_call "$SID" "akb_unlink" "{\"source\":\"$A\",\"target\":\"$B\",\"relation\":\"related_to\"}" > /dev/null
+    FINAL=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$A' AND target_uri='$B' AND kind='explicit'")
+    [ "$FINAL" = "0" ] && pass "INV-10b same-vault unlink deletes edge" || fail "INV-10b" "edge remains: $FINAL"
+  fi
+fi
+
+# ── INV-11: link + delete race — no dangling edge (separate sessions) ─
+if run_inv "INV-11"; then
+  echo "▸ INV-11: concurrent akb_link / akb_delete on same source (separate MCP sessions) → no dangling edge"
+  SID_B=$(mcp_init)
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv11\",\"title\":\"src\",\"content\":\"# s\",\"type\":\"note\"}" | mcp_result_text)
+  S11=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  R=$(mcp_call "$SID" "akb_put" "{\"vault\":\"$VAULT\",\"collection\":\"inv11\",\"title\":\"tgt\",\"content\":\"# t\",\"type\":\"note\"}" | mcp_result_text)
+  T11=$(echo "$R" | python3 -c 'import sys,json;print(json.load(sys.stdin)["uri"])')
+  # Use separate sessions so MCP streamable HTTP doesn't serialize them
+  (mcp_call "$SID"   "akb_link"   "{\"source\":\"$S11\",\"target\":\"$T11\",\"relation\":\"depends_on\"}" > /dev/null) &
+  (mcp_call "$SID_B" "akb_delete" "{\"uri\":\"$S11\"}" > /dev/null) &
+  wait
+  # Invariant: if doc is gone, no edges from it should remain.
+  DOC_PATH="inv11/src.md"
+  DOC_EXIST=$(pg "SELECT COUNT(*) FROM documents WHERE vault_id='$VID' AND path='$DOC_PATH'")
+  EDGE_CNT=$(pg "SELECT COUNT(*) FROM edges WHERE source_uri='$S11'")
+  if [ "$DOC_EXIST" = "0" ] && [ "$EDGE_CNT" = "0" ]; then
+    pass "INV-11 delete won race: no doc, no edges"
+  elif [ "$DOC_EXIST" = "1" ]; then
+    if [ "$EDGE_CNT" -ge 0 ]; then
+      pass "INV-11 link won race: doc kept (edge_cnt=$EDGE_CNT)"
+    else
+      fail "INV-11" "unexpected: doc=$DOC_EXIST edge=$EDGE_CNT"
+    fi
+  else
+    fail "INV-11" "DANGLING: doc=$DOC_EXIST edges=$EDGE_CNT"
+  fi
+  curl -s --max-time 5 -X DELETE "$AKB_URL/mcp/" -H "Authorization: Bearer $PAT" -H "mcp-session-id: $SID_B" > /dev/null 2>&1 || true
+fi
+
+# ── INV-12: SQL token rewriter — string literal preserved ─────────────
+if run_inv "INV-12"; then
+  echo "▸ INV-12: column-name substring inside string literal not rewritten"
+  mcp_call "$SID" "akb_create_table" "{\"vault\":\"$VAULT\",\"name\":\"inv12_t\",\"columns\":[{\"name\":\"label\",\"type\":\"text\"},{\"name\":\"qty\",\"type\":\"number\"}]}" > /dev/null
+  mcp_call "$SID" "akb_sql" "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO inv12_t (label, qty) VALUES ('label_contains_qty_word', 42)\"}" > /dev/null
+  R=$(mcp_call "$SID" "akb_sql" "{\"vault\":\"$VAULT\",\"sql\":\"SELECT label FROM inv12_t WHERE qty = 42\"}" | mcp_result_text)
+  LABEL=$(echo "$R" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d["items"][0]["label"] if d.get("items") else "MISSING")')
+  if [ "$LABEL" = "label_contains_qty_word" ]; then
+    pass "INV-12 string literal preserved through token-aware rewriter"
+  else
+    fail "INV-12" "label corrupted: '$LABEL' (expected 'label_contains_qty_word')"
+  fi
+fi
+
+# ── Cleanup MCP session ───────────────────────────────────────────────
+curl -s --max-time 5 -X DELETE "$AKB_URL/mcp/" -H "Authorization: Bearer $PAT" -H "mcp-session-id: $SID" > /dev/null 2>&1 || true
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  for f in "${FAILURES[@]}"; do echo "    - $f"; done
+fi
+echo "════════════════════════════════════════════"
+exit $FAIL

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1,0 +1,337 @@
+"""Unit-level invariant tests for audit-v2 fixes that don't fit a
+shell-bombardment shape.
+
+Covers:
+- INV-3 SessionService.end_session FOR UPDATE — N concurrent calls
+  must produce exactly one "ended" result and exactly one
+  auto_summarize_session (i.e. one row in `memories`).
+- INV-5 sparse_encoder.recompute_stats pg_try_advisory_lock — N
+  concurrent recompute calls; only the lock holder writes, the rest
+  return ``{"skipped": true}``.
+- INV-6 metadata_worker stale guard — DocumentRepository.mark_llm_metadata_filled
+  honours ``expected_blob``; a stale write after the reconciler updated
+  the row returns False and leaves llm_metadata_at unchanged.
+- INV-7 delete_vault orphan chunks — after delete_vault, no chunks rows
+  remain for any source under that vault (documents OR tables OR files).
+
+Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable so
+the suite runs unattended on machines without a dev DB. The audit
+Docker stack default is `postgresql://akb:akb@localhost:5433/akb`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.repositories.document_repo import DocumentRepository
+from app.repositories.vault_repo import VaultRepository
+from app.services.session_service import SessionService
+
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",
+)
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=10)
+    init_sql = (
+        Path(__file__).resolve().parents[2] / "app" / "db" / "init.sql"
+    ).read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(init_sql)
+    # The session_service uses get_pool() (module-global). Wire it to
+    # this test pool for the duration of the test.
+    from app.db import postgres as pg_mod
+    prev = pg_mod._pool
+    pg_mod._pool = pool
+    try:
+        yield pool
+    finally:
+        pg_mod._pool = prev
+        await pool.close()
+
+
+@pytest_asyncio.fixture
+async def vault(pool):
+    vault_repo = VaultRepository(pool)
+    name = f"_inv_unit_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name,
+        description="ephemeral unit-test vault",
+        git_path=f"/tmp/{name}.git",
+        owner_id=None,
+    )
+    try:
+        yield {"id": vid, "name": name}
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+
+
+# ── INV-3: end_session FOR UPDATE dedup ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inv3_end_session_dedup(pool, vault):
+    """Concurrent end_session() must collapse to one ended state and
+    fire auto_summarize_session exactly once.
+    """
+    svc = SessionService()
+    started = await svc.start_session(vault["name"], agent_id="inv3", context=None)
+    sid = started["session_id"]
+
+    # Spawn a user so auto_summarize_session can attribute a memory.
+    async with pool.acquire() as conn:
+        uid = await conn.fetchval(
+            "INSERT INTO users (id, username, email, password_hash, is_admin) "
+            "VALUES (gen_random_uuid(), $1, $2, 'x', false) RETURNING id",
+            f"inv3-{uuid.uuid4().hex[:6]}",
+            f"inv3-{uuid.uuid4().hex[:6]}@test.local",
+        )
+
+    N = 10
+    results = await asyncio.gather(
+        *[svc.end_session(sid, summary=f"summary v{i}", user_id=str(uid)) for i in range(N)]
+    )
+
+    ended_ok = [r for r in results if "ended_at" in r and "error" not in r]
+    already = [r for r in results if r.get("error") == "Session already ended"]
+    other_err = [r for r in results if "error" in r and r["error"] != "Session already ended"]
+
+    assert len(ended_ok) == 1, f"expected 1 successful end, got {len(ended_ok)}: {ended_ok}"
+    assert len(already) == N - 1, f"expected {N-1} 'already ended', got {len(already)}: {already}"
+    assert not other_err, f"unexpected errors: {other_err}"
+
+    # auto_summarize_session must have fired exactly once → one memory row.
+    async with pool.acquire() as conn:
+        mem_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM memories WHERE session_id = $1",
+            uuid.UUID(sid),
+        )
+    assert mem_count == 1, f"expected 1 auto-memory, got {mem_count}"
+
+
+# ── INV-5: BM25 recompute_stats try_advisory_lock ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_inv5_bm25_recompute_lock(pool, vault):
+    """Concurrent recompute_stats: exactly one runs, the rest skip
+    via pg_try_advisory_lock returning false."""
+    from app.services import sparse_encoder
+
+    # Need at least one chunk so the recompute has work to do.
+    async with pool.acquire() as conn:
+        doc_id = uuid.uuid4()
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, 'x.md', 'x', 'note', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            doc_id, vault["id"],
+        )
+        await conn.execute(
+            "INSERT INTO chunks (id, source_type, source_id, vault_id, chunk_index, content) "
+            "VALUES (gen_random_uuid(), 'document', $1, $2, 0, 'hello world')",
+            doc_id, vault["id"],
+        )
+
+    N = 5
+    results = await asyncio.gather(
+        *[sparse_encoder.recompute_stats(batch_size=100) for _ in range(N)]
+    )
+
+    skipped = [r for r in results if r.get("skipped")]
+    ran = [r for r in results if not r.get("skipped")]
+    assert len(ran) == 1, f"expected 1 winner, got {len(ran)}: {ran}"
+    assert len(skipped) == N - 1, f"expected {N-1} skipped, got {len(skipped)}"
+
+
+# ── INV-6: metadata_worker stale guard via expected_blob ───────────
+
+
+@pytest.mark.asyncio
+async def test_inv6_mark_llm_metadata_stale_guard(pool, vault):
+    """mark_llm_metadata_filled honours expected_blob: a worker that
+    claimed at blob 'OLD' must NOT overwrite a row whose external_blob
+    is now 'NEW'.
+    """
+    doc_repo = DocumentRepository(pool)
+    doc_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "source, external_blob, created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, 'ext.md', 't', 'note', 'draft', 'external_git', 'OLD', "
+            "NOW(), NOW(), 'cafef00d', '{}'::text[], '{}'::jsonb)",
+            doc_id, vault["id"],
+        )
+
+    now = datetime.now(timezone.utc)
+
+    # 1) Happy path: expected_blob='OLD' matches → returns True, stamps llm_metadata_at.
+    applied = await doc_repo.mark_llm_metadata_filled(
+        doc_id=doc_id,
+        summary="s1", tags=["a"], doc_type="note", domain="x", now=now,
+        expected_blob="OLD",
+    )
+    assert applied is True
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT summary, llm_metadata_at FROM documents WHERE id = $1", doc_id)
+    assert row["summary"] == "s1"
+    assert row["llm_metadata_at"] is not None
+
+    # 2) Stale path: reconciler swaps blob to 'NEW'; an in-flight worker
+    #    that still has expected_blob='OLD' must be rejected.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE documents SET external_blob = 'NEW', summary = NULL, llm_metadata_at = NULL WHERE id = $1",
+            doc_id,
+        )
+    applied2 = await doc_repo.mark_llm_metadata_filled(
+        doc_id=doc_id,
+        summary="STALE", tags=["x"], doc_type="note", domain="y", now=now,
+        expected_blob="OLD",
+    )
+    assert applied2 is False
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT summary, llm_metadata_at FROM documents WHERE id = $1", doc_id)
+    # Stale write must NOT have stamped anything.
+    assert row["summary"] is None, f"stale write leaked: summary={row['summary']!r}"
+    assert row["llm_metadata_at"] is None
+
+
+# ── INV-7: delete_vault orphan chunks ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inv7_delete_vault_no_orphan_chunks(pool, tmp_path, monkeypatch):
+    """After delete_vault, no chunks remain that point at
+    document/table/file ids that lived in the deleted vault — i.e. the
+    per-source cleanup loop in access_service.delete_vault did its
+    job (B-F8). We seed one of each source type, then verify zero
+    orphans after the destructive call.
+    """
+    from app.config import settings
+    from app.services.role_sync import RoleSync, set_role_sync
+    from app.services import access_service
+
+    # delete_vault calls GitService().cleanup_vault_dirs which insists on a
+    # writeable storage_path. Default is /data/vaults — point it at a tmp dir.
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+
+    # Lifecycle wiring expected by delete_vault → RoleSync grant_table_in_conn / on_table_drop
+    try:
+        from app.services.role_sync import get_role_sync
+        get_role_sync()
+    except RuntimeError:
+        set_role_sync(RoleSync(pool))
+
+    # check_vault_access requires admin (is_admin=true bypasses ownership).
+    async with pool.acquire() as conn:
+        admin_id = await conn.fetchval(
+            "INSERT INTO users (id, username, email, password_hash, is_admin) "
+            "VALUES (gen_random_uuid(), $1, $2, 'x', true) RETURNING id",
+            f"inv7admin-{uuid.uuid4().hex[:6]}",
+            f"inv7admin-{uuid.uuid4().hex[:6]}@test.local",
+        )
+
+    vault_repo = VaultRepository(pool)
+    name = f"_inv7_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name, description="inv7", git_path=f"/tmp/{name}.git", owner_id=admin_id,
+    )
+
+    doc_id = uuid.uuid4()
+    tbl_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        # documents row + its chunk
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, 'd.md', 'd', 'note', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            doc_id, vid,
+        )
+        await conn.execute(
+            "INSERT INTO chunks (id, source_type, source_id, vault_id, chunk_index, content) "
+            "VALUES (gen_random_uuid(), 'document', $1, $2, 0, 'd')",
+            doc_id, vid,
+        )
+        # vault_tables row + its chunk
+        await conn.execute(
+            "INSERT INTO vault_tables (id, vault_id, name, description, columns, created_at) VALUES "
+            "($1, $2, 'tbl_a', 't', '[]'::jsonb, NOW())",
+            tbl_id, vid,
+        )
+        await conn.execute(
+            "INSERT INTO chunks (id, source_type, source_id, vault_id, chunk_index, content) "
+            "VALUES (gen_random_uuid(), 'table', $1, $2, 0, 't')",
+            tbl_id, vid,
+        )
+        # Dynamic PG table the registry points at; delete_vault drops it.
+        await conn.execute(
+            f'CREATE TABLE IF NOT EXISTS "vt_{name}__tbl_a" (id UUID PRIMARY KEY)'
+        )
+        # vault_files row + its chunk
+        await conn.execute(
+            "INSERT INTO vault_files (id, vault_id, name, s3_key, mime_type, size_bytes, created_at) VALUES "
+            "($1, $2, 'f.bin', $3, 'application/octet-stream', 0, NOW())",
+            file_id, vid, f"_inv7_{file_id}",
+        )
+        await conn.execute(
+            "INSERT INTO chunks (id, source_type, source_id, vault_id, chunk_index, content) "
+            "VALUES (gen_random_uuid(), 'file', $1, $2, 0, 'f')",
+            file_id, vid,
+        )
+
+    # Pre-condition: 3 chunks present.
+    async with pool.acquire() as conn:
+        pre = await conn.fetchval(
+            "SELECT COUNT(*) FROM chunks WHERE source_id IN ($1, $2, $3)",
+            doc_id, tbl_id, file_id,
+        )
+    assert pre == 3
+
+    await access_service.delete_vault(user_id=str(admin_id), vault_name=name)
+
+    async with pool.acquire() as conn:
+        post = await conn.fetchval(
+            "SELECT COUNT(*) FROM chunks WHERE source_id IN ($1, $2, $3)",
+            doc_id, tbl_id, file_id,
+        )
+        outbox = await conn.fetchval(
+            "SELECT COUNT(*) FROM vector_delete_outbox WHERE source_id IN ($1, $2, $3)",
+            doc_id, tbl_id, file_id,
+        )
+        vault_still = await conn.fetchval("SELECT COUNT(*) FROM vaults WHERE id = $1", vid)
+
+    assert vault_still == 0, "vault row was not deleted"
+    assert post == 0, f"orphan chunks remain after delete_vault: {post}"
+    assert outbox == 3, (
+        "vector_delete_outbox should carry the three chunk ids forward "
+        f"for the delete worker; got {outbox}"
+    )


### PR DESCRIPTION
## Summary

Two-track verification of every audit-v2 Tier 0 / Tier 1 fix:
1. **`backend/tests/concurrency/test_invariants.sh`** — bombardment + PG ground-truth shell suite (8 invariants, 9 assertions). 9/9 PASS.
2. **`backend/tests/concurrency/test_invariants_unit.py`** — pytest for the four invariants that don't fit a curl-bombardment shape. 4/4 PASS.

Plus one real backend gap surfaced while writing INV-7.

### Shell suite — 9/9 PASS

| ID | audit-v2 fix | what's asserted |
|---|---|---|
| INV-1 | A-F1 `edges.kind` | explicit edge survives N concurrent `akb_update` |
| INV-2 | B-F1 | concurrent `akb_create_table` — exactly 1 wins, 9 conflict |
| INV-4 | D-F7 | `max_views=5` publication, N=20 resolve → `view_count ≤ 5` |
| INV-8 | F-F2 | MCP `version="HEAD~1"` rejected |
| INV-9 | F-F8 | N concurrent `akb_put` to new collection → 1 row / N docs |
| INV-10 | A-F9 | `akb_unlink` cross-vault rejected; same-vault deletes |
| INV-11 | A-F2/F3 | `akb_link` + `akb_delete` race → no dangling edge |
| INV-12 | B-F9 | SQL token rewriter preserves string literals |

Surfaced a Python f-string SyntaxError in the classifier (`{d[\"error\"]...}` is illegal inside an f-string expression). All fails had been printing an empty reason while the backend was actually correct; once fixed, 9/9 pass.

### Unit suite — 4/4 PASS

| ID | what's verified |
|---|---|
| INV-3 | `SessionService.end_session` FOR UPDATE — N concurrent end calls → exactly 1 ended + exactly 1 auto-memory |
| INV-5 | `sparse_encoder.recompute_stats` `pg_try_advisory_lock` — 1 winner / N-1 `{"skipped": true}` |
| INV-6 | `DocumentRepository.mark_llm_metadata_filled` — `expected_blob` stale-guard rejects worker after reconciler swap |
| INV-7 | `access_service.delete_vault` — no orphan chunks + outbox carries every source_type forward |

### Real backend gap found by INV-7

`delete_vault` enqueued `vector_delete_outbox` entries for **document** and **table** chunks, but **file** chunks were left to ride `chunks.vault_id` CASCADE — which silently drops the rows in PG without enqueueing the vector-store delete. Production vector stores would have accumulated orphan points for every file in a deleted vault.

Fix mirrors the `vault_tables` loop: iterate `vault_files` inside the delete TX and call `_drop_source_chunks_with_outbox(conn, "file", id)` for each. Atomic with the rest of the cascade.

```python
vfiles = await conn.fetch("SELECT id FROM vault_files WHERE vault_id = $1", vault_id)
for vf in vfiles:
    await _drop_source_chunks_with_outbox(conn, "file", str(vf["id"]))
```

### Lessons captured

- MCP streamable HTTP serializes requests sharing the same `mcp-session-id` — concurrent `link` + `delete` must use separate sessions.
- The audit Docker stack has no embedding key; `N=20 / CURL_TIMEOUT=20` produces false fails. `N=8 / CURL_TIMEOUT=120` is the stable shell setting.
- Classifier verifier itself can be wrong while the backend is right; PG ground-truth assertion absorbs the fragility.

## Test plan
- [x] `test_invariants.sh` 9/9 on audit Docker stack
- [x] `test_invariants_unit.py` 4/4 against `localhost:5433`
- [x] `test_mcp_e2e.sh` 76/76 (no regression from file-outbox fix)
- [ ] Wire both suites into CI (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)