### PR TITLE
fix(0.3.3): migration 026 idempotency hotfix

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,44 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.3 — 2026-05-28
+
+Hotfix on top of 0.3.2. The 0.3.2 image failed to start on existing
+prod-shaped state: migration 026 (`uri_collection_prefix`, original
+0.3.0 work) re-ran on every backend boot and tripped a
+`UniqueViolationError` on the second pass.
+
+### Cause
+
+`026_uri_collection_prefix._run` rewrites legacy `akb://V/doc/{coll}/{name}`
+URIs to the canonical `akb://V/coll/{coll}/doc/{name}` shape across
+`edges`, `publications`, `events`. After the first deploy on a vault
+the rewrite is complete, but the migration is still in the registry
+that runs on every startup. New edges written between 0.3.0 and 0.3.2
+ended up with the canonical shape directly; the second pass of the
+rewrite would map those onto each other, colliding on
+`UNIQUE (source_uri, target_uri, relation_type)`.
+
+This is an idempotency bug in the original 0.3.0 migration, not in
+the 0.3.2 fix. It surfaced now because nothing had been forcing a
+backend rolling restart on these databases since 0.3.0 went out.
+
+### Fix
+
+`026._run` now starts with a cheap probe: a single SQL that checks
+whether any URI column still matches the legacy shape. If none does,
+the migration logs "no legacy URI shapes remain; skipping" and
+returns. The probe is `LIMIT 1` so it's O(1) once the indexes
+warm up.
+
+### Notes for operators
+
+- 0.3.2 was tagged + released but the image never made it past
+  startup on any cluster that had previously processed migration
+  026. Use 0.3.3.
+- No schema change. The probe is read-only.
+- 0.3.2 changelog body is preserved below for reference.
+
 ## 0.3.2 — 2026-05-28
 
 Follow-up patch to 0.3.1. One new finding surfaced while writing the

--- a/backend/app/db/migrations/026_uri_collection_prefix.py
+++ b/backend/app/db/migrations/026_uri_collection_prefix.py
@@ -67,6 +67,33 @@ async def migrate(conn=None):
 
 
 async def _run(conn):
+    # Idempotency guard. The rewrites below are not safe to re-run after
+    # the first pass: subsequent inserts that use the post-rewrite
+    # canonical URI shape can collide with the unique constraint on
+    # (source_uri, target_uri, relation_type) when we'd rewrite a
+    # legacy duplicate onto the canonical row. Skip the whole migration
+    # once there are no legacy URI shapes left to rewrite.
+    legacy_remaining = await conn.fetchval(
+        """
+        SELECT 1 FROM (
+            SELECT source_uri AS u FROM edges
+             WHERE source_uri ~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+            UNION ALL
+            SELECT target_uri FROM edges
+             WHERE target_uri ~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+            UNION ALL
+            SELECT resource_uri FROM publications
+             WHERE resource_uri ~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+            UNION ALL
+            SELECT resource_uri FROM events
+             WHERE resource_uri ~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+        ) AS legacy LIMIT 1
+        """
+    )
+    if not legacy_remaining:
+        logger.info("Migration 026: no legacy URI shapes remain; skipping")
+        return
+
     async with conn.transaction():
         doc_rewrites = 0
         table_rewrites = 0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.2"
+version = "0.3.3"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

0.3.2 image failed to start on prod-shaped state. Migration 026 (`uri_collection_prefix`, originally 0.3.0) re-runs on every backend boot and the second pass collides on `UNIQUE (source_uri, target_uri, relation_type)`.

### Cause
After the first run, all legacy `akb://V/doc/{coll}/{name}` URIs are already canonical. New edges written between 0.3.0 and 0.3.2 use the canonical shape directly, so the rewrite has nothing to do — but the regexp_replace UPDATE still touches those rows and asyncpg / PG report UniqueViolation on the no-op map. Surfaced now because the prod database hadn't been forced through a full backend restart since 0.3.0 went out.

### Fix
Cheap probe at the top of `026._run`: `LIMIT 1` SQL that checks whether any `edges`/`publications`/`events` URI column still matches the legacy shape. If not, log "no legacy URI shapes remain; skipping" and return early. Read-only, no schema change.

### Test plan
- [x] Audit Docker stack restarts cleanly with the prod-shaped state
- [x] `test_mcp_e2e.sh` 76/76 (no functional regression)
- [ ] After merge: tag `backend-v0.3.3`, GitHub release (latest), K8s deploy, prod E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)