### PR TITLE
fix(0.3.4): publication authz holes + delete-path orphan vectors + search crash + resizable sidebar

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,78 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.4 — 2026-05-28
+
+Security + data-integrity patch. Findings came out of a full
+functional/logic review of the backend (20-subsystem multi-agent pass,
+55 confirmed findings); this release lands the highest-priority cut.
+Each fix was reproduced in the audit stack BEFORE the change and
+re-verified SAFE after. No schema change, no migration.
+
+### Security — publication public surface (unauthenticated)
+
+Publications are served at `/api/v1/public/{slug}` with no auth, so
+these were directly exploitable by anyone with the URL.
+
+- **Public `table_query` ran as the privileged pool role.**
+  `resolve_table_query_publication` executed the canned SQL on the
+  default service-role connection with only `SET TRANSACTION READ ONLY`
+  — no `SET LOCAL ROLE`, no table ACL. A publication such as
+  `SELECT password_hash FROM users` / `SELECT token_hash FROM tokens` /
+  `SELECT * FROM vt_othervault__secret` returned rows to unauthenticated
+  visitors (verified: `SELECT count(*) FROM users` → 59 rows;
+  `SELECT current_user` → `akb`). Now the query runs under the
+  publication CREATOR's PG role (`SET LOCAL ROLE akb_user_<created_by>`),
+  so PG returns 42501 for anything the creator could not read via
+  `akb_sql`. Publications without a recorded creator fail closed (403).
+  Adds `s.created_by` to the resolve SELECT.
+- **`akb_publish` / `create_publication_route` now authorize every vault
+  in `query_vault_names`,** not just the route vault — a writer on one
+  vault could otherwise publish a query reading another vault's tables.
+- **`delete_publication` IDOR fixed.** The REST delete route bound the
+  delete only to the publication id, ignoring the route vault, so a
+  writer on any vault could delete any publication by id. Now scoped to
+  `WHERE id=$1 AND vault_id=$2`; returns 404 otherwise.
+- **`create_snapshot` cross-vault fixed.** Loaded the publication by id
+  with no vault filter (REST and MCP), letting a writer on vault A
+  force-execute and snapshot vault B's publication. Now binds to the
+  authorized vault and rejects with 404 before running the query / S3
+  write.
+
+### Data integrity / correctness
+
+- **`delete_vault` orphaned file-chunk vectors when S3 is configured.**
+  The 0.3.2 file-chunk outbox enqueue ran AFTER the early
+  `DELETE FROM vault_files` (which only fires when S3 is configured), so
+  it read zero rows and every file chunk CASCADE-dropped from PG without
+  a `vector_delete_outbox` entry — permanent orphan points. The 0.3.2
+  unit test missed it because the audit stack has no S3. File ids are now
+  captured (`SELECT id, s3_key`) and enqueued BEFORE the delete.
+- **`FileService.delete` swallowed chunk-delete failures.** The
+  `delete_file_chunks` call was wrapped in a `try/except` that logged and
+  continued, defeating the 03-F1 contract (the enqueue is meant to RAISE
+  so a failure rolls back the file delete). Removed; failures now roll
+  back the whole delete like the document/table/vault paths.
+- **Collection-scoped search 500'd.** The search ACL prefilter's
+  file-candidate branch filtered on `vault_files.collection`, a column
+  dropped in migration 020 (replaced by `collection_id`). Any
+  `search?...&collection=X` with the default `doc_type` raised
+  UndefinedColumn and 500'd the whole request. Now joins `collections`
+  on `collection_id` and prefix-matches `c.path`, same as the documents
+  branch.
+
+### Tests
+
+- `backend/tests/concurrency/repro_pub_security.sh` — before/after
+  VULNERABLE↔SAFE probes for the publication authz holes + the search
+  crash.
+- `test_invariants_unit.py`: `test_inv7b` (delete_vault file outbox with
+  S3 configured) and `test_p1_2` (FileService.delete rollback).
+
+Regression: `test_mcp_e2e` 76/76, `test_invariants.sh` 9/9, unit 6/6.
+Legit flows reverified (own-table publication view, authorized
+multi-vault publish, owner delete/snapshot).
+
 ## 0.3.3 — 2026-05-28
 
 Hotfix on top of 0.3.2. The 0.3.2 image failed to start on existing

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -129,6 +129,14 @@ async def create_publication_route(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     await check_vault_access(user.user_id, vault, required_role="writer")
+    # A table_query publication runs against EVERY vault in
+    # query_vault_names, served to unauthenticated visitors. Authorize
+    # each one so a writer on one vault cannot publish a query that reads
+    # another vault's tables (cross-vault exfiltration).
+    if req.resource_type == "table_query":
+        for qv in (req.query_vault_names or [vault]):
+            if qv != vault:
+                await check_vault_access(user.user_id, qv, required_role="writer")
     # Split the canonical URI into the service-layer args
     # (doc path / file uuid). Reject mismatches between resource_type
     # and URI scheme so callers can't smuggle a doc URI into a file
@@ -194,12 +202,18 @@ async def delete_publication_route(
     publication_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    await check_vault_access(user.user_id, vault, required_role="writer")
+    access = await check_vault_access(user.user_id, vault, required_role="writer")
     try:
         sid = uuid.UUID(publication_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid publication_id")
-    deleted = await publication_service.delete_publication(publication_id=sid)
+    # Bind the delete to the authorized vault — without this a writer on
+    # `vault` could delete any publication by id regardless of owner (IDOR).
+    deleted = await publication_service.delete_publication(
+        publication_id=sid, expected_vault_id=access["vault_id"],
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Publication not found in this vault")
     return {"deleted": deleted}
 
 
@@ -220,13 +234,15 @@ async def create_snapshot_route(
     publication_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    await check_vault_access(user.user_id, vault, required_role="writer")
+    access = await check_vault_access(user.user_id, vault, required_role="writer")
     try:
         sid = uuid.UUID(publication_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid publication_id")
     try:
-        return await publication_service.create_snapshot(sid)
+        return await publication_service.create_snapshot(
+            sid, expected_vault_id=access["vault_id"],
+        )
     except PublicationError as e:
         raise _publication_error_to_http(e)
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -789,7 +789,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
         # PG-side runs inside the transaction below so a mid-flight crash
         # never leaves the vault with phantom vt_* tables or registry
         # rows pointing at dropped physical tables.
-        file_rows = await conn.fetch("SELECT s3_key FROM vault_files WHERE vault_id = $1", vault_id)
+        file_rows = await conn.fetch("SELECT id, s3_key FROM vault_files WHERE vault_id = $1", vault_id)
         if file_rows and settings.s3_endpoint_url:
             from app.services.adapters import s3_adapter
             failed = []
@@ -803,6 +803,17 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                 logger.error("Vault %s: %d/%d S3 files failed to delete", vault_name, len(failed), len(file_rows))
 
         async with conn.transaction():
+            from app.services.index_service import _drop_source_chunks_with_outbox
+
+            # Enqueue file-chunk vector deletes BEFORE deleting vault_files.
+            # chunks.vault_id CASCADE removes file chunks from PG when the
+            # vaults row drops, but vector_delete_outbox doesn't ride the
+            # cascade — so the file ids must be captured (from file_rows,
+            # read above) and enqueued while they still exist, regardless
+            # of whether the S3 branch already removed the vault_files rows.
+            for fr in file_rows:
+                await _drop_source_chunks_with_outbox(conn, "file", str(fr["id"]))
+
             if file_rows and settings.s3_endpoint_url:
                 await conn.execute("DELETE FROM vault_files WHERE vault_id = $1", vault_id)
 
@@ -814,7 +825,6 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
             # delete_vault_chunks only handles source_type='document';
             # tables/files need explicit cleanup because chunks.source_id
             # has no FK (polymorphic source) and would orphan otherwise.
-            from app.services.index_service import _drop_source_chunks_with_outbox
             vtables = await conn.fetch(
                 "SELECT id, name FROM vault_tables WHERE vault_id = $1",
                 vault_id,
@@ -826,19 +836,6 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                 pg_name = table_data_repo.pg_table_name(vault_name, vt["name"])
                 await conn.execute(f"DROP TABLE IF EXISTS {pg_name}")
             await conn.execute("DELETE FROM vault_tables WHERE vault_id = $1", vault_id)
-
-            # File chunks need the same explicit outbox enqueue as table
-            # chunks — chunks.vault_id CASCADE removes the rows from PG,
-            # but vector_delete_outbox doesn't ride the cascade and the
-            # vector-store points would otherwise orphan.
-            vfiles = await conn.fetch(
-                "SELECT id FROM vault_files WHERE vault_id = $1",
-                vault_id,
-            )
-            for vf in vfiles:
-                await _drop_source_chunks_with_outbox(
-                    conn, "file", str(vf["id"]),
-                )
 
             await conn.execute("DELETE FROM todos WHERE vault_id = $1", vault_id)
             await conn.execute("DELETE FROM sessions WHERE vault_id = $1", vault_id)

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -417,10 +417,12 @@ class FileService:
                     )
 
                 # Drop the metadata chunk (outbox-driven vector-store delete).
-                try:
-                    await delete_file_chunks(conn, file_id)
-                except Exception as e:  # noqa: BLE001
-                    logger.warning("file chunk delete failed for %s: %s", file_id, e)
+                # delete_file_chunks → _drop_source_chunks_with_outbox is
+                # designed to RAISE so a failed outbox enqueue rolls back the
+                # whole file delete (03-F1). Do NOT swallow it: swallowing
+                # commits the vault_files delete + s3 enqueue while leaving
+                # the chunk's vector-store point orphaned.
+                await delete_file_chunks(conn, file_id)
 
                 await _enqueue_s3_delete(conn, row["s3_key"])
 

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -18,6 +18,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import asyncpg
 import bcrypt
 import frontmatter
 
@@ -424,17 +425,40 @@ async def create_publication_for_vault(
     )
 
 
-async def delete_publication(*, publication_id: uuid.UUID | None = None, slug: str | None = None) -> bool:
-    """Delete a publication by id or slug. Returns True if deleted."""
+async def delete_publication(
+    *,
+    publication_id: uuid.UUID | None = None,
+    slug: str | None = None,
+    expected_vault_id: uuid.UUID | None = None,
+) -> bool:
+    """Delete a publication by id or slug. Returns True if deleted.
+
+    `expected_vault_id` binds the delete to a vault: the row is removed
+    only if it belongs to that vault. Callers that authorized the request
+    against a specific vault MUST pass it, otherwise a writer on vault A
+    could delete any publication by id regardless of owning vault (IDOR).
+    """
     if not publication_id and not slug:
         raise ValueError("Either publication_id or slug must be provided")
 
     pool = await get_pool()
     async with pool.acquire() as conn:
         if publication_id:
-            result = await conn.execute("DELETE FROM publications WHERE id = $1", publication_id)
+            if expected_vault_id is not None:
+                result = await conn.execute(
+                    "DELETE FROM publications WHERE id = $1 AND vault_id = $2",
+                    publication_id, expected_vault_id,
+                )
+            else:
+                result = await conn.execute("DELETE FROM publications WHERE id = $1", publication_id)
         else:
-            result = await conn.execute("DELETE FROM publications WHERE slug = $1", slug)
+            if expected_vault_id is not None:
+                result = await conn.execute(
+                    "DELETE FROM publications WHERE slug = $1 AND vault_id = $2",
+                    slug, expected_vault_id,
+                )
+            else:
+                result = await conn.execute("DELETE FROM publications WHERE slug = $1", slug)
     deleted = result.endswith(" 1")
     if deleted:
         logger.info("Publication deleted: %s", publication_id or slug)
@@ -602,6 +626,7 @@ async def resolve_publication(
                    s.password_hash, s.max_views, s.view_count, s.expires_at,
                    s.mode, s.snapshot_s3_key, s.snapshot_at,
                    s.section_filter, s.allow_embed, s.title, s.created_at,
+                   s.created_by,
                    v.name AS vault_name
             FROM publications s
             JOIN vaults v ON s.vault_id = v.id
@@ -990,10 +1015,44 @@ async def resolve_table_query_publication(publication: dict, url_params: dict | 
         if not rewritten.strip().upper().startswith(("SELECT", "WITH")):
             raise PublicationError("Only SELECT queries are allowed for publications", status_code=400)
 
+        # Execute under the publication CREATOR's PG role, never the
+        # privileged pool role. Without this, a public (unauthenticated)
+        # visitor's query runs as the service role and can read system
+        # tables (users/tokens) and any vault's vt_* tables — full
+        # cross-vault / system-table exfiltration. Running as
+        # akb_user_<created_by> makes PG return 42501 for anything the
+        # creator could not have read via akb_sql, so a publication can
+        # only ever expose what its author was authorized to see.
+        from app.services.role_sync import user_role_name
+        created_by = publication.get("created_by")
+        if not created_by:
+            # Legacy publications without a recorded creator cannot be
+            # safely scoped — fail closed rather than fall back to the
+            # privileged role.
+            raise PublicationError(
+                "This shared query can no longer be served (no owner on record).",
+                status_code=403,
+            )
+        role = user_role_name(created_by)
         try:
             async with conn.transaction():
                 await conn.execute("SET TRANSACTION READ ONLY")
+                await conn.execute(f'SET LOCAL ROLE "{role}"')
                 rows = await conn.fetch(rewritten, *values)
+        except asyncpg.exceptions.InsufficientPrivilegeError:
+            # 42501 — the creator's role lacks SELECT on a referenced
+            # table (system table or another vault). Do not echo the
+            # table name to the public visitor.
+            raise PublicationError(
+                "This shared query references data that is no longer accessible.",
+                status_code=403,
+            )
+        except asyncpg.exceptions.UndefinedObjectError:
+            # SET LOCAL ROLE to a role that no longer exists (creator deleted).
+            raise PublicationError(
+                "This shared query can no longer be served (owner removed).",
+                status_code=403,
+            )
         except Exception as e:
             msg = str(e)
             if "read-only transaction" in msg:
@@ -1036,11 +1095,20 @@ async def _read_snapshot(publication: dict) -> dict:
     return data
 
 
-async def create_snapshot(publication_id: uuid.UUID) -> dict:
+async def create_snapshot(
+    publication_id: uuid.UUID,
+    *,
+    expected_vault_id: uuid.UUID | None = None,
+) -> dict:
     """Execute a table_query publication's SQL once and store result in S3.
 
     The publication's `mode` is then flipped to 'snapshot' so subsequent visits
     return the cached result instead of re-running the query.
+
+    `expected_vault_id` binds the snapshot to a vault: callers that
+    authorized the request against a specific vault MUST pass it, else a
+    writer on vault A could force-execute and snapshot any publication by
+    id regardless of owning vault (cross-vault execution).
     """
     pool = await get_pool()
     # Session-scoped advisory lock keyed on the publication id so two
@@ -1063,6 +1131,9 @@ async def create_snapshot(publication_id: uuid.UUID) -> dict:
                 publication_id,
             )
             if row is None:
+                raise PublicationNotFound(str(publication_id))
+            # Reject cross-vault snapshots BEFORE running the query / S3 write.
+            if expected_vault_id is not None and row["vault_id"] != expected_vault_id:
                 raise PublicationNotFound(str(publication_id))
 
             publication = _publication_row_to_dict(row)

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -227,13 +227,21 @@ class SearchService:
                         f_conds.append("v.name = $1")
                         f_params.append(vault)
                     if collection:
-                        f_conds.append(f"f.collection = ${len(f_params) + 1}")
+                        # vault_files.collection (TEXT) was dropped in
+                        # migration 020 → collection_id FK. Filter via the
+                        # joined collections.path with a prefix match, same
+                        # semantics as the documents branch above.
+                        f_conds.append(f"c.path LIKE ${len(f_params) + 1} || '%'")
                         f_params.append(collection)
                     acl_sql, acl_params = _vault_acl(len(f_params) + 1)
                     if acl_sql:
                         f_conds.append(acl_sql)
                         f_params.extend(acl_params)
-                    q = "SELECT f.id FROM vault_files f JOIN vaults v ON f.vault_id = v.id"
+                    q = (
+                        "SELECT f.id FROM vault_files f "
+                        "JOIN vaults v ON f.vault_id = v.id "
+                        "LEFT JOIN collections c ON c.id = f.collection_id"
+                    )
                     if f_conds:
                         q += " WHERE " + " AND ".join(f_conds)
                     frows = await conn.fetch(q, *f_params)

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -891,6 +891,14 @@ async def _handle_publish(args: dict, uid: str, user: _MCPUser) -> dict:
         return {"error": f"Unknown resource_type: {resource_type}"}
 
     await check_vault_access(uid, vault_name, required_role="writer")
+    # A table_query publication runs against EVERY vault in
+    # query_vault_names, served to unauthenticated visitors. Authorize
+    # each one — without this a writer on one vault could publish a query
+    # that reads another vault's tables (cross-vault exfiltration).
+    if resource_type == "table_query":
+        for qv in (args.get("query_vault_names") or [vault_name]):
+            if qv != vault_name:
+                await check_vault_access(uid, qv, required_role="writer")
     created_by = uuid.UUID(uid) if uid and uid != _SYSTEM_UID else None
 
     try:
@@ -972,17 +980,22 @@ async def _handle_publications(args: dict, uid: str, user: _MCPUser) -> dict:
 @_h("akb_publication_snapshot")
 async def _handle_publication_snapshot(args: dict, uid: str, user: _MCPUser) -> dict:
     """Create a snapshot of a table_query publication."""
-    await check_vault_access(uid, args["vault"], required_role="writer")
+    access = await check_vault_access(uid, args["vault"], required_role="writer")
     slug = args["slug"]
     pool = await get_pool()
     async with pool.acquire() as conn:
+        # Bind to the authorized vault — without it a writer on `vault`
+        # could snapshot (force-execute) any publication by slug.
         row = await conn.fetchrow(
-            "SELECT id FROM publications WHERE slug = $1", slug,
+            "SELECT id FROM publications WHERE slug = $1 AND vault_id = $2",
+            slug, access["vault_id"],
         )
     if not row:
         return {"error": f"Publication not found: {slug}"}
     try:
-        return await publication_service.create_snapshot(row["id"])
+        return await publication_service.create_snapshot(
+            row["id"], expected_vault_id=access["vault_id"],
+        )
     except publication_service.PublicationError as e:
         return {"error": e.message}
     except Exception as e:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.3"
+version = "0.3.4"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/concurrency/repro_pub_security.sh
+++ b/backend/tests/concurrency/repro_pub_security.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Reproduction probes for the P0 publication-authorization findings and the
+# P1 collection-scoped search crash. Prints a VULNERABLE / SAFE verdict per
+# bug so the same script documents the BEFORE (vulnerable) and AFTER (fixed)
+# states. Targets the audit Docker stack on :8001 by default.
+#
+#   bash backend/tests/concurrency/repro_pub_security.sh
+#
+# Exits non-zero if any probe is still VULNERABLE (so AFTER runs are a gate).
+
+set -uo pipefail
+AKB_URL="${AKB_URL:-http://localhost:8001}"
+JSON=(-H "Content-Type: application/json")
+
+VULN=0
+verdict() { # name, state(VULNERABLE|SAFE), detail
+  if [ "$2" = "VULNERABLE" ]; then echo "  ✗ $1: VULNERABLE — $3"; VULN=$((VULN+1));
+  else echo "  ✓ $1: SAFE — $3"; fi
+}
+
+reg() { # username -> prints PAT
+  local u="$1" pw="testtest1234"
+  curl -s --max-time 20 -X POST "$AKB_URL/api/v1/auth/register" "${JSON[@]}" \
+    -d "{\"username\":\"$u\",\"email\":\"$u@t.local\",\"password\":\"$pw\"}" >/dev/null
+  local jwt
+  jwt=$(curl -s --max-time 20 -X POST "$AKB_URL/api/v1/auth/login" "${JSON[@]}" \
+    -d "{\"username\":\"$u\",\"password\":\"$pw\"}" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+  curl -s --max-time 20 -X POST "$AKB_URL/api/v1/auth/tokens" -H "Authorization: Bearer $jwt" "${JSON[@]}" \
+    -d '{"name":"repro"}' | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])'
+}
+
+TS=$(date +%s)
+U1="reprou1-$TS"; U2="reprou2-$TS"
+VA="repro-a-$TS"; VB="repro-b-$TS"
+
+echo "▸ Setup"
+PAT1=$(reg "$U1"); PAT2=$(reg "$U2")
+[ -z "$PAT1" ] || [ -z "$PAT2" ] && { echo "auth setup failed"; exit 2; }
+AUTH1=(-H "Authorization: Bearer $PAT1"); AUTH2=(-H "Authorization: Bearer $PAT2")
+curl -s --max-time 20 -X POST "$AKB_URL/api/v1/vaults?name=$VA" "${AUTH1[@]}" >/dev/null   # user1 owns A
+curl -s --max-time 20 -X POST "$AKB_URL/api/v1/vaults?name=$VB" "${AUTH2[@]}" >/dev/null   # user2 owns B
+# a table in A so build_table_name_map(A) resolves
+curl -s --max-time 20 -X POST "$AKB_URL/tables/$VA" "${AUTH1[@]}" "${JSON[@]}" \
+  -d '{"name":"items","columns":[{"name":"label","type":"text"}]}' >/dev/null
+echo "  user1=$U1 vaultA=$VA · user2=$U2 vaultB=$VB"
+echo ""
+
+create_pub() { # vault, body, authvar... -> prints "slug publication_id"; auth passed via global AUTHx
+  local vault="$1" body="$2"; shift 2
+  curl -s --max-time 20 -X POST "$AKB_URL/api/v1/publications/$vault/create" "$@" "${JSON[@]}" -d "$body" \
+    | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print("",""); raise SystemExit
+print(d.get("slug","") or "", d.get("publication_id","") or "")' 2>/dev/null
+}
+
+# ── P0-1: public table_query leaks a system table ─────────────────────
+echo "▸ P0-1: public table_query runs against system tables (data exfiltration)"
+read -r SLUG1 PID1 < <(create_pub "$VA" "{\"resource_type\":\"table_query\",\"query_sql\":\"SELECT count(*) AS n FROM users\",\"title\":\"leak\"}" "${AUTH1[@]}")
+if [ -z "$SLUG1" ]; then
+  verdict "P0-1" "SAFE" "publication creation rejected the system-table query (slug empty)"
+else
+  BODY=$(curl -s --max-time 20 "$AKB_URL/api/v1/public/$SLUG1")
+  WHO=$(create_pub "$VA" "{\"resource_type\":\"table_query\",\"query_sql\":\"SELECT current_user AS who\",\"title\":\"who\"}" "${AUTH1[@]}")
+  WHOSLUG=$(echo "$WHO" | awk '{print $1}')
+  WHOBODY=$(curl -s --max-time 20 "$AKB_URL/api/v1/public/$WHOSLUG")
+  ROLE=$(echo "$WHOBODY" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin); r=d.get("rows") or [{}]
+    print(r[0].get("who",""))
+except Exception:
+    print("")' 2>/dev/null)
+  # VULNERABLE if the public (unauthenticated) view actually read the users
+  # table, i.e. returned a numeric count, OR runs as a non per-user role.
+  if echo "$BODY" | grep -qE '"n":[0-9]+'; then
+    verdict "P0-1" "VULNERABLE" "public view read users table → $(echo "$BODY" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("rows"))' 2>/dev/null); runs as role=${ROLE:-?}"
+  elif [ -n "$ROLE" ] && [[ "$ROLE" != akb_user_* ]]; then
+    verdict "P0-1" "VULNERABLE" "public query runs as privileged role '$ROLE' (not a per-user akb_user_ role)"
+  else
+    verdict "P0-1" "SAFE" "users-table read denied; query runs as role='${ROLE:-?}'"
+  fi
+fi
+echo ""
+
+# ── P0-3: delete_publication IDOR (writer on B deletes A's publication) ─
+echo "▸ P0-3: delete_publication ignores vault binding (IDOR)"
+read -r SLUG3 PID3 < <(create_pub "$VA" "{\"resource_type\":\"table_query\",\"query_sql\":\"SELECT label FROM items\",\"title\":\"idor-target\"}" "${AUTH1[@]}")
+if [ -z "$PID3" ]; then
+  echo "  (could not create target publication; skipping)"
+else
+  # user2 has zero access to vault A; deletes A's pub via the vault-B route.
+  DEL=$(curl -s --max-time 20 -o /dev/null -w "%{http_code}" -X DELETE \
+    "$AKB_URL/api/v1/publications/$VB/$PID3" "${AUTH2[@]}")
+  DELBODY=$(curl -s --max-time 20 "$AKB_URL/api/v1/public/$SLUG3" -o /dev/null -w "%{http_code}")
+  # If the pub is now gone (public view 404) AND the delete returned 200, it was deleted cross-vault.
+  STILL=$(curl -s --max-time 20 -X GET "$AKB_URL/api/v1/publications/$VA" "${AUTH1[@]}" \
+    | python3 -c "import sys,json;print(sum(1 for p in json.load(sys.stdin).get('publications',[]) if p.get('publication_id')=='$PID3'))" 2>/dev/null)
+  if [ "$STILL" = "0" ]; then
+    verdict "P0-3" "VULNERABLE" "user2 (no access to A) deleted A's publication via /publications/$VB/ (http=$DEL)"
+  else
+    verdict "P0-3" "SAFE" "cross-vault delete rejected; publication still present (http=$DEL)"
+  fi
+fi
+echo ""
+
+# ── P0-4: create_snapshot cross-vault ─────────────────────────────────
+echo "▸ P0-4: create_snapshot ignores vault binding (cross-vault execution)"
+read -r SLUG4 PID4 < <(create_pub "$VA" "{\"resource_type\":\"table_query\",\"query_sql\":\"SELECT label FROM items\",\"title\":\"snap-target\"}" "${AUTH1[@]}")
+if [ -z "$PID4" ]; then
+  echo "  (could not create target publication; skipping)"
+else
+  SNAP=$(curl -s --max-time 30 -o /dev/null -w "%{http_code}" -X POST \
+    "$AKB_URL/api/v1/publications/$VB/$PID4/snapshot" "${AUTH2[@]}")
+  # A vault-bound impl rejects the cross-vault publication with 404 BEFORE
+  # ever touching the query/S3. Anything else (200 success, or 400/500 from
+  # reaching the S3 step) means the vault binding was not enforced. Note the
+  # audit stack has no S3, so BEFORE this surfaces as a non-404 error.
+  if [ "$SNAP" = "404" ]; then
+    verdict "P0-4" "SAFE" "cross-vault snapshot rejected with 404 before execution"
+  else
+    verdict "P0-4" "VULNERABLE" "snapshot of A's publication via vault-B route was not vault-rejected (http=$SNAP; reached execution)"
+  fi
+fi
+echo ""
+
+# ── P1-3: collection-scoped search crashes on dropped f.collection ────
+echo "▸ P1-3: collection-scoped search references dropped vault_files.collection column"
+# a doc under a collection so the search has a corpus + a collection filter
+curl -s --max-time 20 -X POST "$AKB_URL/documents" "${AUTH1[@]}" "${JSON[@]}" \
+  -d "{\"vault\":\"$VA\",\"collection\":\"specs\",\"title\":\"sdoc\",\"content\":\"# searchable marker xyzzy\",\"type\":\"note\"}" >/dev/null
+SC=$(curl -s --max-time 20 -o /dev/null -w "%{http_code}" \
+  "$AKB_URL/api/v1/search?q=searchable&vault=$VA&collection=specs" "${AUTH1[@]}")
+if [ "$SC" = "500" ]; then
+  verdict "P1-3" "VULNERABLE" "search?collection= returned HTTP 500 (UndefinedColumn f.collection)"
+elif [ "$SC" = "200" ]; then
+  verdict "P1-3" "SAFE" "collection-scoped search returned HTTP 200"
+else
+  verdict "P1-3" "VULNERABLE" "unexpected http=$SC (expected 200 after fix)"
+fi
+echo ""
+
+# ── Cleanup ───────────────────────────────────────────────────────────
+curl -s --max-time 15 -X DELETE "$AKB_URL/api/v1/vaults/$VA" "${AUTH1[@]}" >/dev/null 2>&1 || true
+curl -s --max-time 15 -X DELETE "$AKB_URL/api/v1/vaults/$VB" "${AUTH2[@]}" >/dev/null 2>&1 || true
+
+echo "════════════════════════════════════════════"
+if [ "$VULN" -gt 0 ]; then
+  echo "  $VULN probe(s) VULNERABLE"
+else
+  echo "  All probes SAFE"
+fi
+echo "════════════════════════════════════════════"
+exit "$VULN"

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -335,3 +335,119 @@ async def test_inv7_delete_vault_no_orphan_chunks(pool, tmp_path, monkeypatch):
         "vector_delete_outbox should carry the three chunk ids forward "
         f"for the delete worker; got {outbox}"
     )
+
+
+# ── INV-7b: delete_vault file-chunk outbox with S3 CONFIGURED (P1-1) ─
+
+
+@pytest.mark.asyncio
+async def test_inv7b_delete_vault_file_outbox_with_s3(pool, tmp_path, monkeypatch):
+    """When S3 is configured, delete_vault deletes vault_files early (to
+    issue S3 object deletes), so the file-chunk outbox enqueue must read
+    the file ids BEFORE that delete — otherwise file chunks CASCADE out
+    of PG with no vector_delete_outbox row and orphan in the vector store.
+
+    The default-env inv7 test does not catch this because the audit stack
+    has no S3 (the early `DELETE FROM vault_files` branch is skipped). Here
+    we force S3 on and stub the adapter so the early delete runs.
+    """
+    from app.config import settings
+    from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
+    from app.services import access_service
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    monkeypatch.setattr(settings, "s3_endpoint_url", "http://stub-s3:9000")
+    # Stub the S3 adapter so the early per-file delete loop is a no-op.
+    from app.services.adapters import s3_adapter
+    monkeypatch.setattr(s3_adapter, "delete", lambda *_a, **_k: None)
+
+    try:
+        get_role_sync()
+    except RuntimeError:
+        set_role_sync(RoleSync(pool))
+
+    async with pool.acquire() as conn:
+        admin_id = await conn.fetchval(
+            "INSERT INTO users (id, username, email, password_hash, is_admin) "
+            "VALUES (gen_random_uuid(), $1, $2, 'x', true) RETURNING id",
+            f"inv7badm-{uuid.uuid4().hex[:6]}",
+            f"inv7badm-{uuid.uuid4().hex[:6]}@test.local",
+        )
+    vault_repo = VaultRepository(pool)
+    name = f"_inv7b_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name, description="inv7b", git_path=f"/tmp/{name}.git", owner_id=admin_id,
+    )
+
+    file_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_files (id, vault_id, name, s3_key, mime_type, size_bytes, created_at) VALUES "
+            "($1, $2, 'f.bin', $3, 'application/octet-stream', 0, NOW())",
+            file_id, vid, f"_inv7b_{file_id}",
+        )
+        await conn.execute(
+            "INSERT INTO chunks (id, source_type, source_id, vault_id, chunk_index, content) "
+            "VALUES (gen_random_uuid(), 'file', $1, $2, 0, 'f')",
+            file_id, vid,
+        )
+
+    await access_service.delete_vault(user_id=str(admin_id), vault_name=name)
+
+    async with pool.acquire() as conn:
+        post = await conn.fetchval(
+            "SELECT COUNT(*) FROM chunks WHERE source_id = $1", file_id,
+        )
+        outbox = await conn.fetchval(
+            "SELECT COUNT(*) FROM vector_delete_outbox WHERE source_id = $1", file_id,
+        )
+
+    assert post == 0, f"file chunk should be gone from PG, got {post}"
+    assert outbox == 1, (
+        "file chunk must be enqueued in vector_delete_outbox even when S3 is "
+        f"configured (vault_files deleted early); got {outbox}"
+    )
+
+
+# ── P1-2: FileService.delete must roll back on chunk-delete failure ──
+
+
+@pytest.mark.asyncio
+async def test_p1_2_file_delete_rolls_back_on_chunk_failure(pool, monkeypatch):
+    """FileService.delete wraps the chunk/outbox cleanup in the file-delete
+    transaction. If delete_file_chunks raises (e.g. a failed outbox
+    enqueue), the WHOLE delete must roll back — otherwise the vault_files
+    row + s3-delete enqueue commit while the chunk's vector point orphans.
+    Pre-fix the exception was swallowed and the delete committed anyway.
+    """
+    from app.services import file_service as fs_mod
+    from app.services.file_service import FileService
+
+    vault_repo = VaultRepository(pool)
+    name = f"_p12_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name, description="p12", git_path=f"/tmp/{name}.git", owner_id=None,
+    )
+    file_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_files (id, vault_id, name, s3_key, mime_type, size_bytes, created_at) VALUES "
+            "($1, $2, 'f.bin', $3, 'application/octet-stream', 0, NOW())",
+            file_id, vid, f"_p12_{file_id}",
+        )
+
+    # Force the chunk delete to blow up the way a failed outbox enqueue would.
+    async def _boom(*_a, **_k):
+        raise RuntimeError("simulated outbox enqueue failure")
+
+    monkeypatch.setattr(fs_mod, "delete_file_chunks", _boom)
+
+    with pytest.raises(Exception):
+        await FileService().delete(vid, str(file_id), actor_id="p12")
+
+    # The file row must survive — the transaction rolled back.
+    async with pool.acquire() as conn:
+        still = await conn.fetchval(
+            "SELECT COUNT(*) FROM vault_files WHERE id = $1", file_id,
+        )
+    assert still == 1, "file delete must roll back when chunk delete fails (was swallowed pre-fix)"

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -7,9 +7,26 @@ import { TitleBar, VaultActions, type VaultPageKind } from "@/components/title-b
 import { ErrorBoundary } from "@/components/error-boundary";
 import { VaultRefreshProvider } from "@/contexts/vault-refresh-context";
 
+// Tree (collection) column is drag-resizable. Width persists across
+// sessions in localStorage and is clamped so it can never collapse the
+// content column or overrun the viewport. Double-clicking the handle
+// resets to the default.
+const TREE_MIN = 180;
+const TREE_MAX = 560;
+const TREE_DEFAULT = 260;
+const TREE_WIDTH_KEY = "akb.treeWidth";
+
+function loadTreeWidth(): number {
+  if (typeof window === "undefined") return TREE_DEFAULT;
+  const saved = Number(window.localStorage.getItem(TREE_WIDTH_KEY));
+  return Number.isFinite(saved) && saved >= TREE_MIN && saved <= TREE_MAX
+    ? saved
+    : TREE_DEFAULT;
+}
+
 /**
  * 3-column vault workspace:
- *   [ 200px vault-nav | 260px tree | 1fr content ]
+ *   [ 200px vault-nav | <resizable> tree | 1fr content ]
  * Above them a 36px TitleBar with breadcrumb + VaultActions.
  * Each page renders into the Outlet and owns its inner layout (e.g. the
  * document page still decides where its right-rail outline goes).
@@ -18,6 +35,45 @@ export function VaultShell() {
   const { name } = useParams<{ name: string }>();
   const location = useLocation();
   const [visible, setVisible] = useState(true);
+  const [treeWidth, setTreeWidth] = useState<number>(loadTreeWidth);
+
+  // Persist the chosen width so it survives reloads and vault switches.
+  useEffect(() => {
+    window.localStorage.setItem(TREE_WIDTH_KEY, String(treeWidth));
+  }, [treeWidth]);
+
+  // Pointer-drag resize of the tree column. We capture the pointer on the
+  // handle so the drag keeps tracking even when the cursor leaves the thin
+  // hit area, and lock body cursor/selection for the duration.
+  const dragRef = useRef<{ startX: number; startW: number } | null>(null);
+  const onResizeStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      dragRef.current = { startX: e.clientX, startW: treeWidth };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [treeWidth],
+  );
+  const onResizeMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const next = Math.min(
+      TREE_MAX,
+      Math.max(TREE_MIN, drag.startW + (e.clientX - drag.startX)),
+    );
+    setTreeWidth(next);
+  }, []);
+  const onResizeEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
 
   // Tree defaults to open on every vault switch — clicking the active
   // vault row in the nav (or ⌘\) toggles it.
@@ -130,7 +186,7 @@ export function VaultShell() {
   // room by default. Members/settings/activity follow the same rule —
   // those are vault-level admin pages, not content browsing.
   const showTree = !isGraph && !isAdminPage && visible;
-  const gridCols = showTree ? "200px 260px 1fr" : "200px 1fr";
+  const gridCols = showTree ? `200px ${treeWidth}px 1fr` : "200px 1fr";
 
   return (
     <VaultRefreshProvider refetchTree={refetchTree} refetchVaults={refetchVaults}>
@@ -140,7 +196,7 @@ export function VaultShell() {
           right={<VaultActions vault={name} page={page} />}
         />
         <div
-          className="grid grid-cols-[var(--cols)] flex-1 min-h-0"
+          className="grid grid-cols-[var(--cols)] flex-1 min-h-0 relative"
           style={{ ["--cols" as any]: gridCols }}
         >
           <VaultNav
@@ -154,6 +210,23 @@ export function VaultShell() {
               vault={name}
               onRefetchReady={onTreeRefetchReady}
             />
+          )}
+          {showTree && (
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize collection tree"
+              onPointerDown={onResizeStart}
+              onPointerMove={onResizeMove}
+              onPointerUp={onResizeEnd}
+              onPointerCancel={onResizeEnd}
+              onDoubleClick={() => setTreeWidth(TREE_DEFAULT)}
+              title="Drag to resize · double-click to reset"
+              className="group absolute top-0 bottom-0 z-20 w-2 cursor-col-resize touch-none"
+              style={{ left: `calc(200px + ${treeWidth}px)`, transform: "translateX(-50%)" }}
+            >
+              <div className="mx-auto h-full w-px bg-border transition-colors group-hover:bg-accent group-active:bg-accent" />
+            </div>
           )}
           {/* Content column. The tree toggle lives here so it naturally
               sits on the outlet's left edge — next to the explorer when


### PR DESCRIPTION
## Summary

Security + data-integrity patch (backend 0.3.4) plus a small frontend UX feature. The backend findings came out of a full functional/logic review (20-subsystem multi-agent pass, 55 confirmed findings); this lands the highest-priority cut. Every backend fix was reproduced in the audit stack BEFORE the change and re-verified SAFE after. **No schema change, no migration.**

### Security — publication public surface (unauthenticated `/api/v1/public/{slug}`)
- **Public `table_query` ran as the privileged pool role** — `resolve_table_query_publication` executed the canned SQL on the service-role connection (only `SET TRANSACTION READ ONLY`, no `SET LOCAL ROLE`). Verified: an unauthenticated visitor could run `SELECT count(*) FROM users` → 59 rows, `SELECT current_user` → `akb`. Now runs under the creator's PG role (`akb_user_<created_by>`); 42501 for anything they couldn't read via `akb_sql`. Legacy pubs with no creator fail closed (403).
- **`query_vault_names` now fully authorized** (every referenced vault needs writer), not just the route vault.
- **`delete_publication` IDOR** — REST delete ignored the route vault; now `WHERE id=$1 AND vault_id=$2`, 404 otherwise.
- **`create_snapshot` cross-vault** — bound to the authorized vault, rejects with 404 before query/S3 (REST + MCP).

### Data integrity / correctness
- **`delete_vault` orphaned file-chunk vectors with S3 configured** — the 0.3.2 outbox enqueue ran after the early `DELETE FROM vault_files`, reading zero rows. File ids captured + enqueued before the delete. (The 0.3.2 unit test missed it because the audit stack has no S3.)
- **`FileService.delete` swallowed chunk-delete failures** — removed the try/except so a failed outbox enqueue rolls back the file delete (03-F1).
- **Collection-scoped search 500'd** — filtered on `vault_files.collection`, dropped in migration 020. Now joins `collections` on `collection_id` and prefix-matches `c.path`.

### Frontend
- Drag-resizable collection tree column (180–560px, localStorage-persisted, double-click reset). Rides this deploy; frontend has no separate version tag.

## Test plan
- [x] `repro_pub_security.sh`: P0-1/3/4 + P1-3 VULNERABLE → SAFE
- [x] `test_invariants_unit.py`: `test_inv7b` + `test_p1_2` (6/6)
- [x] `test_mcp_e2e.sh` 76/76, `test_invariants.sh` 9/9
- [x] Legit flows reverified (own-table view, authorized multi-vault publish 200, owner delete/snapshot)
- [x] vault-shell.tsx typechecks clean
- [ ] After merge: tag `backend-v0.3.4`, release, K8s deploy, prod E2E + repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)