### PR TITLE
fix(0.3.5): migration 026 conflict-safe + akb_link URI canonicalization

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,51 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.5 — 2026-05-28
+
+Permanently fixes the recurring migration-026 boot crash and stops new
+legacy-shape edges from being created. The 0.3.3 guard only skipped 026
+when no legacy doc URIs remained; it did not make the rewrite itself
+safe. Legacy edges kept being (re)created by an external caller, so
+every cold restart re-tripped the
+`edges_source_uri_target_uri_relation_type_key` UNIQUE violation and the
+backend crash-looped (twice now in production, each needing a manual DB
+cleanup).
+
+### Fix — migration 026 is now conflict-safe (F2)
+
+Before each rewrite of an `edges` URI column, 026 now DELETEs legacy
+rows whose canonical-rewritten form would collide with an existing row,
+preferring to keep the canonical row (or the smaller id among legacy
+twins). Applied to the doc-shape regex rewrite and the table/file
+temp-table rewrites, for both `source_uri` and `target_uri`. The
+migration is now idempotent AND conflict-safe regardless of the data
+state — verified by seeding a legacy↔canonical twin and running 026
+twice with no error. (This is the exact cleanup that previously had to
+be done by hand on every crash.)
+
+### Fix — `akb_link` stores canonical URIs (F1, root cause)
+
+`kg_service.link_resources` inserted the caller-supplied `source_uri` /
+`target_uri` verbatim. An external tool calling `akb_link` with a
+legacy-shaped but parseable URI (`akb://V/doc/{coll}/{name}`) therefore
+persisted a legacy edge, which 026 then collided on. Both endpoints are
+now canonicalized from their parsed parts (new
+`kg_service.canonicalize_resource_uri` helper) before insert, so the
+explicit-link path can no longer introduce legacy edges. (Edge
+extraction via `_store_edge` already canonicalized; this closes the
+remaining writer.)
+
+### Operator notes
+
+- No schema change.
+- After this release, a cold restart no longer crashes even if legacy
+  edges exist — 026 self-heals. Existing prod legacy edges are
+  rewritten/deduped on the next boot.
+- The external tool that was emitting legacy `akb://V/doc/{coll}/{name}`
+  link URIs (observed in the `pdf-parser-test` vault) should still be
+  updated to send canonical URIs; AKB now tolerates either.
+
 ## 0.3.4 — 2026-05-28
 
 Security + data-integrity patch. Findings came out of a full

--- a/backend/app/db/migrations/026_uri_collection_prefix.py
+++ b/backend/app/db/migrations/026_uri_collection_prefix.py
@@ -99,32 +99,54 @@ async def _run(conn):
         table_rewrites = 0
         file_rewrites = 0
 
+        # `edges` has UNIQUE (source_uri, target_uri, relation_type). A
+        # legacy row whose rewritten form already exists as a canonical
+        # twin (or as another legacy row that rewrites to the same key)
+        # would trip that constraint on the rewrite UPDATE. This migration
+        # re-runs on every boot (no schema_migrations table) and legacy
+        # edges can be (re)created by external tools, so the rewrite MUST
+        # be conflict-safe: drop colliding legacy edge rows BEFORE the
+        # rewrite, preferring to keep the canonical row (or the smaller id
+        # among legacy twins). publications/events have no such constraint.
+
+        DOC_WHERE = "~ '^akb://[^/]+/doc/[^/]+/[^/]+'"
+
+        def doc_canon(expr: str) -> str:
+            return (
+                f"regexp_replace({expr}, "
+                f"'^akb://([^/]+)/doc/(.+)/([^/]+)$', "
+                f"'akb://\\1/coll/\\2/doc/\\3')"
+            )
+
         # ─── DOC URIs ───────────────────────────────────────────
-        # Pure regex rewrite. Pattern: split on the LAST slash inside
-        # the path. PostgreSQL regex group references in
-        # regexp_replace use ``\N`` style.
-        #
-        #   akb://V/doc/{collection}/{basename}   →
+        #   akb://V/doc/{collection}/{basename} →
         #   akb://V/coll/{collection}/doc/{basename}
-        #
-        # If the path has no internal slash (root-level doc) the
-        # pattern doesn't match and the URI is left as-is.
-        for table_col in (
-            ("edges", "source_uri"),
-            ("edges", "target_uri"),
-            ("publications", "resource_uri"),
-            ("events", "resource_uri"),
-        ):
-            t, c = table_col
+        # Root-level docs (no internal slash) don't match and are left as-is.
+        for col in ("source_uri", "target_uri"):
+            other = "target_uri" if col == "source_uri" else "source_uri"
+            # Drop legacy rows that would collide post-rewrite.
+            await conn.execute(
+                f"""
+                DELETE FROM edges l
+                 WHERE l.{col} {DOC_WHERE}
+                   AND EXISTS (
+                     SELECT 1 FROM edges e
+                      WHERE e.id <> l.id
+                        AND e.relation_type = l.relation_type
+                        AND e.{other} = l.{other}
+                        AND {doc_canon('e.' + col)} = {doc_canon('l.' + col)}
+                        AND (
+                          e.{col} !~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+                          OR e.id < l.id
+                        )
+                   )
+                """
+            )
             result = await conn.execute(
                 f"""
-                UPDATE {t}
-                   SET {c} = regexp_replace(
-                         {c},
-                         '^akb://([^/]+)/doc/(.+)/([^/]+)$',
-                         'akb://\\1/coll/\\2/doc/\\3'
-                       )
-                 WHERE {c} ~ '^akb://[^/]+/doc/[^/]+/[^/]+'
+                UPDATE edges
+                   SET {col} = {doc_canon(col)}
+                 WHERE {col} {DOC_WHERE}
                 """
             )
             try:
@@ -132,82 +154,95 @@ async def _run(conn):
             except (ValueError, IndexError):
                 pass
 
-        # ─── TABLE URIs ─────────────────────────────────────────
-        # Build the canonical URI per (vault, table) pair, then UPDATE
-        # rows whose stored URI matches the legacy form.
-        await conn.execute(
-            """
-            CREATE TEMP TABLE _uri_table_rewrite ON COMMIT DROP AS
-            SELECT
-              'akb://' || v.name || '/table/' || t.name AS legacy_uri,
-              CASE WHEN c.path IS NOT NULL THEN
-                'akb://' || v.name || '/coll/' || c.path || '/table/' || t.name
-              ELSE
-                'akb://' || v.name || '/table/' || t.name
-              END AS new_uri
-              FROM vault_tables t
-              JOIN vaults v ON v.id = t.vault_id
-              LEFT JOIN collections c ON c.id = t.collection_id
-            """
-        )
-        # Skip no-op rewrites (root-level table — legacy already canonical)
-        await conn.execute("DELETE FROM _uri_table_rewrite WHERE legacy_uri = new_uri")
-
-        for t, c in (
-            ("edges", "source_uri"),
-            ("edges", "target_uri"),
-            ("publications", "resource_uri"),
-            ("events", "resource_uri"),
-        ):
+        for t, c in (("publications", "resource_uri"), ("events", "resource_uri")):
             result = await conn.execute(
-                f"""
-                UPDATE {t}
-                   SET {c} = r.new_uri
-                  FROM _uri_table_rewrite r
-                 WHERE {t}.{c} = r.legacy_uri
-                """
+                f"UPDATE {t} SET {c} = {doc_canon(c)} WHERE {c} {DOC_WHERE}"
             )
             try:
-                table_rewrites += int(result.split()[-1])
+                doc_rewrites += int(result.split()[-1])
             except (ValueError, IndexError):
                 pass
 
-        # ─── FILE URIs ──────────────────────────────────────────
-        await conn.execute(
-            """
-            CREATE TEMP TABLE _uri_file_rewrite ON COMMIT DROP AS
-            SELECT
-              'akb://' || v.name || '/file/' || f.id::text AS legacy_uri,
-              CASE WHEN c.path IS NOT NULL THEN
-                'akb://' || v.name || '/coll/' || c.path || '/file/' || f.id::text
-              ELSE
-                'akb://' || v.name || '/file/' || f.id::text
-              END AS new_uri
-              FROM vault_files f
-              JOIN vaults v ON v.id = f.vault_id
-              LEFT JOIN collections c ON c.id = f.collection_id
-            """
-        )
-        await conn.execute("DELETE FROM _uri_file_rewrite WHERE legacy_uri = new_uri")
-
-        for t, c in (
-            ("edges", "source_uri"),
-            ("edges", "target_uri"),
-            ("publications", "resource_uri"),
-            ("events", "resource_uri"),
-        ):
-            result = await conn.execute(
-                f"""
-                UPDATE {t}
-                   SET {c} = r.new_uri
-                  FROM _uri_file_rewrite r
-                 WHERE {t}.{c} = r.legacy_uri
+        # ─── TABLE / FILE URIs ──────────────────────────────────
+        # Build per-(vault, resource) legacy→canonical maps, then rewrite
+        # rows whose stored URI matches the legacy form. Same conflict-safe
+        # dance for edges.
+        for kind, tmp, build in (
+            (
+                "table",
+                "_uri_table_rewrite",
                 """
-            )
-            try:
-                file_rewrites += int(result.split()[-1])
-            except (ValueError, IndexError):
-                pass
+                SELECT 'akb://' || v.name || '/table/' || t.name AS legacy_uri,
+                       CASE WHEN c.path IS NOT NULL THEN
+                         'akb://' || v.name || '/coll/' || c.path || '/table/' || t.name
+                       ELSE 'akb://' || v.name || '/table/' || t.name END AS new_uri
+                  FROM vault_tables t
+                  JOIN vaults v ON v.id = t.vault_id
+                  LEFT JOIN collections c ON c.id = t.collection_id
+                """,
+            ),
+            (
+                "file",
+                "_uri_file_rewrite",
+                """
+                SELECT 'akb://' || v.name || '/file/' || f.id::text AS legacy_uri,
+                       CASE WHEN c.path IS NOT NULL THEN
+                         'akb://' || v.name || '/coll/' || c.path || '/file/' || f.id::text
+                       ELSE 'akb://' || v.name || '/file/' || f.id::text END AS new_uri
+                  FROM vault_files f
+                  JOIN vaults v ON v.id = f.vault_id
+                  LEFT JOIN collections c ON c.id = f.collection_id
+                """,
+            ),
+        ):
+            await conn.execute(f"CREATE TEMP TABLE {tmp} ON COMMIT DROP AS {build}")
+            await conn.execute(f"DELETE FROM {tmp} WHERE legacy_uri = new_uri")
+
+            n = 0
+            for col in ("source_uri", "target_uri"):
+                other = "target_uri" if col == "source_uri" else "source_uri"
+                await conn.execute(
+                    f"""
+                    DELETE FROM edges l USING {tmp} r
+                     WHERE l.{col} = r.legacy_uri
+                       AND EXISTS (
+                         SELECT 1 FROM edges e
+                          WHERE e.id <> l.id
+                            AND e.relation_type = l.relation_type
+                            AND e.{other} = l.{other}
+                            AND e.{col} = r.new_uri
+                       )
+                    """
+                )
+                result = await conn.execute(
+                    f"""
+                    UPDATE edges
+                       SET {col} = r.new_uri
+                      FROM {tmp} r
+                     WHERE edges.{col} = r.legacy_uri
+                    """
+                )
+                try:
+                    n += int(result.split()[-1])
+                except (ValueError, IndexError):
+                    pass
+
+            for t, c in (("publications", "resource_uri"), ("events", "resource_uri")):
+                result = await conn.execute(
+                    f"""
+                    UPDATE {t} SET {c} = r.new_uri
+                      FROM {tmp} r WHERE {t}.{c} = r.legacy_uri
+                    """
+                )
+                try:
+                    n += int(result.split()[-1])
+                except (ValueError, IndexError):
+                    pass
+
+            if kind == "table":
+                table_rewrites += n
+            else:
+                file_rewrites += n
 
     if doc_rewrites or table_rewrites or file_rewrites:
         logger.info(

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -135,6 +135,25 @@ async def delete_document_relations(conn, vault_name: str, doc_path: str) -> Non
 
 # ── Explicit link/unlink (agent-driven) ───────────────────────
 
+def canonicalize_resource_uri(parsed) -> str | None:
+    """Rebuild a doc/table/file URI in canonical 0.3.0 form from its parsed
+    parts. Returns None for non-linkable kinds (coll/vault).
+
+    Callers that accept a URI string from outside (akb_link, edge
+    extraction) MUST canonicalize before persisting, otherwise a
+    legacy-shaped but parseable URI (e.g. the pre-0.3.0
+    `akb://V/doc/{coll}/{name}` form) gets stored verbatim and later
+    trips migration 026's rewrite against its canonical twin."""
+    ident = parsed.identifier or ""
+    if parsed.kind == "doc":
+        return doc_uri(parsed.vault, ident)
+    if parsed.kind == "table":
+        return table_uri(parsed.vault, ident, parsed.coll_path)
+    if parsed.kind == "file":
+        return file_uri(parsed.vault, ident, parsed.coll_path)
+    return None
+
+
 async def link_resources(
     vault_name: str,
     source_uri: str,
@@ -175,6 +194,13 @@ async def link_resources(
     target_vault_name = target_parsed.vault
     target_type = target_parsed.kind
     target_id = target_parsed.identifier
+
+    # Canonicalize both endpoints from parsed parts so a legacy-shaped
+    # URI passed by an external caller is stored in 0.3.0 canonical form
+    # (akb://V/coll/<path>/<kind>/<id>) — not verbatim. Verbatim legacy
+    # edges are what migration 026 keeps colliding on at boot.
+    source_uri = canonicalize_resource_uri(source_parsed) or source_uri
+    target_uri = canonicalize_resource_uri(target_parsed) or target_uri
 
     if source_uri == target_uri:
         return {"error": "Cannot link a resource to itself"}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.4"
+version = "0.3.5"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Permanently fixes the **recurring migration-026 boot crash** that took prod down twice (each needing a manual DB cleanup). The 0.3.3 guard only *skipped* 026 when no legacy doc URIs remained — it never made the rewrite itself safe. Legacy edges keep being created by an external caller (observed in the `pdf-parser-test` vault), so every cold restart re-tripped `edges_source_uri_target_uri_relation_type_key` and the backend crash-looped.

### F2 — migration 026 is now conflict-safe
Before each rewrite of an `edges` URI column, 026 DELETEs legacy rows whose canonical-rewritten form would collide with an existing row, preferring to keep the canonical row (or the smaller id among legacy twins). Applied to the doc-shape regex rewrite and the table/file temp-table rewrites, for both `source_uri` and `target_uri`. **Verified**: seed a legacy↔canonical twin, run 026 twice → no error, collider deleted, canonical kept, clean legacy rewritten. This is the exact cleanup that previously had to be done by hand on every crash.

### F1 — root cause: `akb_link` stored legacy URIs verbatim
`kg_service.link_resources` inserted the caller-supplied `source_uri`/`target_uri` as-is. An external tool calling `akb_link` with a legacy-shaped but parseable URI (`akb://V/doc/{coll}/{name}`) persisted a legacy edge → 026 collision. Both endpoints are now canonicalized from their parsed parts (new `canonicalize_resource_uri` helper). **Verified**: `akb_link` with legacy URIs now stores the canonical `akb://V/coll/{coll}/doc/{name}` form.

No schema change. After this, a cold restart self-heals legacy edges instead of crashing.

## Test plan
- [x] 026 conflict-safe + idempotent (legacy↔canonical twin, double-run, no crash)
- [x] akb_link legacy URI → canonical edge (MCP integration)
- [x] test_mcp_e2e 76/76, repro_pub_security 4/4 SAFE, unit 6/6
- [ ] After merge: tag backend-v0.3.5, release, K8s deploy, prod cold-restart sanity

## Note for the external tool owner
The thing emitting legacy `akb://V/doc/{coll}/{name}` link URIs (pdf-parser-test) should still be updated to send canonical URIs; AKB now tolerates either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)