### PR TITLE
fix(0.3.6): archived read-only model + alter reserved cols + collection table cascade + embed index + publication cascade

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,93 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.6 — 2026-05-28
+
+The "P2" cut of the functional/logic review — four data-integrity /
+contract bugs plus one latent publication-cascade bug. Each was
+designed from a current-code blueprint (adversarially checked) and
+verified with a unit test. No schema change, no migration.
+
+### Archived vaults are now genuinely read-only (both directions fixed)
+
+The archive contract was broken in two opposing ways:
+- **Writes weren't blocked.** `check_vault_access` only enforced the
+  archived guard for `required_role == "writer"`, and the akb_sql write
+  surface gated at `reader` then relied on PG ACL — which has no archive
+  concept. A writer/admin/owner could still `INSERT/UPDATE/DELETE` (and
+  `drop_table`/`alter_table`) on an archived vault.
+- **Reads broke after reconcile.** `_reconcile_vault_roles` fetched only
+  non-archived vaults and then *dropped* every group role not in that
+  set, so on the next reconcile (startup + periodic) an archived vault's
+  reader role + table GRANTs were dropped and `akb_sql` SELECT returned
+  42501 for everyone incl. the owner. `_diff_vaults` used a different
+  vault set, so diff/reconcile never converged (`is_clean()` never True).
+
+One coherent model now: archived = READ-ONLY. The write block lives in
+the app layer — `execute_sql` rejects any non-SELECT against an archived
+referenced vault, and `check_vault_access`'s guard fires for `writer`
+AND `admin` (so create/alter/drop table are refused), positioned before
+the admin/owner short-circuits so even a system admin is blocked. PG
+write grants are intentionally preserved (so unarchive is instant), and
+the reconciler now keeps archived vaults' roles by fetching ALL vaults —
+matching `_diff_vaults`. `delete_vault` passes a new `allow_archived=True`
+so you can still delete an archived vault.
+
+### `alter_table` reserved-column guard
+
+`create_table` rejected `id`/`created_at`/`updated_at`/`created_by`, but
+`alter_table` didn't — so `drop_columns=["id"]` dropped the table's
+primary key, and `add_columns=[{name:"created_at",type:"text"}]` made
+the registry lie about a bookkeeping column's type. A shared
+`_validate_column_name` now guards add/drop/rename in both paths
+(reserved names + `^[a-z][a-z0-9_]*$` shape so the registry name can't
+diverge from its `safe_ident` PG identity), with the MCP handler
+surfacing the `ValueError` as a friendly error.
+
+### Collection delete handles tables
+
+`CollectionService.delete` enumerated only documents and files, never
+`vault_tables` — so a collection containing only a table passed the
+empty-mode check and was silently destroyed, and even recursive delete
+left the table (re-homed to vault root via `collection_id`
+ON DELETE SET NULL). It now lists tables under the prefix (`FOR UPDATE`),
+counts them in the empty-mode 409, and in recursive mode tears each one
+down (dynamic PG table + chunk outbox + registry row + edges) inside the
+same transaction, returning a `deleted_tables` count.
+
+### Embedding response paired by `index`, not array order
+
+`_embed_call` zipped the embeddings response to its inputs by position.
+The OpenAI embeddings contract pairs each output to its input via the
+item's `index` field; an OpenAI-compatible gateway that reassembles a
+batched response out of order would silently attach vectors to the wrong
+chunks. The response is now reordered by `index` with a completeness
+assertion (`{0..n-1}`); a malformed/gapped index set is treated as a
+transient error so the worker retries.
+
+### Fix: `delete_publications_for_document` UUID branch built a legacy URI
+
+When called with a doc UUID (vs a canonical URI), it materialized
+`akb://V/doc/{path}` (pre-0.3.0 legacy shape) which never matched the
+canonical `akb://V/coll/{coll}/doc/{name}` stored in
+`publications.resource_uri` — so the cascade silently left orphan
+publications. Now built via `doc_uri`. (Dormant — the only live caller
+passes a canonical URI and the real doc-delete path already uses
+`doc_uri` — but a latent landmine, now closed.)
+
+### Tests
+
+- `test_invariants_unit.py`: archived read-only (write blocked / read
+  works), alter reserved-column guard (PK survives), collection delete
+  table teardown + empty-mode reject, embed index reorder, and the
+  publication-cascade canonical match.
+- Modernized two stale `test_collection_*` cases that still inserted into
+  the `vault_files.collection` column dropped in migration 020.
+
+Regression: `test_mcp_e2e` 76/76, `test_pg_rbac_e2e` 50/50,
+`repro_pub_security` 4/4 SAFE, unit suite green. Archived-vault model
+verified end-to-end (read 200, write/DDL refused).
+
 ## 0.3.5 — 2026-05-28
 
 Permanently fixes the recurring migration-026 boot crash and stops new

--- a/backend/app/api/routes/collections.py
+++ b/backend/app/api/routes/collections.py
@@ -105,5 +105,6 @@ async def delete_collection(
                 "doc_count": exc.doc_count,
                 "file_count": exc.file_count,
                 "sub_collection_count": exc.sub_collection_count,
+                "table_count": exc.table_count,
             },
         )

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -627,6 +627,38 @@ class CollectionRepository:
         async with self.pool.acquire() as acq:
             return await _do(acq)
 
+    async def list_tables_under(
+        self,
+        vault_id: uuid.UUID,
+        path: str,
+        conn=None,
+    ) -> list[dict]:
+        """Return vault_tables whose owning collection path equals `path`
+        exactly or starts with `{path}/`. Covers the collection itself
+        plus every descendant — used by cascade delete to tear down
+        tables that live inside a collection (FK collection_id is
+        ON DELETE SET NULL, so the collection delete would otherwise
+        silently re-home them to vault root). Locked FOR UPDATE so a
+        concurrent drop/alter on the same table serialises.
+        """
+        bare = path.rstrip("/")
+        like = self._like_escape(bare) + "/%"
+        sql = (
+            "SELECT vt.id, vt.name, vt.collection_id, c.path AS collection "
+            "  FROM vault_tables vt "
+            "  JOIN collections c ON c.id = vt.collection_id "
+            " WHERE vt.vault_id = $1 "
+            "   AND (c.path = $2 OR c.path LIKE $3 ESCAPE '\\') "
+            " FOR UPDATE OF vt"
+        )
+        async def _do(c):
+            rows = await c.fetch(sql, vault_id, bare, like)
+            return [dict(r) for r in rows]
+        if conn is not None:
+            return await _do(conn)
+        async with self.pool.acquire() as acq:
+            return await _do(acq)
+
     async def list_collections_under(
         self,
         vault_id: uuid.UUID,

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -44,12 +44,18 @@ def validate_public_access(level: str) -> str:
 
 # ── Permission checks ───────────────────────────────────────
 
-async def check_vault_access(user_id: str, vault_name: str, required_role: str = "reader") -> dict:
+async def check_vault_access(
+    user_id: str, vault_name: str, required_role: str = "reader",
+    *, allow_archived: bool = False,
+) -> dict:
     """Check if user has at least the required role on a vault.
 
     Returns vault info dict if authorized.
     Raises ForbiddenError if not.
     Raises NotFoundError if vault doesn't exist.
+
+    `allow_archived` lets a destructive lifecycle op (delete_vault) run
+    on an archived vault; every normal mutating caller leaves it False.
     """
     pool = await get_pool()
     uid = uuid.UUID(user_id)
@@ -59,12 +65,21 @@ async def check_vault_access(user_id: str, vault_name: str, required_role: str =
         if not vault:
             raise NotFoundError("Vault", vault_name)
 
-        # Check archived vault FIRST — even admin/owner can't write to archived.
-        # Note: admin-role mutations like grant/revoke also block on archived,
-        # but that check lives inside grant_access/revoke_access themselves so
-        # owner-level operations (delete_vault, transfer_ownership, unarchive)
-        # that route through `required_role="admin"` can still proceed.
-        if vault["status"] == "archived" and required_role in ("writer",):
+        # Archived vault = READ-ONLY for EVERYONE incl. admin/owner. This
+        # guard sits BEFORE the is_admin / owner short-circuits below, so
+        # even a system admin or the owner is refused a mutation. It fires
+        # for any mutating-role request: 'writer' (put/update/table row
+        # writes) and 'admin' (drop_table / create_table / alter_table).
+        # PG ACL has no archive concept and we intentionally keep the
+        # write grants intact (so unarchive is instant) — the block lives
+        # here in the app layer. Owner-level lifecycle (unarchive,
+        # transfer_ownership) routes through required_role='owner', and
+        # delete_vault passes allow_archived=True (you archive then delete).
+        if (
+            not allow_archived
+            and vault["status"] == "archived"
+            and required_role in ("writer", "admin")
+        ):
             raise ForbiddenError(f"Vault '{vault_name}' is archived (read-only)")
 
         # External-git mirror vaults are read-only to every user (incl. owner).
@@ -775,7 +790,11 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
     from app.services.git_service import GitService
     from app.services.index_service import delete_vault_chunks
 
-    await check_vault_access(user_id, vault_name, required_role="admin")
+    # Deletion is a lifecycle op that must work on archived vaults (you
+    # archive, then delete) — bypass the archived read-only guard here.
+    await check_vault_access(
+        user_id, vault_name, required_role="admin", allow_archived=True,
+    )
     pool = await get_pool()
     async with pool.acquire() as conn:
         vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -15,15 +15,17 @@ import uuid
 
 from app.db.postgres import get_pool
 from app.exceptions import NotFoundError
-from app.repositories import vault_files_repo
+from app.repositories import table_data_repo, table_registry_repo, vault_files_repo
 from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
 from app.repositories.vault_repo import VaultRepository
 from app.services.git_service import GitService
-from app.services.index_service import delete_document_chunks, delete_file_chunks
+from app.services.index_service import (
+    delete_document_chunks, delete_file_chunks, delete_table_chunks,
+)
 from app.services.kg_service import delete_document_relations
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
-from app.services.uri_service import file_uri
+from app.services.uri_service import file_uri, table_uri
 
 logger = logging.getLogger("akb.collections")
 
@@ -53,6 +55,7 @@ class CollectionNotEmptyError(Exception):
         doc_count: int,
         file_count: int,
         sub_collection_count: int = 0,
+        table_count: int = 0,
     ):
         parts: list[str] = []
         if doc_count:
@@ -61,12 +64,15 @@ class CollectionNotEmptyError(Exception):
             parts.append(f"{file_count} file(s)")
         if sub_collection_count:
             parts.append(f"{sub_collection_count} sub-collection(s)")
+        if table_count:
+            parts.append(f"{table_count} table(s)")
         super().__init__(
             f"Collection has {', '.join(parts) or 'content'}"
         )
         self.doc_count = doc_count
         self.file_count = file_count
         self.sub_collection_count = sub_collection_count
+        self.table_count = table_count
 
 
 def _normalize_path(path: str) -> str:
@@ -219,6 +225,7 @@ class CollectionService:
         docs_count = 0
         files_count = 0
         sub_count = 0
+        tables_count = 0
         # Snapshot for the post-commit git cleanup. Captured inside
         # the TX (so the doc paths reflect exactly the rows we
         # deleted) and consumed after commit so the git call never
@@ -257,6 +264,11 @@ class CollectionService:
 
                 docs = await coll_repo.list_docs_under(vault_id, norm, conn=conn)
                 files = await coll_repo.list_files_under(vault_id, norm, conn=conn)
+                # Tables living in this collection (FK collection_id is
+                # ON DELETE SET NULL, so deleting the collection rows
+                # would otherwise silently re-home them to vault root and
+                # a table-only collection would pass the empty check).
+                tables = await coll_repo.list_tables_under(vault_id, norm, conn=conn)
 
                 # ── Total-empty check ───────────────────────────
                 # Nothing at or under the prefix → genuine 404.
@@ -265,15 +277,16 @@ class CollectionService:
                     and not sub_rows
                     and not docs
                     and not files
+                    and not tables
                 ):
                     raise NotFoundError("Collection", norm)
 
                 # ── Empty-mode reject ───────────────────────────
                 # `recursive=False` succeeds ONLY when the target row
                 # exists and nothing else lives under the prefix.
-                if not recursive and (sub_rows or docs or files):
+                if not recursive and (sub_rows or docs or files or tables):
                     raise CollectionNotEmptyError(
-                        len(docs), len(files), len(sub_rows),
+                        len(docs), len(files), len(sub_rows), len(tables),
                     )
 
                 # ── PG cleanup (same TX, locks still held) ──────
@@ -318,6 +331,22 @@ class CollectionService:
                     await _enqueue_s3_delete(conn, f["s3_key"])
                     await vault_files_repo.delete(conn, uuid.UUID(file_id))
 
+                # Tear down tables BEFORE the collection-row DELETE so
+                # the FK SET NULL never fires on a still-registered table.
+                # Mirror drop_table's internals (dynamic PG table + chunk
+                # outbox + registry row + edges) inside this TX so the
+                # table either disappears completely or not at all.
+                for t in tables:
+                    pg_name = table_data_repo.pg_table_name(vault, t["name"])
+                    await table_data_repo.drop_dynamic_table(conn, pg_name)
+                    await delete_table_chunks(conn, str(t["id"]))
+                    await table_registry_repo.delete(conn, t["id"])
+                    t_uri = table_uri(vault, t["name"], collection=t.get("collection"))
+                    await conn.execute(
+                        "DELETE FROM edges WHERE source_uri = $1 OR target_uri = $1",
+                        t_uri,
+                    )
+
                 # Delete the union of sub-collection ids and the
                 # target row (if it exists). Empty-mode success has
                 # no sub_rows and reaches here only when target_row
@@ -343,11 +372,13 @@ class CollectionService:
                         "deleted_docs": len(docs),
                         "deleted_files": len(files),
                         "deleted_sub_collections": len(sub_rows),
+                        "deleted_tables": len(tables),
                     },
                 )
                 docs_count = len(docs)
                 files_count = len(files)
                 sub_count = len(sub_rows)
+                tables_count = len(tables)
 
                 # Snapshot for post-commit git work.
                 doc_paths_for_git = [d["path"] for d in docs]
@@ -390,8 +421,8 @@ class CollectionService:
                 )
 
         logger.info(
-            "Collection delete: vault=%s path=%s docs=%d files=%d sub=%d",
-            vault, norm, docs_count, files_count, sub_count,
+            "Collection delete: vault=%s path=%s docs=%d files=%d sub=%d tables=%d",
+            vault, norm, docs_count, files_count, sub_count, tables_count,
         )
         return {
             "ok": True,
@@ -399,4 +430,5 @@ class CollectionService:
             "deleted_docs": docs_count,
             "deleted_files": files_count,
             "deleted_sub_collections": sub_count,
+            "deleted_tables": tables_count,
         }

--- a/backend/app/services/index_service.py
+++ b/backend/app/services/index_service.py
@@ -351,8 +351,27 @@ async def _embed_call(
 
     try:
         data = resp.json()
-        return "ok", [item["embedding"] for item in data["data"]], ""
-    except (KeyError, ValueError) as e:
+        items = data["data"]
+        # OpenAI /v1/embeddings pairs each output to its input via the
+        # item's `index` field, NOT array order. Some OpenAI-compatible
+        # gateways / load-balancers fan a batch out to replicas and
+        # reassemble responses out of order; zipping by position would
+        # then attach vectors to the wrong chunks (silent search
+        # corruption). Reorder by `index` and assert the index set is
+        # exactly {0..n-1} before returning a positionally-aligned list.
+        by_index: dict[int, list[float]] = {}
+        for item in items:
+            idx = item["index"]
+            if not isinstance(idx, int) or isinstance(idx, bool):
+                raise ValueError(f"non-int index {idx!r}")
+            if idx in by_index:
+                raise ValueError(f"duplicate index {idx}")
+            by_index[idx] = item["embedding"]
+        n = len(batch)
+        if set(by_index) != set(range(n)):
+            raise ValueError(f"index set {sorted(by_index)} != 0..{n - 1}")
+        return "ok", [by_index[i] for i in range(n)], ""
+    except (KeyError, ValueError, TypeError) as e:
         return "transient", None, f"malformed response: {e}"
 
 

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -474,15 +474,22 @@ async def delete_publications_for_document(document_id: uuid.UUID | str) -> int:
 
     Returns the number of publications deleted.
     """
+    from app.services.uri_service import doc_uri
     pool = await get_pool()
     async with pool.acquire() as conn:
         if isinstance(document_id, str) and document_id.startswith("akb://"):
             uri = document_id
         else:
-            # Materialize the URI from the PG UUID.
+            # Materialize the CANONICAL URI from the PG UUID. The old
+            # `'akb://' || v.name || '/doc/' || d.path` produced the
+            # pre-0.3.0 legacy shape (akb://V/doc/{coll}/{name}), which
+            # never matches the canonical publications.resource_uri
+            # (akb://V/coll/{coll}/doc/{name}) — so the cascade silently
+            # deleted nothing and left orphan publications. Build it via
+            # doc_uri so the DELETE actually matches.
             row = await conn.fetchrow(
                 """
-                SELECT 'akb://' || v.name || '/doc/' || d.path AS uri
+                SELECT v.name AS vault_name, d.path AS path
                   FROM documents d JOIN vaults v ON v.id = d.vault_id
                  WHERE d.id = $1
                 """,
@@ -490,7 +497,7 @@ async def delete_publications_for_document(document_id: uuid.UUID | str) -> int:
             )
             if not row:
                 return 0
-            uri = row["uri"]
+            uri = doc_uri(row["vault_name"], row["path"])
         rows = await conn.fetch(
             "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
             uri,

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -593,7 +593,16 @@ class RoleSync:
     async def _reconcile_vault_roles(
         self, conn: asyncpg.Connection, report: ReconcileReport,
     ) -> None:
-        rows = await conn.fetch("SELECT id, owner_id FROM vaults WHERE status != 'archived' OR status IS NULL")
+        # Archived vaults are READ-ONLY, not deleted: their group roles +
+        # table GRANTs MUST survive reconcile so akb_sql SELECT (and the
+        # 0.3.4 publication table_query, which runs under the creator's
+        # akb_user_* role) keeps working. The write block for archived
+        # vaults lives in the app layer (execute_sql / check_vault_access),
+        # NOT by dropping PG grants — so unarchive needs no re-grant. Only
+        # a real vault DELETE removes these roles (on_vault_delete). MUST
+        # use the SAME vault set as _diff_vaults (all vaults) or is_clean()
+        # never converges.
+        rows = await conn.fetch("SELECT id, owner_id FROM vaults")
         wanted: set[str] = set()
         for r in rows:
             for scope in ("reader", "writer", "admin"):
@@ -746,6 +755,10 @@ class RoleSync:
     async def _diff_vaults(
         self, conn: asyncpg.Connection, diff: RoleStateDiff,
     ) -> None:
+        # MUST use the same vault set as _reconcile_vault_roles — ALL
+        # vaults incl. archived (archived = read-only, roles preserved).
+        # If you ever filter here, mirror it there or is_clean() never
+        # converges (perpetual reconcile/diff flip-flop).
         rows = await conn.fetch("SELECT id FROM vaults")
         wanted: set[str] = set()
         for r in rows:

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -47,6 +47,33 @@ logger = logging.getLogger("akb.tables")
 # Reserved column names that conflict with auto-added bookkeeping columns.
 _RESERVED = {"id", "created_at", "updated_at", "created_by"}
 
+# Column-name shape — same grammar as table names. Enforced on
+# create AND alter so the value stored in the registry cannot diverge
+# from `safe_ident(name)` (which silently maps punctuation to `_`).
+_COLUMN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _validate_column_name(name) -> None:
+    """Reject reserved + malformed column names (raises ValueError).
+
+    Shared by create_table and alter_table so the two paths stay
+    consistent: reserved names collide with the auto-added bookkeeping
+    columns (id/created_at/updated_at/created_by), and the shape check
+    keeps the registry name identical to its `safe_ident` PG identity.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError("Column name must be a non-empty string.")
+    if name.lower() in _RESERVED:
+        raise ValueError(
+            f"Column name '{name}' is reserved (auto-added by AKB). "
+            f"Reserved names: {sorted(_RESERVED)}. Choose a different name."
+        )
+    if not _COLUMN_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid column name {name!r}: must match {_COLUMN_NAME_RE.pattern} "
+            f"(lowercase letter then letters/digits/underscores)."
+        )
+
 
 # ── Indexing helpers ─────────────────────────────────────────────
 
@@ -123,11 +150,7 @@ async def create_table(
                 raise ConflictError(f"Table already exists: {name}")
 
             for col in columns:
-                if col["name"].lower() in _RESERVED:
-                    raise ValueError(
-                        f"Column name '{col['name']}' is reserved (auto-added by AKB). "
-                        f"Reserved names: {sorted(_RESERVED)}. Choose a different name."
-                    )
+                _validate_column_name(col["name"])
 
             collection_id = None
             if collection_path:
@@ -328,6 +351,33 @@ async def alter_table(
             columns = table_registry_repo.parse_columns(table["columns"])
             pg_name = table_data_repo.pg_table_name(vault["name"], table_name)
 
+            # ── Guard rails (mirror create_table) ───────────────────
+            # Reject reserved/malformed names BEFORE any DDL so the whole
+            # alter is atomic: a bad name rolls back the TX with zero
+            # schema change. Covers dropping/renaming the implicit
+            # bookkeeping columns (id/created_at/updated_at/created_by) —
+            # those are exactly the _RESERVED set — so a client can no
+            # longer drop the PK or shadow a reserved name.
+            for col in (add_columns or []):
+                _validate_column_name(col["name"])
+            for col_name in (drop_columns or []):
+                if not isinstance(col_name, str) or not col_name:
+                    raise ValueError("Drop column name must be a non-empty string.")
+                if col_name.lower() in _RESERVED:
+                    raise ValueError(
+                        f"Column '{col_name}' is a reserved bookkeeping column "
+                        f"and cannot be dropped. Reserved: {sorted(_RESERVED)}."
+                    )
+            for old_name, new_name in (rename_columns or {}).items():
+                if not isinstance(old_name, str) or not old_name:
+                    raise ValueError("Rename source column must be a non-empty string.")
+                if old_name.lower() in _RESERVED:
+                    raise ValueError(
+                        f"Column '{old_name}' is a reserved bookkeeping column "
+                        f"and cannot be renamed. Reserved: {sorted(_RESERVED)}."
+                    )
+                _validate_column_name(new_name)
+
             added: list[str] = []
             dropped: list[str] = []
             renamed: dict[str, str] = {}
@@ -442,7 +492,8 @@ async def execute_sql(
         if ";" in sql_check:
             return {"error": "Multi-statement SQL is not allowed. Send one statement at a time."}
 
-        if not rewritten.strip().upper().startswith(_ALLOWED_FIRST_KEYWORDS):
+        upper = rewritten.strip().upper()
+        if not upper.startswith(_ALLOWED_FIRST_KEYWORDS):
             return {
                 "error": (
                     "Only SELECT / WITH / INSERT / UPDATE / DELETE are allowed via "
@@ -450,6 +501,27 @@ async def execute_sql(
                     "akb_drop_table for schema changes."
                 )
             }
+
+        # Archived vaults are READ-ONLY. PG ACL has no archive concept
+        # (write grants are intentionally preserved so unarchive is
+        # instant), so the write block lives here: a non-read statement
+        # (anything but SELECT/WITH) against ANY archived referenced
+        # vault is refused before it touches PG.
+        if not upper.startswith(("SELECT", "WITH")):
+            archived = await conn.fetch(
+                "SELECT name FROM vaults WHERE name = ANY($1::text[]) "
+                "AND status = 'archived'",
+                vault_names,
+            )
+            if archived:
+                names = ", ".join(sorted(r["name"] for r in archived))
+                return {
+                    "error": (
+                        f"Vault '{names}' is archived (read-only); writes via "
+                        f"akb_sql are not allowed. Unarchive the vault first."
+                    ),
+                    "code": "vault_archived",
+                }
 
     try:
         return await get_user_sql_executor().execute(

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -844,7 +844,7 @@ async def _handle_alter_table(args: dict, uid: str, user: _MCPUser) -> dict:
             drop_columns=args.get("drop_columns"),
             rename_columns=args.get("rename_columns"),
         )
-    except NotFoundError as e:
+    except (NotFoundError, ValueError) as e:
         return {"error": str(e)}
 
 
@@ -1111,6 +1111,7 @@ async def _handle_delete_collection(args: dict, uid: str, user: _MCPUser) -> dic
             "doc_count": exc.doc_count,
             "file_count": exc.file_count,
             "sub_collection_count": exc.sub_collection_count,
+            "table_count": exc.table_count,
         }
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.5"
+version = "0.3.6"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -451,3 +451,210 @@ async def test_p1_2_file_delete_rolls_back_on_chunk_failure(pool, monkeypatch):
             "SELECT COUNT(*) FROM vault_files WHERE id = $1", file_id,
         )
     assert still == 1, "file delete must roll back when chunk delete fails (was swallowed pre-fix)"
+
+
+# ── delete_publications_for_document UUID branch must match canonical URI ──
+
+
+@pytest.mark.asyncio
+async def test_delete_publications_for_document_uuid_canonical(pool):
+    """delete_publications_for_document(UUID) previously built a legacy
+    `akb://V/doc/{coll}/{name}` URI that never matched the canonical
+    `akb://V/coll/{coll}/doc/{name}` stored in publications.resource_uri,
+    so the cascade silently left orphan publications. The UUID branch now
+    builds the URI via doc_uri so the DELETE actually matches.
+    """
+    from app.services.publication_service import delete_publications_for_document
+
+    vault_repo = VaultRepository(pool)
+    name = f"_pubdel_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name, description="pubdel", git_path=f"/tmp/{name}.git", owner_id=None,
+    )
+    did = uuid.uuid4()
+    canonical = f"akb://{name}/coll/incidents/doc/report.md"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, 'incidents/report.md', 'r', 'report', 'draft', NOW(), NOW(), "
+            "'cafef00d', '{}'::text[], '{}'::jsonb)",
+            did, vid,
+        )
+        await conn.execute(
+            "INSERT INTO publications (id, slug, vault_id, resource_type, resource_uri, created_at) "
+            "VALUES (gen_random_uuid(), $1, $2, 'document', $3, NOW())",
+            f"slug{uuid.uuid4().hex[:6]}", vid, canonical,
+        )
+
+    deleted = await delete_publications_for_document(did)  # the UUID branch
+
+    async with pool.acquire() as conn:
+        remaining = await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE vault_id = $1", vid,
+        )
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+
+    assert deleted == 1, "UUID branch must materialize the canonical URI and match"
+    assert remaining == 0, "publication should be cascade-deleted, not orphaned"
+
+
+# ── P2: embedding response reordered by `index`, not array position ──
+
+
+@pytest.mark.asyncio
+async def test_p2_embed_index_reorder():
+    """_embed_call must pair each output to its input via the response
+    item's `index` field, not array order. A gateway that returns items
+    out of order would otherwise attach vectors to the wrong chunks.
+    """
+    from app.services import index_service
+
+    class _Resp:
+        status_code = 200
+        def __init__(self, payload):
+            self._p = payload
+        def json(self):
+            return self._p
+
+    class _Client:
+        def __init__(self, payload):
+            self._p = payload
+        async def post(self, *_a, **_k):
+            return _Resp(self._p)
+
+    # Response deliberately OUT OF ORDER (index 2, 0, 1).
+    payload = {"data": [
+        {"index": 2, "embedding": [2.0]},
+        {"index": 0, "embedding": [0.0]},
+        {"index": 1, "embedding": [1.0]},
+    ]}
+    status, embs, _ = await index_service._embed_call(_Client(payload), ["a", "b", "c"], 5.0)
+    assert status == "ok"
+    assert embs == [[0.0], [1.0], [2.0]], "vectors must be positionally aligned by index"
+
+    # A short / gapped index set is a malformed response → transient.
+    bad = {"data": [{"index": 0, "embedding": [0.0]}, {"index": 5, "embedding": [9.0]}]}
+    status2, embs2, _ = await index_service._embed_call(_Client(bad), ["a", "b"], 5.0)
+    assert status2 == "transient" and embs2 is None
+
+
+# ── P2: alter_table reserved-column guard ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2_alter_table_reserved_guard(pool):
+    from app.services import table_service
+    from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
+
+    set_role_sync(RoleSync(pool))
+
+    vault_repo = VaultRepository(pool)
+    name = f"_p2alter_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(name=name, description="x", git_path=f"/tmp/{name}.git", owner_id=None)
+    await get_role_sync().on_vault_create(vid, None)
+    await table_service.create_table(vid, "items", [{"name": "label", "type": "text"}], actor_id="t")
+
+    # dropping the PK must be rejected
+    with pytest.raises(ValueError):
+        await table_service.alter_table(vid, "items", actor_id="t", drop_columns=["id"])
+    # adding a reserved name must be rejected
+    with pytest.raises(ValueError):
+        await table_service.alter_table(vid, "items", actor_id="t",
+                                        add_columns=[{"name": "created_at", "type": "text"}])
+    # renaming onto a reserved name must be rejected
+    with pytest.raises(ValueError):
+        await table_service.alter_table(vid, "items", actor_id="t",
+                                        rename_columns={"label": "id"})
+    # the PK survives all rejected alters
+    async with pool.acquire() as conn:
+        has_id = await conn.fetchval(
+            "SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = 'id'",
+            table_service.table_data_repo.pg_table_name(name, "items"),
+        )
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+    assert has_id == 1, "PK column must still exist after rejected drop"
+
+
+# ── P2: archived vault is read-only via akb_sql ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2_archived_vault_blocks_writes(pool):
+    from app.services import table_service
+    from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
+    from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
+
+    set_role_sync(RoleSync(pool))
+    set_user_sql_executor(UserSqlExecutor(pool))
+
+    async with pool.acquire() as conn:
+        admin = await conn.fetchval(
+            "INSERT INTO users (id, username, email, password_hash, is_admin) "
+            "VALUES (gen_random_uuid(), $1, $2, 'x', true) RETURNING id",
+            f"p2a{uuid.uuid4().hex[:6]}", f"p2a{uuid.uuid4().hex[:6]}@t.local",
+        )
+    vault_repo = VaultRepository(pool)
+    name = f"_p2arch_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(name=name, description="x", git_path=f"/tmp/{name}.git", owner_id=admin)
+    await get_role_sync().on_vault_create(vid, admin)
+    await table_service.create_table(vid, "items", [{"name": "label", "type": "text"}], actor_id="t")
+    await table_service.execute_sql(vault_names=[name], user_id=str(admin),
+                                    sql="INSERT INTO items (label) VALUES ('a')", is_admin=True)
+
+    # archive the vault (status flip only, no role DDL — as archive_vault does)
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE vaults SET status = 'archived' WHERE id = $1", vid)
+
+    # WRITE must be blocked at the app layer
+    w = await table_service.execute_sql(vault_names=[name], user_id=str(admin),
+                                        sql="INSERT INTO items (label) VALUES ('b')", is_admin=True)
+    assert w.get("code") == "vault_archived", f"archived write should be blocked, got {w}"
+
+    # READ must still work
+    r = await table_service.execute_sql(vault_names=[name], user_id=str(admin),
+                                        sql="SELECT label FROM items", is_admin=True)
+    assert r.get("total") == 1, f"archived read should still work, got {r}"
+
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+
+
+# ── P2: collection delete handles tables ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2_collection_delete_handles_tables(pool):
+    from app.services import table_service
+    from app.services.collection_service import CollectionService, CollectionNotEmptyError
+    from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
+
+    set_role_sync(RoleSync(pool))
+
+    vault_repo = VaultRepository(pool)
+    name = f"_p2coll_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(name=name, description="x", git_path=f"/tmp/{name}.git", owner_id=None)
+    await get_role_sync().on_vault_create(vid, None)
+    # a table inside collection 'specs'
+    await table_service.create_table(vid, "items", [{"name": "label", "type": "text"}],
+                                     actor_id="t", collection="specs")
+
+    svc = CollectionService()
+    # non-recursive delete of a table-only collection must NOT silently succeed
+    with pytest.raises(CollectionNotEmptyError) as ei:
+        await svc.delete(vault=name, path="specs", recursive=False, agent_id="t")
+    assert ei.value.table_count == 1
+
+    # recursive delete actually drops the table (registry + dynamic table)
+    out = await svc.delete(vault=name, path="specs", recursive=True, agent_id="t")
+    assert out["deleted_tables"] == 1
+
+    async with pool.acquire() as conn:
+        reg = await conn.fetchval("SELECT COUNT(*) FROM vault_tables WHERE vault_id = $1", vid)
+        pg_tbl = await conn.fetchval(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1",
+            table_service.table_data_repo.pg_table_name(name, "items"),
+        )
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+    assert reg == 0, "registry row must be gone"
+    assert pg_tbl == 0, "dynamic PG table must be dropped"

--- a/backend/tests/test_collection_repo.py
+++ b/backend/tests/test_collection_repo.py
@@ -186,13 +186,23 @@ async def test_list_files_under_includes_folder_and_descendants(pool, vault_id):
             ("media-extra",  "decoy.png",   "k3"),
             ("other",        "other.png",   "k4"),
         ]:
+            # vault_files.collection (TEXT) was dropped in migration 020 →
+            # collection_id FK. Materialize the collection row, then link
+            # the file via collection_id.
+            coll_id = await conn.fetchval(
+                "INSERT INTO collections (id, vault_id, path, name) "
+                "VALUES (gen_random_uuid(), $1, $2, $3) "
+                "ON CONFLICT (vault_id, path) DO UPDATE SET name = EXCLUDED.name "
+                "RETURNING id",
+                vault_id, coll, coll.rsplit("/", 1)[-1],
+            )
             await conn.execute(
                 """
                 INSERT INTO vault_files
-                    (id, vault_id, collection, name, s3_key)
+                    (id, vault_id, collection_id, name, s3_key)
                 VALUES ($1, $2, $3, $4, $5)
                 """,
-                uuid.uuid4(), vault_id, coll, name, key,
+                uuid.uuid4(), vault_id, coll_id, name, key,
             )
 
     rows = await repo.list_files_under(vault_id, "media")

--- a/backend/tests/test_collection_service.py
+++ b/backend/tests/test_collection_service.py
@@ -295,6 +295,7 @@ async def test_delete_empty(service_with_fake_git, vault_name, pool, vault_id):
         "deleted_docs": 0,
         "deleted_files": 0,
         "deleted_sub_collections": 0,
+        "deleted_tables": 0,
     }
     # No docs => no git commit attempted.
     assert fake.calls == []
@@ -380,12 +381,18 @@ async def test_delete_cascade_removes_docs_files_row(
     # the vault_files / s3_delete_outbox path.
     file_id = uuid.uuid4()
     async with pool.acquire() as conn:
+        # vault_files.collection (TEXT) was dropped in migration 020 →
+        # collection_id FK. Resolve the 'drop-me' collection row.
+        coll_id = await conn.fetchval(
+            "SELECT id FROM collections WHERE vault_id = $1 AND path = $2",
+            vault_id, "drop-me",
+        )
         await conn.execute(
             """
-            INSERT INTO vault_files (id, vault_id, collection, name, s3_key)
+            INSERT INTO vault_files (id, vault_id, collection_id, name, s3_key)
             VALUES ($1, $2, $3, $4, $5)
             """,
-            file_id, vault_id, "drop-me", "logo.png", f"k/{file_id}",
+            file_id, vault_id, coll_id, "logo.png", f"k/{file_id}",
         )
 
     out = await service.delete(


### PR DESCRIPTION
## Summary

The **P2 cut** of the functional/logic review — four data-integrity / contract bugs plus one latent publication-cascade bug. Each was designed from a current-code blueprint (adversarially checked by a second agent) and unit-tested. **No schema change, no migration.**

### Archived vaults are now genuinely read-only (both directions)
- **Writes weren't blocked**: `execute_sql` now rejects any non-SELECT against an archived referenced vault, and `check_vault_access`'s archived guard fires for `writer` AND `admin` (before the admin/owner short-circuit) — so INSERT/UPDATE/DELETE + create/alter/drop table are refused for everyone incl. system-admin/owner.
- **Reads broke after reconcile**: `_reconcile_vault_roles` dropped archived vaults' group roles + table GRANTs. It now fetches ALL vaults (matching `_diff_vaults`, so `is_clean()` converges). PG write grants are intentionally kept (app layer blocks writes; unarchive is instant). `delete_vault` passes `allow_archived=True` to stay deletable.

### `alter_table` reserved-column guard
Shared `_validate_column_name` guards add/drop/rename in create+alter (reserved names + `^[a-z][a-z0-9_]*$` shape). `drop_columns=["id"]` can no longer drop the PK; the registry can't diverge from `safe_ident`.

### Collection delete handles tables
`CollectionService.delete` now lists `vault_tables` under the prefix (`FOR UPDATE`), counts them in the empty-mode 409, and recursively tears each down (dynamic table + chunk outbox + registry + edges) in-TX with a `deleted_tables` count. Previously a table-only collection passed the empty check and was silently destroyed; tables were re-homed to vault root via `collection_id` SET NULL.

### Embedding response paired by `index`, not array order
`_embed_call` reorders the response by each item's `index` (with a `{0..n-1}` completeness assert) so an out-of-order OpenAI-compatible gateway can't attach vectors to the wrong chunks. Gapped/duplicate index → transient retry.

### `delete_publications_for_document` UUID branch built a legacy URI
It materialized `akb://V/doc/{path}` (legacy) which never matched the canonical `publications.resource_uri` → orphan publications. Now uses `doc_uri`. (Dormant — only caller passes a canonical URI — but a latent landmine, closed.)

## Test plan
- [x] `test_invariants_unit.py`: archived read-only (write blocked / read works), alter guard (PK survives), collection table teardown + empty reject, embed index reorder, publication cascade
- [x] Modernized two stale `test_collection_*` cases (inserted into the dropped `vault_files.collection` column)
- [x] `test_mcp_e2e` 76/76, `test_pg_rbac_e2e` 50/50, `repro_pub_security` 4/4 SAFE
- [x] Archived-vault verified E2E (read 200, write/DDL refused)
- [ ] After merge: tag backend-v0.3.6, release, K8s deploy, prod verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)