### PR TITLE
chore: relicense to BSL 1.1 (backend) + MIT (proxy carve-out)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,15 @@ By submitting a contribution (pull request, patch, or any code/content
 addition) to this repository, you agree that:
 
 1. Your contribution is licensed to Dnotitia, Inc. and downstream users
-   under [PolyForm Noncommercial 1.0](./LICENSE) — the same terms as the
-   rest of the project.
+   under the license that applies to the directory you're contributing
+   to:
+   - Contributions to `packages/akb-mcp-client/` are licensed under the
+     [MIT License](./packages/akb-mcp-client/LICENSE).
+   - Contributions to every other directory (backend, frontend,
+     deployment manifests, eval, etc.) are licensed under the
+     [Business Source License 1.1](./LICENSE), including the
+     Additional Use Grant currently in effect and the automatic
+     conversion to the Change License (Apache 2.0) on the Change Date.
 2. You grant Dnotitia, Inc. and downstream users a perpetual, worldwide,
    non-exclusive, royalty-free, irrevocable patent license to make, use,
    sell, offer for sale, import, and otherwise transfer your contribution,

--- a/LICENSE
+++ b/LICENSE
@@ -1,137 +1,130 @@
-# PolyForm Noncommercial License 1.0.0
+Business Source License 1.1
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+License text copyright © 2023 MariaDB plc, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB plc.
 
-## Acceptance
+-----------------------------------------------------------------------------
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+Parameters
 
-## Copyright License
+Licensor:             Dnotitia, Inc.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose. However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+Licensed Work:        AKB (Agent Knowledge Base)
+                      The Licensed Work is © 2026 Dnotitia, Inc.
 
-## Distribution License
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided that your aggregate use across all
+                      deployments of the Licensed Work operated by you,
+                      your organization, and any organization you control,
+                      are controlled by, or are under common control with,
+                      is limited to fewer than 100 Named Seats.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software. Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+                      A "Named Seat" is a distinct user account that
+                      exists in the Licensed Work's `users` table at any
+                      point during a calendar month, counted across all
+                      vaults in a single deployment. Service accounts
+                      (accounts created for automated agents, bots, CI,
+                      or other non-human use) and accounts with no
+                      successful interactive login in the trailing 90
+                      days are excluded from the count. A natural person
+                      who holds accounts in multiple deployments counts
+                      once per deployment.
 
-## Notices
+                      Production use at or above 100 Named Seats, and
+                      any offering of the Licensed Work (modified or
+                      not) as a hosted, embedded, or rebranded service
+                      to third parties regardless of seat count, require
+                      a separate commercial license from the Licensor.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software. For example:
+Change Date:          Four years after the date that a given version of
+                      the Licensed Work is first publicly distributed by
+                      the Licensor. Each version of the Licensed Work
+                      has its own Change Date determined by its own
+                      first public distribution.
 
-> Required Notice: Copyright 2026 Dnotitia, Inc.
+Change License:       Apache License, Version 2.0
 
-## Changes and New Works License
+For information about alternative licensing arrangements for the
+Licensed Work, please contact support@dnotitia.com.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+Note: this License covers the AKB backend, frontend, deployment
+manifests, and other components in the parent repository. The npm
+package `akb-mcp` shipped from `packages/akb-mcp-client/` is licensed
+separately under the MIT License — see its package-local LICENSE
+file.
 
-## Patent License
+-----------------------------------------------------------------------------
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+Notice
 
-## Noncommercial Purposes
+Business Source License 1.1
 
-Any noncommercial purpose is a permitted purpose.
+Terms
 
-## Personal Uses
+The Licensor hereby grants you the right to copy, modify, create
+derivative works, redistribute, and make non-production use of the
+Licensed Work. The Licensor may make an Additional Use Grant, above,
+permitting limited production use.
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed
+Work under this License, whichever comes first, the Licensor hereby
+grants you rights under the terms of the Change License, and the rights
+granted in the paragraph above terminate.
 
-## Noncommercial Organizations
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or
+authorized resellers, or you must refrain from using the Licensed Work.
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+All copies of the original and modified Licensed Work, and derivative
+works of the Licensed Work, are subject to this License. This License
+applies separately for each version of the Licensed Work and the Change
+Date may vary for each version of the Licensed Work released by
+Licensor.
 
-## Fair Use
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original
+or modified form from a third party, the terms and conditions set forth
+in this License apply to your use of that work.
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+Any use of the Licensed Work in violation of this License will
+automatically terminate your rights under this License for the current
+and all other versions of the Licensed Work.
 
-## No Other Rights
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or
+logo of Licensor as expressly required by this License).
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED
+ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND
+CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION)
+WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, AND FITNESS FOR A
+PARTICULAR PURPOSE.
 
-## Patent Defense
+MariaDB hereby grants you permission to use this License's text to
+license your works, and to refer to it using the trademark "Business
+Source License", as long as you comply with the Covenants of Licensor
+below.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+Covenants of Licensor
 
-## Violations
+In consideration of the right to use this License's text and the
+"Business Source License" name and trademark, Licensor covenants to
+MariaDB, and to all other recipients of the licensed work being
+provided by Licensor:
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+1. To specify as the Change License the GPL Version 2.0 or any later
+   version, or a license that is compatible with GPL Version 2.0 or a
+   later version, where "compatible" means that software provided under
+   the Change License can be included in a program with software
+   provided under GPL Version 2.0 or a later version. Licensor may
+   specify additional Change Licenses without limitation.
 
-## No Liability
+2. To either: (a) specify an additional grant of rights to use that does
+   not impose any additional restriction on the right granted in this
+   License, as the Additional Use Grant; or (b) insert the text "None".
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+3. To specify a Change Date.
 
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
-
----
-
-Required Notice: Copyright 2026 Dnotitia, Inc.
-
-For commercial licensing inquiries, contact: opensource@dnotitia.com
+4. Not to modify this License in any other way.

--- a/LICENSE-CHANGE.md
+++ b/LICENSE-CHANGE.md
@@ -1,0 +1,171 @@
+# AKB License Change — PolyForm NC 1.0 → Business Source License 1.1
+
+**Effective**: starting with the next AKB release after this document
+lands on `main`. All prior releases remain under their original
+[PolyForm Noncommercial 1.0](https://polyformproject.org/licenses/noncommercial/1.0.0)
+terms.
+
+## Summary
+
+AKB is moving from **PolyForm Noncommercial 1.0** (which forbids any
+commercial use) to **Business Source License 1.1** with a **100 Named
+Seats** Additional Use Grant.
+
+Net effect for users: **the door opens**. Small commercial deployments
+that were previously forbidden are now explicitly permitted. The only
+case where a commercial license is required is at scale (≥100 seats) or
+when offering AKB as a service to third parties.
+
+Each release ships with a 4-year clock — on its Change Date that
+specific release converts automatically to **Apache License 2.0**.
+
+## What changes
+
+| | Before (PolyForm NC 1.0) | After (BSL 1.1) |
+|---|---|---|
+| Non-commercial use | Free | Free |
+| Personal / hobby / research | Free | Free |
+| Educational / public-research orgs | Free | Free |
+| Internal commercial use, <100 seats | **Forbidden** | **Free** |
+| Internal commercial use, ≥100 seats | Forbidden | Commercial license required |
+| Hosted service to third parties | Forbidden | Commercial license required |
+| Modification + redistribution | Free, must stay PolyForm NC | Free, must stay BSL 1.1 (until Change Date) |
+| Eventually becomes OSI-approved OSS? | No | **Yes** — Apache 2.0 four years after each release |
+
+## Why we changed
+
+The PolyForm NC was too restrictive in practice. It blocked legitimate
+small-team adopters (5-person startups, agency engineers wanting to
+self-host) who would never have shown up on our commercial radar
+anyway, and it conflated "agent-based knowledge management is mature
+enough to charge for" with "any commercial touch is forbidden".
+
+BSL 1.1 lets us keep the protection where it actually matters — at
+scale and against commercial hosting / rebranding — while removing
+friction for small teams who want to evaluate, deploy internally, and
+build on top of AKB.
+
+The 4-year convert-to-Apache-2.0 clause is a long-term commitment: any
+version of AKB we ship today is guaranteed to be under a permissive
+OSI-approved license within four years, no further action required.
+That clause is irreversible — we cannot retract it on a given release
+once that release is out.
+
+## The 100 Named Seats line
+
+The Additional Use Grant in the [LICENSE](./LICENSE) is the
+load-bearing text. This section explains the intent in plain language.
+**If the two ever conflict, the LICENSE wins.**
+
+A **Named Seat** is one distinct user account in your AKB deployment's
+`users` table. We count:
+
+- ✅ Human user accounts (interactive login accounts)
+- ❌ Service accounts (bots, CI, automation agents)
+- ❌ Accounts with no successful login in the trailing 90 days
+
+The count is **per deployment**, not per company. A company running
+two separate AKB deployments (e.g. one for engineering, one for
+support) with 80 seats each is fine — neither deployment crosses 100.
+
+The same human person counted across multiple deployments is counted
+once per deployment, not deduplicated.
+
+### Why "Named Seats" and not MAU or revenue
+
+- **Machine-checkable** — anyone (operator or licensor) can run
+  `SELECT COUNT(*) FROM users WHERE ...` and get the answer. No
+  arguments about what "active" means.
+- **Stable** — doesn't depend on whether your business model is paid
+  or free, ad-supported or subscription, profit or non-profit.
+- **Hard to game without lying** — sharing one account across many
+  humans violates intent; we trust good-faith counting.
+
+### What counts as a separate "deployment"
+
+A deployment is one running AKB stack with its own `users` table —
+typically one Postgres database, one bare-repo store, and one set of
+backend/frontend pods. Two deployments that share a database are one
+deployment.
+
+This is a deliberate choice: it means a fork that runs a single
+AKB instance for a large user base needs a commercial license, but
+an organization that genuinely runs many small isolated instances is
+not penalized.
+
+## Examples
+
+| Scenario | Verdict |
+|---|---|
+| Solo founder running AKB for personal notes | Free |
+| 12-person startup running internal AKB for engineering docs | Free |
+| University research lab, 40 grad students | Free |
+| 80-person company running AKB across engineering + ops | Free |
+| 250-person company running AKB for all employees | **Commercial license required** |
+| SaaS provider offering "managed AKB" to clients | **Commercial license required** (regardless of seat count) |
+| OSS project running AKB on a community-facing instance | Free if <100 named seats; talk to us if larger |
+| Fork called "MyKB" with 500 users | **Commercial license required** + must rename (see [TRADEMARKS.md](./TRADEMARKS.md)) |
+
+## What's NOT covered by BSL 1.1
+
+The npm `akb-mcp` proxy (`packages/akb-mcp-client/`) is and stays
+**MIT-licensed**. It's a thin stdio ↔ HTTP forwarder designed to be
+embedded inside arbitrary MCP-aware agent clients (Claude Code,
+Cursor, Windsurf, custom agents). Keeping it MIT removes any
+friction for those embedders — anyone can vendor or redistribute the
+proxy without worrying about seat counts or Change Dates.
+
+The BSL 1.1 terms apply to the AKB backend (the actual knowledge
+base), the frontend, the deployment manifests, and the rest of the
+repo. The 100 Named Seats threshold attaches to a running AKB
+backend, not to client installations.
+
+## What stays the same
+
+- **Trademarks** — [TRADEMARKS.md](./TRADEMARKS.md) is unchanged. The
+  AKB / Dnotitia / Seahorse names and logos remain trademarks of
+  Dnotitia, Inc. and are not licensed via BSL or Apache 2.0.
+- **Contributor terms** — `CONTRIBUTING.md` already pre-authorized this
+  change in §3 (relicensing). Existing contributors do not need to
+  re-sign anything. New contributions will land under BSL 1.1.
+- **Past releases** — every version released under PolyForm NC remains
+  under PolyForm NC for the copies already out there. We do not
+  retroactively relicense old releases.
+
+## Frequently asked
+
+**Is BSL "open source"?** No, not under the OSI definition. It's
+"source-available" until the Change Date, then it becomes OSI-approved
+Apache 2.0. We follow the same convention as HashiCorp, MariaDB,
+Sentry, Couchbase, Materialize.
+
+**Can I modify and redistribute?** Yes — same as before. You must keep
+the BSL 1.1 license intact on your modified copy (you cannot relicense
+it under MIT, for example, until the original Change Date is reached).
+
+**Can my fork remove the 100-seat cap?** No. The Additional Use Grant
+is fixed by the Licensor (Dnotitia). Forks inherit the same terms.
+
+**Will the seat threshold change?** It might in future versions of
+AKB. Each released version is locked to the threshold in effect at
+release time — we cannot raise the threshold for a release that's
+already out (we can only make it more permissive, not stricter).
+
+**What if I cross 100 seats mid-deployment?** Contact us before you
+cross. We won't try to ambush you — the intent is to convert organic
+growth into a conversation, not to sue.
+
+**Will AKB ever go back to "fully open"?** Yes, automatically, on each
+release's Change Date (release date + 4 years). That conversion to
+Apache 2.0 is irrevocable.
+
+**Why not just MIT / Apache from day one?** Because once code is
+permissively licensed, anyone (including a well-capitalized competitor)
+can take it, rebrand it, host it, and undercut the people maintaining
+it. The 4-year BSL window funds the maintenance that gets each release
+to its Apache 2.0 conversion.
+
+## Contact
+
+Commercial licensing, the rationale here, or trademark permission
+requests: **support@dnotitia.com**.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > graph. Drop-in alternative to Confluence / Notion for Claude Code, Cursor,
 > Windsurf, and any MCP-aware agent.
 
-[![License: PolyForm NC](https://img.shields.io/badge/license-PolyForm%20NC%201.0-blue.svg)](./LICENSE)
+[![License: BSL 1.1](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](./LICENSE)
 [![npm: akb-mcp](https://img.shields.io/npm/v/akb-mcp.svg?label=npm%3A%20akb-mcp)](https://www.npmjs.com/package/akb-mcp)
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-orange.svg)](https://modelcontextprotocol.io)
 
@@ -305,24 +305,40 @@ semver lifecycle and is **not** tied to the product version.
 
 ## License
 
-[PolyForm Noncommercial 1.0](./LICENSE) — free for noncommercial use,
-modification, and distribution within the license's noncommercial scope.
-Attribution required.
+The AKB backend, frontend, and deployment manifests are licensed under
+the [Business Source License 1.1](./LICENSE) — source-available, with
+an Additional Use Grant that permits production use (commercial or
+non-commercial) up to a seat-count threshold, automatically converting
+to **Apache License 2.0** four years after each version's first public
+release.
+
+The npm `akb-mcp` proxy (`packages/akb-mcp-client/`) is separately
+licensed under the **MIT License** so it can be freely embedded in any
+agent client without restriction.
+
+**Free production use of the backend** — you may deploy AKB in
+production, commercial or not, provided your aggregate deployment
+serves **fewer than 100 Named Seats** (distinct human user accounts in
+the `users` table, per deployment; service accounts and
+90-day-inactive accounts excluded — see [LICENSE](./LICENSE) for the
+precise definition).
+
+**Commercial license required** for any of:
+
+- Production use of the backend at or above 100 Named Seats.
+- Offering AKB (modified or not) as a hosted service, on-premises
+  product, embedded component, or rebranded distribution to third
+  parties — regardless of seat count.
 
 **Trademarks** — "AKB", "Dnotitia", and "Seahorse" are trademarks of
 Dnotitia, Inc. The software license does not grant trademark rights.
 Forks and derivative works must be distributed under a different name.
 See [TRADEMARKS.md](./TRADEMARKS.md).
 
-**Commercial use** — a commercial license is required to:
-
-- Deploy AKB in any for-profit company's internal or production systems.
-- Offer AKB (modified or not) as a hosted service, on-premises product,
-  embedded component, or rebranded distribution to third parties.
-- Bundle AKB into a commercial product or service.
-
-For commercial licensing or trademark permission requests, contact
-**opensource@dnotitia.com**.
+For commercial licensing, the rationale behind the BSL transition, or
+trademark permission requests, see
+[LICENSE-CHANGE.md](./LICENSE-CHANGE.md) or contact
+**support@dnotitia.com**.
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you've found a security issue in AKB, please report it privately — do
 **not** open a public GitHub issue.
 
-Email **security@dnotitia.com** with:
+Email **support@dnotitia.com** with subject prefix `[SECURITY]` and the following:
 
 - A description of the issue and its impact.
 - Steps to reproduce (proof-of-concept code is welcome).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,8 +1,8 @@
 # AKB Trademarks
 
 "AKB", the AKB logo, "Dnotitia", and "Seahorse" are trademarks of
-**Dnotitia, Inc.** The [PolyForm Noncommercial 1.0](./LICENSE) license
-covers the *software* — it grants **no trademark rights**.
+**Dnotitia, Inc.** The [Business Source License 1.1](./LICENSE) covers
+the *software* — it grants **no trademark rights**.
 
 The license restricts what you can DO with the software.
 The trademark restricts what you can CALL it.
@@ -16,7 +16,7 @@ These are separate legal layers — both apply.
   for storage" — when accurate.
 - Linking to the upstream project as "AKB" in documentation.
 - Distributing unmodified copies under their original name within the
-  noncommercial use grant of the license.
+  Additional Use Grant of the license.
 
 ### Not permitted (without prior written permission from Dnotitia, Inc.)
 
@@ -44,9 +44,10 @@ name creates confusion about who maintains it, who is responsible for
 security fixes, and whose roadmap it follows. The trademark policy
 keeps that signal honest.
 
-The license deliberately keeps software freedom (modify, fork, redistribute
-within the noncommercial grant) separate from name rights (these stay
-with the trademark owner). This is the same pattern used by the Linux
+The license deliberately keeps software freedom (modify, fork,
+redistribute within the BSL's Additional Use Grant, and eventually
+under the Change License) separate from name rights (these stay with
+the trademark owner). This is the same pattern used by the Linux
 Foundation for "Linux", Mozilla for "Firefox" (which is why Debian
 historically shipped "Iceweasel"), and the Apache Software Foundation
 for project names.
@@ -54,4 +55,4 @@ for project names.
 ## Questions or permission requests
 
 For trademark questions or to request written permission, contact
-**opensource@dnotitia.com**.
+**support@dnotitia.com**.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,24 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.4.0 — 2026-06-02
+
+License change: **PolyForm Noncommercial 1.0 → Business Source License
+1.1**. No runtime contract change; this release exists to mark the
+license transition cleanly.
+
+The BSL 1.1 ships with a 100 Named Seats Additional Use Grant — small
+commercial deployments that were previously forbidden are now
+explicitly permitted, while large-scale or third-party-hosting use
+still requires a commercial license. Each release converts
+automatically to Apache License 2.0 four years after its first public
+distribution.
+
+See [LICENSE](../LICENSE) for the load-bearing text and
+[LICENSE-CHANGE.md](../LICENSE-CHANGE.md) for the rationale and FAQ.
+
+Releases ≤ 0.3.6 remain under PolyForm NC 1.0 as originally distributed.
+
 ## 0.3.6 — 2026-05-28
 
 The "P2" cut of the functional/logic review — four data-integrity /

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.6"
+version = "0.4.0"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/eval/agentic-bench/README.md
+++ b/eval/agentic-bench/README.md
@@ -155,5 +155,6 @@ If you fork this for your own domain, you'll write your own
 
 ## License
 
-PolyForm Noncommercial 1.0.0 — same as the parent `dnotitia/akb`
-repository. See [LICENSE](../../LICENSE).
+Business Source License 1.1 — same as the parent `dnotitia/akb`
+repository. See [LICENSE](../../LICENSE) and
+[LICENSE-CHANGE.md](../../LICENSE-CHANGE.md).

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.0.3 — make MIT licensing explicit
+
+No code change. The proxy has always declared `"license": "MIT"` in
+`package.json`, but the only `LICENSE` file in the repo was the root
+PolyForm NC (and now BSL 1.1) covering the AKB backend — leaving the
+proxy's actual license ambiguous to anyone reading the source.
+
+This release ships a package-local `LICENSE` file with the MIT text,
+so the npm tarball is self-contained and the proxy is unambiguously
+MIT regardless of how the repo at large is licensed.
+
+**Why the proxy stays fully open while the backend moved to BSL 1.1**:
+the proxy is a thin stdio ↔ HTTP forwarder meant to be embedded inside
+arbitrary MCP-aware agent clients (Claude Code, Cursor, Windsurf,
+custom agents, etc.). MIT removes any friction for those embedders.
+The AKB backend — the actual knowledge base — is where the BSL
+protection applies. See the root [LICENSE-CHANGE.md](../../LICENSE-CHANGE.md)
+for the rationale on the backend transition.
+
 ## 2.0.2 — bump default request timeout (30s → 5min)
 
 Bug fix: the proxy's per-request timeout was hardcoded to 30s, which

--- a/packages/akb-mcp-client/LICENSE
+++ b/packages/akb-mcp-client/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 Dnotitia, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Note: this MIT license covers ONLY the `akb-mcp` stdio proxy package
+shipped from this directory. The AKB backend, frontend, and other
+components in the parent repository are licensed under the Business
+Source License 1.1 — see the root `LICENSE` and `LICENSE-CHANGE.md`.
+
+The proxy is intentionally MIT so it can be freely embedded, vendored,
+or redistributed inside any MCP-aware agent client without restriction.

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {
     "akb-mcp": "./bin/akb-mcp.mjs"


### PR DESCRIPTION
## Summary

- **Backend / frontend / deploy manifests** → [Business Source License 1.1](./LICENSE) with a **100 Named Seats** Additional Use Grant; each release auto-converts to **Apache License 2.0** four years after first public distribution.
- The npm **`akb-mcp` proxy** stays **MIT** (`packages/akb-mcp-client/LICENSE`, new) — it's a thin embedder-friendly forwarder; BSL protection belongs on the backend.
- Backend `0.3.3 → 0.4.0` (license-only bump); proxy `2.0.2 → 2.0.3` (no runtime change; license metadata made consistent — `package.json` says MIT and the npm tarball now ships its own LICENSE).
- All contact channels (commercial licensing, trademark, security) unified to `support@dnotitia.com` — the other inboxes weren't actually monitored.

See [`LICENSE-CHANGE.md`](./LICENSE-CHANGE.md) for the full rationale + FAQ (why BSL, what the 100-seat line means, what stays the same, edge cases).

## Why this is safe

- `CONTRIBUTING.md` §3 pre-authorized Dnotitia to relicense all contributions — no per-contributor outreach needed. The one external contributor (#65, #67) merged after CONTRIBUTING.md landed, so they're bound by §3.
- Direction is **less restrictive**: PolyForm NC forbade all commercial use; BSL 1.1 with the AUG permits commercial use up to 100 Named Seats. Existing users gain rights; nobody loses any.
- Past releases (≤ 0.3.3) stay under PolyForm NC as originally distributed — we don't retroactively relicense.

## Test plan

- [x] Grep sweep — no `PolyForm` / `Noncommercial` leftovers in tracked files.
- [x] All `@dnotitia.com` contact lines resolve to `support@`.
- [x] `packages/akb-mcp-client/package.json` `"license": "MIT"` matches the new package-local `LICENSE`.
- [x] Root `LICENSE` is BSL 1.1 with Licensor=Dnotitia, AUG=<100 Named Seats, Change Date=release+4yr, Change License=Apache 2.0.
- [x] `backend/pyproject.toml` bumped to `0.4.0`; backend `CHANGELOG.md` has the corresponding entry.
- [x] `packages/akb-mcp-client/package.json` bumped to `2.0.3`; proxy `CHANGELOG.md` explains the metadata fix.
- [ ] Smoke-test: backend container still boots (no runtime code change so this should be a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)