### PR TITLE
fix(0.4.1): document write pool deadlock — one connection per writer

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,49 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.3.7 — 2026-06-02
+
+Connection-pool deadlock on the document write paths under a concurrent
+write burst. Reproduced from an external "E01 multi-vault knowledge
+burst" report (100 PUT + 300 GET returned transport-level "status 0").
+
+### Document writes deadlocked the pool at ≥ `pool_size` concurrent writers
+
+`put`/`update`/`edit`/`delete` each acquired **two** pool connections at
+once: `_path_lock()` held one connection (`lock_conn`, inside a
+transaction holding the `pg_advisory_xact_lock`) for the whole critical
+section, and the body then did a **second** `pool.acquire()` for the
+chunks/relations/events transaction. With `max_size=20`, once 20
+concurrent writers each held a lock connection and then all waited for a
+second connection, none could free one — a textbook hold-and-wait
+deadlock. It only broke when PG's `idle_in_transaction_session_timeout`
+(60s) killed the idle lock transactions, so clients saw 60s hangs →
+`ReadTimeout`. `/livez` stayed green the whole time (it touches neither
+the pool nor the event loop), which is why the failure hid from health
+checks. Reads were collateral: every DB-touching request starved while
+the 20 connections sat frozen.
+
+The trigger is just **20 simultaneous writes to one pod** — a realistic
+bar (a bulk import, or ~20 agents), not only a synthetic stress test.
+
+Fix: each writer now holds **exactly one** pool connection. `_path_lock`
+yields its connection and every DB statement of the critical section
+(conflict pre-check, `get_or_create`, `create`/`update`, chunks,
+relations, events, publication cascade, doc-row delete, collection
+count) runs on that one connection's transaction. `document_repo`'s
+`create`/`update`/`update_hash` gained a `conn=` parameter
+(backward-compatible) so they reuse the caller's connection instead of
+acquiring their own. The pool is now a clean backpressure queue: the
+21st concurrent writer waits for a free connection instead of
+deadlocking. As a bonus, each write is now fully atomic in one
+transaction (doc row + chunks + edges + events commit or roll back
+together). No schema change, no migration.
+
+Verified: a 100-PUT + 300-GET multi-vault burst that returned 0/100 PUT
+and 2/300 GET before now returns 100/100 and 300/300; `test_mcp_e2e`
+76/76, `test_edit_e2e` 37/37, `test_concurrency_repro_e2e` 22/22. Repro
+harness lives at `backend/tests/concurrency/repro_e01_multivault.py`.
+
 ## 0.3.6 — 2026-05-28
 
 The "P2" cut of the functional/logic review — four data-integrity /

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -56,11 +56,14 @@ class DocumentRepository:
         hash_algorithm: str,
         tags: list[str],
         metadata: dict,
+        *,
+        conn=None,
     ) -> uuid.UUID:
         doc_id = uuid.uuid4()
-        async with self.pool.acquire() as conn:
+
+        async def _insert(c):
             try:
-                await conn.execute(
+                await c.execute(
                     """
                     INSERT INTO documents
                         (id, vault_id, collection_id, path, title, doc_type, status,
@@ -79,6 +82,18 @@ class DocumentRepository:
                 # (vault_id, path) is the only UNIQUE constraint that callers
                 # can collide on. Surface it as a 409 instead of a 500.
                 raise ConflictError(f"Document already exists at path: {path}") from e
+
+        # When `conn` is supplied, run on the caller's connection/TX so a
+        # put can hold ONE pool connection for its whole critical section
+        # (advisory lock + create + chunks). Acquiring a *second* connection
+        # here while the caller still holds its lock connection is what
+        # deadlocked the pool under a write burst: ≥ pool_size concurrent
+        # writers each held one conn and waited for a second that never freed.
+        if conn is not None:
+            await _insert(conn)
+        else:
+            async with self.pool.acquire() as c:
+                await _insert(c)
         return doc_id
 
     # Document lookup keys: PG UUID or exact path. MCP / REST handlers
@@ -147,10 +162,9 @@ class DocumentRepository:
         hash_algorithm: str | None = None,
         content_hash_commit: str | None = None,
         tags: list[str] | None = None,
+        conn=None,
     ) -> None:
-        async with self.pool.acquire() as conn:
-            await conn.execute(
-                """
+        sql = """
                 UPDATE documents SET
                     title = COALESCE($1, title),
                     doc_type = COALESCE($2, doc_type),
@@ -164,10 +178,14 @@ class DocumentRepository:
                     content_hash_commit = COALESCE($10, content_hash_commit),
                     tags = COALESCE($11, tags)
                 WHERE id = $12
-                """,
-                title, doc_type, status, summary, domain, now, commit_hash,
-                content_hash, hash_algorithm, content_hash_commit, tags, doc_id,
-            )
+                """
+        args = (title, doc_type, status, summary, domain, now, commit_hash,
+                content_hash, hash_algorithm, content_hash_commit, tags, doc_id)
+        if conn is not None:
+            await conn.execute(sql, *args)
+        else:
+            async with self.pool.acquire() as own_conn:
+                await own_conn.execute(sql, *args)
 
     async def update_hash(
         self,
@@ -176,18 +194,21 @@ class DocumentRepository:
         content_hash: str,
         hash_algorithm: str,
         content_hash_commit: str | None,
+        conn=None,
     ) -> None:
-        async with self.pool.acquire() as conn:
-            await conn.execute(
-                """
+        sql = """
                 UPDATE documents SET
                     content_hash = $1,
                     hash_algorithm = $2,
                     content_hash_commit = $3
                 WHERE id = $4
-                """,
-                content_hash, hash_algorithm, content_hash_commit, doc_id,
-            )
+                """
+        args = (content_hash, hash_algorithm, content_hash_commit, doc_id)
+        if conn is not None:
+            await conn.execute(sql, *args)
+        else:
+            async with self.pool.acquire() as own_conn:
+                await own_conn.execute(sql, *args)
 
     async def delete(self, doc_id: uuid.UUID, *, conn=None) -> None:
         """Delete the documents row. When `conn` is provided the DELETE

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -218,6 +218,7 @@ class DocumentService:
         body: str,
         *,
         persist: bool = True,
+        conn=None,
     ) -> tuple[str, str]:
         content_hash = _body_content_hash(body)
         current_commit = row.get("current_commit")
@@ -234,6 +235,7 @@ class DocumentService:
                 content_hash=content_hash,
                 hash_algorithm=HASH_ALGORITHM,
                 content_hash_commit=current_commit,
+                conn=conn,
             )
         return content_hash, HASH_ALGORITHM
 
@@ -244,15 +246,22 @@ class DocumentService:
         the same logical document path so git HEAD never diverges from
         ``documents.current_commit`` under a race.
 
-        Uses a dedicated short-lived connection / transaction so the
-        existing code paths (which acquire their own connections for
-        git + chunks + relations + events) can keep their structure.
+        Yields the locked connection (already inside a transaction). Callers
+        MUST run every DB statement of their critical section on this one
+        connection — create, chunks, relations, events, counts — instead of
+        acquiring a second pool connection. Holding this connection while
+        acquiring another is what deadlocked the pool under a write burst:
+        once ``pool_size`` writers each held a lock connection and then
+        waited for a second connection, none could free one, so every write
+        (and any read needing the pool) stalled until PG's 60s
+        ``idle_in_transaction_session_timeout`` killed the lock transactions.
+        One connection per writer makes the pool a clean backpressure queue.
         """
         pool = await get_pool()
         async with pool.acquire() as lock_conn:
             async with lock_conn.transaction():
                 await acquire_path_lock(lock_conn, vault_id, file_path)
-                yield
+                yield lock_conn
 
     # ── Put ───────────────────────────────────────────────────
 
@@ -270,24 +279,26 @@ class DocumentService:
         normalized_collection = _normalize_collection(req.collection)
         file_path = f"{normalized_collection}/{slug}.md" if normalized_collection else f"{slug}.md"
 
-        async with self._path_lock(vault_id, file_path):
+        async with self._path_lock(vault_id, file_path) as conn:
             return await self._put_locked(
                 req=req, agent_id=agent_id, vault_id=vault_id,
                 file_path=file_path, slug=slug, now=now,
                 normalized_collection=normalized_collection,
-                doc_repo=doc_repo, coll_repo=coll_repo,
+                doc_repo=doc_repo, coll_repo=coll_repo, conn=conn,
             )
 
     async def _put_locked(
         self, *, req, agent_id, vault_id, file_path, slug, now,
-        normalized_collection, doc_repo, coll_repo,
+        normalized_collection, doc_repo, coll_repo, conn,
     ) -> DocumentPutResponse:
         # Conflict pre-check — now safe under (vault_id, path) advisory lock.
         # The earlier comment about "concurrent puts can still race past
         # this gate" no longer applies: the lock serializes writers on
         # this exact (vault_id, path), so a second caller observes the
         # first caller's row here and 409s before any git mutation.
-        if await doc_repo.find_by_path(vault_id, file_path):
+        # Every DB call below reuses `conn` (the lock connection, already in
+        # a transaction) so the whole put holds exactly one pool connection.
+        if await doc_repo.find_by_path(vault_id, file_path, conn=conn):
             from app.exceptions import ConflictError
             raise ConflictError(f"Document already exists at path: {file_path}")
 
@@ -316,7 +327,7 @@ class DocumentService:
         # used by file_service / table_service / external_git_service —
         # never insert a `path=""` phantom collection row.
         collection_id = (
-            await coll_repo.get_or_create(vault_id, normalized_collection)
+            await coll_repo.get_or_create(vault_id, normalized_collection, conn=conn)
             if normalized_collection
             else None
         )
@@ -329,7 +340,7 @@ class DocumentService:
             title=req.title, doc_type=req.type, status="draft",
             summary=fm_dict.get("summary") or req.summary, domain=req.domain, created_by=agent_id,
             now=now, commit_hash=commit_hash, content_hash=content_hash,
-            hash_algorithm=HASH_ALGORITHM, tags=req.tags, metadata={},
+            hash_algorithm=HASH_ALGORITHM, tags=req.tags, metadata={}, conn=conn,
         )
 
         # Index: write chunks into PG (truth) + best-effort vector-store upsert.
@@ -343,37 +354,36 @@ class DocumentService:
         )
         chunks = chunk_markdown(req.content, metadata_header=meta_header)
 
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                chunks_indexed = await write_source_chunks(
-                    conn, "document", str(pg_doc_id),
-                    vault_id=vault_id,
-                    chunks=chunks,
-                )
-                await store_document_relations(
-                    conn, vault_id, req.vault, file_path,
-                    req.depends_on, req.related_to, [],
-                    req.content,
-                )
-                await emit_event(
-                    conn, "document.put",
-                    vault_id=vault_id,
-                    resource_uri=doc_uri(req.vault, file_path),
-                    actor_id=agent_id,
-                    payload={
-                        "vault": req.vault,
-                        "path": file_path,
-                        "title": req.title,
-                        "doc_type": req.type,
-                        "commit_hash": commit_hash,
-                        "content_hash": content_hash,
-                        "hash_algorithm": HASH_ALGORITHM,
-                        "collection": normalized_collection,
-                    },
-                )
+        # chunks + relations + event run on the lock connection's existing
+        # transaction (opened in `_path_lock`). No second pool.acquire().
+        chunks_indexed = await write_source_chunks(
+            conn, "document", str(pg_doc_id),
+            vault_id=vault_id,
+            chunks=chunks,
+        )
+        await store_document_relations(
+            conn, vault_id, req.vault, file_path,
+            req.depends_on, req.related_to, [],
+            req.content,
+        )
+        await emit_event(
+            conn, "document.put",
+            vault_id=vault_id,
+            resource_uri=doc_uri(req.vault, file_path),
+            actor_id=agent_id,
+            payload={
+                "vault": req.vault,
+                "path": file_path,
+                "title": req.title,
+                "doc_type": req.type,
+                "commit_hash": commit_hash,
+                "content_hash": content_hash,
+                "hash_algorithm": HASH_ALGORITHM,
+                "collection": normalized_collection,
+            },
+        )
 
-        await coll_repo.increment_count(collection_id, now)
+        await coll_repo.increment_count(collection_id, now, conn=conn)
 
         return DocumentPutResponse(
             uri=doc_uri(req.vault, file_path),
@@ -516,10 +526,11 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path):
+        async with self._path_lock(vault_id, file_path) as conn:
             # Re-read under the lock so we observe any commit that landed
-            # between the initial resolution and lock acquisition.
-            row = await doc_repo.find_by_ref(vault_id, doc_ref)
+            # between the initial resolution and lock acquisition. Uses the
+            # lock connection so the whole update holds one pool connection.
+            row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
                 raise NotFoundError("Document", doc_ref)
 
@@ -534,10 +545,10 @@ class DocumentService:
 
             return await self._update_locked(
                 req=req, agent_id=agent_id, vault=vault,
-                vault_id=vault_id, doc_repo=doc_repo, row=row,
+                vault_id=vault_id, doc_repo=doc_repo, row=row, conn=conn,
             )
 
-    async def _update_locked(self, *, req, agent_id, vault, vault_id, doc_repo, row) -> DocumentPutResponse:
+    async def _update_locked(self, *, req, agent_id, vault, vault_id, doc_repo, row, conn) -> DocumentPutResponse:
         now = datetime.now(timezone.utc)
         pg_doc_id = row["id"]
         file_path = row["path"]
@@ -547,7 +558,7 @@ class DocumentService:
             raise NotFoundError("Document file", file_path)
 
         current_fm, current_body = _parse_markdown(current_content)
-        current_hash, _ = await self._ensure_document_hash(doc_repo, row, current_body)
+        current_hash, _ = await self._ensure_document_hash(doc_repo, row, current_body, conn=conn)
         if req.expected_content_hash and req.expected_content_hash != current_hash:
             raise ConflictError(
                 f"content_hash moved: expected {req.expected_content_hash}, "
@@ -593,60 +604,55 @@ class DocumentService:
             summary=req.summary, domain=req.domain, now=now,
             commit_hash=commit_hash, content_hash=content_hash,
             hash_algorithm=HASH_ALGORITHM, content_hash_commit=commit_hash,
-            tags=req.tags,
+            tags=req.tags, conn=conn,
         )
 
         chunks_indexed = 0
-        # One transaction across chunks + relations + event so partial
-        # failure either commits all three or none — previously each
-        # was a separate connection, leaving git ahead of indices and
-        # subscribers missing the `document.update` signal when a
-        # mid-flight failure hit.
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                if req.content is not None:
-                    # Use the values that were actually persisted to DB, not the
-                    # raw request — e.g. req.title may be None when caller kept
-                    # the title unchanged.
-                    meta_header = build_doc_metadata_header(
-                        vault_name=vault, path=file_path,
-                        title=req.title or row["title"],
-                        summary=req.summary if req.summary is not None else row["summary"],
-                        tags=req.tags if req.tags is not None else (list(row["tags"]) if row["tags"] else []),
-                        doc_type=req.type or row["doc_type"],
-                    )
-                    chunks = chunk_markdown(new_body, metadata_header=meta_header)
-                    chunks_indexed = await write_source_chunks(
-                        conn, "document", str(pg_doc_id),
-                        vault_id=vault_id,
-                        chunks=chunks,
-                    )
+        # chunks + relations + event run on the lock connection's existing
+        # transaction (opened in `_path_lock`), so partial failure rolls back
+        # all three together and the whole update holds one pool connection.
+        if req.content is not None:
+            # Use the values that were actually persisted to DB, not the
+            # raw request — e.g. req.title may be None when caller kept
+            # the title unchanged.
+            meta_header = build_doc_metadata_header(
+                vault_name=vault, path=file_path,
+                title=req.title or row["title"],
+                summary=req.summary if req.summary is not None else row["summary"],
+                tags=req.tags if req.tags is not None else (list(row["tags"]) if row["tags"] else []),
+                doc_type=req.type or row["doc_type"],
+            )
+            chunks = chunk_markdown(new_body, metadata_header=meta_header)
+            chunks_indexed = await write_source_chunks(
+                conn, "document", str(pg_doc_id),
+                vault_id=vault_id,
+                chunks=chunks,
+            )
 
-                if req.content is not None or req.depends_on is not None or req.related_to is not None:
-                    depends = current_fm.get("depends_on", []) or []
-                    related = current_fm.get("related_to", []) or []
-                    implements = current_fm.get("implements", []) or []
-                    await store_document_relations(
-                        conn, vault_id, vault, file_path,
-                        depends, related, implements,
-                        new_body,
-                    )
+        if req.content is not None or req.depends_on is not None or req.related_to is not None:
+            depends = current_fm.get("depends_on", []) or []
+            related = current_fm.get("related_to", []) or []
+            implements = current_fm.get("implements", []) or []
+            await store_document_relations(
+                conn, vault_id, vault, file_path,
+                depends, related, implements,
+                new_body,
+            )
 
-                await emit_event(
-                    conn, "document.update",
-                    vault_id=vault_id,
-                    resource_uri=doc_uri(vault, file_path),
-                    actor_id=agent_id,
-                    payload={
-                        "vault": vault,
-                        "path": file_path,
-                        "commit_hash": commit_hash,
-                        "content_hash": content_hash,
-                        "hash_algorithm": HASH_ALGORITHM,
-                        "content_changed": req.content is not None,
-                    },
-                )
+        await emit_event(
+            conn, "document.update",
+            vault_id=vault_id,
+            resource_uri=doc_uri(vault, file_path),
+            actor_id=agent_id,
+            payload={
+                "vault": vault,
+                "path": file_path,
+                "commit_hash": commit_hash,
+                "content_hash": content_hash,
+                "hash_algorithm": HASH_ALGORITHM,
+                "content_changed": req.content is not None,
+            },
+        )
 
         return DocumentPutResponse(
             uri=doc_uri(vault, file_path),
@@ -695,8 +701,8 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path):
-            row = await doc_repo.find_by_ref(vault_id, doc_ref)
+        async with self._path_lock(vault_id, file_path) as conn:
+            row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
                 raise NotFoundError("Document", doc_ref)
             if base_commit and row["current_commit"] != base_commit:
@@ -708,11 +714,12 @@ class DocumentService:
                 vault=vault, vault_id=vault_id, row=row, doc_repo=doc_repo,
                 old_string=old_string, new_string=new_string,
                 replace_all=replace_all, message=message, agent_id=agent_id,
+                conn=conn,
             )
 
     async def _edit_locked(
         self, *, vault, vault_id, row, doc_repo,
-        old_string, new_string, replace_all, message, agent_id,
+        old_string, new_string, replace_all, message, agent_id, conn,
     ) -> DocumentPutResponse:
         now = datetime.now(timezone.utc)
         pg_doc_id = row["id"]
@@ -747,7 +754,7 @@ class DocumentService:
 
         if new_body == current_body:
             content_hash, hash_algorithm = await self._ensure_document_hash(
-                doc_repo, row, current_body,
+                doc_repo, row, current_body, conn=conn,
             )
             return DocumentPutResponse(
                 uri=doc_uri(vault, file_path),
@@ -778,7 +785,7 @@ class DocumentService:
             summary=None, domain=None, now=now,
             commit_hash=commit_hash, content_hash=content_hash,
             hash_algorithm=HASH_ALGORITHM, content_hash_commit=commit_hash,
-            tags=None,
+            tags=None, conn=conn,
         )
 
         # Re-chunk and re-embed (full pipeline — mirrors update())
@@ -793,39 +800,35 @@ class DocumentService:
         related = current_fm.get("related_to", []) or []
         implements = current_fm.get("implements", []) or []
 
-        # Single TX across chunks + relations + event so a crash between
-        # them can't leave the chunk index, the edge graph, and the
-        # event stream in inconsistent states (pre-fix: three separate
-        # connections, no shared TX).
-        chunks_indexed = 0
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                chunks_indexed = await write_source_chunks(
-                    conn, "document", str(pg_doc_id),
-                    vault_id=vault_id,
-                    chunks=chunks,
-                )
-                await store_document_relations(
-                    conn, vault_id, vault, file_path,
-                    depends, related, implements,
-                    new_body,
-                )
-                await emit_event(
-                    conn, "document.update",
-                    vault_id=vault_id,
-                    resource_uri=doc_uri(vault, file_path),
-                    actor_id=agent_id,
-                    payload={
-                        "vault": vault,
-                        "path": file_path,
-                        "commit_hash": commit_hash,
-                        "content_hash": content_hash,
-                        "hash_algorithm": HASH_ALGORITHM,
-                        "content_changed": True,
-                        "source": "edit",
-                    },
-                )
+        # chunks + relations + event run on the lock connection's existing
+        # transaction (opened in `_path_lock`) so a crash between them can't
+        # leave the chunk index, the edge graph, and the event stream in
+        # inconsistent states — and the whole edit holds one pool connection.
+        chunks_indexed = await write_source_chunks(
+            conn, "document", str(pg_doc_id),
+            vault_id=vault_id,
+            chunks=chunks,
+        )
+        await store_document_relations(
+            conn, vault_id, vault, file_path,
+            depends, related, implements,
+            new_body,
+        )
+        await emit_event(
+            conn, "document.update",
+            vault_id=vault_id,
+            resource_uri=doc_uri(vault, file_path),
+            actor_id=agent_id,
+            payload={
+                "vault": vault,
+                "path": file_path,
+                "commit_hash": commit_hash,
+                "content_hash": content_hash,
+                "hash_algorithm": HASH_ALGORITHM,
+                "content_changed": True,
+                "source": "edit",
+            },
+        )
 
         return DocumentPutResponse(
             uri=doc_uri(vault, file_path),
@@ -851,17 +854,17 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path):
+        async with self._path_lock(vault_id, file_path) as conn:
             # Re-resolve under the lock — a concurrent delete may have run.
-            row = await doc_repo.find_by_ref(vault_id, doc_ref)
+            row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
                 raise NotFoundError("Document", doc_ref)
             return await self._delete_locked(
                 vault=vault, vault_id=vault_id, row=row, agent_id=agent_id,
-                doc_repo=doc_repo, coll_repo=coll_repo,
+                doc_repo=doc_repo, coll_repo=coll_repo, conn=conn,
             )
 
-    async def _delete_locked(self, *, vault, vault_id, row, agent_id, doc_repo, coll_repo) -> bool:
+    async def _delete_locked(self, *, vault, vault_id, row, agent_id, doc_repo, coll_repo, conn) -> bool:
         pg_doc_id = row["id"]
         file_path = row["path"]
         collection_id = row["collection_id"]
@@ -881,37 +884,36 @@ class DocumentService:
                 vault, file_path,
             )
 
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                await delete_document_chunks(conn, str(pg_doc_id))
-                await delete_document_relations(conn, vault, file_path)
-                # App-level publication cascade. Previously this rode
-                # on `publications.document_id` ON DELETE CASCADE; that
-                # FK column is gone after migration 022, so we wipe
-                # publications by canonical URI before the doc row
-                # itself goes.
-                await conn.execute(
-                    "DELETE FROM publications WHERE resource_uri = $1",
-                    doc_uri(vault, file_path),
-                )
-                await emit_event(
-                    conn, "document.delete",
-                    vault_id=vault_id,
-                    resource_uri=doc_uri(vault, file_path),
-                    actor_id=agent_id,
-                    payload={
-                        "vault": vault,
-                        "path": file_path,
-                    },
-                )
-                # Doc row delete must share the cascade TX so a crash
-                # between cascade commit and row delete can't leave an
-                # orphan `documents` row with no chunks/edges/publications.
-                await doc_repo.delete(pg_doc_id, conn=conn)
+        # All cascade statements run on the lock connection's existing
+        # transaction (opened in `_path_lock`): a crash between any two of
+        # them can't leave an orphan `documents` row with no
+        # chunks/edges/publications, and the whole delete holds one
+        # pool connection.
+        await delete_document_chunks(conn, str(pg_doc_id))
+        await delete_document_relations(conn, vault, file_path)
+        # App-level publication cascade. Previously this rode
+        # on `publications.document_id` ON DELETE CASCADE; that
+        # FK column is gone after migration 022, so we wipe
+        # publications by canonical URI before the doc row
+        # itself goes.
+        await conn.execute(
+            "DELETE FROM publications WHERE resource_uri = $1",
+            doc_uri(vault, file_path),
+        )
+        await emit_event(
+            conn, "document.delete",
+            vault_id=vault_id,
+            resource_uri=doc_uri(vault, file_path),
+            actor_id=agent_id,
+            payload={
+                "vault": vault,
+                "path": file_path,
+            },
+        )
+        await doc_repo.delete(pg_doc_id, conn=conn)
 
         if collection_id:
-            await coll_repo.decrement_count(collection_id, datetime.now(timezone.utc))
+            await coll_repo.decrement_count(collection_id, datetime.now(timezone.utc), conn=conn)
 
         logger.info("Document deleted: %s", file_path)
         return True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.3.6"
+version = "0.3.7"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/concurrency/repro_e01_multivault.py
+++ b/backend/tests/concurrency/repro_e01_multivault.py
@@ -1,0 +1,153 @@
+"""Repro for the reported 'E01 Multi-vault knowledge burst' failure.
+
+Fires 100 concurrent PUTs + 300 concurrent GETs across N vaults against a
+running AKB backend, while polling /livez. The point is to DECODE what the
+reporter's harness recorded as "status 0": status 0 means no HTTP response
+was obtained, i.e. the client raised before/while talking to the server.
+We capture the exact exception class+message for every failure so we can
+tell a server fault from client-side connection-pool saturation.
+
+Usage:  AKB_URL=http://localhost:8000 python3 repro_e01_multivault.py [client_max_conns]
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from collections import Counter
+
+import httpx
+
+BASE = os.environ.get("AKB_URL", "http://localhost:8000").rstrip("/")
+N_VAULTS = int(os.environ.get("E01_VAULTS", "10"))
+N_PUT = int(os.environ.get("E01_PUT", "100"))
+N_GET = int(os.environ.get("E01_GET", "300"))
+# Client-side connection ceiling. The reporter's harness almost certainly
+# used *some* limit; we sweep it to see if status-0 tracks the CLIENT pool.
+CLIENT_MAX_CONNS = int(sys.argv[1]) if len(sys.argv) > 1 else 100
+
+STAMP = str(int(time.time()))
+U = f"e01-{STAMP}"
+PW = "testtest1234"
+
+
+def pct(xs, p):
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    k = max(0, min(len(s) - 1, int(round((p / 100.0) * (len(s) - 1)))))
+    return s[k]
+
+
+async def record(coro):
+    """Run a request coro, return (status:int, latency_ms:float, err:str|None).
+
+    status 0 == no HTTP response (exception). err carries the decoded cause.
+    """
+    t0 = time.perf_counter()
+    try:
+        r = await coro
+        dt = (time.perf_counter() - t0) * 1000
+        return r.status_code, dt, None
+    except Exception as e:  # noqa: BLE001 -- we WANT to see every failure mode
+        dt = (time.perf_counter() - t0) * 1000
+        return 0, dt, f"{type(e).__name__}: {e}"
+
+
+async def main():
+    print(f"BASE={BASE}  vaults={N_VAULTS}  put={N_PUT}  get={N_GET}  client_max_conns={CLIENT_MAX_CONNS}")
+    limits = httpx.Limits(max_connections=CLIENT_MAX_CONNS, max_keepalive_connections=CLIENT_MAX_CONNS)
+    timeout = httpx.Timeout(60.0, connect=60.0)
+
+    async with httpx.AsyncClient(base_url=BASE, limits=limits, timeout=timeout) as c:
+        # ---- setup: user + PAT ----
+        await c.post("/api/v1/auth/register", json={"username": U, "email": f"{U}@t.local", "password": PW})
+        jwt = (await c.post("/api/v1/auth/login", json={"username": U, "password": PW})).json()["token"]
+        H = {"Authorization": f"Bearer {jwt}"}
+        pat = (await c.post("/api/v1/auth/tokens", headers=H, json={"name": "p"})).json()["token"]
+        A = {"Authorization": f"Bearer {pat}"}
+
+        # ---- setup: N vaults ----
+        vaults = [f"e01v-{STAMP}-{i}" for i in range(N_VAULTS)]
+        for v in vaults:
+            await c.post(f"/api/v1/vaults?name={v}", headers=A)
+
+        # ---- livez poller during the burst ----
+        stop = asyncio.Event()
+        livez_codes: Counter = Counter()
+        livez_lat: list[float] = []
+
+        async def poll_livez():
+            while not stop.is_set():
+                st, dt, _ = await record(c.get("/livez"))
+                livez_codes[st] += 1
+                if st == 200:
+                    livez_lat.append(dt)
+                await asyncio.sleep(0.001)
+
+        livez_task = asyncio.create_task(poll_livez())
+
+        # ---- BURST 1: 100 concurrent PUTs across vaults ----
+        def put_body(i):
+            v = vaults[i % N_VAULTS]
+            return v, {
+                "vault": v, "collection": "burst",
+                "title": f"doc-{i}", "content": f"# doc {i}\n\nbody {i} " + ("x" * 200),
+                "type": "note", "slug": f"doc-{i}",
+            }
+
+        async def do_put(i):
+            v, body = put_body(i)
+            return await record(c.post("/api/v1/documents", headers=A, json=body))
+
+        put_res = await asyncio.gather(*[do_put(i) for i in range(N_PUT)])
+
+        # collect the paths that succeeded so GETs hit real docs
+        ok_targets = []
+        for i in range(N_PUT):
+            st, _, _ = put_res[i]
+            if st in (200, 201):
+                v, _ = put_body(i)
+                ok_targets.append((v, f"burst/doc-{i}.md"))
+
+        # ---- BURST 2: 300 concurrent GETs ----
+        async def do_get(j):
+            if ok_targets:
+                v, docid = ok_targets[j % len(ok_targets)]
+            else:
+                v, docid = vaults[j % N_VAULTS], "burst/doc-0.md"
+            return await record(c.get(f"/api/v1/documents/{v}/{docid}", headers=A))
+
+        get_res = await asyncio.gather(*[do_get(j) for j in range(N_GET)])
+
+        stop.set()
+        await livez_task
+
+        # ---- report ----
+        def summarize(name, res):
+            codes = Counter(st for st, _, _ in res)
+            lat = [dt for st, dt, _ in res if st in (200, 201)]
+            errs = Counter(err for st, _, err in res if err)
+            print(f"\n  {name}: count={len(res)} statuses={dict(codes)} "
+                  f"p50={pct(lat,50):.1f}ms p95={pct(lat,95):.1f}ms max={(max(lat) if lat else 0):.1f}ms")
+            for err, n in errs.most_common():
+                print(f"      [status0 cause x{n}] {err}")
+            # show a couple of non-2xx HTTP bodies if any
+            return codes
+
+        summarize("PUT", put_res)
+        summarize("GET", get_res)
+        print(f"\n  livez: count={sum(livez_codes.values())} statuses={dict(livez_codes)} "
+              f"p50={pct(livez_lat,50):.1f}ms p95={pct(livez_lat,95):.1f}ms max={(max(livez_lat) if livez_lat else 0):.1f}ms")
+
+        # cleanup vaults
+        for v in vaults:
+            try:
+                await c.request("DELETE", f"/api/v1/vaults/{v}", headers=A)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Problem

The document write paths (`put`/`update`/`edit`/`delete` in `document_service.py`) each acquired **two** asyncpg pool connections at once:

- `_path_lock()` held one connection (`lock_conn`, inside a transaction holding the `pg_advisory_xact_lock`) for the whole critical section, and
- the body then did a **second** `pool.acquire()` for the chunks/relations/events transaction.

With `pool max_size=20`, once 20 concurrent writers each held a lock connection and then all waited for a second connection, **none could free one — a hold-and-wait deadlock**. It only broke when PG's `idle_in_transaction_session_timeout` (60s) killed the idle lock transactions, so clients saw 60s hangs → `ReadTimeout`. `/livez` stayed green the whole time (it touches neither the pool nor the event loop), hiding the failure from health checks. Reads were collateral — every DB-touching request starved while the 20 connections sat frozen.

Reproduced from an external **"E01 multi-vault knowledge burst"** report (100 PUT + 300 GET returned transport-level `status 0`). The trigger is just **20 simultaneous writes to one pod** — a realistic bar (a bulk import, or ~20 agents), not only a synthetic stress test.

## Fix

Each writer now holds **exactly one** pool connection. `_path_lock` yields its connection and every DB statement of the critical section (conflict pre-check, `get_or_create`, `create`/`update`, chunks, relations, events, publication cascade, doc-row delete, collection count) runs on that one connection's transaction. `document_repo`'s `create`/`update`/`update_hash` gained a backward-compatible `conn=` parameter so they reuse the caller's connection instead of acquiring their own.

The pool is now a clean backpressure queue: the 21st concurrent writer waits for a free connection instead of deadlocking. Bonus: each write is now fully atomic in one transaction (doc row + chunks + edges + events + collection count commit or roll back together). No schema change, no migration.

## Verification

- **Load**: 100-PUT + 300-GET multi-vault burst that returned **0/100 PUT and 2/300 GET** before now returns **100/100 and 300/300**.
- **Causation (falsification)**: client concurrency 10 (< pool 20) → 100% success; 100 (> 20) → 100% deadlock — single-variable proof.
- **Regression**: `test_mcp_e2e` 76/76, `test_edit_e2e` 37/37, `test_concurrency_repro_e2e` 22/22. (publications/defensive/graph e2e failures are identical on `main` — pre-existing local-env limits: no embedding/S3.)
- **Adversarial review** (4 lenses × adversarial verify, 11 agents): **0 real regressions** confirmed. The lone "confirmed" finding is a data-consistency *improvement* (collection counts now atomic).

Repro harness: `backend/tests/concurrency/repro_e01_multivault.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)