### PR TITLE
chore: restore CI green — fix 22 mypy errors (check) + _FakeDocRepo for conn= (backend-pytest)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,13 +143,22 @@
         "is_secret": false
       }
     ],
+    "backend/CHANGELOG.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/CHANGELOG.md",
+        "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
+        "is_verified": false,
+        "line_number": 372
+      }
+    ],
     "backend/mcp_server/help.py": [
       {
         "type": "Secret Keyword",
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 362,
+        "line_number": 363,
         "is_secret": false
       },
       {
@@ -157,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1091,
+        "line_number": 1093,
         "is_secret": false
       }
     ],
@@ -169,6 +178,15 @@
         "is_verified": false,
         "line_number": 17,
         "is_secret": false
+      }
+    ],
+    "backend/tests/concurrency/test_invariants_unit.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/concurrency/test_invariants_unit.py",
+        "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "backend/tests/test_auth_password_e2e.sh": [
@@ -293,7 +311,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f8c3bceb2fd5655f1c6e2c8b68c19ccc62e2ccd0",
         "is_verified": false,
-        "line_number": 157,
+        "line_number": 178,
         "is_secret": false
       },
       {
@@ -301,7 +319,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bbe89f60c4958c87251488db559df22ee23af1d6",
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 181,
         "is_secret": false
       },
       {
@@ -309,7 +327,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76ae5510aad8e0ef1e4b4bb236a81431460c3e14",
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 185,
         "is_secret": false
       },
       {
@@ -317,7 +335,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "df4ed24356e7fc85ece12773e32b1336f9e49221",
         "is_verified": false,
-        "line_number": 168,
+        "line_number": 189,
         "is_secret": false
       },
       {
@@ -325,7 +343,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "359ac5bd61cb9c32b418f71877fad37f3f8cfd0e",
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 192,
         "is_secret": false
       },
       {
@@ -333,7 +351,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9e14c0dd90b7fd1c6eb295812747e6df9f68524e",
         "is_verified": false,
-        "line_number": 175,
+        "line_number": 196,
         "is_secret": false
       },
       {
@@ -341,7 +359,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d3541691a358a503965df61d03a03b145283e1f6",
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 200,
         "is_secret": false
       },
       {
@@ -349,7 +367,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cf9d8563e81a99bb393c8ce3dedee23909dc0652",
         "is_verified": false,
-        "line_number": 183,
+        "line_number": 204,
         "is_secret": false
       },
       {
@@ -357,7 +375,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cbf41ed160d723d2d3e9b3a7efca841b6bcf6f88",
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 208,
         "is_secret": false
       },
       {
@@ -365,7 +383,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5cb278a68156ae376bea48fb0f872cbc5dfd0a63",
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 212,
         "is_secret": false
       },
       {
@@ -373,7 +391,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d5266ed941af1b1d15330dbd1d3a875c4bc9c81",
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 216,
         "is_secret": false
       },
       {
@@ -381,7 +399,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dfce026d4d3a3c07f4b1217d9f8218c7a659648c",
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 220,
         "is_secret": false
       },
       {
@@ -389,7 +407,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8319864fae2ce720a9588f890930b4dd3f736a4f",
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 226,
         "is_secret": false
       },
       {
@@ -397,7 +415,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96393754ecdf525c798560bfe0e751502aa16dd1",
         "is_verified": false,
-        "line_number": 209,
+        "line_number": 230,
         "is_secret": false
       },
       {
@@ -405,7 +423,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6302a9750ba626bf9d98ea2b93c8044c2c13dd03",
         "is_verified": false,
-        "line_number": 213,
+        "line_number": 234,
         "is_secret": false
       },
       {
@@ -413,7 +431,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "88ca4f0d28c7143e72cc9cfecaf9901c26711cb5",
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 238,
         "is_secret": false
       },
       {
@@ -421,7 +439,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d940d64a49d7ffa54290a8c7258e0f4adf5dbb65",
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 242,
         "is_secret": false
       },
       {
@@ -429,7 +447,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8ce6977002b5073e86067ab6571cbcfa3f770a1e",
         "is_verified": false,
-        "line_number": 226,
+        "line_number": 247,
         "is_secret": false
       },
       {
@@ -437,7 +455,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "261bb1dcc263df7ecdd01a0c01dadf24d04b170e",
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 251,
         "is_secret": false
       },
       {
@@ -445,7 +463,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8a3e5ca7ff5701e917511e537ae08cf06085e3ca",
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 255,
         "is_secret": false
       },
       {
@@ -453,7 +471,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "180e848f306ee232593ddf09bf8f13cb01648197",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 259,
         "is_secret": false
       },
       {
@@ -461,7 +479,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e498b588b82623a989bc184233b01bd904b0ffe8",
         "is_verified": false,
-        "line_number": 242,
+        "line_number": 263,
         "is_secret": false
       },
       {
@@ -469,7 +487,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "72ad9b29d84be5893947b31eab1b18c6a8708b9c",
         "is_verified": false,
-        "line_number": 246,
+        "line_number": 267,
         "is_secret": false
       },
       {
@@ -477,7 +495,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "77697b83c3a3cae58eeb4ac4d64658f94bcc8ac0",
         "is_verified": false,
-        "line_number": 250,
+        "line_number": 271,
         "is_secret": false
       },
       {
@@ -485,7 +503,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "54fa8774d395c4b5321b2dedb260b72d4b371b38",
         "is_verified": false,
-        "line_number": 257,
+        "line_number": 278,
         "is_secret": false
       },
       {
@@ -493,7 +511,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "09404efe0c697675f28ac49e2df4736fb4ba6614",
         "is_verified": false,
-        "line_number": 264,
+        "line_number": 285,
         "is_secret": false
       },
       {
@@ -501,7 +519,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "015001278a609b8806a56281e175ddce9fe657ab",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 291,
         "is_secret": false
       },
       {
@@ -509,7 +527,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6458cb491193acf3fd23e2431345406d864182a8",
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 299,
         "is_secret": false
       },
       {
@@ -517,7 +535,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "61eba76f624f3965458fbcb475d516dd79e3b277",
         "is_verified": false,
-        "line_number": 282,
+        "line_number": 303,
         "is_secret": false
       },
       {
@@ -525,7 +543,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bce2211dbea063d611777b8914263104c8ecb803",
         "is_verified": false,
-        "line_number": 285,
+        "line_number": 306,
         "is_secret": false
       },
       {
@@ -533,7 +551,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e8cc5935afdfd3788eae945e3db3f42e2c3acee6",
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 309,
         "is_secret": false
       },
       {
@@ -541,7 +559,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3fe801d380c7196c8da01d8e53ecfaf12fda8d21",
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 312,
         "is_secret": false
       },
       {
@@ -549,7 +567,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d3405ba928268e4228a3dccdc89600d0a896c339",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 318,
         "is_secret": false
       },
       {
@@ -557,7 +575,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6dc38584efb3a63a07cb8d862c8701cd66acae33",
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 322,
         "is_secret": false
       },
       {
@@ -565,7 +583,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1783efab5b4a6f7ce65c346b422f0afd6b3e74f2",
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 326,
         "is_secret": false
       },
       {
@@ -573,7 +591,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "28a5ad3c3c89735a3e8b507c0f1b22c62bc87111",
         "is_verified": false,
-        "line_number": 309,
+        "line_number": 330,
         "is_secret": false
       },
       {
@@ -581,7 +599,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9ea0cbc8c451603171a7b5c0b2aa47374123a6d3",
         "is_verified": false,
-        "line_number": 313,
+        "line_number": 334,
         "is_secret": false
       },
       {
@@ -589,7 +607,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "16d23c0fa1859adb090c34f7eed667ca262f3f66",
         "is_verified": false,
-        "line_number": 322,
+        "line_number": 343,
         "is_secret": false
       },
       {
@@ -597,7 +615,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fd5a95d1ea888cede210d010fbb956e559a3d0da",
         "is_verified": false,
-        "line_number": 326,
+        "line_number": 347,
         "is_secret": false
       },
       {
@@ -605,7 +623,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5ac4308bf107df4b3ecb4beb323481d62adb9087",
         "is_verified": false,
-        "line_number": 330,
+        "line_number": 351,
         "is_secret": false
       },
       {
@@ -613,7 +631,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c623aa06523a4f1fa3fa7ab1df7db62b378b9432",
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 360,
         "is_secret": false
       },
       {
@@ -621,7 +639,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "63bec2ac98d4c5fcc58ccf35344e251308f56cf9",
         "is_verified": false,
-        "line_number": 342,
+        "line_number": 363,
         "is_secret": false
       },
       {
@@ -629,77 +647,20 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f03b3090ec0f6bcc310df37baf29aff7ea3af1da",
         "is_verified": false,
-        "line_number": 345,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4792a7cb5f934441b51f39e719c89698cd8819b0",
-        "is_verified": false,
-        "line_number": 351,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "36ae1463d92ef753166eda3cf0a370b330d86e0e",
-        "is_verified": false,
-        "line_number": 354,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fd2108f85ee8e7a9567bc8845ef33b3617f249f6",
-        "is_verified": false,
-        "line_number": 357,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "79852f8b416f009897ece7a8354ea56e48a6fba0",
-        "is_verified": false,
-        "line_number": 360,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6b0ef9c6d74adabafd3ddba33111caf0213669c1",
-        "is_verified": false,
-        "line_number": 363,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "70e0115878cbcfa3933ef674125fe6edc40b1ddd",
-        "is_verified": false,
         "line_number": 366,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6158060fd3a28e3bdf7b7e37bcc8c8f3348147f0",
+        "hashed_secret": "fa45202b508365cf1d1f73dc49a8df7f227d202e",
         "is_verified": false,
-        "line_number": 370,
-        "is_secret": false
+        "line_number": 372
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b18a51ff2b05238234261f264ee4810ddb31a3ab",
-        "is_verified": false,
-        "line_number": 374,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d2162ede46b32d726584142e374458026c95c209",
+        "hashed_secret": "4792a7cb5f934441b51f39e719c89698cd8819b0",
         "is_verified": false,
         "line_number": 378,
         "is_secret": false
@@ -707,23 +668,31 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7252305e0579e7dd1ebf234edb891484f3ac7a71",
+        "hashed_secret": "36ae1463d92ef753166eda3cf0a370b330d86e0e",
         "is_verified": false,
-        "line_number": 382,
+        "line_number": 381,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "efb5975d20ddfdefd6f1dbae9cad42004f415db4",
+        "hashed_secret": "fd2108f85ee8e7a9567bc8845ef33b3617f249f6",
         "is_verified": false,
-        "line_number": 386,
+        "line_number": 384,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "00412064d66076b9c76ff3c3a3d6561ac4e9a7c9",
+        "hashed_secret": "79852f8b416f009897ece7a8354ea56e48a6fba0",
+        "is_verified": false,
+        "line_number": 387,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "6b0ef9c6d74adabafd3ddba33111caf0213669c1",
         "is_verified": false,
         "line_number": 390,
         "is_secret": false
@@ -731,9 +700,65 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "70e0115878cbcfa3933ef674125fe6edc40b1ddd",
+        "is_verified": false,
+        "line_number": 393,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "6158060fd3a28e3bdf7b7e37bcc8c8f3348147f0",
+        "is_verified": false,
+        "line_number": 397,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b18a51ff2b05238234261f264ee4810ddb31a3ab",
+        "is_verified": false,
+        "line_number": 401,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d2162ede46b32d726584142e374458026c95c209",
+        "is_verified": false,
+        "line_number": 405,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "7252305e0579e7dd1ebf234edb891484f3ac7a71",
+        "is_verified": false,
+        "line_number": 409,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "efb5975d20ddfdefd6f1dbae9cad42004f415db4",
+        "is_verified": false,
+        "line_number": 413,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "00412064d66076b9c76ff3c3a3d6561ac4e9a7c9",
+        "is_verified": false,
+        "line_number": 417,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9a0af39ecc21dd47b0b1dfb9483190e0370245b1",
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 426,
         "is_secret": false
       },
       {
@@ -741,7 +766,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f6e4240256e2f10f445d8f1bd041ac7e76ead7fe",
         "is_verified": false,
-        "line_number": 408,
+        "line_number": 435,
         "is_secret": false
       },
       {
@@ -749,7 +774,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cbd3d8e48755b4cf61348fffa0850f7dfc54cc1e",
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 439,
         "is_secret": false
       },
       {
@@ -757,7 +782,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
         "is_verified": false,
-        "line_number": 421,
+        "line_number": 448,
         "is_secret": false
       },
       {
@@ -765,7 +790,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
         "is_verified": false,
-        "line_number": 424,
+        "line_number": 451,
         "is_secret": false
       },
       {
@@ -773,7 +798,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 454,
         "is_secret": false
       },
       {
@@ -781,7 +806,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
         "is_verified": false,
-        "line_number": 431,
+        "line_number": 458,
         "is_secret": false
       },
       {
@@ -789,77 +814,20 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 461,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "14ac3697296e2c49906c591edf4b732c3b9a5beb",
+        "is_verified": false,
+        "line_number": 464
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1eda99989faa6ffef8eaad6e29dc992f36c91eb7",
-        "is_verified": false,
-        "line_number": 437,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "849d850746ddf94e2552051b64ad5817dc377516",
-        "is_verified": false,
-        "line_number": 441,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e86e4979d9d712e11a75b4ebec1b901732124d77",
-        "is_verified": false,
-        "line_number": 447,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "860024dc69fce7531fd68cac0382949ebce3602b",
-        "is_verified": false,
-        "line_number": 450,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e7a300573911dfc80ae0808f6cd3ddc96c90975d",
-        "is_verified": false,
-        "line_number": 453,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "af21ea4772d3ec7feac09cde495c71292fb69903",
-        "is_verified": false,
-        "line_number": 456,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "dc782422b02b55cab4ac3a691ad1a7796b5090c2",
-        "is_verified": false,
-        "line_number": 459,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b5b6d48460f3ce7c0ee71c156fa178805b4b632c",
-        "is_verified": false,
-        "line_number": 462,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bcb82578fa8e86968c7019febdeab3965c19ff41",
         "is_verified": false,
         "line_number": 467,
         "is_secret": false
@@ -867,23 +835,39 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
+        "hashed_secret": "849d850746ddf94e2552051b64ad5817dc377516",
         "is_verified": false,
-        "line_number": 470,
+        "line_number": 471,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
+        "hashed_secret": "e86e4979d9d712e11a75b4ebec1b901732124d77",
         "is_verified": false,
-        "line_number": 473,
+        "line_number": 477,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d68cebb7dafe5db1971f5fa821be0e8a901290ad",
+        "hashed_secret": "860024dc69fce7531fd68cac0382949ebce3602b",
+        "is_verified": false,
+        "line_number": 480,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e7a300573911dfc80ae0808f6cd3ddc96c90975d",
+        "is_verified": false,
+        "line_number": 483,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "af21ea4772d3ec7feac09cde495c71292fb69903",
         "is_verified": false,
         "line_number": 486,
         "is_secret": false
@@ -891,9 +875,148 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "dc782422b02b55cab4ac3a691ad1a7796b5090c2",
+        "is_verified": false,
+        "line_number": 489,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2275bc01362cf148fb9d602c7aa4d50e3579ea8b",
+        "is_verified": false,
+        "line_number": 492
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "deec0a4326de1d985f728e3663ee1ee778955e48",
+        "is_verified": false,
+        "line_number": 499
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4d42d25f34197ac24085066fd8525d580b4821b8",
+        "is_verified": false,
+        "line_number": 506
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "754919ceb5e47881598179a8f68f51b0d0bb993b",
+        "is_verified": false,
+        "line_number": 512
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f9f0414023ae73321a6a70929db2fed0e6983156",
+        "is_verified": false,
+        "line_number": 519
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3f478b43c918be4df42505be14787d4a70f6f2ee",
+        "is_verified": false,
+        "line_number": 526
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "7e175ebc63196ab5496401d491463a0b92e85f16",
+        "is_verified": false,
+        "line_number": 533
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bfc406bacac978a3801d8ef75ebe61719bb9ab3d",
+        "is_verified": false,
+        "line_number": 540
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1f23c277e83472a8a62ac645621686d04ada4bdb",
+        "is_verified": false,
+        "line_number": 547
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1b9c17047f466d9841ea37c54273d72f415abb14",
+        "is_verified": false,
+        "line_number": 554
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e5b5cbf08463f0d1d16fee86fa03cdbd80fefde1",
+        "is_verified": false,
+        "line_number": 561
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5afb012326a0b28a4c8393ebf415fadeb65904d2",
+        "is_verified": false,
+        "line_number": 564
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b2d55a52a2634ec112e7006f69338e64617b8399",
+        "is_verified": false,
+        "line_number": 571
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b5b6d48460f3ce7c0ee71c156fa178805b4b632c",
+        "is_verified": false,
+        "line_number": 577,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bcb82578fa8e86968c7019febdeab3965c19ff41",
+        "is_verified": false,
+        "line_number": 582,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
+        "is_verified": false,
+        "line_number": 585,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
+        "is_verified": false,
+        "line_number": 588,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d68cebb7dafe5db1971f5fa821be0e8a901290ad",
+        "is_verified": false,
+        "line_number": 601,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
         "is_verified": false,
-        "line_number": 499,
+        "line_number": 614,
         "is_secret": false
       },
       {
@@ -901,7 +1024,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
         "is_verified": false,
-        "line_number": 512,
+        "line_number": 627,
         "is_secret": false
       },
       {
@@ -909,7 +1032,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
         "is_verified": false,
-        "line_number": 521,
+        "line_number": 636,
         "is_secret": false
       },
       {
@@ -917,7 +1040,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b2334902f0134767ef634449f1b4ad0a6fe4830b",
         "is_verified": false,
-        "line_number": 530,
+        "line_number": 645,
         "is_secret": false
       },
       {
@@ -925,7 +1048,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 654,
         "is_secret": false
       },
       {
@@ -933,7 +1056,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
         "is_verified": false,
-        "line_number": 552,
+        "line_number": 667,
         "is_secret": false
       },
       {
@@ -941,7 +1064,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
         "is_verified": false,
-        "line_number": 561,
+        "line_number": 676,
         "is_secret": false
       },
       {
@@ -949,7 +1072,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cfe0bd31a00a41920823c76d517fe7d062e5337c",
         "is_verified": false,
-        "line_number": 574,
+        "line_number": 689,
         "is_secret": false
       },
       {
@@ -957,7 +1080,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b16b457c3af8581fda0aad82df8a4d25d56b72f5",
         "is_verified": false,
-        "line_number": 587,
+        "line_number": 702,
         "is_secret": false
       },
       {
@@ -965,7 +1088,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "28f0a338a11c78c8b77f06940e97fd7242579d23",
         "is_verified": false,
-        "line_number": 596,
+        "line_number": 711,
         "is_secret": false
       },
       {
@@ -973,7 +1096,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bfb1d8f7fcfdc3951f2a407606332dd0561ea889",
         "is_verified": false,
-        "line_number": 609,
+        "line_number": 724,
         "is_secret": false
       },
       {
@@ -981,7 +1104,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ecb78fb017219f11f062b663841d42dfad9bd607",
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 733,
         "is_secret": false
       },
       {
@@ -989,7 +1112,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "380016634dca8718e45627a3e887a33cfdbf9583",
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 746,
         "is_secret": false
       },
       {
@@ -997,7 +1120,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c93cfee749f39a6731bd90e3b8bfc1c2f39dd0bb",
         "is_verified": false,
-        "line_number": 644,
+        "line_number": 759,
         "is_secret": false
       },
       {
@@ -1005,7 +1128,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "384119563704c0a0c154cfa3a7fb2f1b6e403e4d",
         "is_verified": false,
-        "line_number": 657,
+        "line_number": 772,
         "is_secret": false
       },
       {
@@ -1013,7 +1136,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a9799e49f2382f864dab19d97df038fbcc760f79",
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 785,
         "is_secret": false
       },
       {
@@ -1021,7 +1144,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "237858a86350af1517b45ec07878dc64d875b973",
         "is_verified": false,
-        "line_number": 683,
+        "line_number": 798,
         "is_secret": false
       },
       {
@@ -1029,7 +1152,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e3f56ef687b947b63f8ea90c3f3fcdc7687c0584",
         "is_verified": false,
-        "line_number": 696,
+        "line_number": 811,
         "is_secret": false
       },
       {
@@ -1037,7 +1160,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "938a7b1d49a0c2692666797b3a00b607ba1912d4",
         "is_verified": false,
-        "line_number": 709,
+        "line_number": 824,
         "is_secret": false
       },
       {
@@ -1045,7 +1168,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d2fd9728d554534f81a587647c925c735087ae31",
         "is_verified": false,
-        "line_number": 722,
+        "line_number": 837,
         "is_secret": false
       },
       {
@@ -1053,7 +1176,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8400bcab54bbc669cbe44b013fd300ec181ae04",
         "is_verified": false,
-        "line_number": 735,
+        "line_number": 850,
         "is_secret": false
       },
       {
@@ -1061,7 +1184,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "31625b2b743843d6e5bfb31cd4899c540146d0f8",
         "is_verified": false,
-        "line_number": 744,
+        "line_number": 859,
         "is_secret": false
       },
       {
@@ -1069,7 +1192,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "249cc7d6ea282d76f5efff9fb4ed6ed5d3058d08",
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 868,
         "is_secret": false
       },
       {
@@ -1077,7 +1200,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "446546bba84a6355c159d0562c57c670fea13d34",
         "is_verified": false,
-        "line_number": 766,
+        "line_number": 881,
         "is_secret": false
       },
       {
@@ -1085,7 +1208,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d3f1b8d6e4eca6f79dbaf3cdfbca069ab37a6e8",
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 894,
         "is_secret": false
       },
       {
@@ -1093,7 +1216,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1cfc669b4a91926a20a0c195e64a33fddfc28636",
         "is_verified": false,
-        "line_number": 788,
+        "line_number": 903,
         "is_secret": false
       },
       {
@@ -1101,7 +1224,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "089409fd943a2fb3a5a50b4725a4c96a16bc5d19",
         "is_verified": false,
-        "line_number": 797,
+        "line_number": 912,
         "is_secret": false
       },
       {
@@ -1109,7 +1232,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ccf9afc9b093a34274214374a841c68216c23105",
         "is_verified": false,
-        "line_number": 806,
+        "line_number": 921,
         "is_secret": false
       },
       {
@@ -1117,7 +1240,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "29094c26e288b5cebbc5262a1996e29057328f1f",
         "is_verified": false,
-        "line_number": 815,
+        "line_number": 930,
         "is_secret": false
       },
       {
@@ -1125,7 +1248,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "95362ad9b076707c159a81577f1695dea0ed2eb3",
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 939,
         "is_secret": false
       },
       {
@@ -1133,7 +1256,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dfea0993e072e2f30d0a2cac0b7bda5f6e7f980",
         "is_verified": false,
-        "line_number": 833,
+        "line_number": 948,
         "is_secret": false
       },
       {
@@ -1141,7 +1264,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "15432d91ade7f228054c5d23ceac8d48711a5853",
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 957,
         "is_secret": false
       },
       {
@@ -1149,7 +1272,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "69ae791ca6d7814550c0af06cc57217e4e1388ea",
         "is_verified": false,
-        "line_number": 851,
+        "line_number": 966,
         "is_secret": false
       },
       {
@@ -1157,7 +1280,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "647690124fbe1ff7811211b1ec8ec14c9800de35",
         "is_verified": false,
-        "line_number": 864,
+        "line_number": 979,
         "is_secret": false
       },
       {
@@ -1165,7 +1288,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "167d061ff6451f673f8b7b23cfc556872e86613e",
         "is_verified": false,
-        "line_number": 867,
+        "line_number": 982,
         "is_secret": false
       },
       {
@@ -1173,7 +1296,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a3c9978139549b7ad6ed9366409ef125d1dd51a7",
         "is_verified": false,
-        "line_number": 873,
+        "line_number": 988,
         "is_secret": false
       },
       {
@@ -1181,7 +1304,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf028ac7f6ef311d2c3fa6deac3d8d21ee78d221",
         "is_verified": false,
-        "line_number": 879,
+        "line_number": 994,
         "is_secret": false
       },
       {
@@ -1189,7 +1312,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e03e6bf75e6125b7a1b5615288920c220a709665",
         "is_verified": false,
-        "line_number": 885,
+        "line_number": 1000,
         "is_secret": false
       },
       {
@@ -1197,7 +1320,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "042b174c95d67dbeec1db71bb039b3df82ccbc29",
         "is_verified": false,
-        "line_number": 891,
+        "line_number": 1006,
         "is_secret": false
       },
       {
@@ -1205,7 +1328,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2959fd05231107d39fca7e4a60b08f74b842d512",
         "is_verified": false,
-        "line_number": 897,
+        "line_number": 1012,
         "is_secret": false
       },
       {
@@ -1213,7 +1336,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e5d6a7186daa3461faa5d61d4fddb9b81f69e436",
         "is_verified": false,
-        "line_number": 904,
+        "line_number": 1019,
         "is_secret": false
       },
       {
@@ -1221,7 +1344,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3f1a6c32aef28e208c0a281e4b524dcd62955b11",
         "is_verified": false,
-        "line_number": 911,
+        "line_number": 1026,
         "is_secret": false
       },
       {
@@ -1229,7 +1352,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4760a1ddccbdba27f5ec36f07aac3a0ea707be84",
         "is_verified": false,
-        "line_number": 918,
+        "line_number": 1033,
         "is_secret": false
       },
       {
@@ -1237,7 +1360,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0eac7498a07401ef92ae05e36edeca2b136babc6",
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 1040,
         "is_secret": false
       },
       {
@@ -1245,7 +1368,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9ae74726accd48e3f3045891f87235c86b7994d7",
         "is_verified": false,
-        "line_number": 932,
+        "line_number": 1047,
         "is_secret": false
       },
       {
@@ -1253,7 +1376,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2bee4fa5b83c7b3e6e78ac518e9003967ba9dda0",
         "is_verified": false,
-        "line_number": 939,
+        "line_number": 1054,
         "is_secret": false
       },
       {
@@ -1261,7 +1384,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d8199a971d414e6a1d7992529dd393898d0269d",
         "is_verified": false,
-        "line_number": 945,
+        "line_number": 1060,
         "is_secret": false
       },
       {
@@ -1269,7 +1392,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "128f864d3fbfcbf15f57405d65e23123851b46ef",
         "is_verified": false,
-        "line_number": 950,
+        "line_number": 1065,
         "is_secret": false
       },
       {
@@ -1277,7 +1400,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "29ff50f03a6585d60742f622b04648a4a8fc1026",
         "is_verified": false,
-        "line_number": 956,
+        "line_number": 1071,
         "is_secret": false
       },
       {
@@ -1285,7 +1408,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1b863a5c2935b250e1e1e6ac25be01f5237fc955",
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 1077,
         "is_secret": false
       },
       {
@@ -1293,7 +1416,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6e8f503bb9ad54aa4fb260437f0c4d99786da42b",
         "is_verified": false,
-        "line_number": 965,
+        "line_number": 1080,
         "is_secret": false
       },
       {
@@ -1301,7 +1424,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1e9ff9fee5ad181d3f63618e0267e8ad42826e83",
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 1083,
         "is_secret": false
       },
       {
@@ -1309,7 +1432,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a4104c6b768798df1dcee3268a07bf52d78be029",
         "is_verified": false,
-        "line_number": 971,
+        "line_number": 1086,
         "is_secret": false
       },
       {
@@ -1317,7 +1440,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f915d279eb4e6304b7d59253aac5f2c03998ba37",
         "is_verified": false,
-        "line_number": 974,
+        "line_number": 1089,
         "is_secret": false
       },
       {
@@ -1325,7 +1448,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "18175133a0bfbd55464c73ace84c47069590c74b",
         "is_verified": false,
-        "line_number": 980,
+        "line_number": 1095,
         "is_secret": false
       },
       {
@@ -1333,7 +1456,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "508d40b3672cfb13f23a36745e715b415e68c762",
         "is_verified": false,
-        "line_number": 986,
+        "line_number": 1101,
         "is_secret": false
       },
       {
@@ -1341,7 +1464,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "97a759eaa90dd533faa5241f1d5ca0fd833e9dd4",
         "is_verified": false,
-        "line_number": 992,
+        "line_number": 1107,
         "is_secret": false
       },
       {
@@ -1349,7 +1472,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1fa20c52cdd98d61e2b04f486121b191f8ed7a6d",
         "is_verified": false,
-        "line_number": 998,
+        "line_number": 1113,
         "is_secret": false
       },
       {
@@ -1357,7 +1480,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "191584feecc1fa3c9d768dc786436555baa8b550",
         "is_verified": false,
-        "line_number": 1004,
+        "line_number": 1119,
         "is_secret": false
       },
       {
@@ -1365,7 +1488,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "19e045891a75dee829b5af516116c137836fc558",
         "is_verified": false,
-        "line_number": 1011,
+        "line_number": 1126,
         "is_secret": false
       },
       {
@@ -1373,7 +1496,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "54f68de89504035455c345ef1254fd2992f01787",
         "is_verified": false,
-        "line_number": 1018,
+        "line_number": 1133,
         "is_secret": false
       },
       {
@@ -1381,7 +1504,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8f7bc474ed82152a7558b5ff7d337fdce4978a79",
         "is_verified": false,
-        "line_number": 1025,
+        "line_number": 1140,
         "is_secret": false
       },
       {
@@ -1389,7 +1512,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0568a8e75541d5c0aaf3a47affa876cd94ad7169",
         "is_verified": false,
-        "line_number": 1032,
+        "line_number": 1147,
         "is_secret": false
       },
       {
@@ -1397,7 +1520,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "65303232cd0a1806a21bcdc777bd43a3a06b3d5e",
         "is_verified": false,
-        "line_number": 1044,
+        "line_number": 1159,
         "is_secret": false
       },
       {
@@ -1405,7 +1528,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "92b34295d7111179b606bf11dd4ebadacca6b34d",
         "is_verified": false,
-        "line_number": 1050,
+        "line_number": 1165,
         "is_secret": false
       },
       {
@@ -1413,7 +1536,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c94b32b9d3038396e5129332f00d51911447db62",
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1171,
         "is_secret": false
       },
       {
@@ -1421,7 +1544,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
         "is_verified": false,
-        "line_number": 1060,
+        "line_number": 1175,
         "is_secret": false
       },
       {
@@ -1429,7 +1552,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dd5948fc19318420c8e6994af64244f453a89847",
         "is_verified": false,
-        "line_number": 1065,
+        "line_number": 1180,
         "is_secret": false
       },
       {
@@ -1437,7 +1560,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e2226607ced9f63450bc3224adaf9337e1b35cb6",
         "is_verified": false,
-        "line_number": 1070,
+        "line_number": 1185,
         "is_secret": false
       },
       {
@@ -1445,7 +1568,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a6183e78b0d1c48d3521e3eed540b5521a878c12",
         "is_verified": false,
-        "line_number": 1073,
+        "line_number": 1188,
         "is_secret": false
       },
       {
@@ -1453,7 +1576,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "206be2afac54dd74162b994ffcb40e893e90a26a",
         "is_verified": false,
-        "line_number": 1078,
+        "line_number": 1193,
         "is_secret": false
       },
       {
@@ -1461,7 +1584,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed9421935f627a1a97c9aa87a3b63c2f95f0b0f5",
         "is_verified": false,
-        "line_number": 1084,
+        "line_number": 1199,
         "is_secret": false
       },
       {
@@ -1469,7 +1592,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e0cad2c1c2babcee39a4c25ea773656432e980b5",
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1202,
         "is_secret": false
       },
       {
@@ -1477,7 +1600,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4f30f4179bf6aad2e2db264609aca318cddd0299",
         "is_verified": false,
-        "line_number": 1091,
+        "line_number": 1206,
         "is_secret": false
       },
       {
@@ -1485,7 +1608,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b09adb7e7627fd788edd03017f0e834f5647d5a6",
         "is_verified": false,
-        "line_number": 1095,
+        "line_number": 1210,
         "is_secret": false
       },
       {
@@ -1493,7 +1616,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ce235376083b3facbdd2cda6a4aefd5225f0d76e",
         "is_verified": false,
-        "line_number": 1110,
+        "line_number": 1225,
         "is_secret": false
       },
       {
@@ -1501,7 +1624,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "047379831d05cb76cb6e5e3e70b7994a465065e5",
         "is_verified": false,
-        "line_number": 1116,
+        "line_number": 1231,
         "is_secret": false
       },
       {
@@ -1509,7 +1632,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "23980ce90dce595369dff677108c4861655709ec",
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1234,
         "is_secret": false
       },
       {
@@ -1517,7 +1640,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "23b847f3370f612113c53bca00cffae8e46fb58b",
         "is_verified": false,
-        "line_number": 1122,
+        "line_number": 1237,
         "is_secret": false
       },
       {
@@ -1525,7 +1648,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7739c7a36e8b5c9759887d54c3d3a252d017cb71",
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1240,
         "is_secret": false
       },
       {
@@ -1533,7 +1656,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c2fa7f2e1f8c5eb1df08c76cc8a209e90f90717d",
         "is_verified": false,
-        "line_number": 1128,
+        "line_number": 1243,
         "is_secret": false
       },
       {
@@ -1541,7 +1664,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d4dda0583372eb865e22ea00ae160ceb315aa0df",
         "is_verified": false,
-        "line_number": 1131,
+        "line_number": 1246,
         "is_secret": false
       },
       {
@@ -1549,7 +1672,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4a447bd154e2e23510078adbe2ce49f48b0bf2e4",
         "is_verified": false,
-        "line_number": 1134,
+        "line_number": 1249,
         "is_secret": false
       },
       {
@@ -1557,7 +1680,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
         "is_verified": false,
-        "line_number": 1137,
+        "line_number": 1252,
         "is_secret": false
       },
       {
@@ -1565,7 +1688,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
         "is_verified": false,
-        "line_number": 1140,
+        "line_number": 1255,
         "is_secret": false
       },
       {
@@ -1573,7 +1696,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
         "is_verified": false,
-        "line_number": 1143,
+        "line_number": 1258,
         "is_secret": false
       },
       {
@@ -1581,7 +1704,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "545a34d82a69ee367dc06267bd30705fc686e387",
         "is_verified": false,
-        "line_number": 1146,
+        "line_number": 1261,
         "is_secret": false
       },
       {
@@ -1589,7 +1712,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
         "is_verified": false,
-        "line_number": 1149,
+        "line_number": 1264,
         "is_secret": false
       },
       {
@@ -1597,7 +1720,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 1267,
         "is_secret": false
       },
       {
@@ -1605,7 +1728,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e8168720998b3abca33b151b928077d00829c634",
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1270,
         "is_secret": false
       },
       {
@@ -1613,7 +1736,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "315f040aced6f2876d3822561a1f658a735f0327",
         "is_verified": false,
-        "line_number": 1158,
+        "line_number": 1273,
         "is_secret": false
       },
       {
@@ -1621,7 +1744,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fb450f08e517ca471d1ed41ef8c713864baf5483",
         "is_verified": false,
-        "line_number": 1163,
+        "line_number": 1278,
         "is_secret": false
       },
       {
@@ -1629,7 +1752,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f9e9b7a46fd5e9ecfcefb6346174990fce029f76",
         "is_verified": false,
-        "line_number": 1166,
+        "line_number": 1281,
         "is_secret": false
       },
       {
@@ -1637,7 +1760,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "91ac182754770244539b3544b6e3a16f33f7a622",
         "is_verified": false,
-        "line_number": 1169,
+        "line_number": 1284,
         "is_secret": false
       },
       {
@@ -1645,7 +1768,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1287,
         "is_secret": false
       },
       {
@@ -1653,7 +1776,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
         "is_verified": false,
-        "line_number": 1175,
+        "line_number": 1290,
         "is_secret": false
       },
       {
@@ -1661,7 +1784,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c4508adf2251f0c067f121878dd2e652e7d12fdf",
         "is_verified": false,
-        "line_number": 1178,
+        "line_number": 1293,
         "is_secret": false
       },
       {
@@ -1669,7 +1792,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f28b65ed11eaca443d09b1886fffafba4bc91fc4",
         "is_verified": false,
-        "line_number": 1186,
+        "line_number": 1301,
         "is_secret": false
       },
       {
@@ -1677,7 +1800,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b60280065d793e59e962d0664662789d8bcf726f",
         "is_verified": false,
-        "line_number": 1193,
+        "line_number": 1308,
         "is_secret": false
       },
       {
@@ -1685,7 +1808,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fc5261f9b81175148bb34db06e7e200ed45e2bea",
         "is_verified": false,
-        "line_number": 1199,
+        "line_number": 1314,
         "is_secret": false
       },
       {
@@ -1693,7 +1816,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a50d089f18d903f5cebfa525a6f9af7f1d08c6dd",
         "is_verified": false,
-        "line_number": 1203,
+        "line_number": 1318,
         "is_secret": false
       },
       {
@@ -1701,7 +1824,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "36ff793214a4a43138d87bdf3a2093abbc311d56",
         "is_verified": false,
-        "line_number": 1209,
+        "line_number": 1324,
         "is_secret": false
       },
       {
@@ -1709,7 +1832,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b415b302a50e49d81ef709b69641bd4913bd2f7",
         "is_verified": false,
-        "line_number": 1216,
+        "line_number": 1331,
         "is_secret": false
       },
       {
@@ -1717,7 +1840,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c0aa546007a52ddaa78f0f5d8233acbbd6e9b43b",
         "is_verified": false,
-        "line_number": 1220,
+        "line_number": 1335,
         "is_secret": false
       },
       {
@@ -1725,7 +1848,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e212327cfd6033d6256a51abd3932ccc47df3b36",
         "is_verified": false,
-        "line_number": 1226,
+        "line_number": 1341,
         "is_secret": false
       },
       {
@@ -1733,15 +1856,36 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b333857f3bcd93ff2120b75697b29920db5490c3",
         "is_verified": false,
-        "line_number": 1233,
+        "line_number": 1348,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c7783ffbc6047d282a940a08f8149a73bfde8f4d",
+        "is_verified": false,
+        "line_number": 1352
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bf5fd3db00e8fed584b599f6ef1d591738e104c2",
+        "is_verified": false,
+        "line_number": 1358
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ec24023060b25fd622cd7d6ba844f56bb4ccd6f4",
+        "is_verified": false,
+        "line_number": 1364
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
         "is_verified": false,
-        "line_number": 1237,
+        "line_number": 1367,
         "is_secret": false
       },
       {
@@ -1749,7 +1893,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c55afbe74fbb1c0236127b02c4c00815e04244a9",
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1370,
         "is_secret": false
       },
       {
@@ -1757,7 +1901,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96bcbd5509b2939bfe5c641c0df3863b79b6d8ff",
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1383,
         "is_secret": false
       },
       {
@@ -1765,7 +1909,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a07406dd5a9fe5c13cf9a915057e45666d7b386d",
         "is_verified": false,
-        "line_number": 1256,
+        "line_number": 1386,
         "is_secret": false
       },
       {
@@ -1773,7 +1917,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3240395f6aea7846fbcb340eff5ed612e70761c0",
         "is_verified": false,
-        "line_number": 1267,
+        "line_number": 1397,
         "is_secret": false
       },
       {
@@ -1781,7 +1925,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99fed6667fcafb20f46b5b42f69f448871cb0b9c",
         "is_verified": false,
-        "line_number": 1270,
+        "line_number": 1400,
         "is_secret": false
       },
       {
@@ -1789,7 +1933,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4334db9823b546a567f051d3bbb19b008d4f1bfd",
         "is_verified": false,
-        "line_number": 1273,
+        "line_number": 1403,
         "is_secret": false
       },
       {
@@ -1797,7 +1941,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7f0be5c6564fee17d341cd13469fb880b761d4a8",
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1406,
         "is_secret": false
       },
       {
@@ -1805,7 +1949,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a7b774ea3190f1218d025af8edff4e9b085f81fb",
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1409,
         "is_secret": false
       },
       {
@@ -1813,7 +1957,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c9deed84332364a2f0d212d36462413167391e17",
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1414,
         "is_secret": false
       },
       {
@@ -1821,7 +1965,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "441677734d0b21c40aecefdecbf37c2f0040bef3",
         "is_verified": false,
-        "line_number": 1287,
+        "line_number": 1417,
         "is_secret": false
       },
       {
@@ -1829,7 +1973,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2f582518a7d025e7efbc4ef2cf8cc5cf9487b200",
         "is_verified": false,
-        "line_number": 1291,
+        "line_number": 1421,
         "is_secret": false
       },
       {
@@ -1837,7 +1981,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b2c03df0ed8f8caded3abab58c3b2e3b645dbb28",
         "is_verified": false,
-        "line_number": 1296,
+        "line_number": 1426,
         "is_secret": false
       },
       {
@@ -1845,7 +1989,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f2d08166d55f8cb2912054fc3b1243f2255fac48",
         "is_verified": false,
-        "line_number": 1301,
+        "line_number": 1431,
         "is_secret": false
       },
       {
@@ -1853,7 +1997,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "35ca90e5fa9b87427a5ff8b3f333a7b7d45fc260",
         "is_verified": false,
-        "line_number": 1304,
+        "line_number": 1434,
         "is_secret": false
       },
       {
@@ -1861,7 +2005,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d15b82853a984c45aab87399878c98082bac85ba",
         "is_verified": false,
-        "line_number": 1308,
+        "line_number": 1438,
         "is_secret": false
       },
       {
@@ -1869,7 +2013,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "371ce323d657e273939fdad274085642a4da69de",
         "is_verified": false,
-        "line_number": 1312,
+        "line_number": 1442,
         "is_secret": false
       },
       {
@@ -1877,7 +2021,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
         "is_verified": false,
-        "line_number": 1316,
+        "line_number": 1446,
         "is_secret": false
       },
       {
@@ -1885,7 +2029,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d032728a18c71c0a8e3f18b060f12d1ab9755c47",
         "is_verified": false,
-        "line_number": 1320,
+        "line_number": 1450,
         "is_secret": false
       },
       {
@@ -1893,7 +2037,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b8434babdebe87a28a32c342a9ed215e5fe43378",
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1453,
         "is_secret": false
       },
       {
@@ -1901,7 +2045,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
         "is_verified": false,
-        "line_number": 1327,
+        "line_number": 1457,
         "is_secret": false
       },
       {
@@ -1909,7 +2053,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1461,
         "is_secret": false
       },
       {
@@ -1917,7 +2061,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e0ed71a4c2836a6a251bef5e00b00401cfac286d",
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1464,
         "is_secret": false
       },
       {
@@ -1925,7 +2069,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "247df9c18e18d5126f09f28a433b7c9d2bee21dc",
         "is_verified": false,
-        "line_number": 1338,
+        "line_number": 1468,
         "is_secret": false
       },
       {
@@ -1933,7 +2077,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e92b0b06949b35e8983aee47a7648629b7bfc30a",
         "is_verified": false,
-        "line_number": 1343,
+        "line_number": 1473,
         "is_secret": false
       },
       {
@@ -1941,7 +2085,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0445deb44be67d9973df3ad6d4d78bca844eaa83",
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1476,
         "is_secret": false
       },
       {
@@ -1949,7 +2093,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f3ce430d4c1e91228db9002ad1d3ef9a4847a568",
         "is_verified": false,
-        "line_number": 1349,
+        "line_number": 1479,
         "is_secret": false
       },
       {
@@ -1957,7 +2101,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b83c83894d873c027ba4615d15104944324378f4",
         "is_verified": false,
-        "line_number": 1353,
+        "line_number": 1483,
         "is_secret": false
       },
       {
@@ -1965,7 +2109,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e60ec2921d287de0ac22831deed001823740f61c",
         "is_verified": false,
-        "line_number": 1358,
+        "line_number": 1488,
         "is_secret": false
       },
       {
@@ -1973,7 +2117,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7feb84e7bac9f8cb60fff500f80285507a14318d",
         "is_verified": false,
-        "line_number": 1361,
+        "line_number": 1491,
         "is_secret": false
       },
       {
@@ -1981,7 +2125,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
         "is_verified": false,
-        "line_number": 1365,
+        "line_number": 1495,
         "is_secret": false
       },
       {
@@ -1989,7 +2133,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bc23715592b7602434c2776230d19f43fc479898",
         "is_verified": false,
-        "line_number": 1368,
+        "line_number": 1498,
         "is_secret": false
       },
       {
@@ -1997,7 +2141,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
         "is_verified": false,
-        "line_number": 1372,
+        "line_number": 1502,
         "is_secret": false
       },
       {
@@ -2005,7 +2149,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
         "is_verified": false,
-        "line_number": 1375,
+        "line_number": 1505,
         "is_secret": false
       },
       {
@@ -2013,7 +2157,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
         "is_verified": false,
-        "line_number": 1378,
+        "line_number": 1508,
         "is_secret": false
       },
       {
@@ -2021,7 +2165,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
         "is_verified": false,
-        "line_number": 1381,
+        "line_number": 1511,
         "is_secret": false
       },
       {
@@ -2029,7 +2173,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
         "is_verified": false,
-        "line_number": 1384,
+        "line_number": 1514,
         "is_secret": false
       },
       {
@@ -2037,7 +2181,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "690af56af1384793272c233c11ffb5d354b49fc0",
         "is_verified": false,
-        "line_number": 1387,
+        "line_number": 1517,
         "is_secret": false
       },
       {
@@ -2045,7 +2189,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "43e69c85090264b5501c0964aaa3d048ee08fd37",
         "is_verified": false,
-        "line_number": 1391,
+        "line_number": 1521,
         "is_secret": false
       },
       {
@@ -2053,7 +2197,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
         "is_verified": false,
-        "line_number": 1395,
+        "line_number": 1525,
         "is_secret": false
       },
       {
@@ -2061,7 +2205,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4ed49acfbd180533265d2099f3043963c4a24443",
         "is_verified": false,
-        "line_number": 1399,
+        "line_number": 1529,
         "is_secret": false
       },
       {
@@ -2069,7 +2213,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "428e72f71455a785963f1df5f85c26c6d6ae519b",
         "is_verified": false,
-        "line_number": 1403,
+        "line_number": 1533,
         "is_secret": false
       },
       {
@@ -2077,15 +2221,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
         "is_verified": false,
-        "line_number": 1406,
+        "line_number": 1536,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "621b26766bdddc2a2e0f7eff42ad8426b4b8198d",
+        "is_verified": false,
+        "line_number": 1539
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
         "is_verified": false,
-        "line_number": 1409,
+        "line_number": 1542,
         "is_secret": false
       },
       {
@@ -2093,7 +2244,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8f16039bc2ed9b93d8e319897b70cb25f25dfcc4",
         "is_verified": false,
-        "line_number": 1412,
+        "line_number": 1545,
         "is_secret": false
       },
       {
@@ -2101,7 +2252,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "862951cd71d0412b5e52bae3e952725486a655b0",
         "is_verified": false,
-        "line_number": 1416,
+        "line_number": 1549,
         "is_secret": false
       },
       {
@@ -2109,7 +2260,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3752b70c2c4391586cfb164832e45682b1ecfc22",
         "is_verified": false,
-        "line_number": 1420,
+        "line_number": 1553,
         "is_secret": false
       },
       {
@@ -2117,7 +2268,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf2a7aa50ec6063cbb616daadb50eec0213fa61f",
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1557,
         "is_secret": false
       },
       {
@@ -2125,7 +2276,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
         "is_verified": false,
-        "line_number": 1427,
+        "line_number": 1560,
         "is_secret": false
       },
       {
@@ -2133,7 +2284,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a35cbc541c025ba5ccef5ca780a743f94848a218",
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1565,
         "is_secret": false
       },
       {
@@ -2141,7 +2292,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
         "is_verified": false,
-        "line_number": 1435,
+        "line_number": 1568,
         "is_secret": false
       },
       {
@@ -2149,7 +2300,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ff435d07ef4cb4267aaa7adfdfd11d80984bc826",
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1572,
         "is_secret": false
       },
       {
@@ -2157,7 +2308,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1575,
         "is_secret": false
       },
       {
@@ -2165,7 +2316,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
         "is_verified": false,
-        "line_number": 1446,
+        "line_number": 1579,
         "is_secret": false
       },
       {
@@ -2173,7 +2324,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
         "is_verified": false,
-        "line_number": 1450,
+        "line_number": 1583,
         "is_secret": false
       },
       {
@@ -2181,7 +2332,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
         "is_verified": false,
-        "line_number": 1454,
+        "line_number": 1587,
         "is_secret": false
       },
       {
@@ -2189,7 +2340,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dedc9b22d5635183aab2822ddc8216ffb7bec66",
         "is_verified": false,
-        "line_number": 1458,
+        "line_number": 1591,
         "is_secret": false
       },
       {
@@ -2197,7 +2348,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "07365202aa196d356df406db75704c4807ad833e",
         "is_verified": false,
-        "line_number": 1462,
+        "line_number": 1595,
         "is_secret": false
       },
       {
@@ -2205,7 +2356,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
         "is_verified": false,
-        "line_number": 1466,
+        "line_number": 1599,
         "is_secret": false
       },
       {
@@ -2213,7 +2364,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0b7b9ea94e8e5f945f8ffa476ae48f3060bbed15",
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1603,
         "is_secret": false
       },
       {
@@ -2221,7 +2372,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1606,
         "is_secret": false
       },
       {
@@ -2229,7 +2380,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
         "is_verified": false,
-        "line_number": 1477,
+        "line_number": 1610,
         "is_secret": false
       },
       {
@@ -2237,7 +2388,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
         "is_verified": false,
-        "line_number": 1481,
+        "line_number": 1614,
         "is_secret": false
       },
       {
@@ -2245,7 +2396,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
         "is_verified": false,
-        "line_number": 1485,
+        "line_number": 1618,
         "is_secret": false
       },
       {
@@ -2253,7 +2404,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
         "is_verified": false,
-        "line_number": 1489,
+        "line_number": 1622,
         "is_secret": false
       },
       {
@@ -2261,7 +2412,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
         "is_verified": false,
-        "line_number": 1493,
+        "line_number": 1626,
         "is_secret": false
       },
       {
@@ -2269,7 +2420,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
         "is_verified": false,
-        "line_number": 1497,
+        "line_number": 1630,
         "is_secret": false
       },
       {
@@ -2277,7 +2428,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
         "is_verified": false,
-        "line_number": 1501,
+        "line_number": 1634,
         "is_secret": false
       },
       {
@@ -2285,7 +2436,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
         "is_verified": false,
-        "line_number": 1507,
+        "line_number": 1640,
         "is_secret": false
       },
       {
@@ -2293,7 +2444,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1259773a720ff6c462f3fff70a0881f503563c9e",
         "is_verified": false,
-        "line_number": 1511,
+        "line_number": 1644,
         "is_secret": false
       },
       {
@@ -2301,7 +2452,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
         "is_verified": false,
-        "line_number": 1515,
+        "line_number": 1648,
         "is_secret": false
       },
       {
@@ -2309,7 +2460,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cf3e48f5af3fca6bb9135acdee135247bcae1307",
         "is_verified": false,
-        "line_number": 1524,
+        "line_number": 1657,
         "is_secret": false
       },
       {
@@ -2317,7 +2468,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9565b61bcf2aafa2128576569978e338bdd1a0bc",
         "is_verified": false,
-        "line_number": 1527,
+        "line_number": 1660,
         "is_secret": false
       },
       {
@@ -2325,7 +2476,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b0f6a9f09dd8a0ebc50e6d4a7a81e126cd64ac6a",
         "is_verified": false,
-        "line_number": 1530,
+        "line_number": 1663,
         "is_secret": false
       },
       {
@@ -2333,7 +2484,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
         "is_verified": false,
-        "line_number": 1533,
+        "line_number": 1666,
         "is_secret": false
       },
       {
@@ -2341,7 +2492,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
         "is_verified": false,
-        "line_number": 1537,
+        "line_number": 1670,
         "is_secret": false
       },
       {
@@ -2349,7 +2500,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
         "is_verified": false,
-        "line_number": 1541,
+        "line_number": 1674,
         "is_secret": false
       },
       {
@@ -2357,15 +2508,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
         "is_verified": false,
-        "line_number": 1544,
+        "line_number": 1677,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "0a200afe0142c8d73f691b9b48ad5930e422ed3f",
+        "is_verified": false,
+        "line_number": 1680
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c02b39bafb6389010b678e8a4714d2ddfb10fe59",
         "is_verified": false,
-        "line_number": 1547,
+        "line_number": 1684,
         "is_secret": false
       },
       {
@@ -2373,7 +2531,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "46a4e83f9f3f3670ec1cf4445789431038008dc2",
         "is_verified": false,
-        "line_number": 1550,
+        "line_number": 1687,
         "is_secret": false
       },
       {
@@ -2381,7 +2539,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0fa428c8d3a332eb3100743c0ffc3883c4d6500e",
         "is_verified": false,
-        "line_number": 1553,
+        "line_number": 1690,
         "is_secret": false
       },
       {
@@ -2389,7 +2547,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fc7b2f07f919c3f8e20aa78a1756d2bcca252fb9",
         "is_verified": false,
-        "line_number": 1556,
+        "line_number": 1693,
         "is_secret": false
       },
       {
@@ -2397,7 +2555,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8ba4df7f64f94ef4347bf0d9b894f9075f3b7b69",
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1696,
         "is_secret": false
       },
       {
@@ -2405,7 +2563,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
         "is_verified": false,
-        "line_number": 1563,
+        "line_number": 1700,
         "is_secret": false
       },
       {
@@ -2413,7 +2571,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d9c1f677ee5e5af2247aaa0ab352291ef98e5ea3",
         "is_verified": false,
-        "line_number": 1567,
+        "line_number": 1704,
         "is_secret": false
       },
       {
@@ -2421,7 +2579,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
         "is_verified": false,
-        "line_number": 1570,
+        "line_number": 1707,
         "is_secret": false
       },
       {
@@ -2429,7 +2587,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6c88ecf20f9dc070ee18f0cf59f58b0025f6ec55",
         "is_verified": false,
-        "line_number": 1574,
+        "line_number": 1711,
         "is_secret": false
       },
       {
@@ -2437,7 +2595,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
         "is_verified": false,
-        "line_number": 1578,
+        "line_number": 1715,
         "is_secret": false
       },
       {
@@ -2445,7 +2603,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "abcb73825dfa960775d6eafa968d65b9180d36c5",
         "is_verified": false,
-        "line_number": 1582,
+        "line_number": 1719,
         "is_secret": false
       },
       {
@@ -2453,7 +2611,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "45c675dd5218ee48913576fba5016553db08668f",
         "is_verified": false,
-        "line_number": 1588,
+        "line_number": 1725,
         "is_secret": false
       },
       {
@@ -2461,7 +2619,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "598fd2d32e89e81b375b0ad0273fb1f17c9ba7d5",
         "is_verified": false,
-        "line_number": 1593,
+        "line_number": 1730,
         "is_secret": false
       },
       {
@@ -2469,7 +2627,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2a5c1a897332b7652d1daeb248e27b29123ca884",
         "is_verified": false,
-        "line_number": 1597,
+        "line_number": 1734,
         "is_secret": false
       },
       {
@@ -2477,7 +2635,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99e3e5f5d9f570cf4d4af4bc1c43544b0b2392ef",
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1738,
         "is_secret": false
       },
       {
@@ -2485,7 +2643,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5f036eebfbd4414e9ff18073bd76d55b22376e33",
         "is_verified": false,
-        "line_number": 1605,
+        "line_number": 1742,
         "is_secret": false
       },
       {
@@ -2493,7 +2651,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ad3044be6fc2905d62a5af9d3efa1a83e7c9389b",
         "is_verified": false,
-        "line_number": 1615,
+        "line_number": 1752,
         "is_secret": false
       },
       {
@@ -2501,7 +2659,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8566f6301c749c574462db3cef2c1f3a10a03c0",
         "is_verified": false,
-        "line_number": 1619,
+        "line_number": 1756,
         "is_secret": false
       },
       {
@@ -2509,7 +2667,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "51e9263c74493cd77c2d25adb255b15647d84512",
         "is_verified": false,
-        "line_number": 1623,
+        "line_number": 1760,
         "is_secret": false
       },
       {
@@ -2517,7 +2675,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1790c1f42e3416e31561c46b258d2f69c1608c85",
         "is_verified": false,
-        "line_number": 1627,
+        "line_number": 1764,
         "is_secret": false
       },
       {
@@ -2525,317 +2683,20 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
         "is_verified": false,
-        "line_number": 1631,
+        "line_number": 1768,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ceac1beaa3e65d484e1fce7f4a47b1c1bb1bbec5",
+        "is_verified": false,
+        "line_number": 1771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
-        "is_verified": false,
-        "line_number": 1634,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2fcbf434b04ba0a49ae29f1d9ea0edc30881350b",
-        "is_verified": false,
-        "line_number": 1637,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16d0c877fca994fd1c43bd7f131be967bf4f87b6",
-        "is_verified": false,
-        "line_number": 1641,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
-        "is_verified": false,
-        "line_number": 1645,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c0f64a532897bbd5497996fdfec7cfcd087540ce",
-        "is_verified": false,
-        "line_number": 1648,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fea0d9c5b0c53c41e6a0a961a49cccc170847120",
-        "is_verified": false,
-        "line_number": 1651,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "283a181bd9971789ceaee59c32a0f93e31a7a2a8",
-        "is_verified": false,
-        "line_number": 1654,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4fb28b14ff2c4dfd32138126666d09b3b4779da5",
-        "is_verified": false,
-        "line_number": 1657,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7e1d085812721297b6a5540f3b2d9416d2f57efb",
-        "is_verified": false,
-        "line_number": 1660,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fa3e6343640bdfc534111bedad8e4be8658cb0b0",
-        "is_verified": false,
-        "line_number": 1663,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
-        "is_verified": false,
-        "line_number": 1666,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "76ecd72b3dad674722024145ada2c3d7763456e3",
-        "is_verified": false,
-        "line_number": 1675,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c5b9224d6550ddd6a9d3e700fd0a58360b11ca0d",
-        "is_verified": false,
-        "line_number": 1678,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3594781b38f5d70bb1b747317347cf06b2a0cc01",
-        "is_verified": false,
-        "line_number": 1682,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "76332214739a4c7dd7c65873aa473b0b918d47e4",
-        "is_verified": false,
-        "line_number": 1686,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6469b5be81ddc9f74fdb35bb646526db702e0f3d",
-        "is_verified": false,
-        "line_number": 1690,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "35e9b52d7a5604a386ad789c8c7b5234361ce18e",
-        "is_verified": false,
-        "line_number": 1693,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1a3a9dc68ebcd975166450d240ed228e050a3e8a",
-        "is_verified": false,
-        "line_number": 1697,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9c422f6dfca5f8acb3d3923f7aed45865b8e1168",
-        "is_verified": false,
-        "line_number": 1701,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
-        "is_verified": false,
-        "line_number": 1706,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
-        "is_verified": false,
-        "line_number": 1711,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "184476d985c0d799b82544165cb4d456129f594c",
-        "is_verified": false,
-        "line_number": 1715,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
-        "is_verified": false,
-        "line_number": 1719,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "89345a033a4ecac54d56210d7fb9533fddc58490",
-        "is_verified": false,
-        "line_number": 1723,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9a2925939d58c126684a6bc23cb398ee48ae47fb",
-        "is_verified": false,
-        "line_number": 1727,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
-        "is_verified": false,
-        "line_number": 1731,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "631f4dfe80235f956760243a084b52119f9380ab",
-        "is_verified": false,
-        "line_number": 1734,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
-        "is_verified": false,
-        "line_number": 1738,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
-        "is_verified": false,
-        "line_number": 1741,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
-        "is_verified": false,
-        "line_number": 1744,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
-        "is_verified": false,
-        "line_number": 1747,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "492f7af72b8ed205d898deb4e73463b7077e70a9",
-        "is_verified": false,
-        "line_number": 1750,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b47624d97ee05cf142ba92c5dc738615ef86b0a6",
-        "is_verified": false,
-        "line_number": 1753,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "10872e4d4d8973d18c0af1bd651122c8d5693369",
-        "is_verified": false,
-        "line_number": 1756,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "dfa61d24a9c1a574fb520ffd45b1b2ffe8e92658",
-        "is_verified": false,
-        "line_number": 1759,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0d96d45dd8e09cb4633cd3318f47162fc2257667",
-        "is_verified": false,
-        "line_number": 1763,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
-        "is_verified": false,
-        "line_number": 1767,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c6ee5cc9425c6e106fad752bf1f79925d0f8d332",
-        "is_verified": false,
-        "line_number": 1770,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f09b00d00e74c891c9bbc0614a19d47015e616c1",
         "is_verified": false,
         "line_number": 1774,
         "is_secret": false
@@ -2843,47 +2704,55 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e25be230742364f1ee60067a756da19dc7572126",
+        "hashed_secret": "2fcbf434b04ba0a49ae29f1d9ea0edc30881350b",
         "is_verified": false,
-        "line_number": 1778,
+        "line_number": 1777,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1109544447e298af75035b2bbfc851610f963a65",
+        "hashed_secret": "16d0c877fca994fd1c43bd7f131be967bf4f87b6",
         "is_verified": false,
-        "line_number": 1782,
+        "line_number": 1781,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7495ab514349a9c665180d198d97406b00971d06",
+        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
         "is_verified": false,
-        "line_number": 1786,
+        "line_number": 1785,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "cb41740c5bbb34bb9e00283d48dbf4a56f15d251",
+        "hashed_secret": "c0f64a532897bbd5497996fdfec7cfcd087540ce",
         "is_verified": false,
-        "line_number": 1790,
+        "line_number": 1788,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
+        "hashed_secret": "fea0d9c5b0c53c41e6a0a961a49cccc170847120",
         "is_verified": false,
-        "line_number": 1793,
+        "line_number": 1791,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
+        "hashed_secret": "283a181bd9971789ceaee59c32a0f93e31a7a2a8",
+        "is_verified": false,
+        "line_number": 1794,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4fb28b14ff2c4dfd32138126666d09b3b4779da5",
         "is_verified": false,
         "line_number": 1797,
         "is_secret": false
@@ -2891,7 +2760,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
+        "hashed_secret": "7e1d085812721297b6a5540f3b2d9416d2f57efb",
         "is_verified": false,
         "line_number": 1800,
         "is_secret": false
@@ -2899,7 +2768,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
+        "hashed_secret": "fa3e6343640bdfc534111bedad8e4be8658cb0b0",
         "is_verified": false,
         "line_number": 1803,
         "is_secret": false
@@ -2907,7 +2776,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e9ce08fb0922eb7b6fd8078a79f948726b9b756e",
+        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
         "is_verified": false,
         "line_number": 1806,
         "is_secret": false
@@ -2915,23 +2784,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d5ec021cbb92c3486e38fac176f4f59a6c1d92e8",
+        "hashed_secret": "76ecd72b3dad674722024145ada2c3d7763456e3",
         "is_verified": false,
-        "line_number": 1810,
+        "line_number": 1815,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0168f03d6f1748d5d7ae624a93f711333b69d01c",
-        "is_verified": false,
-        "line_number": 1814,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
+        "hashed_secret": "c5b9224d6550ddd6a9d3e700fd0a58360b11ca0d",
         "is_verified": false,
         "line_number": 1818,
         "is_secret": false
@@ -2939,79 +2800,79 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f88f23dafd3c868018f752bc0f0b816603b8fdcf",
+        "hashed_secret": "3594781b38f5d70bb1b747317347cf06b2a0cc01",
         "is_verified": false,
-        "line_number": 1821,
+        "line_number": 1822,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
+        "hashed_secret": "76332214739a4c7dd7c65873aa473b0b918d47e4",
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1826,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e907e408e8ac716a2dc03c3a56283b57e5bb5c73",
+        "hashed_secret": "6469b5be81ddc9f74fdb35bb646526db702e0f3d",
         "is_verified": false,
-        "line_number": 1828,
+        "line_number": 1830,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4e5e279b264f80f6302507f3bc02028118a5381f",
+        "hashed_secret": "35e9b52d7a5604a386ad789c8c7b5234361ce18e",
         "is_verified": false,
-        "line_number": 1831,
+        "line_number": 1833,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8027d593202ac7fe9ecb516b44ed6ee4788bfa5a",
+        "hashed_secret": "1a3a9dc68ebcd975166450d240ed228e050a3e8a",
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1837,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
+        "hashed_secret": "9c422f6dfca5f8acb3d3923f7aed45865b8e1168",
         "is_verified": false,
-        "line_number": 1838,
+        "line_number": 1841,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
+        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
         "is_verified": false,
-        "line_number": 1842,
+        "line_number": 1846,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "08d197c68a2ed20b47b376a98f1968aa5966e035",
+        "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
         "is_verified": false,
-        "line_number": 1845,
+        "line_number": 1851,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
+        "hashed_secret": "184476d985c0d799b82544165cb4d456129f594c",
         "is_verified": false,
-        "line_number": 1854,
+        "line_number": 1855,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "32f166e925f96dafcba74b3787246df2a06a9e19",
+        "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
         "is_verified": false,
         "line_number": 1859,
         "is_secret": false
@@ -3019,55 +2880,55 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
+        "hashed_secret": "89345a033a4ecac54d56210d7fb9533fddc58490",
         "is_verified": false,
-        "line_number": 1862,
+        "line_number": 1863,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "518c6e09c048b1b3cdbcc4ed47df84e0552aba4c",
+        "hashed_secret": "9a2925939d58c126684a6bc23cb398ee48ae47fb",
         "is_verified": false,
-        "line_number": 1865,
+        "line_number": 1867,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
+        "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
         "is_verified": false,
-        "line_number": 1868,
+        "line_number": 1871,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "987bd819de5601830bd2d22b74c9243d57f14aec",
+        "hashed_secret": "631f4dfe80235f956760243a084b52119f9380ab",
         "is_verified": false,
-        "line_number": 1873,
+        "line_number": 1874,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4c565e2b5132b7df2d3126654bee51cf449f5d8f",
+        "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
         "is_verified": false,
-        "line_number": 1877,
+        "line_number": 1878,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0ec89f07004a01dda54b29e48a86c84f8098fdb6",
+        "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
         "is_verified": false,
-        "line_number": 1880,
+        "line_number": 1881,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ecca8c8ee1920fbd6387220767bdecf3635a3741",
+        "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
         "is_verified": false,
         "line_number": 1884,
         "is_secret": false
@@ -3075,7 +2936,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b48b7cde42a2442c78c359b776b516d8127006c6",
+        "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
+        "is_verified": false,
+        "line_number": 1887,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "492f7af72b8ed205d898deb4e73463b7077e70a9",
         "is_verified": false,
         "line_number": 1890,
         "is_secret": false
@@ -3083,7 +2952,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2fb4be4f309d24f5064ac5496b8c7f59df0bf966",
+        "hashed_secret": "b47624d97ee05cf142ba92c5dc738615ef86b0a6",
+        "is_verified": false,
+        "line_number": 1893,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "10872e4d4d8973d18c0af1bd651122c8d5693369",
         "is_verified": false,
         "line_number": 1896,
         "is_secret": false
@@ -3091,39 +2968,69 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b6acf38d09475b54b197ff0574abc4a7e86c3543",
+        "hashed_secret": "dfa61d24a9c1a574fb520ffd45b1b2ffe8e92658",
         "is_verified": false,
-        "line_number": 1902,
+        "line_number": 1899,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "405ac79c3832190ec6bd61bce50e9390a026af72",
+        "hashed_secret": "0d96d45dd8e09cb4633cd3318f47162fc2257667",
         "is_verified": false,
-        "line_number": 1908,
+        "line_number": 1903,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5f3d1367a38ac4e76290f44b6dc26d3555bbabf5",
+        "hashed_secret": "d0127fd3500968634abcfba5a45d8d9d8a0628dc",
         "is_verified": false,
-        "line_number": 1914,
+        "line_number": 1907
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
+        "is_verified": false,
+        "line_number": 1910,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d86912fe91c497e31a4344f459a68586ce096966",
+        "hashed_secret": "c6ee5cc9425c6e106fad752bf1f79925d0f8d332",
         "is_verified": false,
-        "line_number": 1921,
+        "line_number": 1913,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1509ab36ebf61526ec42f40016db32b0925e96bc",
+        "hashed_secret": "f09b00d00e74c891c9bbc0614a19d47015e616c1",
+        "is_verified": false,
+        "line_number": 1917,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "aa3274ac7d69b31bff9519c6ded94b252aa90a81",
+        "is_verified": false,
+        "line_number": 1921
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e25be230742364f1ee60067a756da19dc7572126",
+        "is_verified": false,
+        "line_number": 1924,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1109544447e298af75035b2bbfc851610f963a65",
         "is_verified": false,
         "line_number": 1928,
         "is_secret": false
@@ -3131,103 +3038,133 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2139b734b30d5642cf104ea814b455bf3f08ca4c",
+        "hashed_secret": "7495ab514349a9c665180d198d97406b00971d06",
         "is_verified": false,
-        "line_number": 1935,
+        "line_number": 1932,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ef73b9a0b786d2e003921cc9967a0a7cd6ae1913",
+        "hashed_secret": "cb41740c5bbb34bb9e00283d48dbf4a56f15d251",
         "is_verified": false,
-        "line_number": 1942,
+        "line_number": 1936,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2ffc317e2ecc11d98e3e05bf565c6575c4cbfd51",
+        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
         "is_verified": false,
-        "line_number": 1948,
+        "line_number": 1939,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "432730c731e24c084f98525d5e133e358dc47b2f",
+        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
         "is_verified": false,
-        "line_number": 1954,
+        "line_number": 1943,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1c386996454f57fad765143b1a1393b4fd15dceb",
+        "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
         "is_verified": false,
-        "line_number": 1958,
+        "line_number": 1946,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "af1761dddd338a777dabd8eb8f1ae8955205a116",
+        "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
         "is_verified": false,
-        "line_number": 1962,
+        "line_number": 1949,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
+        "hashed_secret": "e9ce08fb0922eb7b6fd8078a79f948726b9b756e",
         "is_verified": false,
-        "line_number": 1965,
+        "line_number": 1952,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
+        "hashed_secret": "d5ec021cbb92c3486e38fac176f4f59a6c1d92e8",
         "is_verified": false,
-        "line_number": 1968,
+        "line_number": 1956,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d0bc72b892bf793034931ddf0bdccf8cae2c4164",
+        "hashed_secret": "0168f03d6f1748d5d7ae624a93f711333b69d01c",
         "is_verified": false,
-        "line_number": 1972,
+        "line_number": 1960,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "dc1b9f847614c5a40208a767d4cc7cf0f9b2282a",
+        "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
         "is_verified": false,
-        "line_number": 1975,
+        "line_number": 1964,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
+        "hashed_secret": "27ac029c63fd4a79febe4493812e5fd87d1e0ba8",
         "is_verified": false,
-        "line_number": 1979,
+        "line_number": 1967
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f88f23dafd3c868018f752bc0f0b816603b8fdcf",
+        "is_verified": false,
+        "line_number": 1970,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "96af205313d448bfac749d7820179b113d06c232",
+        "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
         "is_verified": false,
-        "line_number": 1982,
+        "line_number": 1973,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7aa924d4aef9f14c78acee8a31bcbd78b26e9898",
+        "hashed_secret": "c6fac4fc8845592652235008b20d705167bb64c8",
+        "is_verified": false,
+        "line_number": 1977
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e907e408e8ac716a2dc03c3a56283b57e5bb5c73",
+        "is_verified": false,
+        "line_number": 1981,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4e5e279b264f80f6302507f3bc02028118a5381f",
+        "is_verified": false,
+        "line_number": 1984,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8027d593202ac7fe9ecb516b44ed6ee4788bfa5a",
         "is_verified": false,
         "line_number": 1987,
         "is_secret": false
@@ -3235,7 +3172,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1e2228f0d8e0fc2bc3b8740a8ff3d287006b9a38",
+        "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
         "is_verified": false,
         "line_number": 1991,
         "is_secret": false
@@ -3243,135 +3180,52 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
+        "hashed_secret": "b78dedf3b731da4d2939780bf688cc250d6d7803",
         "is_verified": false,
-        "line_number": 1994,
+        "line_number": 1995
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "34ac8d1f4eeb025b1ab1e5b7be252f49a06d3678",
+        "is_verified": false,
+        "line_number": 2001
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c28a77a2c09fc919ec71532ac06775e2d357f682",
+        "is_verified": false,
+        "line_number": 2013
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
+        "is_verified": false,
+        "line_number": 2025,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
+        "hashed_secret": "08d197c68a2ed20b47b376a98f1968aa5966e035",
         "is_verified": false,
-        "line_number": 1997,
+        "line_number": 2028,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "72a79417ad2fe4b674820c0d880ce5119131e9cc",
+        "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
         "is_verified": false,
-        "line_number": 2000,
+        "line_number": 2037,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
-        "is_verified": false,
-        "line_number": 2003,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
-        "is_verified": false,
-        "line_number": 2006,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
-        "is_verified": false,
-        "line_number": 2009,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
-        "is_verified": false,
-        "line_number": 2012,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
-        "is_verified": false,
-        "line_number": 2015,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
-        "is_verified": false,
-        "line_number": 2018,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
-        "is_verified": false,
-        "line_number": 2021,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
-        "is_verified": false,
-        "line_number": 2024,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
-        "is_verified": false,
-        "line_number": 2027,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
-        "is_verified": false,
-        "line_number": 2030,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a43d82b1bb02a76982f03708a4c77d9717f5f5c1",
-        "is_verified": false,
-        "line_number": 2033,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
-        "is_verified": false,
-        "line_number": 2036,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
-        "is_verified": false,
-        "line_number": 2039,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8e193ad7099ffd82fbb600c11c8e057de00db18a",
+        "hashed_secret": "32f166e925f96dafcba74b3787246df2a06a9e19",
         "is_verified": false,
         "line_number": 2042,
         "is_secret": false
@@ -3379,7 +3233,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
+        "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
         "is_verified": false,
         "line_number": 2045,
         "is_secret": false
@@ -3387,7 +3241,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
+        "hashed_secret": "518c6e09c048b1b3cdbcc4ed47df84e0552aba4c",
         "is_verified": false,
         "line_number": 2048,
         "is_secret": false
@@ -3395,7 +3249,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
+        "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
         "is_verified": false,
         "line_number": 2051,
         "is_secret": false
@@ -3403,23 +3257,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
+        "hashed_secret": "987bd819de5601830bd2d22b74c9243d57f14aec",
         "is_verified": false,
-        "line_number": 2054,
+        "line_number": 2056,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
-        "is_verified": false,
-        "line_number": 2057,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
+        "hashed_secret": "4c565e2b5132b7df2d3126654bee51cf449f5d8f",
         "is_verified": false,
         "line_number": 2060,
         "is_secret": false
@@ -3427,7 +3273,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
+        "hashed_secret": "0ec89f07004a01dda54b29e48a86c84f8098fdb6",
         "is_verified": false,
         "line_number": 2063,
         "is_secret": false
@@ -3435,127 +3281,63 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
+        "hashed_secret": "ecca8c8ee1920fbd6387220767bdecf3635a3741",
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2067,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
+        "hashed_secret": "b48b7cde42a2442c78c359b776b516d8127006c6",
         "is_verified": false,
-        "line_number": 2069,
+        "line_number": 2073,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
+        "hashed_secret": "2fb4be4f309d24f5064ac5496b8c7f59df0bf966",
         "is_verified": false,
-        "line_number": 2072,
+        "line_number": 2079,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
+        "hashed_secret": "b6acf38d09475b54b197ff0574abc4a7e86c3543",
         "is_verified": false,
-        "line_number": 2075,
+        "line_number": 2085,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
+        "hashed_secret": "405ac79c3832190ec6bd61bce50e9390a026af72",
         "is_verified": false,
-        "line_number": 2078,
+        "line_number": 2091,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
+        "hashed_secret": "5f3d1367a38ac4e76290f44b6dc26d3555bbabf5",
         "is_verified": false,
-        "line_number": 2081,
+        "line_number": 2097,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
+        "hashed_secret": "d86912fe91c497e31a4344f459a68586ce096966",
         "is_verified": false,
-        "line_number": 2084,
+        "line_number": 2104,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
-        "is_verified": false,
-        "line_number": 2087,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
-        "is_verified": false,
-        "line_number": 2090,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
-        "is_verified": false,
-        "line_number": 2093,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
-        "is_verified": false,
-        "line_number": 2096,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
-        "is_verified": false,
-        "line_number": 2099,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
-        "is_verified": false,
-        "line_number": 2102,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
-        "is_verified": false,
-        "line_number": 2105,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
-        "is_verified": false,
-        "line_number": 2108,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
+        "hashed_secret": "1509ab36ebf61526ec42f40016db32b0925e96bc",
         "is_verified": false,
         "line_number": 2111,
         "is_secret": false
@@ -3563,63 +3345,31 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
+        "hashed_secret": "2139b734b30d5642cf104ea814b455bf3f08ca4c",
         "is_verified": false,
-        "line_number": 2114,
+        "line_number": 2118,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
+        "hashed_secret": "ef73b9a0b786d2e003921cc9967a0a7cd6ae1913",
         "is_verified": false,
-        "line_number": 2117,
+        "line_number": 2125,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
+        "hashed_secret": "2ffc317e2ecc11d98e3e05bf565c6575c4cbfd51",
         "is_verified": false,
-        "line_number": 2120,
+        "line_number": 2131,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
-        "is_verified": false,
-        "line_number": 2123,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
-        "is_verified": false,
-        "line_number": 2126,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "06c654850ce93559d42fd5f657cbee6c4d9b47c5",
-        "is_verified": false,
-        "line_number": 2129,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "31d6671bbf40210dfde8e313a9c03ab41489691d",
-        "is_verified": false,
-        "line_number": 2133,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "aa2add0e083112de14c80fd8d81ec606de67ee43",
+        "hashed_secret": "432730c731e24c084f98525d5e133e358dc47b2f",
         "is_verified": false,
         "line_number": 2137,
         "is_secret": false
@@ -3627,7 +3377,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
+        "hashed_secret": "1c386996454f57fad765143b1a1393b4fd15dceb",
         "is_verified": false,
         "line_number": 2141,
         "is_secret": false
@@ -3635,15 +3385,29 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "782837135014880dce3fa077d0c71f42b61e4614",
+        "hashed_secret": "af1761dddd338a777dabd8eb8f1ae8955205a116",
         "is_verified": false,
-        "line_number": 2144,
+        "line_number": 2145,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e6790cf37e1bb89911a301e911658358eb18670e",
+        "hashed_secret": "38441b3738707765cf9c96bac8bc8cc1ae34037d",
+        "is_verified": false,
+        "line_number": 2148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2cb277435cb97d4859d0d0ae4d891a9f3cd17bef",
+        "is_verified": false,
+        "line_number": 2151
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
         "is_verified": false,
         "line_number": 2154,
         "is_secret": false
@@ -3651,47 +3415,47 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
+        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
         "is_verified": false,
-        "line_number": 2158,
+        "line_number": 2157,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "508ffd78a7522f83c630d98474d58ccf406bd25e",
+        "hashed_secret": "d0bc72b892bf793034931ddf0bdccf8cae2c4164",
         "is_verified": false,
-        "line_number": 2163,
+        "line_number": 2161,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8956daf032bb5c85a1bdbe5b2827259fbce65ae2",
+        "hashed_secret": "dc1b9f847614c5a40208a767d4cc7cf0f9b2282a",
         "is_verified": false,
-        "line_number": 2166,
+        "line_number": 2164,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
+        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
         "is_verified": false,
-        "line_number": 2169,
+        "line_number": 2168,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fd987a3583a86961bbb3db9e742c93a837cd5bf6",
+        "hashed_secret": "96af205313d448bfac749d7820179b113d06c232",
         "is_verified": false,
-        "line_number": 2173,
+        "line_number": 2171,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b5a6f2a2101ff7f7af8d0c6c87c554acea27e0c9",
+        "hashed_secret": "7aa924d4aef9f14c78acee8a31bcbd78b26e9898",
         "is_verified": false,
         "line_number": 2176,
         "is_secret": false
@@ -3699,7 +3463,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7356a0be2ffe123fd4b708a6d09ecdddaa038c22",
+        "hashed_secret": "1e2228f0d8e0fc2bc3b8740a8ff3d287006b9a38",
         "is_verified": false,
         "line_number": 2180,
         "is_secret": false
@@ -3707,7 +3471,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d69c03a6c481565a321e7b90776918eaad16e532",
+        "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
         "is_verified": false,
         "line_number": 2183,
         "is_secret": false
@@ -3715,15 +3479,14 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "316bf5ed09ed2d2511c54a3e60e047e26550c82c",
+        "hashed_secret": "8fd991cd05ad3f6a7f265fc37db4fe1baaea8997",
         "is_verified": false,
-        "line_number": 2187,
-        "is_secret": false
+        "line_number": 2186
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
+        "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
         "is_verified": false,
         "line_number": 2191,
         "is_secret": false
@@ -3731,7 +3494,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0135f1c09e6e6c23cd762374520078171e7bd09e",
+        "hashed_secret": "72a79417ad2fe4b674820c0d880ce5119131e9cc",
         "is_verified": false,
         "line_number": 2194,
         "is_secret": false
@@ -3739,7 +3502,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "533573708ed3eabce514432cd26d532218222659",
+        "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
         "is_verified": false,
         "line_number": 2197,
         "is_secret": false
@@ -3747,47 +3510,54 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "61ff5c8a702d8ffe28063c06487a3a5a0db2ed70",
+        "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
         "is_verified": false,
-        "line_number": 2201,
+        "line_number": 2200,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e1beff0b39929c9538a683456356f4b7da203723",
+        "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2203,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
+        "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
         "is_verified": false,
-        "line_number": 2208,
+        "line_number": 2206,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
+        "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
         "is_verified": false,
-        "line_number": 2211,
+        "line_number": 2209,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
+        "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
         "is_verified": false,
-        "line_number": 2214,
+        "line_number": 2212,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9dd8b7bcb847f86a200200adcb41ae1230319c9a",
+        "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
+        "is_verified": false,
+        "line_number": 2215
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
         "is_verified": false,
         "line_number": 2218,
         "is_secret": false
@@ -3795,31 +3565,46 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ba8a4a4ea1707cd9c5a04000ad2a40c0890c22c6",
+        "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
         "is_verified": false,
-        "line_number": 2223,
+        "line_number": 2221,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
+        "hashed_secret": "9bd0ccdc3670e20b60461bac42b2431894ad8879",
         "is_verified": false,
-        "line_number": 2228,
+        "line_number": 2224
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
+        "is_verified": false,
+        "line_number": 2227,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "15fe871ffc303bd4cf6edbc775f1af448c258e69",
+        "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
         "is_verified": false,
-        "line_number": 2232,
+        "line_number": 2230,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ddd88fae03505e64f6647d5587d4c3e5fd6b78b1",
+        "hashed_secret": "a43d82b1bb02a76982f03708a4c77d9717f5f5c1",
+        "is_verified": false,
+        "line_number": 2233,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
         "is_verified": false,
         "line_number": 2236,
         "is_secret": false
@@ -3827,7 +3612,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "740c72e48345f65f0deefba812581017bd57c614",
+        "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
         "is_verified": false,
         "line_number": 2239,
         "is_secret": false
@@ -3835,39 +3620,47 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "21ce40fa7b942491db7f5babb19538e726c27e8d",
+        "hashed_secret": "8e193ad7099ffd82fbb600c11c8e057de00db18a",
         "is_verified": false,
-        "line_number": 2243,
+        "line_number": 2242,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
+        "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
         "is_verified": false,
-        "line_number": 2247,
+        "line_number": 2245,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
+        "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
         "is_verified": false,
-        "line_number": 2250,
+        "line_number": 2248,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "706884687450108cef742ef7b12010f29167a501",
+        "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
         "is_verified": false,
-        "line_number": 2253,
+        "line_number": 2251,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "33d460d596f1c7ea50a5b8b7b96e0035e398826a",
+        "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
+        "is_verified": false,
+        "line_number": 2254,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
         "is_verified": false,
         "line_number": 2257,
         "is_secret": false
@@ -3875,55 +3668,97 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "623c0b595f4739e5a9e2eabcde54a72be42d9964",
+        "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
         "is_verified": false,
-        "line_number": 2262,
+        "line_number": 2260,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
+        "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
         "is_verified": false,
-        "line_number": 2268,
+        "line_number": 2263,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ef92e3e90926767f04ea05b4fc58e71019cf68d5",
+        "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
         "is_verified": false,
-        "line_number": 2271,
+        "line_number": 2266,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a19482a8f22f3815a3e677a5235a013b2f83db69",
+        "hashed_secret": "3c2938cb5f484c6e9d50335bc9975c0b78acf0e9",
         "is_verified": false,
-        "line_number": 2274,
+        "line_number": 2269
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4a1f2398aa3ec32cdf9982a59dbfc250cd7386df",
+        "is_verified": false,
+        "line_number": 2272
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "cdd288b967597b72fde4c8101168b2c9fcf12b1e",
+        "is_verified": false,
+        "line_number": 2275
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e1b05b747457b4823af87aa8d516e1a30492ef30",
+        "is_verified": false,
+        "line_number": 2278
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f075b69049314fdac9e21c366ff425ed8d0786e2",
+        "is_verified": false,
+        "line_number": 2281
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
+        "is_verified": false,
+        "line_number": 2284,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16615d4a3177908c029aff2e170755a99ece101f",
+        "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
         "is_verified": false,
-        "line_number": 2280,
+        "line_number": 2287,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
+        "hashed_secret": "01de106bcf1c964113bb4ecedc192963fe2a3d9d",
         "is_verified": false,
-        "line_number": 2286,
+        "line_number": 2290
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
+        "is_verified": false,
+        "line_number": 2293,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ac7754e0faf25c9d2f4ee8e116d76278bd94bf92",
+        "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
         "is_verified": false,
         "line_number": 2296,
         "is_secret": false
@@ -3931,47 +3766,118 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d73a56a508095d0d1e21f8c1562879ddc2f7c76b",
+        "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
         "is_verified": false,
-        "line_number": 2306,
+        "line_number": 2299,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "47aa4da18e189137c0be167ad618663a420e0a8f",
+        "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
         "is_verified": false,
-        "line_number": 2313,
+        "line_number": 2302,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
+        "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
         "is_verified": false,
-        "line_number": 2323,
+        "line_number": 2305,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0caeac5cc3573ecc311cd03aa836916728d0d98f",
+        "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
         "is_verified": false,
-        "line_number": 2333,
+        "line_number": 2308,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8eb603f181d16409922883159c02899b089f6d60",
+        "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
         "is_verified": false,
-        "line_number": 2337,
+        "line_number": 2311,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "821c1f3714302cd33664d01f2b9720a19fb53601",
+        "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
+        "is_verified": false,
+        "line_number": 2314,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
+        "is_verified": false,
+        "line_number": 2317,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
+        "is_verified": false,
+        "line_number": 2320,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "48d459b0d80c0a20b52e2cdf9ec1f9e0e0ab642f",
+        "is_verified": false,
+        "line_number": 2323
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
+        "is_verified": false,
+        "line_number": 2326,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
+        "is_verified": false,
+        "line_number": 2329,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
+        "is_verified": false,
+        "line_number": 2332,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
+        "is_verified": false,
+        "line_number": 2335,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
+        "is_verified": false,
+        "line_number": 2338,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
         "is_verified": false,
         "line_number": 2341,
         "is_secret": false
@@ -3979,7 +3885,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
+        "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
         "is_verified": false,
         "line_number": 2344,
         "is_secret": false
@@ -3987,7 +3893,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
+        "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
         "is_verified": false,
         "line_number": 2347,
         "is_secret": false
@@ -3995,7 +3901,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
+        "hashed_secret": "06c654850ce93559d42fd5f657cbee6c4d9b47c5",
         "is_verified": false,
         "line_number": 2350,
         "is_secret": false
@@ -4003,63 +3909,46 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
+        "hashed_secret": "31d6671bbf40210dfde8e313a9c03ab41489691d",
         "is_verified": false,
-        "line_number": 2353,
+        "line_number": 2354,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3c48660b66db6687c2ba1b7ffbac279614eead6e",
+        "hashed_secret": "aa2add0e083112de14c80fd8d81ec606de67ee43",
         "is_verified": false,
-        "line_number": 2356,
+        "line_number": 2358,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5a485a4915f94231f9dc5b355ddda367442ba450",
+        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
         "is_verified": false,
-        "line_number": 2360,
+        "line_number": 2362,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c8749a5afedf4a51c2227b00d41d8b94611d8745",
+        "hashed_secret": "782837135014880dce3fa077d0c71f42b61e4614",
         "is_verified": false,
-        "line_number": 2364,
+        "line_number": 2365,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a622ef066916d153a2c3501013238f36dde578fb",
+        "hashed_secret": "d2669fec82ff8075e9f930c01ee84e8546138d80",
         "is_verified": false,
-        "line_number": 2367,
-        "is_secret": false
+        "line_number": 2375
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6c8d2de91b8087bf6f18c9b505ec528e2bafb7c4",
-        "is_verified": false,
-        "line_number": 2372,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
-        "is_verified": false,
-        "line_number": 2376,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
+        "hashed_secret": "e6790cf37e1bb89911a301e911658358eb18670e",
         "is_verified": false,
         "line_number": 2379,
         "is_secret": false
@@ -4067,7 +3956,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "56029dbb81dfe27cd4bf72c8cfb3213657ce6d56",
+        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
         "is_verified": false,
         "line_number": 2383,
         "is_secret": false
@@ -4075,55 +3964,53 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2fd4d093008863345a56756800819a01bf8e0451",
+        "hashed_secret": "92c55301d403c2ad767661c948e81d7415bf2bde",
         "is_verified": false,
-        "line_number": 2388,
+        "line_number": 2388
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "508ffd78a7522f83c630d98474d58ccf406bd25e",
+        "is_verified": false,
+        "line_number": 2393,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f9fd81843f2a26e1be00fb6acfcb3895cffedfe6",
+        "hashed_secret": "8956daf032bb5c85a1bdbe5b2827259fbce65ae2",
         "is_verified": false,
-        "line_number": 2391,
+        "line_number": 2396,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3b7990b0f82bc9bc6c4ec02744f9c02e76aac827",
+        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
         "is_verified": false,
-        "line_number": 2394,
+        "line_number": 2399,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9072ebcbad57a1ae4256c5ae37c1e7c7ae5325de",
+        "hashed_secret": "fd987a3583a86961bbb3db9e742c93a837cd5bf6",
         "is_verified": false,
-        "line_number": 2398,
+        "line_number": 2403,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
+        "hashed_secret": "ac146bf602874ae179ea81ab6f29853c9b37834e",
         "is_verified": false,
-        "line_number": 2402,
-        "is_secret": false
+        "line_number": 2406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e0c6ae09dd70fa25056d591ada0ad32df0dfe873",
-        "is_verified": false,
-        "line_number": 2405,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9209916909e5ac952f74625bba8de9998c89e832",
+        "hashed_secret": "b5a6f2a2101ff7f7af8d0c6c87c554acea27e0c9",
         "is_verified": false,
         "line_number": 2409,
         "is_secret": false
@@ -4131,7 +4018,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
+        "hashed_secret": "7356a0be2ffe123fd4b708a6d09ecdddaa038c22",
         "is_verified": false,
         "line_number": 2413,
         "is_secret": false
@@ -4139,15 +4026,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
+        "hashed_secret": "d69c03a6c481565a321e7b90776918eaad16e532",
         "is_verified": false,
-        "line_number": 2417,
+        "line_number": 2416,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
+        "hashed_secret": "316bf5ed09ed2d2511c54a3e60e047e26550c82c",
         "is_verified": false,
         "line_number": 2420,
         "is_secret": false
@@ -4155,15 +4042,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4dcc5c09923b9c0c9014f1f416f58aed8360e584",
+        "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
         "is_verified": false,
-        "line_number": 2423,
+        "line_number": 2424,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "64573a1f0df3a66351888c28a0fd9f46793d5d8f",
+        "hashed_secret": "0135f1c09e6e6c23cd762374520078171e7bd09e",
         "is_verified": false,
         "line_number": 2427,
         "is_secret": false
@@ -4171,7 +4058,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "178a2a33e0c0d75178a413e0aac2f8cbab930635",
+        "hashed_secret": "533573708ed3eabce514432cd26d532218222659",
         "is_verified": false,
         "line_number": 2430,
         "is_secret": false
@@ -4179,31 +4066,31 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bdaf8b094715fef6fc9d26c411bc0f51e1f4d6bd",
+        "hashed_secret": "61ff5c8a702d8ffe28063c06487a3a5a0db2ed70",
         "is_verified": false,
-        "line_number": 2433,
+        "line_number": 2434,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
+        "hashed_secret": "e1beff0b39929c9538a683456356f4b7da203723",
         "is_verified": false,
-        "line_number": 2437,
+        "line_number": 2438,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "4c8a960439864672cef22edf28a40c8a3749ed68",
+        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
         "is_verified": false,
-        "line_number": 2440,
+        "line_number": 2441,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bd781c148f26d1f4846c44ad3eb29636a326b436",
+        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
         "is_verified": false,
         "line_number": 2444,
         "is_secret": false
@@ -4211,31 +4098,22 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "39d8cd5856eca22616f5ebddde39509c2326f49a",
+        "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
         "is_verified": false,
-        "line_number": 2448,
+        "line_number": 2447,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "13dbd7fe03595ffcb7e3426dfa277d73c8fafea2",
+        "hashed_secret": "363be5c48e7bb351b455c53ca48cc2859064a753",
         "is_verified": false,
-        "line_number": 2451,
-        "is_secret": false
+        "line_number": 2451
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "eeacdd78906304066ade634711edfa3120b26515",
-        "is_verified": false,
-        "line_number": 2454,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f00390dc74fe6fbe3521da94d3a490c245a42b67",
+        "hashed_secret": "9dd8b7bcb847f86a200200adcb41ae1230319c9a",
         "is_verified": false,
         "line_number": 2457,
         "is_secret": false
@@ -4243,23 +4121,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3110d13a9b5ea115c92df755b6960ba2930c2063",
+        "hashed_secret": "ba8a4a4ea1707cd9c5a04000ad2a40c0890c22c6",
         "is_verified": false,
-        "line_number": 2461,
+        "line_number": 2462,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "20b8ce96348a33cfab4c0ab0d01dfb153a3df2ec",
-        "is_verified": false,
-        "line_number": 2464,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6fb3ba9348e0ff5943ba7aa7073403264fd2f8c2",
+        "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
         "is_verified": false,
         "line_number": 2467,
         "is_secret": false
@@ -4267,7 +4137,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "hashed_secret": "15fe871ffc303bd4cf6edbc775f1af448c258e69",
         "is_verified": false,
         "line_number": 2471,
         "is_secret": false
@@ -4275,39 +4145,39 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7ba6164e769259c13c516ef17747dd9324baa3da",
+        "hashed_secret": "ddd88fae03505e64f6647d5587d4c3e5fd6b78b1",
         "is_verified": false,
-        "line_number": 2474,
+        "line_number": 2475,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "409a34f4b6de0183a007f444dabf33085ef8bf50",
+        "hashed_secret": "740c72e48345f65f0deefba812581017bd57c614",
         "is_verified": false,
-        "line_number": 2477,
+        "line_number": 2478,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
+        "hashed_secret": "21ce40fa7b942491db7f5babb19538e726c27e8d",
         "is_verified": false,
-        "line_number": 2481,
+        "line_number": 2482,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f0661775df2ce05e6c49ee07d6003c0e831cda30",
+        "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
         "is_verified": false,
-        "line_number": 2485,
+        "line_number": 2486,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "565f3763242a541920df2583874a5f95829080f0",
+        "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
         "is_verified": false,
         "line_number": 2489,
         "is_secret": false
@@ -4315,31 +4185,29 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "833fa4ba1671f98715e4450c7fa39b2983ed51ee",
+        "hashed_secret": "319f5729ebb658741e755609688744d9c09d28d8",
         "is_verified": false,
-        "line_number": 2492,
+        "line_number": 2492
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "706884687450108cef742ef7b12010f29167a501",
+        "is_verified": false,
+        "line_number": 2495,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c2cfd88522dc79c5d1764af80e11fb966935bee0",
+        "hashed_secret": "5e7a9cd9685dffe0f398decec2cf82bf4d4c979c",
         "is_verified": false,
-        "line_number": 2496,
-        "is_secret": false
+        "line_number": 2499
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bf3e3cda4d110e6f625eae7b1bc8bd5d9e1cd8d5",
-        "is_verified": false,
-        "line_number": 2500,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d285b26b3ab9fd0767eb725dd5607b8dda63cf6f",
+        "hashed_secret": "33d460d596f1c7ea50a5b8b7b96e0035e398826a",
         "is_verified": false,
         "line_number": 2504,
         "is_secret": false
@@ -4347,47 +4215,39 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
+        "hashed_secret": "623c0b595f4739e5a9e2eabcde54a72be42d9964",
         "is_verified": false,
-        "line_number": 2508,
+        "line_number": 2509,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
+        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
         "is_verified": false,
-        "line_number": 2511,
+        "line_number": 2515,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "019caa87257397d1720cb9ea2634186b43d47704",
+        "hashed_secret": "ef92e3e90926767f04ea05b4fc58e71019cf68d5",
         "is_verified": false,
-        "line_number": 2514,
+        "line_number": 2518,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "hashed_secret": "a19482a8f22f3815a3e677a5235a013b2f83db69",
         "is_verified": false,
-        "line_number": 2520,
+        "line_number": 2521,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a09ac4be578a7b177bc5f823f8624e32f10751fb",
-        "is_verified": false,
-        "line_number": 2523,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "141f1e477a1c43147cfd2dba506a8b057a1acdc4",
+        "hashed_secret": "16615d4a3177908c029aff2e170755a99ece101f",
         "is_verified": false,
         "line_number": 2527,
         "is_secret": false
@@ -4395,23 +4255,15 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "aa2771bf9f4991b2a31ddbb9cb8e7176e37cc542",
+        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
         "is_verified": false,
-        "line_number": 2531,
+        "line_number": 2533,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8239574b4263502316ae4af75858c8537b8f9dc2",
-        "is_verified": false,
-        "line_number": 2538,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3894350d13957352daa8660e7b56bf06e05e494c",
+        "hashed_secret": "ac7754e0faf25c9d2f4ee8e116d76278bd94bf92",
         "is_verified": false,
         "line_number": 2543,
         "is_secret": false
@@ -4419,23 +4271,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e7430d96b3b3f414afb42221d68622d9c9728e1d",
-        "is_verified": false,
-        "line_number": 2546,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
-        "is_verified": false,
-        "line_number": 2550,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
+        "hashed_secret": "d73a56a508095d0d1e21f8c1562879ddc2f7c76b",
         "is_verified": false,
         "line_number": 2553,
         "is_secret": false
@@ -4443,79 +4279,30 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
+        "hashed_secret": "47aa4da18e189137c0be167ad618663a420e0a8f",
         "is_verified": false,
-        "line_number": 2556,
+        "line_number": 2560,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
+        "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
         "is_verified": false,
-        "line_number": 2559,
+        "line_number": 2570,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
+        "hashed_secret": "3abd1bb82453e63ef7279a5b3ba6a45889748374",
         "is_verified": false,
-        "line_number": 2562,
-        "is_secret": false
+        "line_number": 2580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
-        "is_verified": false,
-        "line_number": 2565,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "cfea511a0cbba9944cabfbd30103ce21434865ed",
-        "is_verified": false,
-        "line_number": 2568,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "62c2af8b17725ed8d9e7c506d7975998b6a1a367",
-        "is_verified": false,
-        "line_number": 2571,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f2f138a5ead5a6a39c60b357eada0cb5a3ef1179",
-        "is_verified": false,
-        "line_number": 2574,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "390113d1af6b5ece9a90ea6db402a0008b2a9d08",
-        "is_verified": false,
-        "line_number": 2580,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
-        "is_verified": false,
-        "line_number": 2583,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
+        "hashed_secret": "0caeac5cc3573ecc311cd03aa836916728d0d98f",
         "is_verified": false,
         "line_number": 2593,
         "is_secret": false
@@ -4523,47 +4310,149 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
+        "hashed_secret": "8eb603f181d16409922883159c02899b089f6d60",
         "is_verified": false,
-        "line_number": 2603,
+        "line_number": 2597,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
+        "hashed_secret": "821c1f3714302cd33664d01f2b9720a19fb53601",
         "is_verified": false,
-        "line_number": 2608,
+        "line_number": 2601,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
+        "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
         "is_verified": false,
-        "line_number": 2611,
+        "line_number": 2604,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
+        "hashed_secret": "2395bac8424bd0df1dd4e6f7845a1fcce94eddc3",
         "is_verified": false,
-        "line_number": 2614,
+        "line_number": 2607
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
+        "is_verified": false,
+        "line_number": 2610,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b31bb92bf7baf1d65f14ab82c953a441fffe1b65",
+        "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
         "is_verified": false,
-        "line_number": 2617,
+        "line_number": 2613,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d9cf5d0777adb9d631c26beb399e9290933483ae",
+        "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
+        "is_verified": false,
+        "line_number": 2616,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3c48660b66db6687c2ba1b7ffbac279614eead6e",
+        "is_verified": false,
+        "line_number": 2619,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5a485a4915f94231f9dc5b355ddda367442ba450",
+        "is_verified": false,
+        "line_number": 2623,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c8749a5afedf4a51c2227b00d41d8b94611d8745",
+        "is_verified": false,
+        "line_number": 2627,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a622ef066916d153a2c3501013238f36dde578fb",
+        "is_verified": false,
+        "line_number": 2630,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "6c8d2de91b8087bf6f18c9b505ec528e2bafb7c4",
+        "is_verified": false,
+        "line_number": 2635,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
+        "is_verified": false,
+        "line_number": 2639,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "693b111ce8b1c51840a5cd5ea8d7d3ac7186daa4",
+        "is_verified": false,
+        "line_number": 2642
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
+        "is_verified": false,
+        "line_number": 2645,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "56029dbb81dfe27cd4bf72c8cfb3213657ce6d56",
+        "is_verified": false,
+        "line_number": 2649,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2fd4d093008863345a56756800819a01bf8e0451",
+        "is_verified": false,
+        "line_number": 2654,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f9fd81843f2a26e1be00fb6acfcb3895cffedfe6",
+        "is_verified": false,
+        "line_number": 2657,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3b7990b0f82bc9bc6c4ec02744f9c02e76aac827",
         "is_verified": false,
         "line_number": 2660,
         "is_secret": false
@@ -4571,39 +4460,107 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5c81cb3bbf077a30ebeea809bdba83483c8d5dd8",
+        "hashed_secret": "9072ebcbad57a1ae4256c5ae37c1e7c7ae5325de",
         "is_verified": false,
-        "line_number": 2701,
+        "line_number": 2664,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "05080d4369a5e3691eccb28e69d6988b360bcd22",
+        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
         "is_verified": false,
-        "line_number": 2705,
+        "line_number": 2668,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "710e27fa7e2d80bebfa5cb9a0e3e2833021eab40",
+        "hashed_secret": "e0c6ae09dd70fa25056d591ada0ad32df0dfe873",
         "is_verified": false,
-        "line_number": 2709,
+        "line_number": 2671,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a2424039e79b5ea18e0d0b22f78cc7e6624fa4ad",
+        "hashed_secret": "9209916909e5ac952f74625bba8de9998c89e832",
         "is_verified": false,
-        "line_number": 2713,
+        "line_number": 2675,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f0257d02d23f53e799476af74cf0386375d4b6c2",
+        "hashed_secret": "0f2bb303ba79216a01f706b96e835927a4d8b0e4",
+        "is_verified": false,
+        "line_number": 2679
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a9a99d9ebf0fb2317634f8ee63e4266b6ea65d80",
+        "is_verified": false,
+        "line_number": 2684
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "af3e11c2aa0eb775dd773c890eaa2d39ae5a713b",
+        "is_verified": false,
+        "line_number": 2689
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8321ecc8c6c3f9988c4ea88ccee5347f080ddb82",
+        "is_verified": false,
+        "line_number": 2697
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
+        "is_verified": false,
+        "line_number": 2700,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
+        "is_verified": false,
+        "line_number": 2704,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
+        "is_verified": false,
+        "line_number": 2707,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4dcc5c09923b9c0c9014f1f416f58aed8360e584",
+        "is_verified": false,
+        "line_number": 2710,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "64573a1f0df3a66351888c28a0fd9f46793d5d8f",
+        "is_verified": false,
+        "line_number": 2714,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "178a2a33e0c0d75178a413e0aac2f8cbab930635",
         "is_verified": false,
         "line_number": 2717,
         "is_secret": false
@@ -4611,15 +4568,23 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "hashed_secret": "bdaf8b094715fef6fc9d26c411bc0f51e1f4d6bd",
         "is_verified": false,
-        "line_number": 2722,
+        "line_number": 2720,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "749184805a59b4e245165000ff76d7e916f3efa5",
+        "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
+        "is_verified": false,
+        "line_number": 2724,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4c8a960439864672cef22edf28a40c8a3749ed68",
         "is_verified": false,
         "line_number": 2727,
         "is_secret": false
@@ -4627,7 +4592,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "47f61db9968d9147373f9919fb2d39f044af96d4",
+        "hashed_secret": "bd781c148f26d1f4846c44ad3eb29636a326b436",
         "is_verified": false,
         "line_number": 2731,
         "is_secret": false
@@ -4635,7 +4600,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "60f62b99a14507fe2d275d65d1bc793565396724",
+        "hashed_secret": "39d8cd5856eca22616f5ebddde39509c2326f49a",
         "is_verified": false,
         "line_number": 2735,
         "is_secret": false
@@ -4643,47 +4608,54 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d534a8643166b53f9b72f567856071d026b7d454",
+        "hashed_secret": "13dbd7fe03595ffcb7e3426dfa277d73c8fafea2",
         "is_verified": false,
-        "line_number": 2739,
+        "line_number": 2738,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fd979750316587a434d421119fe616d5325ac2fb",
+        "hashed_secret": "eeacdd78906304066ade634711edfa3120b26515",
         "is_verified": false,
-        "line_number": 2742,
+        "line_number": 2741,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
+        "hashed_secret": "e330a0321dd0fd5aa661cb9df9be6bf37c606a14",
         "is_verified": false,
-        "line_number": 2746,
+        "line_number": 2744
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f00390dc74fe6fbe3521da94d3a490c245a42b67",
+        "is_verified": false,
+        "line_number": 2747,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "f517feec4703cacc2629b34a71b6c4f71dcaaacb",
+        "hashed_secret": "3110d13a9b5ea115c92df755b6960ba2930c2063",
         "is_verified": false,
-        "line_number": 2749,
+        "line_number": 2751,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "5888d1b730d17d304b51d9ac433812c153d85b55",
+        "hashed_secret": "20b8ce96348a33cfab4c0ab0d01dfb153a3df2ec",
         "is_verified": false,
-        "line_number": 2753,
+        "line_number": 2754,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bc001a988dc93a1d9f0b811c8b6f5ed71cd922e8",
+        "hashed_secret": "6fb3ba9348e0ff5943ba7aa7073403264fd2f8c2",
         "is_verified": false,
         "line_number": 2757,
         "is_secret": false
@@ -4691,15 +4663,22 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "e8dcd9d9891c3dea7c5a1d671b950c1cb05d681d",
+        "hashed_secret": "417279a3d4b01a908cff96961ce78f96a84813dc",
         "is_verified": false,
-        "line_number": 2761,
+        "line_number": 2761
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "is_verified": false,
+        "line_number": 2764,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a36905f939ee26516ab756c0896b7e65328989dc",
+        "hashed_secret": "7ba6164e769259c13c516ef17747dd9324baa3da",
         "is_verified": false,
         "line_number": 2767,
         "is_secret": false
@@ -4707,9 +4686,496 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
+        "hashed_secret": "409a34f4b6de0183a007f444dabf33085ef8bf50",
         "is_verified": false,
         "line_number": 2770,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
+        "is_verified": false,
+        "line_number": 2774,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f0661775df2ce05e6c49ee07d6003c0e831cda30",
+        "is_verified": false,
+        "line_number": 2778,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "565f3763242a541920df2583874a5f95829080f0",
+        "is_verified": false,
+        "line_number": 2782,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "833fa4ba1671f98715e4450c7fa39b2983ed51ee",
+        "is_verified": false,
+        "line_number": 2785,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c2cfd88522dc79c5d1764af80e11fb966935bee0",
+        "is_verified": false,
+        "line_number": 2789,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bf3e3cda4d110e6f625eae7b1bc8bd5d9e1cd8d5",
+        "is_verified": false,
+        "line_number": 2793,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d285b26b3ab9fd0767eb725dd5607b8dda63cf6f",
+        "is_verified": false,
+        "line_number": 2797,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
+        "is_verified": false,
+        "line_number": 2801,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
+        "is_verified": false,
+        "line_number": 2804,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "019caa87257397d1720cb9ea2634186b43d47704",
+        "is_verified": false,
+        "line_number": 2807,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d4884001560a07736d778829274e452a06089ffa",
+        "is_verified": false,
+        "line_number": 2813
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "is_verified": false,
+        "line_number": 2821,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a09ac4be578a7b177bc5f823f8624e32f10751fb",
+        "is_verified": false,
+        "line_number": 2824,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "141f1e477a1c43147cfd2dba506a8b057a1acdc4",
+        "is_verified": false,
+        "line_number": 2828,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "aa2771bf9f4991b2a31ddbb9cb8e7176e37cc542",
+        "is_verified": false,
+        "line_number": 2832,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8239574b4263502316ae4af75858c8537b8f9dc2",
+        "is_verified": false,
+        "line_number": 2839,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3894350d13957352daa8660e7b56bf06e05e494c",
+        "is_verified": false,
+        "line_number": 2844,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e7430d96b3b3f414afb42221d68622d9c9728e1d",
+        "is_verified": false,
+        "line_number": 2847,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
+        "is_verified": false,
+        "line_number": 2851,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
+        "is_verified": false,
+        "line_number": 2854,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
+        "is_verified": false,
+        "line_number": 2857,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "158291819a7a643d9b2260cba777de2b33682c18",
+        "is_verified": false,
+        "line_number": 2860
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
+        "is_verified": false,
+        "line_number": 2863,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
+        "is_verified": false,
+        "line_number": 2866
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
+        "is_verified": false,
+        "line_number": 2869,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
+        "is_verified": false,
+        "line_number": 2872,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
+        "is_verified": false,
+        "line_number": 2875
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "cfea511a0cbba9944cabfbd30103ce21434865ed",
+        "is_verified": false,
+        "line_number": 2878,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "62c2af8b17725ed8d9e7c506d7975998b6a1a367",
+        "is_verified": false,
+        "line_number": 2881,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f2f138a5ead5a6a39c60b357eada0cb5a3ef1179",
+        "is_verified": false,
+        "line_number": 2884,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "390113d1af6b5ece9a90ea6db402a0008b2a9d08",
+        "is_verified": false,
+        "line_number": 2890,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
+        "is_verified": false,
+        "line_number": 2893,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "0b2e44ed44bd55fd203dd349370908ded345dec5",
+        "is_verified": false,
+        "line_number": 2903
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1f4f661f8f8639d43ca48fc811858d8451cba434",
+        "is_verified": false,
+        "line_number": 2916
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
+        "is_verified": false,
+        "line_number": 2921,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "fa052b540b5ac7bfca7e3f2a5cdf081e343a3c76",
+        "is_verified": false,
+        "line_number": 2931
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
+        "is_verified": false,
+        "line_number": 2936,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
+        "is_verified": false,
+        "line_number": 2941,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
+        "is_verified": false,
+        "line_number": 2944,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
+        "is_verified": false,
+        "line_number": 2947,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b31bb92bf7baf1d65f14ab82c953a441fffe1b65",
+        "is_verified": false,
+        "line_number": 2950,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d9cf5d0777adb9d631c26beb399e9290933483ae",
+        "is_verified": false,
+        "line_number": 2993,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5c81cb3bbf077a30ebeea809bdba83483c8d5dd8",
+        "is_verified": false,
+        "line_number": 3034,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "05080d4369a5e3691eccb28e69d6988b360bcd22",
+        "is_verified": false,
+        "line_number": 3038,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "710e27fa7e2d80bebfa5cb9a0e3e2833021eab40",
+        "is_verified": false,
+        "line_number": 3042,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a2424039e79b5ea18e0d0b22f78cc7e6624fa4ad",
+        "is_verified": false,
+        "line_number": 3046,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f0257d02d23f53e799476af74cf0386375d4b6c2",
+        "is_verified": false,
+        "line_number": 3050,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "is_verified": false,
+        "line_number": 3055,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "749184805a59b4e245165000ff76d7e916f3efa5",
+        "is_verified": false,
+        "line_number": 3060,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "47f61db9968d9147373f9919fb2d39f044af96d4",
+        "is_verified": false,
+        "line_number": 3064,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "60f62b99a14507fe2d275d65d1bc793565396724",
+        "is_verified": false,
+        "line_number": 3068,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d534a8643166b53f9b72f567856071d026b7d454",
+        "is_verified": false,
+        "line_number": 3072,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "fd979750316587a434d421119fe616d5325ac2fb",
+        "is_verified": false,
+        "line_number": 3075,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
+        "is_verified": false,
+        "line_number": 3079,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f517feec4703cacc2629b34a71b6c4f71dcaaacb",
+        "is_verified": false,
+        "line_number": 3082,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "5888d1b730d17d304b51d9ac433812c153d85b55",
+        "is_verified": false,
+        "line_number": 3086,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bc001a988dc93a1d9f0b811c8b6f5ed71cd922e8",
+        "is_verified": false,
+        "line_number": 3090,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e8dcd9d9891c3dea7c5a1d671b950c1cb05d681d",
+        "is_verified": false,
+        "line_number": 3094,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a36905f939ee26516ab756c0896b7e65328989dc",
+        "is_verified": false,
+        "line_number": 3100,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "62c3e21d5adb13e93e5d3f1d29713d0f45e2696a",
+        "is_verified": false,
+        "line_number": 3103
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "f7db6410f7251082f54e1ac509d653878d66fc6c",
+        "is_verified": false,
+        "line_number": 3108
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
+        "is_verified": false,
+        "line_number": 3126,
         "is_secret": false
       }
     ],
@@ -4742,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-18T10:03:15Z"
+  "generated_at": "2026-06-02T06:06:40Z"
 }

--- a/backend/app/api/routes/knowledge.py
+++ b/backend/app/api/routes/knowledge.py
@@ -30,6 +30,11 @@ def _parse_resource_uri(uri: str, expected_type: str | None = None) -> tuple[str
             detail=f"Invalid AKB URI: {uri!r}. Expected akb://<vault>/<type>/<id>.",
         )
     vault, rtype, ident = parsed.vault, parsed.kind, parsed.identifier
+    if ident is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"AKB URI is missing an identifier: {uri!r}.",
+        )
     if expected_type and rtype != expected_type:
         raise HTTPException(
             status_code=400,

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -37,7 +37,7 @@ async def drill_down(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     parsed = parse_uri(uri)
-    if parsed is None or parsed.kind != "doc":
+    if parsed is None or parsed.kind != "doc" or parsed.identifier is None:
         raise HTTPException(status_code=400, detail=f"Expected a doc URI, got {uri!r}")
     vault, doc_path = parsed.vault, parsed.identifier
     # MCP `akb_drill_down` enforces vault ACL via check_vault_access; the

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import asyncpg
 
 from app.exceptions import ConflictError
+from app.util.text import like_escape
 from app.utils import dumps_jsonb
 
 
@@ -586,11 +587,10 @@ class CollectionRepository:
     # ``_like_escape`` used to live here. The same triple-replace also
     # got copy-pasted into the inline prefix-filter inside
     # ``list_docs_by_depth`` (and into two other repos). Consolidated
-    # at ``app.util.text.like_escape`` — call sites now go through
-    # that, and this alias keeps the existing ``self._like_escape``
-    # call-pattern working without churn.
-    from app.util.text import like_escape as _like_escape_impl
-    _like_escape = staticmethod(_like_escape_impl)
+    # at ``app.util.text.like_escape`` (imported at module top) — call
+    # sites now go through that, and this alias keeps the existing
+    # ``self._like_escape`` call-pattern working without churn.
+    _like_escape = staticmethod(like_escape)
 
     async def list_docs_under(
         self,

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -195,6 +195,12 @@ async def link_resources(
     target_type = target_parsed.kind
     target_id = target_parsed.identifier
 
+    # Linkable kinds (doc/table/file) always carry an identifier; a None
+    # here means a malformed URI slipped past parse_uri. Fail closed so the
+    # advisory-lock + existence checks below can treat both ids as str.
+    if source_id is None or target_id is None:
+        return {"error": "Source or target URI is missing an identifier."}
+
     # Canonicalize both endpoints from parsed parts so a legacy-shaped
     # URI passed by an external caller is stored in 0.3.0 canonical form
     # (akb://V/coll/<path>/<kind>/<id>) — not verbatim. Verbatim legacy
@@ -552,6 +558,8 @@ async def _batch_resolve_names(
         if not parsed:
             continue
         identifier = parsed.identifier
+        if identifier is None:
+            continue
         if rtype == "doc":
             doc_paths.append(identifier)
             doc_uris[identifier] = uri

--- a/backend/app/services/resource_integrity.py
+++ b/backend/app/services/resource_integrity.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import asdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
+from typing import TypedDict
 
 import frontmatter
 
@@ -25,7 +25,7 @@ class ResourceHashRepairReport:
     documents_repaired: int = 0
     files_checked: int = 0
     files_repaired: int = 0
-    errors: list[str] | None = None
+    errors: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         data = asdict(self)
@@ -44,11 +44,19 @@ def document_hash_projection(raw_markdown: str, current_commit: str | None) -> d
     }
 
 
+class FileHashProjection(TypedDict):
+    size_bytes: int
+    content_hash: str
+    hash_algorithm: str
+    etag: str | None
+    storage_version: str | None
+
+
 def file_hash_projection(
     *,
     chunks,
     head: dict,
-) -> dict[str, object]:
+) -> FileHashProjection:
     """Compute the stored byte-hash projection for one S3-backed file."""
 
     return {
@@ -117,7 +125,7 @@ async def repair_resource_hashes(
             for row in file_rows:
                 try:
                     head = await asyncio.to_thread(file_service.s3_adapter.head, row["s3_key"])
-                    projection = await asyncio.to_thread(
+                    file_projection = await asyncio.to_thread(
                         file_hash_projection,
                         chunks=file_service.s3_adapter.iter_chunks(row["s3_key"]),
                         head=head,
@@ -125,11 +133,11 @@ async def repair_resource_hashes(
                     await vault_files_repo.update_confirmed_metadata(
                         conn,
                         row["id"],
-                        size_bytes=projection["size_bytes"],
-                        content_hash=projection["content_hash"],
-                        hash_algorithm=projection["hash_algorithm"],
-                        etag=projection["etag"],
-                        storage_version=projection["storage_version"],
+                        size_bytes=file_projection["size_bytes"],
+                        content_hash=file_projection["content_hash"],
+                        hash_algorithm=file_projection["hash_algorithm"],
+                        etag=file_projection["etag"],
+                        storage_version=file_projection["storage_version"],
                     )
                     report.files_repaired += 1
                 except Exception as error:  # noqa: BLE001

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -284,13 +284,13 @@ def _resolve_parent(args: dict, *, kind_name: str) -> tuple[str, str]:
                 f"Invalid `parent` URI for {kind_name}: {e}"
             ) from e
         return vault, coll or ""
-    vault = args.get("vault")
-    if not vault:
+    vault_name = args.get("vault")
+    if not vault_name:
         raise ValueError(
             f"Either `parent` (akb:// URI) or `vault` is required to "
             f"create a {kind_name}."
         )
-    return vault, args.get("collection") or ""
+    return vault_name, args.get("collection") or ""
 
 
 @_h("akb_get")
@@ -434,9 +434,10 @@ async def _handle_browse(args: dict, uid: str, user: _MCPUser) -> dict:
         except ValueError as exc:
             return {"error": str(exc)}
     else:
-        vault = args.get("vault")
-        if not vault:
+        vault_arg = args.get("vault")
+        if not vault_arg:
             return {"error": "Either `vault` or `uri` is required for akb_browse."}
+        vault = vault_arg
         collection = args.get("collection")
     await check_vault_access(uid, vault, required_role="reader")
     result = await doc_service.browse(
@@ -553,7 +554,7 @@ async def _handle_drill_down(args: dict, uid: str, user: _MCPUser) -> dict:
     if pattern:
         sections = [s for s in sections if pattern in (s.get("content") or "").lower()]
 
-    response: dict = {
+    response = {
         "uri": args["uri"],
         "sections": sections,
         "returned": len(sections),

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -34,6 +34,7 @@ class _FakeDocRepo:
         content_hash: str,
         hash_algorithm: str,
         content_hash_commit: str | None,
+        conn=None,
     ) -> None:
         self.hash_update = {
             "doc_id": doc_id,
@@ -204,6 +205,7 @@ async def test_document_update_rejects_stale_expected_content_hash() -> None:
             vault_id=uuid.uuid4(),
             doc_repo=doc_repo,
             row=row,
+            conn=None,
         )
 
     assert doc_repo.hash_update == {


### PR DESCRIPTION
## Problem

`scripts/check.sh` runs `mypy app/ mcp_server/` as a CI gate, but it had been **red on 22 pre-existing errors** across 6 files — long-standing `Optional`-strictness debt, not introduced by any recent change. (Confirmed: the same 22 errors are present back through the pre-existing history; they predate the recent deadlock fix.)

## Fix

All 22 fixed **properly** — type guards and precise annotations, **no `# type: ignore` suppressions**:

| File | Fix |
|---|---|
| `repositories/document_repo.py` | Move the `like_escape` import from the class body to module top (`Unsupported class scoped import`). |
| `services/kg_service.py` | Fail-closed guard when a linkable URI has no identifier (`str\|None` → `str` for the advisory-lock + existence checks); skip identifier-less URIs in the batch name resolver. |
| `services/resource_integrity.py` | `ResourceHashRepairReport.errors` is a non-Optional `list[str]` (`field(default_factory=list)`); a `FileHashProjection` `TypedDict` gives `file_hash_projection` precise per-key types; rename the file branch's `projection` var so it isn't unified with the document branch's `dict[str, str\|None]`. |
| `api/routes/search.py`, `api/routes/knowledge.py` | Narrow `parsed.identifier` to `str` (400 on a missing identifier) before `drill_down` / returning. |
| `mcp_server/server.py` | Use a distinct name for the `str\|None` `args.get("vault")` so it doesn't clash with the `str` from `split_browse_uri`; drop the duplicate `response: dict` annotation (`no-redef`). |

No runtime behavior change for valid inputs — the new guards only affect malformed URIs (which previously would have failed later anyway).

## Verification

- **mypy**: `Success: no issues found in 117 source files` (run in a CI-equivalent clean env — mypy only, no project deps, matching `check.yml`).
- **ruff**: clean.
- `test_mcp_e2e` **76/76**; `test_graph_replace_e2e` unchanged vs `main` baseline (the lone failure is a pre-existing environmental one — no embedding/S3 locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)