### PR TITLE
fix(0.4.2): collection-retirement vs PUT FK race returned 500 (now 409)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 405
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-02T06:06:40Z"
+  "generated_at": "2026-06-02T07:37:52Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,39 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.4.2 — 2026-06-02
+
+Collection-retirement vs document-PUT race: an unhandled foreign-key
+violation surfaced as HTTP 500 instead of a clean conflict.
+
+### `akb_put` into a collection being deleted returned 500
+
+When a recursive collection delete commits in the exact window between a
+concurrent PUT's `get_or_create` (which observed the collection) and that
+PUT's `INSERT INTO documents` (which still references the now-gone
+`collection_id`), the insert trips `documents_collection_id_fkey`. The
+delete side is fine — `collection_id` is `ON DELETE SET NULL`, so existing
+docs are re-homed — but a *new* insert against the vanished id is an FK
+violation that `document_repo.create` did not catch, so it bubbled up as
+an unhandled `asyncpg.ForeignKeyViolationError` → HTTP 500.
+
+`create` already maps a `UniqueViolationError` (duplicate path) to a 409;
+it now maps a `ForeignKeyViolationError` the same way, with a clear
+"Target collection or vault was concurrently deleted" message. The racing
+writer gets a clean, retryable 409 instead of a 500. No schema change.
+
+Found via an external "E06 collection retirement race" report (40 PUTs
+racing a recursive collection delete). Note: the report's primary symptom
+— all 40 PUTs as transport-level "status 0" — was the 0.4.1 pool-deadlock
+(the deployment under test had regressed to 0.4.0); with the pool fix in
+place the deadlock is gone and only this residual FK 500 remained.
+
+Verified: E06 repro (40 PUTs, seeded to widen the race window) returned
+`{200, 500}` before and `{200, 409}` after (5xx → 0); `test_mcp_e2e`
+76/76, `test_collection_lifecycle_e2e` 36/36; deterministic unit test
+(`test_create_with_deleted_collection_raises_conflict`). Repro harness:
+`backend/tests/concurrency/repro_e05_e06_delete_race.py`.
+
 ## 0.4.1 — 2026-06-02
 
 Connection-pool deadlock on the document write paths under a concurrent

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -83,6 +83,18 @@ class DocumentRepository:
                 # (vault_id, path) is the only UNIQUE constraint that callers
                 # can collide on. Surface it as a 409 instead of a 500.
                 raise ConflictError(f"Document already exists at path: {path}") from e
+            except asyncpg.ForeignKeyViolationError as e:
+                # The parent collection (or vault) was deleted out from under
+                # this insert — a concurrent collection-retirement / vault-delete
+                # race: get_or_create observed the collection, then a DELETE
+                # removed it before this INSERT committed. `collection_id` is
+                # ON DELETE SET NULL, so the *delete* side re-homes existing
+                # docs, but a NEW insert that still references the vanished id
+                # trips the FK. Surface it as a 409 (retryable) instead of an
+                # unhandled 500.
+                raise ConflictError(
+                    f"Target collection or vault was concurrently deleted while creating: {path}"
+                ) from e
 
         # When `conn` is supplied, run on the caller's connection/TX so a
         # put can hold ONE pool connection for its whole critical section

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.4.1"
+version = "0.4.2"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/concurrency/repro_e05_e06_delete_race.py
+++ b/backend/tests/concurrency/repro_e05_e06_delete_race.py
@@ -71,8 +71,8 @@ async def e05(c, A, n):
     dstat = await del_t
     print(f"  delete: status={dstat[0]}")
     codes, z, f = show("get", gets)
-    bad = [g for g in gets if g[0] == 200 and '"content"' not in g[3] and "content" not in g[3]]
-    ok = dstat[0] in (200, 204) and z == 0 and f == 0 and set(codes) <= {200, 404}
+    bad = [g for g in gets if g[0] == 200 and '"content"' not in g[3]]
+    ok = dstat[0] in (200, 204) and z == 0 and f == 0 and len(bad) == 0 and set(codes) <= {200, 404}
     print(f"  VERDICT E05: {'PASS' if ok else 'FAIL'} (delete 2xx; gets only 200/404; no transport/5xx)")
     try: await c.request("DELETE", f"/api/v1/vaults/{v}", headers=A)
     except Exception: pass

--- a/backend/tests/concurrency/repro_e05_e06_delete_race.py
+++ b/backend/tests/concurrency/repro_e05_e06_delete_race.py
@@ -1,0 +1,128 @@
+"""Repro for reported E05 (delete-while-reads) and E06 (collection retirement race).
+
+E05: create one doc, then concurrently DELETE it while N GETs race. Correct:
+     delete -> 200; each GET -> 200 (with full body) or 404; nothing else.
+
+E06: create a collection, then concurrently fire N PUTs into it WHILE the
+     collection is DELETEd (recursive). Correct: every PUT resolves explicitly
+     (200 created / 404 or 409 if the collection/doc lost the race) and the
+     DELETE resolves explicitly — none should be a transport-level "status 0".
+     The reporter saw all 40 PUTs as status 0 (the pool-deadlock signature).
+
+Usage: AKB_URL=... python3 repro_e05_e06_delete_race.py [which: e05|e06|both] [N]
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from collections import Counter
+
+import httpx
+
+BASE = os.environ.get("AKB_URL", "http://localhost:8000").rstrip("/")
+WHICH = sys.argv[1] if len(sys.argv) > 1 else "both"
+N = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+STAMP = str(int(time.time()))
+U = f"e056-{STAMP}"
+PW = "testtest1234"
+
+
+async def rec(coro):
+    t0 = time.perf_counter()
+    try:
+        r = await coro
+        return r.status_code, (time.perf_counter() - t0) * 1000, None, (r.text or "")[:160]
+    except Exception as e:  # noqa: BLE001
+        return 0, (time.perf_counter() - t0) * 1000, f"{type(e).__name__}: {e}", ""
+
+
+def show(name, rows):
+    codes = Counter(r[0] for r in rows)
+    zero = [r for r in rows if r[0] == 0]
+    s5 = [r for r in rows if 500 <= r[0] < 600]
+    print(f"  {name}: count={len(rows)} statuses={dict(codes)}")
+    ec = Counter(r[2] for r in zero if r[2])
+    for err, n in ec.most_common():
+        print(f"      [status0 x{n}] {err}")
+    for r in s5[:2]:
+        print(f"      [HTTP {r[0]}] {r[3]}")
+    return codes, len(zero), len(s5)
+
+
+async def setup(c):
+    await c.post("/api/v1/auth/register", json={"username": U, "email": f"{U}@t.local", "password": PW})
+    jwt = (await c.post("/api/v1/auth/login", json={"username": U, "password": PW})).json()["token"]
+    pat = (await c.post("/api/v1/auth/tokens", headers={"Authorization": f"Bearer {jwt}"}, json={"name": "p"})).json()["token"]
+    return {"Authorization": f"Bearer {pat}"}
+
+
+async def e05(c, A, n):
+    print(f"\n=== E05: delete one doc while {n} GETs race ===")
+    v = f"e05v-{STAMP}"
+    await c.post(f"/api/v1/vaults?name={v}", headers=A)
+    docid = "notes/retained.md"
+    await c.post("/api/v1/documents", headers=A, json={
+        "vault": v, "collection": "notes", "title": "Retained", "content": "# r\n\nbody", "slug": "retained"})
+    url = f"/api/v1/documents/{v}/{docid}"
+    del_t = asyncio.create_task(rec(c.request("DELETE", url, headers=A)))
+    gets = await asyncio.gather(*[rec(c.get(url, headers=A)) for _ in range(n)])
+    dstat = await del_t
+    print(f"  delete: status={dstat[0]}")
+    codes, z, f = show("get", gets)
+    bad = [g for g in gets if g[0] == 200 and '"content"' not in g[3] and "content" not in g[3]]
+    ok = dstat[0] in (200, 204) and z == 0 and f == 0 and set(codes) <= {200, 404}
+    print(f"  VERDICT E05: {'PASS' if ok else 'FAIL'} (delete 2xx; gets only 200/404; no transport/5xx)")
+    try: await c.request("DELETE", f"/api/v1/vaults/{v}", headers=A)
+    except Exception: pass
+
+
+async def e06(c, A, n):
+    print(f"\n=== E06: {n} PUTs into a collection while it is DELETEd (recursive) ===")
+    v = f"e06v-{STAMP}"
+    await c.post(f"/api/v1/vaults?name={v}", headers=A)
+    coll = "retire"
+    # seed docs so the collection exists and the recursive delete has work.
+    # A bigger seed slows the delete cascade, widening the window in which it
+    # commits during a racing PUT's get_or_create->create gap (the FK race).
+    seed = int(os.environ.get("E06_SEED", "1"))
+    for s in range(seed):
+        await c.post("/api/v1/documents", headers=A, json={
+            "vault": v, "collection": coll, "title": f"Seed {s}",
+            "content": f"# seed {s}", "slug": f"seed-{s}"})
+
+    async def put(i):
+        return ("put", i, *(await rec(c.post("/api/v1/documents", headers=A, json={
+            "vault": v, "collection": coll, "title": f"Doc {i}",
+            "content": f"# doc {i}\n\nbody " + ("z" * 80), "slug": f"doc-{i}"}))))
+
+    async def delete_coll():
+        return ("del", *(await rec(c.request("DELETE", f"/api/v1/collections/{v}/{coll}?recursive=true", headers=A))))
+
+    res = await asyncio.gather(delete_coll(), *[put(i) for i in range(n)])
+    puts = [r[2:] for r in res if r[0] == "put"]
+    dele = [r[1:] for r in res if r[0] == "del"][0]
+    print(f"  collection delete: status={dele[0]} {dele[3][:80]}")
+    codes, z, f = show("put", puts)
+    # final browse
+    bstat, _, berr, _ = await rec(c.get(f"/api/v1/browse/{v}", headers=A))
+    print(f"  final browse: status={bstat}{(' '+berr) if berr else ''}")
+    ok = dele[0] not in (0,) and z == 0 and f == 0 and bstat not in (0,)
+    print(f"  VERDICT E06: {'PASS' if ok else 'FAIL'} (puts resolve as 2xx/409, no 5xx/status0)")
+    try: await c.request("DELETE", f"/api/v1/vaults/{v}", headers=A)
+    except Exception: pass
+
+
+async def main():
+    print(f"BASE={BASE}  which={WHICH}")
+    async with httpx.AsyncClient(base_url=BASE, limits=httpx.Limits(max_connections=200, max_keepalive_connections=200), timeout=httpx.Timeout(90.0, connect=60.0)) as c:
+        A = await setup(c)
+        if WHICH in ("e05", "both"):
+            await e05(c, A, N or 50)
+        if WHICH in ("e06", "both"):
+            await e06(c, A, N or 40)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -658,3 +658,37 @@ async def test_p2_collection_delete_handles_tables(pool):
         await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
     assert reg == 0, "registry row must be gone"
     assert pg_tbl == 0, "dynamic PG table must be dropped"
+
+
+# ── E06: collection-retirement vs PUT FK race ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_with_deleted_collection_raises_conflict(pool, vault):
+    """A document insert whose `collection_id` references a collection that no
+    longer exists must surface as ConflictError (409), not an unhandled
+    asyncpg.ForeignKeyViolationError (500).
+
+    This is the E06 'collection retirement race': a PUT's get_or_create
+    observes a collection, a concurrent recursive DELETE removes it, then the
+    PUT's INSERT (still referencing the vanished id) trips
+    `documents_collection_id_fkey`. `collection_id` is ON DELETE SET NULL, so
+    the delete side re-homes existing docs — but a NEW insert against the gone
+    id is an FK violation that must become a clean, retryable 409.
+    """
+    from datetime import datetime, timezone
+
+    from app.exceptions import ConflictError
+
+    doc_repo = DocumentRepository(pool)
+    bogus_collection_id = uuid.uuid4()  # never inserted into `collections`
+    now = datetime.now(timezone.utc)
+
+    with pytest.raises(ConflictError):
+        await doc_repo.create(
+            vault_id=vault["id"], collection_id=bogus_collection_id,
+            path="retire/lost-race.md", title="Doc", doc_type="note",
+            status="draft", summary=None, domain=None, created_by=None, now=now,
+            commit_hash="0" * 40, content_hash="h", hash_algorithm="sha256",
+            tags=[], metadata={},
+        )


### PR DESCRIPTION
## Problem

When a recursive collection delete commits in the exact window between a concurrent `akb_put`'s `get_or_create` (which observed the collection) and that PUT's `INSERT INTO documents` (still referencing the now-gone `collection_id`), the insert trips `documents_collection_id_fkey`.

The **delete** side is fine — `collection_id` is `ON DELETE SET NULL`, so existing docs are re-homed to the vault root — but a **new** insert against the vanished id is an FK violation that `document_repo.create` did not catch, so it bubbled up as an unhandled `asyncpg.ForeignKeyViolationError` → **HTTP 500**.

## Fix

`create` already maps a `UniqueViolationError` (duplicate path) to a 409; it now maps a `ForeignKeyViolationError` the same way, with a clear *"Target collection or vault was concurrently deleted"* message. The racing writer gets a clean, **retryable 409** instead of a 500. No schema change.

## Context

Found via an external **"E06 collection retirement race"** report (40 PUTs racing a recursive collection delete). The report's *primary* symptom — all 40 PUTs as transport-level **"status 0"** — was the **0.4.1 pool-deadlock**: the deployment under test had silently **regressed to 0.4.0**. With the pool fix redeployed, the deadlock is gone and only this residual FK 500 remained — which this PR closes.

## Verification

- **E06 repro** (`repro_e05_e06_delete_race.py`, 40 PUTs seeded to widen the race window): `{200, 500}` before → `{200, 409}` after (5xx → 0), reproduced reliably.
- `test_mcp_e2e` **76/76**, `test_collection_lifecycle_e2e` **36/36**.
- Deterministic unit test `test_create_with_deleted_collection_raises_conflict` (DB-backed; skips in CI like the other invariant DB tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)