### PR TITLE
test: fix E05 repro false-FAIL (body-truncation in the content check)

### DIFF
--- a/backend/tests/concurrency/repro_e05_e06_delete_race.py
+++ b/backend/tests/concurrency/repro_e05_e06_delete_race.py
@@ -71,7 +71,10 @@ async def e05(c, A, n):
     dstat = await del_t
     print(f"  delete: status={dstat[0]}")
     codes, z, f = show("get", gets)
-    bad = [g for g in gets if g[0] == 200 and '"content"' not in g[3]]
+    # invariant: a 200 GET must carry a body (not empty). `rec()` truncates
+    # bodies, so check for emptiness rather than a specific field that may sit
+    # past the truncation point.
+    bad = [g for g in gets if g[0] == 200 and not g[3].strip()]
     ok = dstat[0] in (200, 204) and z == 0 and f == 0 and len(bad) == 0 and set(codes) <= {200, 404}
     print(f"  VERDICT E05: {'PASS' if ok else 'FAIL'} (delete 2xx; gets only 200/404; no transport/5xx)")
     try: await c.request("DELETE", f"/api/v1/vaults/{v}", headers=A)


### PR DESCRIPTION
The E05 verdict in `repro_e05_e06_delete_race.py` (added in #102) checked for `"content"` in the GET body, but `rec()` truncates bodies to 160 chars and `DocumentResponse` serializes `content` past that point — so a valid 200 read was flagged as a "missing body" and E05 false-FAILed.

Fixed to check for an **empty** body instead (the real invariant: a 200 GET must carry a body). Backend behaviour was always correct — verified on prod 0.4.2: E05 `delete 200; gets {200, 404}; no empty bodies, no 5xx/transport` → PASS.

Test-harness only; no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)