### PR TITLE
feat(0.4.3): akb_put can set document status on create (default draft)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 405
+        "line_number": 435
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-02T07:37:52Z"
+  "generated_at": "2026-06-02T08:35:09Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,36 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.4.3 — 2026-06-02
+
+`akb_put` can now set the document `status` on create.
+
+### Optional `status` on document create
+
+`akb_put` previously hard-coded `status: draft` into both the git
+frontmatter and the `documents` row — the only way to land an `active`
+document was to follow up with `akb_update`. `DocumentPutRequest` now
+takes an optional `status` (default `"draft"`, so existing behaviour is
+unchanged) that is stamped through to the frontmatter + DB row. Pass
+`status: "active"` (or `archived`/`superseded`) to publish on create.
+
+The value is validated against the known set
+(`draft`/`active`/`archived`/`superseded`) in `DocumentService.put`
+before any git/DB work — an unknown status returns a clean 422 instead
+of silently landing a typo. Status remains **descriptive metadata** — it
+does not gate search, browse, or access; this just removes the
+put-then-update dance.
+
+The MCP `akb_put` tool schema exposes the new `status` enum; the
+`akb-mcp` proxy forwards it transparently (no proxy release needed). No
+schema change.
+
+Verified: REST + MCP round-trip (`status:"active"` → frontmatter + DB
+`active`; default → `draft`; bad value → 422); `test_mcp_e2e` 76/76,
+`test_edit_e2e` 37/37; unit tests
+`test_put_request_status_defaults_to_draft_and_accepts_active`,
+`test_put_rejects_unknown_status`.
+
 ## 0.4.2 — 2026-06-02
 
 Collection-retirement vs document-PUT race: an unhandled foreign-key

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -6,6 +6,11 @@ from pydantic import BaseModel, Field
 
 from app.util.text import NFCModel
 
+# Allowed document lifecycle statuses. Status is descriptive metadata — it
+# does not gate search / browse / access — but we constrain it to a known
+# set so a typo can't silently land in the frontmatter and DB.
+DOC_STATUSES = ("draft", "active", "archived", "superseded")
+
 
 class DocumentFrontmatter(NFCModel):
     """Canonical frontmatter schema parsed from YAML."""
@@ -34,6 +39,11 @@ class DocumentPutRequest(NFCModel):
     title: str
     content: str
     type: str = "note"
+    # Lifecycle status stamped into the frontmatter + DB row on create.
+    # Defaults to "draft" (the historical behaviour); pass e.g. "active" to
+    # publish on create instead of having to follow up with akb_update.
+    # Validated against DOC_STATUSES in DocumentService.put.
+    status: str = "draft"
     tags: list[str] = Field(default_factory=list)
     domain: str | None = None
     summary: str | None = None

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -108,6 +108,7 @@ import frontmatter
 from app.db.postgres import get_pool
 from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
 from app.models.document import (
+    DOC_STATUSES,
     BrowseItem,
     BrowseResponse,
     DocumentPutRequest,
@@ -165,7 +166,7 @@ def _build_frontmatter(req: DocumentPutRequest, now: datetime) -> dict:
     fm = {
         "title": req.title,
         "type": req.type,
-        "status": "draft",
+        "status": req.status,
         "created_at": now.isoformat(),
         "updated_at": now.isoformat(),
         "tags": req.tags,
@@ -266,6 +267,10 @@ class DocumentService:
     # ── Put ───────────────────────────────────────────────────
 
     async def put(self, req: DocumentPutRequest, agent_id: str | None = None) -> DocumentPutResponse:
+        if req.status not in DOC_STATUSES:
+            raise ValidationError(
+                f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}"
+            )
         vault_repo, doc_repo, coll_repo = await self._repos()
 
         vault_id = await vault_repo.get_id_by_name(req.vault)
@@ -337,7 +342,7 @@ class DocumentService:
         # — user document writes never populate it.
         pg_doc_id = await doc_repo.create(
             vault_id=vault_id, collection_id=collection_id, path=file_path,
-            title=req.title, doc_type=req.type, status="draft",
+            title=req.title, doc_type=req.type, status=req.status,
             summary=fm_dict.get("summary") or req.summary, domain=req.domain, created_by=agent_id,
             now=now, commit_hash=commit_hash, content_hash=content_hash,
             hash_algorithm=HASH_ALGORITHM, tags=req.tags, metadata={}, conn=conn,

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -249,6 +249,7 @@ async def _handle_put(args: dict, uid: str, user: _MCPUser) -> dict:
         title=args["title"],
         content=args["content"],
         type=args.get("type", "note"),
+        status=args.get("status", "draft"),
         tags=args.get("tags", []),
         domain=args.get("domain"),
         summary=args.get("summary"),

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -131,6 +131,16 @@ TOOLS = [
                     "enum": ["note", "report", "decision", "spec", "plan", "session", "task", "reference", "skill"],
                     "default": "note",
                 },
+                "status": {
+                    "type": "string",
+                    "description": (
+                        "Lifecycle status. Defaults to 'draft'; pass 'active' to publish on "
+                        "create instead of promoting later with akb_update. Descriptive "
+                        "metadata only — it does not gate search, browse, or access."
+                    ),
+                    "enum": ["draft", "active", "archived", "superseded"],
+                    "default": "draft",
+                },
                 "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags for classification"},
                 "domain": {"type": "string", "description": "Domain: engineering, product, ops, legal, etc."},
                 "summary": {"type": "string", "description": "Brief summary (auto-generated if omitted)"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.4.2"
+version = "0.4.3"
 description = "Agent Knowledgebase - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -214,3 +214,29 @@ async def test_document_update_rejects_stale_expected_content_hash() -> None:
         "hash_algorithm": "sha256",
         "content_hash_commit": row["current_commit"],
     }
+
+
+# ── akb_put status option ──────────────────────────────────────────
+
+
+def test_put_request_status_defaults_to_draft_and_accepts_active() -> None:
+    from app.models.document import DOC_STATUSES, DocumentPutRequest
+
+    base = dict(vault="v", collection="c", title="t", content="# x")
+    assert DocumentPutRequest(**base).status == "draft"          # backward-compatible default
+    assert DocumentPutRequest(**base, status="active").status == "active"
+    assert set(DOC_STATUSES) == {"draft", "active", "archived", "superseded"}
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_unknown_status() -> None:
+    """An out-of-set status is rejected by DocumentService.put before any
+    DB/git work (the check is the first statement in put()), so this needs
+    no database."""
+    from app.exceptions import ValidationError
+    from app.models.document import DocumentPutRequest
+
+    svc = DocumentService(git=_FakeGit("x"))
+    req = DocumentPutRequest(vault="v", collection="c", title="t", content="# x", status="actve")
+    with pytest.raises(ValidationError):
+        await svc.put(req)


### PR DESCRIPTION
## Why

`akb_put` hard-coded `status: draft` into both the git frontmatter and the `documents` row, so the only way to land an `active` document was a follow-up `akb_update`. This adds an optional `status` on create.

## What

- `DocumentPutRequest` gains an optional **`status`** (default `"draft"` → **existing behaviour unchanged**), stamped through to the frontmatter + DB row.
- Validated against `draft`/`active`/`archived`/`superseded` in `DocumentService.put` **before any git/DB work** — an unknown value returns a clean **422** instead of silently landing a typo.
- The MCP `akb_put` tool schema exposes the `status` enum (with a default). The `akb-mcp` proxy forwards it transparently (it spreads unknown args + preserves the backend schema), so **no proxy release is needed**.

Status remains **descriptive metadata** — it does not gate search, browse, or access. This just removes the put-then-update dance.

## Verification

- REST + MCP round-trip: `status:"active"` → frontmatter + DB `active`; default → `draft`; bad value → `422`.
- `test_mcp_e2e` **76/76**, `test_edit_e2e` **37/37**.
- Unit tests (no DB): `test_put_request_status_defaults_to_draft_and_accepts_active`, `test_put_rejects_unknown_status`.

No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)