### PR TITLE
fix(0.5.4): reject unknown MCP tool args with fuzzy hint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 623
+        "line_number": 661
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-02T11:10:04Z"
+  "generated_at": "2026-06-02T20:12:28Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,44 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.5.4 — 2026-06-03
+
+MCP `_dispatch` now rejects unknown tool arguments with a fuzzy hint
+instead of silently letting them through.
+
+Before: a typo like `akb_activity(user="someone")` (real arg name:
+`author`) fell through `args.get("author")` with no signal, the filter
+quietly disabled, and the unfiltered commit list came back looking
+correct. An agent that trusts its own argument spelling has no way to
+notice. This was the exact failure mode that motivated the gate — a
+session ran a vault-permission audit, two `user=...` calls returned
+identical author-unfiltered output, and the agent reported the result
+as if the filter had applied.
+
+Fix: build `_TOOL_ARG_NAMES` from the `TOOLS` schema list at import
+time, and in `_dispatch` reject any argument key that isn't in the
+allowed set. The response uses the same `{error, hint,
+available_arguments}` shape that `table_service._enrich_undefined_error`
+already returns for SQL column / table not-exist errors, so the
+fuzzy-hint tone is uniform across the API surface.
+
+The `fuzzy_hint` helper (Top-3 close matches via `difflib`, capped
+fallback list) moves from `table_service` to `app.util.text` so both
+callers share a single implementation.
+
+New tests:
+- Unit: `fuzzy_hint` shapes (close match / fallback / truncation) and
+  AST-based `TOOLS ↔ _HANDLERS` sync assertion (no heavy imports).
+- E2E: `test_security_edge_e2e.sh` §10 covers the activity
+  `user`→`author` typo path plus a regression guard that a valid call
+  still passes through the gate.
+
+Follow-up not in this release: error-response shape standardization
+across handlers (currently ~6 distinct shapes — `{error}`,
+`{error, code}`, `{error, code, hint, available_*}`, …). Tracked
+separately; this PR deliberately reuses the existing
+`_enrich_undefined_error` shape rather than introducing a seventh.
+
 ## 0.5.3 — 2026-06-02
 
 Document `status` coherence: leaned the lifecycle to 3 states and gave

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -18,7 +18,6 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from difflib import get_close_matches
 
 import asyncpg
 
@@ -33,6 +32,7 @@ from app.services.index_service import (
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import table_uri
 from app.services.user_sql_executor import PermissionDeniedError, get_user_sql_executor
+from app.util.text import fuzzy_hint
 
 # Re-exported helpers used by publication_service for the
 # `table_query` share path. Other modules import directly from
@@ -555,9 +555,6 @@ async def execute_sql(
         return {"error": msg}
 
 
-# Max items listed in fallback hints (when no fuzzy suggestion strong enough).
-_HINT_LIST_LIMIT = 15
-
 _COLUMN_NOT_EXIST = _re.compile(r'column "([^"]+)" does not exist')
 _RELATION_NOT_EXIST = _re.compile(r'relation "([^"]+)" does not exist')
 
@@ -587,7 +584,7 @@ async def _enrich_undefined_error(
         col_meta = await _fetch_column_meta(conn, allowed_pg_tables)
         if not col_meta:
             return None
-        hint = _fuzzy_hint(bad_col, list(col_meta.keys()), label="columns")
+        hint = fuzzy_hint(bad_col, list(col_meta.keys()), label="columns")
         jsonb_cols = [c for c, t in col_meta.items() if t == "jsonb"]
         if jsonb_cols:
             hint += (
@@ -610,7 +607,7 @@ async def _enrich_undefined_error(
         })
         if not short_names:
             return None
-        hint = _fuzzy_hint(bad_rel, short_names, label="tables")
+        hint = fuzzy_hint(bad_rel, short_names, label="tables")
         hint += (
             "  (Reference vault tables by their short name — the rewriter "
             "prefixes them with `vt_<vault>__` automatically.)"
@@ -647,13 +644,3 @@ async def _fetch_column_meta(conn, table_names: set[str]) -> dict[str, str]:
         list(table_names),
     )
     return {r["name"]: r["type"] for r in rows}
-
-
-def _fuzzy_hint(bad: str, candidates: list[str], *, label: str) -> str:
-    """Top-3 close matches → 'Did you mean…?', else first N as fallback."""
-    suggestions = get_close_matches(bad, candidates, n=3, cutoff=0.6)
-    if suggestions:
-        return f"Did you mean: {', '.join(suggestions)}?"
-    truncated = candidates[:_HINT_LIST_LIMIT]
-    suffix = " …" if len(candidates) > _HINT_LIST_LIMIT else ""
-    return f"Available {label}: {', '.join(truncated)}{suffix}"

--- a/backend/app/util/text.py
+++ b/backend/app/util/text.py
@@ -18,6 +18,7 @@ idempotent) and catches anything caller-side normalization missed.
 from __future__ import annotations
 
 import unicodedata
+from difflib import get_close_matches
 from typing import Any
 
 from pydantic import BaseModel, model_validator
@@ -141,6 +142,26 @@ def normalize_collection_path(path: str | None, *, allow_empty: bool = True) -> 
             )
         parts.append(raw)
     return "/".join(parts)
+
+
+_FUZZY_HINT_LIST_LIMIT = 15
+
+
+def fuzzy_hint(bad: str, candidates: list[str], *, label: str) -> str:
+    """Top-3 close matches → 'Did you mean…?', else first N as fallback.
+
+    Single source of truth for "tell the caller they probably typo'd X
+    and the real names are Y / Z". Used by `akb_sql` column/table
+    error enrichment AND `_dispatch` unknown-argument detection — same
+    tone for both so an agent that recovered from one will recover
+    from the other without re-learning the shape.
+    """
+    suggestions = get_close_matches(bad, candidates, n=3, cutoff=0.6)
+    if suggestions:
+        return f"Did you mean: {', '.join(suggestions)}?"
+    truncated = candidates[:_FUZZY_HINT_LIST_LIMIT]
+    suffix = " …" if len(candidates) > _FUZZY_HINT_LIST_LIMIT else ""
+    return f"Available {label}: {', '.join(truncated)}{suffix}"
 
 
 def like_escape(s: str) -> str:

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -40,7 +40,7 @@ from app.services.access_service import (
     archive_vault,
 )
 from app.services.auth_service import resolve_token
-from app.util.text import to_nfc
+from app.util.text import fuzzy_hint, to_nfc
 from app.services import publication_service, table_service
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.document_repo import DocumentRepository
@@ -110,6 +110,15 @@ search_service = SearchService()
 # ── Handler Registry ────────────────────────────────────────────
 
 _HANDLERS: dict[str, Any] = {}
+
+# Schema-derived: {tool_name: set(allowed_arg_names)}. Used by _dispatch
+# to reject unknown arguments with a fuzzy hint. Built once at import
+# time from the same TOOLS list returned via list_tools, so the
+# "what the agent saw" and "what we accept" can't drift.
+_TOOL_ARG_NAMES: dict[str, set[str]] = {
+    t.name: set((t.inputSchema or {}).get("properties", {}).keys())
+    for t in TOOLS
+}
 
 
 def _h(name: str):
@@ -1166,6 +1175,25 @@ async def _dispatch(name: str, args: dict):
     handler = _HANDLERS.get(name)
     if not handler:
         return {"error": f"Unknown tool: {name}"}
+
+    # Reject unknown arguments before the handler sees them. Without
+    # this, a typo like `akb_activity(user=...)` (real name: `author`)
+    # would silently fall through `args.get("author")` and quietly
+    # disable the filter — agent thinks the filter applied and trusts
+    # an unfiltered result. Surface the typo with a fuzzy hint so the
+    # caller can self-correct on retry; shape matches table_service's
+    # _enrich_undefined_error so the tone is uniform across the API.
+    allowed = _TOOL_ARG_NAMES.get(name)
+    if allowed is not None:
+        unknown = [k for k in args if k not in allowed]
+        if unknown:
+            bad = unknown[0]
+            return {
+                "error": f"Unknown argument '{bad}' for {name}",
+                "hint": fuzzy_hint(bad, sorted(allowed), label="arguments"),
+                "available_arguments": sorted(allowed),
+            }
+
     return await handler(args, uid, user)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.5.3"
+version = "0.5.4"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_mcp_tool_validation_unit.py
+++ b/backend/tests/test_mcp_tool_validation_unit.py
@@ -1,0 +1,84 @@
+"""Unit tests for MCP tool-call validation surface.
+
+Two concerns covered here:
+
+  1. ``fuzzy_hint`` (``app.util.text``) — shared between SQL column /
+     table not-exist enrichment and ``_dispatch`` unknown-arg
+     rejection. Verify the "Did you mean…?" and fallback shapes so the
+     tone stays uniform across both callers.
+
+  2. ``TOOLS`` ↔ ``_HANDLERS`` sync — every advertised tool must have
+     a registered handler and vice versa. Without this test, a tool
+     can drift (declared but unhandled, or registered but absent from
+     ``tools/list``) and the agent would only learn at call time.
+
+The handler list is extracted via AST grep instead of importing
+``mcp_server.server`` (which transitively imports psycopg / kiwipiepy /
+fs setup). Same dependency-avoidance pattern as ``test_mcp_init_unit``.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from app.util.text import fuzzy_hint
+from mcp_server.tools import TOOLS
+
+
+# ── fuzzy_hint ────────────────────────────────────────────────
+
+
+def test_fuzzy_hint_close_match():
+    out = fuzzy_hint("athor", ["author", "vault", "limit"], label="arguments")
+    assert out == "Did you mean: author?"
+
+
+def test_fuzzy_hint_no_match_falls_back_to_list():
+    out = fuzzy_hint("xyz", ["alpha", "beta", "gamma"], label="arguments")
+    assert out.startswith("Available arguments: ")
+    assert "alpha" in out and "gamma" in out
+
+
+def test_fuzzy_hint_truncates_long_candidate_list():
+    candidates = [f"cand{i}" for i in range(30)]
+    out = fuzzy_hint("zzz_no_match", candidates, label="tables")
+    assert " …" in out
+
+
+# ── TOOLS ↔ _HANDLERS sync ────────────────────────────────────
+
+
+def _extract_registered_handlers() -> set[str]:
+    """Pick the name string out of every ``@_h("X")`` in server.py."""
+    server_py = Path(__file__).resolve().parents[1] / "mcp_server" / "server.py"
+    tree = ast.parse(server_py.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "_h"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            names.add(first.value)
+    return names
+
+
+def test_tools_and_handlers_are_in_sync():
+    declared = {t.name for t in TOOLS}
+    registered = _extract_registered_handlers()
+
+    missing_handler = declared - registered
+    missing_tool = registered - declared
+
+    assert not missing_handler, (
+        f"Tools declared in TOOLS but no @_h handler in server.py: "
+        f"{sorted(missing_handler)}"
+    )
+    assert not missing_tool, (
+        f"@_h handlers in server.py but not in TOOLS list: "
+        f"{sorted(missing_tool)}"
+    )

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -440,6 +440,24 @@ RS=$(echo "$INFO" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.g
 curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$PUBLIC_VAULT" \
   -H "Authorization: Bearer $PAT1" >/dev/null
 
+# ── 10. Unknown-arg validation (fuzzy hint) ──────────────────
+echo ""
+echo "▸ 10. Unknown-arg validation (fuzzy hint)"
+
+# Typo `user=` instead of `author=` on akb_activity must be rejected
+# with a fuzzy hint, not silently ignored — silent ignore was the
+# regression that motivated this dispatch-level gate.
+R=$(mcp_as "$PAT1" "$SID1" "akb_activity" "{\"vault\":\"$VAULT1\",\"user\":\"nobody\"}" | mr)
+ERR=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','MISSING'))" 2>/dev/null)
+HINT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hint',''))" 2>/dev/null)
+echo "$ERR" | grep -q "Unknown argument 'user'" && pass "unknown arg surfaced" || fail "unknown arg" "got: $ERR"
+echo "$HINT" | grep -q "author" && pass "fuzzy hint suggests 'author'" || fail "fuzzy hint" "got: $HINT"
+
+# Regression guard: valid call still works through the new gate
+R=$(mcp_as "$PAT1" "$SID1" "akb_activity" "{\"vault\":\"$VAULT1\",\"author\":\"nobody\"}" | mr)
+RET=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('returned','MISSING'))" 2>/dev/null)
+[ "$RET" != "MISSING" ] && pass "valid call passes through" || fail "valid call" "got: $R"
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"


### PR DESCRIPTION
## Summary

- MCP `_dispatch` now rejects unknown tool arguments with a fuzzy-match hint instead of silently letting them through.
- Failure mode caught: a typo like `akb_activity(user=\"someone\")` (real arg name `author`) was falling through `args.get(\"author\")`, the filter quietly disabled, and the unfiltered result looked correct to the agent.
- Lift `_fuzzy_hint` from `table_service` to `app.util.text` so SQL column/table not-exist enrichment and unknown-arg rejection share one implementation and one response shape (`{error, hint, available_*}`).

## What changed

- `app/util/text.py` — new public `fuzzy_hint(bad, candidates, *, label)` (Top-3 close matches via `difflib`, capped fallback list).
- `app/services/table_service.py` — removed local `_fuzzy_hint`, switched to `app.util.text.fuzzy_hint`. No behavioural change.
- `mcp_server/server.py` — `_TOOL_ARG_NAMES` built once at import from the `TOOLS` list; `_dispatch` rejects unknown keys before the handler is called. Response shape matches `_enrich_undefined_error` (no new shape).
- `tests/test_mcp_tool_validation_unit.py` (new) — `fuzzy_hint` shapes (close match / fallback / truncation) + AST-based `TOOLS ↔ _HANDLERS` sync assertion (no heavy imports).
- `tests/test_security_edge_e2e.sh` §10 — covers the activity `user`→`author` typo plus a regression guard that a valid call still passes through the gate.

## Example response

\`\`\`json
{
  \"error\": \"Unknown argument 'user' for akb_activity\",
  \"hint\": \"Did you mean: author?\",
  \"available_arguments\": [\"author\", \"collection\", \"limit\", \"since\", \"vault\"]
}
\`\`\`

## Out of scope (follow-up)

Error-response shape standardization across handlers — currently ~6 distinct shapes (\`{error}\`, \`{error, code}\`, \`{error, code, hint, available_*}\`, …). This PR deliberately reuses the existing \`_enrich_undefined_error\` shape rather than adding a seventh; the cross-handler cleanup will land in a separate PR.

## Test plan

- [x] \`pytest tests/test_mcp_tool_validation_unit.py\` — 4 passed
- [x] \`pytest tests/test_help_skill_unit.py tests/test_mcp_init_unit.py tests/test_search_rerank_fusion.py tests/test_collection_service.py tests/test_cli_resource_integrity_unit.py\` — 19 passed, 21 skipped (regression check)
- [x] \`bash tests/test_security_edge_e2e.sh\` — 63 passed (includes new §10)
- [x] \`bash tests/test_mcp_e2e.sh\` — 73 passed (regression)
- [x] \`bash tests/test_pg_rbac_e2e.sh\` — 50 passed (regression)
- [ ] Reviewer: verify the new \`{error, hint, available_arguments}\` shape doesn't conflict with any agent-side parser expecting the old "unknown arg → silently dropped" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)