### PR TITLE
fix(0.5.6): collapse error-response shapes to one canonical envelope (BREAKING)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 714
+        "line_number": 803
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-03T06:27:58Z"
+  "generated_at": "2026-06-03T06:56:56Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,95 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.5.6 — 2026-06-03  *(breaking error-response shape)*
+
+Error responses across the backend now share one envelope. Until
+0.5.5 there were ~6 distinct shapes — bare `{error}`, `{error,
+code}`, `{error, code, pg_sqlstate}`, `{error, hint, available_*}`,
+`{error, message, hint}` — and every new handler that wanted to
+surface a hint or metadata reinvented a slightly different one.
+Agents that wanted to auto-recover had to learn each case's field
+names; new error paths kept proliferating new shapes.
+
+### Canonical shape
+
+Every error return from `akb_*` MCP tools and the REST surface now
+matches:
+
+```json
+{
+  "error":   "<human-readable message>",
+  "code":    "<stable enum>",
+  "hint":    "<optional self-correction guidance>",
+  "details": { "<optional case-specific metadata>": "..." }
+}
+```
+
+`error` + `code` are always present. `hint` and `details` are
+opt-in. **Top-level meta fields that used to live alongside `error`
+have moved into `details`** — `available_columns`,
+`available_tables`, `available_arguments`, `pg_sqlstate`,
+`doc_count` / `file_count` / etc. on a non-empty-collection error.
+
+### Code catalogue (initial)
+
+Stable strings, defined in `app/util/errors.py`:
+
+| code                | When                                                                     |
+|---------------------|--------------------------------------------------------------------------|
+| `not_found`         | Resource doesn't exist (vault, doc, table, version, publication, user)    |
+| `permission_denied` | PG ACL denied (cross-vault probe); `details.pg_sqlstate` carries SQLSTATE |
+| `vault_archived`    | Write attempted against an archived vault                                 |
+| `invalid_argument`  | Generic argument-shape problem (missing required, wrong format, …)        |
+| `invalid_uri`       | `akb://…` URI couldn't be parsed                                          |
+| `invalid_path`      | Collection / file path failed normalisation                               |
+| `unknown_argument`  | Tool called with an arg key not in its schema (0.5.4)                     |
+| `unknown_tool`      | `_dispatch` got a tool name not in `_HANDLERS`                            |
+| `conflict`          | OCC mismatch / non-empty collection delete without `recursive`            |
+| `no_op`             | Update request had nothing to update                                      |
+| `edit_failed`       | `akb_edit` couldn't apply (no match / non-unique / empty old_string)      |
+| `multi_statement`   | `akb_sql` got `;`-separated statements                                    |
+| `method_not_allowed`| `akb_sql` got DDL or other non-DML                                        |
+| `sql_error`         | Generic PG error after enrichment                                         |
+| `undefined_column`  | SQL column doesn't exist; `details.available_columns` + `hint`            |
+| `undefined_table`   | SQL relation doesn't exist; `details.available_tables` + `hint`           |
+| `cross_vault_link`  | (reserved for future link cross-vault rejection)                          |
+| `self_link`         | `akb_link` source == target                                               |
+| `internal_error`    | Uncategorised exception fall-through (prefer a specific code over this)   |
+
+### Breaking changes
+
+If you parse error responses programmatically:
+
+1. **`error` is now always a human message**, not sometimes a code.
+   The old `{"error": "edit_failed", "message": "..."}` shape is
+   gone — use `code == "edit_failed"` and read `error` for the
+   message.
+2. **Aux fields moved under `details`**. `response.available_columns`
+   → `response.details.available_columns`. Same for
+   `available_tables`, `available_arguments`, `pg_sqlstate`,
+   `doc_count` / `file_count` / `sub_collection_count` / `table_count`
+   on `akb_delete_collection`.
+3. **`hint` stays top-level** (it's the dominant self-correction
+   signal — burying it under `details` would hurt agent UX).
+
+The frontend uses only `error` (verified — `frontend/src/lib/api.ts`
+throws `new Error(body.error || body.detail)`) and the akb-mcp
+stdio proxy is pass-through, so neither needs changes. Direct REST
+clients and agents that inspected the aux fields by their old
+top-level names need to look one level deeper.
+
+### Tests
+
+- `test_errors_unit.py` (new, 5 cases): envelope shape — minimal,
+  with hint, with details kwargs, `code` always present.
+- E2E migrated: `test_mcp_e2e.sh` (`available_columns` →
+  `details.available_columns`), `test_edit_e2e.sh` and
+  `test_security_edge_e2e.sh` (`error == "edit_failed"` →
+  `code == "edit_failed"`, `message` → `error`).
+- Full regression: unit 30 passed; main / security / pg_rbac e2e
+  green against the 0.5.6 backend.
+
 ## 0.5.5 — 2026-06-03
 
 Vault tables with hyphenated or non-ASCII display names are now

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -14,6 +14,7 @@ from app.exceptions import ConflictError, ForbiddenError, NotFoundError, Validat
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
+from app.util.errors import NOT_FOUND, err
 
 logger = logging.getLogger("akb.access")
 
@@ -799,7 +800,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
     async with pool.acquire() as conn:
         vault = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)
         if not vault:
-            return {"error": f"Vault not found: {vault_name}"}
+            return err(f"Vault not found: {vault_name}", code=NOT_FOUND)
         vault_id = vault["id"]
 
         # Delete S3 files BEFORE the DB cascade — this part cannot be

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -20,6 +20,13 @@ import uuid
 
 from app.db.postgres import get_pool
 from app.services.uri_service import parse_uri, doc_uri, table_uri, file_uri
+from app.util.errors import (
+    err,
+    INVALID_ARGUMENT,
+    INVALID_URI,
+    NOT_FOUND,
+    SELF_LINK,
+)
 
 logger = logging.getLogger("akb.graph")
 
@@ -173,20 +180,22 @@ async def link_resources(
     source_parsed = parse_uri(source_uri)
     target_parsed = parse_uri(target_uri)
     if not source_parsed:
-        return {"error": f"Invalid source URI: {source_uri}"}
+        return err(f"Invalid source URI: {source_uri}", code=INVALID_URI)
     if not target_parsed:
-        return {"error": f"Invalid target URI: {target_uri}"}
+        return err(f"Invalid target URI: {target_uri}", code=INVALID_URI)
     _LINKABLE = ("doc", "table", "file")
     if source_parsed.kind not in _LINKABLE:
-        return {"error": (
+        return err(
             f"Cannot link from a {source_parsed.kind} URI ({source_uri}). "
-            f"Linkable kinds: {_LINKABLE}."
-        )}
+            f"Linkable kinds: {_LINKABLE}.",
+            code=INVALID_ARGUMENT,
+        )
     if target_parsed.kind not in _LINKABLE:
-        return {"error": (
+        return err(
             f"Cannot link to a {target_parsed.kind} URI ({target_uri}). "
-            f"Linkable kinds: {_LINKABLE}."
-        )}
+            f"Linkable kinds: {_LINKABLE}.",
+            code=INVALID_ARGUMENT,
+        )
 
     source_vault_name = source_parsed.vault
     source_type = source_parsed.kind
@@ -199,7 +208,7 @@ async def link_resources(
     # here means a malformed URI slipped past parse_uri. Fail closed so the
     # advisory-lock + existence checks below can treat both ids as str.
     if source_id is None or target_id is None:
-        return {"error": "Source or target URI is missing an identifier."}
+        return err("Source or target URI is missing an identifier.", code=INVALID_URI)
 
     # Canonicalize both endpoints from parsed parts so a legacy-shaped
     # URI passed by an external caller is stored in 0.3.0 canonical form
@@ -209,7 +218,7 @@ async def link_resources(
     target_uri = canonicalize_resource_uri(target_parsed) or target_uri
 
     if source_uri == target_uri:
-        return {"error": "Cannot link a resource to itself"}
+        return err("Cannot link a resource to itself", code=SELF_LINK)
 
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -220,19 +229,19 @@ async def link_resources(
                 "SELECT id FROM vaults WHERE name = $1", vault_name,
             )
             if not vault:
-                return {"error": f"Vault not found: {vault_name}"}
+                return err(f"Vault not found: {vault_name}", code=NOT_FOUND)
             vault_id = vault["id"]
 
             source_vault = await conn.fetchrow(
                 "SELECT id FROM vaults WHERE name = $1", source_vault_name,
             )
             if not source_vault:
-                return {"error": f"Source vault not found: {source_vault_name}"}
+                return err(f"Source vault not found: {source_vault_name}", code=NOT_FOUND)
             target_vault = await conn.fetchrow(
                 "SELECT id FROM vaults WHERE name = $1", target_vault_name,
             )
             if not target_vault:
-                return {"error": f"Target vault not found: {target_vault_name}"}
+                return err(f"Target vault not found: {target_vault_name}", code=NOT_FOUND)
 
             # Acquire the same path advisory lock the doc write paths use so
             # akb_link serialises with akb_delete / akb_update on either
@@ -253,11 +262,11 @@ async def link_resources(
             if not await _resource_exists(
                 conn, source_vault["id"], source_type, source_id,
             ):
-                return {"error": f"Source resource not found: {source_uri}"}
+                return err(f"Source resource not found: {source_uri}", code=NOT_FOUND)
             if not await _resource_exists(
                 conn, target_vault["id"], target_type, target_id,
             ):
-                return {"error": f"Target resource not found: {target_uri}"}
+                return err(f"Target resource not found: {target_uri}", code=NOT_FOUND)
 
             await conn.execute(
                 """
@@ -507,7 +516,7 @@ async def get_provenance(doc_id: str, *, vault_id: uuid.UUID) -> dict:
             doc_id, vault_id,
         )
         if not row:
-            return {"error": "Document not found"}
+            return err("Document not found", code=NOT_FOUND)
 
         uri = doc_uri(row["vault_name"], row["path"])
         relations = await get_resource_relations(row["vault_name"], uri, vault_id=vault_id)

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -32,6 +32,16 @@ from app.services.index_service import (
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import table_uri
 from app.services.user_sql_executor import PermissionDeniedError, get_user_sql_executor
+from app.util.errors import (
+    err,
+    METHOD_NOT_ALLOWED,
+    MULTI_STATEMENT,
+    PERMISSION_DENIED,
+    SQL_ERROR,
+    UNDEFINED_COLUMN,
+    UNDEFINED_TABLE,
+    VAULT_ARCHIVED,
+)
 from app.util.text import fuzzy_hint
 
 # Re-exported helpers used by publication_service for the
@@ -490,17 +500,19 @@ async def execute_sql(
 
         sql_check = rewritten.rstrip(";").strip()
         if ";" in sql_check:
-            return {"error": "Multi-statement SQL is not allowed. Send one statement at a time."}
+            return err(
+                "Multi-statement SQL is not allowed. Send one statement at a time.",
+                code=MULTI_STATEMENT,
+            )
 
         upper = rewritten.strip().upper()
         if not upper.startswith(_ALLOWED_FIRST_KEYWORDS):
-            return {
-                "error": (
-                    "Only SELECT / WITH / INSERT / UPDATE / DELETE are allowed via "
-                    "akb_sql. Use akb_create_table / akb_alter_table / "
-                    "akb_drop_table for schema changes."
-                )
-            }
+            return err(
+                "Only SELECT / WITH / INSERT / UPDATE / DELETE are allowed via "
+                "akb_sql. Use akb_create_table / akb_alter_table / "
+                "akb_drop_table for schema changes.",
+                code=METHOD_NOT_ALLOWED,
+            )
 
         # Archived vaults are READ-ONLY. PG ACL has no archive concept
         # (write grants are intentionally preserved so unarchive is
@@ -515,13 +527,11 @@ async def execute_sql(
             )
             if archived:
                 names = ", ".join(sorted(r["name"] for r in archived))
-                return {
-                    "error": (
-                        f"Vault '{names}' is archived (read-only); writes via "
-                        f"akb_sql are not allowed. Unarchive the vault first."
-                    ),
-                    "code": "vault_archived",
-                }
+                return err(
+                    f"Vault '{names}' is archived (read-only); writes via "
+                    f"akb_sql are not allowed. Unarchive the vault first.",
+                    code=VAULT_ARCHIVED,
+                )
 
     try:
         return await get_user_sql_executor().execute(
@@ -533,12 +543,13 @@ async def execute_sql(
     except PermissionDeniedError as e:
         # PG ACL denied — the boundary working as designed. Surface
         # the PG error verbatim so callers know it came from PG, not
-        # from application validation.
-        return {
-            "error": str(e),
-            "code": "permission_denied",
-            "pg_sqlstate": e.pg_sqlstate,
-        }
+        # from application validation. `pg_sqlstate` lives under
+        # `details` per the canonical shape.
+        return err(
+            str(e),
+            code=PERMISSION_DENIED,
+            pg_sqlstate=e.pg_sqlstate,
+        )
     except Exception as e:  # noqa: BLE001 — fall through to enrichment
         msg = str(e)
         # Try to enrich column/table-not-exist errors with fuzzy-match
@@ -552,7 +563,7 @@ async def execute_sql(
             )
         if enriched:
             return enriched
-        return {"error": msg}
+        return err(msg, code=SQL_ERROR)
 
 
 _COLUMN_NOT_EXIST = _re.compile(r'column "([^"]+)" does not exist')
@@ -591,11 +602,12 @@ async def _enrich_undefined_error(
                 f"  (jsonb columns — use `<col>::text ILIKE '%X%'`: "
                 f"{', '.join(jsonb_cols)})"
             )
-        return {
-            "error": err_msg,
-            "hint": hint,
-            "available_columns": list(col_meta.keys()),
-        }
+        return err(
+            err_msg,
+            code=UNDEFINED_COLUMN,
+            hint=hint,
+            available_columns=list(col_meta.keys()),
+        )
 
     # ── Relation/table not exist ────────────────────────────────
     if m := _RELATION_NOT_EXIST.search(err_msg):
@@ -612,11 +624,12 @@ async def _enrich_undefined_error(
             "  (Reference vault tables by their short name — the rewriter "
             "prefixes them with `vt_<vault>__` automatically.)"
         )
-        return {
-            "error": err_msg,
-            "hint": hint,
-            "available_tables": short_names,
-        }
+        return err(
+            err_msg,
+            code=UNDEFINED_TABLE,
+            hint=hint,
+            available_tables=short_names,
+        )
 
     return None
 

--- a/backend/app/services/todo_service.py
+++ b/backend/app/services/todo_service.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import date as _date, datetime, timezone
 
 from app.db.postgres import get_pool
+from app.util.errors import NOT_FOUND, NO_OP, err
 
 
 async def create_todo(
@@ -140,7 +141,7 @@ async def update_todo(todo_id: str, **kwargs) -> dict:
     async with pool.acquire() as conn:
         todo = await conn.fetchrow("SELECT * FROM todos WHERE id = $1", uuid.UUID(todo_id))
         if not todo:
-            return {"error": "Todo not found"}
+            return err("Todo not found", code=NOT_FOUND)
 
         sets, params, idx = [], [], 1
         if "status" in kwargs:
@@ -173,7 +174,7 @@ async def update_todo(todo_id: str, **kwargs) -> dict:
             idx += 1
 
         if not sets:
-            return {"error": "Nothing to update"}
+            return err("Nothing to update", code=NO_OP)
 
         params.append(uuid.UUID(todo_id))
         await conn.execute(f"UPDATE todos SET {', '.join(sets)} WHERE id = ${idx}", *params)

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -1,0 +1,101 @@
+"""Single source of truth for error-response shape.
+
+Background — until 0.5.5, error returns across the backend had ~6
+distinct shapes: bare `{error}`, `{error, code}`, `{error, code,
+pg_sqlstate}`, `{error, hint, available_*}`, `{error, message,
+hint}`, etc. Every new handler that wanted to surface an auxiliary
+hint reinvented a slightly different envelope. Agents that wanted to
+auto-recover had to learn each case's field names.
+
+0.5.6 collapses everything to one shape::
+
+    {
+      "error":   <human-readable message>,         # always
+      "code":    <stable enum>,                    # always
+      "hint":    <self-correction guidance>,       # optional
+      "details": { ... case-specific metadata }    # optional
+    }
+
+The frontend never read auxiliary fields, the akb-mcp stdio proxy
+just passes the envelope through, and the only e2e assertion on a
+top-level meta field was `test_mcp_e2e`'s `available_columns` check
+(now `details.available_columns`). Beyond that, callers that
+inspected `pg_sqlstate`, `available_tables`, `available_arguments`,
+or `message` need to look one level deeper.
+
+Use ``err(...)`` everywhere. Don't hand-craft error dicts; the
+flat-vs-nested rule has to be enforced in one place or it drifts
+back to ~6 shapes within a quarter.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+# ── Stable error codes ────────────────────────────────────────
+#
+# Code strings are part of the contract — callers (agents,
+# scripts) branch on them. Add to this list before using a new
+# one; do not coin codes inline at the call site.
+
+# Resource lookup
+NOT_FOUND = "not_found"
+
+# Authorization / permission
+PERMISSION_DENIED = "permission_denied"
+VAULT_ARCHIVED = "vault_archived"
+
+# Caller-side input
+INVALID_ARGUMENT = "invalid_argument"      # generic argument shape problem
+INVALID_URI = "invalid_uri"                # akb:// URI parse failure
+INVALID_PATH = "invalid_path"              # collection / file path failure
+UNKNOWN_ARGUMENT = "unknown_argument"      # arg key not in tool schema (0.5.4)
+UNKNOWN_TOOL = "unknown_tool"
+CONFLICT = "conflict"                      # version / expected-state mismatch
+NO_OP = "no_op"                            # nothing to update / already in state
+EDIT_FAILED = "edit_failed"                # akb_edit: old_string match / uniqueness failure
+
+# SQL surface — `akb_sql`
+MULTI_STATEMENT = "multi_statement"
+METHOD_NOT_ALLOWED = "method_not_allowed"  # DDL via akb_sql, etc.
+SQL_ERROR = "sql_error"                    # generic PG error after enrichment
+UNDEFINED_COLUMN = "undefined_column"
+UNDEFINED_TABLE = "undefined_table"
+
+# Knowledge-graph linking
+CROSS_VAULT_LINK = "cross_vault_link"
+SELF_LINK = "self_link"
+
+# Catch-all when an exception bubbles up without a more specific
+# classification. Prefer a specific code over this.
+INTERNAL_ERROR = "internal_error"
+
+
+# ── Builder ───────────────────────────────────────────────────
+
+
+def err(
+    message: str,
+    code: str,
+    *,
+    hint: str | None = None,
+    **details: Any,
+) -> dict:
+    """Build the canonical error response envelope.
+
+    >>> err("Vault is archived", code=VAULT_ARCHIVED)
+    {'error': 'Vault is archived', 'code': 'vault_archived'}
+
+    >>> err("Unknown argument 'user'", code=UNKNOWN_ARGUMENT,
+    ...     hint="Did you mean: author?",
+    ...     available_arguments=['author', 'vault'])
+    {'error': "Unknown argument 'user'", 'code': 'unknown_argument',
+     'hint': 'Did you mean: author?',
+     'details': {'available_arguments': ['author', 'vault']}}
+    """
+    out: dict[str, Any] = {"error": message, "code": code}
+    if hint is not None:
+        out["hint"] = hint
+    if details:
+        out["details"] = details
+    return out

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -40,6 +40,17 @@ from app.services.access_service import (
     archive_vault,
 )
 from app.services.auth_service import resolve_token
+from app.util.errors import (
+    err,
+    CONFLICT,
+    EDIT_FAILED,
+    INVALID_ARGUMENT,
+    INVALID_PATH,
+    INVALID_URI,
+    NOT_FOUND,
+    UNKNOWN_ARGUMENT,
+    UNKNOWN_TOOL,
+)
 from app.util.text import fuzzy_hint, to_nfc
 from app.services import publication_service, table_service
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
@@ -229,7 +240,7 @@ async def _handle_create_vault(args: dict, uid: str, user: _MCPUser) -> dict:
             external_git=args.get("external_git"),
         )
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
     response = {
         "vault_id": vault_id, "name": args["name"],
         "template": args.get("template"),
@@ -249,7 +260,7 @@ async def _handle_put(args: dict, uid: str, user: _MCPUser) -> dict:
     try:
         vault, collection = _resolve_parent(args, kind_name="document")
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
     await check_vault_access(uid, vault, required_role="writer")
     req = DocumentPutRequest(
         vault=vault,
@@ -267,7 +278,7 @@ async def _handle_put(args: dict, uid: str, user: _MCPUser) -> dict:
     try:
         result = await doc_service.put(req, agent_id=user.username)
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
     return result.model_dump()
 
 
@@ -310,12 +321,11 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
     version = args.get("version")
     if version:
         if not HEX_COMMIT_RE.fullmatch(version):
-            return {
-                "error": (
-                    "version must be a 7-64 char lowercase hex commit hash; "
-                    "symbolic refs (HEAD~N, refs/heads/main, ...) are not accepted"
-                )
-            }
+            return err(
+                "version must be a 7-64 char lowercase hex commit hash; "
+                "symbolic refs (HEAD~N, refs/heads/main, ...) are not accepted",
+                code=INVALID_ARGUMENT,
+            )
         # Read specific version from Git. Strip frontmatter (yaml meta
         # block at top) before returning content — the un-versioned
         # akb_get path does the same via doc_service.get, and any
@@ -324,12 +334,12 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
         import frontmatter as _fm
         doc = await _find_doc(vault, doc_path)
         if not doc:
-            return {"error": "Document not found"}
+            return err("Document not found", code=NOT_FOUND)
         from app.services.git_service import GitService
         git = GitService()
         raw = git.read_file(vault, doc["path"], commit=version)
         if raw is None:
-            return {"error": f"Version not found: {version}"}
+            return err(f"Version not found: {version}", code=NOT_FOUND)
         try:
             body = _fm.loads(raw).content
         except Exception:
@@ -356,7 +366,7 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
         }
     doc = await doc_service.get(vault, doc_path)
     if not doc:
-        return {"error": "Document not found"}
+        return err("Document not found", code=NOT_FOUND)
     return doc.model_dump()
 
 
@@ -379,7 +389,7 @@ async def _handle_update(args: dict, uid: str, user: _MCPUser) -> dict:
     )
     result = await doc_service.update(vault, doc_path, req, agent_id=user.username)
     if not result:
-        return {"error": "Document not found"}
+        return err("Document not found", code=NOT_FOUND)
     return result.model_dump()
 
 
@@ -400,19 +410,19 @@ async def _handle_edit(args: dict, uid: str, user: _MCPUser) -> dict:
         )
         return result.model_dump()
     except EditError as e:
-        return {
-            "error": "edit_failed",
-            "message": str(e),
-            "hint": "Use akb_get to verify current content, then retry with adjusted old_string.",
-        }
+        return err(
+            str(e),
+            code=EDIT_FAILED,
+            hint="Use akb_get to verify current content, then retry with adjusted old_string.",
+        )
     except ConflictError as e:
         # base_commit OCC mismatch: a concurrent writer moved the doc
         # between the agent's read and edit submission.
-        return {
-            "error": "conflict",
-            "message": str(e),
-            "hint": "Document was modified since base_commit. Re-read with akb_get and retry.",
-        }
+        return err(
+            str(e),
+            code=CONFLICT,
+            hint="Document was modified since base_commit. Re-read with akb_get and retry.",
+        )
 
 
 @_h("akb_delete")
@@ -441,11 +451,11 @@ async def _handle_browse(args: dict, uid: str, user: _MCPUser) -> dict:
         try:
             vault, collection = split_browse_uri(uri_arg)
         except ValueError as exc:
-            return {"error": str(exc)}
+            return err(str(exc), code=INVALID_URI)
     else:
         vault_arg = args.get("vault")
         if not vault_arg:
-            return {"error": "Either `vault` or `uri` is required for akb_browse."}
+            return err("Either `vault` or `uri` is required for akb_browse.", code=INVALID_ARGUMENT)
         vault = vault_arg
         collection = args.get("collection")
     await check_vault_access(uid, vault, required_role="reader")
@@ -500,7 +510,7 @@ async def _handle_grep(args: dict, uid: str, user: _MCPUser) -> dict:
         if args.get("vault"):
             await check_vault_access(uid, args["vault"], required_role="writer")
         else:
-            return {"error": "vault is required when using replace"}
+            return err("vault is required when using replace", code=INVALID_ARGUMENT)
     result = await search_service.grep(
         pattern=args["pattern"],
         vault=args.get("vault"),
@@ -685,15 +695,14 @@ async def _handle_diff(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     commit = args.get("commit", "")
     if not HEX_COMMIT_RE.fullmatch(commit):
-        return {
-            "error": (
-                "commit must be a 7-64 char lowercase hex hash; "
-                "symbolic refs are not accepted"
-            )
-        }
+        return err(
+            "commit must be a 7-64 char lowercase hex hash; "
+            "symbolic refs are not accepted",
+            code=INVALID_ARGUMENT,
+        )
     doc = await _find_doc(vault, doc_path)
     if not doc:
-        return {"error": f"Document not found: {args['uri']}"}
+        return err(f"Document not found: {args['uri']}", code=NOT_FOUND)
     from app.services.git_service import GitService
     git = GitService()
     return git.file_diff(vault, doc["path"], commit)
@@ -704,7 +713,7 @@ async def _handle_relations(args: dict, uid: str, user: _MCPUser) -> dict:
     uri = args["uri"]
     parsed = parse_uri(uri)
     if parsed is None:
-        return {"error": f"Invalid AKB URI: '{uri}'"}
+        return err(f"Invalid AKB URI: '{uri}'", code=INVALID_URI)
     vault = parsed.vault
     access = await check_vault_access(uid, vault, required_role="reader")
     relations = await get_resource_relations(
@@ -723,12 +732,12 @@ async def _handle_graph(args: dict, uid: str, user: _MCPUser) -> dict:
     if uri:
         parsed = parse_uri(uri)
         if parsed is None:
-            return {"error": f"Invalid AKB URI: '{uri}'"}
+            return err(f"Invalid AKB URI: '{uri}'", code=INVALID_URI)
         vault = parsed.vault
     else:
         v = args.get("vault")
         if not v:
-            return {"error": "Either `uri` or `vault` is required"}
+            return err("Either `uri` or `vault` is required", code=INVALID_ARGUMENT)
         vault = v
     access = await check_vault_access(uid, vault, required_role="reader")
     return await get_graph(
@@ -751,9 +760,9 @@ async def _handle_link(args: dict, uid: str, user: _MCPUser) -> dict:
     src_parsed = parse_uri(args["source"])
     tgt_parsed = parse_uri(args["target"])
     if src_parsed is None or tgt_parsed is None:
-        return {"error": "Both source and target must be valid akb:// URIs"}
+        return err("Both source and target must be valid akb:// URIs", code=INVALID_URI)
     if src_parsed.vault != tgt_parsed.vault:
-        return {"error": "source and target must belong to the same vault"}
+        return err("source and target must belong to the same vault", code=INVALID_ARGUMENT)
     vault = src_parsed.vault
     await check_vault_access(uid, vault, required_role="writer")
     return await link_resources(
@@ -768,9 +777,9 @@ async def _handle_unlink(args: dict, uid: str, user: _MCPUser) -> dict:
     src_parsed = parse_uri(args["source"])
     tgt_parsed = parse_uri(args["target"])
     if src_parsed is None or tgt_parsed is None:
-        return {"error": "Both source and target must be valid akb:// URIs"}
+        return err("Both source and target must be valid akb:// URIs", code=INVALID_URI)
     if src_parsed.vault != tgt_parsed.vault:
-        return {"error": "source and target must belong to the same vault"}
+        return err("source and target must belong to the same vault", code=INVALID_ARGUMENT)
     vault = src_parsed.vault
     access = await check_vault_access(uid, vault, required_role="writer")
     return await unlink_resources(
@@ -786,7 +795,7 @@ async def _handle_provenance(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     doc = await _find_doc(vault, doc_path)
     if not doc:
-        return {"error": "Document not found"}
+        return err("Document not found", code=NOT_FOUND)
     return await get_provenance(str(doc["id"]), vault_id=doc["vault_id"])
 
 
@@ -795,7 +804,7 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
     try:
         vault, collection = _resolve_parent(args, kind_name="table")
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
     access = await check_vault_access(uid, vault, required_role="writer")
     try:
         return await table_service.create_table(
@@ -805,7 +814,7 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
             collection=collection or None,
         )
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
 
 
 @_h("akb_sql")
@@ -813,7 +822,7 @@ async def _handle_sql(args: dict, uid: str, user: _MCPUser) -> dict:
     sql = args["sql"].strip()
     vaults = args.get("vaults") or ([args["vault"]] if args.get("vault") else [])
     if not vaults:
-        return {"error": "Must specify vault or vaults parameter"}
+        return err("Must specify vault or vaults parameter", code=INVALID_ARGUMENT)
 
     # Check access on all referenced vaults — minimum reader. This is
     # the application's friendly 403 gate; if the caller has no
@@ -841,7 +850,7 @@ async def _handle_drop_table(args: dict, uid: str, user: _MCPUser) -> dict:
             access["vault_id"], table_name, actor_id=user.username,
         )
     except NotFoundError as e:
-        return {"error": str(e)}
+        return err(str(e), code=NOT_FOUND)
 
 
 @_h("akb_alter_table")
@@ -856,8 +865,10 @@ async def _handle_alter_table(args: dict, uid: str, user: _MCPUser) -> dict:
             drop_columns=args.get("drop_columns"),
             rename_columns=args.get("rename_columns"),
         )
-    except (NotFoundError, ValueError) as e:
-        return {"error": str(e)}
+    except NotFoundError as e:
+        return err(str(e), code=NOT_FOUND)
+    except ValueError as e:
+        return err(str(e), code=INVALID_ARGUMENT)
 
 
 _SYSTEM_UID = "00000000-0000-0000-0000-000000000000"
@@ -876,18 +887,18 @@ async def _handle_publish(args: dict, uid: str, user: _MCPUser) -> dict:
     vault_name: str | None = None
     if resource_type == "document":
         if not uri:
-            return {"error": "`uri` is required for resource_type=document"}
+            return err("`uri` is required for resource_type=document", code=INVALID_ARGUMENT)
         vault_name, doc_path = split_uri(uri, expected_type="doc")
     elif resource_type == "file":
         if not uri:
-            return {"error": "`uri` is required for resource_type=file"}
+            return err("`uri` is required for resource_type=file", code=INVALID_ARGUMENT)
         vault_name, file_id = split_uri(uri, expected_type="file")
     elif resource_type == "table_query":
         vault_name = args.get("vault")
         if not vault_name:
-            return {"error": "`vault` is required for resource_type=table_query"}
+            return err("`vault` is required for resource_type=table_query", code=INVALID_ARGUMENT)
     else:
-        return {"error": f"Unknown resource_type: {resource_type}"}
+        return err(f"Unknown resource_type: {resource_type}", code=INVALID_ARGUMENT)
 
     await check_vault_access(uid, vault_name, required_role="writer")
     # A table_query publication runs against EVERY vault in
@@ -919,7 +930,7 @@ async def _handle_publish(args: dict, uid: str, user: _MCPUser) -> dict:
             created_by=created_by,
         )
     except ValueError as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
 
     return {
         "published": True,
@@ -963,7 +974,7 @@ async def _handle_unpublish(args: dict, uid: str, user: _MCPUser) -> dict:
         count = await publication_service.delete_publications_for_document(args["uri"])
         return {"published": False, "deleted_publications": count}
 
-    return {"error": "Either slug or uri is required"}
+    return err("Either slug or uri is required", code=INVALID_ARGUMENT)
 
 
 @_h("akb_publications")
@@ -990,15 +1001,15 @@ async def _handle_publication_snapshot(args: dict, uid: str, user: _MCPUser) -> 
             slug, access["vault_id"],
         )
     if not row:
-        return {"error": f"Publication not found: {slug}"}
+        return err(f"Publication not found: {slug}", code=NOT_FOUND)
     try:
         return await publication_service.create_snapshot(
             row["id"], expected_vault_id=access["vault_id"],
         )
     except publication_service.PublicationError as e:
-        return {"error": e.message}
+        return err(e.message, code=INVALID_ARGUMENT)
     except Exception as e:
-        return {"error": str(e)}
+        return err(str(e), code=INVALID_ARGUMENT)
 
 
 @_h("akb_vault_info")
@@ -1037,7 +1048,7 @@ async def _handle_whoami(args: dict, uid: str, user: _MCPUser) -> dict:
             uuid.UUID(uid),
         )
         if not row:
-            return {"error": "User not found"}
+            return err("User not found", code=NOT_FOUND)
         return {
             "user_id": str(row["id"]),
             "username": row["username"],
@@ -1078,7 +1089,7 @@ async def _handle_create_collection(args: dict, uid: str, user: _MCPUser) -> dic
             agent_id=uid,
         )
     except InvalidPathError as exc:
-        return {"error": "invalid_path", "message": str(exc)}
+        return err(str(exc), code=INVALID_PATH)
 
 
 @_h("akb_delete_collection")
@@ -1095,16 +1106,16 @@ async def _handle_delete_collection(args: dict, uid: str, user: _MCPUser) -> dic
             agent_id=uid,
         )
     except InvalidPathError as exc:
-        return {"error": "invalid_path", "message": str(exc)}
+        return err(str(exc), code=INVALID_PATH)
     except CollectionNotEmptyError as exc:
-        return {
-            "error": "not_empty",
-            "message": str(exc),
-            "doc_count": exc.doc_count,
-            "file_count": exc.file_count,
-            "sub_collection_count": exc.sub_collection_count,
-            "table_count": exc.table_count,
-        }
+        return err(
+            str(exc),
+            code=CONFLICT,
+            doc_count=exc.doc_count,
+            file_count=exc.file_count,
+            sub_collection_count=exc.sub_collection_count,
+            table_count=exc.table_count,
+        )
 
 
 @_h("akb_history")
@@ -1114,7 +1125,7 @@ async def _handle_history(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, vault, required_role="reader")
     doc = await _find_doc(vault, doc_path)
     if not doc:
-        return {"error": f"Document not found: {args['uri']}"}
+        return err(f"Document not found: {args['uri']}", code=NOT_FOUND)
     from app.services.git_service import GitService
     git = GitService()
     # Pass the doc's created_at as a lineage boundary so commits from a
@@ -1174,25 +1185,24 @@ async def _dispatch(name: str, args: dict):
 
     handler = _HANDLERS.get(name)
     if not handler:
-        return {"error": f"Unknown tool: {name}"}
+        return err(f"Unknown tool: {name}", code=UNKNOWN_TOOL)
 
     # Reject unknown arguments before the handler sees them. Without
     # this, a typo like `akb_activity(user=...)` (real name: `author`)
     # would silently fall through `args.get("author")` and quietly
     # disable the filter — agent thinks the filter applied and trusts
-    # an unfiltered result. Surface the typo with a fuzzy hint so the
-    # caller can self-correct on retry; shape matches table_service's
-    # _enrich_undefined_error so the tone is uniform across the API.
+    # an unfiltered result.
     allowed = _TOOL_ARG_NAMES.get(name)
     if allowed is not None:
         unknown = [k for k in args if k not in allowed]
         if unknown:
             bad = unknown[0]
-            return {
-                "error": f"Unknown argument '{bad}' for {name}",
-                "hint": fuzzy_hint(bad, sorted(allowed), label="arguments"),
-                "available_arguments": sorted(allowed),
-            }
+            return err(
+                f"Unknown argument '{bad}' for {name}",
+                code=UNKNOWN_ARGUMENT,
+                hint=fuzzy_hint(bad, sorted(allowed), label="arguments"),
+                available_arguments=sorted(allowed),
+            )
 
     return await handler(args, uid, user)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.5.5"
+version = "0.5.6"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_collection_lifecycle_e2e.sh
+++ b/backend/tests/test_collection_lifecycle_e2e.sh
@@ -155,9 +155,9 @@ for p in "${INVALID_PATHS[@]}"; do
   # JSON-escape the path
   esc_p=$(python3 -c "import sys,json; print(json.dumps(sys.argv[1]))" "$p")
   R=$(mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":$esc_p}" | mcp_result)
-  ERR=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null)
-  [ "$ERR" = "invalid_path" ] && pass "rejected invalid path: $(printf %q "$p")" \
-    || fail "invalid path '$p'" "expected error=invalid_path, got error='$ERR'; raw=$R"
+  CODE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('code',''))" 2>/dev/null)
+  [ "$CODE" = "invalid_path" ] && pass "rejected invalid path: $(printf %q "$p")" \
+    || fail "invalid path '$p'" "expected code=invalid_path, got code='$CODE'; raw=$R"
 done
 
 # ── 7. Delete empty collection ──────────────────────────────
@@ -195,11 +195,11 @@ NE_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)
 
 # Delete without recursive
 R=$(mcp_call akb_delete_collection "{\"vault\":\"$VAULT\",\"path\":\"docs\"}" | mcp_result)
-NE_ERR=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null)
-NE_DC=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('doc_count', -1))" 2>/dev/null)
-[ "$NE_ERR" = "not_empty" ] && [ "$NE_DC" -ge 1 ] 2>/dev/null \
-  && pass "non-empty delete rejected with error=not_empty, doc_count=$NE_DC" \
-  || fail "non-empty no-recursive" "error=$NE_ERR doc_count=$NE_DC; raw=$R"
+NE_CODE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('code',''))" 2>/dev/null)
+NE_DC=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('details',{}).get('doc_count', -1))" 2>/dev/null)
+[ "$NE_CODE" = "conflict" ] && [ "$NE_DC" -ge 1 ] 2>/dev/null \
+  && pass "non-empty delete rejected with code=conflict, doc_count=$NE_DC" \
+  || fail "non-empty no-recursive" "code=$NE_CODE doc_count=$NE_DC; raw=$R"
 
 # Doc must still exist
 R=$(mcp_call akb_get "{\"uri\":\"$NE_DOC_URI\"}" | mcp_result)
@@ -335,11 +335,11 @@ NP_HTTP=$(curl -sk -o /dev/null -w "%{http_code}" \
 # Bonus: same via MCP — sub_collection_count surfaces on `not_empty`
 R=$(mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":\"nested2/inner\"}" | mcp_result)
 R=$(mcp_call akb_delete_collection "{\"vault\":\"$VAULT\",\"path\":\"nested2\"}" | mcp_result)
-NP_MCP_ERR=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null)
-NP_MCP_SUB=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sub_collection_count', -1))" 2>/dev/null)
-[ "$NP_MCP_ERR" = "not_empty" ] && [ "$NP_MCP_SUB" -ge 1 ] 2>/dev/null \
-  && pass "MCP delete_collection on nested parent → not_empty sub_collection_count=$NP_MCP_SUB" \
-  || fail "MCP nested not_empty" "error=$NP_MCP_ERR sub_collection_count=$NP_MCP_SUB; raw=$R"
+NP_MCP_CODE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('code',''))" 2>/dev/null)
+NP_MCP_SUB=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('details',{}).get('sub_collection_count', -1))" 2>/dev/null)
+[ "$NP_MCP_CODE" = "conflict" ] && [ "$NP_MCP_SUB" -ge 1 ] 2>/dev/null \
+  && pass "MCP delete_collection on nested parent → conflict sub_collection_count=$NP_MCP_SUB" \
+  || fail "MCP nested not_empty" "code=$NP_MCP_CODE sub_collection_count=$NP_MCP_SUB; raw=$R"
 
 # ── Summary ──────────────────────────────────────────────────
 echo ""

--- a/backend/tests/test_edit_e2e.sh
+++ b/backend/tests/test_edit_e2e.sh
@@ -180,7 +180,7 @@ echo ""
 echo "▸ 3. Not-Found Error"
 
 R=$(mcp_call akb_edit "{\"uri\":\"$DOC_URI\",\"old_string\":\"this string definitely does not exist in document xyz\",\"new_string\":\"replacement\"}" | mcp_result)
-NOT_FOUND_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed' and 'not found' in d.get('message','').lower())" 2>/dev/null)
+NOT_FOUND_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'not found' in d.get('error','').lower())" 2>/dev/null)
 [ "$NOT_FOUND_ERR" = "True" ] && pass "Not-found old_string returns edit_failed" || fail "Not found" "$R"
 
 HAS_HINT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('hint' in d)" 2>/dev/null)
@@ -196,7 +196,7 @@ DUP_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin
 [ -n "$DUP_DOC_URI" ] && pass "Duplicate doc created" || fail "Dup doc" "$R"
 
 R=$(mcp_call akb_edit "{\"uri\":\"$DUP_DOC_URI\",\"old_string\":\"DUPLICATE LINE\",\"new_string\":\"X\"}" | mcp_result)
-NOT_UNIQUE_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); m=d.get('message',''); print(d.get('error','')=='edit_failed' and 'appears 3 times' in m)" 2>/dev/null)
+NOT_UNIQUE_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'appears 3 times' in d.get('error',''))" 2>/dev/null)
 [ "$NOT_UNIQUE_ERR" = "True" ] && pass "Non-unique old_string rejected (3 occurrences)" || fail "Not unique" "$R"
 
 # ── 5. replace_all ──────────────────────────────────────────────
@@ -216,7 +216,7 @@ echo ""
 echo "▸ 6. Empty old_string"
 
 R=$(mcp_call akb_edit "{\"uri\":\"$DOC_URI\",\"old_string\":\"\",\"new_string\":\"anything\"}" | mcp_result)
-EMPTY_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed' and 'empty' in d.get('message','').lower())" 2>/dev/null)
+EMPTY_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'empty' in d.get('error','').lower())" 2>/dev/null)
 [ "$EMPTY_ERR" = "True" ] && pass "Empty old_string rejected" || fail "Empty old_string" "$R"
 
 # ── 7. No-op edit (old == new) ──────────────────────────────────
@@ -288,7 +288,7 @@ echo "▸ 10. Frontmatter Safety"
 
 # Try editing something that exists only in frontmatter → should not match
 R=$(mcp_call akb_edit "{\"uri\":\"$DOC_URI\",\"old_string\":\"Edit Target\",\"new_string\":\"Hacked Title\"}" | mcp_result)
-FM_SAFE=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed')" 2>/dev/null)
+FM_SAFE=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed')" 2>/dev/null)
 [ "$FM_SAFE" = "True" ] && pass "Frontmatter-only text not editable (body-only scope)" || fail "Frontmatter safety" "$R"
 
 R=$(mcp_call akb_get "{\"uri\":\"$DOC_URI\"}" | mcp_result)
@@ -301,7 +301,7 @@ echo "▸ 11. Access Control"
 
 if [ -n "$READER_SID" ]; then
   R=$(mcp_call_as_reader akb_edit "{\"uri\":\"$DOC_URI\",\"old_string\":\"Content of section B is here.\",\"new_string\":\"reader attempted edit\"}" | mcp_result)
-  DENIED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); err=str(d.get('error',''))+str(d.get('message','')); print('403' in err or 'forbidden' in err.lower() or 'permission' in err.lower() or 'writer' in err.lower() or 'role' in err.lower())" 2>/dev/null)
+  DENIED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); err=str(d.get('error',''))+str(d.get('code','')); print('403' in err or 'forbidden' in err.lower() or 'permission' in err.lower() or 'writer' in err.lower() or 'role' in err.lower())" 2>/dev/null)
   [ "$DENIED" = "True" ] && pass "Reader cannot edit (access denied)" || fail "Reader edit" "$R"
 else
   fail "Reader MCP session" "no READER_SID"

--- a/backend/tests/test_errors_unit.py
+++ b/backend/tests/test_errors_unit.py
@@ -1,0 +1,58 @@
+"""Unit tests for the error-envelope builder."""
+from __future__ import annotations
+
+from app.util.errors import (
+    err,
+    NOT_FOUND,
+    PERMISSION_DENIED,
+    UNKNOWN_ARGUMENT,
+    VAULT_ARCHIVED,
+)
+
+
+def test_minimal_envelope_has_error_and_code_only():
+    out = err("Vault is archived", code=VAULT_ARCHIVED)
+    assert out == {"error": "Vault is archived", "code": "vault_archived"}
+    assert "hint" not in out
+    assert "details" not in out
+
+
+def test_hint_is_optional_and_top_level():
+    out = err("Doc not found", code=NOT_FOUND, hint="Try `akb_browse` first")
+    assert out["hint"] == "Try `akb_browse` first"
+    assert "details" not in out
+
+
+def test_details_collects_kwargs_under_details_key():
+    out = err(
+        "Unknown argument 'user'",
+        code=UNKNOWN_ARGUMENT,
+        hint="Did you mean: author?",
+        available_arguments=["author", "collection", "vault"],
+    )
+    assert out["details"] == {
+        "available_arguments": ["author", "collection", "vault"],
+    }
+    # Top-level stays clean — no leakage of details keys
+    assert "available_arguments" not in out
+
+
+def test_multiple_details_kwargs_all_land_under_details():
+    out = err(
+        "permission denied for table foo",
+        code=PERMISSION_DENIED,
+        pg_sqlstate="42501",
+        attempted_action="SELECT",
+    )
+    assert out["details"] == {
+        "pg_sqlstate": "42501",
+        "attempted_action": "SELECT",
+    }
+
+
+def test_code_field_is_always_set():
+    """Regression guard for the original drift problem — never let a
+    bare-error dict slip through without a `code`."""
+    out = err("oops", code="something")
+    assert "code" in out
+    assert out["code"] == "something"

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -339,7 +339,7 @@ print('yes' if t and any(c.get('name')=='product' for c in t.get('columns', []))
 # Wrong column name → fuzzy hint (issue #36)
 R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT * FROM mcp_items WHERE producct = 'Widget'\"}" | mcp_result)
 HINT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hint',''))" 2>/dev/null)
-AVAIL=$(echo "$R" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('available_columns',[])))" 2>/dev/null)
+AVAIL=$(echo "$R" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('details',{}).get('available_columns',[])))" 2>/dev/null)
 case "$HINT" in
   *"Did you mean"*"product"*) pass "akb_sql wrong column suggests 'product'" ;;
   *) fail "akb_sql column hint" "got hint=$HINT, avail=$AVAIL" ;;

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -231,12 +231,12 @@ EDIT_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdi
 
 # 3a. Edit: old_string not found → error
 R=$(mcp_as "$PAT1" "$SID1" "akb_edit" "{\"uri\":\"$EDIT_DOC_URI\",\"old_string\":\"NOTHING LIKE THIS EXISTS\",\"new_string\":\"whatever\"}" | mr)
-NOT_FOUND_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed' and 'not found' in d.get('message','').lower())" 2>/dev/null)
+NOT_FOUND_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'not found' in d.get('error','').lower())" 2>/dev/null)
 [ "$NOT_FOUND_ERR" = "True" ] && pass "Edit: old_string not found rejected" || fail "Edit not found" "$R"
 
 # 3b. Edit: old_string not unique → error
 R=$(mcp_as "$PAT1" "$SID1" "akb_edit" "{\"uri\":\"$EDIT_DOC_URI\",\"old_string\":\"Beta repeated\",\"new_string\":\"Beta replaced\"}" | mr)
-NOT_UNIQUE_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed' and 'appears' in d.get('message',''))" 2>/dev/null)
+NOT_UNIQUE_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'appears' in d.get('error',''))" 2>/dev/null)
 [ "$NOT_UNIQUE_ERR" = "True" ] && pass "Edit: non-unique old_string rejected" || fail "Edit non-unique" "$R"
 
 # 3c. Edit: valid single replacement
@@ -251,7 +251,7 @@ EDIT_ALL_COMMIT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.s
 
 # 3e. Edit: empty old_string rejected
 R=$(mcp_as "$PAT1" "$SID1" "akb_edit" "{\"uri\":\"$EDIT_DOC_URI\",\"old_string\":\"\",\"new_string\":\"x\"}" | mr)
-EMPTY_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','')=='edit_failed' and 'empty' in d.get('message','').lower())" 2>/dev/null)
+EMPTY_ERR=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code','')=='edit_failed' and 'empty' in d.get('error','').lower())" 2>/dev/null)
 [ "$EMPTY_ERR" = "True" ] && pass "Edit: empty old_string rejected" || fail "Empty old_string" "$R"
 
 # Section 4 (Memory Category Filtering) and 5 (memory cross-user


### PR DESCRIPTION
Standardises every error return from `akb_*` MCP tools and the REST surface on **one** envelope:

\`\`\`json
{
  \"error\":   \"<human-readable message>\",
  \"code\":    \"<stable enum>\",
  \"hint\":    \"<optional self-correction guidance>\",
  \"details\": { \"<optional case-specific metadata>\": \"...\" }
}
\`\`\`

## Why

Until 0.5.5 there were ~6 distinct shapes — \`{error}\`, \`{error, code}\`, \`{error, code, pg_sqlstate}\`, \`{error, hint, available_*}\`, \`{error, message, hint}\`, etc. Each new handler that wanted to surface a hint or metadata reinvented a slightly different envelope. Agents that wanted to auto-recover had to learn each case's field names, and the shape kept proliferating (would have been 7 with 0.5.4's \`available_arguments\`).

This is the moment to collapse — frontend reads only \`error\`, the akb-mcp proxy is pass-through, no external API contract exists yet. Doing it later means doing it under a contract.

## What moved (BREAKING for direct REST / agent consumers)

| Old (top-level)       | New                              |
|-----------------------|----------------------------------|
| \`available_columns\`   | \`details.available_columns\`     |
| \`available_tables\`    | \`details.available_tables\`      |
| \`available_arguments\` | \`details.available_arguments\`   |
| \`pg_sqlstate\`         | \`details.pg_sqlstate\`           |
| \`doc_count\`, \`file_count\`, \`sub_collection_count\`, \`table_count\` (on non-empty collection delete) | \`details.*\` |
| \`{error: \"edit_failed\", message: ...}\`   | \`{error: <message>, code: \"edit_failed\"}\` |
| \`{error: \"invalid_path\", message: ...}\`  | \`{error: <message>, code: \"invalid_path\"}\` |

\`hint\` stays top-level — it's the dominant self-correction signal and burying it would hurt agent UX.

## Code catalogue (initial, in \`app/util/errors.py\`)

\`not_found\` · \`permission_denied\` · \`vault_archived\` · \`invalid_argument\` · \`invalid_uri\` · \`invalid_path\` · \`unknown_argument\` · \`unknown_tool\` · \`conflict\` · \`no_op\` · \`edit_failed\` · \`multi_statement\` · \`method_not_allowed\` · \`sql_error\` · \`undefined_column\` · \`undefined_table\` · \`cross_vault_link\` · \`self_link\` · \`internal_error\`

Full mapping in the CHANGELOG.

## Blast radius

- **Frontend**: no change (\`api.ts:58\` reads only \`body.error\`).
- **akb-mcp stdio proxy**: no change (pass-through).
- **REST clients / agents reading aux fields**: must look one level deeper.

## Touched

- \`app/util/errors.py\` (new): \`err()\` helper + 19 stable code constants.
- 55 call sites migrated across \`app/services/\` (table, access, kg, todo) and \`mcp_server/server.py\`.
- \`_dispatch\` unknown-arg gate (0.5.4) re-shaped — same data, new envelope.

## Tests

- \`test_errors_unit.py\` (new, 5 cases): envelope shape — minimal, with hint, with details kwargs, \`code\` always present.
- E2E migrated: \`test_mcp_e2e.sh\` (\`available_columns\` → \`details.available_columns\`), \`test_edit_e2e.sh\` and \`test_security_edge_e2e.sh\` (\`error == \"edit_failed\"\` → \`code == \"edit_failed\"\`, \`message\` → \`error\`), \`test_collection_lifecycle_e2e.sh\` (\`not_empty\` → \`conflict\` + \`details.doc_count\`).
- Local regression green: mcp 75/75, security 63/63, pg_rbac 50/50, edit 37/37, collection 36/36, stdio_files 18/18, put_file_param 15/15.
- \`test_rerank_e2e.py\` has 2 pre-existing failures on main (unrelated — search ACL guard).

## Test plan

- [x] Unit + 7 e2e suites green locally against 0.5.6 backend
- [x] Spot-check pre-existing test_rerank_e2e failure on main — unrelated to this PR
- [ ] Reviewer: confirm \`hint\` stays top-level is the right call (alternative is \`details.hint\` for uniformity, but it loses agent-UX prominence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)