### PR TITLE
fix(0.5.7): post-0.5.6 cleanup — REST sql_name parity, catalogue gate, dead-code trim

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 803
+        "line_number": 857
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-03T06:56:56Z"
+  "generated_at": "2026-06-03T10:58:46Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,60 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.5.7 — 2026-06-03
+
+Post-0.5.6 cleanup pass — five findings from a code-quality audit
+of the last four releases (0.5.4–0.5.6).
+
+### REST `sql_name` symmetry (issue #110 follow-up)
+
+`GET /api/v1/tables/{vault}` now includes `sql_name` on each table
+item, matching what MCP `akb_browse` started returning in 0.5.5. REST
+clients were unintentionally excluded from the contract — they had to
+guess the sanitisation rule the same way the original seahorse-mcp
+table viewer did before #110. Additive field; no breaking change.
+
+### Catalogue-enforcement test (drift gate)
+
+`tests/test_errors_unit.py` gains two AST-level sync tests:
+
+- `test_every_err_call_uses_catalogue_constant` — every `err(code=X)`
+  call in `app/` + `mcp_server/` must use a constant from
+  `app/util/errors.py`, not an ad-hoc string. Catches the next
+  contributor who writes `code="some_new_thing"` inline.
+- `test_catalogue_has_no_orphan_constants` — every constant in the
+  catalogue must be imported somewhere. Catches forward-declared
+  codes that get carried release-to-release without ever shipping a
+  call site (`CROSS_VAULT_LINK`, `INTERNAL_ERROR` were exactly this
+  in 0.5.6 — see "Dropped" below).
+
+Together these make the 0.5.6 "one shape" promise self-enforcing
+rather than depending on review vigilance.
+
+### Dropped
+
+- `CROSS_VAULT_LINK`, `INTERNAL_ERROR` — declared in 0.5.6's
+  catalogue but never imported. YAGNI; re-add when the first call
+  site lands.
+
+### Internal cleanup (no behaviour change)
+
+- `app/services/table_service.py`: dropped the late `import re as _re`
+  alias — the file already has `import re` at the top, and `_re.compile`
+  was only used in two patterns that now just say `re.compile`.
+- `_enrich_undefined_error` docstring rewritten to spell out the
+  canonical envelope it now returns (was accurate but vague — easy to
+  mis-read by a future maintainer).
+
+### Tests
+
+Unit: 16/16 (5 envelope shape + 2 catalogue sync + 3 fuzzy_hint
++ 1 TOOLS↔_HANDLERS sync + 5 table identifier).
+
+E2E: re-ran the suites touched by 0.5.4–0.5.6 (mcp, security, edit,
+collection_lifecycle, pg_rbac, stdio_files, put_file_param) against
+0.5.7 locally — all green.
+
 ## 0.5.6 — 2026-06-03  *(breaking error-response shape)*
 
 Error responses across the backend now share one envelope. Until

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -252,6 +252,10 @@ async def list_tables(vault_id: uuid.UUID) -> list[dict]:
                 "vault": vault["name"],
                 "collection": r["collection"],
                 "name": r["name"],
+                # SQL-side identifier the caller must pass to akb_sql —
+                # mirrors `BrowseItem.sql_name` so REST clients have the
+                # same contract MCP clients got in 0.5.5 (issue #110).
+                "sql_name": table_data_repo.pg_short_name(r["name"]),
                 "description": r["description"],
                 "columns": table_registry_repo.parse_columns(r["columns"]),
                 "row_count": count,
@@ -459,8 +463,6 @@ async def alter_table(
     }
 
 
-import re as _re
-
 # Statement keywords allowed via `akb_sql`. Kept as a friendly
 # pre-flight check: PG would also reject non-DML at the role level
 # (akb_user_* roles have no CREATE/ALTER/DROP/GRANT privilege), but
@@ -566,8 +568,8 @@ async def execute_sql(
         return err(msg, code=SQL_ERROR)
 
 
-_COLUMN_NOT_EXIST = _re.compile(r'column "([^"]+)" does not exist')
-_RELATION_NOT_EXIST = _re.compile(r'relation "([^"]+)" does not exist')
+_COLUMN_NOT_EXIST = re.compile(r'column "([^"]+)" does not exist')
+_RELATION_NOT_EXIST = re.compile(r'relation "([^"]+)" does not exist')
 
 
 async def _enrich_undefined_error(
@@ -583,8 +585,12 @@ async def _enrich_undefined_error(
     rewritten table list (e.g. ``{"vt_sales__pipeline"}``) — we never
     suggest names from other vaults.
 
-    Returns None when the error isn't a recoverable shape, letting the
-    caller fall through to the verbatim PG message.
+    Returns the canonical 0.5.6 error envelope (``err(...)`` with
+    ``code=undefined_column`` or ``undefined_table``, ``hint``, and
+    ``details.available_columns`` / ``details.available_tables``), or
+    ``None`` when the PG message isn't a recoverable shape — in which
+    case the caller falls through to the verbatim PG message wrapped
+    in ``err(msg, code=SQL_ERROR)``.
     """
     if not allowed_pg_tables:
         return None

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -63,12 +63,7 @@ UNDEFINED_COLUMN = "undefined_column"
 UNDEFINED_TABLE = "undefined_table"
 
 # Knowledge-graph linking
-CROSS_VAULT_LINK = "cross_vault_link"
 SELF_LINK = "self_link"
-
-# Catch-all when an exception bubbles up without a more specific
-# classification. Prefer a specific code over this.
-INTERNAL_ERROR = "internal_error"
 
 
 # ── Builder ───────────────────────────────────────────────────

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.5.6"
+version = "0.5.7"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_errors_unit.py
+++ b/backend/tests/test_errors_unit.py
@@ -1,6 +1,26 @@
-"""Unit tests for the error-envelope builder."""
+"""Unit tests for the error-envelope builder.
+
+Two concerns covered here:
+
+  1. Envelope shape — minimal / with hint / with details kwargs / `code`
+     always present.
+
+  2. Catalogue enforcement — every `err(..., code=X)` call site in the
+     backend uses a string constant defined in ``app/util/errors.py``,
+     not an ad-hoc literal. Without this, 0.5.6's "one shape" promise
+     drifts back to ~6 shapes within a quarter (the same way the
+     original error sprawl happened).
+
+The catalogue check uses AST grep so it stays dependency-light and
+doesn't trigger import of the full handler chain. Same pattern as
+``test_mcp_tool_validation_unit``'s TOOLS↔_HANDLERS sync.
+"""
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
+from app.util import errors as errors_mod
 from app.util.errors import (
     err,
     NOT_FOUND,
@@ -56,3 +76,106 @@ def test_code_field_is_always_set():
     out = err("oops", code="something")
     assert "code" in out
     assert out["code"] == "something"
+
+
+# ── Catalogue enforcement ─────────────────────────────────────
+
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_SCAN_ROOTS = [
+    _BACKEND_ROOT / "app",
+    _BACKEND_ROOT / "mcp_server",
+]
+
+
+def _catalogue_constants() -> dict[str, str]:
+    """{NAME: value} for every UPPER_SNAKE str constant in errors.py."""
+    return {
+        name: value
+        for name, value in vars(errors_mod).items()
+        if name.isupper() and isinstance(value, str)
+    }
+
+
+def _collect_err_code_args() -> list[tuple[Path, int, ast.AST]]:
+    """Find every `err(..., code=X)` call. Returns (file, line, code_arg_node)."""
+    findings: list[tuple[Path, int, ast.AST]] = []
+    for root in _SCAN_ROOTS:
+        for py in root.rglob("*.py"):
+            try:
+                tree = ast.parse(py.read_text())
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not (isinstance(func, ast.Name) and func.id == "err"):
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "code":
+                        findings.append((py, node.lineno, kw.value))
+    return findings
+
+
+def test_every_err_call_uses_catalogue_constant():
+    """Every `code=` argument to `err()` must be either:
+      - an `ast.Name` whose id is a catalogue constant (preferred), or
+      - an `ast.Constant` whose string value is in the catalogue values
+        (allowed but discouraged — flagged in the error message).
+    Ad-hoc strings unknown to the catalogue fail the test — that's the
+    drift this gate is meant to catch.
+    """
+    catalogue = _catalogue_constants()
+    catalogue_names = set(catalogue.keys())
+    catalogue_values = set(catalogue.values())
+
+    offenders: list[str] = []
+    for py, lineno, code_node in _collect_err_code_args():
+        rel = py.relative_to(_BACKEND_ROOT)
+        if isinstance(code_node, ast.Name):
+            if code_node.id not in catalogue_names:
+                offenders.append(
+                    f"{rel}:{lineno}: code={code_node.id!s} — name not in catalogue"
+                )
+        elif isinstance(code_node, ast.Constant) and isinstance(code_node.value, str):
+            if code_node.value not in catalogue_values:
+                offenders.append(
+                    f"{rel}:{lineno}: code={code_node.value!r} — literal not in catalogue"
+                )
+        else:
+            offenders.append(
+                f"{rel}:{lineno}: non-constant `code=` expression"
+                f" ({ast.dump(code_node)}); use a catalogue constant instead"
+            )
+
+    assert not offenders, (
+        "err() calls using codes outside app/util/errors.py catalogue:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_catalogue_has_no_orphan_constants():
+    """Every catalogue constant should be imported by at least one
+    caller — orphan constants are a YAGNI smell that already bit us
+    (`CROSS_VAULT_LINK`, `INTERNAL_ERROR` were carried for one release
+    without any call site). Drop them or use them; don't carry forward
+    declarations indefinitely.
+    """
+    catalogue_names = set(_catalogue_constants().keys())
+
+    referenced: set[str] = set()
+    for root in _SCAN_ROOTS:
+        for py in root.rglob("*.py"):
+            if py.name == "errors.py":
+                continue
+            src = py.read_text()
+            for name in catalogue_names:
+                if name in src:
+                    referenced.add(name)
+
+    orphans = catalogue_names - referenced
+    assert not orphans, (
+        f"Catalogue constants defined but never imported: {sorted(orphans)}. "
+        "Drop them or wire up the call site."
+    )

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -375,6 +375,13 @@ R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT COUNT(*) as cnt FRO
 CNT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('items',[{}])[0].get('cnt','MISSING'))" 2>/dev/null)
 [ -n "$CNT" ] && [ "$CNT" != "MISSING" ] && pass "akb_sql round-trip via sql_name" || fail "akb_sql round-trip" "got: $R"
 
+# 0.5.7: REST `GET /tables/{vault}` must mirror the MCP shape and
+# include `sql_name` too — issue #110 originally only fixed the MCP
+# path, leaving direct REST clients to guess the sanitisation rule.
+REST_SQL=$(curl -sk "$BASE_URL/api/v1/tables/$VAULT" -H "Authorization: Bearer $PAT" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((t.get('sql_name','MISSING') for t in d.get('items',[]) if t.get('name')=='mcp_items'), 'MISSING'))" 2>/dev/null)
+[ "$REST_SQL" = "mcp_items" ] && pass "REST /tables exposes sql_name" || fail "REST sql_name" "got: $REST_SQL"
+
 # ── 12. Publish via MCP ──────────────────────────────────────
 echo ""
 echo "▸ 12. Publish via MCP"


### PR DESCRIPTION
Five findings from a code-quality audit of the last four merged PRs (0.5.4 → 0.5.6).

## High-signal

### 1. REST \`sql_name\` symmetry (issue #110 follow-up)

\`GET /api/v1/tables/{vault}\` now includes \`sql_name\` on each item, matching what MCP \`akb_browse\` started returning in 0.5.5. REST clients were unintentionally excluded — they had to guess the sanitisation rule the same way #110 had originally fixed for MCP clients. Half of the contract surface still required guessing.

\`\`\`
# before
GET /api/v1/tables/sales → {items: [{name: \"pipeline-snapshots\", ...}]}      # no sql_name
# after
GET /api/v1/tables/sales → {items: [{name: \"pipeline-snapshots\", sql_name: \"pipeline_snapshots\", ...}]}
\`\`\`

Additive field; non-breaking for existing REST consumers.

### 2. Catalogue-enforcement test (drift gate)

\`tests/test_errors_unit.py\` gains two AST sync checks:

| Test | What it catches |
|---|---|
| \`test_every_err_call_uses_catalogue_constant\` | Inline string codes — \`err(\"...\", code=\"some_new_thing\")\` — that drift back toward the ~6 distinct shapes 0.5.6 collapsed |
| \`test_catalogue_has_no_orphan_constants\` | Forward-declared codes that get carried release-to-release without ever shipping a call site (caught \`CROSS_VAULT_LINK\` + \`INTERNAL_ERROR\` from 0.5.6 — see Drop below) |

Together these make the 0.5.6 \"one shape\" promise self-enforcing rather than dependent on review vigilance.

## Cleanup

### 3. Dropped \`CROSS_VAULT_LINK\` + \`INTERNAL_ERROR\` from the catalogue

Declared in 0.5.6 but never imported. YAGNI — re-add when the first call site lands. The new orphan-constants test would have caught them automatically.

### 4. Removed \`import re as _re\` alias in \`table_service.py\`

The file already had \`import re\` at the top (used by \`_TABLE_NAME_RE\`); the late \`import re as _re\` was a refactor leftover. Two \`_re.compile\` call sites now just say \`re.compile\`.

### 5. \`_enrich_undefined_error\` docstring rewritten

The 0.5.6 migration changed what this function returns (\`err(...)\` envelope with \`code\` + \`details\`), but the docstring still described the pre-0.5.6 shape in vague terms. Now explicit.

## Verified

- Unit: **16/16** (5 envelope shape + 2 catalogue sync (new) + 3 fuzzy_hint + 1 TOOLS↔_HANDLERS sync + 5 table identifier)
- E2E green against 0.5.7 locally:
  - \`test_mcp_e2e.sh\` **76/76** (new REST \`sql_name\` case in §11b)
  - \`test_security_edge_e2e.sh\` 63/63
  - \`test_edit_e2e.sh\` 37/37
  - \`test_collection_lifecycle_e2e.sh\` 36/36
  - \`test_pg_rbac_e2e.sh\` 50/50
- \`test_rerank_e2e.py\`: 5 skipped (PR #114), no failures

## Out of scope

- \`backend/app/main.py:196\` returns \`{\"error\": str(e)}\` inside a \`/health\` status snapshot — intentional exception (the field describes a probed subsystem's last error, not an API error envelope). Left alone.
- \`_TABLE_NAME_RE\` still rejects hyphen / non-ASCII at create time. Existing rename of the prod legacy tables (sales/공공사업기회 → public_sector_opportunities, sales/pipeline-snapshots → pipeline_snapshots) was done out-of-band in this session.

## Test plan

- [x] Unit suite green
- [x] 5 e2e suites green locally (incl. new REST case)
- [x] AST gate catches the two dropped constants (verified by running with them present — test fails as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)