### PR TITLE
fix(0.5.8): retire half-done migration leftovers across the repo

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 857
+        "line_number": 923
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-03T10:58:46Z"
+  "generated_at": "2026-06-03T16:04:26Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,72 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.5.8 — 2026-06-04  *(minor breaking — `query` alias removed)*
+
+Whole-repo "half-done migration" sweep. The 0.5.4–0.5.7 stream
+closed several files cleanly but left a few dead seams behind. This
+release retires them.
+
+### `query` alias on `akb_list_vaults` + `akb_browse` removed
+
+The `query` arg was kept "for one minor release" when `filter` became
+the canonical name (0.3.x era — `akb_search.query` started to collide
+with `query` as filter). That release window expired five versions
+ago. Both `tools.py` inputSchemas dropped the `query` property and
+`_filter_arg` (`mcp_server/server.py`) no longer reads it.
+
+**Breaking note**: a caller still passing `query="..."` now hits the
+0.5.4 unknown-arg gate and gets a fuzzy-hint response pointing at
+`filter`. Frontend uses neither; akb-mcp proxy is pass-through. No
+known external caller needs migration, but flagged here so anyone who
+finds a 4xx in logs can self-diagnose.
+
+### `build_table_name_map` backward-compat keys deleted
+
+`table_data_repo.build_table_name_map` was carrying two extra keys per
+table — the raw display name and `replace("-", "_")` — "for pre-fix
+callers". After 0.5.5's `pg_short_name` keying landed and the prod
+legacy hyphen / non-ASCII tables were renamed (out-of-band rename in
+this session), neither key is reachable: the SQL tokenizer accepts
+only `[A-Za-z_][A-Za-z0-9_]*`, and no table with a hyphen in its
+display name exists any more. Two lines + comment removed.
+
+### Frontend delete-vault dialog text
+
+`delete-vault-dialog.tsx` still promised the dialog would wipe
+"sessions, memories" alongside other vault content. Those PG tables
+were dropped by migration 031 (0.5.0). Wording updated to match
+what's actually deleted.
+
+### Docstring drift
+
+- `ParsedUri` docstring no longer claims "3-tuple unpack backward
+  compatibility" — every call site in the codebase reads parsed
+  attributes (`parsed.vault`, `parsed.kind`, …), never unpacks.
+  Field-order rationale rewritten as plain surface description.
+- `frontend/src/lib/api.ts` 7-line "Memory client surface removed in
+  v0.5.0" tombstone compressed to a one-liner that describes the
+  current state instead of the deleted past.
+
+### Out of scope / deferred
+
+- `_TABLE_NAME_RE` continues to reject hyphen / non-ASCII at create
+  time. Existing legacy tables were renamed in this session; making
+  create permissive is a separate design (URI escaping, column rules,
+  frontend display).
+- Boot-time migration list in `db/postgres.py` — 11 entries, all
+  idempotent and cheap. Trimming them needs a "schema-state snapshot"
+  policy decision (when does an applied migration get folded into
+  `init.sql` and dropped from the runner?). Tracked separately.
+- `app/main.py:196` `/health` field still emits a raw `{"error": str(e)}`
+  — intentional exception per 0.5.7.
+
+### Verified
+
+Unit 16/16; e2e green against 0.5.8 locally on the suites this PR
+touches (mcp, security, edit, collection, pg_rbac). Frontend type
+check + lint pass.
+
 ## 0.5.7 — 2026-06-03
 
 Post-0.5.6 cleanup pass — five findings from a code-quality audit

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -150,13 +150,6 @@ async def build_table_name_map(conn, vault_names: list[str]) -> dict[str, str]:
             table_map[f"{sanitized_vault}__{short}"] = pg_name
             if len(vault_names) == 1:
                 table_map[short] = pg_name
-                # Backward-compat keys: pre-fix callers that referenced
-                # the display name directly (ASCII tables where display
-                # == short) keep working. Harmless on non-ASCII —
-                # display-name keys are never matched anyway because
-                # the SQL tokenizer accepts only ``[A-Za-z_][A-Za-z0-9_]*``.
-                table_map[t["name"]] = pg_name
-                table_map[t["name"].replace("-", "_")] = pg_name
     return table_map
 
 

--- a/backend/app/services/uri_service.py
+++ b/backend/app/services/uri_service.py
@@ -81,16 +81,12 @@ RESOURCE_TYPES = ("doc", "table", "file", "coll")
 class ParsedUri(NamedTuple):
     """Structured view of an AKB URI.
 
-    Field order ``(vault, kind, identifier, coll_path)`` is chosen so
-    legacy callers that unpack the result as a 3-tuple
-    ``vault, kind, identifier = parse_uri(...)`` keep working — the
-    new ``coll_path`` is appended at the end as an optional 4th
-    element. Indexing also stays compatible:
+    Fields in surface-first order:
 
-      - ``parsed[0]`` is ``vault``
-      - ``parsed[1]`` is ``kind`` (`doc` / `table` / `file` /
-        `coll` / `vault`)
-      - ``parsed[2]`` is ``identifier``
+      - ``vault``      — vault name
+      - ``kind``       — ``doc`` / ``table`` / ``file`` / ``coll`` / ``vault``
+      - ``identifier`` — kind-specific id (see below)
+      - ``coll_path``  — collection path prefix, ``""`` for vault root
 
     For docs ``identifier`` is the **full vault-relative path** (coll
     prefix + basename) so call sites that join it back to
@@ -141,9 +137,9 @@ def parse_uri(uri: str) -> ParsedUri | None:
         ident = _strip_trailing_slash(ident)
         if ident is None:
             return None
-        # Doc identifier is the full path so legacy
-        # ``vault, kind, path = parse_uri(uri)`` unpacking still
-        # produces a usable ``documents.path`` value.
+        # Doc identifier carries the full vault-relative path so call
+        # sites can splice it straight into ``documents.path`` queries
+        # without re-joining the collection prefix.
         if rtype == "doc":
             ident = f"{coll_path}/{ident}"
         return ParsedUri(vault=vault, kind=rtype, identifier=ident, coll_path=coll_path)

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -178,12 +178,13 @@ def _paginate(items_or_payload, args: dict, items_key: str = "vaults") -> dict:
 def _filter_arg(args: dict) -> str:
     """Return the substring filter (case-insensitive, stripped).
 
-    Accepts `filter` (canonical) or `query` (legacy alias) — list_vaults
-    and browse historically used `query`, but `query` now collides with
-    `akb_search.query` (a semantic retrieval string). New callers should
-    pass `filter`; `query` stays accepted for one minor release.
+    Only `filter` is accepted — the historical `query` alias was
+    removed in 0.5.8 once it had outlived its one-release grace
+    window (introduced for the akb_search collision in 0.3.x).
+    A caller still passing `query=` now hits the 0.5.4 unknown-arg
+    gate and gets a fuzzy "Did you mean `filter`?" response.
     """
-    raw = args.get("filter") or args.get("query") or ""
+    raw = args.get("filter") or ""
     return raw.strip().lower()
 
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -55,7 +55,6 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "filter": {"type": "string", "description": "Substring filter against name+description (case-insensitive)."},
-                "query": {"type": "string", "description": "DEPRECATED alias for `filter`. Use `filter` in new code."},
                 "limit": {"type": "integer", "description": "Cap result count."},
                 "offset": {"type": "integer", "description": "Skip first N (default 0)."},
                 "include_archived": {"type": "boolean", "description": "Include archived vaults (default false)."},
@@ -297,7 +296,6 @@ TOOLS = [
                     "description": "Filter by content type",
                 },
                 "filter": {"type": "string", "description": "Substring filter on item name/path (case-insensitive)."},
-                "query": {"type": "string", "description": "DEPRECATED alias for `filter`. Use `filter` in new code."},
                 "limit": {"type": "integer", "description": "Cap returned item count."},
                 "offset": {"type": "integer", "description": "Skip first N items (default 0)."},
                 "include_summary": {"type": "boolean", "description": "Include the per-item summary field (default false, drops to keep payload small)."},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.5.7"
+version = "0.5.8"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/src/components/delete-vault-dialog.tsx
+++ b/frontend/src/components/delete-vault-dialog.tsx
@@ -68,8 +68,8 @@ export function DeleteVaultDialog({
           <DialogDescription>
             This removes <span className="font-mono font-semibold text-foreground">{vault}</span>{" "}
             and everything inside it: documents, tables, files (including S3 objects),
-            relations, embeddings, sessions, memories, the git repository, and access
-            grants. This cannot be undone.
+            relations, embeddings, the git repository, and access grants. This cannot
+            be undone.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -587,14 +587,8 @@ export const createPublicationSnapshot = (vault: string, publication_id: string)
 export const searchUsers = (query?: string) =>
   api<{ users: any[] }>(`/users/search${query ? `?q=${encodeURIComponent(query)}` : ""}`);
 
-// Memory client surface (recallMemories / forgetMemory / forgetCategory /
-// Memory) was removed in v0.5.0 alongside the akb_remember/recall/forget
-// MCP tools and the /api/v1/memory REST endpoints. Agent dedicated
-// memory now lives in the auto-provisioned `agent-memory-{username}`
-// vault and is read/written via the standard documents+browse client
-// API just like any other vault. The settings-page "Memory" tab was
-// dropped; a dedicated UI for browsing the memory vault is a future
-// follow-up if needed.
+// Agent memory is just another vault (`agent-memory-{username}`)
+// since v0.5.0 — read/write via the standard documents+browse API.
 
 // ── Admin ──
 export interface AdminUser {


### PR DESCRIPTION
Whole-repo \"where's the unfinished cleanup\" sweep. The 0.5.4–0.5.7 stream closed several files cleanly but a handful of dead seams hung on. This release retires them.

## Changes

### \`query\` alias removed from \`akb_list_vaults\` + \`akb_browse\`

The grace window for the \`query\` arg expired five versions ago (introduced when \`filter\` became canonical in 0.3.x, marked \"one minor release\"). Both \`tools.py\` inputSchemas dropped the property and \`_filter_arg\` (\`mcp_server/server.py\`) no longer reads \`args.get(\"query\")\`.

**Minor breaking**: a caller still passing \`query=\"...\"\` now hits the 0.5.4 unknown-arg gate and gets a fuzzy hint pointing at \`filter\`. The frontend uses neither, the akb-mcp proxy is pass-through, and tests already used \`filter\`.

### \`build_table_name_map\` backward-compat keys deleted

After 0.5.5's \`pg_short_name\` keying landed and the prod legacy hyphen / non-ASCII tables were renamed (out-of-band in this session), neither extra key is reachable — the SQL tokenizer accepts only \`[A-Za-z_][A-Za-z0-9_]*\`, and no hyphenated display name exists any more. Two lines + comment removed.

### Frontend delete-vault dialog text

The dialog still promised \"sessions, memories\" would be wiped — those PG tables were dropped by migration 031 (0.5.0). Wording updated.

### Docstring drift

- \`ParsedUri\` docstring no longer claims \"3-tuple unpack backward compatibility\" — every call site reads parsed attributes (\`parsed.vault\`, \`parsed.kind\`, …), none unpack.
- \`frontend/src/lib/api.ts\` 7-line \"Memory client surface removed\" tombstone compressed to a one-liner describing the current state.

## Audit findings explicitly deferred

These came up in the same audit but aren't included here:

| Finding | Why deferred |
|---|---|
| \`scoped=False, max_depth=None\` fallback in \`table_registry_repo\` + \`vault_files_repo\` | Audit flagged as dead; closer inspection found live callers (\`table_service.list_tables\`, \`file_service\` with \`collection is None\`). Not dead. |
| \`_TABLE_NAME_RE\` create-time policy | Hyphen / non-ASCII names still rejected at create; legacy reach already shipped in 0.5.5. Making create permissive needs URI escaping + frontend display design. |
| Boot-time migration list (\`db/postgres.py\`) | 11 entries, all idempotent. Trimming needs a \"when does an applied migration fold into \`init.sql\`\" policy decision. |
| \`app/main.py:196\` \`/health\` raw error field | Intentional exception (status snapshot field, not an API error envelope), per 0.5.7. |

## Verified

- Unit 16/16
- E2E green against 0.5.8 locally: mcp 76/76, security 63/63, edit 37/37, collection 36/36, pg_rbac 50/50
- Frontend file changes (delete-vault dialog text, api.ts comment) — no logic changed, just copy

## Test plan

- [x] Unit suite passes (catalogue gate confirms no orphan codes introduced)
- [x] 5 e2e suites green locally
- [x] \`detect-secrets\` baseline refreshed
- [ ] Reviewer: confirm the minor break on \`query\` alias is acceptable (no external callers known; agents calling \`query=\"...\"\` will get the fuzzy-hint pointing them to \`filter\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)