### PR TITLE
chore: replace dead-branch identifier guard with assert in akb_unpublish

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -971,12 +971,17 @@ async def _handle_unpublish(args: dict, uid: str, user: _MCPUser) -> dict:
     if args.get("uri"):
         from app.services.uri_service import parse_uri
         parsed = parse_uri(args["uri"])
-        if parsed is None or parsed.kind not in ("doc", "file") or not parsed.identifier:
+        if parsed is None or parsed.kind not in ("doc", "file"):
             return err(
                 f"`uri` must be a doc or file URI (got {parsed.kind if parsed else 'invalid'}: "
                 f"{args['uri']!r}). table_query publications must be removed by slug.",
                 code=INVALID_URI,
             )
+        # Typed URIs (doc/file/table) always carry an identifier — parse_uri
+        # returns None for shapes that don't. The kind check above already
+        # narrowed to doc/file, so this assert is purely to tell the
+        # typechecker what the URI grammar already guarantees.
+        assert parsed.identifier is not None
         await check_vault_access(uid, parsed.vault, required_role="writer")
         if parsed.kind == "doc":
             count = await publication_service.delete_publications_for_document(args["uri"])


### PR DESCRIPTION
Follow-up to #118.

The 0.6.0 PR added a `not parsed.identifier` clause to the URI-branch
guard in `_handle_unpublish` just to satisfy mypy. That third clause is
dead at runtime — once we've narrowed `parsed.kind` to `doc` / `file`,
the URI grammar already guarantees `identifier` is non-None (parse_uri
returns None for shapes that don't carry one).

A defensive check that can never fire reads as if there's a real third
failure mode there, which is exactly the "code that lies to the reader"
smell. Replace with `assert parsed.identifier is not None` so the
invariant is named instead of papered over.

Same mypy narrowing, honest intent.

## Test plan

- [x] `bash scripts/check.sh` — ruff + mypy + tsc + vitest + secrets all pass