### PR TITLE
chore: post-0.6.0 publication review followups

### DIFF
--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -356,10 +356,10 @@ async def publication_meta(slug: str, request: Request):
                     "mime_type": file_row["mime_type"],
                     "size_bytes": file_row["size_bytes"],
                 })
-    elif rt == ResourceType.DOCUMENT:
-        meta["title"] = publication.get("title")
     elif rt == ResourceType.TABLE_QUERY:
         meta["query_params"] = publication.get("query_params") or {}
+    # DOCUMENT path needs no per-type augmentation — meta["title"] was
+    # already set from the publication dict above.
 
     return meta
 
@@ -688,7 +688,7 @@ async def oembed(url: str, format: str = "json"):
                 if f_row:
                     title = f_row["name"]
         elif rt == ResourceType.TABLE_QUERY:
-            title = "Shared query"  # display title; ok to keep "shared" in user-facing copy
+            title = "Shared query"
     title = title or "AKB Publication"
 
     return {

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -145,7 +145,12 @@ def parse_expires_in(expires_in: str | None) -> datetime | None:
     return datetime.now(timezone.utc) + timedelta(seconds=n * _DURATION_UNITS[m.group(2)])
 
 
-_PUBLIC_FIELDS = (
+# Keys passed through from the row into the public response as-is. The
+# final public dict is this set plus the two derived keys added by
+# ``to_public_dict``: ``share_url`` (absolute URL built from the slug)
+# and ``password_protected`` (boolean derived from ``password_hash``).
+# Add new public-facing columns here, not in two places.
+_PUBLIC_PASSTHROUGH_FIELDS = (
     "slug",
     "resource_type",
     "resource_uri",
@@ -190,6 +195,9 @@ def _row_to_internal_dict(row) -> dict:
             d[k] = str(v)
         elif hasattr(v, "isoformat"):
             d[k] = v.isoformat()
+    # query_params may arrive as a JSON string (asyncpg default for jsonb)
+    # or as an already-parsed dict (some asyncpg codec configurations).
+    # Normalize both shapes plus the NULL row case to a real dict.
     qp = d.get("query_params")
     if isinstance(qp, str):
         try:
@@ -201,6 +209,11 @@ def _row_to_internal_dict(row) -> dict:
             )
     elif qp is None:
         d["query_params"] = {}
+    elif not isinstance(qp, dict):
+        raise PublicationError(
+            f"Unexpected query_params type {type(qp).__name__} for publication {d.get('slug', '?')}",
+            status_code=500,
+        )
     return d
 
 
@@ -216,7 +229,7 @@ def to_public_dict(internal: dict) -> dict:
     Callers must NEVER hand-build a publication response dict — go through
     this function so the shape stays single-source-of-truth.
     """
-    out: dict = {k: internal.get(k) for k in _PUBLIC_FIELDS}
+    out: dict = {k: internal.get(k) for k in _PUBLIC_PASSTHROUGH_FIELDS}
     out["share_url"] = _share_url(internal["slug"])
     out["password_protected"] = bool(internal.get("password_hash"))
     return out
@@ -501,12 +514,21 @@ async def delete_publication(
     return deleted
 
 
-async def delete_publications_for_document(document_id: uuid.UUID | str) -> int:
+async def delete_publications_for_document(
+    document_id: uuid.UUID | str,
+    *,
+    expected_vault_id: uuid.UUID | None = None,
+) -> int:
     """Delete all publications for a given document, identified by either
     its canonical URI (preferred — keeps the URI canonical story end-to-end)
     or, for backwards compatibility with internal callers that still hold
     the doc's UUID, the PG UUID. UUID inputs trigger a one-row join to
     materialize the URI then drive the DELETE.
+
+    ``expected_vault_id`` adds an explicit vault binding to the DELETE,
+    matching what ``delete_publication(slug=…, expected_vault_id=…)`` does.
+    The URI itself already encodes the vault, so this is belt-and-suspenders
+    against any future code path that could fan a URI out across vaults.
 
     Returns the number of publications deleted.
     """
@@ -534,17 +556,32 @@ async def delete_publications_for_document(document_id: uuid.UUID | str) -> int:
             if not row:
                 return 0
             uri = doc_uri(row["vault_name"], row["path"])
-        rows = await conn.fetch(
-            "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
-            uri,
-        )
+        if expected_vault_id is not None:
+            rows = await conn.fetch(
+                "DELETE FROM publications WHERE resource_uri = $1 AND vault_id = $2 RETURNING id",
+                uri, expected_vault_id,
+            )
+        else:
+            rows = await conn.fetch(
+                "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
+                uri,
+            )
     return len(rows)
 
 
-async def delete_publications_for_file(file_id: uuid.UUID | str, vault_name: str) -> int:
+async def delete_publications_for_file(
+    file_id: uuid.UUID | str,
+    vault_name: str,
+    *,
+    expected_vault_id: uuid.UUID | None = None,
+) -> int:
     """Delete all publications for a given file. Looks up the file's
     collection so the URI matches the canonical form stored in the
-    ``publications.resource_uri`` column."""
+    ``publications.resource_uri`` column.
+
+    ``expected_vault_id`` adds an explicit vault binding to the DELETE
+    (see ``delete_publications_for_document`` for rationale).
+    """
     from app.services.uri_service import file_uri
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -560,10 +597,16 @@ async def delete_publications_for_file(file_id: uuid.UUID | str, vault_name: str
         )
         collection = coll_row["collection"] if coll_row else None
         uri = file_uri(vault_name, str(file_id), collection=collection)
-        rows = await conn.fetch(
-            "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
-            uri,
-        )
+        if expected_vault_id is not None:
+            rows = await conn.fetch(
+                "DELETE FROM publications WHERE resource_uri = $1 AND vault_id = $2 RETURNING id",
+                uri, expected_vault_id,
+            )
+        else:
+            rows = await conn.fetch(
+                "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
+                uri,
+            )
     return len(rows)
 
 
@@ -1079,7 +1122,7 @@ async def resolve_table_query_publication(publication: dict, url_params: dict | 
         "total": len(result_rows),
         "query_params": param_defs,
         "applied_params": {n: url_params.get(n) for n in param_defs},
-        "mode": publication.get("mode", Mode.LIVE),
+        "mode": publication["mode"],
     }
 
 

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -65,6 +65,14 @@ UNDEFINED_TABLE = "undefined_table"
 # Knowledge-graph linking
 SELF_LINK = "self_link"
 
+# Server-side — anything the caller can't fix. Reach for this only
+# when the failure is genuinely "our problem", not a caller-side
+# argument shape or lookup issue. Backed by the MCP dispatch's
+# last-resort catch (unhandled exceptions land here) and by handlers
+# that explicitly want to surface a 5xx-class failure (e.g. upstream
+# storage write failure in akb_publication_snapshot).
+INTERNAL = "internal"
+
 
 # ── Builder ───────────────────────────────────────────────────
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -44,6 +44,7 @@ from app.util.errors import (
     err,
     CONFLICT,
     EDIT_FAILED,
+    INTERNAL,
     INVALID_ARGUMENT,
     INVALID_PATH,
     INVALID_URI,
@@ -1047,7 +1048,7 @@ async def _handle_publication_snapshot(args: dict, uid: str, user: _MCPUser) -> 
             return err(e.message, code=NOT_FOUND)
         if 400 <= e.status_code < 500:
             return err(e.message, code=INVALID_ARGUMENT)
-        raise  # 5xx — let the dispatch catch-all surface it as a server error
+        return err(e.message, code=INTERNAL)
 
 
 @_h("akb_vault_info")
@@ -1214,7 +1215,16 @@ async def call_tool(name: str, arguments: dict):
         result = await _dispatch(name, arguments)
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False, default=str))]
     except Exception as e:
-        return [TextContent(type="text", text=json.dumps({"error": str(e)}, ensure_ascii=False))]
+        # Last-resort envelope so the canonical {error, code, ...} shape
+        # introduced in 0.5.6 holds for every response path — including
+        # unhandled exceptions that bubble up past handler-level
+        # try/except blocks. Specific handlers should still catch their
+        # known failure modes and return err(...) with a more precise
+        # code; this only catches what nothing else does.
+        return [TextContent(
+            type="text",
+            text=json.dumps(err(str(e), code=INTERNAL), ensure_ascii=False, default=str),
+        )]
 
 
 async def _dispatch(name: str, args: dict):

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -982,12 +982,19 @@ async def _handle_unpublish(args: dict, uid: str, user: _MCPUser) -> dict:
         # narrowed to doc/file, so this assert is purely to tell the
         # typechecker what the URI grammar already guarantees.
         assert parsed.identifier is not None
-        await check_vault_access(uid, parsed.vault, required_role="writer")
+        access = await check_vault_access(uid, parsed.vault, required_role="writer")
+        # Pass vault_id through to the service so the DELETE is explicitly
+        # vault-bound, mirroring the slug branch above. The URI already
+        # encodes the vault, but pinning the DELETE makes the cross-vault
+        # invariant local rather than depending on URI canonicalization.
         if parsed.kind == "doc":
-            count = await publication_service.delete_publications_for_document(args["uri"])
+            count = await publication_service.delete_publications_for_document(
+                args["uri"], expected_vault_id=access["vault_id"],
+            )
         else:  # file
             count = await publication_service.delete_publications_for_file(
                 parsed.identifier, parsed.vault,
+                expected_vault_id=access["vault_id"],
             )
         return {"deleted": count}
 
@@ -1032,7 +1039,15 @@ async def _handle_publication_snapshot(args: dict, uid: str, user: _MCPUser) -> 
             row["id"], expected_vault_id=row["vault_id"],
         )
     except publication_service.PublicationError as e:
-        return err(e.message, code=INVALID_ARGUMENT)
+        # Map by status_code rather than flattening everything to
+        # INVALID_ARGUMENT — `create_snapshot` raises 502 on S3 upload
+        # failure (not the caller's fault) and 404 if the row vanished
+        # between the lookup above and the locked re-read inside.
+        if e.status_code == 404:
+            return err(e.message, code=NOT_FOUND)
+        if 400 <= e.status_code < 500:
+            return err(e.message, code=INVALID_ARGUMENT)
+        raise  # 5xx — let the dispatch catch-all surface it as a server error
 
 
 @_h("akb_vault_info")


### PR DESCRIPTION
Follow-ups to #118 + #119, from an independent code-quality review of the 0.6.0 publication surface.

## What changed

### (P0) snapshot handler — error-code flattening

`_handle_publication_snapshot` caught every `PublicationError` and returned it as `INVALID_ARGUMENT`, which is wrong for the 502 raised by `create_snapshot` on S3 upload failure (not the caller's fault) and for the 404 the locked re-read can produce if the row vanished mid-call. Now maps by `status_code`:
- 404 → `NOT_FOUND`
- 4xx → `INVALID_ARGUMENT`
- 5xx → `INTERNAL` (new code, see below)

### (P1) `akb_unpublish(uri=…)` missing vault binding

The slug branch already passed `expected_vault_id` to the service for belt-and-suspenders IDOR protection; the uri branch relied solely on the URI encoding the vault. Now `delete_publications_for_document` / `delete_publications_for_file` accept optional `expected_vault_id`, and the uri branch threads the access dict's vault_id through. Same explicit vault-binding model on both sides.

### (P1) `resolve_table_query_publication` dead default

`publication.get("mode", Mode.LIVE)` — the dict comes from `_row_to_internal_dict` where `mode` is a NOT NULL column with `'live'` default, so the fallback could never fire. Replaced with direct subscript so the code stops lying about a path that doesn't exist.

### (P1) `publication_meta` dead elif

The `DOCUMENT` branch re-assigned `meta["title"]` to the same value set three lines above unconditionally. No-op; removed and added a one-line comment so the absence reads as intentional.

### (P1) Stale comment on default table_query title

`# display title; ok to keep "shared" in user-facing copy` referenced context that wasn't in the surrounding code. Removed.

### (P2) `_PUBLIC_FIELDS` → `_PUBLIC_PASSTHROUGH_FIELDS`

Docstring names the two derived keys (`share_url`, `password_protected`) that `to_public_dict` adds on top, so future contributors have one place to add new public-facing columns.

### (P2) `query_params` raw-dict passthrough now explicit

`_row_to_internal_dict` previously accepted an already-parsed dict as a silent third branch between the string and None cases. Added an explicit `isinstance(qp, dict)` check + clear error for any other type.

### Bonus — finish the 0.5.6 envelope unification

While reviewing, noticed the `call_tool` dispatch's last-resort `except Exception` was missed in #113 and was still returning `{error: str(e)}` with no `code`. That meant every handler that `raise`d instead of returning `err(...)` broke the canonical envelope contract.

This PR closes that gap:
1. New stable code `INTERNAL` in `app/util/errors.py`.
2. `call_tool` last-resort returns `err(str(e), code=INTERNAL)` so every response carries the canonical `{error, code, hint?, details?}` shape.
3. `_handle_publication_snapshot`'s 5xx case now returns `err(..., code=INTERNAL)` directly instead of raising into the catch-all.

## Test plan

- [x] `bash scripts/check.sh` (ruff + mypy + tsc + vitest + secrets)
- [x] `bash backend/tests/test_publications_e2e.sh` — 97/97
- [x] `bash backend/tests/test_mcp_e2e.sh` — 76/76

🤖 Generated with [Claude Code](https://claude.com/claude-code)