### PR TITLE
feat(0.6.2): BM25 fallback when the embed API is unavailable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1165
+        "line_number": 1244
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-04T14:08:15Z"
+  "generated_at": "2026-06-04T16:30:24Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,85 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.6.2 — 2026-06-05  *(patch — BM25 fallback when the embed API is unavailable)*
+
+### Bug fix
+
+Before 0.6.2, `embed_worker` treated dense+sparse as an atomic pair:
+if the embedding API was unreachable (or `embed_base_url` empty),
+the whole batch was `_mark_failure`'d and nothing landed in
+`vector_index`. Result: self-hosted instances that didn't configure
+an embedding endpoint, and any temporary upstream outage, dropped to
+**0 search hits across the affected vault** — not "embedding leg
+degraded, BM25 still works", which is what the search-pipeline
+docstrings and the `embed_base_url` doc-comment implied.
+
+The fix removes the all-or-nothing coupling end-to-end so dense is
+genuinely optional:
+
+- **`vector_store.upsert_one`**: signature now
+  `dense: list[float] | None` across all three drivers. `None` means
+  "store this point with sparse only". pgvector writes a NULL column;
+  qdrant omits the dense entry from its named-vectors dict; seahorse
+  omits the column from the upsert row.
+- **`vector_index.chunks.dense`** column is now nullable, and the
+  HNSW index is *partial* (`WHERE dense IS NOT NULL`) so sparse-only
+  rows don't get indexed for dense KNN and don't appear as
+  zero-vector neighbours in the dense leg. The dense leg's
+  `ORDER BY dense <=> $1` SQL gains the matching `WHERE dense IS NOT
+  NULL` filter. Existing deployments idempotently lose the `NOT NULL`
+  constraint and have the legacy full HNSW dropped+rebuilt as partial
+  at the next `ensure_collection` (startup).
+- **`embed_worker`** distinguishes three cases that used to all
+  bucket as failure:
+  1. `embed_base_url == ""` → intentional, no embed call attempted,
+     log at DEBUG, every row → sparse-only indexed, `succeeded`
+     counter increments normally.
+  2. embed configured + transient outage → log WARNING once per
+     batch, fall through to sparse-only for this batch (do not
+     retry-storm). The `_mark_failure` / `vector_retry_count` flow is
+     reserved for problems the worker can actually fix on its own
+     next pass (sparse encoder failure, vector_store unavailable).
+  3. sparse encoder or vector_store failure → real `_mark_failure`,
+     normal retry semantics unchanged.
+
+The search side already had the symmetric `query_dense=None` path
+in `search_service` and the driver `hybrid_search` implementations,
+so the sparse-only fallback became end-to-end correct as soon as
+the indexing side stopped withholding rows.
+
+### Manual verification
+
+Reproduces the embed-disabled scenario directly: set `embed_base_url:
+""` in `config/app.yaml`, rebuild + restart the backend, create a doc,
+wait for `/health` `pending=0`, then search. The doc lands in
+`vector_index.chunks` with `dense IS NULL` + posting rows populated,
+and the BM25 leg returns it. Confirmed in the docker-compose dev
+stack:
+
+```
+score=0.0164 title="Symantec DLP issue"
+total=1
+```
+
+Regression: `bash backend/tests/test_publications_e2e.sh` 97/97,
+`bash backend/tests/test_mcp_e2e.sh` 76/76.
+
+### Out of scope (follow-ups)
+
+- **Automatic dense backfill** when an embed endpoint is configured
+  *after* sparse-only rows already exist. The current worker keeps
+  picking up `vector_indexed_at IS NULL` rows; sparse-only rows have
+  it set, so they're considered done. A separate explicit reindex
+  tool (or a `dense_pending` flag column) is the cleanest next step.
+- pgvector `posting`-shape: this release only validated the `arrays`
+  shape (the dev / prod default) end-to-end. The `posting`-shape code
+  paths went through the same diff and compile, but were not
+  e2e-exercised. Operators on the posting shape should re-run the
+  regression suite before pinning `:0.6.2`.
+
+---
+
 ## 0.6.1 — 2026-06-04  *(patch — three latent bugs around the 0.6.0 surface, plus envelope close-out)*
 
 Three honest bug fixes that surfaced during the post-0.6.0 review, plus

--- a/backend/app/services/embed_worker.py
+++ b/backend/app/services/embed_worker.py
@@ -128,35 +128,47 @@ async def _process_once() -> int:
 
     # Stage 2: embedding API. Outside any PG transaction — the conn
     # pool stays free during the network round-trip.
+    #
+    # Three branches the rest of the worker must distinguish:
+    #   (a) `embed_base_url` unset      — embed intentionally disabled.
+    #       Skip the call entirely; every row in the batch goes through
+    #       the sparse-only fallback path. Not an error.
+    #   (b) embed configured + reachable — normal hybrid index.
+    #   (c) embed configured + transient outage — log warning, drop to
+    #       the sparse-only fallback for this batch. NOT a per-row
+    #       failure: BM25 search still works against the indexed row,
+    #       and retry storms against a down upstream are pointless.
     texts = [r["content"] or "" for r in batch]
-    try:
-        embeddings = await generate_embeddings(texts)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("Embedding call crashed: %s", e)
-        embeddings = []
-
-    if not embeddings or len(embeddings) != len(batch):
-        # Batch-wide failure (API down, malformed response).
-        for row in batch:
-            await _mark_failure(
-                pool, row["id"], row["vector_retry_count"],
-                "embedding API returned no/partial result",
+    embed_enabled = bool(settings.embed_base_url)
+    embeddings: list[list[float]] = []
+    if not embed_enabled:
+        logger.debug(
+            "embedding disabled (embed_base_url unset); "
+            "indexing batch=%d as sparse-only",
+            len(batch),
+        )
+    else:
+        try:
+            embeddings = await generate_embeddings(texts)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "embedding API call failed (sparse-only fallback for this batch): %s", e,
             )
-        return 0
+            embeddings = []
+
+    # Pad to batch length so the per-row loop can always zip. Missing
+    # entries are an empty list, which becomes None at the driver
+    # boundary and is stored as a NULL dense column.
+    embeddings_padded: list[list[float]] = (
+        embeddings + [[]] * (len(batch) - len(embeddings))
+    )
 
     # Stage 3: per-chunk transaction. Each iteration is atomic over
     # vector_store.upsert + chunks.UPDATE — outer rollback can no
     # longer leave the vector store with an unmarked row.
     store = get_vector_store()
     succeeded = 0
-    for row, dense in zip(batch, embeddings):
-        if not dense:
-            await _mark_failure(
-                pool, row["id"], row["vector_retry_count"],
-                "empty embedding vector",
-            )
-            continue
-
+    for row, dense in zip(batch, embeddings_padded):
         content = row["content"] or ""
         try:
             sparse_idx, sparse_vals = await sparse_encoder.encode_document(content)
@@ -195,7 +207,11 @@ async def _process_once() -> int:
                         content=content,
                         section_path=row["section_path"],
                         chunk_index=int(row["chunk_index"] or 0),
-                        dense=dense,
+                        # Empty list → None at the driver boundary. The
+                        # driver writes NULL / omits the dense vector;
+                        # the partial dense index + sparse leg do the
+                        # right thing without further branching.
+                        dense=dense if dense else None,
                         sparse_indices=sparse_idx,
                         sparse_values=sparse_vals,
                         source_type=row["source_type"] or "document",

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -73,7 +73,7 @@ class VectorStore(Protocol):
         content: str,
         section_path: str | None,
         chunk_index: int,
-        dense: list[float],
+        dense: list[float] | None,
         sparse_indices: list[int],
         sparse_values: list[float],
         source_type: str,
@@ -81,6 +81,14 @@ class VectorStore(Protocol):
     ) -> None:
         """Upsert one chunk. Driver stores dense + sparse + payload
         atomically. `dense` and `sparse_*` are pre-computed by callers.
+
+        ``dense=None`` is a valid input — the embed worker uses it as the
+        BM25-only fallback path when the embedding API is unavailable.
+        Drivers must accept the point with only sparse vectors (NULL dense
+        column / sparse-only Qdrant point / seahorse sparse-only row);
+        ``hybrid_search`` already has the symmetric ``query_dense=None``
+        path so dense-less points only contribute to the sparse leg.
+
         Pass `conn` to share an outer PG transaction (atomic with the
         caller's own writes)."""
 

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -195,6 +195,9 @@ class PgvectorStore:
         await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
         await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{self._schema}"')
 
+        # `dense` is nullable: the embed worker upserts sparse-only points
+        # when the embedding API is unavailable, and the dense leg of
+        # hybrid_search filters them out via the partial HNSW index below.
         if self._sparse_shape == "arrays":
             await conn.execute(
                 f"""
@@ -205,7 +208,7 @@ class PgvectorStore:
                     section_path    TEXT,
                     content         TEXT NOT NULL,
                     chunk_index     INTEGER NOT NULL,
-                    dense           vector({self._dense_dim}) NOT NULL,
+                    dense           vector({self._dense_dim}),
                     sparse_terms    BIGINT[] NOT NULL DEFAULT '{{}}',
                     sparse_weights  REAL[]   NOT NULL DEFAULT '{{}}',
                     indexed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -222,7 +225,7 @@ class PgvectorStore:
                     section_path    TEXT,
                     content         TEXT NOT NULL,
                     chunk_index     INTEGER NOT NULL,
-                    dense           vector({self._dense_dim}) NOT NULL,
+                    dense           vector({self._dense_dim}),
                     indexed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )
                 """
@@ -250,6 +253,13 @@ class PgvectorStore:
                 """
             )
 
+        # Existing deployments may have `dense` from the pre-0.6.2
+        # NOT NULL era. Drop the constraint idempotently so the
+        # sparse-only fallback can actually store a NULL.
+        await conn.execute(
+            f'ALTER TABLE "{self._schema}".chunks ALTER COLUMN dense DROP NOT NULL'
+        )
+
         # Common indexes (both shapes).
         await conn.execute(
             f"""
@@ -257,14 +267,32 @@ class PgvectorStore:
                 ON "{self._schema}".chunks (source_id)
             """
         )
+        # Pre-0.6.2 installs have a full HNSW index over `dense` that
+        # cannot index NULL rows — drop it so the partial form below
+        # actually takes effect. `CREATE INDEX IF NOT EXISTS` would
+        # otherwise no-op when the legacy index is still present.
+        legacy_def = await conn.fetchval(
+            """
+            SELECT indexdef FROM pg_indexes
+            WHERE schemaname = $1 AND indexname = 'idx_vi_chunks_dense'
+            """,
+            self._schema,
+        )
+        if legacy_def and "WHERE" not in legacy_def:
+            await conn.execute(
+                f'DROP INDEX IF EXISTS "{self._schema}".idx_vi_chunks_dense'
+            )
         # HNSW for dense KNN. m=16, ef_construction=64 are pgvector's
-        # defaults and serve us well at <1M points.
+        # defaults and serve us well at <1M points. Partial — sparse-only
+        # rows (dense IS NULL) are excluded from the index so the dense
+        # leg only ever sees points that actually have an embedding.
         await conn.execute(
             f"""
             CREATE INDEX IF NOT EXISTS idx_vi_chunks_dense
                 ON "{self._schema}".chunks
                 USING hnsw (dense vector_cosine_ops)
                 WITH (m = 16, ef_construction = 64)
+                WHERE dense IS NOT NULL
             """
         )
 
@@ -287,7 +315,7 @@ class PgvectorStore:
         content: str,
         section_path: str | None,
         chunk_index: int,
-        dense: list[float],
+        dense: list[float] | None,
         sparse_indices: list[int],
         sparse_values: list[float],
         source_type: str,
@@ -298,7 +326,10 @@ class PgvectorStore:
         sid = uuid.UUID(str(source_id))
         # `dense` goes through pgvector's binary codec — list[float]
         # straight into asyncpg's bind. No text literal, no `::vector`
-        # cast needed.
+        # cast needed. `None` (sparse-only fallback when the embed API
+        # was unavailable) becomes a NULL row and is excluded from the
+        # partial HNSW index by the WHERE clause above.
+        dense_param: list[float] | None = list(dense) if dense else None
         try:
             async with self._conn(conn) as c:
                 if self._sparse_shape == "arrays":
@@ -321,7 +352,7 @@ class PgvectorStore:
                             indexed_at     = NOW()
                         """,
                         cid, source_type, sid, section_path or "",
-                        content, int(chunk_index), list(dense),
+                        content, int(chunk_index), dense_param,
                         list(sparse_indices), [float(v) for v in sparse_values],
                     )
                 else:  # posting
@@ -341,7 +372,7 @@ class PgvectorStore:
                             indexed_at   = NOW()
                         """,
                         cid, source_type, sid, section_path or "",
-                        content, int(chunk_index), list(dense),
+                        content, int(chunk_index), dense_param,
                     )
                     # Replace posting rows for this chunk.
                     await c.execute(
@@ -469,12 +500,15 @@ class PgvectorStore:
         limit: int,
     ) -> list[str]:
         # Binary codec → list[float] passes through directly.
+        # `WHERE dense IS NOT NULL` mirrors the partial HNSW index above —
+        # sparse-only points (embed API was down when they were indexed)
+        # contribute only to the sparse leg, never to the dense KNN.
         if src_uuids:
             rows = await conn.fetch(
                 f"""
                 SELECT chunk_id::text AS chunk_id
                 FROM "{self._schema}".chunks
-                WHERE source_id = ANY($2::uuid[])
+                WHERE source_id = ANY($2::uuid[]) AND dense IS NOT NULL
                 ORDER BY dense <=> $1
                 LIMIT $3
                 """,
@@ -485,6 +519,7 @@ class PgvectorStore:
                 f"""
                 SELECT chunk_id::text AS chunk_id
                 FROM "{self._schema}".chunks
+                WHERE dense IS NOT NULL
                 ORDER BY dense <=> $1
                 LIMIT $2
                 """,

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -119,7 +119,7 @@ class QdrantStore:
         content: str,
         section_path: str | None,
         chunk_index: int,
-        dense: list[float],
+        dense: list[float] | None,
         sparse_indices: list[int],
         sparse_values: list[float],
         source_type: str,
@@ -129,7 +129,13 @@ class QdrantStore:
         await self.ensure_collection()
         client = self._get_client()
 
-        vectors: dict[str, Any] = {DENSE_VECTOR_NAME: dense}
+        # Qdrant named-vectors collections accept points that carry only a
+        # subset of the declared vectors — leave dense out when the embed
+        # API was unavailable; the dense leg of hybrid_search will then
+        # have nothing to score against for this point.
+        vectors: dict[str, Any] = {}
+        if dense:
+            vectors[DENSE_VECTOR_NAME] = dense
         if sparse_indices:
             vectors[SPARSE_VECTOR_NAME] = qm.SparseVector(
                 indices=sparse_indices, values=sparse_values,

--- a/backend/app/services/vector_store/seahorse.py
+++ b/backend/app/services/vector_store/seahorse.py
@@ -281,7 +281,7 @@ class SeahorseStore:
         content: str,
         section_path: str | None,
         chunk_index: int,
-        dense: list[float],
+        dense: list[float] | None,
         sparse_indices: list[int],
         sparse_values: list[float],
         source_type: str,
@@ -289,7 +289,7 @@ class SeahorseStore:
     ) -> None:
         del conn
         await self.ensure_collection()
-        row = {
+        row: dict[str, Any] = {
             COL_ID: _seahorse_pk(str(chunk_id)),
             COL_EXTERNAL_CHUNK_ID: str(chunk_id),
             COL_SOURCE_TYPE: source_type,
@@ -297,9 +297,13 @@ class SeahorseStore:
             COL_SECTION_PATH: section_path or "",
             COL_CONTENT: content,
             COL_CHUNK_INDEX: int(chunk_index),
-            COL_DENSE: list(dense),
             COL_SPARSE: _sparse_to_str(sparse_indices, sparse_values),
         }
+        # Sparse-only row when the embed API was unavailable. Seahorse
+        # treats a missing vector column as NULL; the dense ANN leg
+        # then has nothing to score against for this row.
+        if dense:
+            row[COL_DENSE] = list(dense)
         # Insert is JSONL with text/plain — `application/json` is rejected.
         body = json.dumps(row, ensure_ascii=False)
         try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.6.1"
+version = "0.6.2"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Implements the fix promised in the [#117 comment correction](https://github.com/dnotitia/akb/issues/117#issuecomment-4623929819).

## Why

Before 0.6.2, `embed_worker` treated dense+sparse as an atomic pair: when the embedding API was unreachable, the whole batch was `_mark_failure`'d and nothing landed in `vector_index`. Self-hosted instances without `embed_base_url`, and any transient upstream outage, dropped to **0 search hits per vault** — not "BM25 still works", which is what the search-pipeline docstrings implied.

## What changed (interface)

- **`vector_store.upsert_one(dense: list[float] | None)`** — base + all three drivers. `None` means "sparse-only point". pgvector writes NULL, qdrant omits the named-vector entry, seahorse drops the column.
- **`vector_index.chunks.dense`** is now nullable. HNSW becomes a partial index (`WHERE dense IS NOT NULL`) so sparse-only points don't pollute dense KNN. Dense-leg search SQL gains the matching `WHERE dense IS NOT NULL`. Existing schemas drop the NOT NULL constraint and rebuild the HNSW as partial at the next `ensure_collection` (startup).
- **`embed_worker`** distinguishes three cases that previously all bucketed as failure:
  1. `embed_base_url == ""` → intentional. Skip the embed call, debug log, sparse-only index. Not a failure.
  2. embed configured + transient outage → one warning log, sparse-only fallback for the batch. Not a retry case (the worker can't make the upstream come back).
  3. sparse encoder OR vector_store failure → real `_mark_failure`, `vector_retry_count` increments, normal retry semantics unchanged.

## What did NOT change

- search-side `query_dense=None` path was already in place in `search_service` and all three driver `hybrid_search` implementations. It just had no points to find before this PR.
- `/health` backfill stats schema is unchanged (no new `dense_pending` field — see follow-up).

## Manual verification

`embed_base_url: ""` in `config/app.yaml`, rebuild + restart backend, create a doc, wait for `/health` `pending=0`:

```
$ curl … "/api/v1/search?q=Symantec+DLP&vault=…"
  score=0.0164 title=Symantec DLP issue
total= 1
```

DB state confirms the design:
```
chunks indexed=true / vector_index.chunks.dense=NULL / posting rows populated
```

## Regression

- `bash backend/tests/test_publications_e2e.sh` — **97/97**
- `bash backend/tests/test_mcp_e2e.sh` — **76/76**

## Follow-ups (out of scope)

- **Automatic dense backfill** when an embed endpoint gets configured *after* sparse-only rows already exist. Today the worker's claim filter (`vector_indexed_at IS NULL`) skips them — they look "done". A separate explicit reindex tool, or a `dense_pending` flag column, is the cleanest next step.
- **pgvector `posting`-shape** code paths went through the same diff and compile, but were not e2e-exercised in this PR (dev/prod default is `arrays`). Operators on the posting shape should re-run the regression suite before pinning `:0.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)