### PR TITLE
chore(0.6.3): 0.6.2 review findings — kill useless-point footgun, hygiene

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1244
+        "line_number": 1324
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-04T16:30:24Z"
+  "generated_at": "2026-06-04T16:54:23Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,86 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.6.3 — 2026-06-05  *(patch — 0.6.2 review findings)*
+
+Independent review of the 0.6.2 BM25 fallback surface turned up one
+real correctness gap and a handful of hygiene items. Two larger
+suggestions (per-row reject signalling, `CONCURRENTLY` HNSW rebuild)
+were considered but kept out as over-engineering at the current scale.
+See the *Considered and rejected* section below.
+
+### Bug fix
+
+**`embed_worker` could now create useless points** when the embed API
+was disabled / failed AND the row's sparse vector was also empty
+(whitespace-only or OOV-only content). Before this PR the per-row loop
+would call `vector_store.upsert_one(dense=None, sparse_indices=[])`,
+producing a pgvector row with `dense IS NULL AND sparse_terms = '{}'`
+(invisible to both legs) or a Qdrant `vectors={}` upsert (rejected by
+the driver with a less specific error than the actual cause). Now the
+worker fails such rows up-front with `"no indexable signal (no dense
+embedding + empty sparse)"`; they go through normal retry semantics
+and stop accumulating in the index. The pre-0.6.2 atomic-pair check
+covered this implicitly — 0.6.2's relaxation re-opened the gap.
+
+### Hygiene
+
+- **`vector_store.base.has_dense(dense)`** — single source of truth
+  TypeGuard for "this point has a usable dense vector". All three
+  drivers (`pgvector`, `qdrant`, `seahorse`) and `embed_worker` now
+  branch on this helper instead of inlining three different falsy
+  checks. mypy narrows `dense` to `list[float]` inside the guarded
+  block, so call sites no longer need redundant asserts.
+- **`embeddings_padded` is now `list[list[float] | None]`**, padded
+  with explicit `None` instead of `[]` and a falsy-game comment. The
+  three-branch comment block at the top of stage 2 was shortened — the
+  "per-row reject" sub-case the 0.6.2 PR drafted around turned out
+  not to be distinguishable from a batch outage without a richer
+  upstream contract; if that ever becomes a signal we want, surface it
+  from `generate_embeddings` directly.
+- **Mismatched batch length is now an explicit error log + outage
+  promotion** rather than a silent zip-shorter footgun
+  (`if embeddings and len(embeddings) != len(batch): logger.error(…)`).
+- **`pgvector.ensure_collection` legacy-HNSW check** now inspects
+  `pg_index.indpred IS NOT NULL` instead of `"WHERE" in indexdef`. The
+  textual probe was correct on PG 16 but brittle across PG version
+  upgrades that could re-format `indexdef`; `indpred` is the
+  catalog's stable boolean for "this index has a WHERE clause".
+- **`config.py` `embed_base_url` comment** said "required" — stale
+  since 0.6.2. Now reads "Optional; unset disables the dense leg →
+  BM25-only retrieval".
+- **`vector_store.base.upsert_one` docstring** was claiming atomicity
+  across all drivers ("stores dense + sparse + payload atomically").
+  pgvector joins the caller's PG transaction; Qdrant and Seahorse
+  ignore `conn` and rely on `chunk_id` idempotence for recovery. Now
+  spelled out explicitly.
+
+### Considered and rejected
+
+- **Per-row reject signalling.** The review flagged that a single-row
+  `[]` from the embed API would look identical to a batch outage at
+  the worker. Investigated and kept out: `generate_embeddings`
+  currently has no upstream contract for partial responses (a missing
+  row is treated as a batch-level failure inside `index_service`), so
+  distinguishing the case at the worker would just be a guard for a
+  scenario we can't actually produce. If the upstream ever surfaces
+  per-row rejects, the worker should grow a `dense=[]` branch then;
+  pre-emptive guards for impossible states age into liabilities.
+- **HNSW `CREATE CONCURRENTLY`.** At the current single-digit-K chunks
+  scale the rebuild is sub-second; CONCURRENTLY's own failure mode
+  (an `INVALID` leftover index that `IF NOT EXISTS` then refuses to
+  recreate) is genuinely worse than the brief lock. The doc-comment
+  records this trade-off so a future maintainer at a much larger
+  chunks count can re-evaluate.
+
+### Verification
+
+- `bash scripts/check.sh` — ruff + mypy + tsc + vitest + secrets pass.
+- `bash backend/tests/test_publications_e2e.sh` — 97/97.
+- `bash backend/tests/test_mcp_e2e.sh` — 76/76.
+
+---
+
 ## 0.6.2 — 2026-06-05  *(patch — BM25 fallback when the embed API is unavailable)*
 
 ### Bug fix

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,7 +45,11 @@ class Settings(BaseModel):
     # re-claim. Has to exceed the longest realistic initial bootstrap.
     external_git_claim_lookahead_secs: int = 3600
 
-    # Embedding — required for indexing/search
+    # Embedding — optional since 0.6.2. Unset (empty string) disables the
+    # dense leg: `embed_worker` skips the upstream call, every chunk lands
+    # in vector_index with `dense IS NULL`, and `hybrid_search` serves
+    # results from the BM25 leg alone. Set to an OpenAI-compatible
+    # `/v1/embeddings` endpoint to enable hybrid retrieval.
     embed_base_url: str = "http://localhost:8080/v1"
     embed_model: str = "text-embedding-3-small"
     embed_api_key: str = ""

--- a/backend/app/services/embed_worker.py
+++ b/backend/app/services/embed_worker.py
@@ -32,6 +32,7 @@ from app.services import sparse_encoder
 from app.services._backfill import BackfillRunner, MAX_RETRIES, next_attempt_delay
 from app.services.index_service import generate_embeddings
 from app.services.vector_store import VectorStoreUnavailable, get_vector_store
+from app.services.vector_store.base import has_dense
 
 logger = logging.getLogger("akb.embed_worker")
 
@@ -127,17 +128,20 @@ async def _process_once() -> int:
         return 0
 
     # Stage 2: embedding API. Outside any PG transaction — the conn
-    # pool stays free during the network round-trip.
+    # pool stays free during the network round-trip. Three failure
+    # modes are merged here into the same outcome (sparse-only batch);
+    # only the log differs:
     #
-    # Three branches the rest of the worker must distinguish:
-    #   (a) `embed_base_url` unset      — embed intentionally disabled.
-    #       Skip the call entirely; every row in the batch goes through
-    #       the sparse-only fallback path. Not an error.
-    #   (b) embed configured + reachable — normal hybrid index.
-    #   (c) embed configured + transient outage — log warning, drop to
-    #       the sparse-only fallback for this batch. NOT a per-row
-    #       failure: BM25 search still works against the indexed row,
-    #       and retry storms against a down upstream are pointless.
+    #   (a) `embed_base_url` unset       — embed intentionally disabled.
+    #   (b) configured + transient outage — `generate_embeddings` raised.
+    #   (c) configured + partial response — len mismatch; treated as
+    #       outage rather than guessing which rows were rejected.
+    #
+    # In all three the per-row loop below sees `None` for that row
+    # and sparse-only indexes. Per-row rejects (single-row `[]` from
+    # the API while the rest succeeded) can't be distinguished from
+    # outages without a richer upstream contract; if that becomes a
+    # signal we care about, surface it from `generate_embeddings`.
     texts = [r["content"] or "" for r in batch]
     embed_enabled = bool(settings.embed_base_url)
     embeddings: list[list[float]] = []
@@ -156,11 +160,19 @@ async def _process_once() -> int:
             )
             embeddings = []
 
-    # Pad to batch length so the per-row loop can always zip. Missing
-    # entries are an empty list, which becomes None at the driver
-    # boundary and is stored as a NULL dense column.
-    embeddings_padded: list[list[float]] = (
-        embeddings + [[]] * (len(batch) - len(embeddings))
+    # `generate_embeddings` returns either [] (batch-wide failure / not
+    # called) or exactly one list-per-row. Catch any other length here
+    # loudly rather than silently mismatching with `zip`.
+    if embeddings and len(embeddings) != len(batch):
+        logger.error(
+            "embedding API returned %d results for batch=%d; treating as outage",
+            len(embeddings), len(batch),
+        )
+        embeddings = []
+    # Pad to batch length so the per-row loop always zips. A `None`
+    # entry means "no dense vector for this row".
+    embeddings_padded: list[list[float] | None] = list(embeddings) + [None] * (
+        len(batch) - len(embeddings)
     )
 
     # Stage 3: per-chunk transaction. Each iteration is atomic over
@@ -176,6 +188,20 @@ async def _process_once() -> int:
             await _mark_failure(
                 pool, row["id"], row["vector_retry_count"],
                 f"sparse encode failed: {e}",
+            )
+            continue
+
+        # Refuse useless points up-front: a chunk with neither dense nor
+        # sparse signal would write a NULL+empty pgvector row or a
+        # vectors={} Qdrant point (the latter is rejected by the driver
+        # with a less specific error). Cause is whitespace-only or
+        # OOV-only content during an embed-disabled / outage state; the
+        # operator should see it as a real failure, not a sparse-only
+        # success.
+        if not has_dense(dense) and not sparse_idx:
+            await _mark_failure(
+                pool, row["id"], row["vector_retry_count"],
+                "no indexable signal (no dense embedding + empty sparse)",
             )
             continue
 
@@ -207,11 +233,7 @@ async def _process_once() -> int:
                         content=content,
                         section_path=row["section_path"],
                         chunk_index=int(row["chunk_index"] or 0),
-                        # Empty list → None at the driver boundary. The
-                        # driver writes NULL / omits the dense vector;
-                        # the partial dense index + sparse leg do the
-                        # right thing without further branching.
-                        dense=dense if dense else None,
+                        dense=dense,
                         sparse_indices=sparse_idx,
                         sparse_values=sparse_vals,
                         source_type=row["source_type"] or "document",

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -17,7 +17,7 @@ inputs without restructuring callers.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Protocol, TypeGuard, runtime_checkable
 
 
 @dataclass
@@ -39,6 +39,23 @@ class VectorStoreUnavailable(Exception):
     """Driver-side transient failure. Worker paths catch and back off;
     read paths let it propagate so `search` returns empty instead of
     serving stale or partial results."""
+
+
+def has_dense(dense: list[float] | None) -> TypeGuard[list[float]]:
+    """Single source of truth for "this point has a dense vector".
+
+    Callers (workers, drivers) pass ``None`` for "the embed API was
+    unavailable for this row" and ``list[float]`` for "here's the
+    embedding". The TypeGuard return lets mypy narrow ``dense`` to
+    ``list[float]`` inside an ``if has_dense(dense):`` body so call
+    sites don't need a redundant ``assert``.
+
+    Drivers should branch on this helper instead of inlining
+    ``if dense and len(dense) > 0:`` or ``if dense is not None:``.
+    Three copies that disagreed about whether ``[]`` is "dense" is
+    exactly the contract drift this helper exists to prevent.
+    """
+    return dense is not None and len(dense) > 0
 
 
 @runtime_checkable
@@ -79,18 +96,24 @@ class VectorStore(Protocol):
         source_type: str,
         source_id: str,
     ) -> None:
-        """Upsert one chunk. Driver stores dense + sparse + payload
-        atomically. `dense` and `sparse_*` are pre-computed by callers.
+        """Upsert one chunk into the driver. `dense` and `sparse_*` are
+        pre-computed by the caller (`embed_worker` for indexing).
 
-        ``dense=None`` is a valid input — the embed worker uses it as the
-        BM25-only fallback path when the embedding API is unavailable.
-        Drivers must accept the point with only sparse vectors (NULL dense
-        column / sparse-only Qdrant point / seahorse sparse-only row);
-        ``hybrid_search`` already has the symmetric ``query_dense=None``
-        path so dense-less points only contribute to the sparse leg.
+        ``dense=None`` is the BM25-only fallback the worker uses when the
+        embedding API is unavailable. Drivers must store the point with
+        only sparse vectors — pgvector writes NULL into the `dense`
+        column (excluded from the partial HNSW index by its WHERE
+        clause), Qdrant omits the dense entry from its named-vectors
+        dict, Seahorse omits the dense column. `hybrid_search` has the
+        symmetric `query_dense=None` path so dense-less points only
+        contribute to the sparse leg.
 
-        Pass `conn` to share an outer PG transaction (atomic with the
-        caller's own writes)."""
+        Atomicity guarantees are driver-specific. pgvector joins the
+        caller's PG transaction when `conn` is provided (the upsert
+        commits with the caller's own writes). Qdrant and Seahorse ignore
+        `conn` — their writes are external and non-transactional from
+        PG's perspective, so recovery for half-completed batches relies
+        on `chunk_id` idempotence (the worker can safely re-upsert)."""
 
     async def delete_point(self, chunk_id: str, *, conn=None) -> None:
         """Remove a single chunk by id. Idempotent."""

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -36,7 +36,7 @@ from typing import Literal
 
 import asyncpg
 
-from .base import VectorHit, VectorStoreUnavailable
+from .base import VectorHit, VectorStoreUnavailable, has_dense
 
 logger = logging.getLogger("akb.vector_store.pgvector")
 
@@ -268,17 +268,24 @@ class PgvectorStore:
             """
         )
         # Pre-0.6.2 installs have a full HNSW index over `dense` that
-        # cannot index NULL rows — drop it so the partial form below
-        # actually takes effect. `CREATE INDEX IF NOT EXISTS` would
-        # otherwise no-op when the legacy index is still present.
-        legacy_def = await conn.fetchval(
+        # cannot accept NULL rows — drop it so the partial form below
+        # actually takes effect. Inspect `pg_index.indpred` rather than
+        # the textual `pg_indexes.indexdef`: indpred is non-NULL iff
+        # the index has a WHERE clause, format-agnostic across PG
+        # versions.
+        legacy_full_idx = await conn.fetchval(
             """
-            SELECT indexdef FROM pg_indexes
-            WHERE schemaname = $1 AND indexname = 'idx_vi_chunks_dense'
+            SELECT 1
+              FROM pg_index i
+              JOIN pg_class c     ON c.oid = i.indexrelid
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = $1
+               AND c.relname = 'idx_vi_chunks_dense'
+               AND i.indpred IS NULL
             """,
             self._schema,
         )
-        if legacy_def and "WHERE" not in legacy_def:
+        if legacy_full_idx:
             await conn.execute(
                 f'DROP INDEX IF EXISTS "{self._schema}".idx_vi_chunks_dense'
             )
@@ -286,6 +293,10 @@ class PgvectorStore:
         # defaults and serve us well at <1M points. Partial — sparse-only
         # rows (dense IS NULL) are excluded from the index so the dense
         # leg only ever sees points that actually have an embedding.
+        # (Not CONCURRENTLY: at the current scale the rebuild is
+        # sub-second, and CONCURRENTLY's failure mode — an INVALID
+        # leftover index that `IF NOT EXISTS` then refuses to recreate —
+        # is worse than the brief lock.)
         await conn.execute(
             f"""
             CREATE INDEX IF NOT EXISTS idx_vi_chunks_dense
@@ -329,7 +340,9 @@ class PgvectorStore:
         # cast needed. `None` (sparse-only fallback when the embed API
         # was unavailable) becomes a NULL row and is excluded from the
         # partial HNSW index by the WHERE clause above.
-        dense_param: list[float] | None = list(dense) if dense else None
+        # `list(dense)` is a defensive copy: the caller may reuse the
+        # list across batches and asyncpg binds by reference.
+        dense_param: list[float] | None = list(dense) if has_dense(dense) else None
         try:
             async with self._conn(conn) as c:
                 if self._sparse_shape == "arrays":

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -18,7 +18,7 @@ from typing import Any
 from qdrant_client import AsyncQdrantClient
 from qdrant_client import models as qm
 
-from .base import VectorHit, VectorStoreUnavailable
+from .base import VectorHit, VectorStoreUnavailable, has_dense
 
 logger = logging.getLogger("akb.vector_store.qdrant")
 
@@ -134,7 +134,7 @@ class QdrantStore:
         # API was unavailable; the dense leg of hybrid_search will then
         # have nothing to score against for this point.
         vectors: dict[str, Any] = {}
-        if dense:
+        if has_dense(dense):
             vectors[DENSE_VECTOR_NAME] = dense
         if sparse_indices:
             vectors[SPARSE_VECTOR_NAME] = qm.SparseVector(

--- a/backend/app/services/vector_store/seahorse.py
+++ b/backend/app/services/vector_store/seahorse.py
@@ -29,7 +29,7 @@ from typing import Any
 
 import httpx
 
-from .base import VectorHit, VectorStoreUnavailable
+from .base import VectorHit, VectorStoreUnavailable, has_dense
 
 logger = logging.getLogger("akb.vector_store.seahorse")
 
@@ -302,7 +302,7 @@ class SeahorseStore:
         # Sparse-only row when the embed API was unavailable. Seahorse
         # treats a missing vector column as NULL; the dense ANN leg
         # then has nothing to score against for this row.
-        if dense:
+        if has_dense(dense):
             row[COL_DENSE] = list(dense)
         # Insert is JSONL with text/plain — `application/json` is rejected.
         body = json.dumps(row, ensure_ascii=False)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.6.2"
+version = "0.6.3"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Follow-up to #122 (0.6.2 BM25 fallback). Independent review found one real correctness gap and a handful of hygiene items. Two larger suggestions were considered and rejected as over-engineering at current scale (recorded in CHANGELOG).

## Bug fix

**Useless points slip into the index.** 0.6.1 had an atomic dense+sparse gate; 0.6.2 relaxed both legs to optional and lost the "neither leg" check. The worker would then call `vector_store.upsert_one(dense=None, sparse_indices=[])` on whitespace-only or OOV-only content:

- **pgvector** → row with `dense IS NULL AND sparse_terms = '{}'` — invisible to both legs but counted as `vector_indexed_at IS NOT NULL`.
- **Qdrant** → `vectors={}` upsert, driver-side reject with a less specific error than the actual cause.

Fix: explicit `if not has_dense(dense) and not sparse_idx: _mark_failure("no indexable signal (no dense embedding + empty sparse)")` before upsert, so the row enters normal retry semantics instead of accumulating in the index.

## Hygiene

- **`vector_store.base.has_dense(dense)` TypeGuard** — single source of truth for "this point has a usable dense vector". All three drivers (pgvector, qdrant, seahorse) and `embed_worker` branch on it; mypy narrows `dense` to `list[float]` inside the guard.
- **`embeddings_padded: list[list[float] | None]`** with explicit `None` padding (was `[]` sentinel + falsy game).
- **Length mismatch is now `logger.error` + outage promotion** instead of silent `zip`-shorter.
- **`pgvector.ensure_collection` legacy-HNSW check** uses `pg_index.indpred IS NOT NULL` instead of `"WHERE" in indexdef` — stable across PG version upgrades.
- **`config.py` `embed_base_url` comment** was `"required"` — stale since 0.6.2.
- **`vector_store.base.upsert_one` docstring** was claiming atomicity across all drivers — pgvector joins caller TX, others rely on chunk_id idempotence.

## Considered and rejected (recorded in CHANGELOG)

- **Per-row reject signalling.** `generate_embeddings` doesn't surface partial responses (any missing row is a batch-level failure inside `index_service`), so distinguishing per-row reject from outage at the worker would just guard a scenario we can't produce. If the upstream ever surfaces it, the worker should grow a `dense=[]` branch then. Pre-emptive guards for impossible states age into liabilities.
- **HNSW `CREATE CONCURRENTLY`.** At single-digit-K chunks the rebuild is sub-second; CONCURRENTLY's INVALID-leftover failure mode is worse than the brief lock. Doc-comment records the trade-off for a future maintainer at larger scale.

## Verification

- `bash scripts/check.sh` — ruff + mypy + tsc + vitest + secrets all green.
- `bash backend/tests/test_publications_e2e.sh` — 97/97.
- `bash backend/tests/test_mcp_e2e.sh` — 76/76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)