### PR TITLE
chore(0.6.6): clear 18 mypy errors 0.6.5 exposed + exact-pin runtime deps

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1514
+        "line_number": 1573
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T02:31:38Z"
+  "generated_at": "2026-06-05T03:13:13Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,65 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.6.6 — 2026-06-05  *(patch — clear the 18 mypy errors 0.6.5 exposed + exact-pin runtime deps)*
+
+The 0.6.5 Python 3.11 → 3.14 bump closed the "CI runs a different
+analyzer than dev" gap but left 18 mypy errors actually surfaced —
+the older runtime had been hiding them via wider stub inference.
+This release works through every one of them and pins runtime deps
+so the image's behavior is also reproducible.
+
+### Cleared 18 mypy errors (no behavior change)
+
+- `app/services/git_service.py` (14): `commit.tree.traverse()` yields
+  `Tree | Blob | Submodule | tuple` and we were narrowing with
+  `item.type == "blob"`. Replaced with `isinstance(item, Blob)`, which
+  both narrows for the type checker AND skips submodule pointers /
+  nested trees explicitly. `repo.iter_commits(**kwargs)` — gitpython's
+  stub forbids `**kwargs` splatting (each named param is individually
+  typed); spelled out the argument shapes. `c.message` is typed as
+  `str | bytes`; normalised via `str(...)`. `d.b_path`/`d.a_path` and
+  `item.path` come back as `str | PathLike[str] | None`; made the str
+  narrowing explicit with `str(...)` + None-skip.
+- `app/services/events_publisher.py` (1): `redis-py`'s `xadd` stub
+  takes the wider `dict[bytes|bytearray|memoryview|str|int|float, …]`;
+  dict invariance means our narrower `dict[bytes, bytes]` was
+  rejected. Widened the helper's return type and added a
+  `cast(dict, fields)` at the call site.
+- `app/services/vector_store/qdrant.py` (1): qdrant-client 1.13+
+  narrowed `timeout` to `int | None` even though the runtime still
+  accepts floats. Changed `30.0` → `30`.
+- `mcp_server/server.py` (2): `_handle_get` reused the identifier
+  `doc` for two different shapes — a `dict` in the version branch, a
+  `DocumentResponse` on the un-versioned path. Renamed the latter to
+  `response`.
+
+`mypy --python-version 3.14` now reports `Success: no issues found
+in 119 source files`.
+
+### Runtime deps exact-pinned
+
+The main `dependencies` block in `backend/pyproject.toml` was
+floor-only (`>=`); a silent resolver upgrade could swap backend image
+behavior on a re-deploy. Bumps are now an explicit code change. Pins
+captured from the resolved set in the 0.6.5 image (post Python 3.14
+base rebuild) and verified end-to-end:
+- `fastapi==0.136.3`, `uvicorn[standard]==0.49.0`, `pydantic==2.13.4`
+- `asyncpg==0.31.0`, `pgvector==0.4.2`, `gitpython==3.1.50`
+- `python-frontmatter==1.3.0`, `httpx==0.28.1`, `mcp[cli]==1.27.2`
+- `pyyaml==6.0.3`, `python-multipart==0.0.32`, `pyjwt==2.13.0`
+- `bcrypt==5.0.0`, `boto3==1.43.23`, `qdrant-client==1.18.0`
+- `kiwipiepy==0.23.1`, `redis==8.0.0`
+
+### Verification
+
+- `bash scripts/check.sh` — green.
+- `bash backend/tests/test_publications_e2e.sh` — 97/97.
+- `bash backend/tests/test_mcp_e2e.sh` — 76/76.
+- `bash backend/tests/test_hybrid_search_e2e.sh` — 25/25.
+
+---
+
 ## 0.6.5 — 2026-06-05  *(patch — pin static-analysis tooling + Python 3.11 → 3.14)*
 
 ### Python 3.11 → 3.14

--- a/backend/app/services/events_publisher.py
+++ b/backend/app/services/events_publisher.py
@@ -26,6 +26,7 @@ import json
 import logging
 import time
 from datetime import datetime, timedelta, timezone
+from typing import cast
 
 import redis.asyncio as redis_async
 
@@ -138,9 +139,15 @@ async def _mark_failure(conn, event_id: int, attempts: int, error: str) -> None:
     )
 
 
-def _xadd_fields(row: dict) -> dict[bytes, bytes]:
+def _xadd_fields(row: dict) -> dict[bytes | str, bytes | str]:
     """Pack a row into Redis stream fields. All values are encoded as
-    bytes — subscribers parse `payload` as JSON, the rest as UTF-8."""
+    bytes — subscribers parse `payload` as JSON, the rest as UTF-8.
+
+    The return type widens to the union redis-py's `xadd` stub
+    declares (`bytes | bytearray | memoryview | str | int | float`);
+    we only ever fill it with bytes, but dict invariance means
+    `dict[bytes, bytes]` is not a subtype of the wider union the
+    stub expects."""
     # asyncpg returns JSONB as either a dict/list or a str depending on
     # codec registration; normalise to a JSON string for the stream.
     payload = row["payload"]
@@ -149,7 +156,7 @@ def _xadd_fields(row: dict) -> dict[bytes, bytes]:
     else:
         payload_str = payload or "{}"
 
-    fields: dict[bytes, bytes] = {
+    fields: dict[bytes | str, bytes | str] = {
         b"id": str(row["id"]).encode(),
         b"occurred_at": row["occurred_at"].isoformat().encode(),
         b"kind": row["kind"].encode(),
@@ -191,9 +198,15 @@ async def _process_once() -> int:
         for row in batch:
             fields = _xadd_fields(row)
             try:
+                # redis-py's xadd stub takes the wider
+                # `dict[bytes|bytearray|memoryview|str|int|float, ...]`
+                # union; dict invariance means our narrower
+                # `dict[bytes|str, bytes|str]` is rejected even though
+                # every value we put is one of the accepted types.
+                # Runtime conversion is unchanged.
                 await client.xadd(
                     settings.redis_event_stream,
-                    fields,
+                    cast(dict, fields),
                     maxlen=settings.redis_stream_maxlen,
                     approximate=True,
                 )

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -28,7 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, quote
 
-from git import Repo, cmd as git_cmd
+from git import Blob, Repo, cmd as git_cmd
 from git.exc import GitError
 
 from app.config import settings
@@ -394,9 +394,14 @@ class GitService:
         repo = self._get_repo(vault_name)
         commit = repo.commit(sha)
         out: dict[str, str] = {}
+        # tree.traverse() yields Tree | Blob | Submodule | tuple; we only
+        # want blobs. `isinstance(item, Blob)` narrows the union for the
+        # type checker AND skips submodule pointers / nested trees at
+        # runtime (the `item.type == "blob"` check left both to mypy's
+        # imagination).
         for item in commit.tree.traverse():
-            if item.type == "blob":
-                out[item.path] = item.hexsha
+            if isinstance(item, Blob):
+                out[str(item.path)] = item.hexsha
         return out
 
     def last_commit_for_path(
@@ -416,12 +421,14 @@ class GitService:
         """
         repo = self._get_repo(vault_name)
         try:
-            kwargs = {"paths": path, "max_count": 1}
-            commits = (
-                list(repo.iter_commits(rev, **kwargs))
-                if rev is not None
-                else list(repo.iter_commits(**kwargs))
-            )
+            # Branched calls — gitpython's iter_commits stub forbids
+            # **kwargs splatting (each named param is typed
+            # individually). Spell out the two argument shapes
+            # explicitly.
+            if rev is not None:
+                commits = list(repo.iter_commits(rev, paths=path, max_count=1))
+            else:
+                commits = list(repo.iter_commits(paths=path, max_count=1))
         except (ValueError, GitError):
             return None
         return commits[0].hexsha if commits else None
@@ -741,19 +748,28 @@ class GitService:
         """
         repo = self._get_repo(vault_name)
         try:
-            kwargs: dict = {"max_count": max_count}
-            if since:
-                kwargs["since"] = since
-            if path:
-                kwargs["paths"] = path
-            commits = list(repo.iter_commits(**kwargs))
+            # gitpython's iter_commits stub forbids **kwargs splatting
+            # (each named param is typed individually). Two branches by
+            # which optional flags are present — explicit, mypy-clean.
+            if since and path:
+                commits = list(repo.iter_commits(max_count=max_count, since=since, paths=path))
+            elif since:
+                commits = list(repo.iter_commits(max_count=max_count, since=since))
+            elif path:
+                commits = list(repo.iter_commits(max_count=max_count, paths=path))
+            else:
+                commits = list(repo.iter_commits(max_count=max_count))
         except (ValueError, GitError):
             return []
 
         results = []
         for c in commits:
-            # Parse commit message for action/summary
-            lines = c.message.strip().split("\n")
+            # Parse commit message for action/summary. `c.message` is
+            # `str | bytes` per the stub; in practice gitpython always
+            # decodes to str via its `default_encoding`. `str(...)` is
+            # a cheap normalisation that also satisfies mypy.
+            message = str(c.message)
+            lines = message.strip().split("\n")
             subject = lines[0] if lines else ""
             body_lines = [line.strip() for line in lines[1:] if line.strip()]
 
@@ -764,20 +780,32 @@ class GitService:
                     meta[k.strip().lower()] = v.strip()
 
             # Get changed files
-            changed_files = []
+            changed_files: list[dict] = []
             try:
                 if c.parents:
                     diffs = c.parents[0].diff(c)
                     for d in diffs:
-                        path = d.b_path or d.a_path
-                        if path and not path.startswith("."):
-                            change_type = "added" if d.new_file else ("deleted" if d.deleted_file else "modified")
-                            changed_files.append({"path": path, "change": change_type})
+                        # `b_path`/`a_path` are typed as
+                        # `str | PathLike[str] | None`; we want a plain
+                        # str for the response payload either way.
+                        diff_path_raw = d.b_path or d.a_path
+                        if diff_path_raw is None:
+                            continue
+                        diff_path = str(diff_path_raw)
+                        if diff_path.startswith("."):
+                            continue
+                        change_type = "added" if d.new_file else ("deleted" if d.deleted_file else "modified")
+                        changed_files.append({"path": diff_path, "change": change_type})
                 else:
-                    # Initial commit
+                    # Initial commit — every blob in the tree counts as
+                    # "added". `isinstance(item, Blob)` narrows the
+                    # traverse() union AND skips submodules cleanly.
                     for item in c.tree.traverse():
-                        if item.type == "blob" and not item.path.startswith("."):
-                            changed_files.append({"path": item.path, "change": "added"})
+                        if not isinstance(item, Blob):
+                            continue
+                        blob_path = str(item.path)
+                        if not blob_path.startswith("."):
+                            changed_files.append({"path": blob_path, "change": "added"})
             except (GitError, TypeError):
                 pass
 

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -60,7 +60,10 @@ class QdrantStore:
         # especially right after bulk re-index when undeleted-segment
         # overhead lingers until the optimizer's vacuum sweep catches up.
         self._client = AsyncQdrantClient(
-            url=self._url, api_key=self._api_key, timeout=30.0
+            # qdrant-client 1.13+ stubs narrowed `timeout` to int|None
+            # even though the runtime still accepts float. Integer
+            # seconds is what we want anyway at this scale.
+            url=self._url, api_key=self._api_key, timeout=30,
         )
         return self._client
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -366,10 +366,14 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
             "hash_algorithm": HASH_ALGORITHM,
             "content": body,
         }
-    doc = await doc_service.get(vault, doc_path)
-    if not doc:
+    # Different name from the `doc: dict` used in the version branch
+    # above — same identifier reused for a different shape (pydantic
+    # model here, dict there) was confusing mypy and is now actually
+    # clearer for readers too.
+    response = await doc_service.get(vault, doc_path)
+    if not response:
         return err("Document not found", code=NOT_FOUND)
-    return doc.model_dump()
+    return response.model_dump()
 
 
 @_h("akb_update")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,26 +1,33 @@
 [project]
 name = "akb"
-version = "0.6.5"
+version = "0.6.6"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
+# Runtime deps are exact-pinned for the same reproducibility reason
+# the [dev] tools below are: a silent resolver upgrade should not be
+# able to swap our backend image's behavior on a re-deploy. Bumps are
+# an explicit code change. The versions below were the resolved set
+# at 0.6.6 release time, after the Python 3.14 base image rebuild;
+# they have all been observed working end-to-end in the publications
+# / MCP / hybrid-search regression suites.
 dependencies = [
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.30.0",
-    "pydantic>=2.0.0",
-    "asyncpg>=0.30.0",
-    "pgvector>=0.3.0",
-    "gitpython>=3.1.0",
-    "python-frontmatter>=1.1.0",
-    "httpx>=0.27.0",
-    "mcp[cli]>=1.0.0",
-    "pyyaml>=6.0.0",
-    "python-multipart>=0.0.9",
-    "pyjwt>=2.0.0",
-    "bcrypt>=4.0.0",
-    "boto3>=1.35.0",
-    "qdrant-client>=1.12.0",
-    "kiwipiepy>=0.17.0",
-    "redis>=5.0.0",
+    "fastapi==0.136.3",
+    "uvicorn[standard]==0.49.0",
+    "pydantic==2.13.4",
+    "asyncpg==0.31.0",
+    "pgvector==0.4.2",
+    "gitpython==3.1.50",
+    "python-frontmatter==1.3.0",
+    "httpx==0.28.1",
+    "mcp[cli]==1.27.2",
+    "pyyaml==6.0.3",
+    "python-multipart==0.0.32",
+    "pyjwt==2.13.0",
+    "bcrypt==5.0.0",
+    "boto3==1.43.23",
+    "qdrant-client==1.18.0",
+    "kiwipiepy==0.23.1",
+    "redis==8.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The 0.6.5 Python 3.11 → 3.14 bump closed the "CI runs a different analyzer than dev" gap but left 18 mypy errors actually surfaced — the older runtime had been hiding them via wider stub inference. This release works through every one of them and pins runtime deps so the image's behavior is also reproducible.

## Cleared 18 mypy errors (no behavior change)

- `git_service.py` (14): `commit.tree.traverse()` narrowed via `isinstance(item, Blob)` (also imports `Blob`). `repo.iter_commits(**kwargs)` rewritten as explicit per-shape calls (stub forbids splatting). `c.message` normalised via `str(...)`. `d.b_path`/`d.a_path`/`item.path` narrowed via `str(...)` + None-skip.
- `events_publisher.py` (1): `redis-py xadd` stub takes wider union; widened helper return + `cast(dict, …)` at call site.
- `vector_store/qdrant.py` (1): qdrant-client 1.13+ narrowed `timeout` to `int|None`; `30.0` → `30`.
- `mcp_server/server.py` (2): `_handle_get` reused identifier `doc` for two shapes; renamed the `DocumentResponse` one to `response`.

`mypy --python-version 3.14`: `Success: no issues found in 119 source files`.

## Runtime deps exact-pinned

Main `dependencies` block was floor-only (`>=`); a silent resolver upgrade could swap backend image behavior on a re-deploy. Captured from the resolved set in the 0.6.5 image (post Python 3.14 base rebuild) and verified e2e.

## Test plan

- [x] `mypy --python-version 3.14 app/ mcp_server/` — 0 errors
- [x] `bash scripts/check.sh` — green
- [x] `bash backend/tests/test_publications_e2e.sh` — 97/97
- [x] `bash backend/tests/test_mcp_e2e.sh` — 76/76
- [x] `bash backend/tests/test_hybrid_search_e2e.sh` — 25/25
- [ ] After merge: tag `backend-v0.6.6`, release, prod + demo redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)