### PR TITLE
feat(0.7.0): split seahorse driver into seahorse-cloud + new self-hosted seahorse-db

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1573
+        "line_number": 1671
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T03:13:13Z"
+  "generated_at": "2026-06-05T04:51:49Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,104 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.0 — 2026-06-05  *(minor — split `seahorse` driver into `seahorse-cloud` + new self-hosted `seahorse-db`)*
+
+### What
+
+Two vector-store drivers under the Seahorse brand, separated:
+
+- **`seahorse-cloud`** (renamed from `seahorse`) — talks to the
+  managed Seahorse Cloud BFF + per-table data-plane host. Zero
+  infrastructure to run; you supply tenant + token + table.
+- **`seahorse-db`** (new) — talks to a self-hosted SeahorseDB cluster
+  via its Coral coordinator HTTP API. You run Coral + Writer +
+  Reader(s) + Redis + Kafka + sparse-embedding-server yourself
+  (SeahorseDB monorepo's `deploy/docker-compose.yml` brings up a
+  minimal stack on one box).
+
+The pre-0.7.0 single `seahorse` driver value implicitly meant
+cloud. Keeping the name ambiguous would have been a footgun the
+moment a self-hosted user filled in `seahorsedb_coordinator_url`
+expecting the same enum value to "just work".
+
+### Driver matrix now
+
+| `vector_store_driver` | required settings                                       |
+| --------------------- | ------------------------------------------------------- |
+| `qdrant`              | `vector_url` (+ optional `vector_api_key`)              |
+| `pgvector`            | `vector_store_dsn` blank reuses main PG                 |
+| `seahorse-cloud`      | `seahorse_cloud_token` + `seahorse_cloud_tenant_uuid` + |
+|                       | one of `..._table_name` / `..._table_uuid`              |
+| `seahorse-db`         | `seahorsedb_coordinator_url` (Coral HTTP API)           |
+
+### Config migration (BREAKING)
+
+If you were using the `seahorse` driver pre-0.7.0:
+
+```diff
+-vector_store_driver: seahorse
+-seahorse_management_url: "https://console.seahorse.dnotitia.ai/bff"
+-seahorse_token: "shsk_..."
+-seahorse_tenant_uuid: "..."
+-seahorse_table_name: "..."
+-seahorse_auto_create: true
++vector_store_driver: seahorse-cloud
++seahorse_cloud_management_url: "https://console.seahorse.dnotitia.ai/bff"
++seahorse_cloud_token: "shsk_..."
++seahorse_cloud_tenant_uuid: "..."
++seahorse_cloud_table_name: "..."
++seahorse_cloud_auto_create: true
+```
+
+`pydantic` config has `extra="forbid"`, so an un-migrated `seahorse_*`
+key fails the app launch loudly with the bad key name — no silent
+fallback. That's intentional; a half-migrated config silently
+sending writes to the wrong driver is the worst possible outcome.
+
+Default driver is unchanged (`qdrant`). prod + demo run `pgvector`,
+so neither is affected by this rename.
+
+### New driver implementation notes
+
+- Surface area: 5 methods (`ensure_collection`, `health`, `upsert_one`,
+  `delete_point`, `hybrid_search`) — same Protocol as the other drivers,
+  no service-layer changes needed.
+- Coral endpoint mapping is documented at the top of
+  `backend/app/services/vector_store/seahorse_db.py`.
+- Sparse encoding: AKB's parallel `sparse_indices` + `sparse_values`
+  arrays are zipped into Coral's `[[term_id, weight], ...]` shape at
+  the driver boundary. The rest of AKB stays Coral-shape-free.
+- Label mapping: SeahorseDB identifies records by `u64` labels; AKB
+  uses UUID `chunk_id`. We take the first 8 bytes of the UUID
+  (big-endian). Birthday-paradox safe to ~2^32 chunks per table.
+- Eventual consistency: Coral's `POST /data` returns on Kafka-accept,
+  not on visibility. `embed_worker` marks `vector_indexed_at` at the
+  same point — the search-visibility gap (~10-30s) is the same
+  asymmetry any async-indexing pipeline has.
+- Race-safety: documented as ⚠ in `base.py`'s audit table; Coral
+  serializes concurrent `POST /catalog/tables` server-side so peer
+  startups mostly converge, but no advisory-lock-grade guarantee
+  like pgvector.
+
+### What this PR does NOT do
+
+- No production migration. prod + demo stay on `pgvector`. A future
+  PR may add an opt-in seahorse-db validation tier; that's a separate
+  decision based on operational ergonomics of running the 7-container
+  SeahorseDB stack.
+- No integration test against a live Coral. The driver is type-checked
+  and unit-friendly; an e2e is the next PR once we decide where the
+  SeahorseDB stack lives (host machine vs CI runner vs neither).
+- No proxy/frontend change.
+
+### Verification
+
+- `bash scripts/check.sh` — green (ruff + mypy + tsc + vitest + secrets).
+- `mypy --python-version 3.14 app/services/vector_store/` —
+  `Success: no issues found in 7 source files`.
+
+---
+
 ## 0.6.6 — 2026-06-05  *(patch — clear the 18 mypy errors 0.6.5 exposed + exact-pin runtime deps)*
 
 The 0.6.5 Python 3.11 → 3.14 bump closed the "CI runs a different

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -106,7 +106,18 @@ class Settings(BaseModel):
     public_base_url: str = ""
 
     # Vector store (hybrid dense + BM25). Driver-pluggable.
-    vector_store_driver: Literal["qdrant", "pgvector", "seahorse"] = "qdrant"
+    #
+    # The two `seahorse-*` drivers are intentionally separate:
+    #   - `seahorse-cloud` talks to the managed Seahorse Cloud BFF +
+    #     per-table data-plane host (zero infrastructure to run).
+    #   - `seahorse-db`    talks to a self-hosted SeahorseDB Coral
+    #     coordinator (single HTTP URL; you run Coral + Writer +
+    #     Reader(s) + Redis + Kafka + sparse-embedding yourself).
+    # Pre-0.7.0 there was only one `seahorse` enum value that meant
+    # cloud — config migration is `seahorse` → `seahorse-cloud`.
+    vector_store_driver: Literal[
+        "qdrant", "pgvector", "seahorse-cloud", "seahorse-db"
+    ] = "qdrant"
 
     # Pgvector driver settings.
     vector_store_dsn: str = ""              # blank = reuse main PG pool
@@ -125,12 +136,28 @@ class Settings(BaseModel):
     # for table lifecycle + per-table data-plane host. The driver
     # discovers the data-plane host from the management lookup; only
     # set the management URL + token + tenant + table identifier.
-    seahorse_management_url: str = "https://console.seahorse.dnotitia.ai/bff"
-    seahorse_token: str = ""                # secret.yaml — Bearer (shsk_...)
-    seahorse_tenant_uuid: str = ""
-    seahorse_table_name: str = ""           # one of (table_name, table_uuid) required
-    seahorse_table_uuid: str = ""
-    seahorse_auto_create: bool = False      # auto-provision the AKB-shaped table
+    seahorse_cloud_management_url: str = "https://console.seahorse.dnotitia.ai/bff"
+    seahorse_cloud_token: str = ""          # secret.yaml — Bearer (shsk_...)
+    seahorse_cloud_tenant_uuid: str = ""
+    seahorse_cloud_table_name: str = ""     # one of (table_name, table_uuid) required
+    seahorse_cloud_table_uuid: str = ""
+    seahorse_cloud_auto_create: bool = False  # auto-provision the AKB-shaped table
+
+    # SeahorseDB (self-hosted) driver settings. Single-URL entry: the
+    # Coral coordinator's HTTP API. Coral handles routing to the
+    # underlying Writer/Reader cluster, so the driver does not need
+    # to know about individual nodes. `seahorsedb_table_name` is the
+    # logical table the AKB chunks go into; the driver auto-creates
+    # it with the AKB sparse+dense shape when `seahorsedb_auto_create`
+    # is true and the table is absent on startup.
+    seahorsedb_coordinator_url: str = "http://localhost:3003"
+    seahorsedb_table_name: str = "akb_chunks"
+    seahorsedb_distance: Literal["cosine", "l2", "ip"] = "cosine"
+    seahorsedb_auto_create: bool = True
+    # HTTP timeout for Coral calls. Inserts go through Kafka (async)
+    # so the request itself is fast; raise this if upstream Kafka
+    # broker latency spikes on your deployment.
+    seahorsedb_request_timeout_secs: float = 30.0
 
     # Indexing worker — claim size per batch. Larger = fewer round-trips
     # to the embedding API but longer per-batch wall clock and bigger

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -110,9 +110,13 @@ class VectorStore(Protocol):
             ``collection_exists()`` check. Probably fine because Qdrant
             ``create_collection`` is idempotent server-side, but no
             explicit cross-process guard.
-          - ``SeahorseStore``: ⚠ BFF ``_bff_get_table()`` + optional
+          - ``SeahorseCloudStore``: ⚠ BFF ``_bff_get_table()`` + optional
             auto-create; same race-window shape as Qdrant.
-        Both ⚠ drivers should be audited before they go to prod at
+          - ``SeahorseDbStore``: ⚠ Coral ``GET /catalog/tables`` + optional
+            auto-create on Coral; same race-window shape as the two ⚠
+            above. Coral does serialize concurrent ``POST /catalog/tables``
+            server-side, so racing peers mostly converge.
+        All ⚠ drivers should be audited before they go to prod at
         scale; the asymmetry exists because only pgvector has ever
         actually shipped a schema migration step here.
         """

--- a/backend/app/services/vector_store/factory.py
+++ b/backend/app/services/vector_store/factory.py
@@ -2,12 +2,13 @@
 
 Driver matrix:
 
-| `vector_store_driver` | required settings                                   |
-| --------------------- | --------------------------------------------------- |
-| `qdrant`              | `vector_url` (+ optional `vector_api_key`)          |
-| `pgvector`            | `vector_store_dsn` blank reuses main PG             |
-| `seahorse`            | `seahorse_token` + `seahorse_tenant_uuid` + one of  |
-|                       | `seahorse_table_name` / `seahorse_table_uuid`       |
+| `vector_store_driver` | required settings                                          |
+| --------------------- | ---------------------------------------------------------- |
+| `qdrant`              | `vector_url` (+ optional `vector_api_key`)                 |
+| `pgvector`            | `vector_store_dsn` blank reuses main PG                    |
+| `seahorse-cloud`      | `seahorse_cloud_token` + `seahorse_cloud_tenant_uuid` +    |
+|                       | one of `seahorse_cloud_table_name` / `..._table_uuid`      |
+| `seahorse-db`         | `seahorsedb_coordinator_url` (single Coral HTTP URL)       |
 
 The driver and sparse-shape values are validated at config load
 (pydantic Literals); the factory only needs to dispatch.
@@ -54,30 +55,49 @@ def get_vector_store() -> VectorStore:
             sparse_shape=settings.vector_store_sparse_shape,
             get_main_pool=get_pool,
         )
-    elif driver == "seahorse":
-        from .seahorse import SeahorseStore
-        if not settings.seahorse_token:
+    elif driver == "seahorse-cloud":
+        from .seahorse_cloud import SeahorseCloudStore
+        if not settings.seahorse_cloud_token:
             raise RuntimeError(
-                "vector_store_driver=seahorse requires seahorse_token (Bearer) "
-                "in secret.yaml."
+                "vector_store_driver=seahorse-cloud requires "
+                "seahorse_cloud_token (Bearer) in secret.yaml."
             )
-        if not settings.seahorse_tenant_uuid:
+        if not settings.seahorse_cloud_tenant_uuid:
             raise RuntimeError(
-                "vector_store_driver=seahorse requires seahorse_tenant_uuid."
+                "vector_store_driver=seahorse-cloud requires "
+                "seahorse_cloud_tenant_uuid."
             )
-        if not (settings.seahorse_table_name or settings.seahorse_table_uuid):
+        if not (
+            settings.seahorse_cloud_table_name
+            or settings.seahorse_cloud_table_uuid
+        ):
             raise RuntimeError(
-                "vector_store_driver=seahorse requires either "
-                "seahorse_table_name or seahorse_table_uuid."
+                "vector_store_driver=seahorse-cloud requires either "
+                "seahorse_cloud_table_name or seahorse_cloud_table_uuid."
             )
-        _singleton = SeahorseStore(
-            management_url=settings.seahorse_management_url,
-            token=settings.seahorse_token,
-            tenant_uuid=settings.seahorse_tenant_uuid,
-            table_name=settings.seahorse_table_name or None,
-            table_uuid=settings.seahorse_table_uuid or None,
+        _singleton = SeahorseCloudStore(
+            management_url=settings.seahorse_cloud_management_url,
+            token=settings.seahorse_cloud_token,
+            tenant_uuid=settings.seahorse_cloud_tenant_uuid,
+            table_name=settings.seahorse_cloud_table_name or None,
+            table_uuid=settings.seahorse_cloud_table_uuid or None,
             dense_dim=settings.embed_dimensions,
-            auto_create=settings.seahorse_auto_create,
+            auto_create=settings.seahorse_cloud_auto_create,
+        )
+    elif driver == "seahorse-db":
+        from .seahorse_db import SeahorseDbStore
+        if not settings.seahorsedb_coordinator_url:
+            raise RuntimeError(
+                "vector_store_driver=seahorse-db requires "
+                "seahorsedb_coordinator_url (Coral HTTP API)."
+            )
+        _singleton = SeahorseDbStore(
+            coordinator_url=settings.seahorsedb_coordinator_url,
+            table_name=settings.seahorsedb_table_name,
+            dense_dim=settings.embed_dimensions,
+            distance=settings.seahorsedb_distance,
+            auto_create=settings.seahorsedb_auto_create,
+            timeout=settings.seahorsedb_request_timeout_secs,
         )
     else:
         # Unreachable given the Literal at config load; kept for safety

--- a/backend/app/services/vector_store/seahorse_cloud.py
+++ b/backend/app/services/vector_store/seahorse_cloud.py
@@ -2,13 +2,13 @@
 
 Talks to Seahorse Cloud's two-plane API:
 
-- **Management (BFF)** at `seahorse_management_url` for table
+- **Management (BFF)** at `seahorse_cloud_management_url` for table
   lifecycle (list / get / create / delete).
 - **Per-table data plane host** for upsert / search / delete-row /
   schema. The host is discovered from the management response (each
   table gets its own subdomain) and cached on `ensure_collection`.
 
-A single `SeahorseStore` instance maps to a single Seahorse table.
+A single `SeahorseCloudStore` instance maps to a single Seahorse table.
 Multiple AKB sources (different `source_id`) live in the same table
 and are separated by SQL `WHERE` filters at search time.
 
@@ -84,7 +84,7 @@ def _sparse_to_str(indices: list[int], values: list[float]) -> str:
     return " ".join(f"{int(i)}:{float(v)}" for i, v in zip(indices, values))
 
 
-class SeahorseStore:
+class SeahorseCloudStore:
     """VectorStore impl over Seahorse Cloud's TABLE_V2 + BFF API."""
 
     def __init__(
@@ -101,13 +101,13 @@ class SeahorseStore:
     ):
         if not (table_name or table_uuid):
             raise ValueError(
-                "SeahorseStore requires either table_name or table_uuid "
+                "SeahorseCloudStore requires either table_name or table_uuid "
                 "(blank both)."
             )
         if not token:
-            raise ValueError("SeahorseStore requires a bearer token.")
+            raise ValueError("SeahorseCloudStore requires a bearer token.")
         if not tenant_uuid:
-            raise ValueError("SeahorseStore requires tenant_uuid.")
+            raise ValueError("SeahorseCloudStore requires tenant_uuid.")
         self._mgmt_url = management_url.rstrip("/")
         self._token = token
         self._tenant_uuid = tenant_uuid
@@ -172,7 +172,7 @@ class SeahorseStore:
                         f"name={self._table_name!r}, "
                         f"uuid={self._table_uuid!r}). "
                         "Create it in the console first or set "
-                        "seahorse_auto_create: true in app.yaml."
+                        "seahorse_cloud_auto_create: true in app.yaml."
                     )
                 tbl = await self._create_table()
             self._validate_schema(tbl)
@@ -196,7 +196,7 @@ class SeahorseStore:
         if not self._table_name:
             raise VectorStoreUnavailable(
                 "Cannot auto-create Seahorse table without "
-                "seahorse_table_name (uuid alone won't do "
+                "seahorse_cloud_table_name (uuid alone won't do "
                 "— it doesn't exist yet)."
             )
         body = {

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -1,0 +1,323 @@
+"""SeahorseDB (self-hosted) driver for the VectorStore Protocol.
+
+Talks to a Coral coordinator (Rust HTTP API), which fronts a SeahorseDB
+Writer/Reader cluster + Redis + Kafka. Coral is the single entry point
+— this driver never speaks to Writer/Reader/Redis directly.
+
+Endpoint map (Coral HTTP API, see Coral's ``src/interface/http/routes.rs``):
+
+  - ``GET  /health``                                — health
+  - ``POST /catalog/tables``                        — create
+  - ``GET  /catalog/tables/{name}``                 — exists
+  - ``POST /catalog/tables/{name}/data``            — insert (Kafka async)
+  - ``POST /catalog/tables/{name}/data/delete``     — delete
+  - ``POST /catalog/tables/{name}/data/hybrid-search``  — fused dense+sparse
+
+Sparse encoding contract: the AKB ``embed_worker`` + ``sparse_encoder``
+emits two parallel arrays ``sparse_indices: list[int]`` +
+``sparse_values: list[float]``. Coral takes the equivalent shape as a
+list of ``[term_id, weight]`` pairs — we zip at the driver boundary so
+the rest of AKB never sees the Coral-specific shape.
+
+Label mapping: SeahorseDB identifies records by a ``u64`` label. AKB
+uses ``chunk_id`` (UUID). We map UUID → u64 by taking the first 8
+bytes (big-endian) of the UUID's raw 16-byte form. This is a one-way
+hash from AKB's perspective; collisions inside one table would only
+happen at ~2^32 chunks (birthday paradox) — well above any realistic
+single-vault scale and within the eventual-rebuild cost budget if we
+ever hit it.
+
+Async / eventual-consistency caveat: inserts at Coral go through
+Kafka before they reach Writer + Reader. ``POST /data`` returns once
+the message is in Kafka, NOT once the row is searchable. Callers that
+need "the chunk I just upserted shows up in the next search" (e.g.
+some AKB integration tests) need to poll Coral's
+``/catalog/tables/{name}/data/scan`` or accept ~10-30s eventual
+visibility. ``embed_worker`` is fine — it marks `vector_indexed_at`
+on Kafka-accept, and the next search-time gap is the same gap any
+async indexing pipeline has.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+import httpx
+
+from .base import VectorHit, VectorStoreUnavailable, has_dense
+
+
+logger = logging.getLogger("akb.vector_store.seahorse_db")
+
+
+def _chunk_id_to_label(chunk_id: str) -> int:
+    """UUID -> SeahorseDB u64 label.
+
+    First 8 bytes of the UUID's binary form, interpreted big-endian.
+    Stable, dependency-free, no DB round-trip. Collisions are
+    birthday-paradox bounded — ~2^32 chunks per table before a 50%
+    chance of any pair colliding, far beyond any realistic vault."""
+    raw = uuid.UUID(chunk_id).bytes
+    return int.from_bytes(raw[:8], "big", signed=False)
+
+
+class SeahorseDbStore:
+    """VectorStore driver targeting a self-hosted SeahorseDB cluster
+    via its Coral coordinator HTTP API.
+
+    Construction is config-only — no network calls. The lazy
+    ``ensure_collection`` does the catalog setup on first use (and
+    is called from lifespan startup so the cost lands at boot, not
+    on the first search request)."""
+
+    def __init__(
+        self,
+        *,
+        coordinator_url: str,
+        table_name: str,
+        dense_dim: int,
+        distance: str = "cosine",
+        auto_create: bool = True,
+        timeout: float = 30.0,
+    ):
+        self._url = coordinator_url.rstrip("/")
+        self._table = table_name
+        self._dense_dim = dense_dim
+        self._distance = distance
+        self._auto_create = auto_create
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+        self._ensured_collection = False
+        self._ensure_lock = asyncio.Lock()
+
+    async def _http(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._url, timeout=self._timeout,
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        """Test-only: close the underlying HTTP client. Production
+        path keeps it open for the process lifetime."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ── VectorStore Protocol ──────────────────────────────────────
+
+    async def ensure_collection(self, *, conn=None) -> None:
+        """Create the AKB-shaped table on Coral if missing. No-op when
+        the table is already there or ``auto_create=False`` (operator
+        manages schema externally)."""
+        if self._ensured_collection:
+            return
+        async with self._ensure_lock:
+            if self._ensured_collection:
+                return
+            http = await self._http()
+            try:
+                resp = await http.get(f"/catalog/tables/{self._table}")
+            except httpx.HTTPError as e:
+                raise VectorStoreUnavailable(
+                    f"Coral unreachable at {self._url}: {e}"
+                ) from e
+
+            if resp.status_code == 200:
+                self._ensured_collection = True
+                return
+            if resp.status_code != 404:
+                raise VectorStoreUnavailable(
+                    f"Coral GET /catalog/tables/{self._table} → "
+                    f"{resp.status_code}: {resp.text[:200]}"
+                )
+
+            if not self._auto_create:
+                raise VectorStoreUnavailable(
+                    f"table {self._table!r} absent on Coral and "
+                    f"seahorsedb_auto_create=false; create it manually "
+                    f"or flip the flag in app.yaml."
+                )
+
+            create_payload = self._build_create_table_payload()
+            try:
+                resp = await http.post(
+                    "/catalog/tables", json=create_payload,
+                )
+            except httpx.HTTPError as e:
+                raise VectorStoreUnavailable(
+                    f"Coral POST /catalog/tables: {e}"
+                ) from e
+            if resp.status_code not in (200, 201, 409):
+                # 409 = raced with a peer that already created it; OK.
+                raise VectorStoreUnavailable(
+                    f"Coral POST /catalog/tables → "
+                    f"{resp.status_code}: {resp.text[:200]}"
+                )
+            self._ensured_collection = True
+
+    async def health(self) -> bool:
+        try:
+            http = await self._http()
+            resp = await http.get("/health", timeout=5.0)
+            return resp.status_code == 200
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def upsert_one(
+        self,
+        *,
+        conn=None,
+        chunk_id: str,
+        content: str,
+        section_path: str | None,
+        chunk_index: int,
+        dense: list[float] | None,
+        sparse_indices: list[int],
+        sparse_values: list[float],
+        source_type: str,
+        source_id: str,
+    ) -> None:
+        record: dict[str, Any] = {
+            "id": _chunk_id_to_label(chunk_id),
+            "chunk_id": chunk_id,
+            "content": content,
+            "section_path": section_path or "",
+            "chunk_index": chunk_index,
+            "source_type": source_type,
+            "source_id": source_id,
+        }
+        if has_dense(dense):
+            record["embedding"] = dense
+        if sparse_indices:
+            # Coral consumes sparse as a list of [term_id, weight] pairs.
+            record["sparse"] = [
+                [int(t), float(w)]
+                for t, w in zip(sparse_indices, sparse_values)
+            ]
+
+        http = await self._http()
+        try:
+            resp = await http.post(
+                f"/catalog/tables/{self._table}/data",
+                json={"records": [record]},
+            )
+        except httpx.HTTPError as e:
+            raise VectorStoreUnavailable(
+                f"Coral POST /data: {e}"
+            ) from e
+        if resp.status_code not in (200, 202):
+            raise VectorStoreUnavailable(
+                f"Coral POST /data → {resp.status_code}: {resp.text[:200]}"
+            )
+
+    async def delete_point(self, chunk_id: str, *, conn=None) -> None:
+        label = _chunk_id_to_label(chunk_id)
+        http = await self._http()
+        try:
+            resp = await http.post(
+                f"/catalog/tables/{self._table}/data/delete",
+                json={"labels": [label]},
+            )
+        except httpx.HTTPError as e:
+            raise VectorStoreUnavailable(
+                f"Coral POST /data/delete: {e}"
+            ) from e
+        # 200 OK or 404 (already gone — idempotent).
+        if resp.status_code not in (200, 202, 404):
+            raise VectorStoreUnavailable(
+                f"Coral POST /data/delete → "
+                f"{resp.status_code}: {resp.text[:200]}"
+            )
+
+    async def hybrid_search(
+        self,
+        *,
+        query_text: str,
+        query_dense: list[float] | None,
+        query_sparse_indices: list[int],
+        query_sparse_values: list[float],
+        source_ids: list[str] | None,
+        limit: int,
+        prefetch_per_leg: int,
+    ) -> list[VectorHit]:
+        payload: dict[str, Any] = {
+            "k": limit,
+            "ef": max(prefetch_per_leg, limit * 2),
+        }
+        if has_dense(query_dense):
+            payload["query_vector"] = query_dense
+        if query_sparse_indices:
+            payload["sparse_query"] = [
+                [int(t), float(w)]
+                for t, w in zip(query_sparse_indices, query_sparse_values)
+            ]
+        if source_ids:
+            payload["filter"] = {
+                "Keyword": {"field": "source_id", "values": source_ids},
+            }
+
+        http = await self._http()
+        try:
+            resp = await http.post(
+                f"/catalog/tables/{self._table}/data/hybrid-search",
+                json=payload,
+            )
+        except httpx.HTTPError as e:
+            raise VectorStoreUnavailable(
+                f"Coral POST /hybrid-search: {e}"
+            ) from e
+        if resp.status_code != 200:
+            raise VectorStoreUnavailable(
+                f"Coral POST /hybrid-search → "
+                f"{resp.status_code}: {resp.text[:200]}"
+            )
+
+        body = resp.json()
+        hits: list[VectorHit] = []
+        for row in body.get("hits", []):
+            hits.append(VectorHit(
+                chunk_id=row.get("chunk_id") or "",
+                source_type=row.get("source_type") or "",
+                source_id=row.get("source_id") or "",
+                section_path=row.get("section_path") or "",
+                content=row.get("content") or "",
+                score=float(row.get("score") or 0.0),
+            ))
+        return hits
+
+    # ── internals ─────────────────────────────────────────────────
+
+    def _build_create_table_payload(self) -> dict[str, Any]:
+        """AKB-shaped table: id (label) + chunk_id (UUID string) +
+        content + section_path + chunk_index + source_type + source_id
+        + embedding (dense vector) + sparse (hybrid index).
+        Mirrors what `_handle_get` / search_service expect to round-
+        trip back."""
+        return {
+            "name": self._table,
+            "dimension": self._dense_dim,
+            "distance_space": _distance_to_coral(self._distance),
+            "schema": {
+                "columns": [
+                    {"name": "id", "column_type": "Int64", "primary_key": True},
+                    {"name": "chunk_id", "column_type": "String"},
+                    {"name": "embedding",
+                     "column_type": {"Vector": self._dense_dim}},
+                    {"name": "sparse", "column_type": "SparseVector"},
+                    {"name": "content", "column_type": "String"},
+                    {"name": "section_path", "column_type": "String"},
+                    {"name": "chunk_index", "column_type": "Int32"},
+                    {"name": "source_type", "column_type": "String"},
+                    {"name": "source_id", "column_type": "String"},
+                ],
+            },
+        }
+
+
+def _distance_to_coral(d: str) -> str:
+    """AKB config uses lowercase; Coral's enum is PascalCase."""
+    return {"cosine": "Cosine", "l2": "L2", "ip": "InnerProduct"}[d]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.6.6"
+version = "0.7.0"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -119,14 +119,25 @@ vector_store_sparse_shape: posting
 vector_url: ""
 vector_collection: chunks
 
-# Seahorse Cloud driver settings (ignored unless driver is seahorse).
+# Seahorse Cloud driver settings (ignored unless driver is "seahorse-cloud").
 # Two-plane API: management (BFF) for table lifecycle + per-table
 # data-plane host (auto-discovered from BFF response).
-seahorse_management_url: "https://console.seahorse.dnotitia.ai/bff"
-seahorse_tenant_uuid: ""
-seahorse_table_name: ""    # one of (table_name, table_uuid) required
-seahorse_table_uuid: ""
-seahorse_auto_create: false   # set true to provision the AKB-shaped table on first boot
+seahorse_cloud_management_url: "https://console.seahorse.dnotitia.ai/bff"
+seahorse_cloud_tenant_uuid: ""
+seahorse_cloud_table_name: ""    # one of (table_name, table_uuid) required
+seahorse_cloud_table_uuid: ""
+seahorse_cloud_auto_create: false   # set true to provision the AKB-shaped table on first boot
+
+# SeahorseDB self-hosted driver settings (ignored unless driver is "seahorse-db").
+# Single-URL entry: the Coral coordinator. Coral routes to the
+# Writer/Reader cluster + Redis + Kafka behind it — bring those up
+# via SeahorseDB's deploy/docker-compose.yml (see the SeahorseDB
+# monorepo's docs/integration-test for a minimal local stack).
+seahorsedb_coordinator_url: "http://localhost:3003"
+seahorsedb_table_name: "akb_chunks"
+seahorsedb_distance: "cosine"        # cosine | l2 | ip
+seahorsedb_auto_create: true         # let AKB provision the table shape on first boot
+seahorsedb_request_timeout_secs: 30.0
 
 # === Indexing worker tuning ===
 # Chunks claimed per worker tick. Larger = fewer round-trips to the

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -33,7 +33,7 @@ vector_api_key: ""
 
 # === Seahorse Cloud Bearer token (optional) ===
 # Only needed if vector_store_driver: seahorse. Format: shsk_<...>.
-seahorse_token: ""
+seahorse_cloud_token: ""
 
 # === Redis password (optional) ===
 # Only needed if `redis_url` in app.yaml is set. Must match the password


### PR DESCRIPTION
Two vector-store drivers under the Seahorse brand, separated:

- **`seahorse-cloud`** (renamed from `seahorse`) — managed Seahorse Cloud BFF + per-table data-plane host.
- **`seahorse-db`** (new) — self-hosted SeahorseDB cluster via its Coral coordinator HTTP API.

Pre-0.7.0 the single `seahorse` value implicitly meant cloud. Keeping the name ambiguous would be a footgun the moment a self-hosted user filled in `seahorsedb_coordinator_url` expecting that enum value to "just work".

## Driver matrix

| `vector_store_driver` | required settings |
|---|---|
| `qdrant` | `vector_url` (+ optional `vector_api_key`) |
| `pgvector` | `vector_store_dsn` blank reuses main PG |
| `seahorse-cloud` | `seahorse_cloud_token` + `seahorse_cloud_tenant_uuid` + one of `..._table_name` / `..._table_uuid` |
| `seahorse-db` | `seahorsedb_coordinator_url` (Coral HTTP API) |

## New driver implementation

- 5 VectorStore Protocol methods (`ensure_collection`, `health`, `upsert_one`, `delete_point`, `hybrid_search`) — same Protocol as the other drivers, no service-layer changes.
- Coral endpoint mapping documented at top of `backend/app/services/vector_store/seahorse_db.py`.
- Sparse encoding boundary: AKB's parallel `sparse_indices` + `sparse_values` arrays zipped into Coral's `[[term_id, weight], ...]` inside the driver. Rest of AKB stays Coral-shape-free.
- Label mapping: UUID `chunk_id` → SeahorseDB `u64` label = first 8 bytes (big-endian). Birthday-paradox safe to ~2^32 chunks per table.
- Race-safety: documented as ⚠ in `base.py`'s audit table; Coral serializes concurrent `POST /catalog/tables` server-side so peers mostly converge.

## Background — confirmed Coral standalone earlier this session

Built + ran the SeahorseDB monorepo's `cloud-functional-test` stack on ARM64 Mac:
- `infra::basic_api` — ✅ 285ms (health + nodes_list + registered node IDs)
- `hybrid::basic_api` — ✅ 2488ms (hybrid table create/insert/search/filtered)

So we know Coral's surface is real and the standalone stack runs locally. Only fixes needed: mecab-ko `./configure --build=$(uname -m)-unknown-linux-gnu` for ARM64 + ceph mounts redirected to `/tmp/seahorse-*` empty dirs.

## Config migration is BREAKING

```diff
-vector_store_driver: seahorse
-seahorse_management_url: "https://console.seahorse.dnotitia.ai/bff"
-seahorse_token: "shsk_..."
-seahorse_tenant_uuid: "..."
-seahorse_table_name: "..."
-seahorse_auto_create: true
+vector_store_driver: seahorse-cloud
+seahorse_cloud_management_url: "https://console.seahorse.dnotitia.ai/bff"
+seahorse_cloud_token: "shsk_..."
+seahorse_cloud_tenant_uuid: "..."
+seahorse_cloud_table_name: "..."
+seahorse_cloud_auto_create: true
```

`pydantic` config has `extra="forbid"`, so an un-migrated `seahorse_*` key fails the app launch loudly. That's intentional — silent fallback would send writes to the wrong driver.

Default driver unchanged (`qdrant`). prod + demo run `pgvector`, so neither is affected by this rename.

## What this PR does NOT do

- No production migration. prod + demo stay on `pgvector`.
- No integration test against a live Coral. Driver is type-checked + unit-friendly; e2e is the next PR once we decide where the SeahorseDB stack lives (host machine vs CI runner vs neither).
- No proxy / frontend change.

## Test plan

- [x] `bash scripts/check.sh` — green (ruff + mypy + tsc + vitest + secrets)
- [x] `mypy --python-version 3.14 app/services/vector_store/` — `Success: no issues found in 7 source files`
- [x] `bash backend/tests/test_publications_e2e.sh` — 97/97
- [x] `bash backend/tests/test_mcp_e2e.sh` — 76/76
- [x] `bash backend/tests/test_hybrid_search_e2e.sh` — 25/25
- [ ] After merge: tag `backend-v0.7.0`, GitHub Release, **no** prod/demo deploy (driver isn't used by either yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)