### PR TITLE
fix(0.7.2): seahorse-db driver wire formats actually verified end-to-end (retracts 0.7.0/0.7.1 claims)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1719
+        "line_number": 1835
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T05:07:30Z"
+  "generated_at": "2026-06-05T05:59:59Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,7 +5,123 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.2 — 2026-06-05  *(patch — `seahorse-db` driver wire format actually verified end-to-end; retracts 0.7.0/0.7.1 false-positive claims)*
+
+### Retraction of 0.7.0 + 0.7.1 status claims
+
+0.7.0 shipped the `seahorse-db` driver with wire formats reverse-
+engineered from `routes.rs` path strings alone. 0.7.1 added an opt-in
+smoke E2E that claimed 6/6 PASS. Both releases overstated what was
+verified. Running the driver against a live Coral coordinator in
+this release uncovered that:
+
+- The route prefix is `/v2/tables/...`, NOT `/v2/catalog/tables/...`
+  (we had `catalog/` in there) and NOT `/catalog/tables/...` (0.7.0
+  shape). Wrong prefixes fell through to the same-port gRPC
+  fallback and returned `HTTP/1.1 200 OK` + `content-type:
+  application/grpc` + `grpc-status: 12`. The 0.7.1 smoke checked
+  status code only and counted every call as a pass.
+- `POST /v2/tables` expects flat `table_name` + top-level `columns`
+  (SCREAMING_SNAKE types: `INT64`, `STRING`, `{name: DENSE_VECTOR,
+  element: FLOAT32, dim}`, `{name: SPARSE_VECTOR}`) + `segmentation`
+  (`{strategy: hash, columns: [id], buckets: 1, composition:
+  single}`) + `indexes` (lowercase `hnsw` / `inverted`). 0.7.0
+  emitted nested `schema.columns` with `column_type` keys, no
+  segmentation, PascalCase index types, and `distance_space: Cosine`
+  — every field name and shape was off.
+- HNSW only accepts `space: "ip" | "l2"`. `cosine` is rejected at
+  segment build time (`Hnsw index does not support cosinespace`).
+  AKB callers using cosine-equivalent retrieval must normalise to
+  unit norm and use `ip`. The `seahorsedb_distance` Literal is now
+  `"l2" | "ip"`.
+- `POST /v2/tables/{name}/data` requires
+  `Content-Type: application/x-ndjson` (JSONL). `application/json`
+  fails with HTTP 400 `400102 Unsupported Content-Type for /data
+  insert`. 0.7.0 sent `application/json` + a `{"records": [...]}`
+  wrapper, both wrong.
+- Sparse vectors are a **single string** per row
+  (`"term_id:weight term_id:weight"`, space-separated), not a list
+  of pairs.
+- `POST /v2/tables/{name}/data/delete` payload is
+  `{"delete_condition": "<SQL WHERE clause>"}`, not
+  `{"labels": [u64, ...]}`.
+- `POST /v2/tables/{name}/data/hybrid-search` payload uses separate
+  `dense` and `sparse` config objects (each with `column`,
+  `vectors`, optional `parameters`), a `fusion` block, an SQL
+  `projection` string, and an SQL `filter` string. Response is
+  enveloped: `body["data"]["data"][0]` is the hit list (one
+  resultset per query vector).
+
+### End-to-end verification in this release
+
+- Backend started with `vector_store_driver: seahorse-db` pointed
+  at a live Coral. Lifespan `ensure_collection` made the table:
+  `GET /v2/tables/akb_validation → 404` then
+  `POST /v2/tables → 200 application/json`.
+- Document put via AKB REST API → `embed_worker` claimed the
+  chunks → driver POSTed each row as JSONL to
+  `/v2/tables/akb_validation/data` → Coral returned `200 OK` with
+  `inserted_row_count: 1` per chunk.
+- AKB search REST endpoint with `vault=sdb-test&q=Korean tokenization`
+  → driver POSTed hybrid-search → Coral returned 2 hits with the
+  expected `content`/`source_id`/`chunk_id`/`score` fields →
+  AKB rendered the hits at `/api/v1/search`. **Every response
+  checked for `content-type: application/json` to rule out gRPC
+  fallback.**
+
+### Driver gaps still present (honestly)
+
+- **Dense-less (BM25-only) upsert + search not supported.** The
+  embedding column is currently `nullable: false`; ingest raises
+  `VectorStoreUnavailable` when `dense=None`. To match pgvector's
+  BM25 fallback we'd need a NULL embedding column AND a
+  sparse-only search path on Coral (single-leg vector search
+  endpoint exists; not wired through this driver yet).
+- **BM25 per-query metadata not sent.** Hybrid search omits
+  `parameters` and `metadata` on the sparse leg; Coral falls back
+  to defaults. AKB has `bm25_stats` (N, avgdl, df), so the
+  retrieval quality could improve by shipping them per query.
+- **Race-safety still ⚠.** No PG-advisory-lock-grade primitive
+  on Coral; concurrent `ensure_collection` peers rely on Coral's
+  server-side serialisation.
+- **No `test_hybrid_search_e2e.sh` against seahorse-db yet.** AKB's
+  25-scenario hybrid suite still runs only against pgvector. The
+  driver-level smoke (`test_seahorse_db_e2e.sh`) needs its own
+  rewrite to match the corrected wire formats — that's the next
+  PR. Until then, "driver works on a single happy-path doc" is
+  what we claim, not "production ready".
+- **Kafka eventual consistency UX.** Coral's `POST /data` returns
+  on Kafka-accept, not on visibility (~10-30s lag). `embed_worker`
+  marks `vector_indexed_at` on insert-accept, so a doc you just
+  put may not appear in search for that window. Same shape any
+  async-indexing driver has, but worth knowing.
+
+### Files changed
+
+- `backend/app/services/vector_store/seahorse_db.py` — every wire
+  format and the helpers (`_encode_sparse_string`,
+  `_validate_uuid_for_sql`, `_is_grpc_fallback`). The
+  `_is_grpc_fallback` content-type check is the safety net that
+  prevented this miss from happening again.
+- `backend/app/config.py` — `seahorsedb_distance` Literal
+  `"cosine" | "l2" | "ip"` → `"l2" | "ip"` (cosine was never
+  valid).
+
+### What this PR does NOT do
+
+- Does NOT publish a corrected `test_seahorse_db_e2e.sh` (that
+  ships in the next PR with content-type assertions baked in).
+- Does NOT change prod / demo — both still pgvector.
+- Does NOT cover the BM25-only / sparse-only path.
+
+---
+
 ## 0.7.1 — 2026-06-05  *(patch — `seahorse-db` driver wire-shape smoke E2E + `.gitignore` overlay slot)*
+
+⚠ **RETRACTED by 0.7.2**: the "6/6 PASS" claim in this release is
+a false positive. Every request fell through Coral's gRPC fallback
+on the unmatched HTTP REST path, so the smoke validated nothing.
+See 0.7.2's retraction section.
 
 ### `backend/tests/test_seahorse_db_e2e.sh`
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -152,7 +152,12 @@ class Settings(BaseModel):
     # is true and the table is absent on startup.
     seahorsedb_coordinator_url: str = "http://localhost:3003"
     seahorsedb_table_name: str = "akb_chunks"
-    seahorsedb_distance: Literal["cosine", "l2", "ip"] = "cosine"
+    # SeahorseDB's HNSW supports `l2` and `ip` only (cosine produces
+    # "cosinespace" which the HNSW backend rejects at segment build
+    # time with `Hnsw index does not support cosinespace`). For
+    # cosine-equivalent retrieval, normalize embeddings to unit norm
+    # at the caller and use `ip`.
+    seahorsedb_distance: Literal["l2", "ip"] = "ip"
     seahorsedb_auto_create: bool = True
     # HTTP timeout for Coral calls. Inserts go through Kafka (async)
     # so the request itself is fast; raise this if upstream Kafka

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -6,12 +6,21 @@ Writer/Reader cluster + Redis + Kafka. Coral is the single entry point
 
 Endpoint map (Coral HTTP API, see Coral's ``src/interface/http/routes.rs``):
 
-  - ``GET  /health``                                — health
-  - ``POST /catalog/tables``                        — create
-  - ``GET  /catalog/tables/{name}``                 — exists
-  - ``POST /catalog/tables/{name}/data``            — insert (Kafka async)
-  - ``POST /catalog/tables/{name}/data/delete``     — delete
-  - ``POST /catalog/tables/{name}/data/hybrid-search``  — fused dense+sparse
+  - ``GET  /health``                                          — health (general_routes, no /v2)
+  - ``POST /v2/tables``                               — create
+  - ``GET  /v2/tables/{name}``                        — get/exists
+  - ``POST /v2/tables/{name}/data``                   — insert (Kafka async)
+  - ``POST /v2/tables/{name}/data/delete``            — delete
+  - ``POST /v2/tables/{name}/data/hybrid-search``     — fused dense+sparse
+
+The catalog/data surface lives under ``/v2`` (the only stable Coral
+HTTP namespace). Unmatched paths fall through to tonic's gRPC
+fallback on the same port and return 200 + ``content-type:
+application/grpc`` + ``grpc-status: 12`` — easy to misread as
+success. **Always sanity-check `content-type`, not just status
+code**, if Coral evolves the prefix again. 0.7.1 shipped without
+the ``/v2`` prefix and the smoke E2E falsely PASSed against gRPC
+fallback — that miss is what 0.7.2 fixes.
 
 Sparse encoding contract: the AKB ``embed_worker`` + ``sparse_encoder``
 emits two parallel arrays ``sparse_indices: list[int]`` +
@@ -32,7 +41,7 @@ Kafka before they reach Writer + Reader. ``POST /data`` returns once
 the message is in Kafka, NOT once the row is searchable. Callers that
 need "the chunk I just upserted shows up in the next search" (e.g.
 some AKB integration tests) need to poll Coral's
-``/catalog/tables/{name}/data/scan`` or accept ~10-30s eventual
+``/v2/tables/{name}/data/scan`` or accept ~10-30s eventual
 visibility. ``embed_worker`` is fine — it marks `vector_indexed_at`
 on Kafka-accept, and the next search-time gap is the same gap any
 async indexing pipeline has.
@@ -41,6 +50,7 @@ async indexing pipeline has.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from typing import Any
@@ -51,6 +61,27 @@ from .base import VectorHit, VectorStoreUnavailable, has_dense
 
 
 logger = logging.getLogger("akb.vector_store.seahorse_db")
+
+
+def _validate_uuid_for_sql(s: str) -> str:
+    """Reject anything that isn't a UUID before interpolating into a
+    SQL WHERE clause. AKB source_ids are always UUIDs; this is purely
+    defense in depth against any caller mistake."""
+    uuid.UUID(s)
+    return s
+
+
+def _encode_sparse_string(
+    indices: list[int], values: list[float],
+) -> str:
+    """Encode AKB's parallel sparse arrays into Coral's
+    ``"term_id:weight term_id:weight"`` string format (space-separated,
+    one pair per token). Verified against the live Coral hybrid
+    search request handler — sparse vectors arrive as a single string
+    on this column, not as a list of pairs or as a JSON sub-object."""
+    if not indices:
+        return ""
+    return " ".join(f"{int(t)}:{float(w):.6g}" for t, w in zip(indices, values))
 
 
 def _chunk_id_to_label(chunk_id: str) -> int:
@@ -107,6 +138,15 @@ class SeahorseDbStore:
             await self._client.aclose()
             self._client = None
 
+    @staticmethod
+    def _is_grpc_fallback(resp: httpx.Response) -> bool:
+        """True when Coral's gRPC fallback served this — REST path was
+        unmatched. Surface looks like ``HTTP/1.1 200 OK`` so a naive
+        ``status_code == 200`` check passes; the only honest signal is
+        the ``content-type`` header (`application/grpc*`)."""
+        ct = resp.headers.get("content-type", "")
+        return ct.startswith("application/grpc")
+
     # ── VectorStore Protocol ──────────────────────────────────────
 
     async def ensure_collection(self, *, conn=None) -> None:
@@ -120,18 +160,25 @@ class SeahorseDbStore:
                 return
             http = await self._http()
             try:
-                resp = await http.get(f"/catalog/tables/{self._table}")
+                resp = await http.get(f"/v2/tables/{self._table}")
             except httpx.HTTPError as e:
                 raise VectorStoreUnavailable(
                     f"Coral unreachable at {self._url}: {e}"
                 ) from e
 
+            if self._is_grpc_fallback(resp):
+                raise VectorStoreUnavailable(
+                    f"Coral GET /v2/tables/{self._table} fell "
+                    f"through to the gRPC fallback (HTTP REST route "
+                    f"unmatched). Check the Coral version + the /v2 "
+                    f"prefix used by this driver."
+                )
             if resp.status_code == 200:
                 self._ensured_collection = True
                 return
             if resp.status_code != 404:
                 raise VectorStoreUnavailable(
-                    f"Coral GET /catalog/tables/{self._table} → "
+                    f"Coral GET /v2/tables/{self._table} → "
                     f"{resp.status_code}: {resp.text[:200]}"
                 )
 
@@ -145,7 +192,7 @@ class SeahorseDbStore:
             create_payload = self._build_create_table_payload()
             try:
                 resp = await http.post(
-                    "/catalog/tables", json=create_payload,
+                    "/v2/tables", json=create_payload,
                 )
             except httpx.HTTPError as e:
                 raise VectorStoreUnavailable(
@@ -181,6 +228,22 @@ class SeahorseDbStore:
         source_type: str,
         source_id: str,
     ) -> None:
+        """Insert a single record into the AKB-shaped Coral table.
+
+        Coral's ``/data`` insert handler accepts JSONL (one JSON object
+        per line) with ``Content-Type: application/x-ndjson`` — plain
+        ``application/json`` is rejected with HTTP 400 / error_code
+        400102 ``Unsupported Content-Type``. (Arrow IPC stream is also
+        accepted but we have no Arrow producer on the AKB side.)
+
+        Sparse vectors are encoded as a single string of
+        ``"term_id:weight term_id:weight"`` (space-separated pairs)
+        — the format Coral's BM25 sparse index consumes (see
+        ``coral-models/src/api/vector.rs`` ``QueryVectors::Sparse``).
+        Empty sparse_indices means OOV/empty BM25 — we still need a
+        non-null value to satisfy the column's ``nullable=false``, so
+        emit an empty string.
+        """
         record: dict[str, Any] = {
             "id": _chunk_id_to_label(chunk_id),
             "chunk_id": chunk_id,
@@ -189,47 +252,76 @@ class SeahorseDbStore:
             "chunk_index": chunk_index,
             "source_type": source_type,
             "source_id": source_id,
+            "sparse": _encode_sparse_string(sparse_indices, sparse_values),
         }
         if has_dense(dense):
             record["embedding"] = dense
-        if sparse_indices:
-            # Coral consumes sparse as a list of [term_id, weight] pairs.
-            record["sparse"] = [
-                [int(t), float(w)]
-                for t, w in zip(sparse_indices, sparse_values)
-            ]
+        else:
+            # Schema requires embedding NOT NULL; we don't yet have a
+            # BM25-only path for seahorse-db. Surface explicitly so the
+            # worker's per-row failure path catches it instead of Coral
+            # rejecting the whole row with a less specific error.
+            raise VectorStoreUnavailable(
+                "seahorse-db driver requires a dense embedding per row; "
+                "BM25-only fallback (dense=None) is not yet supported."
+            )
 
+        body = json.dumps(record, separators=(",", ":"))
         http = await self._http()
         try:
             resp = await http.post(
-                f"/catalog/tables/{self._table}/data",
-                json={"records": [record]},
+                f"/v2/tables/{self._table}/data",
+                content=body.encode("utf-8"),
+                headers={"Content-Type": "application/x-ndjson"},
             )
         except httpx.HTTPError as e:
             raise VectorStoreUnavailable(
-                f"Coral POST /data: {e}"
+                f"Coral POST /v2/tables/{self._table}/data: {e}"
             ) from e
+        if self._is_grpc_fallback(resp):
+            raise VectorStoreUnavailable(
+                f"Coral POST /v2/tables/{self._table}/data fell through "
+                f"to the gRPC fallback (HTTP REST route unmatched)."
+            )
         if resp.status_code not in (200, 202):
             raise VectorStoreUnavailable(
-                f"Coral POST /data → {resp.status_code}: {resp.text[:200]}"
+                f"Coral POST /v2/tables/{self._table}/data → "
+                f"{resp.status_code}: {resp.text[:200]}"
             )
 
     async def delete_point(self, chunk_id: str, *, conn=None) -> None:
-        label = _chunk_id_to_label(chunk_id)
+        """Coral's data-delete is a SQL WHERE clause string under
+        ``delete_condition`` (coral-models/src/api/data.rs
+        ``DataDeleteRequest``), NOT a list of primary-key values.
+
+        We use the ``chunk_id`` column (the round-tripped UUID
+        string) as the filter — it's stable, exact, and matches how
+        AKB tracks the row. SQL string-quoting is single-quote;
+        chunk_id values are UUIDs so no escaping required.
+        Idempotent: Coral returns 200 even when the row was
+        already gone (verified)."""
+        # Defensive guard: AKB only ever calls delete_point with a
+        # well-formed UUID, but a stray apostrophe would corrupt the
+        # WHERE clause. Reject anything that doesn't parse as a UUID.
+        uuid.UUID(chunk_id)
         http = await self._http()
         try:
             resp = await http.post(
-                f"/catalog/tables/{self._table}/data/delete",
-                json={"labels": [label]},
+                f"/v2/tables/{self._table}/data/delete",
+                json={"delete_condition": f"chunk_id = '{chunk_id}'"},
             )
         except httpx.HTTPError as e:
             raise VectorStoreUnavailable(
-                f"Coral POST /data/delete: {e}"
+                f"Coral POST /v2/tables/{self._table}/data/delete: {e}"
             ) from e
-        # 200 OK or 404 (already gone — idempotent).
-        if resp.status_code not in (200, 202, 404):
+        if self._is_grpc_fallback(resp):
             raise VectorStoreUnavailable(
-                f"Coral POST /data/delete → "
+                f"Coral POST /v2/tables/{self._table}/data/delete fell "
+                f"through to the gRPC fallback (HTTP REST route unmatched)."
+            )
+        if resp.status_code not in (200, 202):
+            raise VectorStoreUnavailable(
+                f"Coral POST /v2/tables/{self._table}/data/delete → "
                 f"{resp.status_code}: {resp.text[:200]}"
             )
 
@@ -244,41 +336,101 @@ class SeahorseDbStore:
         limit: int,
         prefetch_per_leg: int,
     ) -> list[VectorHit]:
+        """Coral's hybrid search takes:
+
+        - ``top_k``: int                              (final fused result count)
+        - ``dense``: ``DenseVectorSearchConfig``
+            - ``column``: name of the dense vector column ("embedding")
+            - ``vectors``: list[list[float]]          (batch; we send one)
+            - ``parameters.ef_search``: HNSW ef       (optional)
+        - ``sparse``: ``SparseVectorSearchConfig``
+            - ``column``: "sparse"
+            - ``vectors``: list[str]                  ("term_id:weight ..." each)
+            - ``parameters``/``metadata``: BM25       (we omit — server
+              defaults work without per-query metadata; the alternative
+              is shipping `N`, `avgdl`, `df` from `bm25_stats` which is
+              wasteful per request)
+        - ``fusion``: ``{type: "rrf", parameters: {k}}``
+        - ``projection``: SQL projection string       ("col1, col2")
+        - ``filter``: SQL WHERE clause                ("source_id IN ('a','b')")
+
+        Response shape (verified):
+            ``{"data": {"data": [[ {chunk_id, ..., score}, ... ]]}}``
+        — the outer ``data`` wraps the response envelope, the inner
+        ``data`` is a list of resultsets (one per query vector). We
+        always send one query vector so we read ``[0]``.
+        """
+        # Dense-only and sparse-only modes both need a non-empty
+        # ``vectors`` payload on the empty-side config or Coral
+        # returns 400. We could fall back to the single-leg vector
+        # search endpoints when one side is missing, but that's a
+        # bigger driver change — for now both legs must be present.
+        if not has_dense(query_dense):
+            raise VectorStoreUnavailable(
+                "seahorse-db hybrid_search requires query_dense; "
+                "dense-less query path is not yet implemented."
+            )
+
+        sparse_string = _encode_sparse_string(
+            query_sparse_indices, query_sparse_values,
+        )
+
         payload: dict[str, Any] = {
-            "k": limit,
-            "ef": max(prefetch_per_leg, limit * 2),
+            "top_k": limit,
+            "dense": {
+                "column": "embedding",
+                "vectors": [list(query_dense)],
+                "parameters": {
+                    "ef_search": max(prefetch_per_leg, limit * 2),
+                },
+            },
+            "sparse": {
+                "column": "sparse",
+                "vectors": [sparse_string or " "],
+                # BM25 parameters/metadata omitted on purpose — see
+                # the docstring; Coral picks defaults.
+            },
+            "fusion": {"type": "rrf", "parameters": {"k": 60}},
+            "projection": (
+                "chunk_id, source_type, source_id, section_path, content"
+            ),
         }
-        if has_dense(query_dense):
-            payload["query_vector"] = query_dense
-        if query_sparse_indices:
-            payload["sparse_query"] = [
-                [int(t), float(w)]
-                for t, w in zip(query_sparse_indices, query_sparse_values)
-            ]
         if source_ids:
-            payload["filter"] = {
-                "Keyword": {"field": "source_id", "values": source_ids},
-            }
+            # SQL WHERE clause — Coral parses this directly. Each
+            # `source_id` is a UUID, so the IN list is safe to
+            # build by interpolation. Defensive check + quote.
+            quoted = ", ".join(f"'{_validate_uuid_for_sql(s)}'" for s in source_ids)
+            payload["filter"] = f"source_id IN ({quoted})"
 
         http = await self._http()
         try:
             resp = await http.post(
-                f"/catalog/tables/{self._table}/data/hybrid-search",
+                f"/v2/tables/{self._table}/data/hybrid-search",
                 json=payload,
             )
         except httpx.HTTPError as e:
             raise VectorStoreUnavailable(
-                f"Coral POST /hybrid-search: {e}"
+                f"Coral POST /v2/tables/{self._table}/data/hybrid-search: {e}"
             ) from e
+        if self._is_grpc_fallback(resp):
+            raise VectorStoreUnavailable(
+                "Coral POST hybrid-search fell through to gRPC fallback."
+            )
         if resp.status_code != 200:
             raise VectorStoreUnavailable(
-                f"Coral POST /hybrid-search → "
+                f"Coral POST /v2/tables/{self._table}/data/hybrid-search → "
                 f"{resp.status_code}: {resp.text[:200]}"
             )
 
         body = resp.json()
+        # Envelope: top-level `data` wraps the response; inner `data`
+        # is a list-of-resultsets (one per query vector). One query.
+        outer = body.get("data") or {}
+        resultsets = outer.get("data") or []
+        rows = resultsets[0] if resultsets else []
+
         hits: list[VectorHit] = []
-        for row in body.get("hits", []):
+        for row in rows:
             hits.append(VectorHit(
                 chunk_id=row.get("chunk_id") or "",
                 source_type=row.get("source_type") or "",
@@ -292,32 +444,84 @@ class SeahorseDbStore:
     # ── internals ─────────────────────────────────────────────────
 
     def _build_create_table_payload(self) -> dict[str, Any]:
-        """AKB-shaped table: id (label) + chunk_id (UUID string) +
-        content + section_path + chunk_index + source_type + source_id
-        + embedding (dense vector) + sparse (hybrid index).
-        Mirrors what `_handle_get` / search_service expect to round-
-        trip back."""
+        """AKB-shaped table — wire format matches Coral's
+        ``CreateTableRequest`` (coral-models/src/api/schema.rs).
+
+        Shape (verified against the live Coral that ships with
+        SeahorseDB SDDEV-244/monorepo-coral-sparse):
+
+            table_name:  str
+            columns:     list[Column]            top-level (not nested)
+                Column = {name, type, nullable, max_length?}
+                type:
+                  scalar -> "INT64" | "FLOAT64" | "BOOL" | "STRING"
+                            (SCREAMING_SNAKE_CASE)
+                  dense  -> {"name": "DENSE_VECTOR",
+                             "element": "FLOAT32",
+                             "dim": int}
+                  sparse -> {"name": "SPARSE_VECTOR"}
+            primary_key: list[str]               separate from per-column flag
+            indexes:     list[ExternalIndex]
+                ExternalIndex = {type, column, params?}
+                  type: "HNSW" | "INVERTED" | "DISKBASED"
+                  params: {space?, ef_construction?, M?, sparse_model?}
+                    space: "cosine" | "l2" | "ip"
+        """
         return {
-            "name": self._table,
-            "dimension": self._dense_dim,
-            "distance_space": _distance_to_coral(self._distance),
-            "schema": {
-                "columns": [
-                    {"name": "id", "column_type": "Int64", "primary_key": True},
-                    {"name": "chunk_id", "column_type": "String"},
-                    {"name": "embedding",
-                     "column_type": {"Vector": self._dense_dim}},
-                    {"name": "sparse", "column_type": "SparseVector"},
-                    {"name": "content", "column_type": "String"},
-                    {"name": "section_path", "column_type": "String"},
-                    {"name": "chunk_index", "column_type": "Int32"},
-                    {"name": "source_type", "column_type": "String"},
-                    {"name": "source_id", "column_type": "String"},
-                ],
+            "table_name": self._table,
+            # Coral only accepts STRING primary keys (verified — POST /v2/tables
+            # returns "Primary key column 'X' must be of type STRING" on
+            # any other PK type). So `chunk_id` (UUID string) IS the PK,
+            # and there's no separate u64 label column — deletes and PK
+            # lookups reference chunk_id directly via the SQL
+            # delete_condition payload.
+            # `id` (INT64) is the per-row label hashed from chunk_id;
+            # `chunk_id` (STRING) round-trips the UUID so hybrid_search
+            # responses can carry it back to AKB unchanged. Coral
+            # implicitly treats segmentation.columns as the primary
+            # key when `primary_key` is omitted — matching the e2e
+            # `cloud-functional-test::hybrid` reference shape.
+            "columns": [
+                {"name": "id", "type": "INT64", "nullable": False},
+                {"name": "chunk_id", "type": "STRING", "nullable": False},
+                {"name": "embedding",
+                 "type": {"name": "DENSE_VECTOR", "element": "FLOAT32",
+                          "dim": self._dense_dim},
+                 "nullable": False},
+                {"name": "sparse",
+                 "type": {"name": "SPARSE_VECTOR"},
+                 "nullable": False},
+                {"name": "content", "type": "STRING", "nullable": True},
+                {"name": "section_path", "type": "STRING", "nullable": True},
+                {"name": "chunk_index", "type": "INT64", "nullable": True},
+                {"name": "source_type", "type": "STRING", "nullable": False},
+                {"name": "source_id", "type": "STRING", "nullable": False},
+            ],
+            "segmentation": {
+                "strategy": "hash",
+                "columns": ["id"],
+                "buckets": 1,
+                "composition": "single",
             },
+            "indexes": [
+                {
+                    # Lowercase index type strings match the reference
+                    # e2e and the round-trip GET response shape; the
+                    # Rust enum is case-insensitive but `inverted` /
+                    # `hnsw` is the canonical form.
+                    "type": "hnsw",
+                    "column": "embedding",
+                    "params": {
+                        "space": self._distance,  # ip | l2 — HNSW
+                                                  # rejects cosine
+                                                  # at segment build.
+                        "ef_construction": 64,
+                        "M": 16,
+                    },
+                },
+                {
+                    "type": "inverted",
+                    "column": "sparse",
+                },
+            ],
         }
-
-
-def _distance_to_coral(d: str) -> str:
-    """AKB config uses lowercase; Coral's enum is PascalCase."""
-    return {"cosine": "Cosine", "l2": "L2", "ip": "InnerProduct"}[d]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.7.1"
+version = "0.7.2"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_seahorse_db_e2e.sh
+++ b/backend/tests/test_seahorse_db_e2e.sh
@@ -2,6 +2,24 @@
 #
 # SeahorseDB native driver — smoke E2E against a live Coral coordinator.
 #
+# ⚠ 0.7.1 SHIPPED THIS SCRIPT WITH WRONG WIRE FORMATS.
+# Every request used `/catalog/tables/...` paths (no `/v2`, with
+# `catalog/`) — unmatched in Coral, so axum fell through to the same-
+# port tonic gRPC fallback which returns `HTTP/1.1 200 OK` +
+# `content-type: application/grpc` + `grpc-status: 12`. The status-only
+# checks below counted every call as PASS.
+#
+# 0.7.2 fixed the driver's wire formats (see CHANGELOG) and confirmed
+# them end-to-end via the AKB REST API → embed_worker → Coral. The
+# next PR rewrites this script to:
+#   - assert `content-type: application/json` on every response
+#     (gRPC fallback is the canonical hidden failure on this port)
+#   - use the 0.7.2 corrected schemas (segmentation, JSONL insert,
+#     SQL delete_condition, dense+sparse hybrid configs)
+# Until that ships, this script is INTENTIONALLY a no-op skip even
+# when SEAHORSEDB_CORAL_URL is set, so we don't ship another round
+# of false positives.
+#
 # This test is **opt-in by environment variable**:
 #
 #   SEAHORSEDB_CORAL_URL=http://localhost:46834 bash backend/tests/test_seahorse_db_e2e.sh
@@ -33,6 +51,15 @@ set -uo pipefail
 CORAL_URL="${SEAHORSEDB_CORAL_URL:-}"
 BASE_URL="${AKB_URL:-http://localhost:8000}"
 TABLE="${SEAHORSEDB_TABLE_NAME:-akb_e2e_$(date +%s)}"
+
+echo "==> 0.7.2: this script is intentionally a skip until the wire-format-corrected rewrite ships."
+echo "    See backend/CHANGELOG.md (0.7.2) for the retraction of 0.7.1's false-positive 6/6 PASS."
+echo "    Driver itself was verified end-to-end via the AKB REST API → embed_worker → Coral in 0.7.2."
+exit 0
+
+# Past this line is the old 0.7.1 body — kept for reference only,
+# unreachable. The next PR rewrites it with content-type asserts +
+# the 0.7.2 corrected schemas.
 
 if [ -z "$CORAL_URL" ]; then
     echo "==> SEAHORSEDB_CORAL_URL not set; skipping (this is OK in CI)."

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -135,7 +135,7 @@ seahorse_cloud_auto_create: false   # set true to provision the AKB-shaped table
 # monorepo's docs/integration-test for a minimal local stack).
 seahorsedb_coordinator_url: "http://localhost:3003"
 seahorsedb_table_name: "akb_chunks"
-seahorsedb_distance: "cosine"        # cosine | l2 | ip
+seahorsedb_distance: "ip"        # cosine | l2 | ip
 seahorsedb_auto_create: true         # let AKB provision the table shape on first boot
 seahorsedb_request_timeout_secs: 30.0
 


### PR DESCRIPTION
0.7.0 shipped the `seahorse-db` driver with wire formats reverse-engineered from `routes.rs` path strings alone. 0.7.1 added a smoke E2E that claimed 6/6 PASS. **Both releases overstated what was verified.** Running against a live Coral in this release uncovered that:

- Route prefix is `/v2/tables/...`, not `/v2/catalog/tables/...` and not `/catalog/tables/...`. Wrong prefixes fell through to the same-port tonic gRPC fallback, which returns `HTTP/1.1 200 OK` + `content-type: application/grpc` + `grpc-status: 12`. 0.7.1's smoke checked status code only and counted every call as PASS.
- `POST /v2/tables`: flat `table_name` + top-level `columns` (SCREAMING_SNAKE types) + `segmentation` (`hash`, `columns:[id]`, `buckets:1`, `composition:single`) + `indexes` (lowercase `hnsw`/`inverted`).
- HNSW only accepts `space:"ip"|"l2"`. `cosine` is rejected at segment build.
- `POST /v2/tables/{name}/data` requires `Content-Type: application/x-ndjson` (JSONL). `application/json` fails with HTTP 400 400102. 0.7.0 sent `{"records":[...]}` as JSON.
- Sparse vectors: single string per row (`"term:weight term:weight"` space-separated), not list of pairs.
- `POST /v2/tables/{name}/data/delete`: `{"delete_condition":"<SQL WHERE>"}`, not `{"labels":[...]}`.
- `POST /v2/tables/{name}/data/hybrid-search`: separate `dense`+`sparse` config objects, `fusion` block, SQL `projection`/`filter` strings. Response envelope `body["data"]["data"][0]`.

## End-to-end verification in this release

| Step | Result |
|---|---|
| Backend started with `vector_store_driver: seahorse-db` | ✓ Lifespan `ensure_collection` PASS |
| `GET /v2/tables/akb_validation` (cold) | 404 + `application/json` |
| `POST /v2/tables` | **200 + `application/json`** |
| `POST /api/v1/documents` → embed_worker → driver upsert | 6 chunks insert at Coral, `inserted_row_count: 1` per row |
| `GET /api/v1/search?vault=sdb-test&q=Korean tokenization` | **2 hits returned** with `content` / `source_id` / `chunk_id` / `score` |
| All Coral responses | `content-type: application/json` (gRPC fallback ruled out) |

## Honestly-still-broken

- **Dense-less (BM25-only) path** — raises `VectorStoreUnavailable` (no null embedding column yet).
- **BM25 per-query metadata** (N, avgdl, df) — not sent; Coral defaults.
- **Race-safety** — still ⚠ (no Coral primitive equivalent to PG advisory lock).
- **AKB `test_hybrid_search_e2e.sh` 25 scenarios** — not yet run against this driver. Baseline still pgvector.
- **`test_seahorse_db_e2e.sh`** — kept as early-exit skip; next PR rewrites it with content-type asserts + 0.7.2 wire formats. We do NOT ship another round of false-positive smokes.

## Test plan

- [x] `bash scripts/check.sh` — green
- [x] `vector_store_driver: seahorse-db` startup
- [x] embed_worker → Coral insert, log inspection
- [x] AKB REST search → driver hybrid-search → 2 real hits
- [x] every Coral response `content-type: application/json` verified
- [ ] After merge: tag `backend-v0.7.2`, release. No prod/demo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)