### PR TITLE
fix(0.7.3): seahorse-db BM25 metadata + sparse_model=bm25 index param (AKB hybrid e2e 21/25)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1835
+        "line_number": 1953
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T05:59:59Z"
+  "generated_at": "2026-06-05T07:29:44Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,124 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.3 — 2026-06-05  *(patch — `seahorse-db` BM25 metadata + `sparse_model=bm25` index param; AKB hybrid_search e2e 21/25 against live SeahorseDB)*
+
+### `sparse_model: "bm25"` is required on the INVERTED index
+
+0.7.2 emitted `{"type": "inverted", "column": "sparse"}` with no
+`params` on the sparse index. Coral accepts the table without
+complaint at create time, but `POST /v2/tables/{name}/data/hybrid-search`
+later fails with:
+
+```
+HTTP 503
+error_code 503101
+message: "BM25 sparse scoring requires sparse_model=bm25 index"
+```
+
+0.7.3 pins the param explicitly:
+
+```python
+{
+    "type": "inverted",
+    "column": "sparse",
+    "params": {"sparse_model": "bm25"},
+}
+```
+
+This means **every `seahorse-db` table created by 0.7.0/0.7.1/0.7.2 is
+unusable for hybrid_search** — there is no online migration; the
+table has to be dropped and recreated by the driver on next startup.
+At time of writing, no production or demo cluster runs this driver,
+so the practical blast radius is zero. (If you've been experimenting
+locally: drop the table on Coral and `UPDATE chunks SET
+vector_indexed_at = NULL` to re-emit.)
+
+### BM25 metadata is now sent per query
+
+0.7.2 omitted `parameters` and `metadata` on the sparse leg of
+`hybrid-search`, expecting Coral to fall back to reasonable defaults.
+That worked for the basic-shape e2e but produced empty or
+wrong-doc results on the AKB hybrid-search e2e's English-keyword and
+Korean-keyword scenarios. 0.7.3 ships our corpus stats every query:
+
+- `parameters: {k, b}` — pulled from `bm25_stats` (the values AKB
+  uses for ingest-side encoding, kept consistent with retrieval).
+- `metadata.N` and `metadata.avgdl` — same source.
+- `metadata.df` — per-term document frequencies from `bm25_vocab`,
+  one PG batch fetch per search (~ms even at our scale). Coral
+  takes them as a `Vec<String>` of `"term_id:df term_id:df ..."`,
+  one entry per query vector.
+
+One extra `await sparse_encoder.load_df_for_terms(...)` per search
+call. Cheap; the alternative is shipping the full df table to Coral
+once and hoping it doesn't drift.
+
+### AKB `test_hybrid_search_e2e.sh` against live `seahorse-db`
+
+First real run of AKB's 25-scenario hybrid retrieval e2e with the
+driver pointed at a live Coral (built from SeahorseDB monorepo's
+`SDDEV-244/monorepo-coral-sparse` branch, infra-only scenario kept
+up via `--no-cleanup`). **21/25 PASS** vs **25/25 PASS** for the
+same backend running pgvector against the same chunks.
+
+Failures (all four are recall-side, not driver-side):
+
+- `dense: expected PostgreSQL doc, got: <empty>`
+- `bm25-en: expected GraphQL doc, got: <empty>`
+- `bm25-ko: expected Kubernetes doc, got: hybrid-a-… Guide`
+- `isolation-B: expected vault B doc, got: <empty>`
+
+Two interacting causes:
+
+1. **Coral 500 `error_code 500233` under sustained single-row
+   JSONL load** — ~4–7% of `POST /v2/tables/{name}/data` requests
+   come back 500 with no row-level reason, only `tower_http`
+   "response failed" in Coral's log. Reproduces from AKB's
+   `embed_worker` pacing (~10/sec, serial-per-process); does NOT
+   reproduce from direct curl loops (single, dup PK, 30-concurrent
+   all 100% OK). The chunks that hit retry_count >= 8 stay
+   `vector_indexed_at IS NULL` past the e2e's 180s
+   `wait_for_indexing` budget, so the docs they belong to never
+   become searchable.
+   Filed upstream as [SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433)
+   with a standalone Python repro.
+
+2. **Kafka eventual consistency** — `POST /data` returns on
+   Kafka-accept, not on segment-visible. Even chunks that DO get
+   through can be invisible to search for ~10-30s. AKB's
+   `embed_worker` marks `vector_indexed_at` at the same point, so a
+   doc you just put may not show up immediately. Same shape any
+   async-indexing driver has, and not strictly a regression — but
+   the 180s e2e budget assumed pgvector's "indexed = visible"
+   semantics.
+
+### Where this leaves the driver
+
+`seahorse-db` driver now passes the bulk of AKB's retrieval workload
+end-to-end, but is **not** at pgvector-parity yet. Honest gaps still
+in:
+
+- The four e2e scenarios above
+- BM25-only / dense-less path raises `VectorStoreUnavailable`
+- Cross-process race-safety on `ensure_collection` ⚠
+- `test_seahorse_db_e2e.sh` is still an early-exit skip (will be
+  rewritten with content-type asserts + 0.7.3 wire formats next)
+- `embed_worker` retry semantics need a Coral 500 backoff /
+  abandon policy distinct from "vector store unavailable"
+
+### Verification
+
+- `bash scripts/check.sh` — green.
+- `vector_store_driver: seahorse-db` startup, `ensure_collection`
+  with new sparse_model:bm25 schema.
+- One doc put → embed_worker → Coral; one search → driver
+  hybrid-search → 2 real hits with BM25 metadata in the payload.
+- `bash backend/tests/test_hybrid_search_e2e.sh` — 21/25 (vs
+  pgvector 25/25).
+
+---
+
 ## 0.7.2 — 2026-06-05  *(patch — `seahorse-db` driver wire format actually verified end-to-end; retracts 0.7.0/0.7.1 false-positive claims)*
 
 ### Retraction of 0.7.0 + 0.7.1 status claims

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -375,6 +375,37 @@ class SeahorseDbStore:
             query_sparse_indices, query_sparse_values,
         )
 
+        # BM25 metadata + parameters: Coral defaults gave noticeably
+        # worse recall on the 25-scenario hybrid e2e (BM25-en /
+        # BM25-ko / cross-vault-B all missed). Ship our corpus stats
+        # (`N`, `avgdl`) + the per-term df for the query's vocabulary.
+        # Cheap when the vocab is small (typical Kiwi-tokenised
+        # Korean queries are 3-8 tokens), one extra PG fetch per
+        # search. AKB's stats are already cached in sparse_encoder
+        # with a TTL.
+        from app.services import sparse_encoder
+        bm25_stats = await sparse_encoder.load_stats()
+        n_docs = int(bm25_stats.get("total_docs") or 0)
+        avgdl = float(bm25_stats.get("avgdl") or 0.0)
+        sparse_params: dict[str, Any] = {
+            "k": float(bm25_stats.get("k1") or 1.5),
+            "b": float(bm25_stats.get("b") or 0.75),
+        }
+        sparse_metadata: dict[str, Any] | None = None
+        if n_docs > 0 and avgdl > 0 and query_sparse_indices:
+            df_map = await sparse_encoder.load_df_for_terms(query_sparse_indices)
+            # Coral's SparseMetadata.df is `Vec<String>` — one entry per
+            # query vector, each string is "term_id:df term_id:df ...".
+            df_str = " ".join(
+                f"{int(t)}:{int(df_map.get(int(t), 0))}"
+                for t in query_sparse_indices
+            )
+            sparse_metadata = {
+                "N": n_docs,
+                "avgdl": avgdl,
+                "df": [df_str],
+            }
+
         payload: dict[str, Any] = {
             "top_k": limit,
             "dense": {
@@ -387,14 +418,15 @@ class SeahorseDbStore:
             "sparse": {
                 "column": "sparse",
                 "vectors": [sparse_string or " "],
-                # BM25 parameters/metadata omitted on purpose — see
-                # the docstring; Coral picks defaults.
+                "parameters": sparse_params,
             },
             "fusion": {"type": "rrf", "parameters": {"k": 60}},
             "projection": (
                 "chunk_id, source_type, source_id, section_path, content"
             ),
         }
+        if sparse_metadata is not None:
+            payload["sparse"]["metadata"] = sparse_metadata
         if source_ids:
             # SQL WHERE clause — Coral parses this directly. Each
             # `source_id` is a UUID, so the IN list is safe to
@@ -522,6 +554,13 @@ class SeahorseDbStore:
                 {
                     "type": "inverted",
                     "column": "sparse",
+                    # Coral rejects hybrid-search with
+                    # `BM25 sparse scoring requires sparse_model=bm25 index`
+                    # when this is omitted, even though the index is
+                    # created either way. Pin to bm25 explicitly so the
+                    # search-time path can apply our (k, b, N, avgdl, df)
+                    # metadata.
+                    "params": {"sparse_model": "bm25"},
                 },
             ],
         }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.7.2"
+version = "0.7.3"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason


### PR DESCRIPTION
Two driver fixes + the honest 25-scenario e2e result.

## 1. `sparse_model: "bm25"` pinned on the INVERTED index

0.7.0/0.7.1/0.7.2 all emitted `{"type": "inverted", "column": "sparse"}` with no `params`. Coral creates the table either way but later refuses `hybrid-search` with:

```
HTTP 503
error_code 503101
message: "BM25 sparse scoring requires sparse_model=bm25 index"
```

**Every `seahorse-db` table created by 0.7.0-0.7.2 is unusable for hybrid_search** — no online migration; the driver has to drop and recreate on next startup. Practical blast radius is zero: no production cluster runs this driver.

## 2. BM25 metadata sent per `hybrid_search`

0.7.2 omitted `parameters` + `metadata` on the sparse leg, expecting Coral defaults. Worked for basic-shape e2e but produced empty/wrong-doc results on the English-keyword and Korean-keyword scenarios. 0.7.3 ships our corpus stats:

- `parameters.k` + `parameters.b` from `bm25_stats`
- `metadata.N` + `metadata.avgdl` from `bm25_stats`
- `metadata.df` — per-term document frequencies from `bm25_vocab`, one PG batch fetch per search (sub-ms)

## End-to-end against live Coral

SeahorseDB monorepo `SDDEV-244/monorepo-coral-sparse` branch, infra scenario kept up via `--no-cleanup`.

| Step | Result |
|---|---|
| Backend `vector_store_driver: seahorse-db` startup | ✓ `ensure_collection` 200 + JSON |
| Doc put → embed_worker → driver upsert | Chunks insert at Coral, `inserted_row_count: 1` |
| Search via `/api/v1/search` → driver hybrid-search | **2 real hits**, BM25 metadata in payload, all responses `content-type: application/json` |
| `bash backend/tests/test_hybrid_search_e2e.sh` | **21/25** (vs pgvector 25/25) |

## Four remaining e2e failures (all recall-side, not driver)

- `dense recall` — expected PostgreSQL doc, got empty
- `bm25-en` — expected GraphQL doc, got empty
- `bm25-ko` — expected Kubernetes doc, got `hybrid-a-… Guide`
- `isolation-B` — expected vault B doc, got empty

Two interacting upstream causes:

**(a) Coral 500 `error_code 500233`** on ~4-7% of `POST /data` under sustained single-row JSONL load. Reproduces from `embed_worker` (~10/sec serial); does NOT reproduce from direct curl (single / dup PK / 30-concurrent all 100% OK). Chunks that hit `retry_count >= 8` stay unindexed past the 180s `wait_for_indexing` budget. Filed upstream as [SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433) with standalone Python repro.

**(b) Kafka eventual consistency** — `POST /data` returns on Kafka-accept, not on segment-visible. `embed_worker` marks `vector_indexed_at` at the same point. 180s e2e budget assumed pgvector's "indexed = visible" semantics.

## Honest gaps still in `seahorse-db`

- The 4 e2e scenarios above
- BM25-only / dense-less path raises `VectorStoreUnavailable`
- Race-safety on `ensure_collection` ⚠
- `test_seahorse_db_e2e.sh` still an early-exit skip (next PR rewrites with content-type asserts + 0.7.3 wire formats)
- `embed_worker` retry policy for Coral 500 distinct from "vector store unavailable"

## Not deployed

prod + demo unchanged (pgvector). Tag is published; no rollout.

## Test plan

- [x] `bash scripts/check.sh` — green
- [x] `vector_store_driver: seahorse-db` startup, ensure_collection with new sparse_model:bm25 schema
- [x] One doc put → 2 hits round-trip with BM25 metadata
- [x] `bash backend/tests/test_hybrid_search_e2e.sh` — 21/25
- [ ] After merge: tag `backend-v0.7.3`, release. No prod/demo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)