### PR TITLE
fix(0.7.4): pgvector creates `vector` extension before registering the asyncpg codec (#117)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 1953
+        "line_number": 2004
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T07:29:44Z"
+  "generated_at": "2026-06-05T07:51:31Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,57 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.4 — 2026-06-05  *(patch — pgvector driver creates the `vector` extension before registering the asyncpg codec; fixes "unknown type: public.vector" on fresh self-hosted DBs, #117)*
+
+### Semantic search silently returned empty on a fresh self-hosted install
+
+A self-hosted reporter (#117) got zero semantic-search hits on a
+freshly stood-up stack. The backend log showed the embedding endpoint
+answering `200 OK` but every search degrading to empty:
+
+```
+WARNING akb.search: vector hybrid_search failed (unknown type: public.vector); returning empty
+```
+
+**Root cause — codec registered before the extension exists.** The
+`pgvector` driver registers pgvector's asyncpg binary codec
+(`register_vector` → `set_type_codec('vector', schema='public', …)`)
+*before* it runs `CREATE EXTENSION IF NOT EXISTS vector`. asyncpg can't
+build a codec for a type that isn't in the catalog yet, so it raises
+`ValueError: unknown type: public.vector`. That's a `ValueError`, not an
+`asyncpg.PostgresError`, so it slipped past `ensure_collection`'s except
+clause and resurfaced at every `hybrid_search`, where `search_service`
+catches it and returns empty.
+
+The trap is sharpest on the default `pgvector/pgvector` image: the
+extension is *available* but not *created* in a fresh app DB, and the
+one place that would create it (`_do_ensure`) ran *after* the codec
+registration that needed it — a chicken-and-egg that made the first
+`ensure_collection` fail on itself.
+
+Both codec-registration sites are now ordered after extension creation:
+
+- **Own pool** (separate `vector_store_dsn`): a new
+  `_bootstrap_extension()` runs `CREATE EXTENSION IF NOT EXISTS vector`
+  over a one-off connection *before* the pool — whose `init` callback
+  registers the codec — is built.
+- **Shared main pool** (blank DSN): inside `ensure_collection`, the
+  codec is registered *after* `_do_ensure` (whose first statement is
+  the `CREATE EXTENSION`), within the same transaction/connection that
+  already sees its own uncommitted DDL.
+
+Regression test `tests/test_pgvector_ext_bootstrap_e2e.py` exercises the
+real `PgvectorStore` against a throwaway DB with no `vector` extension
+in both pool modes: it failed with the exact `unknown type:
+public.vector` before this change and passes (extension installed +
+dense round-trip + `hybrid_search` returns the chunk) after. Like the
+other DB-backed e2e suites it's excluded from the no-DB CI unit job and
+runs locally / against a deployment.
+
+No schema or data migration. Operators who already worked around this
+by hand (`CREATE EXTENSION vector` + restart) are unaffected; the
+extension creation is idempotent.
+
 ## 0.7.3 — 2026-06-05  *(patch — `seahorse-db` BM25 metadata + `sparse_model=bm25` index param; AKB hybrid_search e2e 21/25 against live SeahorseDB)*
 
 ### `sparse_model: "bm25"` is required on the INVERTED index

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -134,6 +134,16 @@ class PgvectorStore:
                 )
             return await self._get_main_pool()
         if self._own_pool is None:
+            # Bootstrap the extension BEFORE building a pool whose `init`
+            # callback registers the pgvector codec. register_vector ->
+            # asyncpg.set_type_codec('vector', ...) can't build a codec
+            # for a type that doesn't exist yet and raises
+            # `ValueError: unknown type: public.vector` — which would
+            # abort pool creation on any DB where `CREATE EXTENSION
+            # vector` has never run (e.g. a fresh `pgvector/pgvector`
+            # DB: the extension is *available* but not *created*). See #117.
+            await self._bootstrap_extension(self._dsn)
+
             async def _init(conn):
                 # Register pgvector binary codec on every conn the
                 # pool hands out — list[float] in, list[float] out,
@@ -149,6 +159,19 @@ class PgvectorStore:
                 init=_init,
             )
         return self._own_pool
+
+    @staticmethod
+    async def _bootstrap_extension(dsn: str) -> None:
+        """`CREATE EXTENSION IF NOT EXISTS vector` over a one-off conn.
+
+        Used to guarantee the `vector` type exists before any code path
+        registers the pgvector codec (pool `init`). Idempotent; cheap.
+        """
+        conn = await asyncpg.connect(dsn)
+        try:
+            await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        finally:
+            await conn.close()
 
     async def _ensure_codec(self, conn) -> None:
         """Register the pgvector binary codec on `conn` once. Conns
@@ -221,7 +244,6 @@ class PgvectorStore:
             try:
                 pool = await self._pool()
                 async with pool.acquire() as c:
-                    await self._ensure_codec(c)
                     async with c.transaction():
                         # advisory_xact_lock auto-releases on tx end
                         # (commit OR rollback OR conn close), so a
@@ -230,7 +252,19 @@ class PgvectorStore:
                             "SELECT pg_advisory_xact_lock($1)",
                             _advisory_lock_key(self._schema),
                         )
+                        # _do_ensure's first statement is CREATE EXTENSION
+                        # IF NOT EXISTS vector. Register the pgvector codec
+                        # only AFTER it, so the `vector` type exists when
+                        # set_type_codec introspects — otherwise asyncpg
+                        # raises `ValueError: unknown type: public.vector`
+                        # on a fresh DB. This is the shared-main-pool path
+                        # (its conns carry no register_vector init
+                        # callback, unlike our own pool). See #117. The
+                        # same transaction/connection sees its own
+                        # uncommitted CREATE EXTENSION, so registering here
+                        # is safe.
                         await self._do_ensure(c)
+                        await self._ensure_codec(c)
             except asyncpg.PostgresError as e:
                 raise VectorStoreUnavailable(f"schema setup failed: {e}") from e
             self._ensured_collection = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.7.3"
+version = "0.7.4"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_pgvector_ext_bootstrap_e2e.py
+++ b/backend/tests/test_pgvector_ext_bootstrap_e2e.py
@@ -1,0 +1,219 @@
+"""Regression: PgvectorStore must bootstrap the `vector` extension on a
+DB that has never had it created.
+
+Issue #117: on a fresh self-hosted Postgres (the `pgvector/pgvector`
+image ships the extension *available* but not *created* in the app DB),
+`ensure_collection()` registered the pgvector binary codec
+(`register_vector` -> asyncpg `set_type_codec('vector', ...)`) *before*
+running `CREATE EXTENSION vector`. asyncpg can't build a codec for a
+type that doesn't exist yet, so it raised
+
+    ValueError: unknown type: public.vector
+
+That ValueError is not an `asyncpg.PostgresError`, so it escaped
+`ensure_collection`'s except clause and surfaced at every
+`hybrid_search` as `vector hybrid_search failed (unknown type:
+public.vector); returning empty` — i.e. semantic search silently
+returned nothing on every fresh install.
+
+These tests exercise the *real* PgvectorStore against a throwaway DB
+with no `vector` extension, in both pool modes:
+
+  - own pool   (separate `vector_store_dsn`): the codec is registered
+                in the pool `init` callback, so the extension must
+                exist before the pool is built.
+  - shared pool (blank DSN, reuse main pool): the codec is registered
+                inside `ensure_collection`, so the extension must be
+                created first there.
+
+Both must succeed and leave the extension installed; a dense
+round-trip then proves the codec actually took.
+
+DB comes from ``AKB_TEST_DSN`` (default
+``postgresql://akb:akb@localhost:15432/akb`` to match the dev override).  # pragma: allowlist secret
+The DB must have the pgvector extension *available* (e.g. the
+``pgvector/pgvector`` image). The module is skipped when no such
+Postgres is reachable, so a plain ``pytest`` run stays a no-op rather
+than a failure. Named ``*_e2e`` so the CI unit job
+(``pytest -k 'not _e2e'``) excludes it — like the other DB-backed e2e
+suites, it runs locally / against a deployment.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.services.vector_store.pgvector import PgvectorStore
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+def _swap_db(dsn: str, dbname: str) -> str:
+    """Return ``dsn`` with its database name replaced by ``dbname``."""
+    parts = urlsplit(dsn)
+    return urlunsplit(parts._replace(path=f"/{dbname}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+async def _vector_available(dsn: str) -> bool:
+    """True iff the server can install pgvector (so a missing-extension
+    test is meaningful — otherwise CREATE EXTENSION would fail for a
+    reason unrelated to the bug under test)."""
+    conn = await asyncpg.connect(dsn, timeout=2.0)
+    try:
+        row = await conn.fetchval(
+            "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'"
+        )
+        return row is not None
+    finally:
+        await conn.close()
+
+
+@pytest_asyncio.fixture
+async def fresh_db_dsn():
+    """Create a throwaway database with NO `vector` extension, yield its
+    DSN, and drop it on teardown."""
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    if not await _vector_available(_DSN):
+        pytest.skip("pgvector extension not available on this server")
+
+    admin = await asyncpg.connect(_DSN)
+    dbname = f"pgvec_ext_regr_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{dbname}"')
+    try:
+        # Sanity: the fresh DB must NOT have the extension yet, else the
+        # test proves nothing.
+        probe = await asyncpg.connect(_swap_db(_DSN, dbname))
+        try:
+            present = await probe.fetchval(
+                "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+            )
+        finally:
+            await probe.close()
+        assert present is None, "throwaway DB unexpectedly has the vector extension"
+
+        yield _swap_db(_DSN, dbname)
+    finally:
+        # FORCE terminates any leftover pool connections (PG13+).
+        await admin.execute(f'DROP DATABASE IF EXISTS "{dbname}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _extension_installed(dsn: str) -> bool:
+    conn = await asyncpg.connect(dsn)
+    try:
+        return (
+            await conn.fetchval(
+                "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+            )
+        ) is not None
+    finally:
+        await conn.close()
+
+
+async def _dense_roundtrip(pool) -> list[float]:
+    """Push a list[float] through the registered binary codec and read
+    it back. Fails loudly if the codec isn't registered."""
+    async with pool.acquire() as c:
+        val = await c.fetchval("SELECT $1::vector(4)", [0.25, 0.5, 0.75, 1.0])
+    return [float(x) for x in val]
+
+
+async def test_ensure_collection_bootstraps_extension_own_pool(fresh_db_dsn):
+    """Own-pool mode (separate vector_store_dsn): codec is registered in
+    the pool init callback, so the extension must be created before the
+    pool is built."""
+    store = PgvectorStore(
+        dsn=fresh_db_dsn,
+        schema="vector_index",
+        dense_dim=4,
+        sparse_shape="posting",
+        get_main_pool=None,
+    )
+
+    # The regression: this raised `ValueError: unknown type: public.vector`
+    # before the fix.
+    await store.ensure_collection()
+
+    assert await _extension_installed(fresh_db_dsn), (
+        "ensure_collection did not install the vector extension"
+    )
+
+    pool = await store._pool()
+    assert await _dense_roundtrip(pool) == pytest.approx([0.25, 0.5, 0.75, 1.0])
+
+    # Full round-trip through the public surface: the path that returned
+    # empty for the user must now return the chunk.
+    chunk_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    await store.upsert_one(
+        chunk_id=chunk_id,
+        content="symantec dlp cpu spike",
+        section_path=None,
+        chunk_index=0,
+        dense=[0.25, 0.5, 0.75, 1.0],
+        sparse_indices=[1, 2],
+        sparse_values=[1.0, 0.5],
+        source_type="document",
+        source_id=source_id,
+    )
+    hits = await store.hybrid_search(
+        query_text="cpu spike",
+        query_dense=[0.25, 0.5, 0.75, 1.0],
+        query_sparse_indices=[1, 2],
+        query_sparse_values=[1.0, 0.5],
+        source_ids=None,
+        limit=5,
+        prefetch_per_leg=10,
+    )
+    assert len(hits) >= 1, "hybrid_search returned empty after the fix"
+
+    if store._own_pool is not None:
+        await store._own_pool.close()
+
+
+async def test_ensure_collection_bootstraps_extension_shared_pool(fresh_db_dsn):
+    """Shared-pool mode (blank DSN): the driver reuses a main pool whose
+    connections have NO register_vector init callback, so the codec is
+    registered inside ensure_collection — the extension must be created
+    first there."""
+    main_pool = await asyncpg.create_pool(dsn=fresh_db_dsn, min_size=1, max_size=4)
+    try:
+        store = PgvectorStore(
+            dsn=None,
+            schema="vector_index",
+            dense_dim=4,
+            sparse_shape="posting",
+            get_main_pool=lambda: _ready(main_pool),
+        )
+        await store.ensure_collection()
+        assert await _extension_installed(fresh_db_dsn)
+        assert await _dense_roundtrip(main_pool) == pytest.approx(
+            [0.25, 0.5, 0.75, 1.0]
+        )
+    finally:
+        await main_pool.close()
+
+
+async def _ready(pool):
+    """get_main_pool is awaited by the driver; wrap the already-created
+    pool in a coroutine."""
+    return pool


### PR DESCRIPTION
Fixes #117.

## Symptom

A self-hosted reporter got **zero semantic-search hits** on a fresh stack. The backend log showed the embedding endpoint answering `200 OK` but every search degrading to empty:

```
WARNING akb.search: vector hybrid_search failed (unknown type: public.vector); returning empty
```

## Root cause — codec registered before the extension exists

The `pgvector` driver registers pgvector's asyncpg binary codec (`register_vector` → asyncpg `set_type_codec('vector', schema='public', …)`) **before** running `CREATE EXTENSION IF NOT EXISTS vector`. asyncpg can't build a codec for a type that isn't in the catalog yet, so it raises:

```
ValueError: unknown type: public.vector
```

That's a `ValueError`, **not** an `asyncpg.PostgresError`, so it slipped past `ensure_collection`'s `except asyncpg.PostgresError` clause and resurfaced at every `hybrid_search`, where `search_service` catches it and returns empty.

Sharpest on the default `pgvector/pgvector` image: the extension is *available* but not *created* in a fresh app DB, and the only code that would create it (`_do_ensure`) ran **after** the codec registration that needed it — the first `ensure_collection` fails on itself (chicken-and-egg).

## Fix

Order **both** codec-registration sites after extension creation:

- **Own pool** (separate `vector_store_dsn`): new `_bootstrap_extension()` runs `CREATE EXTENSION IF NOT EXISTS vector` over a one-off connection **before** building the pool whose `init` callback registers the codec.
- **Shared main pool** (blank DSN): register the codec **after** `_do_ensure` inside `ensure_collection`, within the same transaction/connection that already sees its own uncommitted `CREATE EXTENSION`.

## Verification

New regression test `backend/tests/test_pgvector_ext_bootstrap_e2e.py` drives the **real** `PgvectorStore` against a throwaway DB with no `vector` extension, in **both** pool modes.

| | before fix | after fix |
|---|---|---|
| own-pool `ensure_collection` | `ValueError: unknown type: public.vector` | ✅ extension installed + dense round-trip + `hybrid_search` returns the chunk |
| shared-pool `ensure_collection` | `ValueError: unknown type: public.vector` | ✅ |

Also: `mypy` ✅, `ruff` ✅, `bandit` (project config) ✅. The pre-existing DB-backed auth/concurrency unit failures reproduce on `main` too (they need a fully-initialised DB the bare container doesn't provide) — unrelated to this change.

Named `*_e2e` so the no-DB CI unit job (`pytest -k 'not _e2e'`) excludes it, like the other DB-backed suites — it runs locally / against a deployment.

## Notes

Idempotent; **no schema/data migration**. Operators who already worked around this by hand (`CREATE EXTENSION vector` + restart) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)