### PR TITLE
fix(all-in-one): make the bundled image buildable + bootable again (Python 3.14 + config drift)

### DIFF
--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -62,13 +62,23 @@ RUN curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio \
     curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc \
         -o /usr/local/bin/mc && chmod +x /usr/local/bin/mc
 
-# Backend deps in an isolated venv so PEP 668 doesn't bite us.
-RUN python3 -m venv /opt/venv && pip install --no-cache-dir --upgrade pip
+# Backend requires Python >=3.14 (backend/pyproject.toml). The pgvector
+# base image (debian bookworm) only ships system python 3.11 — kept
+# above for entrypoint.sh's stdlib scripting (token gen + config
+# rendering). uv provisions a standalone CPython 3.14 for the backend's
+# /opt/venv so `pip install akb` actually resolves; building against the
+# bookworm 3.11 fails with "requires a different Python: 3.11 not in
+# '>=3.14'" — the all-in-one was unbuildable from 0.6.5's 3.14 bump
+# until this.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+RUN uv venv --python 3.14 /opt/venv
 
 COPY backend/pyproject.toml /tmp/akb-backend/pyproject.toml
 COPY backend/app /tmp/akb-backend/app
 COPY backend/mcp_server /tmp/akb-backend/mcp_server
-RUN pip install --no-cache-dir /tmp/akb-backend && rm -rf /tmp/akb-backend
+RUN uv pip install --python /opt/venv/bin/python --no-cache /tmp/akb-backend \
+    && rm -rf /tmp/akb-backend
 
 # Backend source (used at runtime — venv only carries dependencies).
 COPY backend /app/backend

--- a/deploy/all-in-one/app.yaml
+++ b/deploy/all-in-one/app.yaml
@@ -41,7 +41,12 @@ jwt_expire_hours: 24
 # === Server ===
 host: 0.0.0.0
 port: 8000
-public_base_url: ""
+# Ingress origin for absolute publication share URLs. Required at
+# startup (lifecycle._validate_required_settings). Defaults to the
+# in-container nginx port; override at `docker run` with
+# `-e PUBLIC_BASE_URL=https://akb.example.com` when exposed behind a
+# real host (entrypoint.sh applies it).
+public_base_url: http://localhost:8080
 
 # === Vector store — pgvector reusing the in-container PG ===
 vector_store_driver: pgvector

--- a/deploy/all-in-one/entrypoint.sh
+++ b/deploy/all-in-one/entrypoint.sh
@@ -86,6 +86,10 @@ overrides = {
     "embed_dimensions": os.environ.get("EMBED_DIMENSIONS", ""),
     "llm_base_url":   os.environ.get("LLM_BASE_URL", ""),
     "llm_model":      os.environ.get("LLM_MODEL", ""),
+    # Origin for absolute publication share URLs. Defaults in app.yaml to
+    # http://localhost:8080; override when the container is exposed behind
+    # a real host so share_url links resolve.
+    "public_base_url": os.environ.get("PUBLIC_BASE_URL", ""),
 }
 for key, val in overrides.items():
     if not val:

--- a/deploy/all-in-one/secret.yaml.template
+++ b/deploy/all-in-one/secret.yaml.template
@@ -11,5 +11,4 @@ s3_access_key: "${S3_ACCESS_KEY}"
 s3_secret_key: "${S3_SECRET_KEY}"
 
 vector_api_key: ""
-seahorse_token: ""
 redis_password: ""


### PR DESCRIPTION
The all-in-one image (`dnseahorse/akb`) had silently rotted — last Docker Hub publish was **0.3.0**. Caught by actually building + booting it. Three breakages, all fixed here:

| # | Breakage | Fix |
|---|----------|-----|
| 1 | **Unbuildable** since 0.6.5's Python 3.11→3.14 bump — base `pgvector/pgvector:pg16` (bookworm) ships system python 3.11, so `pip install akb` dies with `requires a different Python: 3.11 not in '>=3.14'` | `uv` provisions a standalone CPython 3.14 for `/opt/venv`; base 3.11 kept for `entrypoint.sh` stdlib scripting |
| 2 | **Config drift** — `secret.yaml.template` still set `seahorse_token`, removed in 0.7.0's seahorse split; Settings is extra-forbid → pydantic `ValidationError` at startup | dropped the line (all-in-one uses pgvector, needs no seahorse token) |
| 3 | **Missing required setting** — `lifecycle._validate_required_settings` now demands `public_base_url`; app.yaml left it `""` → `Required configuration missing: AKB_PUBLIC_BASE_URL` | defaulted to `http://localhost:8080`; `PUBLIC_BASE_URL` env override wired through entrypoint |

## Verification (rebuilt `linux/amd64` image)

- ✅ all 5 services + seed `RUNNING` (`supervisorctl status`)
- ✅ `vector` extension + `vector_index` schema created
- ✅ `/readyz` 200, `/health` `status: ok`, `vector_store.reachable: true`
- ✅ real `PAT` → `POST /api/v1/documents` → `GET /api/v1/search` round-trip returns the doc via BM25 (no embed key needed); `backfill.upsert.indexed` advanced

Bundles backend **0.7.4** (includes the pgvector ext-bootstrap fix, #117 / #132).

No backend code change — `deploy/all-in-one/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)