### PR TITLE
docs(0.7.6): seahorse-db BM25-only fallback documented as structurally unsupported

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2063
+        "line_number": 2152
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T09:56:44Z"
+  "generated_at": "2026-06-05T10:24:05Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,95 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.6 — 2026-06-05  *(patch — `seahorse-db` BM25-only fallback documented as structurally unsupported)*
+
+### What
+
+0.7.3 left "BM25-only / dense-less path" in the gap list. After
+trying to wire it in 0.7.6 we hit a structural blocker:
+
+```bash
+$ curl -X POST $CORAL/v2/tables -d '{
+    "table_name": "...",
+    "columns": [
+        {"name": "embedding", "type": {"name": "DENSE_VECTOR", ...}, "nullable": true},
+        ...
+    ], ...
+}'
+HTTP 400
+error_code 400101
+"Invalid argument: Vector column 'embedding' must not be nullable"
+```
+
+`coral-models/src/api/schema.rs` says the field can carry
+`nullable: true`, but the field's own docstring warns "even if this
+is set to true for Vector type, the server may reject it at
+validation time" — and the live Coral does exactly that on every
+build we've tested. There's no honest way to insert a sparse-only
+row, and therefore no honest way to retrieve one.
+
+Three workarounds were considered and rejected:
+
+1. **Zero-vector for dense=None**. The HNSW index treats every
+   sparse-only row as equidistant from any dense query, so dense
+   recall silently degrades to "random sparse subset" and fusion
+   results become noise. Pretending the row had a vector when it
+   doesn't is dishonest under the AKB sparse_encoder contract.
+2. **`bm25_only` BOOL column + dense-leg filter**. Adds an always-on
+   `WHERE bm25_only = false` to every hybrid_search and a separate
+   sparse-only search path. Big driver change, but the catalog
+   constraint above means we'd still have to write a synthetic
+   embedding value — there's no "skip dense" Coral can express on
+   insert. Same dishonest-on-disk problem as (1), with more
+   moving parts.
+3. **A second sparse-only table alongside the hybrid one**. Doubles
+   the operational surface (two Coral tables, two segment streams,
+   two indexing-state checkpoints) for a feature parity the other
+   drivers expose for free. Not worth it.
+
+### Changes
+
+- `seahorse_db.py` module docstring now states BM25-only is
+  structurally unsupported, with a citation to the catalog 400 and
+  the schema.rs docstring.
+- `upsert_one(dense=None)` and `hybrid_search(query_dense=None)` both
+  raise `VectorStoreUnavailable` with the structural reason and the
+  "use pgvector or qdrant" recommendation in the message. Same
+  behavior as 0.7.3, just clearer about *why* it's permanent.
+- `config.py`'s `vector_store_driver` docstring carries a new
+  paragraph spelling out which drivers tolerate `embed_base_url`
+  being unset/unreachable (pgvector / qdrant) and which don't
+  (both seahorse drivers). Operators picking a driver now have
+  the embed-API-availability dimension in front of them.
+
+### What this means for operators
+
+- If `embed_base_url` is reliable in your environment (OpenRouter,
+  managed embed endpoint, OpenAI), `seahorse-db` is fine — every
+  AKB chunk has a real embedding and the driver behaves like the
+  others.
+- If `embed_base_url` may be empty (self-hosted, no model yet) OR
+  intermittent (degraded endpoint), `seahorse-db` will stall the
+  indexing queue on `dense=None` chunks until the endpoint
+  recovers. Use `pgvector` or `qdrant` if that's the failure mode
+  you need to absorb.
+
+### Not deployed
+
+prod + demo still pgvector. The 4 e2e fails 0.7.3 reported stay open
+— this release closes the BM25-only path as "won't fix in driver";
+the other three (Coral 500 #SeahorseDB/433, Kafka eventual
+consistency budget, retry policy) are still upstream-side.
+
+### Verification
+
+- `bash scripts/check.sh` — green.
+- Coral live-rejection of `nullable: true` on the vector column
+  confirmed by direct curl against `POST /v2/tables`. Documented
+  inline.
+
+---
+
 ## 0.7.5 — 2026-06-05  *(patch — `test_seahorse_db_e2e.sh` rewritten with content-type asserts + 0.7.3 wire formats; 13/13 against live Coral)*
 
 ### What

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,16 @@ class Settings(BaseModel):
     #     Reader(s) + Redis + Kafka + sparse-embedding yourself).
     # Pre-0.7.0 there was only one `seahorse` enum value that meant
     # cloud — config migration is `seahorse` → `seahorse-cloud`.
+    #
+    # BM25-only resilience: only `pgvector` (and the
+    # similarly-permissive `qdrant`) tolerate ``embed_base_url``
+    # being unset or unreachable — the embed_worker's BM25 fallback
+    # writes ``dense=NULL`` rows and ``hybrid_search`` serves them
+    # from the sparse leg alone. Both `seahorse-cloud` and
+    # `seahorse-db` reject the catalog migration that would allow a
+    # NULL embedding column, so on those drivers an embed-API
+    # outage stalls the indexing queue. Pick a driver that matches
+    # your embedding-availability assumptions.
     vector_store_driver: Literal[
         "qdrant", "pgvector", "seahorse-cloud", "seahorse-db"
     ] = "qdrant"

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -45,6 +45,20 @@ some AKB integration tests) need to poll Coral's
 visibility. ``embed_worker`` is fine — it marks `vector_indexed_at`
 on Kafka-accept, and the next search-time gap is the same gap any
 async indexing pipeline has.
+
+**BM25-only fallback is NOT supported by this driver.** pgvector
+ships ``dense IS NULL`` rows + a partial HNSW index when the
+embedding API is unavailable, so AKB's ``embed_base_url`` can be left
+unset and the BM25 leg still serves results. Coral rejects that path
+at the catalog level: ``POST /v2/tables`` with ``embedding`` column
+``nullable: true`` returns ``HTTP 400 error_code 400101 "Vector
+column 'embedding' must not be nullable"`` (see
+``coral-models/src/api/schema.rs`` — the field's own docstring warns
+"server may reject it at validation time even if nullable=true").
+Both ``upsert_one(dense=None)`` and ``hybrid_search(query_dense=None)``
+therefore raise ``VectorStoreUnavailable`` immediately. Operators
+who need BM25-only resilience should run pgvector or qdrant; an
+``embed_base_url`` outage will fail the upsert path here.
 """
 
 from __future__ import annotations
@@ -257,13 +271,21 @@ class SeahorseDbStore:
         if has_dense(dense):
             record["embedding"] = dense
         else:
-            # Schema requires embedding NOT NULL; we don't yet have a
-            # BM25-only path for seahorse-db. Surface explicitly so the
-            # worker's per-row failure path catches it instead of Coral
-            # rejecting the whole row with a less specific error.
+            # Coral's CreateTableRequest rejects ``nullable: true`` on
+            # vector columns at validation time (HTTP 400 error_code
+            # 400101 "Vector column 'embedding' must not be nullable",
+            # see module docstring). There's no honest way to upsert
+            # a sparse-only row into this schema, so we fail loud and
+            # let the worker's per-row failure path catch it instead
+            # of Coral's whole-batch rejection with a less specific
+            # error. Operators who need BM25-only resilience under an
+            # embed-API outage should run pgvector or qdrant.
             raise VectorStoreUnavailable(
-                "seahorse-db driver requires a dense embedding per row; "
-                "BM25-only fallback (dense=None) is not yet supported."
+                "seahorse-db requires a dense embedding per row "
+                "(Coral schema forbids NULL on vector columns). "
+                "BM25-only fallback is structurally unsupported by "
+                "this driver — use pgvector / qdrant if "
+                "embed_base_url may be unset or unreachable."
             )
 
         body = json.dumps(record, separators=(",", ":"))
@@ -362,13 +384,20 @@ class SeahorseDbStore:
         """
         # Dense-only and sparse-only modes both need a non-empty
         # ``vectors`` payload on the empty-side config or Coral
-        # returns 400. We could fall back to the single-leg vector
-        # search endpoints when one side is missing, but that's a
-        # bigger driver change — for now both legs must be present.
+        # returns 400. The single-leg vector-search endpoints
+        # (``/v2/tables/{name}/data/indexes/{index}/vector-search``)
+        # exist, but the corresponding upsert path is structurally
+        # blocked by Coral's NOT NULL on the embedding column (see
+        # module docstring), so we can't reach a state where this
+        # branch would be useful for AKB — the table can never
+        # contain a sparse-only row to retrieve. Failing loud here
+        # is consistent with `upsert_one`'s dense=None refusal.
         if not has_dense(query_dense):
             raise VectorStoreUnavailable(
-                "seahorse-db hybrid_search requires query_dense; "
-                "dense-less query path is not yet implemented."
+                "seahorse-db hybrid_search requires query_dense "
+                "(Coral schema forbids NULL on the embedding column, "
+                "so a sparse-only row can never exist to retrieve). "
+                "Use pgvector / qdrant for BM25-only search."
             )
 
         sparse_string = _encode_sparse_string(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.7.5"
+version = "0.7.6"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason


### PR DESCRIPTION
0.7.3 left "BM25-only / dense-less path" in the gap list. Wiring it in 0.7.6 hit a Coral catalog blocker that makes it structurally impossible to implement honestly.

## The blocker

```bash
$ curl -X POST $CORAL/v2/tables -d '{
    "table_name": "...",
    "columns": [
        {"name": "embedding", "type": {"name": "DENSE_VECTOR", ...}, "nullable": true},
        ...
    ], ...
}'
HTTP 400 error_code 400101
"Invalid argument: Vector column 'embedding' must not be nullable"
```

`coral-models/src/api/schema.rs` admits this in its own docstring: "even if this is set to true for Vector type, the server may reject it at validation time" — and the live Coral does exactly that.

No honest way to insert a sparse-only row → no honest way to retrieve one.

## Workarounds considered and rejected

| Idea | Why rejected |
|---|---|
| Zero-vector for `dense=None` | Dense recall silently degrades to random sparse subset; dishonest under the `sparse_encoder` contract. |
| `bm25_only` BOOL column + dense-leg filter | Still needs a synthetic embedding value on insert; same dishonest-on-disk problem with more moving parts. |
| Second sparse-only table alongside the hybrid one | Doubles operational surface (2 tables, 2 segment streams, 2 checkpoints) for parity the other drivers expose for free. |

## Changes

- `seahorse_db.py` module docstring states BM25-only is structurally unsupported, with citation to the catalog 400.
- `upsert_one(dense=None)` and `hybrid_search(query_dense=None)` both raise `VectorStoreUnavailable` with the structural reason and "use pgvector / qdrant" recommendation. Same behavior as 0.7.3, just clearer about **why** it's permanent.
- `config.py`'s `vector_store_driver` docstring spells out which drivers tolerate `embed_base_url` being unset/unreachable (pgvector / qdrant) and which don't (both seahorse drivers).

## For operators

| Embed availability | Recommended driver |
|---|---|
| Reliable (OpenRouter, managed endpoint, OpenAI) | `seahorse-db` works fine |
| Possibly unset (self-hosted no model yet) OR intermittent (degraded endpoint) | `pgvector` or `qdrant` — `seahorse-db` will stall the indexing queue on `dense=None` chunks |

## What this closes

Closes the BM25-only gap from 0.7.3 as "won't fix in driver". The three other gaps stay open:
- Coral 500 on sustained insert load — [SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433)
- Kafka eventual consistency vs. e2e visibility budget — upstream
- `embed_worker` retry policy for Coral 500 distinct from "vector store unavailable" — future driver work

prod + demo unchanged (pgvector).

## Test plan

- [x] `bash scripts/check.sh` — green
- [x] Coral live-rejection of `nullable: true` on vector column confirmed by direct curl
- [ ] After merge: tag `backend-v0.7.6`, release. No prod/demo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)