### PR TITLE
fix(0.7.7): seahorse-db two real driver bugs uncovered (signed i64 PK + raw-mode BM25 weights)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2152
+        "line_number": 2227
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T10:24:05Z"
+  "generated_at": "2026-06-05T13:56:56Z"
 }

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ outside.
 │                  Storage Layer                           │
 │   Git bare repos       │  PostgreSQL 16 (text + meta SoT)│
 │                        │  Vector store (driver):         │
-│                        │    pgvector  (default, same PG) │
-│                        │    qdrant    (optional)         │
-│                        │    seahorse  (managed, optional)│
+│                        │    pgvector       (default, PG) │
+│                        │    qdrant         (optional)    │
+│                        │    seahorse-cloud (managed)     │
+│                        │    seahorse-db    (self-hosted) │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -166,11 +167,14 @@ related_to: ["akb://eng/coll/meetings/doc/2026-05-01-payments.md"]
 ## Quick Start
 
 AKB ships as a **3-container stack** (PostgreSQL with pgvector + backend +
-frontend). You bring an OpenAI-compatible embedding endpoint (OpenAI,
-OpenRouter, self-hosted vLLM/TEI, etc.) — that's the only required external
-dependency for core CRUD and search. Prefer running a separate Qdrant
-cluster, or pointing at a managed Seahorse Cloud table? See *Vector store*
-below.
+frontend). For semantic (dense) search you bring an OpenAI-compatible
+embedding endpoint (OpenAI, OpenRouter, self-hosted vLLM/TEI, etc.). It is
+not strictly required: with no embed endpoint (or during an outage) the
+pgvector and Qdrant drivers **degrade to BM25-only** lexical search rather
+than returning nothing — dense is genuinely optional end-to-end (the
+`seahorse-db` driver is the exception; see *Vector store* below). Prefer
+running a separate Qdrant cluster, or pointing at Seahorse? See *Vector
+store* below.
 
 ```bash
 # 1. Configure
@@ -192,7 +196,7 @@ configuration** — no environment variables are read by the backend. Mount the
 ### Vector store (driver-pluggable)
 
 Hybrid search (dense + BM25 sparse, RRF-fused) runs through a driver
-interface. Three drivers ship; pick at config time:
+interface. Four drivers ship; pick at config time:
 
 - **`pgvector`** (default) — uses the same Postgres container that holds
   application data. The pgvector/pgvector image pre-installs the
@@ -202,14 +206,22 @@ interface. Three drivers ship; pick at config time:
 - **`qdrant`** — runs a separate Qdrant container; native RRF via the
   Query API. Useful when you already operate Qdrant or want to scale
   the vector store independently of Postgres.
-- **`seahorse`** — points at a managed [Seahorse Cloud][shc] table over
-  its TABLE_V2 + BFF API (Bearer auth, per-table host). No
-  infrastructure to run on your side; you provision a table in the
+- **`seahorse-cloud`** — points at a managed [Seahorse Cloud][shc] table
+  over its BFF management API + per-table data-plane host (Bearer auth).
+  No infrastructure to run on your side; you provision a table in the
   Seahorse console (or let the driver auto-create one) and AKB stores
   its chunks there. Native RRF, server-side BM25. See
   [`docs/vector-store-seahorse.md`](./docs/vector-store-seahorse.md)
   for the end-to-end setup walkthrough (sign-up → token → schema →
   config).
+- **`seahorse-db`** — points at a **self-hosted SeahorseDB** cluster via
+  its Coral coordinator HTTP API. You run Coral + Writer + Reader(s) +
+  Redis + Kafka + a sparse-embedding server yourself (the SeahorseDB
+  monorepo's `deploy/docker-compose.yml` brings up a minimal single-box
+  stack). Native dense+sparse hybrid. Unlike the other drivers it does
+  **not** support BM25-only fallback when the embed API is down (its
+  sparse path is server-side and structurally coupled to a live embed
+  step) — keep an embedding endpoint reachable for this driver.
 
 [shc]: https://console.seahorse.dnotitia.ai
 
@@ -226,18 +238,24 @@ $EDITOR config/app.yaml     # vector_store_driver: qdrant
 
 # Seahorse Cloud (managed; full guide in docs/vector-store-seahorse.md):
 docker compose up           # no extra container needed
-$EDITOR config/app.yaml     # vector_store_driver: seahorse
-                            # seahorse_tenant_uuid: <your tenant>
-                            # seahorse_table_name: <your table>
-$EDITOR config/secret.yaml  # seahorse_token: shsk_<...>
+$EDITOR config/app.yaml     # vector_store_driver: seahorse-cloud
+                            # seahorse_cloud_tenant_uuid: <your tenant>
+                            # seahorse_cloud_table_name: <your table>
+$EDITOR config/secret.yaml  # seahorse_cloud_token: shsk_<...>
+
+# SeahorseDB (self-hosted cluster reached via the Coral coordinator):
+docker compose up           # run the SeahorseDB stack separately
+$EDITOR config/app.yaml     # vector_store_driver: seahorse-db
+                            # seahorsedb_coordinator_url: http://localhost:3003
+                            # seahorsedb_table_name: akb_chunks
 ```
 
 Embedding model + dimensions are also fully pluggable via
 `embed_base_url` / `embed_model` / `embed_dimensions` — the codebase has
 no hard-coded model. For pgvector with HNSW, keep `embed_dimensions ≤ 2000`
 (or 4000 with `halfvec`); larger models fall back to exact scan.
-Qdrant/Seahorse have no such limit (Qdrant up to 65536, Seahorse up to
-its table-defined dim).
+Qdrant / Seahorse (cloud or db) have no such limit (Qdrant up to 65536,
+Seahorse up to its table-defined dim).
 
 ### LLM features (optional)
 
@@ -264,7 +282,7 @@ operator-private overlay under `deploy/k8s/internal/`.
 
 ```
 akb/
-├── backend/                  # Python 3.11 / FastAPI / asyncpg / GitPython
+├── backend/                  # Python 3.14 / FastAPI / asyncpg / GitPython
 │   ├── app/
 │   │   ├── api/routes/       # REST endpoints
 │   │   ├── services/         # Business logic + workers
@@ -287,11 +305,12 @@ akb/
 
 ## Tech Stack
 
-- **Backend**: Python 3.11, FastAPI, Uvicorn, asyncpg, GitPython, MCP SDK
+- **Backend**: Python 3.14, FastAPI, Uvicorn, asyncpg, GitPython, MCP SDK
 - **Database**: PostgreSQL 16 (main DB needs no extension; the same
   pgvector/pgvector image hosts the optional vector_index schema)
-- **Vector store**: driver-pluggable (pgvector default; Qdrant or
-  Seahorse Cloud optional — hybrid dense + BM25 sparse, RRF fusion)
+- **Vector store**: driver-pluggable (pgvector default; Qdrant,
+  Seahorse Cloud, or self-hosted SeahorseDB optional — hybrid dense +
+  BM25 sparse, RRF fusion; BM25-only fallback when embed is down)
 - **Event stream** (optional): PG `events` outbox + Redis Streams fanout
 - **Frontend**: React 19, TypeScript, Vite, Tailwind CSS v4, Radix UI
 - **Auth**: JWT + Personal Access Tokens (PATs)

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,81 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.7.7 — 2026-06-05  *(patch — `seahorse-db` two real bugs in our own driver, not Coral: unsigned i64 PK label + double-BM25 sparse weights)*
+
+The Coral `error_code 500233` we filed as [SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433) and the 4 retrieval-side failures from 0.7.3 (`dense`, `bm25-en`, `bm25-ko`, `isolation-B`) both turned out to be bugs in **this driver**, not in SeahorseDB. Reading Coral's source code with the actual log lines in hand isolated both in about an hour.
+
+### Real cause #1 — unsigned i64 PK label
+
+`_chunk_id_to_label` hashed the UUID's first 8 bytes as **unsigned**:
+
+```python
+return int.from_bytes(raw[:8], "big", signed=False)
+```
+
+Coral's JSONL ingest path parses INT64 columns through `arrow_json::Decoder`. Arrow's INT64 is signed; values > 2^63 - 1 fail the JSON-to-RecordBatch conversion with a generic `ComponentError::Arrow(_)` → HTTP 500 `error_code 500233 "Internal error"` (no row context, because the parser errors before the body is even traversed).
+
+Random UUIDs have a high bit set in their first 8 bytes about 50% of the time. The "sustained insert load 4-7% reject rate" we observed in 0.7.3 was a sampling artifact — the **actual** rejection rate for in-flight batches was much higher; the worker just retries each chunk up to 8 times before abandoning, so most rows eventually landed once retried with the bit unset, and only the worst-luck ~5% remained unindexed past the e2e budget.
+
+Direct check on the live PG vault that was reproducing the failure:
+
+```
+chunk_id                              label                  fits_in_i64
+7471f432-c50f-47e5-9bff-7b169c24e3ec   8390756079659599845   OK
+3e781cd3-49c4-4aa2-9973-f80492ba116c   4501379521358088866   OK
+565c66b6-959c-4779-b09c-2205fa5c185c   6222961719499310969   OK
+cf5c4205-7f7b-48ae-ab49-2fe10a5bd1f3   14941890255089518766  OVERFLOW
+eb486b7b-c81c-4ebd-b74a-17998e6daa03   16953918976618679997  OVERFLOW
+```
+
+40% overflow on a sample of 5 — perfectly consistent with the ~50% prior.
+
+**Fix**: `signed=True`. One character. The label space is still the full 64 bits; signedness has no effect on collision probability. The docstring now explains the constraint and points back to SeahorseDB#433 so the next reader doesn't reinvent the bug.
+
+**Reported back upstream**: SeahorseDB#433's "no row context on 500233" surface complaint is mostly cosmetic now — the error type was always Arrow, but the response body's `"Internal error"` makes it hard to find. Upstream may want to enrich the error context, but the driver-side fix removes the user-facing symptom entirely.
+
+### Real cause #2 — double-BM25 sparse weight encoding
+
+`sparse_encoder` ships AKB's BM25 in a **pre-baked dot-product form** specifically tuned for pgvector's posting table: doc weight = saturated TF, query weight = IDF, dot = BM25 score. Dropping that into Coral's inverted index — which **also** applies BM25 saturation + computes IDF from the metadata we pass at search time — produces:
+
+- Doc side: `BM25_saturate(saturated_TF)` → over-saturated TF, downstream relevance collapses for high-TF terms
+- Query side: `IDF × IDF = IDF²` → over-weights rare terms, under-weights medium-rare ones
+
+That's the 0.7.3 narrative's "4 retrieval failures unexplained by `vector_indexed_at` numbers" answered. The chunks were indexed; the rankings were just structurally wrong.
+
+`seahorse-index/src/sparse/scoring.rs:13-37` shows Coral's exact BM25 component formula. `seahorse-index/src/sparse/parser.rs:158-176` confirms doc-side weight is the raw `term_frequency` parameter, expecting raw TF. No vocab management on the SeahorseDB side — caller (us) owns vocab + emits `(term_id, raw_tf)` per doc and `(term_id, 1.0)` per query term with per-term `df` in the query metadata.
+
+**Fix**: `sparse_encoder` now branches on `settings.vector_store_driver`:
+
+- `pgvector`, `qdrant`, `seahorse-cloud` → unchanged pre-baked encoding (saturated TF + IDF). Their stores either don't compute BM25 (pgvector/qdrant) or don't care (cloud).
+- `seahorse-db` → new raw branch. Doc weight = raw TF, query weight = 1.0. Coral applies the BM25 math at search time from the (k, b, N, avgdl, df) we already ship.
+
+Module docstring carries the convention table. `_use_raw_weights()` is the single source of truth — adding a future driver means picking which of the two columns it lives in.
+
+### Reverses 0.7.6's "structurally unsupported" claim partially
+
+0.7.6 closed BM25-only fallback as structurally impossible because of Coral's NOT NULL on vector columns. That part stays — `dense=None` ingest is still rejected. But the four hybrid-search failures it was lumped in with were unrelated to the NULL constraint; they were the two driver bugs above. 0.7.6 narrative now reads as overclaim — we attributed driver bugs to the catalog. Not retracting 0.7.6 in a follow-up version because 0.7.6's NOT NULL finding is still accurate; just noting here that the "4 e2e fails are recall-side" reasoning in 0.7.3 was wrong about *why* and the "BM25-only is the cause" reasoning in 0.7.6 was wrong about *which fails*.
+
+### Verification
+
+- `_chunk_id_to_label`: confirmed `signed=True` makes the same UUIDs that previously generated overflow labels fit in i64; backend log under `seahorse-db` mode now reads 0 × 500 across all POST /data calls (was previously 100% on a fresh table).
+- `sparse_encoder._use_raw_weights()`: returns True only when `settings.vector_store_driver == "seahorse-db"`.
+- Fresh local validation: 1 vault, 1 Kubernetes doc with mixed Korean/English content, raw-mode ingest:
+  - `q=쿠버네티스` → Kubernetes Guide #1 (correct)
+  - `q=Korean tokenization` → hello.md #1 (correct)
+- 25-scenario `test_hybrid_search_e2e.sh` against the same Coral with both fixes active: **pending in background at release prep time; expected to clear the 4 prior failures.** Will append the result to this CHANGELOG entry on PR merge.
+
+### Files
+
+- `backend/app/services/vector_store/seahorse_db.py` — `_chunk_id_to_label` unsigned → signed, docstring expanded with the Arrow overflow explanation
+- `backend/app/services/sparse_encoder.py` — new `_use_raw_weights()` selector; `encode_document` and `encode_query` each branch on it; module docstring carries the convention table
+
+### prod / demo
+
+Unchanged. Both still pgvector and unaffected by the seahorse-db driver work in this release.
+
+---
+
 ## 0.7.6 — 2026-06-05  *(patch — `seahorse-db` BM25-only fallback documented as structurally unsupported)*
 
 ### What

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -11,6 +11,25 @@
 - Query encoding goes through the same tokenizer + vocab; OOV terms are
   dropped silently.
 
+Two doc/query weight conventions live behind the same public API,
+selected by ``settings.vector_store_driver``:
+
+  - **pre-baked** (pgvector, qdrant, seahorse-cloud): doc weight =
+    saturated TF, query weight = IDF. The dot product yields BM25
+    directly — the vector store doesn't need to know about BM25 at
+    all, and pgvector's posting table just sums products.
+  - **raw** (seahorse-db): doc weight = raw TF (token count), query
+    weight = 1.0. The vector store applies the BM25 formula itself
+    from (N, avgdl, df-per-query-term) metadata passed at search time.
+    Sending pre-baked weights here causes double-saturation on the
+    doc side AND double-IDF on the query side; the BM25 ranking
+    becomes proportional to IDF² × saturated_TF instead of
+    IDF × saturated_TF.
+
+Both encodings tokenize and look up term ids identically — only the
+weight definition differs. Adding a new driver means picking which of
+the two it is in ``_use_raw_weights()``.
+
 Kiwi is a hard dependency: if import or initialization fails the module
 raises on first use. Falling back to a different tokenizer would produce
 terms that don't match the vocab (indexed with Kiwi) and silently tank
@@ -356,10 +375,18 @@ def _idf(df: int, total_docs: int) -> float:
     return math.log(1.0 + (total_docs - df + 0.5) / (df + 0.5))
 
 
+def _use_raw_weights() -> bool:
+    """True when the active vector_store_driver computes BM25 internally
+    and expects raw TF on the doc side + weight=1.0 on the query side.
+    See module docstring for the convention table."""
+    return settings.vector_store_driver == "seahorse-db"
+
+
 async def encode_document(text: str) -> tuple[list[int], list[float]]:
-    """Encode a document chunk to a BM25 sparse vector (indices, values).
-    Appends new terms to the vocab as a side effect. For query-time use
-    `encode_query` which never touches the vocab.
+    """Encode a document chunk to a sparse (indices, values) tuple.
+
+    Weight convention depends on the active driver (see module
+    docstring). Both branches share tokenization + vocab insertion.
     """
     tokens = await tokenize(text)
     if not tokens:
@@ -367,6 +394,21 @@ async def encode_document(text: str) -> tuple[list[int], list[float]]:
 
     term_counts = Counter(tokens)
     vocab = await get_or_create_term_ids(term_counts.keys())
+
+    if _use_raw_weights():
+        # Raw TF. The downstream driver (seahorse-db) feeds these
+        # into Coral's inverted index as raw term frequencies; the
+        # BM25 saturation/normalization is applied by the index at
+        # search time using the (k, b, avgdl) parameters the driver
+        # passes in `hybrid_search`.
+        raw_indices: list[int] = []
+        raw_values: list[float] = []
+        for term, tf in term_counts.items():
+            tid = vocab.get(term)
+            if tid is not None:
+                raw_indices.append(tid)
+                raw_values.append(float(tf))
+        return raw_indices, raw_values
 
     stats = await load_stats()
     # total_docs is only needed for query-side IDF (see encode_query); doc
@@ -400,13 +442,11 @@ async def encode_document(text: str) -> tuple[list[int], list[float]]:
 
 
 async def encode_query(text: str) -> tuple[list[int], list[float]]:
-    """Encode a query to BM25 sparse vector. Uses IDF as term weight; OOV
-    terms are dropped. No new terms are registered.
+    """Encode a query to a sparse (indices, values) tuple. OOV terms
+    are dropped; no new terms are registered.
 
-    Common terms are kept — BM25 IDF already down-weights them. Over-
-    aggressive filtering caused false negatives on legitimate informative
-    words. The sparse-prefetch gate in VectorStore.hybrid_search handles
-    nonsense queries without hurting recall here.
+    Weight convention depends on the active driver (see module
+    docstring).
     """
     tokens = await tokenize(text)
     if not tokens:
@@ -416,22 +456,32 @@ async def encode_query(text: str) -> tuple[list[int], list[float]]:
     if not vocab:
         return [], []
 
+    if _use_raw_weights():
+        # Driver-side BM25: query weight = 1.0; the inverted index
+        # multiplies by IDF derived from the per-term-df metadata
+        # `hybrid_search` ships. OOV-but-in-vocab terms still pass
+        # through with weight 1.0 — the index will compute their IDF
+        # from the df we send.
+        indices = list(vocab.values())
+        values = [1.0] * len(indices)
+        return indices, values
+
     df_map = await load_df_for_terms(vocab.values())
     stats = await load_stats()
     total_docs = int(stats.get("total_docs") or 0)
     if total_docs <= 0:
         return list(vocab.values()), [1.0] * len(vocab)
 
-    indices: list[int] = []
-    values: list[float] = []
+    indices_idf: list[int] = []
+    values_idf: list[float] = []
     for term, tid in vocab.items():
         df = df_map.get(tid, 0)
         w = _idf(df, total_docs)
         if w <= 0:
             continue
-        indices.append(tid)
-        values.append(float(w))
-    return indices, values
+        indices_idf.append(tid)
+        values_idf.append(float(w))
+    return indices_idf, values_idf
 
 
 # ── Corpus stats recompute ────────────────────────────────────────

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -99,14 +99,26 @@ def _encode_sparse_string(
 
 
 def _chunk_id_to_label(chunk_id: str) -> int:
-    """UUID -> SeahorseDB u64 label.
+    """UUID -> SeahorseDB i64 label.
 
-    First 8 bytes of the UUID's binary form, interpreted big-endian.
-    Stable, dependency-free, no DB round-trip. Collisions are
-    birthday-paradox bounded — ~2^32 chunks per table before a 50%
-    chance of any pair colliding, far beyond any realistic vault."""
+    First 8 bytes of the UUID's binary form, interpreted big-endian as
+    **signed** i64. The signedness matters: Coral's JSONL ingest
+    parses INT64 columns through Arrow, which rejects unsigned values
+    > 2^63 - 1 with ``ComponentError::Arrow`` and surfaces as HTTP 500
+    ``error_code 500233 "Internal error"`` with no row context. About
+    half of all random UUIDs have a high bit set in their first 8
+    bytes, so an unsigned variant of this function reliably 500s on
+    roughly that fraction of inserts under sustained load — exactly the
+    pattern we filed as SeahorseDB#433. ``signed=True`` keeps the full
+    64-bit space addressable on the i64 side and removes that failure
+    mode.
+
+    Collisions are birthday-paradox bounded — ~2^32 chunks per table
+    before a 50% chance of any pair colliding, far beyond any realistic
+    vault. Signedness has no effect on collision probability.
+    """
     raw = uuid.UUID(chunk_id).bytes
-    return int.from_bytes(raw[:8], "big", signed=False)
+    return int.from_bytes(raw[:8], "big", signed=True)
 
 
 class SeahorseDbStore:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.7.6"
+version = "0.7.7"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason


### PR DESCRIPTION
The Coral `error_code 500233` we filed as [SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433) and the 4 retrieval-side failures from 0.7.3 (`dense`, `bm25-en`, `bm25-ko`, `isolation-B`) both turned out to be bugs in **this driver**, not in SeahorseDB. Reading Coral's source code with the actual log lines in hand isolated both.

## Bug #1 — `_chunk_id_to_label` was unsigned

```python
return int.from_bytes(uuid_bytes[:8], "big", signed=False)
```

Coral's JSONL ingest parses INT64 columns through `arrow_json::Decoder`. Arrow's INT64 is signed; values `> 2^63 - 1` fail the JSON-to-RecordBatch conversion with `ComponentError::Arrow(_)` → HTTP 500 `error_code 500233 "Internal error"` (no row context).

~50% of random UUIDs have a high bit set in their first 8 bytes. Live PG sample:

```
chunk_id                              label                  fits_in_i64
7471f432-c50f-47e5-9bff-7b169c24e3ec   8390756079659599845   OK
3e781cd3-49c4-4aa2-9973-f80492ba116c   4501379521358088866   OK
565c66b6-959c-4779-b09c-2205fa5c185c   6222961719499310969   OK
cf5c4205-7f7b-48ae-ab49-2fe10a5bd1f3   14941890255089518766  OVERFLOW
eb486b7b-c81c-4ebd-b74a-17998e6daa03   16953918976618679997  OVERFLOW
```

Under retry-with-backoff the worst-luck ~5% survived as abandoned; that's what 0.7.3 reported as the visible reject rate, but the per-request rate was actually ~50%.

**Fix**: `signed=True`. One character. Same label space, same collision probability.

## Bug #2 — Double-BM25 sparse weights

`sparse_encoder` ships AKB's BM25 in **pre-baked dot-product form** specifically tuned for pgvector: doc weight = saturated TF, query weight = IDF, dot = BM25 score. Coral's inverted index **also** applies BM25 saturation + computes IDF from per-query metadata, so the resulting score is `BM25_sat(saturated_TF) × IDF² × query_weight`, not BM25.

`seahorse-index/src/sparse/scoring.rs:13-37` shows Coral's actual formula. It expects raw TF on doc side and query weight = 1.0; saturation/IDF/normalization are applied at search time from `(k, b, N, avgdl, df)` we already ship.

**Fix**: `sparse_encoder` branches on `settings.vector_store_driver`. `pgvector` / `qdrant` / `seahorse-cloud` get the unchanged pre-baked encoding. `seahorse-db` gets a new raw branch (doc = raw TF, query = 1.0). `_use_raw_weights()` is the single source of truth — adding a future driver picks one column or the other.

## Verification

| | Before 0.7.7 | After 0.7.7 |
|---|---|---|
| POST /data on fresh table | 100% 500 reject | 0% reject |
| `q=쿠버네티스` | `<empty>` | kubernetes-guide.md #1 |
| `q=Korean tokenization` | `<empty>` | hello.md #1 |
| 25-scenario hybrid e2e | 21/25 | **pending — running in background at PR open** |

## What this reverses

0.7.6 closed BM25-only fallback as "structurally impossible" because Coral rejects `nullable: true` on vector columns. That part stays correct — `dense=None` ingest still raises `VectorStoreUnavailable`. But blaming the 0.7.3 four-fail recall on the NOT NULL constraint was wrong. The four fails were the two driver bugs above; the NOT NULL constraint is a separate concern.

## Upstream report

[SeahorseDB#433](https://github.com/dn-inc/SeahorseDB/issues/433) closing comment posted with the i64 overflow explanation. The remaining ask is response-body context enrichment — the Arrow error chain knows the field/row that choked, but the 500 response surfaces a bare `"Internal error"`. Not a blocker.

## Test plan

- [x] `bash scripts/check.sh` — green
- [x] `_chunk_id_to_label(uuid)` with `signed=True` produces values in `[-2^63, 2^63 - 1]`
- [x] Backend with `vector_store_driver: seahorse-db` on fresh `akb_raw_v2` table: 28/28 chunks insert with 0 × 500
- [x] Two Korean + English searches return the correct doc at rank 1
- [ ] 25-scenario `test_hybrid_search_e2e.sh` (running in background; will update on completion)
- [ ] After merge: tag `backend-v0.7.7`, release. No prod/demo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)