### PR TITLE
fix(0.8.3): pgvector — commit CREATE EXTENSION before codec registration on shared-main-pool path

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -39,3 +39,54 @@ jobs:
         # backend pod (test_indexable_e2e.py, test_rerank_e2e.py).
         # Shell e2e suites under tests/*.sh aren't picked up by pytest.
         run: pytest tests/ -k 'not _e2e' -v --tb=short
+
+  pgvector-e2e:
+    # DB-backed bootstrap tests that the unit job skips (`-k 'not
+    # _e2e'`). They need a real Postgres with pgvector *available but
+    # not created* — the fresh-DB scenario — so they self-skipped in CI
+    # and never ran. This job runs them, guarding the #117-class
+    # extension-bootstrap regressions.
+    #
+    # Caveat: these tests do NOT reproduce the 0.8.3 shared-main-pool
+    # `unknown type: public.vector` manifestation — it passes pre-fix in
+    # isolation even with a faithful backend-pool replica; the deployed
+    # trigger is a startup concurrency race a single-threaded test can't
+    # recreate (see backend/CHANGELOG.md 0.8.3). That case is covered by
+    # a deploy-time reset-cycle check, not here.
+    name: pgvector e2e (live DB)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: akb
+          POSTGRES_PASSWORD: akb  # pragma: allowlist secret
+          POSTGRES_DB: akb
+        ports:
+          - 15432:5432
+        options: >-
+          --health-cmd "pg_isready -U akb"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install backend (runtime + dev)
+        working-directory: backend
+        run: |
+          pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Run pgvector DB-backed e2e tests
+        working-directory: backend
+        env:
+          # Matches the fixture default + the dev compose override.
+          AKB_TEST_DSN: postgresql://akb:akb@localhost:15432/akb  # pragma: allowlist secret
+        run: pytest tests/test_pgvector_ext_bootstrap_e2e.py -v --tb=short

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2499
+        "line_number": 2519
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T10:25:32Z"
+  "generated_at": "2026-06-06T14:40:15Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,26 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.3 — 2026-06-06  *(patch — pgvector bootstrap: commit `CREATE EXTENSION` before codec registration on the shared-main-pool path)*
+
+Semantic search silently returned empty on a **fresh shared-PG deployment** (`vector_store_driver: pgvector` with a blank `vector_url`, i.e. the pgvector index lives in the main application DB). Every search logged `vector hybrid_search failed (unknown type: public.vector); returning empty` and the indexing worker could never drain — chunks stayed `vector_indexed_at IS NULL` forever.
+
+### Root cause
+
+`PgvectorStore.ensure_collection()` ran `CREATE EXTENSION IF NOT EXISTS vector` and then registered the pgvector binary codec (`register_vector` → asyncpg `set_type_codec('vector', …)`) **inside the same uncommitted transaction**. asyncpg's codec introspection cannot resolve a type created by an as-yet-uncommitted `CREATE EXTENSION`, so it raised `ValueError: unknown type: public.vector`. That `ValueError` is not an `asyncpg.PostgresError`, so it escaped `ensure_collection`'s except clause and surfaced at every `hybrid_search`.
+
+#117 (0.7.4) fixed this for the **separate-DSN** pool mode by bootstrapping the extension on its own committed connection in `_pool()` before building the codec-registering pool — but the **shared-main-pool** path (`dsn is None`) never gets that pre-commit, and #117 assumed the same-transaction create was visible to the codec. It is not. The bug only triggers on a DB where the extension has never been created, so existing installs (extension already present) never saw it; the first real exercise of the fresh-shared-pool path was a demo PVC-wipe reset.
+
+### Fix
+
+`ensure_collection()` now issues `CREATE EXTENSION IF NOT EXISTS vector` as a **committed (autocommit) statement before** opening the schema-build transaction, so the `vector` type is resolvable when the codec registers. Idempotent and a no-op once the extension exists; covers both pool modes.
+
+### Verification (and a caveat on the test)
+
+Validated against the actual failing environment — a full demo PVC-wipe **reset → seed → search** cycle on the deployed backend: after the fix the lifecycle logs `Vector store schema ensured (eager init)` (previously `eager init failed: unknown type: public.vector`), the `vector` extension is created with no manual step, and all chunks index (`vector_indexed_at` drains to 0) so search returns hits.
+
+Note this manifestation **does not reproduce in isolation**: running `test_pgvector_ext_bootstrap_e2e.py` against a fresh `pgvector/pgvector:pg16` DB — and even a faithful replica of the backend's pool lifecycle (`min_size=2`, `init.sql` warm-up, real queries, identical asyncpg/pgvector pins) — passes on the *pre-fix* code too. The deployed trigger is almost certainly the lifespan eager-init racing the embed workers to be the first `ensure_collection` caller, which a single-threaded test can't recreate. The pgvector e2e tests are now wired into CI (`pgvector-e2e` job in `backend-pytest.yml`) as general bootstrap hardening for the #117-class scenarios, but they are **not** a gate for this concurrency-specific manifestation — that is covered by the deploy-time reset-cycle check above.
+
 ## 0.8.2 — 2026-06-06  *(patch — bulk migration: `VectorStore.upsert_batch`, REST seahorse-db multi-line JSONL, resume + per-row fallback)*
 
 `scripts/migrate_pgvector_to_seahorsedb.py` was the bottleneck for any operator moving a real-sized vault from pgvector to a self-hosted Coral. 0.7.9's script issued one `upsert_one` per chunk — fine for the first 65 rows we tested with, painful at 350 k. This release routes the script through a new Protocol-level batch path and adds the operational surface every bulk migration actually needs: a checkpoint file so a connection drop doesn't restart from zero, and a per-row fallback so a single transient batch failure doesn't cost a few hundred chunks.

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -244,6 +244,25 @@ class PgvectorStore:
             try:
                 pool = await self._pool()
                 async with pool.acquire() as c:
+                    # CREATE EXTENSION must be COMMITTED before the codec is
+                    # registered. register_vector -> set_type_codec('vector')
+                    # introspects pg_catalog for the `vector` type; an
+                    # extension created inside the *same uncommitted*
+                    # transaction is NOT resolvable and asyncpg raises
+                    # `ValueError: unknown type: public.vector` on a fresh DB.
+                    #
+                    # The separate-DSN path bootstraps the extension on its
+                    # own committed connection in `_pool()` (see
+                    # `_bootstrap_extension`). The shared-main-pool path
+                    # (`vector_url=""`, dsn is None) skips that, so it must
+                    # commit the extension here — outside the transaction
+                    # block below — before _ensure_codec runs. #117 fixed the
+                    # separate-DSN case but assumed the same-tx create was
+                    # visible to the codec; it is not, so shared-PG self-host
+                    # deployments still broke on a fresh DB (e.g. after a
+                    # demo PVC-wipe reset). This autocommit statement is
+                    # idempotent and a no-op once the extension exists.
+                    await c.execute("CREATE EXTENSION IF NOT EXISTS vector")
                     async with c.transaction():
                         # advisory_xact_lock auto-releases on tx end
                         # (commit OR rollback OR conn close), so a
@@ -252,17 +271,10 @@ class PgvectorStore:
                             "SELECT pg_advisory_xact_lock($1)",
                             _advisory_lock_key(self._schema),
                         )
-                        # _do_ensure's first statement is CREATE EXTENSION
-                        # IF NOT EXISTS vector. Register the pgvector codec
-                        # only AFTER it, so the `vector` type exists when
-                        # set_type_codec introspects — otherwise asyncpg
-                        # raises `ValueError: unknown type: public.vector`
-                        # on a fresh DB. This is the shared-main-pool path
-                        # (its conns carry no register_vector init
-                        # callback, unlike our own pool). See #117. The
-                        # same transaction/connection sees its own
-                        # uncommitted CREATE EXTENSION, so registering here
-                        # is safe.
+                        # _do_ensure re-runs CREATE EXTENSION IF NOT EXISTS
+                        # (no-op now) then builds the schema/tables; the
+                        # codec registers cleanly because the type is
+                        # already committed above.
                         await self._do_ensure(c)
                         await self._ensure_codec(c)
             except asyncpg.PostgresError as e:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.2"
+version = "0.8.3"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason


### PR DESCRIPTION
## Problem

On a **fresh shared-PG deployment** (`vector_store_driver: pgvector` with a blank `vector_url` — the pgvector index lives in the main application DB), semantic search silently returned empty. Every query logged:

```
vector hybrid_search failed (unknown type: public.vector); returning empty
```

and the indexing worker never drained — chunks stayed `vector_indexed_at IS NULL` forever.

## Root cause

`PgvectorStore.ensure_collection()` ran `CREATE EXTENSION IF NOT EXISTS vector` and then registered the pgvector binary codec (`register_vector` → asyncpg `set_type_codec('vector', …)`) **inside the same uncommitted transaction**. asyncpg can't resolve a type created by an as-yet-uncommitted `CREATE EXTENSION`, so it raised `ValueError: unknown type: public.vector`. That `ValueError` is not an `asyncpg.PostgresError`, so it escaped `ensure_collection`'s except clause and surfaced at every `hybrid_search`.

#117 (0.7.4) fixed this for the **separate-DSN** pool mode by bootstrapping the extension on its own committed connection in `_pool()` before building the codec-registering pool — but the **shared-main-pool** path (`dsn is None`) never gets that pre-commit, and #117 assumed the same-transaction create was visible to the codec. It is not. The bug only triggers where the extension has never been created, so existing installs never saw it; the first real exercise of the fresh-shared-pool path was a demo PVC-wipe reset.

## Fix

`ensure_collection()` now issues `CREATE EXTENSION IF NOT EXISTS vector` as a **committed (autocommit) statement before** opening the schema-build transaction, so the `vector` type is resolvable when the codec registers. Idempotent, a no-op once the extension exists, and covers both pool modes.

## Verification — and an honest caveat

Validated against the **actual failing environment**: a full PVC-wipe **reset → seed → search** cycle on the deployed backend. After the fix the lifecycle logs `Vector store schema ensured (eager init)` (previously `eager init failed: unknown type: public.vector`), the extension is created with no manual step, all chunks index (`pending → 0`), and search returns hits.

This manifestation **does not reproduce in isolation**: `test_pgvector_ext_bootstrap_e2e.py` against a fresh `pgvector/pgvector:pg16` DB — and even a faithful replica of the backend's pool lifecycle (`min_size=2`, `init.sql` warm-up, real queries, identical asyncpg/pgvector pins) — passes on the *pre-fix* code too. The deployed trigger is almost certainly the lifespan eager-init racing the embed workers to be the first `ensure_collection` caller, which a single-threaded test can't recreate.

This PR also wires the previously-skipped pgvector bootstrap e2e tests into CI (`pgvector-e2e` job in `backend-pytest.yml`) as general hardening for the #117-class scenarios — but, per the above, they are **not** a gate for this concurrency-specific case. A true gate would be a concurrent cold-boot smoke of the shipped image (follow-up).

## Changes
- `backend/app/services/vector_store/pgvector.py` — commit `CREATE EXTENSION` before codec registration
- `backend/pyproject.toml` — 0.8.2 → 0.8.3
- `backend/CHANGELOG.md` — 0.8.3 entry
- `.github/workflows/backend-pytest.yml` — `pgvector-e2e` job (live pgvector service container) running the previously-skipped bootstrap tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)