### PR TITLE
docs(readme): add "Try it live" public demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ Any agent client that speaks **MCP (Streamable HTTP or stdio)**:
   [`akb-mcp`](https://www.npmjs.com/package/akb-mcp) stdio proxy
 - Custom agents — direct HTTP `POST /mcp/` with a Bearer token
 
+## Try it live
+
+A public demo runs at **[akb-demo.agent.seahorse.dnotitia.ai](https://akb-demo.agent.seahorse.dnotitia.ai)**.
+Browse and search a small fictional-organization knowledge base — product docs,
+a company handbook, agent session notes, and an engineering wiki, cross-linked
+by the URI graph — right in your browser, no signup. To wire it into your own
+agent, sign up with any email (a throwaway address is fine) and point the
+[`akb-mcp`](https://www.npmjs.com/package/akb-mcp) proxy at
+`https://akb-demo.agent.seahorse.dnotitia.ai/mcp/`.
+
+> ⚠️ **Throwaway demo.** It is public, wiped and re-seeded weekly, and runs on
+> minimal resources with **no uptime, privacy, or data guarantees**. Don't put
+> anything real or sensitive in it — treat every write as public and ephemeral.
+> For real use, [self-host](#quick-start) in three containers.
+
 ## Why AKB
 
 Most knowledge tools are built for humans clicking through a UI. Agents need a


### PR DESCRIPTION
Adds a **Try it live** section near the top of the README, linking the public demo at `akb-demo.agent.seahorse.dnotitia.ai`.

The demo is a small fictional-organization knowledge base (product / handbook / agent-notes / engineering, cross-linked by the URI graph) so search, the graph, and tables all have real content to chew on. Visitors can browse/search in the browser with no signup, or sign up with any throwaway email to connect their own agent via the `akb-mcp` proxy.

Includes a prominent disclaimer covering the three things a throwaway demo must say up front: it's **public**, **wiped weekly**, on **minimal resources**, with **no uptime/privacy/data guarantees** — don't store anything real.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)