### PR TITLE
chore(akb-mcp): 2.0.4 — add mcpName for MCP Registry ownership

### DIFF
--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.4 — MCP Registry: add `mcpName`
+
+No code change. Adds `"mcpName": "io.github.dnotitia/akb"` to
+`package.json`. The official MCP Registry verifies server ownership by
+matching this field on the published npm package against the registry
+entry's name — so the package must ship it before `akb-mcp` can be
+listed (and cascade to downstream directories). Behaviour is unchanged.
+
 ## 2.0.3 — make MIT licensing explicit
 
 No code change. The proxy has always declared `"license": "MIT"` in

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "akb-mcp",
-  "version": "2.0.3",
+  "version": "2.0.4",
+  "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {
     "akb-mcp": "./bin/akb-mcp.mjs"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dnotitia/akb",
     "source": "github"
   },
-  "version": "2.0.3",
+  "version": "2.0.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "akb-mcp",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
`mcp-publisher publish` rejected `akb-mcp@2.0.3`:

> NPM package 'akb-mcp' is missing required 'mcpName' field. Add this to your package.json: `"mcpName": "io.github.dnotitia/akb"`

The MCP Registry verifies server ownership by matching `mcpName` on the **published** npm package against the registry entry's name. So:

- `package.json`: add `"mcpName": "io.github.dnotitia/akb"`, bump 2.0.3 → 2.0.4
- `server.json`: sync version to 2.0.4
- CHANGELOG entry

No runtime/behavior change. **Next steps (after merge):** maintainer runs `npm publish` for 2.0.4 (manual gate), then `mcp-publisher publish` to list it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)