### PR TITLE
fix(agent-memory): user_id-keyed vaults + accept Claude Code SessionEnd reasons

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2519
+        "line_number": 2540
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5208,5 +5208,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T14:40:15Z"
+  "generated_at": "2026-06-06T18:06:58Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -16,7 +16,7 @@ The memory vault name is now keyed on the immutable `user_id` (a UUID, always a 
 
 - Works for any username, including all-CJK.
 - The name never drifts when a user later changes username / display_name / email. The human-readable identity moved to the vault **`description`** (`_memory_vault_description`), which is refreshed from the current profile on every `SessionStart`.
-- **Back-compat:** `ensure_memory_vault` / `_resolve_memory_vault` probe the pre-migration `agent-memory-{slug(username)}` name and **adopt** an existing vault rather than orphaning it — so vaults provisioned under the old scheme keep working with no data migration.
+- **Back-compat:** `ensure_memory_vault` / `_resolve_memory_vault` probe the pre-migration `agent-memory-{slug(username)}` name and **adopt** an existing vault rather than orphaning it — so vaults provisioned under the old scheme keep working with no data migration. Adoption is **owner-scoped** (`owner_id = user_id`): distinct usernames can slugify to the same legacy name, so the name alone is not proof of ownership — a legacy vault owned by someone else is ignored and the user gets their own canonical vault.
 
 ### 2. Claude Code SessionEnd `reason` values were all rejected
 `EndRequest.reason` only accepted the neutral cross-harness set (`completed`/`aborted`/`error`/`window_close`/`user_close`/`stop`), but Claude Code emits `clear`/`logout`/`prompt_input_exit`/`bypass_permissions_disabled`/`other`/`resume`. The plugin forwards the hook reason verbatim, so **every** `SessionEnd` returned `422` and no `recap.md` was ever written.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,27 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.4 — 2026-06-07  *(patch — agent-memory: user_id-keyed vaults + Claude Code SessionEnd reasons)*
+
+Two fixes to the agent-session lifecycle surface (`/api/v1/agent-sessions/*`) that together made the `akb-claude-code` lifecycle plugin unusable for a large class of users. Both were confirmed against a live deployment before the fix.
+
+### 1. Non-ASCII usernames could not provision a memory vault
+`sanitise_username()` NFKD-folds to ASCII and rejects an empty result, so an all-CJK username (e.g. `한병전`) raised `username cannot be safely slugified` and **every** `SessionStart` returned `422` — the user never got a memory vault at all.
+
+The memory vault name is now keyed on the immutable `user_id` (a UUID, always a valid slug) via `memory_vault_name(user_id)` instead of the mutable, possibly-non-ASCII username. Consequences:
+
+- Works for any username, including all-CJK.
+- The name never drifts when a user later changes username / display_name / email. The human-readable identity moved to the vault **`description`** (`_memory_vault_description`), which is refreshed from the current profile on every `SessionStart`.
+- **Back-compat:** `ensure_memory_vault` / `_resolve_memory_vault` probe the pre-migration `agent-memory-{slug(username)}` name and **adopt** an existing vault rather than orphaning it — so vaults provisioned under the old scheme keep working with no data migration.
+
+### 2. Claude Code SessionEnd `reason` values were all rejected
+`EndRequest.reason` only accepted the neutral cross-harness set (`completed`/`aborted`/`error`/`window_close`/`user_close`/`stop`), but Claude Code emits `clear`/`logout`/`prompt_input_exit`/`bypass_permissions_disabled`/`other`/`resume`. The plugin forwards the hook reason verbatim, so **every** `SessionEnd` returned `422` and no `recap.md` was ever written.
+
+`reason` now accepts the Claude Code values verbatim too — mirroring how `source` already accepts Claude Code's raw `SessionStart` values — so a plugin needs no client-side mapping table. Unknown reasons are still rejected (`422`).
+
+### Tests
+`backend/tests/test_agent_sessions_e2e.sh` gains coverage for both: Claude Code reasons accepted (§12) and CJK-username provisioning + user_id-keyed vault + description label (§13). Full suite: 37 passed.
+
 ## 0.8.3 — 2026-06-06  *(patch — pgvector bootstrap: commit `CREATE EXTENSION` before codec registration on the shared-main-pool path)*
 
 Semantic search silently returned empty on a **fresh shared-PG deployment** (`vector_store_driver: pgvector` with a blank `vector_url`, i.e. the pgvector index lives in the main application DB). Every search logged `vector hybrid_search failed (unknown type: public.vector); returning empty` and the indexing worker could never drain — chunks stayed `vector_indexed_at IS NULL` forever.

--- a/backend/app/api/routes/agent_sessions.py
+++ b/backend/app/api/routes/agent_sessions.py
@@ -36,6 +36,7 @@ from app.services.agent_memory_service import (
     AGENT_ID_MAX_LEN,
     DEFAULT_RECALL_LIMIT,
     EndBody,
+    ReasonLiteral,
     SESSION_ID_MAX_LEN,
     SnapshotBody,
     StartBody,
@@ -71,15 +72,11 @@ class StartRequest(BaseModel):
 
 
 class EndRequest(BaseModel):
-    reason: Literal[
-        # neutral / cross-harness canonical
-        "completed", "aborted", "error", "window_close", "user_close", "stop",
-        # Claude Code SessionEnd raw reasons — accepted verbatim so the
-        # plugin can forward the hook payload without a mapping table
-        # (mirrors how `source` accepts Claude Code's raw values).
-        "clear", "logout", "prompt_input_exit", "bypass_permissions_disabled",
-        "other", "resume",
-    ]
+    # Accepts each harness's raw SessionEnd reason verbatim (incl. Claude
+    # Code's clear/logout/prompt_input_exit/bypass_permissions_disabled/
+    # other/resume) so the plugin needs no client-side mapping. Single
+    # source of truth lives in the service as `ReasonLiteral`.
+    reason: ReasonLiteral
     summary: str = ""
     outcome: Literal["success", "partial", "abandoned"] = "success"
     touched_uris: list[str] | None = None

--- a/backend/app/api/routes/agent_sessions.py
+++ b/backend/app/api/routes/agent_sessions.py
@@ -72,8 +72,13 @@ class StartRequest(BaseModel):
 
 class EndRequest(BaseModel):
     reason: Literal[
-        "completed", "aborted", "error",
-        "window_close", "user_close", "stop",
+        # neutral / cross-harness canonical
+        "completed", "aborted", "error", "window_close", "user_close", "stop",
+        # Claude Code SessionEnd raw reasons — accepted verbatim so the
+        # plugin can forward the hook payload without a mapping table
+        # (mirrors how `source` accepts Claude Code's raw values).
+        "clear", "logout", "prompt_input_exit", "bypass_permissions_disabled",
+        "other", "resume",
     ]
     summary: str = ""
     outcome: Literal["success", "partial", "abandoned"] = "success"

--- a/backend/app/services/agent_memory_service.py
+++ b/backend/app/services/agent_memory_service.py
@@ -4,9 +4,12 @@ Replaces the legacy `memory_service` + `session_service` pair that was
 removed in v0.4.0. The new model layers cleanly on top of the existing
 vault / collection / document primitives:
 
-  - **One memory vault per user**, named ``agent-memory-{username}``,
-    auto-provisioned on first plugin call. Owned by the user, no other
-    grants — naturally owner-only.
+  - **One memory vault per user**, named ``agent-memory-{user_id}``
+    (keyed on the immutable UUID, not the username, so it works for
+    non-ASCII usernames and never drifts on rename), auto-provisioned on
+    first plugin call. The human-readable identity lives in the vault
+    ``description`` and is refreshed each SessionStart. Owned by the
+    user, no other grants — naturally owner-only.
   - **One collection per agent session**, at
     ``sessions/{YYYY-MM-DD}/{agent_id}/{session_id}``. The composite
     ``(agent_id, session_id)`` key avoids collisions when the same user
@@ -44,8 +47,11 @@ logger = logging.getLogger("akb.agent_memory")
 
 # ── Constants ────────────────────────────────────────────────
 
-#: Vault name template. ``{username_safe}`` is the sanitised username —
-#: see ``sanitise_username``.
+#: Vault name template. The slot holds the immutable ``user_id`` (UUID)
+#: for new vaults — see ``memory_vault_name``. The slot name is kept as
+#: ``{username_safe}`` for back-compat with ``legacy_memory_vault_name``,
+#: which still formats it with the sanitised username to locate and adopt
+#: pre-migration vaults.
 MEMORY_VAULT_TEMPLATE = "agent-memory-{username_safe}"
 
 #: Top-level collections inside a memory vault. Folders, not enforced
@@ -75,11 +81,20 @@ AGENT_ID_MAX_LEN = 40
 #: causes. Recorded for analytics; behaviour is identical (idempotent).
 SOURCE_VALUES = ("startup", "resume", "clear", "compact", "first_use")
 
-#: SessionEnd `reason` enum — Cursor sessionEnd's reason verbatim, plus
-#: ``stop`` to cover Claude Code's Stop hook semantics.
+#: SessionEnd `reason` enum. Accepts each harness's raw reason verbatim
+#: — mirroring how ``SOURCE_VALUES`` accepts Claude Code's raw `source`
+#: strings — so a plugin can forward the hook payload unmodified without
+#: a client-side mapping table (the original cause of the 422-on-every-
+#: SessionEnd bug). The first row is the neutral / cross-harness set;
+#: the second row is Claude Code's SessionEnd `reason` values (see the
+#: Claude Code hooks reference). Recorded as a tag for analytics; the
+#: behavioural branch is `outcome`, not `reason`.
 REASON_VALUES = (
-    "completed", "aborted", "error",
-    "window_close", "user_close", "stop",
+    # neutral / cross-harness canonical
+    "completed", "aborted", "error", "window_close", "user_close", "stop",
+    # Claude Code SessionEnd raw reasons
+    "clear", "logout", "prompt_input_exit", "bypass_permissions_disabled",
+    "other", "resume",
 )
 
 #: SessionEnd `outcome` enum — agent-level summary of whether the
@@ -208,8 +223,53 @@ def session_collection_path(date_str: str, agent_id_safe: str, session_id_safe: 
     return f"sessions/{date_str}/{agent_id_safe}/{session_id_safe}"
 
 
-def memory_vault_name(username: str) -> str:
-    return MEMORY_VAULT_TEMPLATE.format(username_safe=sanitise_username(username))
+_UUID_SAFE_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def memory_vault_name(user_id: str) -> str:
+    """Canonical memory-vault name, derived from the immutable ``user_id``.
+
+    A UUID is pure ASCII (``[0-9a-f-]``) so it is *always* a valid vault
+    slug — unlike ``username``, which may be all-CJK (e.g. ``한병전``) and
+    slugify to the empty string, which used to crash provisioning. Keying
+    on ``user_id`` also means the vault name never drifts when a user
+    later changes their username, display_name, or email — those are
+    surfaced through the vault *description* instead (see
+    ``_memory_vault_description``), refreshed on every SessionStart.
+    """
+    if not user_id:
+        raise ValidationError("user_id is required to derive a memory vault name")
+    uid = _UUID_SAFE_RE.sub("", str(user_id).strip().lower())
+    if not uid:
+        raise ValidationError(f"user_id is not vault-name-safe: {user_id!r}")
+    return MEMORY_VAULT_TEMPLATE.format(username_safe=uid)
+
+
+def legacy_memory_vault_name(username: str) -> str | None:
+    """Pre-migration vault name (``agent-memory-{slug(username)}``).
+
+    Returns ``None`` when the username does not slugify (the exact case
+    the user_id-based scheme exists to fix), so callers can probe for an
+    older username-keyed vault and adopt it instead of orphaning it.
+    """
+    try:
+        return MEMORY_VAULT_TEMPLATE.format(username_safe=sanitise_username(username))
+    except ValidationError:
+        return None
+
+
+def _memory_vault_description(
+    username: str, display_name: str | None, email: str | None,
+) -> str:
+    """Human-readable label for the memory vault, kept in the mutable
+    ``description`` so the immutable ``user_id``-keyed name stays stable
+    while the displayed identity tracks the user's current profile."""
+    who = (display_name or "").strip() or username
+    contact = f" <{email}>" if email else ""
+    return (
+        f"Agent dedicated memory for {who}{contact} (login: {username}). "
+        "Auto-provisioned by the AKB lifecycle plugin. Owner-only — no shared access."
+    )
 
 
 # ── Service ──────────────────────────────────────────────────
@@ -230,26 +290,48 @@ class AgentMemoryService:
     async def ensure_memory_vault(self, user_id: str, username: str) -> dict:
         """Return the user's memory vault, creating it if missing.
 
-        Idempotent — repeated calls return the existing vault. The
-        caller is the owner; no grants are added, so the vault is
-        owner-only by default (mirrors AKB's RBAC convention for
-        private vaults).
+        The vault name is keyed on the immutable ``user_id``
+        (``memory_vault_name``) so provisioning works for non-ASCII
+        usernames and never drifts when the user later renames. For
+        back-compat we probe the pre-migration
+        ``agent-memory-{slug(username)}`` name and *adopt* it when the
+        user_id-keyed vault does not exist yet — so existing memory
+        vaults are not orphaned by this change.
+
+        Idempotent — repeated calls return the existing vault and refresh
+        its human-readable ``description`` from the caller's current
+        profile (display_name / email). The caller is the owner; no
+        grants are added, so the vault is owner-only by default.
         """
-        name = memory_vault_name(username)
+        canonical = memory_vault_name(user_id)
+        legacy = legacy_memory_vault_name(username)
         pool = await get_pool()
         async with pool.acquire() as conn:
-            row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", name)
+            prof = await conn.fetchrow(
+                "SELECT username, display_name, email FROM users WHERE id = $1",
+                uuid.UUID(str(user_id)),
+            )
+            name = canonical
+            row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", canonical)
+            if not row and legacy and legacy != canonical:
+                row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", legacy)
+                if row:
+                    name = legacy  # adopt the pre-migration username-keyed vault
+
+        description = _memory_vault_description(
+            prof["username"] if prof else username,
+            prof["display_name"] if prof else None,
+            prof["email"] if prof else None,
+        )
+
         if row:
+            await self._refresh_vault_description(name, description)
             return {"name": name, "vault_id": str(row["id"]), "created": False}
 
         try:
             vault_id = await self.doc_service.create_vault(
-                name=name,
-                description=(
-                    f"Agent dedicated memory for {username}. "
-                    "Auto-provisioned by the AKB lifecycle plugin. "
-                    "Owner-only — no shared access."
-                ),
+                name=canonical,
+                description=description,
                 owner_id=user_id,
                 public_access="none",
             )
@@ -257,16 +339,52 @@ class AgentMemoryService:
             # Race: another concurrent start_session call provisioned
             # it between the SELECT and the create call. Re-read.
             async with pool.acquire() as conn:
-                row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", name)
+                row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", canonical)
             if not row:
                 raise
-            return {"name": name, "vault_id": str(row["id"]), "created": False}
+            return {"name": canonical, "vault_id": str(row["id"]), "created": False}
 
         logger.info(
             "Auto-provisioned memory vault %s for user %s (%s)",
-            name, username, user_id[:8],
+            canonical, username, str(user_id)[:8],
         )
-        return {"name": name, "vault_id": str(vault_id), "created": True}
+        return {"name": canonical, "vault_id": str(vault_id), "created": True}
+
+    async def _refresh_vault_description(self, vault_name: str, description: str) -> None:
+        """Best-effort sync of the vault's human-readable label. Never
+        fatal — a failed refresh must not block session start."""
+        try:
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE vaults SET description = $1, updated_at = NOW() "
+                    "WHERE name = $2 AND description IS DISTINCT FROM $1",
+                    description, vault_name,
+                )
+        except Exception:  # noqa: BLE001 — label sync is non-critical
+            logger.warning(
+                "memory vault description refresh failed for %s", vault_name,
+                exc_info=True,
+            )
+
+    async def _resolve_memory_vault(self, user_id: str, username: str) -> str:
+        """Resolve the existing memory-vault name for read/write paths:
+        the user_id-keyed name if present, else an adopted legacy
+        username-keyed vault, else the user_id-keyed name (the
+        not-yet-created default)."""
+        canonical = memory_vault_name(user_id)
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            if await conn.fetchval("SELECT 1 FROM vaults WHERE name = $1", canonical):
+                return canonical
+            legacy = legacy_memory_vault_name(username)
+            if (
+                legacy
+                and legacy != canonical
+                and await conn.fetchval("SELECT 1 FROM vaults WHERE name = $1", legacy)
+            ):
+                return legacy
+        return canonical
 
     # ── Session lifecycle ──────────────────────────────────
 
@@ -362,7 +480,7 @@ class AgentMemoryService:
             )
 
         sid_safe = sanitise_session_id(session_id)
-        memory_vault = memory_vault_name(username)
+        memory_vault = await self._resolve_memory_vault(user_id, username)
         existing = await self._find_session_collection_by_sid(memory_vault, sid_safe)
         if not existing:
             raise NotFoundError("agent session", session_id)
@@ -425,7 +543,7 @@ class AgentMemoryService:
         need for a collection-update API that AKB does not yet expose.
         """
         sid_safe = sanitise_session_id(session_id)
-        memory_vault = memory_vault_name(username)
+        memory_vault = await self._resolve_memory_vault(user_id, username)
         existing = await self._find_session_collection_by_sid(memory_vault, sid_safe)
         if not existing:
             raise NotFoundError("agent session", session_id)
@@ -482,7 +600,7 @@ class AgentMemoryService:
         plugins consume the top-N and never paginate further.
         """
         sanitise_session_id(session_id)  # validate shape (raises on bad id); result unused here
-        memory_vault = memory_vault_name(username)
+        memory_vault = await self._resolve_memory_vault(user_id, username)
 
         if not scopes:
             scopes = ["preferences", "learnings"]
@@ -506,7 +624,7 @@ class AgentMemoryService:
         session_id: str,
     ) -> dict:
         sid_safe = sanitise_session_id(session_id)
-        memory_vault = memory_vault_name(username)
+        memory_vault = await self._resolve_memory_vault(user_id, username)
         existing = await self._find_session_collection_by_sid(memory_vault, sid_safe)
         if not existing:
             raise NotFoundError("agent session", session_id)
@@ -530,7 +648,7 @@ class AgentMemoryService:
         limit: int,
         offset: int,
     ) -> dict:
-        memory_vault = memory_vault_name(username)
+        memory_vault = await self._resolve_memory_vault(user_id, username)
         pool = await get_pool()
         clauses = ["v.name = $1", "c.path LIKE 'sessions/%'"]
         args: list = [memory_vault]

--- a/backend/app/services/agent_memory_service.py
+++ b/backend/app/services/agent_memory_service.py
@@ -37,6 +37,7 @@ import unicodedata
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Literal, get_args
 
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError
@@ -89,13 +90,17 @@ SOURCE_VALUES = ("startup", "resume", "clear", "compact", "first_use")
 #: the second row is Claude Code's SessionEnd `reason` values (see the
 #: Claude Code hooks reference). Recorded as a tag for analytics; the
 #: behavioural branch is `outcome`, not `reason`.
-REASON_VALUES = (
+#: Single source of truth for the accepted reasons. The REST route
+#: imports ``ReasonLiteral`` for its Pydantic field so the HTTP-layer
+#: enum and this service-layer guard can never drift apart.
+ReasonLiteral = Literal[
     # neutral / cross-harness canonical
     "completed", "aborted", "error", "window_close", "user_close", "stop",
     # Claude Code SessionEnd raw reasons
     "clear", "logout", "prompt_input_exit", "bypass_permissions_disabled",
     "other", "resume",
-)
+]
+REASON_VALUES = get_args(ReasonLiteral)
 
 #: SessionEnd `outcome` enum — agent-level summary of whether the
 #: session achieved its goal. Independent of `reason` (a session can
@@ -305,16 +310,26 @@ class AgentMemoryService:
         """
         canonical = memory_vault_name(user_id)
         legacy = legacy_memory_vault_name(username)
+        uid = uuid.UUID(str(user_id))
         pool = await get_pool()
         async with pool.acquire() as conn:
             prof = await conn.fetchrow(
                 "SELECT username, display_name, email FROM users WHERE id = $1",
-                uuid.UUID(str(user_id)),
+                uid,
             )
             name = canonical
             row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", canonical)
             if not row and legacy and legacy != canonical:
-                row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", legacy)
+                # Adopt a pre-migration vault only if THIS user owns it —
+                # distinct usernames can slugify to the same legacy name
+                # (e.g. case-folding or NFKD-stripping collisions), so the
+                # name alone is not proof of ownership. A legacy vault
+                # owned by someone else falls through to creating this
+                # user's own canonical vault.
+                row = await conn.fetchrow(
+                    "SELECT id FROM vaults WHERE name = $1 AND owner_id = $2",
+                    legacy, uid,
+                )
                 if row:
                     name = legacy  # adopt the pre-migration username-keyed vault
 
@@ -378,10 +393,16 @@ class AgentMemoryService:
             if await conn.fetchval("SELECT 1 FROM vaults WHERE name = $1", canonical):
                 return canonical
             legacy = legacy_memory_vault_name(username)
+            # Owner-scoped, same as ensure_memory_vault's adoption: never
+            # resolve to a legacy vault this user does not own (usernames
+            # can slugify to a shared legacy name).
             if (
                 legacy
                 and legacy != canonical
-                and await conn.fetchval("SELECT 1 FROM vaults WHERE name = $1", legacy)
+                and await conn.fetchval(
+                    "SELECT 1 FROM vaults WHERE name = $1 AND owner_id = $2",
+                    legacy, uuid.UUID(str(user_id)),
+                )
             ):
                 return legacy
         return canonical

--- a/backend/mcp_server/instructions.py
+++ b/backend/mcp_server/instructions.py
@@ -21,5 +21,5 @@ When writing into a vault:
 6. Reference resources by the akb:// URIs returned by tool calls — do not reassemble paths yourself.
 7. For other surfaces (akb_publish, akb_todo, akb_activity, akb_history), call akb_help() for an overview.
 
-Agent memory is handled outside the MCP tool-use loop — the AKB lifecycle plugin (akb-claude-code, akb-cursor, ...) drives /api/v1/agent-sessions REST endpoints automatically. As an agent, your own memory vault (named agent-memory-{your-username}) is accessible via the normal akb_search / akb_browse / akb_get tools just like any other vault.
+Agent memory is handled outside the MCP tool-use loop — the AKB lifecycle plugin (akb-claude-code, akb-cursor, ...) drives /api/v1/agent-sessions REST endpoints automatically. As an agent, your own memory vault (named agent-memory-{your-user-id}, with your display name in its description) is accessible via the normal akb_search / akb_browse / akb_get tools just like any other vault — find it with akb_list_vaults rather than reconstructing the name.
 """

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.3"
+version = "0.8.4"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_agent_sessions_e2e.sh
+++ b/backend/tests/test_agent_sessions_e2e.sh
@@ -329,6 +329,49 @@ echo "$R" | grep -q "한글유저" \
   && pass "CJK vault description carries display name" \
   || fail "CJK description" "label missing: ${R:0:200}"
 
+# ── 14. Legacy adoption is owner-scoped (no cross-user hijack) ──
+# Two usernames that slugify to the SAME legacy name (case-fold
+# collision). User A owns a pre-migration vault under that slug; user B
+# must NOT adopt it — B falls through to its own user_id-keyed vault.
+echo ""
+echo "▸ 14. Legacy adoption refuses a vault owned by another user"
+
+SLUG="collide-${TS}"
+LEGACY_NAME="agent-memory-${SLUG}"
+A_USER="Collide-${TS}"   # slug → collide-${TS}
+B_USER="COLLIDE-${TS}"   # slug → collide-${TS}  (same)
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H "$H_JSON" \
+  -d "{\"username\":\"$A_USER\",\"email\":\"a-${TS}@t.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+A_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H "$H_JSON" \
+  -d "{\"username\":\"$A_USER\",\"password\":\"test1234\"}" | py 'import sys,json;print(json.load(sys.stdin)["token"])')
+# A provisions the pre-migration (username-keyed) vault it owns.
+ACODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/vaults?name=${LEGACY_NAME}&description=premig-A" \
+  -H "Authorization: Bearer $A_JWT")
+[ "$ACODE" = "200" ] && pass "user A owns legacy vault $LEGACY_NAME" \
+  || fail "A legacy vault" "create got $ACODE"
+# Positive back-compat: A adopts its OWN pre-migration vault (not orphaned).
+A_MV=$(curl -sk -X POST "$BASE_URL/api/v1/agent-sessions/collide-a-${TS}" \
+  -H "Authorization: Bearer $A_JWT" -H "$H_JSON" \
+  -d '{"agent_id":"claude-code","source":"startup"}' | jq_field "['memory_vault']")
+[ "$A_MV" = "$LEGACY_NAME" ] && pass "user A adopts its own legacy vault" \
+  || fail "A adoption" "A resolved to $A_MV (expected $LEGACY_NAME)"
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H "$H_JSON" \
+  -d "{\"username\":\"$B_USER\",\"email\":\"b-${TS}@t.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+B_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H "$H_JSON" \
+  -d "{\"username\":\"$B_USER\",\"password\":\"test1234\"}" | py 'import sys,json;print(json.load(sys.stdin)["token"])')
+B_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $B_JWT" -H "$H_JSON" \
+  -d '{"name":"collide-b"}' | py 'import sys,json;print(json.load(sys.stdin)["token"])')
+
+B_MV=$(curl -sk -X POST "$BASE_URL/api/v1/agent-sessions/collide-b-${TS}" \
+  -H "Authorization: Bearer $B_PAT" -H "$H_JSON" \
+  -d '{"agent_id":"claude-code","source":"startup"}' | jq_field "['memory_vault']")
+[ "$B_MV" != "$LEGACY_NAME" ] && echo "$B_MV" | grep -Eq '^agent-memory-[0-9a-f-]{36}$' \
+  && pass "user B got its own user_id vault, not A's legacy ($B_MV)" \
+  || fail "owner-scoped adoption" "B resolved to $B_MV (expected its own uuid vault, not $LEGACY_NAME)"
+
 # ── Summary ────────────────────────────────────────────────
 echo ""
 echo "════════════════════════════════════════════════"

--- a/backend/tests/test_agent_sessions_e2e.sh
+++ b/backend/tests/test_agent_sessions_e2e.sh
@@ -275,6 +275,60 @@ CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
 [ "$CODE" = "401" ] || [ "$CODE" = "403" ] \
   && pass "no auth → $CODE" || fail "no auth" "got $CODE"
 
+# ── 12. Claude Code SessionEnd reasons accepted verbatim ───
+# Regression: every Claude Code SessionEnd `reason` used to 422 (the
+# enum only had the neutral cross-harness values), so the recap was
+# never written. The plugin forwards the hook reason unmodified.
+echo ""
+echo "▸ 12. Claude Code reasons accepted (no client-side mapping)"
+
+for R in clear logout prompt_input_exit bypass_permissions_disabled other resume; do
+  SIDR="cc-reason-${TS}-${R}"
+  curl -sk -X POST "$BASE_URL/api/v1/agent-sessions/$SIDR" \
+    -H "$H_AUTH" -H "$H_JSON" \
+    -d '{"agent_id":"claude-code","source":"startup"}' >/dev/null
+  CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
+    "$BASE_URL/api/v1/agent-sessions/$SIDR/end" \
+    -H "$H_AUTH" -H "$H_JSON" \
+    -d "{\"reason\":\"$R\",\"outcome\":\"success\",\"summary\":\"reason $R\"}")
+  [ "$CODE" = "200" ] && pass "SessionEnd reason=$R → 200" \
+    || fail "reason=$R" "expected 200, got $CODE"
+done
+
+# ── 13. Non-ASCII (CJK) username provisions a user_id vault ──
+# Regression: a username that slugifies to empty (e.g. all-Hangul)
+# used to crash provisioning with "username cannot be safely
+# slugified". The vault is now keyed on the immutable user_id.
+echo ""
+echo "▸ 13. CJK username → user_id-keyed vault (no slugify crash)"
+
+CJK_USER="한글유저-${TS}"
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H "$H_JSON" \
+  -d "{\"username\":\"$CJK_USER\",\"email\":\"cjk-${TS}@t.dev\",\"password\":\"test1234\",\"display_name\":\"한글유저\"}" >/dev/null 2>&1
+CJK_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H "$H_JSON" \
+  -d "{\"username\":\"$CJK_USER\",\"password\":\"test1234\"}" \
+  | py 'import sys,json; print(json.load(sys.stdin)["token"])')
+CJK_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $CJK_JWT" -H "$H_JSON" \
+  -d '{"name":"cjk-e2e"}' \
+  | py 'import sys,json; print(json.load(sys.stdin)["token"])')
+
+R=$(curl -sk -o /tmp/cjk_resp.json -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/agent-sessions/cjk-${TS}" \
+  -H "Authorization: Bearer $CJK_PAT" -H "$H_JSON" \
+  -d '{"agent_id":"claude-code","source":"startup"}')
+[ "$R" = "200" ] && pass "CJK username SessionStart → 200 (was 422)" \
+  || fail "CJK start" "expected 200, got $R ($(head -c 160 /tmp/cjk_resp.json))"
+CJK_MV=$(py 'import sys,json; print(json.load(open("/tmp/cjk_resp.json"))["memory_vault"])')
+echo "$CJK_MV" | grep -Eq '^agent-memory-[0-9a-f-]{36}$' \
+  && pass "CJK vault keyed on user_id ($CJK_MV)" \
+  || fail "CJK vault name" "not user_id-shaped: $CJK_MV"
+# description carries the human label
+R=$(curl -sk "$BASE_URL/api/v1/vaults" -H "Authorization: Bearer $CJK_PAT")
+echo "$R" | grep -q "한글유저" \
+  && pass "CJK vault description carries display name" \
+  || fail "CJK description" "label missing: ${R:0:200}"
+
 # ── Summary ────────────────────────────────────────────────
 echo ""
 echo "════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Two fixes to the agent-session lifecycle surface (`/api/v1/agent-sessions/*`) that together made the `akb-claude-code` lifecycle plugin **unusable for a class of users**. Both were reproduced against a live deployment before fixing, and both have new e2e coverage.

### 1. Non-ASCII usernames couldn't provision a memory vault
`sanitise_username()` NFKD-folds to ASCII and rejects an empty result, so an all-CJK username (e.g. `한병전`) raised `username cannot be safely slugified` → **every `SessionStart` 422'd** and the user never got a memory vault.

Fix: key the vault name on the immutable `user_id` (a UUID — always a valid slug) via `memory_vault_name(user_id)` instead of the mutable, possibly-non-ASCII username.
- Works for any username, including all-CJK.
- Name never drifts on later username/display_name/email change — the human-readable identity moved to the vault **`description`**, refreshed from the current profile on every `SessionStart`.
- **Back-compat:** `ensure_memory_vault` / `_resolve_memory_vault` probe the pre-migration `agent-memory-{slug(username)}` name and **adopt** an existing vault instead of orphaning it — no data migration.

### 2. Claude Code SessionEnd `reason` values were all rejected
`EndRequest.reason` only accepted the neutral set (`completed`/`aborted`/`error`/`window_close`/`user_close`/`stop`), but Claude Code emits `clear`/`logout`/`prompt_input_exit`/`bypass_permissions_disabled`/`other`/`resume`. The plugin forwards the hook reason verbatim → **every `SessionEnd` 422'd**, no `recap.md` ever written.

Fix: `reason` now accepts the Claude Code values verbatim too — mirroring how `source` already accepts Claude Code's raw `SessionStart` values, so no client-side mapping is needed. Unknown reasons still `422`.

## Testing

`backend/tests/test_agent_sessions_e2e.sh`:
- §12 — Claude Code reasons accepted (`clear`/`logout`/`prompt_input_exit`/`bypass_permissions_disabled`/`other`/`resume` → 200)
- §13 — CJK-username provisioning → user_id-keyed vault + description label

Run locally against docker-compose (`AKB_URL=http://localhost:8000`):
- `test_agent_sessions_e2e.sh`: **37 passed, 0 failed**
- `test_mcp_e2e.sh` (regression): **76 passed, 0 failed**

Bumps backend `0.8.3 → 0.8.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)