### PR TITLE
feat(auth): optional Keycloak OIDC SSO login (authN-only, JIT provisioning)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -287,6 +287,24 @@
         "is_secret": false
       }
     ],
+    "deploy/keycloak-dev/akb-realm.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/keycloak-dev/akb-realm.json",
+        "hashed_secret": "7ebcd33ad53137998032087330237a975658f563",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "docker-compose.keycloak.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.keycloak.yaml",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
     "docker-compose.yaml": [
       {
         "type": "Secret Keyword",
@@ -5208,5 +5226,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T18:06:58Z"
+  "generated_at": "2026-06-07T15:34:07Z"
 }

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,13 +1,19 @@
-"""REST API routes for auth — register, login, PAT management."""
+"""REST API routes for auth — register, login, PAT management, Keycloak SSO."""
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import logging
+import urllib.parse
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import RedirectResponse
 
 from app.api.deps import get_current_user
-from app.exceptions import NotFoundError
+from app.config import settings
+from app.exceptions import AKBError, NotFoundError
 from app.services.auth_service import (
     AuthenticatedUser,
     register,
     login,
+    login_with_keycloak_claims,
     create_pat,
     list_pats,
     revoke_pat,
@@ -15,6 +21,8 @@ from app.services.auth_service import (
     update_profile,
 )
 from app.util.text import NFCModel
+
+logger = logging.getLogger("akb.auth.routes")
 
 router = APIRouter()
 
@@ -59,6 +67,119 @@ async def register_user(req: RegisterRequest):
 @router.post("/auth/login", summary="Login and get JWT")
 async def login_user(req: LoginRequest):
     return await login(req.username, req.password)
+
+
+# ── Public auth config (lets the SPA decide which login options to show) ──
+
+@router.get("/auth/config", summary="Public auth configuration")
+async def auth_config():
+    """Unauthenticated. Tells the frontend whether the optional Keycloak
+    SSO button should be shown and where it points. Reveals no secrets."""
+    return {
+        "keycloak": {
+            "enabled": settings.keycloak_enabled,
+            # SPA appends ?redirect=<path> when navigating here.
+            "login_url": "/api/v1/auth/keycloak/login" if settings.keycloak_enabled else None,
+        }
+    }
+
+
+# ── Keycloak OIDC (optional) ──────────────────────────────────────────
+#
+# Only mounted-effective when keycloak_enabled. Each handler 404s when
+# SSO is off so a disabled deployment exposes no live SSO surface.
+
+class KeycloakExchangeRequest(NFCModel):
+    code: str
+
+
+def _require_keycloak() -> None:
+    if not settings.keycloak_enabled:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Keycloak SSO is not enabled")
+
+
+def _safe_redirect_path(raw: str | None) -> str:
+    """Only allow same-site path redirects (must start with a single '/').
+
+    Blocks open-redirects: '//evil.com', 'https://evil.com', backslash and
+    scheme-relative tricks all collapse to '/'.
+    """
+    if not raw or not raw.startswith("/") or raw.startswith("//") or "\\" in raw:
+        return "/"
+    return raw
+
+
+@router.get("/auth/keycloak/login", summary="Begin Keycloak SSO login")
+async def keycloak_login(redirect: str = "/"):
+    _require_keycloak()
+    from app.services.keycloak_oidc import get_keycloak_oidc
+    url = await get_keycloak_oidc().begin_login(_safe_redirect_path(redirect))
+    return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/auth/keycloak/callback", summary="Keycloak SSO redirect callback")
+async def keycloak_callback(request: Request):
+    _require_keycloak()
+    from app.services.keycloak_oidc import get_keycloak_oidc, issue_exchange_code
+
+    params = request.query_params
+    # Keycloak signals user-side errors (e.g. access_denied) as query params.
+    if err := params.get("error"):
+        return _sso_error_redirect(err)
+    code = params.get("code")
+    state = params.get("state")
+    if not code or not state:
+        return _sso_error_redirect("missing_code_or_state")
+
+    svc = get_keycloak_oidc()
+    flow = await svc.consume_state(state)
+    if flow is None:
+        # Unknown/expired/replayed state — CSRF guard.
+        return _sso_error_redirect("invalid_state")
+
+    try:
+        tokens = await svc.exchange_code_for_tokens(code, flow.get("code_verifier"))
+        id_token = tokens.get("id_token")
+        if not id_token:
+            return _sso_error_redirect("no_id_token")
+        claims = await svc.verify_id_token(id_token)
+        login_response = await login_with_keycloak_claims(claims)
+    except AKBError as e:
+        # Don't leak detail into the URL; log server-side, show a code.
+        logger.warning("Keycloak SSO callback failed: %s", e)
+        return _sso_error_redirect("auth_failed")
+
+    # Hand the SPA a one-time code; the token is delivered via POST /exchange.
+    one_time = await issue_exchange_code(login_response)
+    dest = _safe_redirect_path(flow.get("redirect_path", "/"))
+    target = (
+        f"{settings.keycloak_post_login_path}"
+        f"?code={urllib.parse.quote(one_time)}"
+        f"&redirect={urllib.parse.quote(dest, safe='')}"
+    )
+    return RedirectResponse(target, status_code=status.HTTP_302_FOUND)
+
+
+@router.post("/auth/keycloak/exchange", summary="Exchange one-time SSO code for a JWT")
+async def keycloak_exchange(req: KeycloakExchangeRequest):
+    _require_keycloak()
+    from app.services.keycloak_oidc import redeem_exchange_code
+    result = await redeem_exchange_code(req.code)
+    if result is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, "Invalid or expired exchange code"
+        )
+    # Same {token, user} shape as POST /auth/login.
+    return result
+
+
+def _sso_error_redirect(reason: str) -> RedirectResponse:
+    """Bounce a failed SSO browser navigation back to the login page with a
+    short reason code the SPA can surface (avoids dumping JSON at the user)."""
+    return RedirectResponse(
+        f"/auth?sso_error={urllib.parse.quote(reason, safe='')}",
+        status_code=status.HTTP_302_FOUND,
+    )
 
 
 @router.get("/auth/me", summary="Get current user info")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -150,7 +150,9 @@ async def keycloak_callback(request: Request):
         return _sso_error_redirect("auth_failed")
 
     # Hand the SPA a one-time code; the token is delivered via POST /exchange.
-    one_time = await issue_exchange_code(login_response)
+    # Stash the Keycloak id_token too so the SPA can pass it back as
+    # id_token_hint on logout (seamless RP-initiated logout, no KC prompt).
+    one_time = await issue_exchange_code({**login_response, "kc_id_token": id_token})
     dest = _safe_redirect_path(flow.get("redirect_path", "/"))
     target = (
         f"{settings.keycloak_post_login_path}"
@@ -158,6 +160,25 @@ async def keycloak_callback(request: Request):
         f"&redirect={urllib.parse.quote(dest, safe='')}"
     )
     return RedirectResponse(target, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/auth/keycloak/logout", summary="RP-initiated Keycloak logout")
+async def keycloak_logout(id_token_hint: str | None = None):
+    """End the Keycloak SSO session (so the next SSO login prompts again /
+    can switch user). AKB already cleared its own JWT client-side; this
+    redirects the browser to Keycloak's end_session_endpoint, which then
+    redirects back to the AKB login page.
+
+    `id_token_hint` (optional) makes the logout seamless (no Keycloak
+    confirmation page). The SPA passes the Keycloak id_token it received at
+    exchange time; without it, Keycloak may show a logout confirmation."""
+    _require_keycloak()
+    from app.services.keycloak_oidc import get_keycloak_oidc
+    post_logout = settings.public_base_url.rstrip("/") + "/auth"
+    url = get_keycloak_oidc().logout_url(
+        id_token_hint=id_token_hint, post_logout_redirect=post_logout
+    )
+    return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
 
 
 @router.post("/auth/keycloak/exchange", summary="Exchange one-time SSO code for a JWT")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -179,6 +179,20 @@ class Settings(BaseModel):
     # becomes an account-spoofing vector. Set false ONLY for a trusted
     # realm where every account's email is controlled out-of-band.
     keycloak_require_verified_email: bool = True
+    # Link an SSO login to a pre-existing AKB account that has the SAME
+    # email but a different auth_provider (e.g. a local/password account).
+    #
+    # Default false → such a collision is rejected (no silent identity
+    # merge; the OSS-safe default). Set true for a MANAGED deployment where
+    # the control plane intentionally pre-provisions an AKB user (+ PAT) for
+    # a member and that same person then logs in via SSO — without linking,
+    # every pre-provisioned member is locked out of SSO. Linking keeps the
+    # existing user_id, so the member's PAT, vault ownership and grants all
+    # survive. SAFE ONLY with verified emails: a cross-provider link is
+    # refused unless the id_token's email_verified is true, regardless of
+    # keycloak_require_verified_email, so a relaxed realm can't be used to
+    # take over an existing account by asserting its email.
+    keycloak_link_by_email: bool = False
     # Absolute URL Keycloak redirects the browser back to after login.
     # Must point at the AKB backend callback route and be registered as a
     # valid redirect URI on the Keycloak client, e.g.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -172,6 +172,13 @@ class Settings(BaseModel):
     keycloak_client_secret: str = ""       # secret.yaml — blank for public (PKCE) clients
     keycloak_public_client: bool = False   # true → PKCE (no client_secret); false → confidential
     keycloak_verify_ssl: bool = True       # set false only for local self-signed Keycloak
+    # Identity is keyed on the verified email. By default we REQUIRE the
+    # id_token's `email_verified` claim to be true before provisioning /
+    # adopting an AKB user — otherwise an IdP that allows unverified or
+    # self-asserted emails (open self-registration, social federation)
+    # becomes an account-spoofing vector. Set false ONLY for a trusted
+    # realm where every account's email is controlled out-of-band.
+    keycloak_require_verified_email: bool = True
     # Absolute URL Keycloak redirects the browser back to after login.
     # Must point at the AKB backend callback route and be registered as a
     # valid redirect URI on the Keycloak client, e.g.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -141,6 +141,51 @@ class Settings(BaseModel):
     jwt_algorithm: str = "HS256"
     jwt_expire_hours: int = 24
 
+    # Auth — Keycloak OIDC (OPTIONAL external IdP). Disabled by default.
+    #
+    # When `keycloak_enabled` is false NONE of these are read and AKB uses
+    # local username/password + PAT exactly as before — the SSO routes
+    # return 404 and zero Keycloak code runs. Enabling adds an SSO login
+    # path that, on success, JIT-provisions an AKB user (keyed by email)
+    # and issues a normal AKB JWT; the internal user model, PG-native
+    # RBAC, and PATs are all unchanged. Keycloak is authentication only —
+    # it never drives AKB authorization.
+    #
+    # Flat `keycloak_*` keys (matching jwt_* / s3_* / embed_*) so the
+    # secret can live in secret.yaml without the shallow app.yaml+secret.yaml
+    # merge clobbering a nested block. Derived OIDC endpoints are computed
+    # properties off `keycloak_issuer` — no .well-known fetch needed.
+    #
+    # See docs/designs/keycloak-oidc/00-overview.md.
+    keycloak_enabled: bool = False
+    keycloak_server_url: str = ""          # e.g. https://auth.example.com (no /realms suffix)
+    # Optional backchannel base URL for server→Keycloak calls (token
+    # exchange + JWKS). Defaults to keycloak_server_url. Set this only
+    # when the backend reaches Keycloak at a different address than the
+    # browser does — split-horizon ingress in prod, or the
+    # localhost-vs-container-DNS gap in local docker. The issuer and the
+    # browser-facing authorization/logout endpoints always use
+    # keycloak_server_url, so the `iss` claim stays the public URL.
+    keycloak_internal_url: str = ""
+    keycloak_realm: str = "akb"
+    keycloak_client_id: str = "akb-web"
+    keycloak_client_secret: str = ""       # secret.yaml — blank for public (PKCE) clients
+    keycloak_public_client: bool = False   # true → PKCE (no client_secret); false → confidential
+    keycloak_verify_ssl: bool = True       # set false only for local self-signed Keycloak
+    # Absolute URL Keycloak redirects the browser back to after login.
+    # Must point at the AKB backend callback route and be registered as a
+    # valid redirect URI on the Keycloak client, e.g.
+    #   http://localhost:3000/api/v1/auth/keycloak/callback
+    keycloak_redirect_uri: str = ""
+    # SPA path the callback bounces the browser to with a one-time code.
+    # Relative → resolves against the request origin (same host the user
+    # is already on), so it works for both :3000 dev proxy and prod ingress.
+    keycloak_post_login_path: str = "/auth/callback"
+    # One-time exchange-code TTL (seconds). The callback hands the SPA a
+    # short-lived opaque code; the SPA trades it for the AKB JWT over a
+    # POST so the token never rides in a URL. Keep this small.
+    keycloak_exchange_code_ttl_secs: int = 60
+
     # Server
     host: str = "0.0.0.0"
     port: int = 8000
@@ -265,6 +310,43 @@ class Settings(BaseModel):
     # Audit log — its own nested section so the surface can grow without
     # littering the flat top level. See AuditSettings above.
     audit: AuditSettings = Field(default_factory=AuditSettings)
+
+    # ── Keycloak OIDC derived endpoints ───────────────────────────
+    # All computed off the realm issuer so only server_url + realm are
+    # configured. Standard Keycloak OIDC paths under /realms/<realm>.
+
+    @property
+    def keycloak_issuer(self) -> str:
+        # Public issuer — must equal the `iss` claim Keycloak stamps on
+        # tokens (driven by the browser-facing hostname).
+        return f"{self.keycloak_server_url.rstrip('/')}/realms/{self.keycloak_realm}"
+
+    @property
+    def _keycloak_backchannel_issuer(self) -> str:
+        # Internal realm base for server→Keycloak calls; falls back to the
+        # public URL when no separate backchannel address is configured.
+        base = (self.keycloak_internal_url or self.keycloak_server_url).rstrip("/")
+        return f"{base}/realms/{self.keycloak_realm}"
+
+    @property
+    def keycloak_authorization_endpoint(self) -> str:
+        # Browser-facing → public issuer.
+        return f"{self.keycloak_issuer}/protocol/openid-connect/auth"
+
+    @property
+    def keycloak_token_endpoint(self) -> str:
+        # Server→Keycloak → backchannel issuer.
+        return f"{self._keycloak_backchannel_issuer}/protocol/openid-connect/token"
+
+    @property
+    def keycloak_jwks_uri(self) -> str:
+        # Server→Keycloak → backchannel issuer.
+        return f"{self._keycloak_backchannel_issuer}/protocol/openid-connect/certs"
+
+    @property
+    def keycloak_end_session_endpoint(self) -> str:
+        # Browser-facing → public issuer.
+        return f"{self.keycloak_issuer}/protocol/openid-connect/logout"
 
     @property
     def database_url(self) -> str:

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -25,7 +25,13 @@ CREATE TABLE IF NOT EXISTS users (
     -- before the user explicitly revokes valid until natural expiry.
     -- Set to NOW() via POST /auth/revoke-all-sessions, admin force-logout,
     -- and automatically inside change_password.
-    tokens_revoked_before TIMESTAMPTZ NOT NULL DEFAULT TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    tokens_revoked_before TIMESTAMPTZ NOT NULL DEFAULT TIMESTAMPTZ '1970-01-01 00:00:00+00',
+    -- How the account authenticates. 'local' = bcrypt password (the
+    -- baseline). 'keycloak' = JIT-provisioned on first OIDC login; its
+    -- password_hash is an unusable sentinel. Advisory only — Keycloak
+    -- itself is gated by keycloak_enabled in config; when SSO is off this
+    -- column is never read. See migration 033.
+    auth_provider TEXT NOT NULL DEFAULT 'local'
 );
 
 -- ============================================================
@@ -45,6 +51,23 @@ CREATE TABLE IF NOT EXISTS tokens (
 
 CREATE INDEX IF NOT EXISTS idx_tokens_hash ON tokens(token_hash);
 CREATE INDEX IF NOT EXISTS idx_tokens_user ON tokens(user_id);
+
+-- ============================================================
+-- OIDC transients — short-lived state for the OPTIONAL Keycloak login
+-- flow (CSRF state + PKCE verifier, and one-time exchange codes mapping
+-- to a freshly minted AKB JWT). HA-safe (shared across replicas),
+-- single-use, TTL-bounded. Stays empty when Keycloak is disabled.
+-- See migration 034.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oidc_transients (
+    key         TEXT PRIMARY KEY,
+    kind        TEXT NOT NULL,          -- 'state' | 'exchange'
+    payload     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_oidc_transients_expiry ON oidc_transients(expires_at);
 
 -- ============================================================
 -- Vaults (each maps to a Git bare repo)

--- a/backend/app/db/migrations/033_users_auth_provider.py
+++ b/backend/app/db/migrations/033_users_auth_provider.py
@@ -1,0 +1,83 @@
+"""Migration 033: add `users.auth_provider` to tag external-IdP accounts.
+
+AKB's baseline auth is local (username/password → bcrypt). The optional
+Keycloak OIDC login path provisions a user row on first SSO login (JIT),
+but such a user has no usable local password. This column records *how*
+the account authenticates so the local login path can refuse a password
+login against an SSO-only account instead of silently failing the bcrypt
+compare.
+
+Values:
+- ``'local'``   — registered via POST /auth/register; has a real bcrypt hash.
+- ``'keycloak'``— JIT-provisioned on first Keycloak login; ``password_hash``
+                  holds an unusable sentinel that no bcrypt input can match.
+
+Default ``'local'`` so every pre-migration row keeps its current behavior.
+The column is NOT a hard auth switch: it is advisory metadata. Keycloak
+itself is gated by ``keycloak_enabled`` in config — when that is false this
+column is simply never read, and AKB behaves exactly as before.
+
+Idempotent: ``ADD COLUMN IF NOT EXISTS`` so re-running is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.033")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    existing = await conn.fetchval(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_name = 'users'
+           AND column_name = 'auth_provider'
+        """
+    )
+    if existing:
+        logger.info(
+            "Migration 033: users.auth_provider already exists; skipping"
+        )
+        return
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE users
+              ADD COLUMN IF NOT EXISTS auth_provider TEXT NOT NULL DEFAULT 'local'
+            """
+        )
+
+    logger.info(
+        "Migration 033 added users.auth_provider (default 'local' — "
+        "existing accounts unaffected; only SSO-provisioned rows differ)"
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/migrations/034_oidc_transients.py
+++ b/backend/app/db/migrations/034_oidc_transients.py
@@ -1,0 +1,77 @@
+"""Migration 034: `oidc_transients` — short-lived OIDC flow state.
+
+The optional Keycloak login flow has two short-lived secrets that must
+survive the redirect round-trip AND work when AKB runs more than one
+backend replica (the login redirect and the callback can land on
+different pods, so in-process dicts would lose the state):
+
+- ``kind='state'``    — CSRF state token + (for PKCE clients) the
+                        code_verifier + the post-login redirect path.
+                        Issued by /auth/keycloak/login, consumed by the
+                        callback.
+- ``kind='exchange'`` — a one-time opaque code mapped to the freshly
+                        minted AKB JWT + user payload. Issued by the
+                        callback, consumed by /auth/keycloak/exchange so
+                        the token is delivered over a POST body instead
+                        of riding in a redirect URL.
+
+Both are single-use (consumed via DELETE … RETURNING) and TTL-bounded
+(``expires_at``). The table is harmless when Keycloak is disabled — it
+simply stays empty.
+
+Idempotent: ``CREATE TABLE IF NOT EXISTS``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.034")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS oidc_transients (
+                key         TEXT PRIMARY KEY,
+                kind        TEXT NOT NULL,
+                payload     JSONB NOT NULL DEFAULT '{}'::jsonb,
+                expires_at  TIMESTAMPTZ NOT NULL,
+                created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_oidc_transients_expiry "
+            "ON oidc_transients(expires_at)"
+        )
+
+    logger.info("Migration 034 ensured oidc_transients table")
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -117,6 +117,8 @@ async def _apply_migrations() -> None:
         "030_resource_content_hash.py",         # documents/vault_files content_hash projection for manifests and preconditions
         "031_drop_memories_sessions.py",        # drop legacy memories+sessions tables; agent memory is now vault-shaped
         "032_drop_supersedes.py",               # drop never-used documents.supersedes column (status leaned to draft/active/archived)
+        "033_users_auth_provider.py",           # users.auth_provider ('local' default | 'keycloak' for JIT-provisioned SSO accounts)
+        "034_oidc_transients.py",               # oidc_transients: short-lived OIDC state + one-time exchange codes (HA-safe; empty when Keycloak off)
     ):
         module = _load_migration(filename)
         if module is None:

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -42,7 +42,14 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(password: str, password_hash: str) -> bool:
-    return bcrypt.checkpw(password.encode(), password_hash.encode())
+    # Defensive: an SSO-provisioned account stores a non-bcrypt sentinel
+    # hash (see provision_keycloak_user). bcrypt.checkpw raises ValueError
+    # on a malformed hash; treat that as "no match" so a stray local-login
+    # attempt against an SSO account returns 401, not 500.
+    try:
+        return bcrypt.checkpw(password.encode(), password_hash.encode())
+    except ValueError:
+        return False
 
 
 # ── JWT ──────────────────────────────────────────────────────
@@ -127,11 +134,16 @@ async def login(username: str, password: str) -> dict:
         row = await conn.fetchrow(
             """
             SELECT id, username, email, password_hash, display_name, is_admin,
-                   tokens_revoked_before
+                   tokens_revoked_before, auth_provider
               FROM users WHERE username = $1 OR email = $1
             """,
             username,
         )
+        # SSO-provisioned accounts have no usable local password. Reject
+        # the local-login path explicitly with the same generic message
+        # so we don't leak which accounts are SSO-backed.
+        if row and row["auth_provider"] != "local":
+            raise AuthenticationError("Invalid credentials")
         if not row or not verify_password(password, row["password_hash"]):
             raise AuthenticationError("Invalid credentials")
 
@@ -153,6 +165,114 @@ async def login(username: str, password: str) -> dict:
                 "is_admin": row["is_admin"],
             },
         }
+
+
+# ── Keycloak SSO (optional external IdP) ─────────────────────────────
+#
+# bcrypt hashes start with "$2"; this sentinel is deliberately NOT a
+# valid bcrypt hash, so an SSO account can never be authenticated through
+# /auth/login (verify_password returns False on the malformed hash, and
+# login() refuses non-'local' providers up front anyway).
+_SSO_SENTINEL_HASH = "!keycloak-sso:no-local-login!"
+
+
+async def _unique_username(conn, base: str | None) -> str:
+    """Derive a unique username from a Keycloak claim, suffixing on collision."""
+    base = (base or "").strip() or "user"
+    candidate = base
+    for _ in range(8):
+        taken = await conn.fetchval("SELECT 1 FROM users WHERE username = $1", candidate)
+        if not taken:
+            return candidate
+        candidate = f"{base}-{secrets.token_hex(2)}"
+    return f"{base}-{secrets.token_hex(4)}"
+
+
+async def login_with_keycloak_claims(claims: dict) -> dict:
+    """Map a verified Keycloak ID token to an AKB session.
+
+    First login JIT-provisions an AKB user (keyed by email) and its
+    per-user PG role; subsequent logins reuse the row. Returns the same
+    ``{token, user}`` shape as :func:`login` so the SSO callback path is
+    indistinguishable downstream.
+
+    Keycloak is authentication only — ``realm_access.roles`` are NOT
+    mapped to AKB ``is_admin`` or vault grants here (see the design doc).
+    """
+    email = (claims.get("email") or "").strip().lower()
+    if not email:
+        # AKB keys identity on email; without it we cannot map to a user.
+        raise AuthenticationError("Keycloak account has no email claim")
+    display_name = claims.get("name") or claims.get("preferred_username")
+    preferred_username = claims.get("preferred_username") or email.split("@")[0]
+
+    pool = await get_pool()
+    new_user_id: uuid.UUID | None = None
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, username, email, display_name, is_admin,
+                   tokens_revoked_before, auth_provider
+              FROM users WHERE email = $1
+            """,
+            email,
+        )
+        if row is not None:
+            if row["auth_provider"] != "keycloak":
+                # A local account already owns this email. Auto-linking is
+                # deliberately out of scope (design doc) — fail loudly
+                # rather than silently merging identities.
+                raise ConflictError(
+                    "An account with this email already exists with password "
+                    "login; SSO linking is not enabled. Contact an admin."
+                )
+            user_id = row["id"]
+            uname = row["username"]
+            not_before = row["tokens_revoked_before"] + timedelta(seconds=1)
+            user_payload = {
+                "id": str(row["id"]),
+                "username": row["username"],
+                "email": row["email"],
+                "display_name": row["display_name"],
+                "is_admin": row["is_admin"],
+            }
+        else:
+            user_id = uuid.uuid4()
+            uname = await _unique_username(conn, preferred_username)
+            # INSERT + outbox event in one tx so a rollback drops both.
+            async with conn.transaction():
+                await conn.execute(
+                    """
+                    INSERT INTO users (id, username, email, password_hash,
+                                       display_name, auth_provider)
+                    VALUES ($1, $2, $3, $4, $5, 'keycloak')
+                    """,
+                    user_id, uname, email, _SSO_SENTINEL_HASH, display_name,
+                )
+                await emit_event(
+                    conn,
+                    "auth.user_provisioned",
+                    actor_id=str(user_id),
+                    payload={"auth_provider": "keycloak", "email": email},
+                )
+            new_user_id = user_id
+            not_before = None
+            user_payload = {
+                "id": str(user_id),
+                "username": uname,
+                "email": email,
+                "display_name": display_name,
+                "is_admin": False,
+            }
+
+    # PG-native RBAC: create the per-user role outside the insert's
+    # connection, mirroring register(). Best-effort — the reconciler at
+    # next startup rebuilds any role this misses.
+    if new_user_id is not None:
+        await get_role_sync().on_user_create(new_user_id)
+
+    token = create_jwt(str(user_id), uname, not_before=not_before)
+    return {"token": token, "user": user_payload}
 
 
 class BadPasswordChange(Exception):

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -225,12 +225,27 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
         )
         if row is not None:
             if row["auth_provider"] != "keycloak":
-                # A local account already owns this email. Auto-linking is
-                # deliberately out of scope (design doc) — fail loudly
-                # rather than silently merging identities.
-                raise ConflictError(
-                    "An account with this email already exists with password "
-                    "login; SSO linking is not enabled. Contact an admin."
+                # A different-provider account (e.g. a local/password user the
+                # managed control plane pre-provisioned) already owns this
+                # email. Link it to this SSO identity only when explicitly
+                # enabled AND the email is verified — otherwise fail loudly
+                # rather than silently merging / risking takeover.
+                if not settings.keycloak_link_by_email:
+                    raise ConflictError(
+                        "An account with this email already exists with password "
+                        "login; SSO linking is not enabled. Contact an admin."
+                    )
+                if claims.get("email_verified") is not True:
+                    raise AuthenticationError(
+                        "Cannot link SSO to the existing account: email is not "
+                        "verified by the identity provider"
+                    )
+                # Adopt: keep the existing user_id (and thus its PATs, vault
+                # ownership, grants). Flip auth_provider to 'keycloak' so the
+                # now-unused local password can no longer be used to log in.
+                await conn.execute(
+                    "UPDATE users SET auth_provider = 'keycloak' WHERE id = $1",
+                    row["id"],
                 )
             user_id = row["id"]
             uname = row["username"]
@@ -283,10 +298,27 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
                     """,
                     email,
                 )
-                if row is None or row["auth_provider"] != "keycloak":
+                if row is None:
                     raise ConflictError(
                         "An account with this email already exists; "
                         "SSO linking is not enabled. Contact an admin."
+                    )
+                if row["auth_provider"] != "keycloak":
+                    # Same link-by-email rule as the non-race path.
+                    if not settings.keycloak_link_by_email:
+                        raise ConflictError(
+                            "An account with this email already exists with "
+                            "password login; SSO linking is not enabled. "
+                            "Contact an admin."
+                        )
+                    if claims.get("email_verified") is not True:
+                        raise AuthenticationError(
+                            "Cannot link SSO to the existing account: email is "
+                            "not verified by the identity provider"
+                        )
+                    await conn.execute(
+                        "UPDATE users SET auth_provider = 'keycloak' WHERE id = $1",
+                        row["id"],
                     )
                 user_id = row["id"]
                 uname = row["username"]

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -203,6 +203,12 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
     if not email:
         # AKB keys identity on email; without it we cannot map to a user.
         raise AuthenticationError("Keycloak account has no email claim")
+    # Identity is keyed on email — refuse unverified emails so a realm that
+    # permits self-asserted addresses can't be used to provision/adopt an
+    # AKB account under someone else's email. Gated so a trusted realm can
+    # opt out (keycloak_require_verified_email=false).
+    if settings.keycloak_require_verified_email and claims.get("email_verified") is not True:
+        raise AuthenticationError("Identity provider has not verified this email address")
     display_name = claims.get("name") or claims.get("preferred_username")
     preferred_username = claims.get("preferred_username") or email.split("@")[0]
 
@@ -239,31 +245,59 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
         else:
             user_id = uuid.uuid4()
             uname = await _unique_username(conn, preferred_username)
-            # INSERT + outbox event in one tx so a rollback drops both.
-            async with conn.transaction():
-                await conn.execute(
+            try:
+                # INSERT + outbox event in one tx so a rollback drops both.
+                async with conn.transaction():
+                    await conn.execute(
+                        """
+                        INSERT INTO users (id, username, email, password_hash,
+                                           display_name, auth_provider)
+                        VALUES ($1, $2, $3, $4, $5, 'keycloak')
+                        """,
+                        user_id, uname, email, _SSO_SENTINEL_HASH, display_name,
+                    )
+                    await emit_event(
+                        conn,
+                        "auth.user_provisioned",
+                        actor_id=str(user_id),
+                        payload={"auth_provider": "keycloak", "email": email},
+                    )
+                new_user_id = user_id
+                not_before = None
+                user_payload = {
+                    "id": str(user_id),
+                    "username": uname,
+                    "email": email,
+                    "display_name": display_name,
+                    "is_admin": False,
+                }
+            except asyncpg.UniqueViolationError:
+                # Concurrent first-login for the same email won the race.
+                # Re-fetch and treat as the existing user (idempotent JIT)
+                # instead of bubbling a raw 500.
+                row = await conn.fetchrow(
                     """
-                    INSERT INTO users (id, username, email, password_hash,
-                                       display_name, auth_provider)
-                    VALUES ($1, $2, $3, $4, $5, 'keycloak')
+                    SELECT id, username, email, display_name, is_admin,
+                           tokens_revoked_before, auth_provider
+                      FROM users WHERE email = $1
                     """,
-                    user_id, uname, email, _SSO_SENTINEL_HASH, display_name,
+                    email,
                 )
-                await emit_event(
-                    conn,
-                    "auth.user_provisioned",
-                    actor_id=str(user_id),
-                    payload={"auth_provider": "keycloak", "email": email},
-                )
-            new_user_id = user_id
-            not_before = None
-            user_payload = {
-                "id": str(user_id),
-                "username": uname,
-                "email": email,
-                "display_name": display_name,
-                "is_admin": False,
-            }
+                if row is None or row["auth_provider"] != "keycloak":
+                    raise ConflictError(
+                        "An account with this email already exists; "
+                        "SSO linking is not enabled. Contact an admin."
+                    )
+                user_id = row["id"]
+                uname = row["username"]
+                not_before = row["tokens_revoked_before"] + timedelta(seconds=1)
+                user_payload = {
+                    "id": str(row["id"]),
+                    "username": row["username"],
+                    "email": row["email"],
+                    "display_name": row["display_name"],
+                    "is_admin": row["is_admin"],
+                }
 
     # PG-native RBAC: create the per-user role outside the insert's
     # connection, mirroring register(). Best-effort — the reconciler at

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -1,0 +1,296 @@
+"""Keycloak OIDC client — the OPTIONAL external-IdP login path.
+
+This module is *only* exercised when ``settings.keycloak_enabled`` is
+true. With it off, nothing here runs and AKB authenticates exactly as
+before (local username/password + PAT).
+
+Design (see docs/designs/keycloak-oidc/00-overview.md):
+
+- Keycloak authenticates the person at the front door using the OIDC
+  **authorization-code** flow (+ PKCE S256 for public clients).
+- The ID token is verified **locally** against Keycloak's JWKS (RS256,
+  cached, refetched once on key rotation) — no remote introspection on
+  the hot path.
+- Keycloak is **authentication only**. The caller maps the verified
+  identity (by email) to an internal AKB user and mints a normal AKB
+  JWT; the internal user model, PG-native RBAC, and PATs are untouched.
+
+Implemented on the dependencies AKB already ships — ``httpx`` for the
+token/JWKS HTTP calls and ``pyjwt`` for RS256 verification. No new
+third-party packages.
+
+Transient flow state (CSRF ``state`` + PKCE verifier, and the one-time
+exchange codes) is persisted in the ``oidc_transients`` table so the
+redirect round-trip works across multiple backend replicas. Each entry
+is single-use and TTL-bounded.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import jwt
+from jwt.algorithms import RSAAlgorithm
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import AKBError, AuthenticationError
+
+logger = logging.getLogger("akb.keycloak")
+
+# OIDC scopes requested at the authorization endpoint. `openid` is
+# mandatory for an ID token; `profile`+`email` populate name/email claims
+# we map onto the AKB user.
+_SCOPE = "openid profile email"
+
+
+# ── Transient store (oidc_transients table) ──────────────────────────
+#
+# Two single-use, TTL-bounded record kinds backing the redirect flow.
+# Consume is an atomic DELETE … RETURNING so a code can never be redeemed
+# twice even under concurrent callbacks.
+
+
+async def _store_issue(key: str, kind: str, payload: dict, ttl_secs: int) -> None:
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_secs)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        # Opportunistic GC of expired rows — cheap with the expiry index,
+        # keeps the table from accumulating abandoned login attempts.
+        await conn.execute("DELETE FROM oidc_transients WHERE expires_at <= NOW()")
+        await conn.execute(
+            """
+            INSERT INTO oidc_transients (key, kind, payload, expires_at)
+            VALUES ($1, $2, $3::jsonb, $4)
+            """,
+            key, kind, json.dumps(payload), expires_at,
+        )
+
+
+async def _store_consume(key: str, kind: str) -> dict | None:
+    """Atomically fetch+delete a non-expired transient. None if absent/expired."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM oidc_transients
+             WHERE key = $1 AND kind = $2 AND expires_at > NOW()
+            RETURNING payload
+            """,
+            key, kind,
+        )
+    if row is None:
+        return None
+    payload = row["payload"]
+    # asyncpg returns JSONB as str unless a codec is registered.
+    return json.loads(payload) if isinstance(payload, str) else payload
+
+
+class KeycloakOIDC:
+    """Stateless-per-process OIDC client. All flow state lives in PG."""
+
+    def __init__(self) -> None:
+        # JWKS cached in-process; refetched on key rotation (kid miss).
+        self._jwks: dict[str, Any] | None = None
+        self._http: httpx.AsyncClient | None = None
+
+    # ── HTTP client (honors verify_ssl) ──────────────────────────────
+    def _client(self) -> httpx.AsyncClient:
+        # A dedicated client (not the shared embedding/LLM pool) because
+        # verify must follow keycloak_verify_ssl, which is a per-client
+        # setting in httpx. Reused across calls for connection keep-alive.
+        if self._http is None:
+            self._http = httpx.AsyncClient(
+                verify=settings.keycloak_verify_ssl,
+                timeout=httpx.Timeout(15.0, connect=10.0),
+            )
+        return self._http
+
+    async def aclose(self) -> None:
+        if self._http is not None:
+            await self._http.aclose()
+            self._http = None
+
+    # ── PKCE helpers (RFC 7636) ──────────────────────────────────────
+    @staticmethod
+    def _make_code_verifier() -> str:
+        return secrets.token_urlsafe(64)[:128]
+
+    @staticmethod
+    def _make_code_challenge(verifier: str) -> str:
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    # ── Authorization request ────────────────────────────────────────
+    async def begin_login(self, redirect_path: str = "/") -> str:
+        """Create CSRF state (+PKCE for public clients) and return the
+        Keycloak authorization URL to redirect the browser to."""
+        state = secrets.token_urlsafe(32)
+        payload: dict[str, str] = {"redirect_path": redirect_path}
+        params: dict[str, str] = {
+            "client_id": settings.keycloak_client_id,
+            "redirect_uri": settings.keycloak_redirect_uri,
+            "response_type": "code",
+            "scope": _SCOPE,
+            "state": state,
+        }
+        if settings.keycloak_public_client:
+            verifier = self._make_code_verifier()
+            payload["code_verifier"] = verifier
+            params["code_challenge"] = self._make_code_challenge(verifier)
+            params["code_challenge_method"] = "S256"
+
+        await _store_issue(
+            state, "state", payload,
+            ttl_secs=600,  # 10 min to complete the Keycloak login screen
+        )
+        return f"{settings.keycloak_authorization_endpoint}?{urllib.parse.urlencode(params)}"
+
+    async def consume_state(self, state: str) -> dict | None:
+        """Verify+consume the CSRF state. Returns {redirect_path, code_verifier?}."""
+        return await _store_consume(state, "state")
+
+    # ── Token exchange ───────────────────────────────────────────────
+    async def exchange_code_for_tokens(
+        self, code: str, code_verifier: str | None
+    ) -> dict[str, Any]:
+        data: dict[str, str] = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": settings.keycloak_redirect_uri,
+            "client_id": settings.keycloak_client_id,
+        }
+        if settings.keycloak_public_client:
+            if code_verifier:
+                data["code_verifier"] = code_verifier
+        else:
+            data["client_secret"] = settings.keycloak_client_secret
+
+        try:
+            resp = await self._client().post(
+                settings.keycloak_token_endpoint, data=data
+            )
+        except httpx.HTTPError as e:
+            logger.error("Keycloak token exchange network error: %s", e)
+            raise AKBError("Keycloak unreachable during token exchange", status_code=502) from e
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Keycloak token exchange failed: %s %s",
+                resp.status_code, resp.text[:500],
+            )
+            # A bad/expired/replayed code is a client-side auth failure.
+            raise AuthenticationError("Authorization code exchange failed")
+        return resp.json()
+
+    # ── JWKS + ID-token verification ─────────────────────────────────
+    async def _fetch_jwks(self, *, force: bool = False) -> dict[str, Any]:
+        if self._jwks is not None and not force:
+            return self._jwks
+        try:
+            resp = await self._client().get(settings.keycloak_jwks_uri)
+        except httpx.HTTPError as e:
+            logger.error("Keycloak JWKS fetch network error: %s", e)
+            raise AKBError("Keycloak unreachable fetching JWKS", status_code=502) from e
+        if resp.status_code != 200:
+            logger.error("Keycloak JWKS fetch failed: %s", resp.status_code)
+            raise AKBError("Failed to fetch Keycloak public keys", status_code=502)
+        self._jwks = resp.json()
+        return self._jwks
+
+    @staticmethod
+    def _find_key(jwks: dict[str, Any], kid: str) -> dict | None:
+        return next(
+            (k for k in jwks.get("keys", []) if k.get("kid") == kid), None
+        )
+
+    async def verify_id_token(self, id_token: str) -> dict[str, Any]:
+        """Verify a Keycloak ID token locally and return its claims.
+
+        Validates signature (RS256), audience (client_id), issuer (realm),
+        and expiry. Refetches JWKS once if the token's ``kid`` is unknown
+        (key rotation) before giving up.
+        """
+        try:
+            header = jwt.get_unverified_header(id_token)
+        except jwt.InvalidTokenError as e:
+            raise AuthenticationError(f"Malformed ID token: {e}") from e
+
+        kid = header.get("kid")
+        if not kid:
+            raise AuthenticationError("ID token missing kid header")
+
+        jwks = await self._fetch_jwks()
+        key = self._find_key(jwks, kid)
+        if key is None:
+            # Unknown kid — Keycloak likely rotated keys. Refetch once.
+            jwks = await self._fetch_jwks(force=True)
+            key = self._find_key(jwks, kid)
+        if key is None:
+            raise AuthenticationError("No matching Keycloak public key for token")
+
+        try:
+            public_key = RSAAlgorithm.from_jwk(json.dumps(key))
+            claims = jwt.decode(
+                id_token,
+                public_key,
+                algorithms=["RS256"],
+                audience=settings.keycloak_client_id,
+                issuer=settings.keycloak_issuer,
+                options={"require": ["exp", "iat", "aud", "iss", "sub"]},
+            )
+        except jwt.InvalidTokenError as e:
+            logger.warning("Keycloak ID token verification failed: %s", e)
+            raise AuthenticationError(f"Invalid ID token: {e}") from e
+
+        return claims
+
+    # ── Logout URL ───────────────────────────────────────────────────
+    def logout_url(self, id_token_hint: str | None, post_logout_redirect: str | None) -> str:
+        params: dict[str, str] = {}
+        if post_logout_redirect:
+            params["post_logout_redirect_uri"] = post_logout_redirect
+        if id_token_hint:
+            params["id_token_hint"] = id_token_hint
+        else:
+            params["client_id"] = settings.keycloak_client_id
+        return f"{settings.keycloak_end_session_endpoint}?{urllib.parse.urlencode(params)}"
+
+
+# Lazy module-level singleton.
+_service: KeycloakOIDC | None = None
+
+
+def get_keycloak_oidc() -> KeycloakOIDC:
+    global _service
+    if _service is None:
+        _service = KeycloakOIDC()
+    return _service
+
+
+# ── One-time exchange code (callback → SPA) ──────────────────────────
+
+
+async def issue_exchange_code(login_response: dict) -> str:
+    """Store the freshly minted AKB JWT + user payload under a one-time
+    opaque code and return the code. The SPA trades it via /exchange so
+    the token is delivered in a POST body, never in a redirect URL."""
+    code = secrets.token_urlsafe(32)
+    await _store_issue(
+        code, "exchange", login_response,
+        ttl_secs=settings.keycloak_exchange_code_ttl_secs,
+    )
+    return code
+
+
+async def redeem_exchange_code(code: str) -> dict | None:
+    """Atomically redeem a one-time exchange code → {token, user} or None."""
+    return await _store_consume(code, "exchange")

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -33,6 +33,22 @@ def _validate_required_settings() -> None:
             "publication response carries an absolute share_url; e.g. "
             "https://akb.example.com)"
         )
+    # Keycloak is OPTIONAL — only validate its config when it's turned on.
+    # When enabled, an incomplete config would 500 mid-login instead of
+    # failing the deploy, so fail fast here.
+    if settings.keycloak_enabled:
+        if not settings.keycloak_server_url:
+            missing.append("keycloak_server_url (keycloak_enabled is true)")
+        if not settings.keycloak_redirect_uri:
+            missing.append(
+                "keycloak_redirect_uri (keycloak_enabled is true — the "
+                "backend callback URL registered on the Keycloak client)"
+            )
+        if not settings.keycloak_public_client and not settings.keycloak_client_secret:
+            missing.append(
+                "keycloak_client_secret (confidential client — set it in "
+                "secret.yaml, or set keycloak_public_client: true for PKCE)"
+            )
     if missing:
         raise RuntimeError(
             "Required configuration missing:\n  - " + "\n  - ".join(missing)
@@ -158,4 +174,8 @@ async def stop_workers() -> None:
 
 async def shutdown_storage() -> None:
     await http_pool.close_client()
+    # Close the optional Keycloak OIDC client if it was ever constructed.
+    if settings.keycloak_enabled:
+        from app.services.keycloak_oidc import get_keycloak_oidc
+        await get_keycloak_oidc().aclose()
     await close_pool()

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -93,6 +93,9 @@ jwt_expire_hours: 24
 # keycloak_client_id: "akb-web"
 # keycloak_public_client: false      # true → PKCE (no client_secret needed)
 # keycloak_verify_ssl: true          # false only for local self-signed Keycloak
+# keycloak_require_verified_email: true   # refuse id_tokens whose email_verified≠true
+#                                         # (identity is keyed on email). Set false ONLY
+#                                         # for a trusted realm with controlled emails.
 # keycloak_redirect_uri: "https://akb.example.com/api/v1/auth/keycloak/callback"
 # keycloak_post_login_path: "/auth/callback"
 # keycloak_exchange_code_ttl_secs: 60

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -96,6 +96,10 @@ jwt_expire_hours: 24
 # keycloak_require_verified_email: true   # refuse id_tokens whose email_verified≠true
 #                                         # (identity is keyed on email). Set false ONLY
 #                                         # for a trusted realm with controlled emails.
+# keycloak_link_by_email: false           # link SSO to a pre-existing same-email account
+#                                         # (e.g. one the managed control plane provisioned).
+#                                         # Keeps the user_id/PATs; only links VERIFIED emails.
+#                                         # Default false = no silent merge (OSS-safe).
 # keycloak_redirect_uri: "https://akb.example.com/api/v1/auth/keycloak/callback"
 # keycloak_post_login_path: "/auth/callback"
 # keycloak_exchange_code_ttl_secs: 60

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -78,6 +78,26 @@ s3_region: ""
 jwt_algorithm: HS256
 jwt_expire_hours: 24
 
+# === Auth — Keycloak OIDC (OPTIONAL external IdP; OFF by default) ===
+# Leave keycloak_enabled false and AKB uses local username/password + PAT
+# exactly as before — none of the keys below are read and the SSO routes
+# return 404. Turn it on to add an SSO login button; on success AKB
+# JIT-provisions a user (by email) and issues a normal AKB JWT. Keycloak
+# is authentication only — it never drives AKB authorization.
+# Full design: docs/designs/keycloak-oidc/00-overview.md
+#
+# keycloak_enabled: false
+# keycloak_server_url: "https://auth.example.com"   # no /realms suffix (browser-facing; sets the issuer)
+# keycloak_internal_url: ""          # optional backchannel URL (server→Keycloak); blank → use server_url
+# keycloak_realm: "akb"
+# keycloak_client_id: "akb-web"
+# keycloak_public_client: false      # true → PKCE (no client_secret needed)
+# keycloak_verify_ssl: true          # false only for local self-signed Keycloak
+# keycloak_redirect_uri: "https://akb.example.com/api/v1/auth/keycloak/callback"
+# keycloak_post_login_path: "/auth/callback"
+# keycloak_exchange_code_ttl_secs: 60
+# keycloak_client_secret lives in secret.yaml (never commit it)
+
 # === Server ===
 host: 0.0.0.0
 port: 8000

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -10,6 +10,13 @@ db_password: akb
 # REPLACE before any non-local deploy. Generate one:  openssl rand -hex 32
 jwt_secret: dev-only-change-me-before-deploying-anywhere-real
 
+# === Keycloak client secret (optional) ===
+# Only needed when `keycloak_enabled: true` in app.yaml AND the client is
+# confidential (`keycloak_public_client: false`). Copy the client secret
+# from Keycloak → Clients → akb-web → Credentials. Leave blank for public
+# (PKCE) clients. NEVER commit a real value.
+keycloak_client_secret: ""
+
 # === Embedding API key (required) ===
 # Provider key for `embed_base_url` in app.yaml.
 embed_api_key: ""

--- a/deploy/keycloak-dev/akb-realm.json
+++ b/deploy/keycloak-dev/akb-realm.json
@@ -1,0 +1,47 @@
+{
+  "realm": "akb",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "clients": [
+    {
+      "clientId": "akb-web",
+      "name": "AKB Web",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-akb-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "http://localhost:3000/*",
+        "http://localhost:8000/*",
+        "http://localhost:5173/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:8000",
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/*##http://localhost:5173/*"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "email": "alice@example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Alice",
+      "lastName": "Example",
+      "credentials": [
+        { "type": "password", "value": "alice-password", "temporary": false }
+      ],
+      "realmRoles": ["default-roles-akb"]
+    }
+  ]
+}

--- a/docker-compose.keycloak.yaml
+++ b/docker-compose.keycloak.yaml
@@ -1,0 +1,57 @@
+# OPTIONAL local Keycloak overlay — for developing/testing the optional
+# Keycloak SSO login path. NOT part of the default stack.
+#
+# Usage:
+#   docker compose -f docker-compose.yaml -f docker-compose.keycloak.yaml up
+#
+# Then enable SSO in config/app.yaml (these match the imported realm
+# `deploy/keycloak-dev/akb-realm.json` and the split localhost/container URLs):
+#
+#   keycloak_enabled: true
+#   keycloak_server_url: "http://localhost:8080"      # browser-facing → issuer
+#   keycloak_internal_url: "http://keycloak:8080"     # backend → keycloak container
+#   keycloak_realm: "akb"
+#   keycloak_client_id: "akb-web"
+#   keycloak_verify_ssl: false
+#   keycloak_redirect_uri: "http://localhost:3000/api/v1/auth/keycloak/callback"
+#
+# and in config/secret.yaml:
+#   keycloak_client_secret: "local-akb-dev-secret"
+#
+# Test user (in the imported realm): alice / alice-password (alice@example.com).
+#
+# The realm import ships a FIXED dev client secret ("local-akb-dev-secret").
+# That is a throwaway local value (same spirit as the hard-coded `akb`
+# Postgres password in docker-compose.yaml) — never reuse it anywhere real.
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      # Public (browser-facing) URL → pins the token `iss` to localhost:8080.
+      KC_HOSTNAME: http://localhost:8080
+      # Allow server-side (backend→keycloak:8080) calls under a different
+      # host than KC_HOSTNAME without rejection.
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+    volumes:
+      - ./deploy/keycloak-dev:/opt/keycloak/data/import:ro
+    ports:
+      - "8080:8080"
+    healthcheck:
+      # 26.x exposes health on the management port (9000) by default; the
+      # realm OIDC discovery doc is a reliable readiness signal on 8080.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+
+  backend:
+    # Backend must be able to resolve the `keycloak` service name for the
+    # backchannel (token + JWKS) calls.
+    depends_on:
+      keycloak:
+        condition: service_started

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -1,0 +1,250 @@
+# Keycloak OIDC login (optional external IdP) — Design
+
+**Status**: implemented + locally validated (real Keycloak 26 + browser e2e), awaiting review
+**Started**: 2026-06-07
+**Reference impl**: `seahorse-mcp-agent-server` (`app/auth.py`, `app/routers/auth.py`)
+**AKB build**: httpx + pyjwt only (no new deps); PG-backed transient store (HA-safe)
+
+## Statement
+
+AKB gains an **optional** Keycloak OIDC login path alongside the existing
+local username/password + PAT auth. Keycloak handles **authentication
+only** (the front door). AKB's internal user model, JWT issuance, and the
+entire PostgreSQL-ACL authorization model stay exactly as they are today.
+
+When `keycloak.enabled = false` (the default), nothing changes — every
+existing code path runs untouched. When enabled, Keycloak becomes an
+additional way to obtain an **AKB-issued** JWT; it does not replace the
+AKB JWT, PAT, or PG-role machinery.
+
+## Why Keycloak is authN-only (the core constraint)
+
+The seahorse agent server uses the Keycloak `id_token` directly as its
+runtime identity (HttpOnly cookie, JWKS-verified per request, identity =
+`email`/`preferred_username`/`sub`). **AKB cannot do this.**
+
+AKB's authorization is bound to the internal `users.id` UUID:
+
+- PG-native RBAC keys every role on it — `akb_user_<uid>`
+  (`role_sync.py:94`), and `SET LOCAL ROLE akb_user_<uid>` runs every
+  `akb_sql` query (`user_sql_executor.py:112`).
+- `vault_access(vault_id, user_id, role)`, vault ownership, PAT
+  (`tokens.user_id`), and JWT revocation (`tokens_revoked_before`) all
+  reference the internal UUID.
+
+If we validated Keycloak tokens directly in `resolve_token()` and used the
+Keycloak `sub`, then PG roles, PATs, and vault ownership would all break —
+there would be no `akb_user_<sub>` role, no `vault_access` rows for that
+identity, etc.
+
+**Therefore: Keycloak authenticates a person at the front door; AKB then
+maps that person to an internal user row (by email) and issues its own
+JWT via the existing `create_jwt()`.** The internal UUID — and everything
+keyed on it — is preserved.
+
+## Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Keycloak role | authN-only; **no** role/group mapping | is_admin & vault grants stay AKB-internal. Smallest blast radius; extend later. |
+| First login | **JIT auto-provision** by email | Any realm member who authenticates gets an AKB user + `akb_user_<uid>` role via the existing `on_user_create` hook. |
+| Token delivery to SPA | **one-time code exchange** (60s TTL) | Keeps AKB's Bearer + localStorage model; no token in URL history; no cookie-auth rewrite of the API client. |
+| Default | `enabled = false` | Local auth is the baseline; Keycloak is opt-in per deployment. |
+
+## Flow
+
+```
+[SPA]  GET /api/v1/auth/keycloak/login?redirect=/
+         → 302 to Keycloak authorization_endpoint
+           (state CSRF + PKCE S256, scope="openid profile email")
+
+[Keycloak login screen]
+
+       GET /api/v1/auth/keycloak/callback?code&state
+         1. verify+consume state (PG; PKCE code_verifier for public clients)
+         2. exchange code → tokens at token_endpoint (httpx)
+         3. verify id_token locally: JWKS RS256, kid match, aud/iss/exp
+            (pyjwt RSAAlgorithm.from_jwk; JWKS cached, refetched once on
+             key rotation / kid miss)
+         4. resolve internal user by email:
+              - found    → user_id
+              - not found→ provision_external_user(email, name, sub):
+                             INSERT users (auth_provider='keycloak')
+                             + RoleSync.on_user_create(uid)   [existing hook]
+         5. token = create_jwt(uid, username)                 [existing fn]
+         6. one_time_code = issue(token, ttl=60s)
+         7. 302 to {frontend}/auth/callback?code=<one_time_code>
+
+[SPA]  /auth/callback
+         POST /api/v1/auth/keycloak/exchange { code }
+         → { token, user }      ← identical shape to POST /auth/login
+         → setToken(token)      ← existing frontend code, unchanged
+         → navigate(redirect)
+```
+
+The `/exchange` response intentionally mirrors the existing
+`/auth/login` response (`{token, user:{id,username,email,display_name,is_admin}}`)
+so the SPA reuses `setToken()` and the rest of the Bearer flow verbatim.
+
+## Token validation (ported from seahorse, AKB deps)
+
+- **Local JWKS, no remote introspection.** Fetch JWKS from
+  `keycloak_jwks_uri`, cache in-process, match `kid` from the token
+  header, build the key with `jwt.algorithms.RSAAlgorithm.from_jwk(...)`
+  and decode with pyjwt `algorithms=["RS256"], audience=keycloak_client_id,
+  issuer=keycloak_issuer, options={"require": ["exp","iat","aud","iss","sub"]}`.
+  On a `kid` miss the JWKS is refetched once (key rotation) before failing.
+- This validation applies **only to the Keycloak `id_token` during
+  callback**. It is not on the per-request hot path — once AKB issues its
+  own JWT, `resolve_token()` handles every subsequent request exactly as
+  today (HS256 AKB JWT or `akb_` PAT).
+
+## Backend changes (file by file, as built)
+
+**New**
+- `backend/app/services/keycloak_oidc.py` — `KeycloakOIDC` class +
+  module singleton `get_keycloak_oidc()`. Builds the authorization URL,
+  exchanges code for tokens (httpx, honoring `keycloak_verify_ssl` via a
+  dedicated client), fetches/caches JWKS, verifies the id_token with
+  **pyjwt** RS256 (`RSAAlgorithm.from_jwk`), refetching JWKS once on a
+  `kid` miss. Also hosts the PG-backed transient store helpers
+  (`_store_issue` / `_store_consume`) and the one-time exchange-code
+  helpers (`issue_exchange_code` / `redeem_exchange_code`).
+- Transient store is the PG table `oidc_transients` (HA-safe across
+  replicas) — NOT an in-process dict. Holds both `kind='state'` (CSRF +
+  PKCE verifier + redirect path) and `kind='exchange'` (one-time code →
+  `{token, user}`). Single-use via `DELETE … RETURNING`, TTL-bounded,
+  opportunistically GC'd on issue.
+
+**Modified (additive only)**
+- `backend/app/api/routes/auth.py` — add `GET /auth/config` (public),
+  `GET /auth/keycloak/login`, `GET /auth/keycloak/callback`,
+  `POST /auth/keycloak/exchange`. Each SSO route `_require_keycloak()`s
+  → **404 when disabled**. Same-site `_safe_redirect_path()` guard blocks
+  open-redirects; callback failures bounce to `/auth?sso_error=<code>`.
+- `backend/app/services/auth_service.py` — add
+  `login_with_keycloak_claims(claims) -> {token, user}` (JIT-provision by
+  email + `on_user_create`, dedup on re-login, `ConflictError` if a
+  `local` account owns the email). `login()` now rejects non-`'local'`
+  providers; `verify_password()` is hardened against the non-bcrypt
+  sentinel. `create_jwt()` / `resolve_token()` **unchanged**.
+- `backend/app/config.py` — flat `keycloak_*` settings + derived-endpoint
+  properties (see below). `keycloak_enabled` defaults `false`.
+- `backend/app/services/lifecycle.py` — fail-fast validation when
+  enabled; close the Keycloak httpx client on shutdown.
+
+**Schema (migrations 033, 034 + init.sql)**
+- `033` — `users.auth_provider TEXT NOT NULL DEFAULT 'local'`. SSO users
+  get `'keycloak'` + a sentinel `password_hash`; local `/auth/login` is
+  rejected for non-`'local'` providers.
+- `034` — `oidc_transients` table (stays empty when SSO is off).
+
+## Config (flat `keycloak_*` keys)
+
+Flat keys (not a nested block) match the existing `jwt_*` / `s3_*` /
+`embed_*` convention AND avoid the shallow `app.yaml`+`secret.yaml` merge
+clobbering a nested mapping — so the secret can live in `secret.yaml`
+independently.
+
+```yaml
+# config/app.yaml  (non-secret)
+keycloak_enabled: false                # default — local auth only
+keycloak_server_url: https://auth.example.com   # browser-facing → issuer
+keycloak_internal_url: ""              # optional backchannel (server→KC); blank → server_url
+keycloak_realm: akb
+keycloak_client_id: akb-web
+keycloak_public_client: false          # true → PKCE, no client_secret
+keycloak_verify_ssl: true
+keycloak_redirect_uri: https://akb.example.com/api/v1/auth/keycloak/callback
+keycloak_post_login_path: /auth/callback
+keycloak_exchange_code_ttl_secs: 60
+# config/secret.yaml
+keycloak_client_secret: "<from Keycloak client credentials>"
+```
+
+- `keycloak_client_secret` lives only in `secret.yaml` (gitignored) —
+  matches `feedback_oss_no_secrets`. (AKB reads no env vars, so the
+  seahorse `client_secret_env` indirection is replaced by secret.yaml.)
+- **Split-horizon** `keycloak_internal_url`: when set, the **backchannel**
+  calls (token + JWKS) use it while the **issuer** and browser-facing
+  authorization/logout endpoints stay on `keycloak_server_url`. Solves
+  both prod (internal vs ingress URL) and the local docker
+  `localhost`-vs-`container-DNS` gap. Blank → single-URL (the common case).
+- OIDC endpoints are computed properties off the realm issuer — no
+  `.well-known` fetch.
+- Vendor name `keycloak` in keys is fine: external product name, not an
+  internal storage driver, so `feedback_driver_neutral_naming` (qdrant/
+  vector_*) does not apply.
+
+## Frontend changes
+
+- `frontend/src/pages/auth.tsx` — when `/auth/config` reports
+  `keycloak.enabled`, render an "SSO 로그인" button linking to
+  `/api/v1/auth/keycloak/login?redirect=<current>`. Existing
+  username/password form stays as the local fallback.
+- `frontend/src/pages/auth-callback.tsx` (new) — read `?code`, POST to
+  `/auth/keycloak/exchange`, `setToken(token)`, navigate. No keycloak-js /
+  oidc-client dependency (same as seahorse's plain-fetch SPA).
+- `frontend/src/lib/api.ts` — no change to the Bearer transport; only add
+  the two new endpoint helpers.
+
+## Differences from seahorse (and why)
+
+| Aspect | seahorse | AKB | Why different |
+|---|---|---|---|
+| Runtime identity | Keycloak id_token (cookie) | AKB-issued JWT | AKB authZ keyed on internal UUID |
+| Token transport | HttpOnly cookies | Bearer + localStorage (unchanged) | Avoid rewriting API client + PAT model |
+| Per-request verify | JWKS on every request | JWKS only at callback | AKB JWT/PAT path already exists |
+| First login | allow-list gate | JIT auto-provision | Decision locked; simpler onboarding |
+| Roles | `realm_access.roles` → admin | authN-only | Keep authZ AKB-internal for v1 |
+
+## Out of scope (v1) / future
+
+- Keycloak group → `vault_access` sync, and `realm_access.roles` → is_admin.
+  Hook point exists (`RoleSync`); revisit once authN ships.
+- Token refresh: AKB JWT is short-lived and re-obtained by re-login through
+  Keycloak (SSO session makes this seamless). A silent-refresh endpoint can
+  be added later if needed.
+- Single-logout / front-channel logout.
+- Account linking UX when a local user and a Keycloak email collide
+  (v1: same-email login adopts the existing row; surface a clear error if
+  the existing row is `auth_provider='local'` until linking is designed).
+
+## Local test harness
+
+Optional overlay `docker-compose.keycloak.yaml` + realm fixture
+`deploy/keycloak-dev/akb-realm.json` (realm `akb`, confidential client
+`akb-web` with a throwaway dev secret, test user `alice/alice-password`).
+
+```
+docker compose -f docker-compose.yaml -f docker-compose.keycloak.yaml up
+# then set keycloak_* in config/app.yaml + secret.yaml (see overlay header)
+```
+
+## Validation (done 2026-06-07)
+
+Validated against a real **Keycloak 26** (realm imported) + throwaway
+Postgres, exercising the actual backend modules and a real browser.
+
+- **Backend integration (20/20)** — config endpoint derivation; OIDC
+  JWKS RS256 verify of a real id_token; tampered-token rejection; issuer
+  enforcement; JIT provisioning (`auth_provider='keycloak'`, sentinel
+  hash); `akb_user_<uid>` + `akb_authenticated` PG roles created; dedup on
+  re-login (exactly one row); local-login rejected for SSO accounts;
+  `ConflictError` when a local account owns the email; one-time exchange
+  code single-use.
+- **HTTP routes (enabled)** — `/auth/config` → `enabled:true`;
+  `/auth/keycloak/login` → 302 to Keycloak with correct params;
+  open-redirect guard; `/exchange` bad code → 400; invalid `state` →
+  302 `/auth?sso_error=invalid_state`; local register/login regression OK.
+- **Full browser e2e (Playwright)** — `/auth/keycloak/login` → Keycloak
+  login page → `alice` → callback issued one-time code → `/exchange` →
+  AKB JWT → `/auth/me` (auth_method `jwt`, display_name synced) → PAT
+  issuance works → code replay 400.
+- **enabled=false (optional gate)** — `/auth/config` → `enabled:false`;
+  all three SSO routes → 404; local login still works; no Keycloak code
+  runs at boot.
+
+Outstanding before merge: run the full E2E suites (`test_mcp_e2e.sh`,
+`test_pg_rbac_e2e.sh`, `test_security_edge_e2e.sh`) against a compose
+stack as the standard pre-merge gate.

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -119,9 +119,12 @@ so the SPA reuses `setToken()` and the rest of the Bearer flow verbatim.
 **Modified (additive only)**
 - `backend/app/api/routes/auth.py` — add `GET /auth/config` (public),
   `GET /auth/keycloak/login`, `GET /auth/keycloak/callback`,
-  `POST /auth/keycloak/exchange`. Each SSO route `_require_keycloak()`s
-  → **404 when disabled**. Same-site `_safe_redirect_path()` guard blocks
-  open-redirects; callback failures bounce to `/auth?sso_error=<code>`.
+  `POST /auth/keycloak/exchange`, `GET /auth/keycloak/logout`. Each SSO
+  route `_require_keycloak()`s → **404 when disabled**. Same-site
+  `_safe_redirect_path()` guard blocks open-redirects; callback failures
+  bounce to `/auth?sso_error=<code>`. The callback also stashes the KC
+  `id_token` in the exchange payload so the SPA can pass it as
+  `id_token_hint` for a prompt-free RP-initiated logout.
 - `backend/app/services/auth_service.py` — add
   `login_with_keycloak_claims(claims) -> {token, user}` (JIT-provision by
   email + `on_user_create`, dedup on re-login, `ConflictError` if a
@@ -205,7 +208,11 @@ keycloak_client_secret: "<from Keycloak client credentials>"
 - Token refresh: AKB JWT is short-lived and re-obtained by re-login through
   Keycloak (SSO session makes this seamless). A silent-refresh endpoint can
   be added later if needed.
-- Single-logout / front-channel logout.
+- RP-initiated logout IS implemented (`GET /auth/keycloak/logout` →
+  Keycloak `end_session_endpoint`, seamless via `id_token_hint`; the SPA
+  triggers it only for SSO-originated sessions via a localStorage marker,
+  so local-auth logout is untouched). Still out of scope: Keycloak
+  front-channel/back-channel single-logout that notifies *other* RPs.
 - Account linking UX when a local user and a Keycloak email collide
   (v1: same-email login adopts the existing row; surface a clear error if
   the existing row is `auth_provider='local'` until linking is designed).

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -213,9 +213,21 @@ keycloak_client_secret: "<from Keycloak client credentials>"
   triggers it only for SSO-originated sessions via a localStorage marker,
   so local-auth logout is untouched). Still out of scope: Keycloak
   front-channel/back-channel single-logout that notifies *other* RPs.
-- Account linking UX when a local user and a Keycloak email collide
-  (v1: same-email login adopts the existing row; surface a clear error if
-  the existing row is `auth_provider='local'` until linking is designed).
+- Account linking: a same-email collision with a non-`keycloak` account is
+  rejected by default (`ConflictError`, no silent merge). Opt-in
+  `keycloak_link_by_email` (default false) links the SSO identity to the
+  existing account — keeping its `user_id`, PATs, vault ownership and
+  grants — and flips `auth_provider` to `keycloak`. A cross-provider link
+  requires the id_token's `email_verified` to be true (independent of
+  `keycloak_require_verified_email`) so a relaxed realm can't take over an
+  account by asserting its email. This is what the **managed akb-platform**
+  needs: its operator pre-provisions an AKB user (+PAT) per member via
+  `/auth/register` (local), and the same member then logs in via SSO —
+  without linking, every pre-provisioned member is locked out. (Platform
+  wiring: set `keycloak_link_by_email: true` + `keycloak_require_verified_email:
+  true` in the per-tenant AKB backend config. PAT *rotation* after a member
+  has SSO-linked still needs an admin mint API — separate follow-up, since
+  the operator currently mints by logging in with the now-retired password.)
 
 ## Local test harness
 

--- a/frontend/src/components/__tests__/user-menu.test.tsx
+++ b/frontend/src/components/__tests__/user-menu.test.tsx
@@ -12,6 +12,10 @@ vi.mock("@/lib/api", () => ({
     is_admin: false,
   }),
   setToken: vi.fn(),
+  // SSO-aware sign-out helpers (default: not an SSO session → local logout).
+  isSsoSession: vi.fn().mockReturnValue(false),
+  clearSsoSession: vi.fn(),
+  keycloakLogoutUrl: vi.fn().mockReturnValue("/api/v1/auth/keycloak/logout"),
 }));
 
 vi.mock("@/hooks/use-theme", () => ({

--- a/frontend/src/components/user-menu.tsx
+++ b/frontend/src/components/user-menu.tsx
@@ -8,7 +8,7 @@ import {
   Settings as SettingsIcon,
   Sun,
 } from "lucide-react";
-import { getMe, setToken } from "@/lib/api";
+import { getMe, setToken, isSsoSession, clearSsoSession, keycloakLogoutUrl } from "@/lib/api";
 import { useTheme, type Theme } from "@/hooks/use-theme";
 
 interface User {
@@ -129,8 +129,20 @@ export function UserMenu() {
 
           <DropdownMenu.Item
             onSelect={() => {
+              const sso = isSsoSession();
+              // Build the KC logout URL (reads the id_token_hint) BEFORE
+              // clearing the session, otherwise the hint is gone and
+              // Keycloak falls back to a "Do you want to log out?" prompt.
+              const kcLogout = sso ? keycloakLogoutUrl() : null;
               setToken(null);
-              navigate("/auth");
+              clearSsoSession();
+              if (kcLogout) {
+                // RP-initiated logout: end the Keycloak session too, then
+                // KC redirects back to /auth. Full navigation (not SPA).
+                window.location.href = kcLogout;
+              } else {
+                navigate("/auth");
+              }
             }}
             className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-destructive outline-none data-[highlighted]:bg-destructive/10"
           >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,36 @@ export function getToken(): string | null {
   return _token;
 }
 
+// ── SSO session marker (optional Keycloak) ──
+// Records whether the *current* session was obtained via Keycloak SSO, so
+// "Sign out" can also end the Keycloak session (RP-initiated logout) —
+// otherwise the live KC session would silently re-authenticate on the next
+// SSO click. Local-auth sessions never set this, so their logout is
+// unaffected. We also keep the KC id_token to pass as id_token_hint for a
+// prompt-free logout.
+const SSO_FLAG = "akb_sso";
+const KC_HINT = "akb_kc_id_token";
+
+export function markSsoSession(kcIdToken?: string) {
+  localStorage.setItem(SSO_FLAG, "1");
+  if (kcIdToken) localStorage.setItem(KC_HINT, kcIdToken);
+}
+
+export function clearSsoSession() {
+  localStorage.removeItem(SSO_FLAG);
+  localStorage.removeItem(KC_HINT);
+}
+
+export function isSsoSession(): boolean {
+  return localStorage.getItem(SSO_FLAG) === "1";
+}
+
+/** Backend RP-initiated logout endpoint (bounces to KC end_session → /auth). */
+export function keycloakLogoutUrl(): string {
+  const hint = localStorage.getItem(KC_HINT);
+  return `${API_BASE}/auth/keycloak/logout${hint ? `?id_token_hint=${encodeURIComponent(hint)}` : ""}`;
+}
+
 /**
  * Error thrown by `api()` when the server returns a structured 4xx/5xx body
  * (FastAPI `HTTPException(detail=dict)`). Inherits from `Error` so existing

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -123,6 +123,25 @@ export const authLogin = (username: string, password: string) =>
     body: JSON.stringify({ username, password }),
   }).then(parseAuthResponse);
 
+export interface AuthConfig {
+  keycloak: { enabled: boolean; login_url: string | null };
+}
+
+/** Public auth config — drives whether the optional SSO button shows.
+ * Falls back to SSO-disabled if the endpoint is unreachable/old. */
+export const getAuthConfig = (): Promise<AuthConfig> =>
+  fetch(`${API_BASE}/auth/config`)
+    .then((r) => (r.ok ? r.json() : { keycloak: { enabled: false, login_url: null } }))
+    .catch(() => ({ keycloak: { enabled: false, login_url: null } }));
+
+/** Redeem the one-time SSO code from the Keycloak callback for an AKB JWT. */
+export const keycloakExchange = (code: string) =>
+  fetch(`${API_BASE}/auth/keycloak/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+  }).then(parseAuthResponse);
+
 // ── Auth (token) ──
 export const getMe = () => api<any>("/auth/me");
 export const createPAT = (name: string, scopes?: string[], expires_days?: number) =>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { Layout } from "@/components/layout";
 import { VaultShell } from "@/components/vault-shell";
 import AuthPage from "@/pages/auth";
 import AuthForgotPage from "@/pages/auth-forgot";
+import AuthCallbackPage from "@/pages/auth-callback";
 import HomePage from "@/pages/home";
 import VaultPage from "@/pages/vault";
 import VaultIndexPage from "@/pages/vault-index";
@@ -50,6 +51,7 @@ createRoot(document.getElementById("root")!).render(
       <Routes>
         <Route path="/auth" element={<AuthPage />} />
         <Route path="/auth/forgot" element={<AuthForgotPage />} />
+        <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/p/:slug" element={<PublicationPage />} />
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />

--- a/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
+++ b/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@/lib/api", () => ({
   authLogin: vi.fn(),
   authRegister: vi.fn(),
   setToken: vi.fn(),
+  // Optional Keycloak SSO probe — default disabled so the SSO button stays
+  // hidden and AuthPage's mount effect resolves cleanly.
+  getAuthConfig: vi.fn().mockResolvedValue({
+    keycloak: { enabled: false, login_url: null },
+  }),
+  clearSsoSession: vi.fn(),
 }));
 
 const mockedLogin = vi.mocked(authLogin);

--- a/frontend/src/pages/auth-callback.tsx
+++ b/frontend/src/pages/auth-callback.tsx
@@ -26,9 +26,12 @@ export default function AuthCallbackPage() {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
     const redirect = params.get("redirect") || "/";
-    const safeRedirect = redirect.startsWith("/") && !redirect.startsWith("//")
-      ? redirect
-      : "/";
+    // Same-site path only — mirror the backend _safe_redirect_path guard
+    // (block scheme-relative "//" and backslash tricks).
+    const safeRedirect =
+      redirect.startsWith("/") && !redirect.startsWith("//") && !redirect.includes("\\")
+        ? redirect
+        : "/";
 
     if (!code) {
       navigate("/auth?sso_error=missing_code", { replace: true });

--- a/frontend/src/pages/auth-callback.tsx
+++ b/frontend/src/pages/auth-callback.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
-import { keycloakExchange, setToken } from "@/lib/api";
+import { keycloakExchange, markSsoSession, setToken } from "@/lib/api";
 
 /**
  * Keycloak SSO landing page. The backend callback redirects the browser
@@ -43,6 +43,8 @@ export default function AuthCallbackPage() {
           return;
         }
         setToken(r.token);
+        // Mark this as an SSO session so Sign out also ends the KC session.
+        markSsoSession(r.kc_id_token);
         navigate(safeRedirect, { replace: true });
       })
       .catch(() => {

--- a/frontend/src/pages/auth-callback.tsx
+++ b/frontend/src/pages/auth-callback.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import { keycloakExchange, setToken } from "@/lib/api";
+
+/**
+ * Keycloak SSO landing page. The backend callback redirects the browser
+ * here with a one-time `code` (and a same-site `redirect` path). We POST
+ * the code to exchange it for an AKB JWT — the token is delivered in the
+ * response body, never in the URL — store it, then navigate on.
+ *
+ * On any failure we bounce back to /auth with a reason so the user sees a
+ * readable message instead of a dead-end.
+ */
+export default function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const [error, setError] = useState("");
+  // StrictMode double-invokes effects in dev; the code is single-use, so
+  // guard against a second redeem that would always 400.
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const redirect = params.get("redirect") || "/";
+    const safeRedirect = redirect.startsWith("/") && !redirect.startsWith("//")
+      ? redirect
+      : "/";
+
+    if (!code) {
+      navigate("/auth?sso_error=missing_code", { replace: true });
+      return;
+    }
+
+    keycloakExchange(code)
+      .then((r) => {
+        if (r.error || !r.token) {
+          setError(r.error || "Exchange failed");
+          navigate("/auth?sso_error=exchange_failed", { replace: true });
+          return;
+        }
+        setToken(r.token);
+        navigate(safeRedirect, { replace: true });
+      })
+      .catch(() => {
+        navigate("/auth?sso_error=exchange_failed", { replace: true });
+      });
+  }, [navigate]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+      <div className="flex flex-col items-center gap-4 font-mono text-sm text-foreground-muted">
+        {error ? (
+          <span>Redirecting…</span>
+        ) : (
+          <>
+            <Loader2 className="h-6 w-6 animate-spin" aria-hidden />
+            <span>Completing sign-in…</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowRight, Loader2 } from "lucide-react";
-import { authLogin, authRegister, setToken } from "@/lib/api";
+import { authLogin, authRegister, getAuthConfig, setToken } from "@/lib/api";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
@@ -122,6 +122,28 @@ export default function AuthPage() {
   const [displayName, setDisplayName] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [ssoLoginUrl, setSsoLoginUrl] = useState<string | null>(null);
+
+  // Optional Keycloak SSO: show the button only if the backend reports it
+  // enabled. Also surface a friendly message if the callback bounced us
+  // back with ?sso_error=… (browser-level redirect can't return JSON).
+  useEffect(() => {
+    getAuthConfig().then((cfg) => {
+      if (cfg.keycloak.enabled && cfg.keycloak.login_url) {
+        setSsoLoginUrl(cfg.keycloak.login_url);
+      }
+    });
+    const params = new URLSearchParams(window.location.search);
+    const ssoErr = params.get("sso_error");
+    if (ssoErr) setError(`SSO login failed (${ssoErr}). Please try again.`);
+  }, []);
+
+  function startSso() {
+    if (!ssoLoginUrl) return;
+    // Preserve where the user was headed (default home).
+    const redirect = "/";
+    window.location.href = `${ssoLoginUrl}?redirect=${encodeURIComponent(redirect)}`;
+  }
 
   const title = useTyped("Agent Knowledgebase", 60);
   const subText =
@@ -356,6 +378,24 @@ export default function AuthPage() {
                 />
               </TabsContent>
             </Tabs>
+
+            {ssoLoginUrl && (
+              <div className="mt-6">
+                <div className="relative mb-5 flex items-center gap-3">
+                  <div className="tw-rule-dashed h-px flex-1" aria-hidden />
+                  <span className="coord text-foreground-muted">or</span>
+                  <div className="tw-rule-dashed h-px flex-1" aria-hidden />
+                </div>
+                <button
+                  type="button"
+                  onClick={startSso}
+                  className="tw-key flex w-full items-center justify-center gap-2 border border-foreground bg-background px-4 py-2.5 font-mono text-sm font-semibold uppercase tracking-[0.12em] text-foreground"
+                >
+                  Sign in with SSO
+                  <ArrowRight className="h-4 w-4" aria-hidden />
+                </button>
+              </div>
+            )}
           </section>
         </div>
 

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowRight, Loader2 } from "lucide-react";
-import { authLogin, authRegister, getAuthConfig, setToken } from "@/lib/api";
+import { authLogin, authRegister, clearSsoSession, getAuthConfig, setToken } from "@/lib/api";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
@@ -182,6 +182,9 @@ export default function AuthPage() {
         return;
       }
       setToken(r.token);
+      // Local-auth session — make sure no stale SSO marker triggers a
+      // Keycloak logout when this user signs out.
+      clearSsoSession();
       if ("PasswordCredential" in window) {
         const cred = new PasswordCredential({ id: username, password });
         navigator.credentials.store(cred).catch(() => {});


### PR DESCRIPTION
## Summary

Adds an **optional** Keycloak SSO login path alongside the existing local username/password + PAT auth. **Disabled by default** (`keycloak_enabled: false`) — when off, zero Keycloak code runs, the SSO routes return 404, and local auth is byte-for-byte unchanged.

Keycloak authenticates **at the front door only**. On success AKB maps the verified identity (by email) to an internal user via **JIT provisioning** and issues its own JWT with the existing `create_jwt()`. The internal user UUID — and everything keyed on it (PG-native RBAC `akb_user_<uid>`, PATs, vault ownership, JWT revocation) — is preserved. Keycloak roles are **not** mapped to AKB authorization (authN-only for v1).

## Design

`docs/designs/keycloak-oidc/00-overview.md`. Core constraint: AKB authZ is bound to the internal `users.id` UUID, so (unlike the seahorse agent) we cannot use the Keycloak token as the runtime identity — we bridge it to an AKB-issued JWT.

## Key properties (OSS hygiene + optional)

- **No new dependencies** — uses AKB's existing `httpx` (token/JWKS) + `pyjwt` RS256 (`RSAAlgorithm.from_jwk`). No aiohttp/python-jose.
- **HA-safe** — OIDC state + one-time exchange codes persisted in a new `oidc_transients` table (single-use, TTL-bounded); empty when SSO is off.
- **Token never in URL** — SPA redeems a one-time code via POST `/exchange`; keeps the existing Bearer + localStorage model (no cookie-auth rewrite).
- **Secrets** — `keycloak_client_secret` only in gitignored `secret.yaml`; no secrets in tracked files.
- **Split-horizon** — optional `keycloak_internal_url` (backchannel) vs `keycloak_server_url` (issuer/browser).

## Changes

**Backend**: `keycloak_oidc.py` (OIDC client + PG transient store), routes (`/auth/config`, `keycloak/login|callback|exchange`), `auth_service.login_with_keycloak_claims()` (JIT + dedup + conflict), `login()` rejects non-local providers, flat `keycloak_*` config, fail-fast validation, migrations 033/034 + init.sql.

**Frontend**: SSO button gated on `/auth/config`, `auth-callback` page (code→token), api helpers.

**Local test harness**: `docker-compose.keycloak.yaml` overlay + `deploy/keycloak-dev/akb-realm.json` (realm `akb`, client `akb-web`, user `alice`).

## Validation

- **Real Keycloak 26 backend integration**: 20/20 (JWKS RS256 verify, tampered-token reject, issuer enforce, JIT provisioning, PG role creation, dedup, local-login guard, email-collision conflict, one-time code single-use).
- **Full browser e2e (Playwright)**: login → Keycloak → callback → one-time code → exchange → AKB JWT → `/auth/me` → PAT issuance; code replay 400.
- **enabled=false gate**: `/auth/config` `enabled:false`, all SSO routes 404, local login intact, no Keycloak code at boot.
- **Regression suites**: `test_mcp_e2e` 76/76, `test_pg_rbac_e2e` 50/50, `test_security_edge_e2e` 63/63 (fresh DB, migrations 033/034 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)