### PR TITLE
fix(db): migration ledger — stop re-running chunks ALTERs on every boot (rollout lock crashloop)

### DIFF
--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -9,6 +9,20 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ============================================================
+-- Migration ledger — records which migration scripts have been applied
+-- so they are NOT re-run on every boot. Several migrations ALTER the hot
+-- `chunks` table (ACCESS EXCLUSIVE lock); re-running them each startup
+-- races live workers' open transactions and can stall a rolling deploy.
+-- With the ledger, a steady-state boot runs zero migration DDL.
+-- (init.sql itself is still re-run every boot — it is pure CREATE … IF
+-- NOT EXISTS and takes no conflicting locks.)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
 -- Users
 -- ============================================================
 CREATE TABLE IF NOT EXISTS users (

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -83,9 +83,57 @@ def _load_migration(filename: str):
     return module
 
 
+async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, backoff: float = 4.0) -> None:
+    """Apply one migration under a bounded lock_timeout, retrying on a lock
+    conflict, then record it in the ledger.
+
+    Migrations that ALTER `chunks` need an ACCESS EXCLUSIVE lock. During a
+    rolling deploy the outgoing pod's workers may still hold an open
+    transaction on that table; without a bound the ALTER would block until
+    the connection's 30s statement_timeout cancels it (QueryCanceledError),
+    crashing startup. A short lock_timeout makes us fail fast and retry
+    until the lock clears (the server also kills idle-in-transaction holders
+    at 60s). The pooled connection's state is reset on release, so the
+    per-migration `SET lock_timeout` does not leak to other callers.
+    """
+    import logging
+    log = logging.getLogger("akb.migrations")
+    for attempt in range(retries):
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute("SET lock_timeout = '5s'")
+                await module.migrate(conn=conn)
+                await conn.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES ($1) "
+                    "ON CONFLICT (filename) DO NOTHING",
+                    filename,
+                )
+            return
+        except (asyncpg.LockNotAvailableError, asyncpg.QueryCanceledError) as e:
+            if attempt < retries - 1:
+                log.warning(
+                    "Migration %s blocked on a lock (attempt %d/%d): %s — retrying in %.0fs",
+                    filename, attempt + 1, retries, e, backoff,
+                )
+                await asyncio.sleep(backoff)
+            else:
+                raise
+
+
 async def _apply_migrations() -> None:
-    """Run all idempotent migration scripts in order. Safe to call repeatedly."""
+    """Apply migration scripts once each, in order. Safe to call repeatedly.
+
+    A `schema_migrations` ledger records applied files so steady-state boots
+    run ZERO migration DDL — see the ledger note in init.sql for why that
+    matters (the `chunks` ALTERs take an ACCESS EXCLUSIVE lock that races
+    live workers during a rolling deploy). Unrecorded migrations run via
+    :func:`_run_one_migration` (bounded lock_timeout + retry).
+    """
     pool = await get_pool()
+    async with pool.acquire() as conn:
+        applied = {
+            r["filename"] for r in await conn.fetch("SELECT filename FROM schema_migrations")
+        }
     for filename in (
         "002_public_shares.py",     # legacy is_public/public_slug → public_shares
         "003_rename_public_shares.py",  # public_shares → publications
@@ -120,8 +168,9 @@ async def _apply_migrations() -> None:
         "033_users_auth_provider.py",           # users.auth_provider ('local' default | 'keycloak' for JIT-provisioned SSO accounts)
         "034_oidc_transients.py",               # oidc_transients: short-lived OIDC state + one-time exchange codes (HA-safe; empty when Keycloak off)
     ):
+        if filename in applied:
+            continue
         module = _load_migration(filename)
         if module is None:
             continue
-        async with pool.acquire() as conn:
-            await module.migrate(conn=conn)
+        await _run_one_migration(pool, filename, module)


### PR DESCRIPTION
## Problem
Every backend boot re-ran the full migration list. Several migrations `ALTER TABLE chunks ADD COLUMN IF NOT EXISTS …` — an ACCESS EXCLUSIVE lock even as a no-op. During a **rolling deploy** the outgoing pod's workers still hold open transactions on `chunks`, so the new pod's ALTER blocks until the 30s `statement_timeout` cancels it (`QueryCanceledError`), which `init_db`'s retry loop doesn't catch → startup crashes into a ~32s restart loop. Observed repeatedly in the live `akb` namespace this session (had to `pg_terminate_backend` the idle-in-transaction holder by hand each rollout).

## Fix
- **`schema_migrations` ledger** (init.sql): `_apply_migrations` skips files already recorded, so a steady-state boot runs **zero migration DDL** and takes no `chunks` lock.
- **`_run_one_migration`**: the migrations that still run (new ones, or the one-time re-run when the ledger is first created) execute under a bounded `lock_timeout='5s'` with retry + backoff, so a transient lock → retry instead of hang/crash. Pooled-connection state resets on release, so the per-migration `SET` doesn't leak.

## Verification (throwaway PG, apply-twice + lock injection)
- ledger populated (32) → re-boot adds nothing (idempotent)
- **a held `ACCESS EXCLUSIVE` lock on `chunks` no longer stalls a steady-state boot (0.0s)** — the core regression
- a forced re-run under a transient lock retries (5s lock_timeout) and succeeds once released
- full `scripts/check.sh` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)