### PR TITLE
feat(admin): mint a PAT for any user (admin-authenticated, by id/email)

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -209,6 +209,49 @@ async def admin_reset_user_password(
     return {"temporary_password": temp, "username": username}
 
 
+class AdminMintTokenRequest(NFCModel):
+    name: str
+    expires_days: int | None = None
+
+
+@router.post(
+    "/admin/users/{user_ref}/tokens",
+    summary="[admin] Mint a PAT for any user (by id or email)",
+)
+async def admin_mint_user_token(
+    user_ref: str,
+    req: AdminMintTokenRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Issue a Personal Access Token on behalf of another user.
+
+    The normal ``POST /auth/tokens`` mints for the *caller*, which forces
+    the caller to know that user's password. A managed control plane that
+    provisions members (and especially after a member SSO-links, retiring
+    their local password) has no password to log in with — so it needs an
+    admin-authenticated way to mint a member's PAT by email. Returns the raw
+    token once, same shape as ``/auth/tokens``.
+    """
+    _require_admin(user)
+    import uuid as _uuid
+    from app.db.postgres import get_pool
+    from app.services.auth_service import create_pat
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        try:
+            uid = _uuid.UUID(user_ref)
+            row = await conn.fetchrow("SELECT id FROM users WHERE id = $1", uid)
+        except ValueError:
+            # Not a UUID → treat as an email (how the platform keys members).
+            row = await conn.fetchrow(
+                "SELECT id FROM users WHERE email = $1", user_ref
+            )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+    return await create_pat(str(row["id"]), req.name, expires_days=req.expires_days)
+
+
 @router.get(
     "/admin/role-state",
     summary="[admin] Diff PG role state against the AKB catalog (read-only)",

--- a/backend/tests/test_auth_password_e2e.sh
+++ b/backend/tests/test_auth_password_e2e.sh
@@ -160,6 +160,46 @@ HTTP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
   -H "Authorization: Bearer $ADMIN_JWT")
 [ "$HTTP" = "404" ] && pass "bogus user → 404" || fail "bogus user" "got $HTTP"
 
+# ── 3. Admin mint PAT for another user ─────────────────────
+echo ""
+echo "▸ 3. /admin/users/{ref}/tokens (admin mints a PAT for another user)"
+
+# By email (how the managed platform keys members; needed for SSO-linked
+# users who have no usable password to log in and self-mint).
+MINTED=$(curl -sk -X POST "$BASE_URL/api/v1/admin/users/$USER@t.dev/tokens" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"admin-minted"}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))')
+[ -n "$MINTED" ] && pass "admin mint by email → PAT" || fail "admin mint" "no token"
+
+# The minted PAT authenticates AS the target user.
+MINTED_ID=$(me_user_id "$MINTED")
+[ "$MINTED_ID" = "$USER_ID" ] && pass "minted PAT acts as target" \
+  || fail "minted PAT identity" "got $MINTED_ID want $USER_ID"
+
+# By user-id also works.
+HTTP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
+  "$BASE_URL/api/v1/admin/users/$USER_ID/tokens" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"by-id"}')
+[ "$HTTP" = "200" ] && pass "admin mint by id → 200" || fail "mint by id" "got $HTTP"
+
+# Non-admin → 403. Use a FRESH non-admin user (the earlier admin reset
+# revoked the original target user's sessions, so its JWT would 401).
+NA_JWT=$(register_and_login "pw-e2e-na-$TS" "fresh-na-secret-12")
+HTTP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
+  "$BASE_URL/api/v1/admin/users/$USER_ID/tokens" \
+  -H "Authorization: Bearer $NA_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"x"}')
+[ "$HTTP" = "403" ] && pass "non-admin mint → 403" || fail "non-admin mint" "got $HTTP"
+
+# Unknown user → 404.
+HTTP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
+  "$BASE_URL/api/v1/admin/users/nobody-$TS@t.dev/tokens" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"x"}')
+[ "$HTTP" = "404" ] && pass "unknown user mint → 404" || fail "unknown mint" "got $HTTP"
+
 # Summary
 echo ""
 echo "═══════════════════════════════════"


### PR DESCRIPTION
## Why
The managed akb-platform operator provisions members and needs each member's PAT for the agent. After a member SSO-links (PR #149's `keycloak_link_by_email`), their local password is retired, so the operator can no longer `login`-then-`/auth/tokens` to mint. This adds an admin-authenticated mint-for-another-user endpoint so the platform's admin/bot credential can issue PATs by email without any password.

## What
`POST /api/v1/admin/users/{ref}/tokens` — `{name, expires_days?}`:
- `{ref}` resolves by UUID, else by email (how the platform keys members).
- `_require_admin` gate; reuses `create_pat()`; returns the raw token once (same shape as `/auth/tokens`).
- 403 non-admin · 404 unknown user · 401 unauthenticated.

## Test
Added to `test_auth_password_e2e.sh` (▸3): mint by email → PAT authenticates **as the target**, mint by id → 200, non-admin → 403, unknown → 404. `scripts/check.sh` green locally.

Note: the platform side (make the bot user an AKB admin + call this endpoint) is a separate akb-platform change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)