### PR TITLE
test(e2e): fix stale assertions (depth→hops, table uri, help GET headers, seed-aware empty-vault)

### DIFF
--- a/backend/tests/test_defensive_e2e.sh
+++ b/backend/tests/test_defensive_e2e.sh
@@ -227,20 +227,25 @@ echo "▸ 6. Empty Vault Operations"
 EMPTY_VAULT="def-empty-$(date +%s)"
 m "akb_create_vault" "{\"name\":\"$EMPTY_VAULT\",\"description\":\"empty\"}" >/dev/null
 
-# Browse empty vault
+# Browse a fresh vault. Every non-mirror vault is seeded with a starter
+# overview/vault-skill.md (document_service seeds it on create), so a fresh
+# vault is not literally empty — it carries just that seed. Assert a small
+# bounded count (catches a vault that wrongly accumulates content) rather
+# than 0.
 R=$(m "akb_browse" "{\"vault\":\"$EMPTY_VAULT\"}")
 EMPTY_ITEMS=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('items',[])))" 2>/dev/null)
-[ "$EMPTY_ITEMS" = "0" ] && pass "Browse empty vault: 0 items" || fail "Empty browse" "items=$EMPTY_ITEMS"
+[ "$EMPTY_ITEMS" -le 2 ] 2>/dev/null && pass "Browse fresh vault: $EMPTY_ITEMS items (seeded vault-skill)" || fail "Empty browse" "items=$EMPTY_ITEMS"
 
 # Search empty vault
 R=$(m "akb_search" "{\"query\":\"anything\",\"vault\":\"$EMPTY_VAULT\"}")
 EMPTY_SEARCH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('total',0))" 2>/dev/null)
 [ "$EMPTY_SEARCH" = "0" ] && pass "Search empty vault: 0 results" || fail "Empty vault search" "$R"
 
-# Activity on new vault — may have init commit
+# Activity on a fresh vault — the init commit plus the seeded vault-skill
+# commit (≤2).
 R=$(m "akb_activity" "{\"vault\":\"$EMPTY_VAULT\"}")
 EMPTY_ACT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('activity',[])))" 2>/dev/null)
-[ "$EMPTY_ACT" -le 1 ] 2>/dev/null && pass "Activity on new vault: $EMPTY_ACT entries (init commit)" || fail "Empty activity" "entries=$EMPTY_ACT"
+[ "$EMPTY_ACT" -le 2 ] 2>/dev/null && pass "Activity on new vault: $EMPTY_ACT entries (init + skill seed)" || fail "Empty activity" "entries=$EMPTY_ACT"
 
 m "akb_delete_vault" "{\"name\":\"$EMPTY_VAULT\"}" >/dev/null 2>&1
 

--- a/backend/tests/test_graph_replace_e2e.sh
+++ b/backend/tests/test_graph_replace_e2e.sh
@@ -151,7 +151,7 @@ REL_COUNT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); pri
 [ "$REL_COUNT" -ge 1 ] 2>/dev/null && pass "Relations visible from A ($REL_COUNT)" || fail "Relations" "$R"
 
 # Check graph
-R=$(m1 "akb_graph" "{\"uri\":\"$URI_A\",\"depth\":1}")
+R=$(m1 "akb_graph" "{\"uri\":\"$URI_A\",\"hops\":1}")
 NODES=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('nodes',[])))" 2>/dev/null)
 EDGES=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('edges',[])))" 2>/dev/null)
 [ "$NODES" -ge 2 ] 2>/dev/null && pass "Graph: $NODES nodes, $EDGES edges" || fail "Graph" "$R"

--- a/backend/tests/test_help_skill_template_e2e.sh
+++ b/backend/tests/test_help_skill_template_e2e.sh
@@ -16,7 +16,10 @@ echo "$RESP" | grep -q "{vault}" && pass "{vault} placeholder kept intact" || fa
 echo "$RESP" | grep -q '\${{secrets.X}}' && pass "Secrets placeholder literal" || fail "T5" "secrets placeholder collapsed"
 
 echo "▸ Content-Type is text/markdown"
-CT=$(curl -sk -I "$BASE_URL/api/v1/help/skill-template" | grep -i "^content-type:" | tr -d '\r')
+# Inspect the GET response headers (-D -). The route is GET-only, so a HEAD
+# (`curl -I`) returns 405 application/json — that would be testing the wrong
+# thing, not the actual content type the endpoint serves.
+CT=$(curl -sk -o /dev/null -D - "$BASE_URL/api/v1/help/skill-template" | grep -i "^content-type:" | tr -d '\r')
 echo "$CT" | grep -qi "text/markdown" && pass "Content-Type text/markdown" || fail "T6" "Content-Type should be text/markdown, got: $CT"
 
 echo ""

--- a/backend/tests/test_table_crud_envelope_e2e.sh
+++ b/backend/tests/test_table_crud_envelope_e2e.sh
@@ -69,12 +69,14 @@ CREATE=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
   -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$TABLE\",\"description\":\"customers\",\"columns\":[{\"name\":\"email\",\"type\":\"text\"},{\"name\":\"age\",\"type\":\"number\"}]}")
-assert_keys "create" "$CREATE" kind id vault name columns
+# Tables are URI-addressed (no `d-` id like documents) — the envelope key
+# is `uri`, not `id`.
+assert_keys "create" "$CREATE" kind uri vault name columns
 assert_value "create" "$CREATE" "v=d['kind']" "table"
 assert_value "create" "$CREATE" "v=d['vault']" "$VAULT"
 assert_value "create" "$CREATE" "v=d['name']" "$TABLE"
 
-TABLE_ID=$(echo "$CREATE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+TABLE_URI=$(echo "$CREATE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["uri"])')
 
 echo ""
 echo "▸ 2. List tables — envelope shape"
@@ -87,7 +89,7 @@ assert_value "list" "$LIST" "v=d['vault']" "$VAULT"
 assert_value "list" "$LIST" "v=d['total']" "1"
 assert_value "list" "$LIST" "v=d['items'][0]['kind']" "table"
 assert_value "list" "$LIST" "v=d['items'][0]['name']" "$TABLE"
-assert_value "list" "$LIST" "v=d['items'][0]['id']" "$TABLE_ID"
+assert_value "list" "$LIST" "v=d['items'][0]['uri']" "$TABLE_URI"
 
 echo ""
 echo "▸ 3. SQL SELECT — envelope shape (rows → items)"
@@ -113,7 +115,7 @@ echo "▸ 4. Drop table — envelope shape"
 
 DROP=$(curl -sk -X DELETE "$BASE_URL/api/v1/tables/$VAULT/$TABLE" \
   -H "Authorization: Bearer $PAT")
-assert_keys "drop" "$DROP" kind id vault name deleted
+assert_keys "drop" "$DROP" kind uri vault name deleted
 assert_value "drop" "$DROP" "v=d['kind']" "table"
 assert_value "drop" "$DROP" "v=d['vault']" "$VAULT"
 assert_value "drop" "$DROP" "v=d['name']" "$TABLE"

--- a/backend/tests/test_unified_browse_edges_e2e.sh
+++ b/backend/tests/test_unified_browse_edges_e2e.sh
@@ -243,13 +243,13 @@ echo "  Node types: $NODE_TYPES"
 HAS_MIXED=$(echo "$R" | python3 -c "import sys,json; nodes=json.load(sys.stdin)['nodes']; types=set(n['resource_type'] for n in nodes); print('doc' in types and 'table' in types)" 2>/dev/null)
 [ "$HAS_MIXED" = "True" ] && pass "Graph has mixed node types (doc+table)" || fail "Graph mixed" "single type only"
 
-# Subgraph from table
-R=$(mcp_call akb_graph "{\"uri\":\"$TABLE_URI\",\"depth\":2}" | mcp_result)
+# Subgraph from table (akb_graph uses `hops`, not `depth`)
+R=$(mcp_call akb_graph "{\"uri\":\"$TABLE_URI\",\"hops\":2}" | mcp_result)
 SUB_NODES=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['nodes']))" 2>/dev/null)
 [ "$SUB_NODES" -ge 2 ] 2>/dev/null && pass "Subgraph from table: $SUB_NODES nodes" || fail "Subgraph" "expected >=2"
 
-# Subgraph from doc via resource_uri
-R=$(mcp_call akb_graph "{\"uri\":\"$DOC1_URI\",\"depth\":1}" | mcp_result)
+# Subgraph from doc via resource_uri (akb_graph uses `hops`, not `depth`)
+R=$(mcp_call akb_graph "{\"uri\":\"$DOC1_URI\",\"hops\":1}" | mcp_result)
 DOC_GRAPH=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['nodes']))" 2>/dev/null)
 [ "$DOC_GRAPH" -ge 1 ] 2>/dev/null && pass "Subgraph from doc URI: $DOC_GRAPH nodes" || fail "Doc subgraph" "failed"
 


### PR DESCRIPTION
## Context
Triage of the pre-existing e2e failures (all reproduce on `main`, unrelated to the recent Keycloak/auth work). Classified each as **TC bug vs product bug** — all were stale tests; fixed here. The product is correct in every case.

## Fixes (TC bugs)
| Suite | Stale assertion | Reality |
|---|---|---|
| `graph_replace`, `unified_browse_edges` | `akb_graph {depth}` | arg renamed **`hops`**; backend rejects `depth` (akb_browse still uses `depth`) |
| `table_crud_envelope` | envelope key `id` | tables are **URI-addressed** → key is `uri` (only documents have a `d-` id) |
| `help_skill_template` | `curl -I` (HEAD) Content-Type | route is GET-only → HEAD 405 json; **GET correctly serves `text/markdown`** |
| `defensive` | "empty vault" → 0 browse items / ≤1 activity | every vault is seeded with `overview/vault-skill.md` on create → assert the small seeded baseline (≤2) |

## Verified
Each suite green on a throwaway pgvector stack: graph_replace 29, table_crud_envelope 40, help_skill_template 6, defensive 33, unified_browse_edges 116. `scripts/check.sh` green.

## Not changed (not defects)
`collection_hierarchy`, `events_emit`, `s3_delete_outbox` verify via `kubectl exec … psql` against the **cluster** Postgres while creating data through `AKB_URL` — they only pass when `AKB_URL` and the kubectl-targeted pod are the **same deployment** (run against a live cluster, not a host-isolated backend). No product or test defect; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)