### PR TITLE
test(e2e): portable DB access — drop hardcoded/foreign paths (fix broken admin+DB suites)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,16 +189,6 @@
         "line_number": 20
       }
     ],
-    "backend/tests/test_auth_password_e2e.sh": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "backend/tests/test_auth_password_e2e.sh",
-        "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
-        "is_verified": false,
-        "line_number": 29,
-        "is_secret": false
-      }
-    ],
     "backend/tests/test_collection_repo.py": [
       {
         "type": "Basic Auth Credentials",
@@ -5226,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T15:34:07Z"
+  "generated_at": "2026-06-07T17:00:36Z"
 }

--- a/backend/tests/test_auth_password_e2e.sh
+++ b/backend/tests/test_auth_password_e2e.sh
@@ -16,22 +16,26 @@ echo "║   Password Recovery E2E                  ║"
 echo "║   Target: $BASE_URL"
 echo "╚══════════════════════════════════════════╝"
 
-# Helper: promote a user to admin via the backend container's Python.
-# `docker compose exec` runs inside the backend image which pip-installed
-# all backend deps (asyncpg is on PATH). NO uv — container does not ship it.
-# stderr stays visible so failures surface in the test log instead of being
-# masked as a downstream "non-admin → 403" misattribution.
+# Portable DB access for the admin bootstrap. Defaults to the cluster via
+# kubectl (matching "run E2E against the deployed URL"); override AKB_PG_EXEC
+# for a local stack, e.g.:
+#   AKB_PG_EXEC="docker compose exec -T postgres"
+#   AKB_PG_EXEC="docker exec -i akb-postgres-1"   (set AKB_PG_USER if needed)
+PG_NS="${AKB_NS:-akb}"
+PG_POD="${AKB_PG_POD:-postgres-0}"
+PG_USER="${AKB_PG_USER:-akbuser}"
+PG_DB="${AKB_PG_DB:-akb}"
+run_psql() {
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$PG_NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
+}
+
+# Helper: promote a user to admin (registration never creates admins).
 promote_admin() {
-  local uname="$1"
-  docker compose exec -T backend python -c "
-import asyncio, asyncpg
-async def go():
-    dsn = 'postgresql://akb:akb@postgres:5432/akb'
-    conn = await asyncpg.connect(dsn)
-    await conn.execute('UPDATE users SET is_admin = TRUE WHERE username = \$1', '$uname')
-    await conn.close()
-asyncio.run(go())
-" >/dev/null
+  run_psql "UPDATE users SET is_admin = TRUE WHERE username = '$1'" >/dev/null
 }
 
 # Helper: register + login → echo JWT

--- a/backend/tests/test_collection_hierarchy_e2e.sh
+++ b/backend/tests/test_collection_hierarchy_e2e.sh
@@ -34,7 +34,14 @@ pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
 run_psql() {
-  kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  # Portable: AKB_PG_EXEC overrides for a local stack (e.g.
+  # "docker compose exec -T postgres" or "docker exec -i akb-postgres-1");
+  # default targets the cluster via kubectl.
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
 }
 
 # ── Setup ────────────────────────────────────────────────────────

--- a/backend/tests/test_events_emit_e2e.sh
+++ b/backend/tests/test_events_emit_e2e.sh
@@ -25,14 +25,22 @@ ERRORS=()
 pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
-# Skip when not running against a k8s-deployed backend.
-if ! command -v kubectl >/dev/null 2>&1; then
-  echo "kubectl not available — skipping events DB verification"
+# DB verification needs either AKB_PG_EXEC (local override) or kubectl
+# (cluster). Skip only when neither is available.
+if [ -z "${AKB_PG_EXEC:-}" ] && ! command -v kubectl >/dev/null 2>&1; then
+  echo "no AKB_PG_EXEC and kubectl unavailable — skipping events DB verification"
   exit 0
 fi
 
 run_psql() {
-  kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  # Portable: AKB_PG_EXEC overrides for a local stack (e.g.
+  # "docker compose exec -T postgres" or "docker exec -i akb-postgres-1");
+  # default targets the cluster via kubectl.
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
 }
 
 echo "▸ Setup"

--- a/backend/tests/test_jwt_revocation_e2e.sh
+++ b/backend/tests/test_jwt_revocation_e2e.sh
@@ -18,6 +18,22 @@ BASE_URL="${AKB_URL:-http://localhost:8001}"
 TS=$(date +%s)
 PASS=0; FAIL=0; ERRORS=()
 
+# Portable DB access (admin bootstrap). Defaults to the cluster via kubectl
+# — matching "run E2E against the deployed URL". Override AKB_PG_EXEC for a
+# local stack, e.g. AKB_PG_EXEC="docker compose exec -T postgres" or
+# AKB_PG_EXEC="docker exec -i akb-postgres-1" (and AKB_PG_USER as needed).
+PG_NS="${AKB_NS:-akb}"
+PG_POD="${AKB_PG_POD:-postgres-0}"
+PG_USER="${AKB_PG_USER:-akbuser}"
+PG_DB="${AKB_PG_DB:-akb}"
+run_psql() {
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$PG_NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
+}
+
 pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
@@ -101,11 +117,7 @@ TGT_JWT=$(register_and_login "$TARGET")
 
 ADMINU="jwtad-$TS"
 register_and_login "$ADMINU" >/dev/null
-docker compose -p akb-audit \
-  -f /Users/kwoo2/Desktop/storage/akb-audit/docker-compose.yaml \
-  -f /Users/kwoo2/Desktop/storage/akb-audit/docker-compose.audit.yaml \
-  exec -T postgres psql -U akb -d akb -c \
-  "UPDATE users SET is_admin = true WHERE username = '$ADMINU';" >/dev/null
+run_psql "UPDATE users SET is_admin = true WHERE username = '$ADMINU'" >/dev/null
 
 # Login again to pick up the now-admin flag (is_admin is read live, but
 # need a JWT to call admin endpoints).

--- a/backend/tests/test_s3_delete_outbox_e2e.sh
+++ b/backend/tests/test_s3_delete_outbox_e2e.sh
@@ -24,13 +24,20 @@ ERRORS=()
 pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
-if ! command -v kubectl >/dev/null 2>&1; then
-  echo "kubectl not available — skipping outbox verification"
+if [ -z "${AKB_PG_EXEC:-}" ] && ! command -v kubectl >/dev/null 2>&1; then
+  echo "no AKB_PG_EXEC and kubectl unavailable — skipping outbox verification"
   exit 0
 fi
 
 run_psql() {
-  kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  # Portable: AKB_PG_EXEC overrides for a local stack (e.g.
+  # "docker compose exec -T postgres" or "docker exec -i akb-postgres-1");
+  # default targets the cluster via kubectl.
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
 }
 
 echo "▸ Setup"
@@ -56,7 +63,7 @@ curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT" \
 # Insert a synthetic vault_files row directly (skip S3 upload step —
 # we're testing the DB-side outbox enqueue, not the S3 round-trip).
 VAULT_ID=$(run_psql "SELECT id FROM vaults WHERE name = '$VAULT'")
-FILE_ID=$(run_psql "INSERT INTO vault_files (vault_id, collection, name, s3_key, mime_type, size_bytes, description, created_by) VALUES ('$VAULT_ID', '', 'synthetic.txt', '$VAULT/$(date +%s)_synthetic.txt', 'text/plain', 12, '', '$USER') RETURNING id" | head -n 1)
+FILE_ID=$(run_psql "INSERT INTO vault_files (vault_id, collection_id, name, s3_key, mime_type, size_bytes, description, created_by) VALUES ('$VAULT_ID', NULL, 'synthetic.txt', '$VAULT/$(date +%s)_synthetic.txt', 'text/plain', 12, '', '$USER') RETURNING id" | head -n 1)
 S3_KEY=$(run_psql "SELECT s3_key FROM vault_files WHERE id = '$FILE_ID'" | head -n 1)
 
 [ -n "$FILE_ID" ] && pass "synthetic file row inserted ($FILE_ID)" || { fail "setup" "no file row"; exit 1; }


### PR DESCRIPTION
## Problem
The DB-touching e2e suites each reached Postgres a different, non-portable way → broken for anyone but the author:
- **test_jwt_revocation** hardcoded a co-worker's machine path (`docker compose -p akb-audit -f /Users/kwoo2/Desktop/storage/…`) to promote its admin → T4/T7 failed on every other machine ("broken for everyone but kwoo2").
- **test_auth_password** promoted via `docker compose exec backend python` with an embedded dsn (also a baselined secret).
- **test_collection_hierarchy / events_emit / s3_delete_outbox** used `kubectl exec` only → unusable against a local stack.

## Fix
One portable `run_psql` across all five: defaults to the cluster (kubectl), overridable via **`AKB_PG_EXEC`** for any local stack:
```
AKB_PG_EXEC="docker compose exec -T postgres" …
AKB_PG_EXEC="docker exec -i akb-postgres-1" AKB_PG_USER=akb …
```
kubectl-skip guards now also accept `AKB_PG_EXEC`. Plus a stale-schema fix: s3_delete_outbox inserted into `vault_files.collection` (dropped by migration 020) → `collection_id` NULL.

## Verified
All five green against a local pg (AKB_URL + AKB_PG_EXEC same DB): jwt_revocation 19, auth_password 18, collection_hierarchy 17, events_emit 7, s3_delete_outbox 5. `scripts/check.sh` green (removing the embedded dsn also dropped a baselined secret).

Note: deliberately NOT using first-user-auto-admin here (its first-vs-not-first dependency is brittle); the suites promote explicitly via the portable helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)