### PR TITLE
fix(frontend/graph): restore node detail panel + consolidate sidebar toggle

### DIFF
--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -4,6 +4,8 @@ import { ChevronDown, ChevronRight, ExternalLink, Pin, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/empty-state";
 import { getDocument, getRelations, getProvenance, drillDown } from "@/lib/api";
 import { ALL_NODE_KINDS, ALL_RELATIONS, type NodeKind, type RelationKind, kindToSegment } from "./graph-types";
 import { Section } from "./Section";
@@ -95,6 +97,31 @@ export function GraphDetailPanel({
         </button>
       </header>
 
+      {docQuery.isLoading ? (
+        // Progressive-loading: a skeleton stands in for the fetch so the
+        // panel never reads as "nothing showed up" while data is in flight.
+        <div className="px-3 py-3 flex flex-col gap-3" aria-busy="true">
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : docQuery.isError ? (
+        // Error-recovery: reuse the app's standard EmptyState (same shape the
+        // graph canvas uses for its load failure). A node can point at a
+        // deleted/renamed doc, or the fetch can transiently fail — surface it
+        // with a retry path instead of rendering blank.
+        <EmptyState
+          title="Couldn't load this resource."
+          description={String((docQuery.error as Error)?.message || docQuery.error || "unknown error")}
+          action={
+            <Button size="sm" variant="outline" onClick={() => docQuery.refetch()}>
+              Retry
+            </Button>
+          }
+        />
+      ) : (
+        <>
       <div className="px-3 py-3 border-b border-border">
         <h2 className="font-serif text-2xl leading-tight mb-1">{doc?.title || "…"}</h2>
         <p className="coord text-foreground-muted truncate" title={uri}>{uri}</p>
@@ -235,6 +262,8 @@ export function GraphDetailPanel({
           </div>
         )}
       </Section>
+        </>
+      )}
     </aside>
   );
 }

--- a/frontend/src/components/graph/GraphSidebar.tsx
+++ b/frontend/src/components/graph/GraphSidebar.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/graph/GraphSidebar.tsx
 import { useEffect, useRef, useState } from "react";
-import { Search as SearchIcon, X } from "lucide-react";
+import { PanelLeftClose, Search as SearchIcon, X } from "lucide-react";
 import { searchDocs } from "@/lib/api";
 import { useGraphHistory } from "@/hooks/use-graph-history";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -20,6 +20,8 @@ interface Props {
   view: GraphView;
   onChange: (next: GraphView) => void;
   onNavigate: (queryString: string) => void;
+  /** When provided, renders a collapse control in the sidebar header. */
+  onCollapse?: () => void;
 }
 
 interface SearchHit {
@@ -28,7 +30,7 @@ interface SearchHit {
   type: NodeKind;
 }
 
-export function GraphSidebar({ vault, view, onChange, onNavigate }: Props) {
+export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: Props) {
   const { recent, pushRecent, clearRecent, saved, saveView, deleteView } =
     useGraphHistory(vault);
   const [query, setQuery] = useState("");
@@ -119,6 +121,21 @@ export function GraphSidebar({ vault, view, onChange, onNavigate }: Props) {
       className="flex flex-col h-full overflow-y-auto border-r border-border bg-surface"
       aria-label="Graph controls"
     >
+      {onCollapse && (
+        <div className="flex items-center justify-between h-9 px-2 border-b border-border shrink-0">
+          <span className="coord text-foreground-muted">GRAPH</span>
+          <button
+            type="button"
+            onClick={onCollapse}
+            aria-label="Hide sidebar"
+            title="Hide sidebar"
+            className="inline-flex h-6 w-6 items-center justify-center text-foreground-muted hover:text-foreground hover:bg-surface-muted cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+
       <Section label="ENTRY POINT" className="px-2">
         <div className="relative">
           <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-foreground-muted pointer-events-none" />

--- a/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
@@ -104,6 +104,56 @@ describe("GraphDetailPanel · document node", () => {
   });
 });
 
+describe("GraphDetailPanel · fetch states", () => {
+  it("shows an error state with a retry control when the document fetch fails", async () => {
+    getDocument.mockRejectedValue(new Error("404 not found"));
+    getRelations.mockResolvedValue({ doc_id: "d-x", uri: "u", relations: [] });
+
+    render(
+      wrap(
+        <GraphDetailPanel
+          vault="akb"
+          docId="d-x"
+          kind="document"
+          uri="akb://akb/doc/x"
+          onSelectUri={() => {}}
+          onFitToNode={() => {}}
+          onClose={() => {}}
+        />,
+      ),
+    );
+
+    expect(await screen.findByText(/couldn't load this resource/i)).toBeTruthy();
+    expect(screen.getByText(/404 not found/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+
+  it("re-fetches when Retry is clicked", async () => {
+    getDocument
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce({ doc_id: "d-x", title: "Recovered", content: "" });
+    getRelations.mockResolvedValue({ doc_id: "d-x", uri: "u", relations: [] });
+
+    const u = userEvent.setup();
+    render(
+      wrap(
+        <GraphDetailPanel
+          vault="akb"
+          docId="d-x"
+          kind="document"
+          uri="akb://akb/doc/x"
+          onSelectUri={() => {}}
+          onFitToNode={() => {}}
+          onClose={() => {}}
+        />,
+      ),
+    );
+
+    await u.click(await screen.findByRole("button", { name: /retry/i }));
+    expect(await screen.findByText("Recovered")).toBeTruthy();
+  });
+});
+
 describe("GraphDetailPanel · table node", () => {
   it("does not show preview for tables", async () => {
     getDocument.mockResolvedValue({

--- a/frontend/src/components/graph/__tests__/use-graph-data.test.ts
+++ b/frontend/src/components/graph/__tests__/use-graph-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { mergeGraph, bfsExpand, applyFilters, isDegraded } from "../use-graph-data";
+import { mergeGraph, bfsExpand, applyFilters, isDegraded, docIdFromUri } from "../use-graph-data";
+import { docUri } from "@/lib/uri";
 import { DEFAULT_VIEW, type GraphNode, type GraphEdge } from "../graph-types";
 
 describe("mergeGraph", () => {
@@ -96,6 +97,55 @@ describe("isDegraded", () => {
   it("flips at > 500 raw nodes (unfiltered count)", () => {
     expect(isDegraded(500)).toBe(false);
     expect(isDegraded(501)).toBe(true);
+  });
+});
+
+describe("docIdFromUri", () => {
+  // The regression this guards: before the canonical-aware rewrite the
+  // regex only matched `akb://V/doc/...`, so collection-scoped docs (the
+  // common case) returned null — the detail panel never opened and BFS
+  // neighbour expansion silently dropped every collection node.
+  it("resolves a collection-scoped doc to its full vault-relative path", () => {
+    expect(docIdFromUri("akb://gnu/coll/specs/2026/doc/api.md")).toBe("specs/2026/api.md");
+  });
+
+  it("resolves a single-segment collection doc", () => {
+    expect(docIdFromUri("akb://v/coll/notes/doc/hello.md")).toBe("notes/hello.md");
+  });
+
+  it("resolves a vault-root doc (no collection segment)", () => {
+    expect(docIdFromUri("akb://v/doc/readme.md")).toBe("readme.md");
+  });
+
+  it("resolves the legacy multi-segment root shape (root regex captures full tail)", () => {
+    expect(docIdFromUri("akb://v/doc/specs/legacy/api.md")).toBe("specs/legacy/api.md");
+  });
+
+  it("returns the bare identifier for tables and files (collection part dropped)", () => {
+    expect(docIdFromUri("akb://v/coll/data/table/metrics")).toBe("metrics");
+    expect(docIdFromUri("akb://v/table/metrics")).toBe("metrics");
+    expect(docIdFromUri("akb://v/coll/assets/file/8f1c.png")).toBe("8f1c.png");
+    expect(docIdFromUri("akb://v/file/8f1c.png")).toBe("8f1c.png");
+  });
+
+  it("percent-decodes spaces in collection path and leaf", () => {
+    expect(docIdFromUri("akb://v/coll/my%20notes/doc/a%20b.md")).toBe("my notes/a b.md");
+  });
+
+  it("returns null for vault-only and collection-only URIs", () => {
+    expect(docIdFromUri("akb://v")).toBeNull();
+    expect(docIdFromUri("akb://v/coll/specs/2026")).toBeNull();
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(docIdFromUri("not-a-uri")).toBeNull();
+    expect(docIdFromUri("")).toBeNull();
+  });
+
+  it("round-trips with the docUri builder for nested collection paths", () => {
+    for (const path of ["readme.md", "notes/hello.md", "specs/2026/api.md", "a/b/c/d.md"]) {
+      expect(docIdFromUri(docUri("v", path))).toBe(path);
+    }
   });
 });
 

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -1,6 +1,7 @@
 // frontend/src/components/graph/use-graph-data.ts
 import { useQuery } from "@tanstack/react-query";
 import { getGraph, getRelations, type RelationRow } from "@/lib/api";
+import { parseUri } from "@/lib/uri";
 import {
   ALL_NODE_KINDS,
   type GraphEdge,
@@ -134,9 +135,39 @@ function rowToNeighbor(row: RelationRow): GraphNode | null {
 // Multi-segment paths (e.g. `specs/2026/foo.md`) are preserved intact —
 // `find_by_ref` on the backend matches the metadata `id` or the `path LIKE`
 // fallback against this full tail.
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+/**
+ * Resolve the backend lookup identifier from a resource URI.
+ *
+ * Thin adapter over `parseUri` in `lib/uri.ts` — the single source of
+ * truth for the AKB URI scheme (it mirrors backend `uri_service.py`).
+ * `parseUri().id` already yields the right identifier per kind:
+ *  - doc   → the document *path* within the vault (`collPath/basename`)
+ *  - table → the table name
+ *  - file  → the file id (uuid)
+ *
+ * We add only what's specific to backend lookups: restrict to addressable
+ * resource kinds (vault/coll URIs carry no document id → null) and
+ * percent-decode, since `getDocument`/`getRelations`/… expect the decoded
+ * path. Delegating keeps graph node selection + BFS expansion from drifting
+ * when the scheme evolves — the prior hand-rolled regex only matched the
+ * legacy root shape, so collection-scoped docs (the common case) resolved
+ * to null and the detail panel never opened.
+ */
 export function docIdFromUri(uri: string): string | null {
-  const m = uri.match(/^akb:\/\/[^/]+\/(?:doc|table|file)\/(.+)$/);
-  return m ? decodeURIComponent(m[1]) : null;
+  const parsed = parseUri(uri);
+  if (!parsed || (parsed.kind !== "doc" && parsed.kind !== "table" && parsed.kind !== "file")) {
+    return null;
+  }
+  // parseUri preserves raw URI encoding; decode for the backend lookup.
+  return safeDecode(parsed.id);
 }
 
 export async function bfsExpand(args: BfsExpandArgs): Promise<GraphPayload> {

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { PanelLeftOpen } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
@@ -93,15 +93,21 @@ export default function GraphPage() {
     // TODO(graph-context-menu): floating menu with Pin/Unpin/Hide/Copy/Open-new-tab.
   }
 
-  const selectedNode = view.selected
-    ? merged.nodes.find(
-        (n) =>
-          n.uri === view.selected ||
-          n.doc_id === view.selected ||
-          docIdFromUri(n.uri) === view.selected,
-      )
-    : undefined;
-  const selectedDocId = selectedNode ? (selectedNode.doc_id || docIdFromUri(selectedNode.uri)) : null;
+  // Resolve the selected node + its lookup id once per (graph, selection)
+  // change rather than on every render — the find scans up to ~200 nodes and
+  // each comparison may parse a URI.
+  const { selectedNode, selectedDocId } = useMemo(() => {
+    const node = view.selected
+      ? merged.nodes.find(
+          (n) =>
+            n.uri === view.selected ||
+            n.doc_id === view.selected ||
+            docIdFromUri(n.uri) === view.selected,
+        )
+      : undefined;
+    const docId = node ? node.doc_id || docIdFromUri(node.uri) : null;
+    return { selectedNode: node, selectedDocId: docId };
+  }, [merged, view.selected]);
   const detailOpen = !!selectedNode && !!selectedDocId;
 
   const gridCols = `${sidebarOpen ? "240px" : "40px"} 1fr ${detailOpen ? "320px" : "0px"}`;
@@ -119,28 +125,26 @@ export default function GraphPage() {
           onNavigate={(qs) => {
             navigate({ search: qs.startsWith("?") ? qs : `?${qs}` }, { replace: true });
           }}
+          onCollapse={() => setSidebarOpen(false)}
         />
       ) : (
-        <button
-          type="button"
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-          className="h-9 w-9 m-2 inline-flex items-center justify-center border border-border bg-surface text-foreground-muted hover:text-foreground"
-        >
-          <PanelLeftOpen className="h-4 w-4" />
-        </button>
+        // Collapsed rail: the sole "expand" affordance. The matching
+        // "collapse" control lives in the sidebar header (GraphSidebar
+        // onCollapse) so there is exactly one toggle, always on the left.
+        <div className="flex flex-col items-center border-r border-border bg-surface">
+          <button
+            type="button"
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Show sidebar"
+            title="Show sidebar"
+            className="h-9 w-9 mt-2 inline-flex items-center justify-center text-foreground-muted hover:text-foreground hover:bg-surface-muted cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <PanelLeftOpen className="h-4 w-4" />
+          </button>
+        </div>
       )}
 
       <div className="relative bg-background overflow-hidden">
-        <button
-          type="button"
-          onClick={() => setSidebarOpen((v) => !v)}
-          aria-label={sidebarOpen ? "Hide sidebar" : "Show sidebar"}
-          className="absolute top-3 right-3 z-10 h-8 w-8 inline-flex items-center justify-center bg-surface border border-border text-foreground-muted hover:text-foreground"
-        >
-          {sidebarOpen ? <PanelLeftClose className="h-3 w-3" /> : <PanelLeftOpen className="h-3 w-3" />}
-        </button>
-
         {degraded && (
           <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 bg-warning/10 border border-warning text-warning px-3 py-1 font-mono text-[10px] uppercase">
             {rawNodeCount} nodes — pick an entry point to explore


### PR DESCRIPTION
## Problem
Clicking a graph node showed **no detail panel**. `docIdFromUri` only matched the legacy `akb://V/doc/...` shape and returned `null` for the 0.3.0 canonical collection scheme `akb://V/coll/<path>/doc/<name>` (the common case) — so `selectedDocId` was null and the panel never opened. The same gap made BFS neighbour expansion silently drop collection nodes. Separately, a floating sidebar-toggle button was stuck at the far right of the canvas, duplicating the rail toggle.

## Fix
- **`docIdFromUri` → delegate to the shared canonical parser** (`lib/uri.ts` `parseUri`) instead of a second, divergent regex. This is exactly the "two parsers for one scheme drift apart on the next change" failure that caused the bug — now there's a single source of truth. Restricts to doc/table/file kinds and percent-decodes for the backend lookup.
- **Sidebar toggle consolidation**: remove the floating far-right button; collapse control lives in the sidebar header, expand control on the collapsed rail — exactly one toggle, always on the left.
- **Detail panel loading/error states**: skeleton while fetching, `EmptyState` + Retry on failure (reusing the same component the canvas error uses), so an in-flight or failed fetch no longer reads as "nothing showed up".
- **Memoize** `selectedNode`/`selectedDocId` (the per-node URI parse was rerunning every render).

## Tests
- New `docIdFromUri` coverage: canonical / root / legacy / table / file / percent-decode / null / `docUri` round-trip.
- New detail-panel error-state + retry coverage.
- Graph vitest suite: **48 passing**; tsc clean on changed files; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)