### PR TITLE
fix(frontend): reveal CSS-truncated names on hover via native title (app-wide)

### DIFF
--- a/frontend/src/components/__tests__/vault-explorer.test.tsx
+++ b/frontend/src/components/__tests__/vault-explorer.test.tsx
@@ -62,6 +62,15 @@ describe("VaultExplorer — rendering", () => {
     expect(screen.getByRole("treeitem", { name: /audit_log/ })).toBeInTheDocument();
   });
 
+  it("exposes the full name via a title attribute so truncated rows reveal it on hover", async () => {
+    renderAt("/vault/v");
+    // Collection row: the name span carries title=name for the CSS-truncated label.
+    const collectionName = await screen.findByText("architecture");
+    expect(collectionName).toHaveAttribute("title", "architecture");
+    // Leaf row (root-level table is visible without expanding any collection).
+    expect(screen.getByText("audit_log")).toHaveAttribute("title", "audit_log");
+  });
+
   it("exposes ARIA treeview semantics", async () => {
     renderAt("/vault/v");
     const tree = await screen.findByRole("tree", { name: /v explorer/ });

--- a/frontend/src/components/doc-outline.tsx
+++ b/frontend/src/components/doc-outline.tsx
@@ -31,7 +31,7 @@ export function DocumentOutline({
                     : "border-transparent text-foreground-muted hover:text-foreground hover:border-border-strong"
                 }`}
               >
-                <span className="truncate block text-[12px]">{h.text}</span>
+                <span title={h.text} className="truncate block text-[12px]">{h.text}</span>
               </a>
             </li>
           );

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -219,7 +219,7 @@ export function GraphDetailPanel({
           {sectionsOpen && (
             <ul className="mb-2 flex flex-col gap-px">
               {(secQuery.data?.sections || []).map((s: any, i: number) => (
-                <li key={i} className="coord truncate">‣ {s.heading || s.title || `section ${i}`}</li>
+                <li key={i} title={s.heading || s.title || `section ${i}`} className="coord truncate">‣ {s.heading || s.title || `section ${i}`}</li>
               ))}
             </ul>
           )}
@@ -322,6 +322,7 @@ function RelGroup({
             <button
               type="button"
               onClick={() => onSelectUri(r.other_uri)}
+              title={r.other_name}
               className="flex-1 text-left text-[11px] hover:text-accent truncate"
             >
               {r.other_name}

--- a/frontend/src/components/graph/GraphSidebar.tsx
+++ b/frontend/src/components/graph/GraphSidebar.tsx
@@ -157,7 +157,7 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                   onClick={() => commitEntry(h)}
                   className="w-full flex items-center justify-between gap-2 px-2 h-7 text-left text-[11px] hover:bg-surface-muted"
                 >
-                  <span className="truncate">{h.title}</span>
+                  <span title={h.title} className="truncate">{h.title}</span>
                   <span className="coord">{h.type}</span>
                 </button>
               </li>
@@ -166,7 +166,7 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
         )}
         {view.entry && hits.length === 0 && (
           <div className="mt-1 flex items-center justify-between gap-2 px-2 h-7 text-[11px] bg-surface-muted">
-            <span className="truncate">entry: {view.entry}</span>
+            <span title={`entry: ${view.entry}`} className="truncate">entry: {view.entry}</span>
             <button
               type="button"
               onClick={() => onChange({ ...view, entry: undefined })}
@@ -278,6 +278,7 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                 <button
                   type="button"
                   onClick={() => onChange({ ...view, entry: r.doc_id })}
+                  title={r.title}
                   className="w-full text-left px-2 h-7 text-[11px] hover:bg-surface-muted active:bg-accent/10 active:text-foreground truncate"
                 >
                   {r.title}
@@ -333,6 +334,7 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                 <button
                   type="button"
                   onClick={() => onNavigate(s.url)}
+                  title={s.name}
                   className="flex-1 text-left px-2 h-7 text-[11px] hover:bg-surface-muted active:opacity-60 transition-opacity duration-150 truncate"
                 >
                   {s.name}

--- a/frontend/src/components/history-list.tsx
+++ b/frontend/src/components/history-list.tsx
@@ -180,7 +180,10 @@ function RowContent({
       <span className={active ? "text-accent" : "text-accent"}>
         {(entry.hash || "").slice(0, 7)}
       </span>
-      <span className={cn("truncate", active ? "text-accent" : "text-foreground-muted")}>
+      <span
+        title={`${entry.agent || entry.author || "unknown"}${entry.subject ? ` · ${entry.subject}` : ""}`}
+        className={cn("truncate", active ? "text-accent" : "text-foreground-muted")}
+      >
         <span className={active ? "text-accent" : "text-foreground-muted"}>
           {entry.agent || entry.author || "unknown"}
         </span>

--- a/frontend/src/components/invite-member-dialog.tsx
+++ b/frontend/src/components/invite-member-dialog.tsx
@@ -168,16 +168,16 @@ export function InviteMemberDialog({
                           }`}
                         >
                           <div className="flex items-baseline gap-2">
-                            <span className="font-mono text-sm font-medium truncate">
+                            <span title={u.username} className="font-mono text-sm font-medium truncate">
                               {u.username}
                             </span>
                             {u.display_name && (
-                              <span className="text-xs text-foreground-muted truncate">
+                              <span title={u.display_name} className="text-xs text-foreground-muted truncate">
                                 {u.display_name}
                               </span>
                             )}
                           </div>
-                          <div className="coord truncate">{u.email}</div>
+                          <div title={u.email} className="coord truncate">{u.email}</div>
                         </button>
                       </li>
                     );

--- a/frontend/src/components/user-menu.tsx
+++ b/frontend/src/components/user-menu.tsx
@@ -76,11 +76,11 @@ export function UserMenu() {
           {/* Identity header */}
           <div className="px-3 py-2 border-b border-border mb-1">
             <div className="coord">ACCOUNT</div>
-            <div className="text-sm font-medium text-foreground truncate mt-0.5">
+            <div title={label} className="text-sm font-medium text-foreground truncate mt-0.5">
               {label}
             </div>
             {user?.email && (
-              <div className="font-mono text-[11px] text-foreground-muted truncate">
+              <div title={user.email} className="font-mono text-[11px] text-foreground-muted truncate">
                 {user.email}
               </div>
             )}

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -229,6 +229,7 @@ export function VaultExplorer({
       <header className="border-b border-border px-3 py-2 flex items-center justify-between gap-2 shrink-0">
         <Link
           to={`/vault/${vault}`}
+          title={vault}
           className="font-mono text-sm font-semibold truncate text-foreground hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {vault}
@@ -432,7 +433,7 @@ const TreeRow = memo(function TreeRow({
             className="h-3 w-3 shrink-0 text-foreground-muted group-hover:text-accent transition-colors"
             aria-hidden
           />
-          <span className="truncate font-medium tracking-tight text-[13px] text-foreground">{node.name}</span>
+          <span title={node.name} className="truncate font-medium tracking-tight text-[13px] text-foreground">{node.name}</span>
           {count > 0 && <span className="coord ml-auto shrink-0">{count}</span>}
         </button>
         {canWrite && onCreateSubCollection && (
@@ -490,7 +491,7 @@ const TreeRow = memo(function TreeRow({
         className={`h-3 w-3 shrink-0 ${leafIconColor} group-hover:text-accent transition-colors`}
         aria-hidden
       />
-      <span className="truncate text-[13px] text-foreground group-hover:text-accent">{node.name}</span>
+      <span title={node.name} className="truncate text-[13px] text-foreground group-hover:text-accent">{node.name}</span>
       {isSkill && <SkillBadge defined className="ml-auto shrink-0" />}
     </Link>
   );

--- a/frontend/src/components/vault-nav.tsx
+++ b/frontend/src/components/vault-nav.tsx
@@ -170,7 +170,7 @@ function NavItem({
         )}
       >
         <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span className="truncate">{label}</span>
+        <span title={label} className="truncate">{label}</span>
       </Link>
     );
   }
@@ -190,7 +190,7 @@ function NavItem({
         className="flex items-center gap-2 px-2 flex-1 min-w-0 h-7 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
       >
         <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span className="truncate">{label}</span>
+        <span title={label} className="truncate">{label}</span>
       </Link>
       <button
         type="button"

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -596,7 +596,7 @@ export default function DocumentPage() {
             {doc.is_public && doc.public_slug ? (
               <div className="flex flex-col gap-1.5 text-xs">
                 <div className="coord">§ PUBLISHED</div>
-                <div className="font-mono text-[11px] text-foreground truncate">
+                <div title={`/p/${doc.public_slug}`} className="font-mono text-[11px] text-foreground truncate">
                   /p/{doc.public_slug}
                 </div>
                 <div className="flex items-center gap-3 text-[11px]">
@@ -694,7 +694,7 @@ export default function DocumentPage() {
                           className="grid grid-cols-[88px_1fr] gap-1.5 py-0.5 group hover:bg-surface-muted -mx-1 px-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                         >
                           <span className={relColor}>{r.relation || "relates"}</span>
-                          <span className="text-foreground truncate group-hover:text-accent">
+                          <span title={label} className="text-foreground truncate group-hover:text-accent">
                             → {label}
                           </span>
                         </Link>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -240,14 +240,14 @@ export default function HomePage() {
                     <span className="coord tabular-nums">
                       {String(i + 1).padStart(2, "0")}
                     </span>
-                    <span className="coord font-mono tabular-nums truncate">
+                    <span title={c.vault} className="coord font-mono tabular-nums truncate">
                       {c.vault}
                     </span>
                     <div className="min-w-0">
-                      <div className="text-sm font-medium tracking-tight truncate text-foreground group-hover:text-accent">
+                      <div title={c.title} className="text-sm font-medium tracking-tight truncate text-foreground group-hover:text-accent">
                         {c.title}
                       </div>
-                      <div className="coord truncate">{c.path}</div>
+                      <div title={c.path} className="coord truncate">{c.path}</div>
                     </div>
                     <span className="coord tabular-nums w-[52px] text-right">
                       {timeAgo(c.changed_at)}
@@ -510,7 +510,7 @@ export default function HomePage() {
                         key={p.token_id}
                         className="flex items-center justify-between gap-2 px-2 py-1.5 text-xs"
                       >
-                        <span className="truncate text-foreground font-medium">{p.name}</span>
+                        <span title={p.name} className="truncate text-foreground font-medium">{p.name}</span>
                         <div className="flex items-center gap-2 shrink-0">
                           <span className="coord tabular-nums">
                             {p.last_used_at ? timeAgo(p.last_used_at) : "—"}

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -162,6 +162,7 @@ export default function PublicationsPage() {
                       <Icon className="h-3.5 w-3.5 shrink-0 translate-y-0.5 text-foreground-muted" aria-hidden />
                       <Link
                         to={resourceHref(p)}
+                        title={p.title || p.slug}
                         className="text-sm font-medium tracking-tight truncate text-foreground hover:text-accent"
                       >
                         {p.title || p.slug}
@@ -176,7 +177,7 @@ export default function PublicationsPage() {
                         />
                       )}
                     </div>
-                    <div className="coord truncate mt-1 font-mono">
+                    <div title={`/p/${p.slug}`} className="coord truncate mt-1 font-mono">
                       /p/{p.slug}
                     </div>
                   </div>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -628,7 +628,7 @@ export default function SettingsPage() {
                         <span className="coord tabular-nums shrink-0">
                           {String(i + 1).padStart(2, "0")}
                         </span>
-                        <span className="text-sm font-medium truncate text-foreground">
+                        <span title={p.name} className="text-sm font-medium truncate text-foreground">
                           {p.name}
                         </span>
                         <code className="font-mono text-[11px] text-foreground-muted">
@@ -985,16 +985,17 @@ export default function SettingsPage() {
                           </span>
                           <span
                             data-testid="admin-user-name"
+                            title={u.username}
                             className="text-sm font-medium truncate text-foreground"
                           >
                             {u.username}
                           </span>
                           {u.display_name && u.display_name !== u.username && (
-                            <span className="text-sm text-foreground-muted truncate hidden sm:inline">
+                            <span title={u.display_name} className="text-sm text-foreground-muted truncate hidden sm:inline">
                               {u.display_name}
                             </span>
                           )}
-                          <code className="font-mono text-[11px] text-foreground-muted truncate hidden md:inline">
+                          <code title={u.email} className="font-mono text-[11px] text-foreground-muted truncate hidden md:inline">
                             {u.email}
                           </code>
                           {u.is_admin && (

--- a/frontend/src/pages/vault-activity.tsx
+++ b/frontend/src/pages/vault-activity.tsx
@@ -147,7 +147,7 @@ export default function VaultActivityPage() {
                   <span className="font-mono text-[11px] text-accent tabular-nums">
                     {(e.hash || "").slice(0, 7)}
                   </span>
-                  <span className="font-mono text-xs text-foreground truncate">
+                  <span title={e.agent || e.author || "unknown"} className="font-mono text-xs text-foreground truncate">
                     <GitCommit
                       className="inline-block h-3 w-3 mr-1 text-info -translate-y-px"
                       aria-hidden
@@ -155,7 +155,7 @@ export default function VaultActivityPage() {
                     {e.agent || e.author || "unknown"}
                   </span>
                   <div className="min-w-0">
-                    <div className="text-sm tracking-tight truncate text-foreground group-hover:text-accent">
+                    <div title={e.subject || primary?.path || "(no subject)"} className="text-sm tracking-tight truncate text-foreground group-hover:text-accent">
                       {e.subject || primary?.path || "(no subject)"}
                     </div>
                     {primary && (

--- a/frontend/src/pages/vault-members.tsx
+++ b/frontend/src/pages/vault-members.tsx
@@ -239,7 +239,7 @@ export default function VaultMembersPage() {
                     </span>
                   )}
                 </div>
-                <div className="coord truncate">{m.email}</div>
+                <div title={m.email} className="coord truncate">{m.email}</div>
               </div>
               <div className="flex items-center gap-3 shrink-0">
                 {canManage && m.role !== "owner" && currentUser && m.username !== currentUser.username ? (

--- a/frontend/src/pages/vault.tsx
+++ b/frontend/src/pages/vault.tsx
@@ -242,10 +242,10 @@ export default function VaultPage() {
                     {String(i + 1).padStart(2, "0")}
                   </span>
                   <div className="min-w-0">
-                    <div className="text-sm font-medium tracking-tight truncate text-foreground group-hover:text-accent">
+                    <div title={c.title} className="text-sm font-medium tracking-tight truncate text-foreground group-hover:text-accent">
                       {c.title}
                     </div>
-                    <div className="coord truncate">{c.path}</div>
+                    <div title={c.path} className="coord truncate">{c.path}</div>
                   </div>
                   <div className="flex items-baseline gap-3 shrink-0">
                     <span className="coord font-mono tabular-nums">
@@ -316,11 +316,11 @@ export default function VaultPage() {
                         className="group grid grid-cols-[70px_140px_1fr_auto_54px] gap-3 py-1 items-baseline hover:bg-surface-muted -mx-2 px-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
                       >
                         <span className="text-accent">{(c.hash || "").slice(0, 7)}</span>
-                        <span className="text-foreground truncate">
+                        <span title={c.agent || c.author || "unknown"} className="text-foreground truncate">
                           <span className="text-info">◆ </span>
                           {c.agent || c.author || "unknown"}
                         </span>
-                        <span className="text-foreground truncate">
+                        <span title={c.subject || filePath} className="text-foreground truncate">
                           {c.subject || filePath}
                           {filesCount > 1 && (
                             <span className="text-foreground-muted"> · +{filesCount - 1}</span>


### PR DESCRIPTION
## Problem
Single-line labels truncated by Tailwind `truncate` across the app's sidebars and lists gave users **no way to read the full text** when it was cut off (the original report: collection names in the vault explorer).

## Fix
Add the native `title` attribute — the existing codebase convention (`GraphDetailPanel`'s URI line, the explorer's action buttons) — to every CSS-`truncate`d element that renders a **dynamic** name/title/path/email/id, so hovering reveals the full value. No Tooltip component introduced: the zero-JS native `title` is the right altitude for dense, up-to-300-row trees (a Radix Tooltip per row would add portals/state/listeners and is barely used elsewhere).

Discovered + applied via a per-file sweep (one agent per file → no edit conflicts), then every added `title=` was reviewed by hand.

### Surfaces covered (34 labels)
- **Vault explorer**: collection rows, doc/table/file leaves, vault header
- **Vault nav** (active + inactive rows)
- **Graph**: sidebar (search hits, entry, recent, saved views) + detail panel (relations, sections)
- **Doc outline**, **history list** (author · subject), **user menu**, **invite-member dialog**
- **Pages**: home, vault, vault-activity, vault-members, publications, document, settings

### Conservatively skipped
Static labels, long prose/summaries, counts/badges, and elements **already** carrying a title (e.g. `table.tsx` cells already use `title={cell}`; `search.tsx` had no `truncate` class — only a `truncated` state var).

## Tests / verification
- New assertion: vault-explorer rows expose the full name via `title`.
- **Full frontend suite: 232 passing**; `tsc` + `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)