### PR TITLE
feat(frontend): doc-create affordances + resizable vault-nav column

### DIFF
--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -1,9 +1,10 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
   File,
+  FilePlus,
   FileText,
   FolderPlus,
   Network,
@@ -67,6 +68,7 @@ export function VaultExplorer({
   onRefetchReady,
 }: VaultExplorerProps) {
   const { tree, loading, error, refetch } = useVaultTree(vault);
+  const navigate = useNavigate();
   const refreshCtx = useVaultRefresh();
   // Prefer the explicit prop; otherwise fall back to context. This lets
   // tests render the explorer with no provider and still wire mutation
@@ -298,6 +300,11 @@ export function VaultExplorer({
               vault={vault}
               onToggle={toggle}
               canWrite={canWrite}
+              onCreateDoc={(node) =>
+                navigate(
+                  `/vault/${vault}/doc/new?collection=${encodeURIComponent(node.path)}`,
+                )
+              }
               onCreateSubCollection={(node) => openCreate(node.path)}
               onDeleteCollection={(node) =>
                 setDeleteTarget({
@@ -403,10 +410,13 @@ interface RowProps {
    *  collection row. Parent opens the create dialog with this node's
    *  path prefilled as the parent. */
   onCreateSubCollection?: (node: TreeNode) => void;
+  /** Fired when the user clicks the doc icon on a collection row. Parent
+   *  routes to the new-document page with this collection prefilled. */
+  onCreateDoc?: (node: TreeNode) => void;
 }
 
 const TreeRow = memo(function TreeRow({
-  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, onDeleteCollection, onCreateSubCollection,
+  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, onDeleteCollection, onCreateSubCollection, onCreateDoc,
 }: RowProps) {
   const indent = { paddingLeft: `${depth * 12 + 12}px` };
 
@@ -435,6 +445,21 @@ const TreeRow = memo(function TreeRow({
           <span className="truncate font-medium tracking-tight text-[13px] text-foreground">{node.name}</span>
           {count > 0 && <span className="coord ml-auto shrink-0">{count}</span>}
         </button>
+        {canWrite && onCreateDoc && (
+          <button
+            type="button"
+            onClick={(e) => {
+              // Stop the row's expand-toggle from also firing.
+              e.stopPropagation();
+              onCreateDoc(node);
+            }}
+            title={`New document in ${node.path}`}
+            aria-label={`Create document in ${node.path}`}
+            className="shrink-0 px-2 inline-flex items-center justify-center text-foreground-muted hover:text-accent transition-colors cursor-pointer opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <FilePlus className="h-3 w-3" aria-hidden />
+          </button>
+        )}
         {canWrite && onCreateSubCollection && (
           <button
             type="button"

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -6,27 +6,18 @@ import { VaultNav } from "@/components/vault-nav";
 import { TitleBar, VaultActions, type VaultPageKind } from "@/components/title-bar";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { VaultRefreshProvider } from "@/contexts/vault-refresh-context";
+import { useColumnResize } from "@/hooks/use-column-resize";
 
-// Tree (collection) column is drag-resizable. Width persists across
-// sessions in localStorage and is clamped so it can never collapse the
-// content column or overrun the viewport. Double-clicking the handle
-// resets to the default.
-const TREE_MIN = 180;
-const TREE_MAX = 560;
-const TREE_DEFAULT = 260;
-const TREE_WIDTH_KEY = "akb.treeWidth";
-
-function loadTreeWidth(): number {
-  if (typeof window === "undefined") return TREE_DEFAULT;
-  const saved = Number(window.localStorage.getItem(TREE_WIDTH_KEY));
-  return Number.isFinite(saved) && saved >= TREE_MIN && saved <= TREE_MAX
-    ? saved
-    : TREE_DEFAULT;
-}
+// Both the vault-nav (col 1) and the collection tree (col 2) are
+// drag-resizable. Widths persist across sessions in localStorage and are
+// clamped so a column can never collapse a neighbour or overrun the
+// viewport. Double-clicking a handle resets it to its default.
+const NAV_RESIZE = { storageKey: "akb.navWidth", min: 180, max: 420, default: 200 };
+const TREE_RESIZE = { storageKey: "akb.treeWidth", min: 180, max: 560, default: 260 };
 
 /**
  * 3-column vault workspace:
- *   [ 200px vault-nav | <resizable> tree | 1fr content ]
+ *   [ <resizable> vault-nav | <resizable> tree | 1fr content ]
  * Above them a 36px TitleBar with breadcrumb + VaultActions.
  * Each page renders into the Outlet and owns its inner layout (e.g. the
  * document page still decides where its right-rail outline goes).
@@ -35,45 +26,8 @@ export function VaultShell() {
   const { name } = useParams<{ name: string }>();
   const location = useLocation();
   const [visible, setVisible] = useState(true);
-  const [treeWidth, setTreeWidth] = useState<number>(loadTreeWidth);
-
-  // Persist the chosen width so it survives reloads and vault switches.
-  useEffect(() => {
-    window.localStorage.setItem(TREE_WIDTH_KEY, String(treeWidth));
-  }, [treeWidth]);
-
-  // Pointer-drag resize of the tree column. We capture the pointer on the
-  // handle so the drag keeps tracking even when the cursor leaves the thin
-  // hit area, and lock body cursor/selection for the duration.
-  const dragRef = useRef<{ startX: number; startW: number } | null>(null);
-  const onResizeStart = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      dragRef.current = { startX: e.clientX, startW: treeWidth };
-      e.currentTarget.setPointerCapture(e.pointerId);
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    },
-    [treeWidth],
-  );
-  const onResizeMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const drag = dragRef.current;
-    if (!drag) return;
-    const next = Math.min(
-      TREE_MAX,
-      Math.max(TREE_MIN, drag.startW + (e.clientX - drag.startX)),
-    );
-    setTreeWidth(next);
-  }, []);
-  const onResizeEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!dragRef.current) return;
-    dragRef.current = null;
-    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId);
-    }
-    document.body.style.cursor = "";
-    document.body.style.userSelect = "";
-  }, []);
+  const nav = useColumnResize(NAV_RESIZE);
+  const tree = useColumnResize(TREE_RESIZE);
 
   // Tree defaults to open on every vault switch — clicking the active
   // vault row in the nav (or ⌘\) toggles it.
@@ -164,11 +118,25 @@ export function VaultShell() {
       <VaultRefreshProvider refetchTree={refetchTree} refetchVaults={refetchVaults}>
         <div className="flex flex-col h-full min-h-0">
           <TitleBar crumbs={[{ label: "Vaults" }]} />
-          <div className="grid grid-cols-[200px_1fr] flex-1 min-h-0">
+          <div
+            className="grid grid-cols-[var(--cols)] flex-1 min-h-0 relative"
+            style={{ ["--cols" as any]: `${nav.width}px 1fr` }}
+          >
             <VaultNav
               current=""
               onRefetchReady={onVaultsRefetchReady}
             />
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize vault list"
+              {...nav.handlers}
+              title="Drag to resize · double-click to reset"
+              className="group absolute top-0 bottom-0 z-20 w-2 cursor-col-resize touch-none"
+              style={{ left: `${nav.width}px`, transform: "translateX(-50%)" }}
+            >
+              <div className="mx-auto h-full w-px bg-border transition-colors group-hover:bg-accent group-active:bg-accent" />
+            </div>
             <div className="min-w-0 min-h-0 overflow-y-auto bg-background">
               <ErrorBoundary resetKeys={[location.pathname]}>
                 <Outlet />
@@ -186,7 +154,9 @@ export function VaultShell() {
   // room by default. Members/settings/activity follow the same rule —
   // those are vault-level admin pages, not content browsing.
   const showTree = !isGraph && !isAdminPage && visible;
-  const gridCols = showTree ? `200px ${treeWidth}px 1fr` : "200px 1fr";
+  const gridCols = showTree
+    ? `${nav.width}px ${tree.width}px 1fr`
+    : `${nav.width}px 1fr`;
 
   return (
     <VaultRefreshProvider refetchTree={refetchTree} refetchVaults={refetchVaults}>
@@ -205,6 +175,20 @@ export function VaultShell() {
             onCurrentVaultClick={toggleTree}
             treeOpen={visible}
           />
+          {/* Vault-nav resize handle — sits on the nav column's right edge.
+              Always present (the nav column is shown on every vault route),
+              independent of whether the tree column is visible. */}
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize vault list"
+            {...nav.handlers}
+            title="Drag to resize · double-click to reset"
+            className="group absolute top-0 bottom-0 z-20 w-2 cursor-col-resize touch-none"
+            style={{ left: `${nav.width}px`, transform: "translateX(-50%)" }}
+          >
+            <div className="mx-auto h-full w-px bg-border transition-colors group-hover:bg-accent group-active:bg-accent" />
+          </div>
           {showTree && (
             <VaultExplorer
               vault={name}
@@ -216,14 +200,13 @@ export function VaultShell() {
               role="separator"
               aria-orientation="vertical"
               aria-label="Resize collection tree"
-              onPointerDown={onResizeStart}
-              onPointerMove={onResizeMove}
-              onPointerUp={onResizeEnd}
-              onPointerCancel={onResizeEnd}
-              onDoubleClick={() => setTreeWidth(TREE_DEFAULT)}
+              {...tree.handlers}
               title="Drag to resize · double-click to reset"
               className="group absolute top-0 bottom-0 z-20 w-2 cursor-col-resize touch-none"
-              style={{ left: `calc(200px + ${treeWidth}px)`, transform: "translateX(-50%)" }}
+              style={{
+                left: `calc(${nav.width}px + ${tree.width}px)`,
+                transform: "translateX(-50%)",
+              }}
             >
               <div className="mx-auto h-full w-px bg-border transition-colors group-hover:bg-accent group-active:bg-accent" />
             </div>

--- a/frontend/src/hooks/use-column-resize.ts
+++ b/frontend/src/hooks/use-column-resize.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Pointer-drag resize for a fixed-width grid column. Width persists
+ * across sessions in localStorage and is clamped to [min, max] so the
+ * column can never collapse a neighbour or overrun the viewport.
+ *
+ * Spread `handlers` onto the drag handle element. The handle captures
+ * the pointer on press so the drag keeps tracking even when the cursor
+ * leaves the thin hit area, and locks body cursor/selection for the
+ * duration. Double-clicking the handle resets to `default`.
+ *
+ * Used by VaultShell for both the vault-nav column and the collection
+ * tree column.
+ */
+export interface ColumnResizeOptions {
+  storageKey: string;
+  min: number;
+  max: number;
+  /** Width used before any user drag (and on double-click reset). */
+  default: number;
+}
+
+export interface ColumnResize {
+  width: number;
+  setWidth: (w: number) => void;
+  reset: () => void;
+  handlers: {
+    onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void;
+    onDoubleClick: () => void;
+  };
+}
+
+export function useColumnResize({
+  storageKey,
+  min,
+  max,
+  default: def,
+}: ColumnResizeOptions): ColumnResize {
+  const load = (): number => {
+    if (typeof window === "undefined") return def;
+    const saved = Number(window.localStorage.getItem(storageKey));
+    return Number.isFinite(saved) && saved >= min && saved <= max ? saved : def;
+  };
+  const [width, setWidth] = useState<number>(load);
+
+  // Persist the chosen width so it survives reloads and vault switches.
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, String(width));
+  }, [storageKey, width]);
+
+  const dragRef = useRef<{ startX: number; startW: number } | null>(null);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      dragRef.current = { startX: e.clientX, startW: width };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [width],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      setWidth(
+        Math.min(max, Math.max(min, drag.startW + (e.clientX - drag.startX))),
+      );
+    },
+    [min, max],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
+
+  const reset = useCallback(() => setWidth(def), [def]);
+
+  return {
+    width,
+    setWidth,
+    reset,
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+      onDoubleClick: reset,
+    },
+  };
+}

--- a/frontend/src/pages/document-new.tsx
+++ b/frontend/src/pages/document-new.tsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy, useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ArrowLeft, ArrowRight, ChevronRight, Loader2 } from "lucide-react";
 import { ApiError, putDocument } from "@/lib/api";
 import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
+import { useVaultTree, type TreeNode } from "@/hooks/use-vault-tree";
 import { MarkdownEditorFallback } from "@/components/markdown-editor-fallback";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,11 +13,37 @@ import { Textarea } from "@/components/ui/textarea";
 
 const MarkdownEditor = lazy(() => import("@/components/markdown-editor"));
 
+/** Flatten every collection path in the tree (depth-first) for the
+ *  COLLECTION datalist. The tree nests sub-collections under their
+ *  parent, so a recursive walk yields the full `a/b/c` paths. */
+function collectCollectionPaths(nodes: TreeNode[], out: string[] = []): string[] {
+  for (const node of nodes) {
+    if (node.kind === "collection") {
+      out.push(node.path);
+      if (node.children) collectCollectionPaths(node.children, out);
+    }
+  }
+  return out;
+}
+
 export default function DocumentNewPage() {
   const { name } = useParams<{ name: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { tree } = useVaultTree(name);
+  // Existing collections power the picker datalist; new names are still
+  // accepted (the field stays a free-text input — "created automatically
+  // if new").
+  const collectionOptions = useMemo(
+    () => Array.from(new Set(collectCollectionPaths(tree ?? []))).sort(),
+    [tree],
+  );
   const [title, setTitle] = useState("");
-  const [collection, setCollection] = useState("");
+  // Prefill from `?collection=` so the tree's per-row "new doc" button
+  // can drop the user straight into the owning collection.
+  const [collection, setCollection] = useState(
+    () => searchParams.get("collection") ?? "",
+  );
   const [type, setType] = useState<DocType>("note");
   const [domain, setDomain] = useState("");
   const [summary, setSummary] = useState("");
@@ -182,8 +209,15 @@ export default function DocumentNewPage() {
               placeholder="e.g. engineering/specs"
               className="font-mono"
               maxLength={120}
+              list="doc-collection-options"
+              autoComplete="off"
             />
-            <div className="coord">CREATED AUTOMATICALLY IF NEW</div>
+            <datalist id="doc-collection-options">
+              {collectionOptions.map((c) => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
+            <div className="coord">PICK EXISTING · OR TYPE A NEW PATH (CREATED AUTOMATICALLY)</div>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="doc-type">Type</Label>


### PR DESCRIPTION
Three additive frontend UX fixes around document creation, all surfaced from user feedback.

## What & why

### 1. "New document" action on every collection tree row
Collection rows already had hover actions for *new sub-collection* and *delete*; creating a document under a collection had no in-tree affordance. Added a `FilePlus` hover button that routes to the new-document page with the collection prefilled (`/vault/:name/doc/new?collection=<path>`). Writer+ only, same gating as the other row actions.

### 2. COLLECTION field is now a picker (not blind free-text)
The new-document form asked users to *type* a collection path with no hint of what already exists. It's now an `<input list>` + `<datalist>` of the vault's existing collections (from `useVaultTree`) — pick from existing, **or** type a brand-new path (still "created automatically if new"). Also consumes the `?collection=` query param from #1 to prefill.

### 3. Vault-nav (VAULTS) column is drag-resizable
Long vault names (`agent-memory-…`) were permanently truncated in the fixed-200px nav column. The collection-tree column was already resizable; the nav column now is too. Width persists in `localStorage` (`akb.navWidth`). The tree/nav pointer-drag logic is extracted into a shared `useColumnResize` hook used by both columns.

## Verification
- `bash scripts/check.sh` green locally (ruff, mypy, bandit, eslint 0 errors, tsc clean, vitest 220/220, detect-secrets).
- Manual e2e against a local docker-compose stack (Playwright): created an Engineering-template vault, confirmed all 7 collection rows show the new-doc button, clicking it lands on `…/doc/new?collection=specs` with the field prefilled, the datalist carries all 7 collections, a new-path is still typeable, nav-column drag resizes 200→280px and persists, and an end-to-end doc creation saved to `specs/verify-doc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)