### PR TITLE
feat(frontend/graph): Obsidian-style cluster view (collection grouping + force + rounded hulls)

### DIFF
--- a/frontend/src/components/graph/GraphCanvas.tsx
+++ b/frontend/src/components/graph/GraphCanvas.tsx
@@ -1,7 +1,7 @@
 // frontend/src/components/graph/GraphCanvas.tsx
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import ForceGraph2D, { type ForceGraphMethods } from "react-force-graph-2d";
-import { Pause, Play, Maximize2, Minus, Plus } from "lucide-react";
+import { Pause, Play, Maximize2, Minus, Plus, Boxes } from "lucide-react";
 import { useTheme } from "@/hooks/use-theme";
 import {
   RELATION_DASH,
@@ -11,6 +11,7 @@ import {
   type GraphColors,
 } from "./graph-types";
 import { endpointUri } from "./use-graph-data";
+import { groupPaint, forceCluster, drawClusterHulls, isDarkBg, CLUSTER_STRENGTH } from "./cluster";
 
 export interface GraphCanvasHandle {
   centerOnNode: (uri: string) => void;
@@ -64,6 +65,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   const { theme } = useTheme();
   const [colors, setColors] = useState<GraphColors>(() => readColors());
   const [frozen, setFrozen] = useState(false);
+  const [clustered, setClustered] = useState(true);
 
   useImperativeHandle(
     ref,
@@ -85,12 +87,12 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   useEffect(() => {
     const fg = fgRef.current;
     if (!fg) return;
-    if (degraded || frozen) {
-      fg.d3Force("center", null);
-      fg.pauseAnimation();
-    } else {
-      fg.resumeAnimation();
-    }
+    // Pause the sim while frozen/degraded. We intentionally leave the built-in
+    // 'center' force installed — pausing already stops all ticks, and nulling
+    // center permanently would let the layout drift off-centre on a later
+    // resume/reheat.
+    if (degraded || frozen) fg.pauseAnimation();
+    else fg.resumeAnimation();
   }, [degraded, frozen]);
 
   // Auto fit-to-view once when nodes first populate
@@ -104,6 +106,8 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     return () => clearTimeout(t);
   }, [nodes.length]);
 
+  // node.group is assigned at data ingest (use-graph-data.ts), so it travels
+  // with the node and this stays a pure filter.
   const visibleNodes = useMemo(
     () => nodes.filter((n) => !hidden.has(n.uri)),
     [nodes, hidden],
@@ -121,31 +125,67 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     [visibleNodes, visibleEdges],
   );
 
+  // Group colors adapt to the active theme (lighter on dark bg, darker on
+  // light bg) so cluster rings/hulls never wash out.
+  const dark = useMemo(() => isDarkBg(colors.background), [colors]);
+
+  // Install/remove the cluster force on the three STATE inputs only — not on
+  // graphData. force-graph already re-feeds nodes + reheats to alpha(1) on
+  // every data change, so depending on graphData here would double-reheat and
+  // jolt the layout on every selection/filter. Cleanup nulls the force so a
+  // StrictMode double-mount stays symmetric.
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!fg) return;
+    const on = clustered && !degraded && !frozen;
+    fg.d3Force("cluster", on ? (forceCluster(CLUSTER_STRENGTH) as never) : null);
+    // Repaint after a toggle/resume: while the engine is live a reheat both
+    // re-clumps the layout and forces a redraw — so turning clusters OFF
+    // actually clears the hulls instead of leaving them until the next pan.
+    if (!degraded && !frozen) fg.d3ReheatSimulation();
+    return () => {
+      fgRef.current?.d3Force("cluster", null);
+    };
+  }, [clustered, degraded, frozen]);
+
+  // Draw the rounded cluster hulls under the nodes/links each frame.
+  const renderFramePre = useCallback(
+    (ctx: CanvasRenderingContext2D, scale: number) => {
+      if (!clustered) return;
+      drawClusterHulls(ctx, graphData.nodes as GraphNode[], scale, dark);
+    },
+    [clustered, graphData, dark],
+  );
+
   const paintNode = useCallback(
     (n: RenderNode, ctx: CanvasRenderingContext2D, scale: number) => {
       const x = n.x || 0;
       const y = n.y || 0;
       const isSelected = n.uri === selected;
       const isPinned = pinned.has(n.uri);
+      // Cluster membership re-tints the node ring (keeping the kind-based
+      // fill + glyph so document/table/file stay distinguishable). Selection
+      // always wins; ungrouped nodes keep their kind stroke.
+      const groupStroke = clustered && n.group ? groupPaint(n.group, dark).node : null;
 
       ctx.beginPath();
       ctx.rect(x - NODE_SIZE / 2, y - NODE_SIZE / 2, NODE_SIZE, NODE_SIZE);
       switch (n.kind) {
         case "document":
           ctx.fillStyle = colors.surfaceMuted;
-          ctx.strokeStyle = isSelected ? colors.accent : colors.foreground;
+          ctx.strokeStyle = isSelected ? colors.accent : (groupStroke ?? colors.foreground);
           ctx.lineWidth = isSelected ? 2.5 : 1.5;
           ctx.setLineDash([]);
           break;
         case "table":
           ctx.fillStyle = colors.surface;
-          ctx.strokeStyle = colors.accent;
+          ctx.strokeStyle = isSelected ? colors.accent : (groupStroke ?? colors.accent);
           ctx.lineWidth = isSelected ? 2.5 : 1.5;
           ctx.setLineDash([]);
           break;
         case "file":
           ctx.fillStyle = "transparent";
-          ctx.strokeStyle = isSelected ? colors.accent : colors.foregroundMuted;
+          ctx.strokeStyle = isSelected ? colors.accent : (groupStroke ?? colors.foregroundMuted);
           ctx.lineWidth = isSelected ? 2.5 : 1;
           ctx.setLineDash([3, 2]);
           break;
@@ -177,7 +217,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         ctx.fillText(label, x, y + NODE_SIZE / 2 + 4);
       }
     },
-    [colors, selected, pinned],
+    [colors, selected, pinned, clustered, dark],
   );
 
   const paintLink = useCallback(
@@ -241,6 +281,12 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     >
       <div className="absolute top-3 left-3 z-10 flex gap-1">
         <CanvasButton
+          onClick={() => setClustered((c) => !c)}
+          label={clustered ? "Hide clusters" : "Show clusters"}
+          icon={Boxes}
+          active={clustered}
+        />
+        <CanvasButton
           onClick={() => setFrozen((f) => !f)}
           label={frozen ? "Resume" : "Freeze"}
           icon={frozen ? Play : Pause}
@@ -270,6 +316,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         linkTarget="target"
         nodeCanvasObject={paintNode as never}
         linkCanvasObject={paintLink as never}
+        onRenderFramePre={renderFramePre as never}
         linkDirectionalArrowLength={5}
         linkDirectionalArrowRelPos={1}
         linkDirectionalArrowColor={colors.foregroundMuted}
@@ -293,10 +340,13 @@ function CanvasButton({
   onClick,
   label,
   icon: Icon,
+  active = false,
 }: {
   onClick: () => void;
   label: string;
   icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  /** Renders a pressed/accent state for toggle buttons. */
+  active?: boolean;
 }) {
   return (
     <button
@@ -304,7 +354,12 @@ function CanvasButton({
       onClick={onClick}
       title={label}
       aria-label={label}
-      className="inline-flex items-center justify-center h-8 w-8 bg-surface border border-border text-foreground-muted hover:text-foreground hover:bg-surface-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-colors cursor-pointer"
+      aria-pressed={active}
+      className={`inline-flex items-center justify-center h-8 w-8 border focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-colors cursor-pointer ${
+        active
+          ? "bg-accent/10 border-accent text-accent"
+          : "bg-surface border-border text-foreground-muted hover:text-foreground hover:bg-surface-muted"
+      }`}
     >
       <Icon className="h-3 w-3" aria-hidden />
     </button>

--- a/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+// Capture the simulation methods + props the component drives, by stubbing
+// react-force-graph-2d with a ref-forwarding placeholder (jsdom can't run the
+// real canvas engine).
+const d3Force = vi.fn();
+const d3ReheatSimulation = vi.fn();
+let lastProps: Record<string, unknown> = {};
+
+vi.mock("react-force-graph-2d", () => ({
+  __esModule: true,
+  default: React.forwardRef(function FGMock(
+    props: Record<string, unknown>,
+    ref: React.Ref<unknown>,
+  ) {
+    lastProps = props;
+    React.useImperativeHandle(ref, () => ({
+      d3Force,
+      d3ReheatSimulation,
+      zoomToFit: vi.fn(),
+      zoom: vi.fn(() => 1),
+      centerAt: vi.fn(),
+      pauseAnimation: vi.fn(),
+      resumeAnimation: vi.fn(),
+    }));
+    return React.createElement("div", { "data-testid": "fg" });
+  }),
+}));
+
+vi.mock("@/hooks/use-theme", () => ({ useTheme: () => ({ theme: "dark" }) }));
+
+import { GraphCanvas } from "../GraphCanvas";
+
+const baseProps = {
+  nodes: [],
+  edges: [],
+  pinned: new Set<string>(),
+  hidden: new Set<string>(),
+  degraded: false,
+  onSelect: () => {},
+  onContextMenu: () => {},
+};
+
+beforeEach(() => {
+  d3Force.mockClear();
+  d3ReheatSimulation.mockClear();
+  lastProps = {};
+});
+afterEach(cleanup);
+
+describe("GraphCanvas — cluster wiring", () => {
+  it("installs the cluster force + reheats + passes the hull render hook when clustering is on (default)", () => {
+    render(<GraphCanvas {...baseProps} />);
+
+    const clusterCalls = d3Force.mock.calls.filter((c) => c[0] === "cluster");
+    expect(clusterCalls.length).toBeGreaterThan(0);
+    // most recent install passed a force FUNCTION (not null)
+    expect(typeof clusterCalls[clusterCalls.length - 1][1]).toBe("function");
+    expect(d3ReheatSimulation).toHaveBeenCalled();
+    expect(typeof lastProps.onRenderFramePre).toBe("function");
+  });
+
+  it("toggling clusters off nulls the force and flips aria-pressed", () => {
+    render(<GraphCanvas {...baseProps} />);
+
+    const onBtn = screen.getByRole("button", { name: /hide clusters/i });
+    expect(onBtn).toHaveAttribute("aria-pressed", "true");
+
+    d3Force.mockClear();
+    fireEvent.click(onBtn);
+
+    const clusterCalls = d3Force.mock.calls.filter((c) => c[0] === "cluster");
+    expect(clusterCalls.length).toBeGreaterThan(0);
+    // every cluster call after toggling off must remove the force (null)
+    expect(clusterCalls.every((c) => c[1] === null)).toBe(true);
+
+    expect(screen.getByRole("button", { name: /show clusters/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+});

--- a/frontend/src/components/graph/__tests__/cluster.test.ts
+++ b/frontend/src/components/graph/__tests__/cluster.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupOf,
+  groupPaint,
+  isDarkBg,
+  convexHull,
+  padHull,
+  traceSmoothClosedPath,
+  forceCluster,
+  drawClusterHulls,
+  type Point,
+} from "../cluster";
+import type { GraphNode } from "../graph-types";
+
+/** Minimal recording stub for CanvasRenderingContext2D used by the hull/path
+ *  tests — captures method-call names and tolerates property assignment. */
+function recordingCtx(): { ctx: CanvasRenderingContext2D; calls: string[] } {
+  const calls: string[] = [];
+  const ctx = new Proxy(
+    {},
+    {
+      get: (_t, prop) => {
+        if (prop === "fillStyle" || prop === "strokeStyle" || prop === "lineWidth") return "";
+        return (..._args: unknown[]) => calls.push(String(prop));
+      },
+      set: () => true,
+    },
+  ) as unknown as CanvasRenderingContext2D;
+  return { ctx, calls };
+}
+
+describe("groupOf", () => {
+  it("groups a collection doc by its TOP-LEVEL collection segment", () => {
+    expect(groupOf("akb://v/coll/specs/2026/doc/api.md")).toBe("specs");
+    expect(groupOf("akb://v/coll/guides/doc/intro.md")).toBe("guides");
+  });
+
+  it("groups tables/files by their top-level collection too", () => {
+    expect(groupOf("akb://v/coll/data/warehouse/table/metrics")).toBe("data");
+    expect(groupOf("akb://v/coll/assets/file/8f1c.png")).toBe("assets");
+  });
+
+  it("returns null for vault-root resources (no collection)", () => {
+    expect(groupOf("akb://v/doc/readme.md")).toBeNull();
+    expect(groupOf("akb://v/table/metrics")).toBeNull();
+  });
+
+  it("returns null for unparseable / vault / collection URIs", () => {
+    expect(groupOf("not-a-uri")).toBeNull();
+    expect(groupOf("akb://v")).toBeNull();
+  });
+});
+
+describe("groupPaint", () => {
+  it("is deterministic for a given group key", () => {
+    expect(groupPaint("specs")).toEqual(groupPaint("specs"));
+  });
+
+  it("returns the three color roles as CSS color strings", () => {
+    const p = groupPaint("specs");
+    expect(p.node).toMatch(/^hsl/);
+    expect(p.hullStroke).toMatch(/^hsla/);
+    expect(p.hullFill).toMatch(/^hsla/);
+  });
+
+  it("usually distinguishes different groups by hue", () => {
+    // Not a hard guarantee (hash collisions exist) but should hold for these.
+    expect(groupPaint("specs").node).not.toBe(groupPaint("guides").node);
+  });
+
+  it("uses a different (darker) ring on a light background", () => {
+    expect(groupPaint("specs", false).node).not.toBe(groupPaint("specs", true).node);
+  });
+});
+
+describe("isDarkBg", () => {
+  it("classifies dark vs light hex backgrounds", () => {
+    expect(isDarkBg("#0f172a")).toBe(true); // app dark bg
+    expect(isDarkBg("#faf9f5")).toBe(false); // app light bg
+    expect(isDarkBg("#000")).toBe(true);
+    expect(isDarkBg("#fff")).toBe(false);
+  });
+
+  it("falls back to dark for unparseable input", () => {
+    expect(isDarkBg("")).toBe(true);
+    expect(isDarkBg("oklch(0.2 0 0)")).toBe(true);
+  });
+});
+
+describe("convexHull", () => {
+  it("returns the 4 corners for a filled square of points", () => {
+    const pts: Point[] = [
+      [0, 0], [10, 0], [10, 10], [0, 10], // corners
+      [5, 5], [3, 7], [8, 2], // interior — must be dropped
+    ];
+    const hull = convexHull(pts);
+    expect(hull).toHaveLength(4);
+    for (const corner of [[0, 0], [10, 0], [10, 10], [0, 10]]) {
+      expect(hull).toContainEqual(corner);
+    }
+  });
+
+  it("returns the input unchanged for fewer than 3 points", () => {
+    expect(convexHull([[1, 1]])).toEqual([[1, 1]]);
+    expect(convexHull([[1, 1], [2, 2]])).toEqual([[1, 1], [2, 2]]);
+  });
+
+  it("collapses 3+ collinear points to < 3 (so the caller draws a circle)", () => {
+    expect(convexHull([[0, 0], [1, 1], [2, 2]]).length).toBeLessThan(3);
+    expect(convexHull([[0, 0], [1, 0], [2, 0], [3, 0]]).length).toBeLessThan(3);
+  });
+});
+
+describe("traceSmoothClosedPath", () => {
+  it("emits one bézier per vertex for a closed smoothed loop (n>=3)", () => {
+    const { ctx, calls } = recordingCtx();
+    const pts: Point[] = [[0, 0], [10, 0], [10, 10], [0, 10]];
+    traceSmoothClosedPath(ctx, pts);
+    expect(calls.filter((c) => c === "bezierCurveTo")).toHaveLength(pts.length);
+    expect(calls).toContain("moveTo");
+    expect(calls).toContain("closePath");
+  });
+
+  it("falls back to straight segments for < 3 points (no bézier)", () => {
+    const { ctx, calls } = recordingCtx();
+    traceSmoothClosedPath(ctx, [[0, 0], [10, 0]]);
+    expect(calls).toContain("moveTo");
+    expect(calls).toContain("lineTo");
+    expect(calls).not.toContain("bezierCurveTo");
+  });
+});
+
+describe("padHull", () => {
+  it("pushes every vertex outward from the centroid", () => {
+    const hull: Point[] = [[0, 0], [10, 0], [10, 10], [0, 10]]; // centroid (5,5)
+    const padded = padHull(hull, 5);
+    // every padded vertex is farther from the centroid than the original
+    for (let i = 0; i < hull.length; i++) {
+      const d0 = Math.hypot(hull[i][0] - 5, hull[i][1] - 5);
+      const d1 = Math.hypot(padded[i][0] - 5, padded[i][1] - 5);
+      expect(d1).toBeGreaterThan(d0);
+    }
+  });
+});
+
+describe("forceCluster", () => {
+  it("nudges same-group nodes toward their shared centroid", () => {
+    const a: GraphNode = { uri: "a", name: "a", kind: "document", group: "g", x: 0, y: 0, vx: 0, vy: 0 };
+    const b: GraphNode = { uri: "b", name: "b", kind: "document", group: "g", x: 10, y: 0, vx: 0, vy: 0 };
+    const f = forceCluster(0.5);
+    f.initialize([a, b]);
+    f(1); // centroid = (5,0): a pulled +x, b pulled -x
+    expect(a.vx!).toBeGreaterThan(0);
+    expect(b.vx!).toBeLessThan(0);
+  });
+
+  it("leaves ungrouped nodes untouched", () => {
+    const lone: GraphNode = { uri: "c", name: "c", kind: "document", group: null, x: 99, y: 99, vx: 0, vy: 0 };
+    const f = forceCluster(0.5);
+    f.initialize([lone]);
+    f(1);
+    expect(lone.vx).toBe(0);
+    expect(lone.vy).toBe(0);
+  });
+});
+
+describe("drawClusterHulls", () => {
+  it("draws one hull per group and skips ungrouped/position-less nodes (smoke)", () => {
+    const { ctx, calls } = recordingCtx();
+    const nodes: GraphNode[] = [
+      { uri: "a", name: "a", kind: "document", group: "g1", x: 0, y: 0 },
+      { uri: "b", name: "b", kind: "document", group: "g1", x: 10, y: 0 },
+      { uri: "c", name: "c", kind: "document", group: "g1", x: 5, y: 10 },
+      { uri: "d", name: "d", kind: "document", group: "g2", x: 100, y: 100 }, // singleton -> circle
+      { uri: "e", name: "e", kind: "document", group: null, x: 0, y: 0 }, // ungrouped -> skipped
+      { uri: "f", name: "f", kind: "document", group: "g1" }, // no position -> skipped
+    ];
+
+    expect(() => drawClusterHulls(ctx, nodes, 1)).not.toThrow();
+    // two groups -> two fills + two strokes
+    expect(calls.filter((c) => c === "fill")).toHaveLength(2);
+    expect(calls.filter((c) => c === "stroke")).toHaveLength(2);
+    // the 3-node group produces a smoothed path (bezier), the singleton a circle (arc)
+    expect(calls).toContain("bezierCurveTo");
+    expect(calls).toContain("arc");
+    // self-contained: must save/restore so it never leaks ctx state to nodes
+    expect(calls).toContain("save");
+    expect(calls).toContain("restore");
+  });
+
+  it("draws nothing when fewer than two groups are present", () => {
+    const { ctx, calls } = recordingCtx();
+    const nodes: GraphNode[] = [
+      { uri: "a", name: "a", kind: "document", group: "only", x: 0, y: 0 },
+      { uri: "b", name: "b", kind: "document", group: "only", x: 10, y: 0 },
+      { uri: "c", name: "c", kind: "document", group: "only", x: 5, y: 10 },
+    ];
+    drawClusterHulls(ctx, nodes, 1);
+    expect(calls).not.toContain("fill");
+    expect(calls).not.toContain("stroke");
+  });
+});

--- a/frontend/src/components/graph/cluster.ts
+++ b/frontend/src/components/graph/cluster.ts
@@ -1,0 +1,280 @@
+// frontend/src/components/graph/cluster.ts
+//
+// Cluster grouping + visual encoding for the graph canvas (Tier 1+2+3):
+//   1. grouping       — groupOf(): which cluster a node belongs to
+//   2. color          — groupPaint(): a stable color per cluster
+//   3. cluster force   — forceCluster(): pulls same-group nodes together
+//   4. rounded hull    — drawClusterHulls(): the translucent "blob" outline
+//
+// Everything here is dependency-free (hand-rolled convex hull + Catmull-Rom
+// smoothing) so it adds no npm package / lockfile churn.
+//
+// Grouping seam: the force, hull, and color readers are all grouping-source
+// agnostic — they only read `node.group`. Today that field is populated from
+// the node's collection (groupOf(), a pure per-URI function: deterministic,
+// flicker-free). To switch to link-structure communities (e.g. Louvain),
+// replace the ANNOTATION step (where node.group is assigned at data ingest):
+// community detection needs the whole edge set, not a single URI, so it can't
+// reuse groupOf()'s signature — it would be a `annotate(nodes, edges)` pass.
+import { parseUri } from "@/lib/uri";
+import type { GraphNode } from "./graph-types";
+
+export type Point = [number, number];
+
+/** Default pull strength of the cluster force (exported for tuning/tests). */
+export const CLUSTER_STRENGTH = 0.18;
+/** Padding (px) between a cluster's outermost nodes and its hull outline. */
+export const HULL_PAD = 26;
+
+/**
+ * The cluster a node belongs to: its TOP-LEVEL collection segment, parsed
+ * from the canonical URI (`akb://V/coll/<top>/<rest>/...`). Top-level (not
+ * full path) keeps clusters few and large, which reads as cleaner blobs.
+ * Root-level resources (no collection) are ungrouped → null (no hull, no
+ * cluster pull, keep their kind color).
+ */
+export function groupOf(uri: string): string | null {
+  const p = parseUri(uri);
+  if (!p || !p.collection) return null;
+  return p.collection.split("/")[0] || null;
+}
+
+// ── Color ───────────────────────────────────────────────────────────────
+
+/** Deterministic string → hue in [0,360) (FNV-1a). Same group key always
+ *  maps to the same hue regardless of how many groups exist, so colors never
+ *  reshuffle/flicker as the graph changes. */
+function hashHue(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0) % 360;
+}
+
+export interface GroupPaint {
+  /** node ring (solid, readable) */
+  node: string;
+  /** hull outline (translucent) */
+  hullStroke: string;
+  /** hull fill (very translucent so nodes/edges underneath stay visible) */
+  hullFill: string;
+}
+
+/** Luminance check on a hex background so colors adapt to the active theme.
+ *  Falls back to "dark" for non-hex / unparseable input. */
+export function isDarkBg(bg: string): boolean {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(bg.trim());
+  if (!m) return true;
+  let hex = m[1];
+  if (hex.length === 3) hex = hex.split("").map((c) => c + c).join("");
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b < 128;
+}
+
+const paintCache = new Map<string, GroupPaint>();
+
+/** Stable, theme-aware color set for a group key. Memoized — called once per
+ *  visible node and per group every frame. On a light background the ring +
+ *  stroke drop to a lower lightness so they don't wash out. */
+export function groupPaint(group: string, dark = true): GroupPaint {
+  const key = `${group}|${dark ? 1 : 0}`;
+  const cached = paintCache.get(key);
+  if (cached) return cached;
+  const h = hashHue(group);
+  const p: GroupPaint = dark
+    ? {
+        node: `hsl(${h}, 65%, 62%)`,
+        hullStroke: `hsla(${h}, 65%, 60%, 0.45)`,
+        hullFill: `hsla(${h}, 65%, 55%, 0.10)`,
+      }
+    : {
+        node: `hsl(${h}, 60%, 42%)`,
+        hullStroke: `hsla(${h}, 60%, 42%, 0.5)`,
+        hullFill: `hsla(${h}, 65%, 50%, 0.13)`,
+      };
+  paintCache.set(key, p);
+  return p;
+}
+
+// ── Geometry ──────────────────────────────────────────────────────────────
+
+/** Andrew's monotone-chain convex hull. Returns hull vertices in order;
+ *  fewer than 3 unique points returns the input as-is (caller draws a
+ *  circle fallback). */
+export function convexHull(points: Point[]): Point[] {
+  const pts = points.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const n = pts.length;
+  if (n < 3) return pts;
+  const cross = (o: Point, a: Point, b: Point) =>
+    (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+  const lower: Point[] = [];
+  for (const p of pts) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0)
+      lower.pop();
+    lower.push(p);
+  }
+  const upper: Point[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const p = pts[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0)
+      upper.pop();
+    upper.push(p);
+  }
+  lower.pop();
+  upper.pop();
+  return lower.concat(upper);
+}
+
+/** Inflate a hull outward from its centroid by `pad` px so the blob clears
+ *  the nodes. Centroid-push (vs edge-bisector) is robust and looks smooth
+ *  once the curve is rounded. */
+export function padHull(hull: Point[], pad: number): Point[] {
+  const n = hull.length;
+  if (n === 0) return hull;
+  let cx = 0;
+  let cy = 0;
+  for (const [x, y] of hull) {
+    cx += x;
+    cy += y;
+  }
+  cx /= n;
+  cy /= n;
+  return hull.map(([x, y]) => {
+    const dx = x - cx;
+    const dy = y - cy;
+    const m = Math.hypot(dx, dy) || 1;
+    return [x + (dx / m) * pad, y + (dy / m) * pad] as Point;
+  });
+}
+
+/** Trace a smooth closed curve through `pts` onto the canvas using a
+ *  Catmull-Rom spline converted to cubic béziers — this is what gives the
+ *  rounded blob look. Caller is responsible for beginPath/fill/stroke. */
+export function traceSmoothClosedPath(ctx: CanvasRenderingContext2D, pts: Point[]): void {
+  const n = pts.length;
+  if (n === 0) return;
+  if (n < 3) {
+    ctx.moveTo(pts[0][0], pts[0][1]);
+    for (let i = 1; i < n; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+    ctx.closePath();
+    return;
+  }
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 0; i < n; i++) {
+    const p0 = pts[(i - 1 + n) % n];
+    const p1 = pts[i];
+    const p2 = pts[(i + 1) % n];
+    const p3 = pts[(i + 2) % n];
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
+    ctx.bezierCurveTo(c1x, c1y, c2x, c2y, p2[0], p2[1]);
+  }
+  ctx.closePath();
+}
+
+/** Draw a rounded translucent hull behind each group's nodes. Call from
+ *  `onRenderFramePre` (under the nodes/links). Cheap: O(nodes) per frame.
+ *  Self-contained (save/restore) so it never leaks ctx state into the node
+ *  paint that follows. */
+export function drawClusterHulls(
+  ctx: CanvasRenderingContext2D,
+  nodes: GraphNode[],
+  globalScale: number,
+  dark = true,
+): void {
+  const groups = new Map<string, Point[]>();
+  for (const n of nodes) {
+    if (!n.group || n.x == null || n.y == null) continue;
+    const arr = groups.get(n.group);
+    if (arr) arr.push([n.x, n.y]);
+    else groups.set(n.group, [[n.x, n.y]]);
+  }
+  // One (or zero) clusters → nothing to distinguish; a single all-enclosing
+  // blob is just noise, so skip drawing it.
+  if (groups.size < 2) return;
+  ctx.save();
+  for (const [group, pts] of groups) {
+    const paint = groupPaint(group, dark);
+    ctx.beginPath();
+    const hull = pts.length >= 3 ? convexHull(pts) : pts;
+    if (hull.length >= 3) {
+      traceSmoothClosedPath(ctx, padHull(hull, HULL_PAD));
+    } else {
+      traceCircleAround(ctx, pts, HULL_PAD);
+    }
+    ctx.fillStyle = paint.hullFill;
+    ctx.fill();
+    ctx.lineWidth = 1.5 / globalScale;
+    ctx.strokeStyle = paint.hullStroke;
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/** Enclosing circle fallback for 1–2 node (or collinear) groups. */
+function traceCircleAround(ctx: CanvasRenderingContext2D, pts: Point[], pad: number): void {
+  let cx = 0;
+  let cy = 0;
+  for (const [x, y] of pts) {
+    cx += x;
+    cy += y;
+  }
+  cx /= pts.length;
+  cy /= pts.length;
+  let r = 0;
+  for (const [x, y] of pts) r = Math.max(r, Math.hypot(x - cx, y - cy));
+  ctx.arc(cx, cy, r + pad, 0, 2 * Math.PI);
+}
+
+// ── Force ───────────────────────────────────────────────────────────────
+
+export interface ClusterForce {
+  (alpha: number): void;
+  initialize: (nodes: GraphNode[]) => void;
+}
+
+/**
+ * A d3-force that nudges each node toward its group's live centroid, so
+ * same-group nodes clump tighter on top of the default link/charge forces.
+ * Ungrouped nodes are left untouched. The pull is scaled by the simulation's
+ * decaying `alpha`, so it eases off as the layout settles.
+ */
+export function forceCluster(strength = CLUSTER_STRENGTH): ClusterForce {
+  let nodes: GraphNode[] = [];
+  const force = (alpha: number) => {
+    const cent = new Map<string, { x: number; y: number; n: number }>();
+    for (const n of nodes) {
+      if (!n.group || n.x == null || n.y == null) continue;
+      const c = cent.get(n.group);
+      if (c) {
+        c.x += n.x;
+        c.y += n.y;
+        c.n++;
+      } else {
+        cent.set(n.group, { x: n.x, y: n.y, n: 1 });
+      }
+    }
+    for (const c of cent.values()) {
+      c.x /= c.n;
+      c.y /= c.n;
+    }
+    const k = strength * alpha;
+    for (const n of nodes) {
+      if (!n.group || n.x == null || n.y == null) continue;
+      const c = cent.get(n.group);
+      if (!c) continue;
+      n.vx = (n.vx ?? 0) + (c.x - n.x) * k;
+      n.vy = (n.vy ?? 0) + (c.y - n.y) * k;
+    }
+  };
+  force.initialize = (ns: GraphNode[]) => {
+    nodes = ns;
+  };
+  return force;
+}

--- a/frontend/src/components/graph/graph-types.ts
+++ b/frontend/src/components/graph/graph-types.ts
@@ -20,6 +20,9 @@ export interface GraphNode {
   kind: NodeKind;
   doc_id?: string;
   doc_type?: string;
+  /** Cluster id (top-level collection) for grouping/coloring/hulls.
+   *  Derived from the URI at render time; null = ungrouped. See cluster.ts. */
+  group?: string | null;
   // simulation-owned positional state
   x?: number; y?: number; vx?: number; vy?: number; fx?: number; fy?: number;
 }

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -2,6 +2,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGraph, getRelations, type RelationRow } from "@/lib/api";
 import { parseUri } from "@/lib/uri";
+import { groupOf } from "./cluster";
 import {
   ALL_NODE_KINDS,
   type GraphEdge,
@@ -128,6 +129,7 @@ function rowToNeighbor(row: RelationRow): GraphNode | null {
     uri: row.uri,
     name: row.name || row.uri,
     kind: normalizeKind(row.resource_type),
+    group: groupOf(row.uri),
   };
 }
 
@@ -181,6 +183,7 @@ export async function bfsExpand(args: BfsExpandArgs): Promise<GraphPayload> {
     name: entry,
     kind: "document",
     doc_id: entry,
+    group: groupOf(seedResp.uri),
   };
   const nodesByUri = new Map<string, GraphNode>([[seedNode.uri, seedNode]]);
   const edgeKeys = new Set<string>();
@@ -250,6 +253,7 @@ export function useFullGraph(vault: string, enabled: boolean) {
         uri: n.uri,
         name: n.name || n.uri,
         kind: normalizeKind(n.resource_type),
+        group: groupOf(n.uri),
       }));
       const edges: GraphEdge[] = resp.edges
         .map((e) => {


### PR DESCRIPTION
## What
An opt-out (default-on) **clustering layer** for the knowledge-graph viewer: densely-related nodes read as visual groups like Obsidian's graph — except the grouping is explicit (by collection) and the rounded "blob" outline is actually drawn.

- **Grouping** — top-level **collection** from the canonical `akb://` URI, assigned at data ingest so it travels with the node. Root-level = ungrouped. `groupOf()` is pure per-URI; swapping to Louvain link-communities later only touches the annotation step (force/hull/color read `node.group`).
- **Color** — stable, **theme-aware** HSL per group (memoized). Node ring re-tints by group; kind fill/glyph kept so doc/table/file stay distinguishable.
- **Force (Tier 2)** — custom d3 force pulls same-group nodes to their live centroid, via `fgRef.d3Force("cluster", …)`.
- **Hull (Tier 3)** — convex hull → centroid pad → **Catmull-Rom smoothing** → translucent fill, drawn under the nodes in `onRenderFramePre`. **No new npm deps** (hand-rolled geometry → no lockfile churn; Docker build unaffected).
- **Toggle** — a canvas control (default on) switches the layer off.

Tunables exported: `CLUSTER_STRENGTH` (0.18), `HULL_PAD` (26).

## Review-hardened
Shipped after a multi-dimension adversarial review. Fixes folded in: cluster force installs on `[clustered,degraded,frozen]` only (no per-selection reheat jitter) with cleanup (StrictMode-safe); freeze no longer permanently nulls the center force (was causing drift on resume); toggling repaints so hulls clear; theme-aware colors (no light-mode washout); hulls skipped when `<2` groups; `ctx` save/restored; group annotation moved out of an impure memo.

## Tests
- New `cluster.ts` unit tests (grouping, convex hull incl. collinear, padding, Catmull-Rom branches, theme color, `<2`-group guard, force).
- New **mocked `GraphCanvas` wiring test** (force install/remove, `aria-pressed` toggle).
- **Full suite: 254 passing (45 files)**; `tsc` + `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)