### PR TITLE
fix(frontend/graph): drop cluster hull, group by week, loosen density + close gaps

### DIFF
--- a/frontend/src/components/graph/GraphCanvas.tsx
+++ b/frontend/src/components/graph/GraphCanvas.tsx
@@ -11,7 +11,16 @@ import {
   type GraphColors,
 } from "./graph-types";
 import { endpointUri } from "./use-graph-data";
-import { groupPaint, forceCluster, drawClusterHulls, isDarkBg, CLUSTER_STRENGTH } from "./cluster";
+import {
+  groupColor,
+  forceCluster,
+  forceCollide,
+  isDarkBg,
+  CLUSTER_STRENGTH,
+  COLLIDE_RADIUS,
+  CHARGE_STRENGTH,
+  DEFAULT_CHARGE,
+} from "./cluster";
 
 export interface GraphCanvasHandle {
   centerOnNode: (uri: string) => void;
@@ -129,33 +138,30 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   // light bg) so cluster rings/hulls never wash out.
   const dark = useMemo(() => isDarkBg(colors.background), [colors]);
 
-  // Install/remove the cluster force on the three STATE inputs only — not on
-  // graphData. force-graph already re-feeds nodes + reheats to alpha(1) on
+  // Install/remove the clustering forces on the three STATE inputs only — not
+  // on graphData. force-graph already re-feeds nodes + reheats to alpha(1) on
   // every data change, so depending on graphData here would double-reheat and
-  // jolt the layout on every selection/filter. Cleanup nulls the force so a
+  // jolt the layout on every selection/filter. Cleanup nulls the forces so a
   // StrictMode double-mount stays symmetric.
+  //
+  // While clustering: forceCluster pulls each group together, forceCollide
+  // keeps nodes spaced (so clumps aren't cramped), and the global charge is
+  // softened so separate clusters sit closer together rather than flying
+  // apart. All restored/removed when clustering is off.
   useEffect(() => {
     const fg = fgRef.current;
     if (!fg) return;
     const on = clustered && !degraded && !frozen;
     fg.d3Force("cluster", on ? (forceCluster(CLUSTER_STRENGTH) as never) : null);
-    // Repaint after a toggle/resume: while the engine is live a reheat both
-    // re-clumps the layout and forces a redraw — so turning clusters OFF
-    // actually clears the hulls instead of leaving them until the next pan.
+    fg.d3Force("collide", on ? (forceCollide(COLLIDE_RADIUS) as never) : null);
+    const charge = fg.d3Force("charge") as { strength?: (v: number) => unknown } | undefined;
+    charge?.strength?.(on ? CHARGE_STRENGTH : DEFAULT_CHARGE);
     if (!degraded && !frozen) fg.d3ReheatSimulation();
     return () => {
       fgRef.current?.d3Force("cluster", null);
+      fgRef.current?.d3Force("collide", null);
     };
   }, [clustered, degraded, frozen]);
-
-  // Draw the rounded cluster hulls under the nodes/links each frame.
-  const renderFramePre = useCallback(
-    (ctx: CanvasRenderingContext2D, scale: number) => {
-      if (!clustered) return;
-      drawClusterHulls(ctx, graphData.nodes as GraphNode[], scale, dark);
-    },
-    [clustered, graphData, dark],
-  );
 
   const paintNode = useCallback(
     (n: RenderNode, ctx: CanvasRenderingContext2D, scale: number) => {
@@ -166,7 +172,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
       // Cluster membership re-tints the node ring (keeping the kind-based
       // fill + glyph so document/table/file stay distinguishable). Selection
       // always wins; ungrouped nodes keep their kind stroke.
-      const groupStroke = clustered && n.group ? groupPaint(n.group, dark).node : null;
+      const groupStroke = clustered && n.group ? groupColor(n.group, dark) : null;
 
       ctx.beginPath();
       ctx.rect(x - NODE_SIZE / 2, y - NODE_SIZE / 2, NODE_SIZE, NODE_SIZE);
@@ -316,7 +322,6 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         linkTarget="target"
         nodeCanvasObject={paintNode as never}
         linkCanvasObject={paintLink as never}
-        onRenderFramePre={renderFramePre as never}
         linkDirectionalArrowLength={5}
         linkDirectionalArrowRelPos={1}
         linkDirectionalArrowColor={colors.foregroundMuted}

--- a/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
@@ -51,18 +51,20 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("GraphCanvas — cluster wiring", () => {
-  it("installs the cluster force + reheats + passes the hull render hook when clustering is on (default)", () => {
+  it("installs the cluster + collide forces and reheats when clustering is on (default)", () => {
     render(<GraphCanvas {...baseProps} />);
 
     const clusterCalls = d3Force.mock.calls.filter((c) => c[0] === "cluster");
+    const collideCalls = d3Force.mock.calls.filter((c) => c[0] === "collide");
     expect(clusterCalls.length).toBeGreaterThan(0);
-    // most recent install passed a force FUNCTION (not null)
+    expect(collideCalls.length).toBeGreaterThan(0);
+    // most recent installs passed a force FUNCTION (not null)
     expect(typeof clusterCalls[clusterCalls.length - 1][1]).toBe("function");
+    expect(typeof collideCalls[collideCalls.length - 1][1]).toBe("function");
     expect(d3ReheatSimulation).toHaveBeenCalled();
-    expect(typeof lastProps.onRenderFramePre).toBe("function");
   });
 
-  it("toggling clusters off nulls the force and flips aria-pressed", () => {
+  it("toggling clusters off nulls the forces and flips aria-pressed", () => {
     render(<GraphCanvas {...baseProps} />);
 
     const onBtn = screen.getByRole("button", { name: /hide clusters/i });
@@ -73,8 +75,11 @@ describe("GraphCanvas — cluster wiring", () => {
 
     const clusterCalls = d3Force.mock.calls.filter((c) => c[0] === "cluster");
     expect(clusterCalls.length).toBeGreaterThan(0);
-    // every cluster call after toggling off must remove the force (null)
+    // every cluster + collide call after toggling off must remove the force
     expect(clusterCalls.every((c) => c[1] === null)).toBe(true);
+    expect(
+      d3Force.mock.calls.filter((c) => c[0] === "collide").every((c) => c[1] === null),
+    ).toBe(true);
 
     expect(screen.getByRole("button", { name: /show clusters/i })).toHaveAttribute(
       "aria-pressed",

--- a/frontend/src/components/graph/__tests__/cluster.test.ts
+++ b/frontend/src/components/graph/__tests__/cluster.test.ts
@@ -1,145 +1,55 @@
 import { describe, it, expect } from "vitest";
 import {
   groupOf,
-  groupPaint,
+  groupColor,
   isDarkBg,
-  convexHull,
-  padHull,
-  traceSmoothClosedPath,
   forceCluster,
-  drawClusterHulls,
-  type Point,
+  forceCollide,
+  COLLIDE_RADIUS,
 } from "../cluster";
 import type { GraphNode } from "../graph-types";
 
-/** Minimal recording stub for CanvasRenderingContext2D used by the hull/path
- *  tests — captures method-call names and tolerates property assignment. */
-function recordingCtx(): { ctx: CanvasRenderingContext2D; calls: string[] } {
-  const calls: string[] = [];
-  const ctx = new Proxy(
-    {},
-    {
-      get: (_t, prop) => {
-        if (prop === "fillStyle" || prop === "strokeStyle" || prop === "lineWidth") return "";
-        return (..._args: unknown[]) => calls.push(String(prop));
-      },
-      set: () => true,
-    },
-  ) as unknown as CanvasRenderingContext2D;
-  return { ctx, calls };
-}
-
 describe("groupOf", () => {
-  it("groups a collection doc by its TOP-LEVEL collection segment", () => {
-    expect(groupOf("akb://v/coll/specs/2026/doc/api.md")).toBe("specs");
+  it("groups by the first two collection segments (week-level for nested vaults)", () => {
+    // weekly-updates/<week>/<topic> → groups by week
+    expect(groupOf("akb://gnu-weekly/coll/weekly-updates/2026-05-12/akb/doc/x.md")).toBe(
+      "weekly-updates/2026-05-12",
+    );
+    expect(groupOf("akb://gnu-weekly/coll/weekly-updates/2026-05-19/operations/doc/y.md")).toBe(
+      "weekly-updates/2026-05-19",
+    );
+  });
+
+  it("uses the whole collection path when it has fewer than two segments", () => {
     expect(groupOf("akb://v/coll/guides/doc/intro.md")).toBe("guides");
+    expect(groupOf("akb://v/coll/data/warehouse/table/metrics")).toBe("data/warehouse");
   });
 
-  it("groups tables/files by their top-level collection too", () => {
-    expect(groupOf("akb://v/coll/data/warehouse/table/metrics")).toBe("data");
-    expect(groupOf("akb://v/coll/assets/file/8f1c.png")).toBe("assets");
-  });
-
-  it("returns null for vault-root resources (no collection)", () => {
+  it("returns null for vault-root resources and unparseable URIs", () => {
     expect(groupOf("akb://v/doc/readme.md")).toBeNull();
-    expect(groupOf("akb://v/table/metrics")).toBeNull();
-  });
-
-  it("returns null for unparseable / vault / collection URIs", () => {
-    expect(groupOf("not-a-uri")).toBeNull();
     expect(groupOf("akb://v")).toBeNull();
+    expect(groupOf("not-a-uri")).toBeNull();
   });
 });
 
-describe("groupPaint", () => {
-  it("is deterministic for a given group key", () => {
-    expect(groupPaint("specs")).toEqual(groupPaint("specs"));
-  });
-
-  it("returns the three color roles as CSS color strings", () => {
-    const p = groupPaint("specs");
-    expect(p.node).toMatch(/^hsl/);
-    expect(p.hullStroke).toMatch(/^hsla/);
-    expect(p.hullFill).toMatch(/^hsla/);
+describe("groupColor", () => {
+  it("is deterministic and theme-aware", () => {
+    expect(groupColor("w/1")).toBe(groupColor("w/1"));
+    expect(groupColor("w/1", false)).not.toBe(groupColor("w/1", true));
+    expect(groupColor("w/1")).toMatch(/^hsl\(/);
   });
 
   it("usually distinguishes different groups by hue", () => {
-    // Not a hard guarantee (hash collisions exist) but should hold for these.
-    expect(groupPaint("specs").node).not.toBe(groupPaint("guides").node);
-  });
-
-  it("uses a different (darker) ring on a light background", () => {
-    expect(groupPaint("specs", false).node).not.toBe(groupPaint("specs", true).node);
+    expect(groupColor("w/1")).not.toBe(groupColor("w/2"));
   });
 });
 
 describe("isDarkBg", () => {
-  it("classifies dark vs light hex backgrounds", () => {
-    expect(isDarkBg("#0f172a")).toBe(true); // app dark bg
-    expect(isDarkBg("#faf9f5")).toBe(false); // app light bg
-    expect(isDarkBg("#000")).toBe(true);
+  it("classifies dark vs light hex backgrounds, defaulting to dark", () => {
+    expect(isDarkBg("#0f172a")).toBe(true);
+    expect(isDarkBg("#faf9f5")).toBe(false);
     expect(isDarkBg("#fff")).toBe(false);
-  });
-
-  it("falls back to dark for unparseable input", () => {
-    expect(isDarkBg("")).toBe(true);
     expect(isDarkBg("oklch(0.2 0 0)")).toBe(true);
-  });
-});
-
-describe("convexHull", () => {
-  it("returns the 4 corners for a filled square of points", () => {
-    const pts: Point[] = [
-      [0, 0], [10, 0], [10, 10], [0, 10], // corners
-      [5, 5], [3, 7], [8, 2], // interior — must be dropped
-    ];
-    const hull = convexHull(pts);
-    expect(hull).toHaveLength(4);
-    for (const corner of [[0, 0], [10, 0], [10, 10], [0, 10]]) {
-      expect(hull).toContainEqual(corner);
-    }
-  });
-
-  it("returns the input unchanged for fewer than 3 points", () => {
-    expect(convexHull([[1, 1]])).toEqual([[1, 1]]);
-    expect(convexHull([[1, 1], [2, 2]])).toEqual([[1, 1], [2, 2]]);
-  });
-
-  it("collapses 3+ collinear points to < 3 (so the caller draws a circle)", () => {
-    expect(convexHull([[0, 0], [1, 1], [2, 2]]).length).toBeLessThan(3);
-    expect(convexHull([[0, 0], [1, 0], [2, 0], [3, 0]]).length).toBeLessThan(3);
-  });
-});
-
-describe("traceSmoothClosedPath", () => {
-  it("emits one bézier per vertex for a closed smoothed loop (n>=3)", () => {
-    const { ctx, calls } = recordingCtx();
-    const pts: Point[] = [[0, 0], [10, 0], [10, 10], [0, 10]];
-    traceSmoothClosedPath(ctx, pts);
-    expect(calls.filter((c) => c === "bezierCurveTo")).toHaveLength(pts.length);
-    expect(calls).toContain("moveTo");
-    expect(calls).toContain("closePath");
-  });
-
-  it("falls back to straight segments for < 3 points (no bézier)", () => {
-    const { ctx, calls } = recordingCtx();
-    traceSmoothClosedPath(ctx, [[0, 0], [10, 0]]);
-    expect(calls).toContain("moveTo");
-    expect(calls).toContain("lineTo");
-    expect(calls).not.toContain("bezierCurveTo");
-  });
-});
-
-describe("padHull", () => {
-  it("pushes every vertex outward from the centroid", () => {
-    const hull: Point[] = [[0, 0], [10, 0], [10, 10], [0, 10]]; // centroid (5,5)
-    const padded = padHull(hull, 5);
-    // every padded vertex is farther from the centroid than the original
-    for (let i = 0; i < hull.length; i++) {
-      const d0 = Math.hypot(hull[i][0] - 5, hull[i][1] - 5);
-      const d1 = Math.hypot(padded[i][0] - 5, padded[i][1] - 5);
-      expect(d1).toBeGreaterThan(d0);
-    }
   });
 });
 
@@ -149,7 +59,7 @@ describe("forceCluster", () => {
     const b: GraphNode = { uri: "b", name: "b", kind: "document", group: "g", x: 10, y: 0, vx: 0, vy: 0 };
     const f = forceCluster(0.5);
     f.initialize([a, b]);
-    f(1); // centroid = (5,0): a pulled +x, b pulled -x
+    f(1); // centroid (5,0): a pulled +x, b pulled -x
     expect(a.vx!).toBeGreaterThan(0);
     expect(b.vx!).toBeLessThan(0);
   });
@@ -164,39 +74,33 @@ describe("forceCluster", () => {
   });
 });
 
-describe("drawClusterHulls", () => {
-  it("draws one hull per group and skips ungrouped/position-less nodes (smoke)", () => {
-    const { ctx, calls } = recordingCtx();
-    const nodes: GraphNode[] = [
-      { uri: "a", name: "a", kind: "document", group: "g1", x: 0, y: 0 },
-      { uri: "b", name: "b", kind: "document", group: "g1", x: 10, y: 0 },
-      { uri: "c", name: "c", kind: "document", group: "g1", x: 5, y: 10 },
-      { uri: "d", name: "d", kind: "document", group: "g2", x: 100, y: 100 }, // singleton -> circle
-      { uri: "e", name: "e", kind: "document", group: null, x: 0, y: 0 }, // ungrouped -> skipped
-      { uri: "f", name: "f", kind: "document", group: "g1" }, // no position -> skipped
-    ];
-
-    expect(() => drawClusterHulls(ctx, nodes, 1)).not.toThrow();
-    // two groups -> two fills + two strokes
-    expect(calls.filter((c) => c === "fill")).toHaveLength(2);
-    expect(calls.filter((c) => c === "stroke")).toHaveLength(2);
-    // the 3-node group produces a smoothed path (bezier), the singleton a circle (arc)
-    expect(calls).toContain("bezierCurveTo");
-    expect(calls).toContain("arc");
-    // self-contained: must save/restore so it never leaks ctx state to nodes
-    expect(calls).toContain("save");
-    expect(calls).toContain("restore");
+describe("forceCollide", () => {
+  it("pushes overlapping nodes apart", () => {
+    const a: GraphNode = { uri: "a", name: "a", kind: "document", x: 0, y: 0 };
+    const b: GraphNode = { uri: "b", name: "b", kind: "document", x: 2, y: 0 }; // far closer than 2*radius
+    const before = Math.abs(a.x! - b.x!);
+    const f = forceCollide(COLLIDE_RADIUS);
+    f.initialize([a, b]);
+    f(1);
+    expect(Math.abs(a.x! - b.x!)).toBeGreaterThan(before);
   });
 
-  it("draws nothing when fewer than two groups are present", () => {
-    const { ctx, calls } = recordingCtx();
-    const nodes: GraphNode[] = [
-      { uri: "a", name: "a", kind: "document", group: "only", x: 0, y: 0 },
-      { uri: "b", name: "b", kind: "document", group: "only", x: 10, y: 0 },
-      { uri: "c", name: "c", kind: "document", group: "only", x: 5, y: 10 },
-    ];
-    drawClusterHulls(ctx, nodes, 1);
-    expect(calls).not.toContain("fill");
-    expect(calls).not.toContain("stroke");
+  it("leaves nodes already farther apart than 2·radius alone", () => {
+    const a: GraphNode = { uri: "a", name: "a", kind: "document", x: 0, y: 0 };
+    const b: GraphNode = { uri: "b", name: "b", kind: "document", x: COLLIDE_RADIUS * 4, y: 0 };
+    const f = forceCollide(COLLIDE_RADIUS);
+    f.initialize([a, b]);
+    f(1);
+    expect(a.x).toBe(0);
+    expect(b.x).toBe(COLLIDE_RADIUS * 4);
+  });
+
+  it("skips nodes without positions", () => {
+    const a: GraphNode = { uri: "a", name: "a", kind: "document" };
+    const b: GraphNode = { uri: "b", name: "b", kind: "document", x: 0, y: 0 };
+    const f = forceCollide(COLLIDE_RADIUS);
+    f.initialize([a, b]);
+    expect(() => f(1)).not.toThrow();
+    expect(b.x).toBe(0);
   });
 });

--- a/frontend/src/components/graph/cluster.ts
+++ b/frontend/src/components/graph/cluster.ts
@@ -1,49 +1,51 @@
 // frontend/src/components/graph/cluster.ts
 //
-// Cluster grouping + visual encoding for the graph canvas (Tier 1+2+3):
-//   1. grouping       — groupOf(): which cluster a node belongs to
-//   2. color          — groupPaint(): a stable color per cluster
-//   3. cluster force   — forceCluster(): pulls same-group nodes together
-//   4. rounded hull    — drawClusterHulls(): the translucent "blob" outline
+// Force-based clustering for the graph canvas — NO drawn hull/outline. Nodes
+// in the same group are pulled together and tinted, so dense groups settle
+// into naturally round clumps (the way a force-directed graph clusters),
+// without any border or background fill.
 //
-// Everything here is dependency-free (hand-rolled convex hull + Catmull-Rom
-// smoothing) so it adds no npm package / lockfile churn.
+//   1. grouping  — groupOf(): which cluster a node belongs to
+//   2. color     — groupColor(): a stable, theme-aware ring tint per group
+//   3. forces    — forceCluster() pulls a group together; forceCollide()
+//                  keeps nodes from overlapping (so clumps aren't cramped)
 //
-// Grouping seam: the force, hull, and color readers are all grouping-source
-// agnostic — they only read `node.group`. Today that field is populated from
-// the node's collection (groupOf(), a pure per-URI function: deterministic,
-// flicker-free). To switch to link-structure communities (e.g. Louvain),
-// replace the ANNOTATION step (where node.group is assigned at data ingest):
-// community detection needs the whole edge set, not a single URI, so it can't
-// reuse groupOf()'s signature — it would be a `annotate(nodes, edges)` pass.
+// Dependency-free. Grouping seam: the forces + color read node.group, which
+// is assigned at data ingest (use-graph-data) from the node's collection.
 import { parseUri } from "@/lib/uri";
 import type { GraphNode } from "./graph-types";
 
-export type Point = [number, number];
-
-/** Default pull strength of the cluster force (exported for tuning/tests). */
-export const CLUSTER_STRENGTH = 0.18;
-/** Padding (px) between a cluster's outermost nodes and its hull outline. */
-export const HULL_PAD = 26;
+// ── Tunables (exported so they're easy to find + adjust) ──────────────────
+/** How many leading collection segments define a cluster. For nested vaults
+ *  like `weekly-updates/<week>/<topic>` this groups by WEEK at depth 2
+ *  (everything under one top-level collection would otherwise be one blob). */
+export const GROUP_DEPTH = 2;
+/** How hard same-group nodes are pulled toward their shared centroid. */
+export const CLUSTER_STRENGTH = 0.22;
+/** Minimum spacing radius per node (px) — stops clumps from cramming. */
+export const COLLIDE_RADIUS = 15;
+/** Global node repulsion while clustering. Less negative than d3's -30
+ *  default, so separate clusters sit CLOSER together instead of flying apart;
+ *  forceCollide handles local spacing instead of charge. */
+export const CHARGE_STRENGTH = -14;
+/** d3 / force-graph default many-body charge, restored when clustering off. */
+export const DEFAULT_CHARGE = -30;
 
 /**
- * The cluster a node belongs to: its TOP-LEVEL collection segment, parsed
- * from the canonical URI (`akb://V/coll/<top>/<rest>/...`). Top-level (not
- * full path) keeps clusters few and large, which reads as cleaner blobs.
- * Root-level resources (no collection) are ungrouped → null (no hull, no
- * cluster pull, keep their kind color).
+ * The cluster a node belongs to: the first GROUP_DEPTH segments of its
+ * collection path (from the canonical akb:// URI). Root-level resources
+ * (no collection) are ungrouped → null.
  */
 export function groupOf(uri: string): string | null {
   const p = parseUri(uri);
   if (!p || !p.collection) return null;
-  return p.collection.split("/")[0] || null;
+  return p.collection.split("/").slice(0, GROUP_DEPTH).join("/") || null;
 }
 
-// ── Color ───────────────────────────────────────────────────────────────
+// ── Color ─────────────────────────────────────────────────────────────────
 
 /** Deterministic string → hue in [0,360) (FNV-1a). Same group key always
- *  maps to the same hue regardless of how many groups exist, so colors never
- *  reshuffle/flicker as the graph changes. */
+ *  maps to the same hue regardless of how many groups exist (no flicker). */
 function hashHue(s: string): number {
   let h = 2166136261;
   for (let i = 0; i < s.length; i++) {
@@ -51,15 +53,6 @@ function hashHue(s: string): number {
     h = Math.imul(h, 16777619);
   }
   return (h >>> 0) % 360;
-}
-
-export interface GroupPaint {
-  /** node ring (solid, readable) */
-  node: string;
-  /** hull outline (translucent) */
-  hullStroke: string;
-  /** hull fill (very translucent so nodes/edges underneath stay visible) */
-  hullFill: string;
 }
 
 /** Luminance check on a hex background so colors adapt to the active theme.
@@ -75,177 +68,33 @@ export function isDarkBg(bg: string): boolean {
   return 0.299 * r + 0.587 * g + 0.114 * b < 128;
 }
 
-const paintCache = new Map<string, GroupPaint>();
+const colorCache = new Map<string, string>();
 
-/** Stable, theme-aware color set for a group key. Memoized — called once per
- *  visible node and per group every frame. On a light background the ring +
- *  stroke drop to a lower lightness so they don't wash out. */
-export function groupPaint(group: string, dark = true): GroupPaint {
+/** Stable, theme-aware ring color for a group key (memoized — called per
+ *  visible node every frame). Darker on a light background so it reads. */
+export function groupColor(group: string, dark = true): string {
   const key = `${group}|${dark ? 1 : 0}`;
-  const cached = paintCache.get(key);
+  const cached = colorCache.get(key);
   if (cached) return cached;
   const h = hashHue(group);
-  const p: GroupPaint = dark
-    ? {
-        node: `hsl(${h}, 65%, 62%)`,
-        hullStroke: `hsla(${h}, 65%, 60%, 0.45)`,
-        hullFill: `hsla(${h}, 65%, 55%, 0.10)`,
-      }
-    : {
-        node: `hsl(${h}, 60%, 42%)`,
-        hullStroke: `hsla(${h}, 60%, 42%, 0.5)`,
-        hullFill: `hsla(${h}, 65%, 50%, 0.13)`,
-      };
-  paintCache.set(key, p);
-  return p;
+  const col = dark ? `hsl(${h}, 65%, 62%)` : `hsl(${h}, 60%, 42%)`;
+  colorCache.set(key, col);
+  return col;
 }
 
-// ── Geometry ──────────────────────────────────────────────────────────────
+// ── Forces ──────────────────────────────────────────────────────────────
 
-/** Andrew's monotone-chain convex hull. Returns hull vertices in order;
- *  fewer than 3 unique points returns the input as-is (caller draws a
- *  circle fallback). */
-export function convexHull(points: Point[]): Point[] {
-  const pts = points.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-  const n = pts.length;
-  if (n < 3) return pts;
-  const cross = (o: Point, a: Point, b: Point) =>
-    (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
-  const lower: Point[] = [];
-  for (const p of pts) {
-    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0)
-      lower.pop();
-    lower.push(p);
-  }
-  const upper: Point[] = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const p = pts[i];
-    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0)
-      upper.pop();
-    upper.push(p);
-  }
-  lower.pop();
-  upper.pop();
-  return lower.concat(upper);
-}
-
-/** Inflate a hull outward from its centroid by `pad` px so the blob clears
- *  the nodes. Centroid-push (vs edge-bisector) is robust and looks smooth
- *  once the curve is rounded. */
-export function padHull(hull: Point[], pad: number): Point[] {
-  const n = hull.length;
-  if (n === 0) return hull;
-  let cx = 0;
-  let cy = 0;
-  for (const [x, y] of hull) {
-    cx += x;
-    cy += y;
-  }
-  cx /= n;
-  cy /= n;
-  return hull.map(([x, y]) => {
-    const dx = x - cx;
-    const dy = y - cy;
-    const m = Math.hypot(dx, dy) || 1;
-    return [x + (dx / m) * pad, y + (dy / m) * pad] as Point;
-  });
-}
-
-/** Trace a smooth closed curve through `pts` onto the canvas using a
- *  Catmull-Rom spline converted to cubic béziers — this is what gives the
- *  rounded blob look. Caller is responsible for beginPath/fill/stroke. */
-export function traceSmoothClosedPath(ctx: CanvasRenderingContext2D, pts: Point[]): void {
-  const n = pts.length;
-  if (n === 0) return;
-  if (n < 3) {
-    ctx.moveTo(pts[0][0], pts[0][1]);
-    for (let i = 1; i < n; i++) ctx.lineTo(pts[i][0], pts[i][1]);
-    ctx.closePath();
-    return;
-  }
-  ctx.moveTo(pts[0][0], pts[0][1]);
-  for (let i = 0; i < n; i++) {
-    const p0 = pts[(i - 1 + n) % n];
-    const p1 = pts[i];
-    const p2 = pts[(i + 1) % n];
-    const p3 = pts[(i + 2) % n];
-    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
-    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
-    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
-    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
-    ctx.bezierCurveTo(c1x, c1y, c2x, c2y, p2[0], p2[1]);
-  }
-  ctx.closePath();
-}
-
-/** Draw a rounded translucent hull behind each group's nodes. Call from
- *  `onRenderFramePre` (under the nodes/links). Cheap: O(nodes) per frame.
- *  Self-contained (save/restore) so it never leaks ctx state into the node
- *  paint that follows. */
-export function drawClusterHulls(
-  ctx: CanvasRenderingContext2D,
-  nodes: GraphNode[],
-  globalScale: number,
-  dark = true,
-): void {
-  const groups = new Map<string, Point[]>();
-  for (const n of nodes) {
-    if (!n.group || n.x == null || n.y == null) continue;
-    const arr = groups.get(n.group);
-    if (arr) arr.push([n.x, n.y]);
-    else groups.set(n.group, [[n.x, n.y]]);
-  }
-  // One (or zero) clusters → nothing to distinguish; a single all-enclosing
-  // blob is just noise, so skip drawing it.
-  if (groups.size < 2) return;
-  ctx.save();
-  for (const [group, pts] of groups) {
-    const paint = groupPaint(group, dark);
-    ctx.beginPath();
-    const hull = pts.length >= 3 ? convexHull(pts) : pts;
-    if (hull.length >= 3) {
-      traceSmoothClosedPath(ctx, padHull(hull, HULL_PAD));
-    } else {
-      traceCircleAround(ctx, pts, HULL_PAD);
-    }
-    ctx.fillStyle = paint.hullFill;
-    ctx.fill();
-    ctx.lineWidth = 1.5 / globalScale;
-    ctx.strokeStyle = paint.hullStroke;
-    ctx.stroke();
-  }
-  ctx.restore();
-}
-
-/** Enclosing circle fallback for 1–2 node (or collinear) groups. */
-function traceCircleAround(ctx: CanvasRenderingContext2D, pts: Point[], pad: number): void {
-  let cx = 0;
-  let cy = 0;
-  for (const [x, y] of pts) {
-    cx += x;
-    cy += y;
-  }
-  cx /= pts.length;
-  cy /= pts.length;
-  let r = 0;
-  for (const [x, y] of pts) r = Math.max(r, Math.hypot(x - cx, y - cy));
-  ctx.arc(cx, cy, r + pad, 0, 2 * Math.PI);
-}
-
-// ── Force ───────────────────────────────────────────────────────────────
-
-export interface ClusterForce {
+export interface SimForce {
   (alpha: number): void;
   initialize: (nodes: GraphNode[]) => void;
 }
 
 /**
- * A d3-force that nudges each node toward its group's live centroid, so
- * same-group nodes clump tighter on top of the default link/charge forces.
- * Ungrouped nodes are left untouched. The pull is scaled by the simulation's
- * decaying `alpha`, so it eases off as the layout settles.
+ * Pulls each node toward its group's live centroid (velocity-based, scaled by
+ * the decaying alpha). Ungrouped nodes are left to the default forces. This is
+ * what makes a group settle into a round clump.
  */
-export function forceCluster(strength = CLUSTER_STRENGTH): ClusterForce {
+export function forceCluster(strength = CLUSTER_STRENGTH): SimForce {
   let nodes: GraphNode[] = [];
   const force = (alpha: number) => {
     const cent = new Map<string, { x: number; y: number; n: number }>();
@@ -271,6 +120,44 @@ export function forceCluster(strength = CLUSTER_STRENGTH): ClusterForce {
       if (!c) continue;
       n.vx = (n.vx ?? 0) + (c.x - n.x) * k;
       n.vy = (n.vy ?? 0) + (c.y - n.y) * k;
+    }
+  };
+  force.initialize = (ns: GraphNode[]) => {
+    nodes = ns;
+  };
+  return force;
+}
+
+/**
+ * Positional anti-overlap: nudges any two nodes closer than 2·radius apart so
+ * clumps stay breathable rather than cramped. O(n²) — fine for the ≤200-node
+ * graphs this viewer renders.
+ */
+export function forceCollide(radius = COLLIDE_RADIUS, strength = 0.8): SimForce {
+  let nodes: GraphNode[] = [];
+  const force = () => {
+    const n = nodes.length;
+    const min = radius * 2;
+    const min2 = min * min;
+    for (let i = 0; i < n; i++) {
+      const a = nodes[i];
+      if (a.x == null || a.y == null) continue;
+      for (let j = i + 1; j < n; j++) {
+        const b = nodes[j];
+        if (b.x == null || b.y == null) continue;
+        let dx = a.x - b.x;
+        let dy = a.y - b.y;
+        const d2 = dx * dx + dy * dy;
+        if (d2 === 0 || d2 >= min2) continue;
+        const d = Math.sqrt(d2);
+        const push = ((min - d) / d) * strength * 0.5;
+        dx *= push;
+        dy *= push;
+        a.x += dx;
+        a.y += dy;
+        b.x -= dx;
+        b.y -= dy;
+      }
     }
   };
   force.initialize = (ns: GraphNode[]) => {


### PR DESCRIPTION
Feedback iteration on the cluster view (#158).

## Changes
- **Remove the hull entirely** — no border, no translucent background. Clusters now read purely from the natural force layout (round clumps) + per-group node tint. Deletes the convex-hull / Catmull-Rom / `drawClusterHulls` path.
- **Group by week** — `GROUP_DEPTH=2` (first two collection segments) instead of top-level. Every `gnu-weekly` doc is under one top-level collection (`weekly-updates`), so top-level grouping collapsed to a single blob; depth-2 groups `weekly-updates/<week>/<topic>` **by week** so a week's docs gather together.
- **Looser within a cluster** — new `forceCollide` (positional anti-overlap sized to the node) so clumps are breathable, not cramped.
- **Closer between clusters** — soften global charge while clustering (`-14` vs the `-30` default); collide handles local spacing instead of long-range charge.
- `groupPaint` → `groupColor` (node ring tint string; hull colors removed), still memoized + theme-aware.

Tunables exported: `GROUP_DEPTH`, `CLUSTER_STRENGTH`, `COLLIDE_RADIUS`, `CHARGE_STRENGTH`.

## Tests
Updated cluster unit tests (group-by-week, collide separation, color) + GraphCanvas wiring (cluster+collide install/remove, aria-pressed). **Full suite 245 passing**; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)