### PR TITLE
fix(backend/graph): strip code spans before link extraction (no ghost edges)

### DIFF
--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -34,6 +34,22 @@ logger = logging.getLogger("akb.graph")
 _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 # Matches akb:// URIs anywhere in text
 _AKB_URI_RE = re.compile(r"akb://[^\s\)>`]+")
+# Code spans — fenced blocks (``` / ~~~) and inline (`…`). Anything inside
+# is example/snippet text, NOT a real link: a session report quoting
+# `akb://project-akb/...`, a regex example `akb://\1/coll/\2/doc/\3`, or a
+# JSON fragment `"incidents/a.md"` must NOT become a graph edge to a
+# (usually non-existent) target. Strip code before scanning for links.
+_FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def strip_code_spans(content: str) -> str:
+    """Remove fenced + inline code spans so example links inside them are not
+    extracted as relations. Replaces each span with a space to preserve
+    surrounding token boundaries."""
+    content = _FENCED_CODE_RE.sub(" ", content)
+    content = _INLINE_CODE_RE.sub(" ", content)
+    return content
 
 
 # ── Link extraction from markdown body ───────────────────────
@@ -42,8 +58,9 @@ def extract_markdown_links(content: str) -> list[str]:
     """Extract internal document references from markdown links.
 
     Returns list of targets (paths, doc IDs, or akb:// URIs).
-    Filters out external URLs (http/https/mailto).
+    Filters out external URLs (http/https/mailto) and code-span contents.
     """
+    content = strip_code_spans(content)
     targets: list[str] = []
     seen: set[str] = set()
 

--- a/backend/tests/test_kg_extract_links_unit.py
+++ b/backend/tests/test_kg_extract_links_unit.py
@@ -1,0 +1,47 @@
+"""Unit tests for kg_service markdown link extraction.
+
+Regression guard: example links inside code spans (fenced blocks + inline
+`code`) must NOT be extracted as relations. Session reports quote URIs like
+`akb://project-akb/...`, regex examples `akb://\\1/coll/\\2/doc/\\3`, and JSON
+fragments `"incidents/a.md"` — none of which are real links, and all of which
+previously became dangling `links_to` edges (ghost graph nodes).
+"""
+from __future__ import annotations
+
+from app.services.kg_service import extract_markdown_links, strip_code_spans
+
+
+def test_inline_code_uri_is_not_extracted():
+    content = "후속 doc: `akb://project-akb/coll/designs/doc/x.md` 참고."
+    assert extract_markdown_links(content) == []
+
+
+def test_fenced_code_block_is_not_extracted():
+    content = (
+        "Example:\n\n```\n"
+        'akb://V/coll/incidents/doc/a.md\n'
+        "[link](path.md)\n"
+        "```\n\nend."
+    )
+    assert extract_markdown_links(content) == []
+
+
+def test_regex_example_in_code_is_not_extracted():
+    content = "Migration 026 replacement is `akb://\\1/coll/\\2/doc/\\3`."
+    assert extract_markdown_links(content) == []
+
+
+def test_real_prose_links_are_still_extracted():
+    content = (
+        "See [the spec](./specs/api.md) and "
+        "akb://v/coll/notes/doc/intro.md for context."
+    )
+    out = extract_markdown_links(content)
+    assert "specs/api.md" in out
+    assert "akb://v/coll/notes/doc/intro.md" in out
+
+
+def test_strip_code_spans_removes_code_keeps_prose():
+    stripped = strip_code_spans("`akb://x/coll/y/doc/z.md` keep-this")
+    assert "akb://" not in stripped
+    assert "keep-this" in stripped


### PR DESCRIPTION
## Problem
`extract_markdown_links` scanned the entire document body, so any `*.md` token or `akb://…` URI **inside a code block or inline `code`** became a `links_to` edge — usually to a non-existent target. Result: dangling "ghost" nodes in the knowledge graph (seen in `gnu-weekly`): regex examples (`akb://\1/coll/\2/doc/\3`), JSON fragments (`"incidents/a.md"`), placeholders (`akb://V/...`, `akb://vault/doc/path.md`), and quoted cross-vault refs (`akb://project-akb/...`) in session reports.

## Fix
Strip fenced (` ``` ` / `~~~`) and inline (`` `…` ``) code spans before extraction. Real prose markdown links and bare URIs are still extracted — only code-span contents are skipped. Pure function, no DB/schema change.

Existing dangling edges are cleaned by re-indexing the affected docs (the indexer deletes implicit edges and re-extracts from the now-stripped body).

## Tests
New unit test: inline / fenced / regex-example code is ignored; real prose links still extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)