### PR TITLE
fix(frontend/graph): don't reheat the simulation on node selection (cluster drift)

### DIFF
--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -53,10 +53,30 @@ export default function GraphPage() {
     setOverlay({ nodes: [], edges: [] });
   }, [view.entry, view.hops, vault]);
 
-  const merged = useMemo(() => {
-    const m = mergeGraph(base || { nodes: [], edges: [] }, overlay);
-    return applyFilters(m, view);
-  }, [base, overlay, view]);
+  // Selection is highlight-only and MUST NOT relayout the graph. `view` is a
+  // fresh object on every selection (URL search change → queryToView), so
+  // depending on `view` here rebuilt `merged` — and thus graphData identity —
+  // on every click, which made force-graph reheat the simulation (alpha=1)
+  // and the clusters drift farther apart each click. Recompute only when the
+  // graph STRUCTURE changes (data, overlay, filters, entry/hops); a stable
+  // structureKey across selection keeps graphData identity stable → no reheat.
+  const structureKey = useMemo(
+    () =>
+      JSON.stringify({
+        entry: view.entry ?? null,
+        hops: view.hops,
+        types: [...view.types].sort(),
+        relations: [...view.relations].sort(),
+      }),
+    [view],
+  );
+  const merged = useMemo(
+    () => applyFilters(mergeGraph(base || { nodes: [], edges: [] }, overlay), view),
+    // `selected` is intentionally excluded; structureKey captures every view
+    // field that affects graph structure/filtering.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [base, overlay, structureKey],
+  );
 
   const canvasRef = useRef<GraphCanvasHandle>(null);
 


### PR DESCRIPTION
## Problem
Clicking a node made clusters drift farther apart **on every click**.

Chain: select → `setView({…, selected})` → URL search change → `view` recomputed as a **new object** → `merged` useMemo (dep `view`) recomputed → `applyFilters` returns a fresh edges array → GraphCanvas `graphData` **identity changes** → force-graph treats it as a data change and **reheats the sim to alpha=1**. With the cluster/collide forces + softened charge (no inter-cluster attraction), each reheat pushed clusters farther out → cumulative drift.

## Fix
Selection is highlight-only and must not relayout. Recompute `merged` **only when the graph structure changes** (data, overlay, type/relation filters, entry/hops) via a stable `structureKey`, excluding `selected`. graphData identity stays stable across clicks → no reheat → no drift. Filter/expand still relayout as before.

## Verification
tsc + eslint clean on `graph.tsx`; graph + pages vitest suites green (94 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)