### PR TITLE
fix(frontend/graph): relations open the doc + visible selected-node highlight

### DIFF
--- a/frontend/src/components/graph/GraphCanvas.tsx
+++ b/frontend/src/components/graph/GraphCanvas.tsx
@@ -200,6 +200,24 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
       ctx.stroke();
       ctx.setLineDash([]);
 
+      // Selected node: a glowing accent halo ring so the selection is
+      // unmistakable (the inner accent border alone read too subtly).
+      if (isSelected) {
+        const pad = 5;
+        ctx.save();
+        ctx.shadowColor = colors.accent;
+        ctx.shadowBlur = 12;
+        ctx.strokeStyle = colors.accent;
+        ctx.lineWidth = 2;
+        ctx.strokeRect(
+          x - NODE_SIZE / 2 - pad,
+          y - NODE_SIZE / 2 - pad,
+          NODE_SIZE + pad * 2,
+          NODE_SIZE + pad * 2,
+        );
+        ctx.restore();
+      }
+
       if (isPinned) {
         ctx.fillStyle = colors.accent;
         ctx.fillRect(x + NODE_SIZE / 2 - 3, y - NODE_SIZE / 2, 3, 3);

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -15,7 +15,8 @@ interface Props {
   docId: string;
   kind: NodeKind;
   uri: string;
-  onSelectUri: (uri: string) => void;
+  /** Navigate to (open) the related resource's own document page. */
+  onOpenUri: (uri: string) => void;
   onFitToNode: (uri: string) => void;
   onClose: () => void;
   onTogglePin?: () => void;
@@ -47,7 +48,7 @@ export function GraphDetailPanel({
   docId,
   kind,
   uri,
-  onSelectUri,
+  onOpenUri,
   onFitToNode,
   onClose,
   onTogglePin,
@@ -187,7 +188,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="out"
                 rows={g.rows}
-                onSelectUri={onSelectUri}
+                onOpenUri={onOpenUri}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -197,7 +198,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="in"
                 rows={g.rows}
-                onSelectUri={onSelectUri}
+                onOpenUri={onOpenUri}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -302,13 +303,13 @@ function RelGroup({
   relation,
   direction,
   rows,
-  onSelectUri,
+  onOpenUri,
   onFitToNode,
 }: {
   relation: RelationKind;
   direction: "in" | "out";
   rows: GroupedRel["rows"];
-  onSelectUri: (uri: string) => void;
+  onOpenUri: (uri: string) => void;
   onFitToNode: (uri: string) => void;
 }) {
   return (
@@ -318,20 +319,26 @@ function RelGroup({
       </p>
       <ul className="flex flex-col gap-px pl-2">
         {rows.map((r) => (
-          <li key={r.other_uri} className="flex items-center gap-1">
+          <li key={r.other_uri} className="group flex items-center gap-1">
+            {/* Primary click opens the related document's own page. */}
             <button
               type="button"
-              onClick={() => onSelectUri(r.other_uri)}
-              title={r.other_name}
-              className="flex-1 text-left text-[11px] hover:text-accent truncate"
+              onClick={() => onOpenUri(r.other_uri)}
+              title={`${r.other_name} — 열기`}
+              className="flex-1 inline-flex items-center gap-1 min-w-0 text-left text-[11px] text-foreground hover:text-accent hover:underline cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {r.other_name}
+              <span className="truncate">{r.other_name}</span>
+              <ExternalLink
+                className="h-2.5 w-2.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-hidden
+              />
             </button>
             <button
               type="button"
               onClick={() => onFitToNode(r.other_uri)}
-              aria-label="Center on node"
-              className="text-foreground-muted hover:text-foreground"
+              aria-label="Locate in graph"
+              title="Locate in graph"
+              className="shrink-0 text-foreground-muted hover:text-foreground cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               ⌖
             </button>

--- a/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
@@ -60,7 +60,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onOpenUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -72,6 +72,34 @@ describe("GraphDetailPanel · document node", () => {
     expect(screen.getByText("alpha")).toBeTruthy();
     expect(screen.getByText(/depends_on/i)).toBeTruthy();
     expect(screen.getByText(/line1/)).toBeTruthy();
+  });
+
+  it("calls onOpenUri with the target when a related document is clicked", async () => {
+    getDocument.mockResolvedValue({ doc_id: "d-1", title: "Hello", content: "" });
+    getRelations.mockResolvedValue({
+      doc_id: "d-1",
+      uri: "akb://akb/doc/x",
+      relations: [
+        { direction: "outgoing", relation: "depends_on", uri: "akb://akb/doc/y", name: "Y", resource_type: "document" },
+      ],
+    });
+    const onOpenUri = vi.fn();
+    const u = userEvent.setup();
+    render(
+      wrap(
+        <GraphDetailPanel
+          vault="akb"
+          docId="d-1"
+          kind="document"
+          uri="akb://akb/doc/x"
+          onOpenUri={onOpenUri}
+          onFitToNode={() => {}}
+          onClose={() => {}}
+        />,
+      ),
+    );
+    await u.click(await screen.findByRole("button", { name: "Y" }));
+    expect(onOpenUri).toHaveBeenCalledWith("akb://akb/doc/y");
   });
 
   it("defers META fetches until the section expands", async () => {
@@ -91,7 +119,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="u"
-          onSelectUri={() => {}}
+          onOpenUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -116,7 +144,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onOpenUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -142,7 +170,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onOpenUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -170,7 +198,7 @@ describe("GraphDetailPanel · table node", () => {
           docId="t-1"
           kind="table"
           uri="u"
-          onSelectUri={() => {}}
+          onOpenUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/graph/use-graph-data";
 import { viewToQuery, queryToView } from "@/components/graph/graph-state";
 import { kindToSegment, type GraphEdge, type GraphNode, type GraphView } from "@/components/graph/graph-types";
+import { parseUri } from "@/lib/uri";
 
 const DOUBLECLICK_MS = 250;
 
@@ -194,7 +195,7 @@ export default function GraphPage() {
             ref={canvasRef}
             nodes={merged.nodes}
             edges={merged.edges}
-            selected={view.selected}
+            selected={selectedNode?.uri}
             pinned={pinned}
             hidden={hidden}
             degraded={degraded}
@@ -210,11 +211,15 @@ export default function GraphPage() {
           docId={selectedDocId}
           kind={selectedNode.kind}
           uri={selectedNode.uri}
-          onSelectUri={(uri) => {
-            const sel = docIdFromUri(uri) ?? uri;
-            setView({ ...view, selected: sel });
+          onOpenUri={(openUri) => {
+            // Clicking a related resource navigates to its own document page
+            // (using the target URI's OWN vault, which may differ).
+            const p = parseUri(openUri);
+            const id = docIdFromUri(openUri);
+            if (!p || !id || (p.kind !== "doc" && p.kind !== "table" && p.kind !== "file")) return;
+            navigate(`/vault/${p.vault}/${p.kind}/${encodeURIComponent(id)}`);
           }}
-          onFitToNode={(uri) => canvasRef.current?.centerOnNode(uri)}
+          onFitToNode={(fitUri) => canvasRef.current?.centerOnNode(fitUri)}
           onClose={() => setView({ ...view, selected: undefined })}
           onTogglePin={() => {
             setPinned((prev) => {


### PR DESCRIPTION
Two graph-viewer UX gaps:

## 1. Selected node had no visual highlight
Root cause: `graph.tsx` passed `selected={view.selected}` (the doc **id**, e.g. `coll/foo.md`) but `paintNode` compares `n.uri === selected` (a full `akb://…` URI) — never matched, so `isSelected` was always false → nothing ever highlighted. Now pass the resolved node's URI (`selectedNode?.uri`) and draw a **glowing accent halo ring** around the selected node.

## 2. Relations now open the document
Clicking a related doc in the RELATIONS list only "selected" it (which silently did nothing / closed the panel for out-of-graph nodes). Now the name **navigates to that document's own page** (`onOpenUri` → `/vault/<its vault>/<kind>/<id>`, using the target URI's own vault). Open affordance added (ExternalLink on hover, cursor-pointer, focus ring); the ⌖ button is relabeled "Locate in graph".

## Tests
Relation click → `onOpenUri(target)`; panel tests updated for the renamed prop. **Full suite 246 passing**; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)