### PR TITLE
fix(frontend/graph): relation click selects node in-graph + highlight its edges

### DIFF
--- a/frontend/src/components/graph/GraphCanvas.tsx
+++ b/frontend/src/components/graph/GraphCanvas.tsx
@@ -251,16 +251,28 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
       if (!src || !tgt) return;
       const dash = RELATION_DASH[l.relation];
       const isAccent = l.relation === "implements" || l.relation === "derived_from";
+      // Edges touching the selected node light up (accent + thicker + glow);
+      // the rest dim so the selected node's connections stand out.
+      const incident = selected != null && (src.uri === selected || tgt.uri === selected);
+      ctx.save();
       ctx.beginPath();
       ctx.moveTo(src.x || 0, src.y || 0);
       ctx.lineTo(tgt.x || 0, tgt.y || 0);
-      ctx.strokeStyle = isAccent ? colors.accent : colors.foregroundMuted;
-      ctx.lineWidth = l.relation === "attached_to" ? 1 : 1.5;
+      if (incident) {
+        ctx.strokeStyle = colors.accent;
+        ctx.lineWidth = 2.5;
+        ctx.shadowColor = colors.accent;
+        ctx.shadowBlur = 6;
+      } else {
+        ctx.strokeStyle = isAccent ? colors.accent : colors.foregroundMuted;
+        ctx.lineWidth = l.relation === "attached_to" ? 1 : 1.5;
+        if (selected != null) ctx.globalAlpha = 0.3;
+      }
       ctx.setLineDash(dash);
       ctx.stroke();
-      ctx.setLineDash([]);
+      ctx.restore();
     },
-    [colors],
+    [colors, selected],
   );
 
   const handleNodeClick = useCallback(

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/graph/GraphDetailPanel.tsx
 import { useState } from "react";
-import { ChevronDown, ChevronRight, ExternalLink, Pin, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Crosshair, ExternalLink, Pin, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,8 +15,8 @@ interface Props {
   docId: string;
   kind: NodeKind;
   uri: string;
-  /** Navigate to (open) the related resource's own document page. */
-  onOpenUri: (uri: string) => void;
+  /** Select (highlight) the related resource's node in the graph. */
+  onSelectUri: (uri: string) => void;
   onFitToNode: (uri: string) => void;
   onClose: () => void;
   onTogglePin?: () => void;
@@ -48,7 +48,7 @@ export function GraphDetailPanel({
   docId,
   kind,
   uri,
-  onOpenUri,
+  onSelectUri,
   onFitToNode,
   onClose,
   onTogglePin,
@@ -188,7 +188,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="out"
                 rows={g.rows}
-                onOpenUri={onOpenUri}
+                onSelectUri={onSelectUri}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -198,7 +198,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="in"
                 rows={g.rows}
-                onOpenUri={onOpenUri}
+                onSelectUri={onSelectUri}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -303,13 +303,13 @@ function RelGroup({
   relation,
   direction,
   rows,
-  onOpenUri,
+  onSelectUri,
   onFitToNode,
 }: {
   relation: RelationKind;
   direction: "in" | "out";
   rows: GroupedRel["rows"];
-  onOpenUri: (uri: string) => void;
+  onSelectUri: (uri: string) => void;
   onFitToNode: (uri: string) => void;
 }) {
   return (
@@ -320,27 +320,22 @@ function RelGroup({
       <ul className="flex flex-col gap-px pl-2">
         {rows.map((r) => (
           <li key={r.other_uri} className="group flex items-center gap-1">
-            {/* Primary click opens the related document's own page. */}
+            {/* Click selects + centers the related node in the graph (it
+                highlights there) rather than navigating away. */}
             <button
               type="button"
-              onClick={() => onOpenUri(r.other_uri)}
-              title={`${r.other_name} — 열기`}
-              className="flex-1 inline-flex items-center gap-1 min-w-0 text-left text-[11px] text-foreground hover:text-accent hover:underline cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                onSelectUri(r.other_uri);
+                onFitToNode(r.other_uri);
+              }}
+              title={`${r.other_name} — 그래프에서 선택`}
+              className="flex-1 inline-flex items-center gap-1 min-w-0 text-left text-[11px] text-foreground hover:text-accent cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <span className="truncate">{r.other_name}</span>
-              <ExternalLink
+              <Crosshair
                 className="h-2.5 w-2.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
                 aria-hidden
               />
-            </button>
-            <button
-              type="button"
-              onClick={() => onFitToNode(r.other_uri)}
-              aria-label="Locate in graph"
-              title="Locate in graph"
-              className="shrink-0 text-foreground-muted hover:text-foreground cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              ⌖
             </button>
           </li>
         ))}

--- a/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
@@ -60,7 +60,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="akb://akb/doc/x"
-          onOpenUri={() => {}}
+          onSelectUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -74,7 +74,7 @@ describe("GraphDetailPanel · document node", () => {
     expect(screen.getByText(/line1/)).toBeTruthy();
   });
 
-  it("calls onOpenUri with the target when a related document is clicked", async () => {
+  it("calls onSelectUri with the target when a related document is clicked", async () => {
     getDocument.mockResolvedValue({ doc_id: "d-1", title: "Hello", content: "" });
     getRelations.mockResolvedValue({
       doc_id: "d-1",
@@ -83,7 +83,7 @@ describe("GraphDetailPanel · document node", () => {
         { direction: "outgoing", relation: "depends_on", uri: "akb://akb/doc/y", name: "Y", resource_type: "document" },
       ],
     });
-    const onOpenUri = vi.fn();
+    const onSelectUri = vi.fn();
     const u = userEvent.setup();
     render(
       wrap(
@@ -92,14 +92,14 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="akb://akb/doc/x"
-          onOpenUri={onOpenUri}
+          onSelectUri={onSelectUri}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
       ),
     );
     await u.click(await screen.findByRole("button", { name: "Y" }));
-    expect(onOpenUri).toHaveBeenCalledWith("akb://akb/doc/y");
+    expect(onSelectUri).toHaveBeenCalledWith("akb://akb/doc/y");
   });
 
   it("defers META fetches until the section expands", async () => {
@@ -119,7 +119,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="u"
-          onOpenUri={() => {}}
+          onSelectUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -144,7 +144,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onOpenUri={() => {}}
+          onSelectUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -170,7 +170,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onOpenUri={() => {}}
+          onSelectUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -198,7 +198,7 @@ describe("GraphDetailPanel · table node", () => {
           docId="t-1"
           kind="table"
           uri="u"
-          onOpenUri={() => {}}
+          onSelectUri={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/graph/use-graph-data";
 import { viewToQuery, queryToView } from "@/components/graph/graph-state";
 import { kindToSegment, type GraphEdge, type GraphNode, type GraphView } from "@/components/graph/graph-types";
-import { parseUri } from "@/lib/uri";
 
 const DOUBLECLICK_MS = 250;
 
@@ -211,13 +210,11 @@ export default function GraphPage() {
           docId={selectedDocId}
           kind={selectedNode.kind}
           uri={selectedNode.uri}
-          onOpenUri={(openUri) => {
-            // Clicking a related resource navigates to its own document page
-            // (using the target URI's OWN vault, which may differ).
-            const p = parseUri(openUri);
-            const id = docIdFromUri(openUri);
-            if (!p || !id || (p.kind !== "doc" && p.kind !== "table" && p.kind !== "file")) return;
-            navigate(`/vault/${p.vault}/${p.kind}/${encodeURIComponent(id)}`);
+          onSelectUri={(selUri) => {
+            // Select (highlight) the related node in the graph — stay here,
+            // don't navigate away.
+            const sel = docIdFromUri(selUri) ?? selUri;
+            setView({ ...view, selected: sel });
           }}
           onFitToNode={(fitUri) => canvasRef.current?.centerOnNode(fitUri)}
           onClose={() => setView({ ...view, selected: undefined })}


### PR DESCRIPTION
1. **Relation click selects the node in the graph** (not navigate). #164 wrongly made the RELATIONS list navigate to the doc page; the intent was to *click that node in the graph*. Reverted to `onSelectUri` + `centerOnNode`, so clicking a related doc highlights its node in place (glow halo) and switches the panel to it. The header **Open** button is still how you leave to the doc page. The per-row ⌖ is folded into the name click; a Crosshair hint shows on hover.

2. **Selected node's edges light up.** In `paintLink`, links incident to the selected node render accent + thicker + glow; other links dim (`globalAlpha 0.3`) while something is selected — so the node's connections are obvious at a glance.

Tests: relation click → `onSelectUri(target)`; **246 passing**; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)