### PR TITLE
feat(frontend/graph): auto-add a related node when it isn't rendered

### DIFF
--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { getDocument, getRelations, getProvenance, drillDown } from "@/lib/api";
-import { ALL_NODE_KINDS, ALL_RELATIONS, type NodeKind, type RelationKind, kindToSegment } from "./graph-types";
+import { ALL_NODE_KINDS, ALL_RELATIONS, type NodeKind, type RelationKind, type RelatedRef, kindToSegment } from "./graph-types";
 import { Section } from "./Section";
 
 interface Props {
@@ -15,8 +15,9 @@ interface Props {
   docId: string;
   kind: NodeKind;
   uri: string;
-  /** Select (highlight) the related resource's node in the graph. */
-  onSelectUri: (uri: string) => void;
+  /** Select (highlight) the related resource's node in the graph — adding it
+   *  to the graph first if it isn't currently rendered. */
+  onSelectRelated: (rel: RelatedRef) => void;
   onFitToNode: (uri: string) => void;
   onClose: () => void;
   onTogglePin?: () => void;
@@ -48,7 +49,7 @@ export function GraphDetailPanel({
   docId,
   kind,
   uri,
-  onSelectUri,
+  onSelectRelated,
   onFitToNode,
   onClose,
   onTogglePin,
@@ -188,7 +189,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="out"
                 rows={g.rows}
-                onSelectUri={onSelectUri}
+                onSelectRelated={onSelectRelated}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -198,7 +199,7 @@ export function GraphDetailPanel({
                 relation={g.relation}
                 direction="in"
                 rows={g.rows}
-                onSelectUri={onSelectUri}
+                onSelectRelated={onSelectRelated}
                 onFitToNode={onFitToNode}
               />
             ))}
@@ -303,13 +304,13 @@ function RelGroup({
   relation,
   direction,
   rows,
-  onSelectUri,
+  onSelectRelated,
   onFitToNode,
 }: {
   relation: RelationKind;
   direction: "in" | "out";
   rows: GroupedRel["rows"];
-  onSelectUri: (uri: string) => void;
+  onSelectRelated: (rel: RelatedRef) => void;
   onFitToNode: (uri: string) => void;
 }) {
   return (
@@ -320,12 +321,19 @@ function RelGroup({
       <ul className="flex flex-col gap-px pl-2">
         {rows.map((r) => (
           <li key={r.other_uri} className="group flex items-center gap-1">
-            {/* Click selects + centers the related node in the graph (it
-                highlights there) rather than navigating away. */}
+            {/* Click selects + centers the related node in the graph (added
+                to the graph first if it isn't currently rendered) rather than
+                navigating away. */}
             <button
               type="button"
               onClick={() => {
-                onSelectUri(r.other_uri);
+                onSelectRelated({
+                  uri: r.other_uri,
+                  name: r.other_name,
+                  kind: r.other_type,
+                  relation,
+                  direction: direction === "out" ? "outgoing" : "incoming",
+                });
                 onFitToNode(r.other_uri);
               }}
               title={`${r.other_name} — 그래프에서 선택`}

--- a/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphDetailPanel.test.tsx
@@ -60,7 +60,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onSelectRelated={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -74,7 +74,7 @@ describe("GraphDetailPanel · document node", () => {
     expect(screen.getByText(/line1/)).toBeTruthy();
   });
 
-  it("calls onSelectUri with the target when a related document is clicked", async () => {
+  it("calls onSelectRelated with the target when a related document is clicked", async () => {
     getDocument.mockResolvedValue({ doc_id: "d-1", title: "Hello", content: "" });
     getRelations.mockResolvedValue({
       doc_id: "d-1",
@@ -83,7 +83,7 @@ describe("GraphDetailPanel · document node", () => {
         { direction: "outgoing", relation: "depends_on", uri: "akb://akb/doc/y", name: "Y", resource_type: "document" },
       ],
     });
-    const onSelectUri = vi.fn();
+    const onSelectRelated = vi.fn();
     const u = userEvent.setup();
     render(
       wrap(
@@ -92,14 +92,22 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={onSelectUri}
+          onSelectRelated={onSelectRelated}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
       ),
     );
     await u.click(await screen.findByRole("button", { name: "Y" }));
-    expect(onSelectUri).toHaveBeenCalledWith("akb://akb/doc/y");
+    expect(onSelectRelated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: "akb://akb/doc/y",
+        name: "Y",
+        kind: "document",
+        relation: "depends_on",
+        direction: "outgoing",
+      }),
+    );
   });
 
   it("defers META fetches until the section expands", async () => {
@@ -119,7 +127,7 @@ describe("GraphDetailPanel · document node", () => {
           docId="d-1"
           kind="document"
           uri="u"
-          onSelectUri={() => {}}
+          onSelectRelated={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -144,7 +152,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onSelectRelated={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -170,7 +178,7 @@ describe("GraphDetailPanel · fetch states", () => {
           docId="d-x"
           kind="document"
           uri="akb://akb/doc/x"
-          onSelectUri={() => {}}
+          onSelectRelated={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,
@@ -198,7 +206,7 @@ describe("GraphDetailPanel · table node", () => {
           docId="t-1"
           kind="table"
           uri="u"
-          onSelectUri={() => {}}
+          onSelectRelated={() => {}}
           onFitToNode={() => {}}
           onClose={() => {}}
         />,

--- a/frontend/src/components/graph/graph-types.ts
+++ b/frontend/src/components/graph/graph-types.ts
@@ -33,6 +33,17 @@ export interface GraphEdge {
   relation: RelationKind;
 }
 
+/** A related-resource reference from the detail panel's RELATIONS list —
+ *  carries enough (name, kind, relation, direction) to materialize the node
+ *  AND its edge in the graph when the relation isn't currently rendered. */
+export interface RelatedRef {
+  uri: string;
+  name: string;
+  kind: NodeKind;
+  relation: RelationKind;
+  direction: "incoming" | "outgoing";
+}
+
 export interface GraphView {
   entry?: string;
   // BFS traversal radius in edge hops from the entry node. The

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -16,7 +16,8 @@ import {
   docIdFromUri,
 } from "@/components/graph/use-graph-data";
 import { viewToQuery, queryToView } from "@/components/graph/graph-state";
-import { kindToSegment, type GraphEdge, type GraphNode, type GraphView } from "@/components/graph/graph-types";
+import { kindToSegment, type GraphEdge, type GraphNode, type GraphView, type RelatedRef } from "@/components/graph/graph-types";
+import { groupOf } from "@/components/graph/cluster";
 
 const DOUBLECLICK_MS = 250;
 
@@ -130,6 +131,34 @@ export default function GraphPage() {
   }, [merged, view.selected]);
   const detailOpen = !!selectedNode && !!selectedDocId;
 
+  // Clicking a relation in the detail panel selects that node in the graph.
+  // If it isn't currently rendered (filtered out, or outside the loaded
+  // neighbourhood), add it — plus the edge connecting it to the current node —
+  // to the session overlay first, so it appears and can be highlighted.
+  function handleSelectRelated(rel: RelatedRef) {
+    const present = merged.nodes.some((n) => n.uri === rel.uri);
+    if (!present) {
+      const node: GraphNode = { uri: rel.uri, name: rel.name, kind: rel.kind, group: groupOf(rel.uri) };
+      const sourceUri = selectedNode?.uri;
+      const edge: GraphEdge | null = sourceUri
+        ? rel.direction === "outgoing"
+          ? { source: sourceUri, target: rel.uri, relation: rel.relation }
+          : { source: rel.uri, target: sourceUri, relation: rel.relation }
+        : null;
+      setOverlay((prev) => ({
+        nodes: prev.nodes.some((n) => n.uri === rel.uri) ? prev.nodes : [...prev.nodes, node],
+        edges:
+          edge &&
+          !prev.edges.some(
+            (e) => e.source === edge.source && e.target === edge.target && e.relation === edge.relation,
+          )
+            ? [...prev.edges, edge]
+            : prev.edges,
+      }));
+    }
+    setView({ ...view, selected: docIdFromUri(rel.uri) ?? rel.uri });
+  }
+
   const gridCols = `${sidebarOpen ? "240px" : "40px"} 1fr ${detailOpen ? "320px" : "0px"}`;
 
   return (
@@ -210,12 +239,7 @@ export default function GraphPage() {
           docId={selectedDocId}
           kind={selectedNode.kind}
           uri={selectedNode.uri}
-          onSelectUri={(selUri) => {
-            // Select (highlight) the related node in the graph — stay here,
-            // don't navigate away.
-            const sel = docIdFromUri(selUri) ?? selUri;
-            setView({ ...view, selected: sel });
-          }}
+          onSelectRelated={handleSelectRelated}
           onFitToNode={(fitUri) => canvasRef.current?.centerOnNode(fitUri)}
           onClose={() => setView({ ...view, selected: undefined })}
           onTogglePin={() => {


### PR DESCRIPTION
Clicking a relation selects that node in the graph — but if it wasn't rendered (filtered / outside the loaded neighbourhood) there was nothing to select and the panel closed. Now the relation click carries a `RelatedRef` (uri, name, kind, relation, direction) and `graph.tsx` **materialises the missing node + the edge to the current node into the session overlay** before selecting it. The node appears, the layout re-settles, it highlights (glow), and its edge lights up. Existing nodes untouched (dedup by uri).

Tests: relation click → `onSelectRelated(RelatedRef)`; **246 passing**; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)