### PR TITLE
feat(search): restrict akb_search to a set of resource URIs (source_uris) — closes #159

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 356,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1082,
+        "line_number": 1087,
         "is_secret": false
       }
     ],
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T17:00:36Z"
+  "generated_at": "2026-06-08T07:46:02Z"
 }

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -22,12 +22,17 @@ async def search_documents(
     tags: list[str] | None = Query(None),
     limit: int = Query(10, ge=1, le=100),
     include_archived: bool = Query(False, description="Include archived documents (hidden from search by default)."),
+    source_uris: list[str] | None = Query(
+        None,
+        description="Restrict search to this set of resource akb:// URIs (intersected with the other filters + ACL).",
+    ),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     return await search_service.search(
         query=q, vault=vault, collection=collection,
         doc_type=type, tags=tags, limit=limit,
         user_id=user.user_id, include_archived=include_archived,
+        source_uris=source_uris,
     )
 
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -23,6 +23,7 @@ from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.vector_store import VectorHit, get_vector_store
 from app.services.rerank_service import RerankError, rerank
+from app.services.uri_service import parse_uri
 
 logger = logging.getLogger("akb.search")
 
@@ -115,8 +116,15 @@ class SearchService:
         limit: int = 10,
         user_id: str | None = None,
         include_archived: bool = False,
+        source_uris: list[str] | None = None,
     ) -> SearchResponse:
-        """Hybrid search across documents. See module docstring for flow."""
+        """Hybrid search across documents. See module docstring for flow.
+
+        ``source_uris`` (optional) restricts the search to a specific set of
+        resources — each is resolved to its (ACL-checked) source id and
+        intersected with the other filters, so retrieval runs only inside that
+        set. An empty/omitted list means no restriction (default behaviour).
+        """
         # ACL guard mirroring `grep` below: when neither vault nor
         # user_id scopes the query, the prefilter block ends up
         # skipped (has_filters=False) and `_run_vector_search` runs
@@ -142,7 +150,7 @@ class SearchService:
 
         # Always pre-filter when user_id is provided so we never leak
         # documents from vaults the user can't read.
-        has_filters = any([vault, collection, doc_type, tags, user_id])
+        has_filters = any([vault, collection, doc_type, tags, user_id, source_uris])
         candidate_source_ids: list[str] | None = None
 
         if has_filters:
@@ -157,6 +165,18 @@ class SearchService:
                     is_admin = bool(await conn.fetchval(
                         "SELECT is_admin FROM users WHERE id = $1", user_uuid,
                     ))
+
+                # Resolve an explicit `source_uris` scope to per-kind source
+                # ids. ACL is NOT enforced here — the candidate queries below
+                # carry the owner/grant/public predicate, so any resolved id
+                # the user can't read is dropped from the final candidate set.
+                src_doc_ids: list[str] = []
+                src_table_ids: list[str] = []
+                src_file_ids: list[str] = []
+                if source_uris:
+                    src_doc_ids, src_table_ids, src_file_ids = (
+                        await self._resolve_source_uris(conn, source_uris)
+                    )
 
                 def _vault_acl(param_idx: int) -> tuple[str | None, list]:
                     """Returns (sql_fragment, params) for the
@@ -191,6 +211,10 @@ class SearchService:
                     conditions.append(acl_sql)
                     params.extend(acl_params); idx += 1
 
+                if source_uris:
+                    conditions.append(f"d.id = ANY(${idx}::uuid[])")
+                    params.append(src_doc_ids); idx += 1
+
                 # Default-hide archived documents from discovery; opt back in
                 # with include_archived=true. (Status literal — no bind param;
                 # only the document candidate query carries doc status.)
@@ -221,6 +245,9 @@ class SearchService:
                     if acl_sql:
                         t_conds.append(acl_sql)
                         t_params.extend(acl_params)
+                    if source_uris:
+                        t_conds.append(f"t.id = ANY(${len(t_params) + 1}::uuid[])")
+                        t_params.append(src_table_ids)
                     q = "SELECT t.id FROM vault_tables t JOIN vaults v ON t.vault_id = v.id"
                     if t_conds:
                         q += " WHERE " + " AND ".join(t_conds)
@@ -244,6 +271,9 @@ class SearchService:
                     if acl_sql:
                         f_conds.append(acl_sql)
                         f_params.extend(acl_params)
+                    if source_uris:
+                        f_conds.append(f"f.id = ANY(${len(f_params) + 1}::uuid[])")
+                        f_params.append(src_file_ids)
                     q = (
                         "SELECT f.id FROM vault_files f "
                         "JOIN vaults v ON f.vault_id = v.id "
@@ -324,6 +354,72 @@ class SearchService:
             hint=hint,
             results=results,
         )
+
+    async def _resolve_source_uris(
+        self, conn, source_uris: list[str]
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Resolve a list of ``akb://`` resource URIs into per-kind source ids
+        ``(doc_ids, table_ids, file_ids)`` for the candidate prefilter.
+
+        - doc   → ``documents.id`` matched by path OR id (canonical doc URIs
+          carry the full vault-relative path; ``find_by_ref`` semantics)
+        - table → ``vault_tables.id`` matched by ``name`` (UNIQUE per vault)
+        - file  → the URI identifier IS the file uuid; validated, used as-is
+
+        Unparseable / non-resource (coll/vault) / unknown URIs are skipped.
+        ACL is applied later by the candidate queries, so this resolution is
+        purely structural.
+        """
+        doc_refs_by_vault: dict[str, list[str]] = {}
+        table_names_by_vault: dict[str, list[str]] = {}
+        file_ids: list[str] = []
+        for u in source_uris:
+            p = parse_uri(u)
+            if p is None or p.identifier is None:
+                continue
+            if p.kind == "doc":
+                doc_refs_by_vault.setdefault(p.vault, []).append(p.identifier)
+            elif p.kind == "table":
+                table_names_by_vault.setdefault(p.vault, []).append(p.identifier)
+            elif p.kind == "file":
+                try:
+                    uuid.UUID(p.identifier)
+                except ValueError:
+                    continue
+                file_ids.append(p.identifier)
+
+        vault_names = set(doc_refs_by_vault) | set(table_names_by_vault)
+        vault_id_by_name: dict[str, uuid.UUID] = {}
+        if vault_names:
+            rows = await conn.fetch(
+                "SELECT id, name FROM vaults WHERE name = ANY($1)", list(vault_names)
+            )
+            vault_id_by_name = {r["name"]: r["id"] for r in rows}
+
+        doc_ids: list[str] = []
+        for vname, refs in doc_refs_by_vault.items():
+            vid = vault_id_by_name.get(vname)
+            if vid is None:
+                continue
+            rows = await conn.fetch(
+                "SELECT id FROM documents "
+                "WHERE vault_id = $1 AND (path = ANY($2) OR id::text = ANY($2))",
+                vid, refs,
+            )
+            doc_ids.extend(str(r["id"]) for r in rows)
+
+        table_ids: list[str] = []
+        for vname, names in table_names_by_vault.items():
+            vid = vault_id_by_name.get(vname)
+            if vid is None:
+                continue
+            rows = await conn.fetch(
+                "SELECT id FROM vault_tables WHERE vault_id = $1 AND name = ANY($2)",
+                vid, names,
+            )
+            table_ids.extend(str(r["id"]) for r in rows)
+
+        return doc_ids, table_ids, file_ids
 
     async def _hydrate_hits(self, hits: list) -> list[SearchResult]:
         from app.services.index_service import SOURCE_TYPES

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -182,6 +182,11 @@ Combines **vector similarity** (semantic meaning) with **keyword matching**.
 akb_search(query="how does authentication work")
 akb_search(query="gRPC vs REST", vault="engineering", type="decision")
 akb_search(query="invoice", tags=["finance"])
+# restrict to a known set of resources (hybrid retrieval runs only inside them):
+akb_search(query="auth flow", source_uris=[
+    "akb://engineering/coll/specs/doc/auth.md",
+    "akb://engineering/coll/decisions/doc/oauth.md",
+])
 ```
 
 **Results include:**

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -509,6 +509,7 @@ async def _handle_search(args: dict, uid: str, user: _MCPUser) -> dict:
         limit=args.get("limit", 10),
         user_id=uid,
         include_archived=args.get("include_archived", False),
+        source_uris=args.get("source_uris"),
     )
     return result.model_dump()
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -349,6 +349,17 @@ TOOLS = [
                     "default": False,
                     "description": "Include archived documents. Default false — `status: archived` docs are hidden from search.",
                 },
+                "source_uris": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Restrict the search to a specific set of already-known resources "
+                        "by their canonical akb:// URIs (e.g. from a previous akb_search / "
+                        "akb_browse). Hybrid retrieval (dense + BM25 + ranking) runs only "
+                        "inside this set, intersected with the other filters and your access. "
+                        "Omit for the normal whole-vault search."
+                    ),
+                },
             },
             "required": ["query"],
         },

--- a/backend/tests/test_search_source_uris_unit.py
+++ b/backend/tests/test_search_source_uris_unit.py
@@ -1,0 +1,81 @@
+"""Unit tests for SearchService._resolve_source_uris (issue #159).
+
+Mocks the DB connection so we can assert the URI → per-kind source-id
+resolution without a live database:
+  - doc   URI → matched by full vault-relative path
+  - table URI → matched by table name
+  - file  URI → identifier IS the uuid (validated, used as-is)
+  - coll/vault/garbage URIs are skipped
+ACL is enforced by the candidate queries downstream, not here.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.services.search_service import SearchService
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeConn:
+    """Minimal asyncpg-conn stand-in: routes fetch() by SQL substring."""
+
+    def __init__(self, vaults: dict, docs: dict, tables: dict):
+        self._vaults = vaults  # name -> uuid
+        self._docs = docs      # (vault_id, ref) -> uuid
+        self._tables = tables  # (vault_id, name) -> uuid
+
+    async def fetch(self, sql: str, *params):
+        if "FROM vaults" in sql:
+            (names,) = params
+            return [{"id": self._vaults[n], "name": n} for n in names if n in self._vaults]
+        if "FROM documents" in sql:
+            vid, refs = params
+            return [{"id": self._docs[(vid, r)]} for r in refs if (vid, r) in self._docs]
+        if "FROM vault_tables" in sql:
+            vid, names = params
+            return [{"id": self._tables[(vid, n)]} for n in names if (vid, n) in self._tables]
+        return []
+
+
+async def test_resolve_source_uris_per_kind():
+    v_id = uuid.uuid4()
+    d_id = uuid.uuid4()
+    t_id = uuid.uuid4()
+    f_id = str(uuid.uuid4())
+    conn = _FakeConn(
+        vaults={"eng": v_id},
+        docs={(v_id, "specs/auth.md"): d_id},
+        tables={(v_id, "metrics"): t_id},
+    )
+    doc_ids, table_ids, file_ids = await SearchService()._resolve_source_uris(
+        conn,
+        [
+            "akb://eng/coll/specs/doc/auth.md",    # doc  → path "specs/auth.md"
+            "akb://eng/coll/data/table/metrics",   # table → "metrics"
+            f"akb://eng/file/{f_id}",              # file → uuid
+            "akb://eng/coll/specs",                # coll  → skipped
+            "akb://eng",                           # vault → skipped
+            "not-a-uri",                           # garbage → skipped
+        ],
+    )
+    assert doc_ids == [str(d_id)]
+    assert table_ids == [str(t_id)]
+    assert file_ids == [f_id]
+
+
+async def test_resolve_skips_unknown_vault_and_bad_file_uuid():
+    v_id = uuid.uuid4()
+    conn = _FakeConn(vaults={"eng": v_id}, docs={}, tables={})
+    doc_ids, table_ids, file_ids = await SearchService()._resolve_source_uris(
+        conn,
+        [
+            "akb://ghost/coll/x/doc/y.md",   # vault not found → no doc id
+            "akb://eng/file/not-a-uuid",     # invalid uuid → skipped
+        ],
+    )
+    assert doc_ids == []
+    assert table_ids == []
+    assert file_ids == []


### PR DESCRIPTION
Closes #159.

## What
`akb_search` could only scope by `vault`/`collection`/`type`/`tags`. Adds an optional **`source_uris`** filter to run the full hybrid retrieval *inside a known set of resources* (e.g. URIs from a prior `akb_search`/`akb_browse`). Omitted/empty → existing behaviour.

## How
The vector store already restricts hybrid search to a candidate source-id set (existing `candidate_source_ids` path). This layers on top:
- Resolve each `akb://` URI → source id: doc→`documents.id` (path/id), table→`vault_tables.id` (name), file→the uuid is the URI identifier.
- Add `id = ANY(...)` to the per-kind candidate queries.

**Security**: that condition lives in the *same* query as the owner/grant/public ACL predicate, so a URI the caller can't read is dropped from the candidate set — no scope escape. Resolution itself is purely structural (ACL enforced downstream).

Threaded through service + REST `/search` + MCP tool (schema + handler + help).

## Tests
`test_search_source_uris_unit.py`: `_resolve_source_uris` resolves per-kind ids and skips coll/vault/garbage / unknown-vault / bad-uuid (mocked conn). ruff + mypy clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)