### PR TITLE
fix(0.8.5): table create — clean 422 for over-long PG identifiers (E08)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2555
+        "line_number": 2556
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T09:35:12Z"
+  "generated_at": "2026-06-08T09:52:23Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2540
+        "line_number": 2555
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T07:46:02Z"
+  "generated_at": "2026-06-08T09:35:12Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,21 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.5 — 2026-06-08  *(patch — table create: clean 422 for over-long PG identifiers instead of an opaque 500)*
+
+Creating a table whose PostgreSQL identifier `vt_<vault>__<table>` would exceed PostgreSQL's 63-byte `NAMEDATALEN` limit failed with an **opaque HTTP 500**. The over-long name passed table creation but tripped `role_sync._is_safe_pg_table_name` during the in-transaction `GRANT`, which `raise`d `ValueError("unsafe pg_table_name … refusing grant")` deep in the stack. Found by a concurrency test (E08) whose long ephemeral vault name (`prod-conc-…`, 27 chars) + long table name (32 chars) produced a 64-char identifier — exactly one byte over.
+
+The safety check is **correct and stays** — PG *silently truncates* identifiers past 63 bytes, so granting on a truncated `vt_*` name risks a truncation-collision where a privilege lands on the wrong table. We must refuse, not truncate.
+
+What changed is *where* and *how* it's reported:
+
+- `table_service.create_table` now pre-validates the identifier length immediately after deriving `pg_table_name(...)` and **before any DDL**, raising `ValidationError` (HTTP **422**) with a message that names the offending identifier, its length, the limit, and which name (vault or table) to shorten.
+- The sibling name-shape check (the `_TABLE_NAME_RE` guard) was likewise raising a bare `ValueError` → 500; it now raises `ValidationError` (422) too, so every malformed-name rejection is a clean 4xx.
+- The 63-byte bound is now a single named constant `table_data_repo.PG_IDENT_MAX_LEN`, consumed by both the new pre-check and `role_sync`'s defense-in-depth guard (no more magic `63` in two places).
+
+### Tests
+`tests/test_table_identifier_unit.py` pins the constant and the 63/64-byte boundary math. New `tests/test_table_name_length_unit.py` exercises `create_table` with a fake pool: the exact E08 trigger returns 422 **and** never reaches `create_dynamic_table`, and a malformed name returns 422 (not 500). Both run in CI (no DB).
+
 ## 0.8.4 — 2026-06-07  *(patch — agent-memory: user_id-keyed vaults + Claude Code SessionEnd reasons)*
 
 Two fixes to the agent-session lifecycle surface (`/api/v1/agent-sessions/*`) that together made the `akb-claude-code` lifecycle plugin unusable for a large class of users. Both were confirmed against a live deployment before the fix.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -16,9 +16,10 @@ What changed is *where* and *how* it's reported:
 - `table_service.create_table` now pre-validates the identifier length immediately after deriving `pg_table_name(...)` and **before any DDL**, raising `ValidationError` (HTTP **422**) with a message that names the offending identifier, its length, the limit, and which name (vault or table) to shorten.
 - The sibling name-shape check (the `_TABLE_NAME_RE` guard) was likewise raising a bare `ValueError` → 500; it now raises `ValidationError` (422) too, so every malformed-name rejection is a clean 4xx.
 - The 63-byte bound is now a single named constant `table_data_repo.PG_IDENT_MAX_LEN`, consumed by both the new pre-check and `role_sync`'s defense-in-depth guard (no more magic `63` in two places).
+- **MCP transport:** `ValidationError` is an `AKBError`, not a `ValueError`, so the `akb_create_table` handler's `except ValueError` would have let these rejections fall to the dispatch catch-all as `code="internal"` instead of `invalid_argument`. The handler now catches `ValidationError` (→ `invalid_argument`) and `ConflictError` (→ `conflict`, previously also mis-coded `internal`), keeping the error caller-actionable for agents.
 
 ### Tests
-`tests/test_table_identifier_unit.py` pins the constant and the 63/64-byte boundary math. New `tests/test_table_name_length_unit.py` exercises `create_table` with a fake pool: the exact E08 trigger returns 422 **and** never reaches `create_dynamic_table`, and a malformed name returns 422 (not 500). Both run in CI (no DB).
+`tests/test_table_identifier_unit.py` pins the constant and the 63/64-byte boundary math. `tests/test_table_name_length_unit.py` exercises `create_table` with a fake pool: the exact E08 trigger returns 422 **and** never reaches `create_dynamic_table`, a 63-byte identifier passes the guard (off-by-one fence), and a malformed name returns 422 (not 500) — all CI (no DB). `tests/test_mcp_e2e.sh` §11 asserts the over-long name comes back as `invalid_argument` over the real JSON-RPC transport (post-deploy).
 
 ## 0.8.4 — 2026-06-07  *(patch — agent-memory: user_id-keyed vaults + Claude Code SessionEnd reasons)*
 

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -50,6 +50,10 @@ def _sanitize_pg_part(s: str) -> str:
 # different table — so we refuse, rather than truncate, names that
 # don't fit. `role_sync._is_safe_pg_table_name` enforces the same bound
 # as defense-in-depth; this constant is the single source for both.
+# Note the bound is in *bytes*: `_sanitize_pg_part` maps every non-ASCII
+# character to `_`, so the identifier is pure ASCII and a `len()`
+# char-count equals PG's byte count — the equivalence breaks if a future
+# change ever lets multibyte characters through.
 PG_IDENT_MAX_LEN = 63
 
 

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -45,6 +45,14 @@ def _sanitize_pg_part(s: str) -> str:
     return re.sub(r"[^a-z0-9]", "_", s.lower().replace("-", "_"))
 
 
+# PostgreSQL truncates identifiers past NAMEDATALEN-1 (63 bytes by
+# default) *silently*. A truncated `vt_*` name could collide with a
+# different table — so we refuse, rather than truncate, names that
+# don't fit. `role_sync._is_safe_pg_table_name` enforces the same bound
+# as defense-in-depth; this constant is the single source for both.
+PG_IDENT_MAX_LEN = 63
+
+
 def pg_table_name(vault_name: str, table_name: str) -> str:
     """Return the PG table name for a vault-scoped table:
     `vt_{sanitised_vault}__{sanitised_table}`."""

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -78,6 +78,8 @@ from typing import Optional
 
 import asyncpg
 
+from app.repositories.table_data_repo import PG_IDENT_MAX_LEN
+
 logger = logging.getLogger("akb.role_sync")
 
 
@@ -122,8 +124,12 @@ _VT_TABLE_RE = re.compile(r"^vt_[a-z0-9_]+__[a-z0-9_]+$")
 
 def _is_safe_pg_table_name(name: str) -> bool:
     """Guard before interpolating a `vt_*` name into raw SQL. Upstream
-    `pg_table_name` already sanitizes; this is defense-in-depth."""
-    return bool(_VT_TABLE_RE.match(name)) and len(name) <= 63
+    `pg_table_name` already sanitizes; this is defense-in-depth.
+
+    Over-long names are refused here too, but `table_service.create_table`
+    pre-validates the length and returns a clean 422 — so a well-formed
+    request never reaches this guard with an over-long name."""
+    return bool(_VT_TABLE_RE.match(name)) and len(name) <= PG_IDENT_MAX_LEN
 
 
 # ── Reconcile report ──────────────────────────────────────────

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 import asyncpg
 
 from app.db.postgres import get_pool
-from app.exceptions import ConflictError, NotFoundError
+from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.repositories import table_data_repo, table_registry_repo
 from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
@@ -141,7 +141,7 @@ async def create_table(
     # pg_table_name maps any punctuation to underscore — allowing hyphens
     # would let `mcp-items` and `mcp_items` collide on the PG side.
     if not _TABLE_NAME_RE.fullmatch(name):
-        raise ValueError(
+        raise ValidationError(
             f"Invalid table name {name!r}: must match {_TABLE_NAME_RE.pattern}"
         )
     pool = await get_pool()
@@ -170,6 +170,18 @@ async def create_table(
                 )
 
             pg_name = table_data_repo.pg_table_name(vault["name"], name)
+            # Refuse names whose PG identifier would overflow NAMEDATALEN.
+            # PG truncates silently, and role_sync then refuses to GRANT on
+            # the over-long name (raising deep in the stack as a 500). Catch
+            # it here as a clean 422 that names the culprit, before any DDL.
+            if len(pg_name) > table_data_repo.PG_IDENT_MAX_LEN:
+                raise ValidationError(
+                    f"Table name too long: the PostgreSQL identifier "
+                    f"{pg_name!r} is {len(pg_name)} chars, over the "
+                    f"{table_data_repo.PG_IDENT_MAX_LEN}-char limit. Shorten "
+                    f"the vault name ({vault['name']!r}) or table name "
+                    f"({name!r})."
+                )
             try:
                 await table_data_repo.create_dynamic_table(conn, pg_name, columns)
                 await table_registry_repo.insert(

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -29,7 +29,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent
 
 from app.db.postgres import get_pool, init_db, close_pool
-from app.exceptions import ConflictError, NotFoundError
+from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.services.document_service import DocumentService, EditError
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
@@ -828,8 +828,14 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
             description=args.get("description", ""),
             collection=collection or None,
         )
-    except ValueError as e:
+    except (ValidationError, ValueError) as e:
+        # ValidationError: bad table name / over-long PG identifier (422).
+        # ValueError: still raised by _validate_column_name. Both are
+        # caller-fixable — keep the precise invalid_argument code rather
+        # than letting them fall to the dispatch catch-all as `internal`.
         return err(str(e), code=INVALID_ARGUMENT)
+    except ConflictError as e:
+        return err(str(e), code=CONFLICT)
 
 
 @_h("akb_sql")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.4"
+version = "0.8.5"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -302,6 +302,14 @@ R=$(mcp_call akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"mcp_items\",\"co
 TBL_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
 [ -n "$TBL_URI" ] && pass "akb_create_table ($TBL_URI)" || fail "akb_create_table" "no uri"
 
+# Over-long name → the derived `vt_<vault>__<table>` PG identifier exceeds
+# NAMEDATALEN (63). Must come back as a caller-fixable `invalid_argument`,
+# NOT an opaque `internal` (regression guard for the ValidationError fix:
+# the MCP handler's except must catch ValidationError, not just ValueError).
+LONGNAME=$(printf 'a%.0s' {1..70})
+CODE=$(mcp_call akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"$LONGNAME\",\"columns\":[{\"name\":\"x\",\"type\":\"text\"}]}" | mcp_result_field "['code']")
+[ "$CODE" = "invalid_argument" ] && pass "akb_create_table over-long name → invalid_argument" || fail "akb_create_table over-long name" "expected invalid_argument, got '$CODE'"
+
 # Insert via akb_sql
 R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO mcp_items (product, qty) VALUES ('Widget', 100), ('Gadget', 50)\"}" | mcp_result)
 SQL_RES=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null)

--- a/backend/tests/test_table_identifier_unit.py
+++ b/backend/tests/test_table_identifier_unit.py
@@ -13,6 +13,7 @@ can't silently re-introduce the all-underscore drop-out.
 from __future__ import annotations
 
 from app.repositories.table_data_repo import (
+    PG_IDENT_MAX_LEN,
     pg_short_name,
     pg_table_name,
     rewrite_table_names,
@@ -83,3 +84,24 @@ def test_rewriter_leaves_quoted_identifier_alone():
     table_map = {"______": "vt_demo__________"}
     sql = 'SELECT * FROM "______" LIMIT 1'
     assert rewrite_table_names(sql, table_map) == sql
+
+
+# ── identifier length boundary (E08) ───────────────────────────
+
+
+def test_pg_ident_max_len_is_namedatalen_minus_one():
+    """PG's default NAMEDATALEN is 64; usable identifier length is 63.
+    Lock the constant so a refactor can't silently change the bound
+    `table_service` and `role_sync` both rely on."""
+    assert PG_IDENT_MAX_LEN == 63
+
+
+def test_pg_table_name_length_boundary():
+    """E08 regression: a long vault + long table name can push
+    `vt_<vault>__<table>` exactly one byte over the limit, where PG
+    would silently truncate (risking a GRANT collision). Pin the math
+    that `create_table`'s pre-check guards against."""
+    fits = pg_table_name("a" * 27, "b" * 31)  # 3 + 27 + 2 + 31 = 63
+    over = pg_table_name("a" * 27, "b" * 32)  # 3 + 27 + 2 + 32 = 64
+    assert len(fits) == PG_IDENT_MAX_LEN
+    assert len(over) == PG_IDENT_MAX_LEN + 1

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -87,6 +87,39 @@ async def test_create_table_rejects_overlong_pg_name(monkeypatch):
     assert str(table_service.table_data_repo.PG_IDENT_MAX_LEN) in ei.value.message
 
 
+async def test_create_table_accepts_pg_name_at_limit(monkeypatch):
+    """Lower boundary: a 63-byte identifier (vault 27 + table 31) must
+    PASS the length guard. Proves the check is `>` not `>=`/off-by-one —
+    the math test alone can't catch a guard that rejects a legit 63-char
+    name. We stub create_dynamic_table to record it was reached, then
+    abort so the fake conn never has to carry the full DDL."""
+    vault_name = "prod-conc-1780908249-8ml717"        # 27 chars
+    table_name = "report_metrics_1780908249_8ml71"    # 31 chars → 3+27+2+31 = 63
+    assert len(table_service.table_data_repo.pg_table_name(vault_name, table_name)) == 63
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn(vault_name))
+
+    monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
+
+    reached = {}
+
+    async def _reached_then_stop(*a, **k):
+        reached["ddl"] = True  # guard let the 63-char name through
+        raise RuntimeError("stop after guard")
+
+    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _reached_then_stop)
+
+    with pytest.raises(RuntimeError, match="stop after guard"):
+        await table_service.create_table(
+            uuid.uuid4(),
+            table_name,
+            [{"name": "amount", "type": "integer"}],
+            actor_id="tester",
+        )
+    assert reached.get("ddl"), "the 63-char name was wrongly rejected by the length guard"
+
+
 async def test_create_table_invalid_name_is_422_not_500():
     """The sibling name-shape check raises ValidationError synchronously
     (before `get_pool`), so a malformed name is a clean 422 rather than an

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -20,9 +20,16 @@ from app.services import table_service
 pytestmark = pytest.mark.asyncio
 
 
-class _FakeTx:
+class _AsyncCtx:
+    """Async context manager yielding a fixed value — covers both shapes
+    create_table enters: ``pool.acquire()`` (→ conn) and
+    ``conn.transaction()`` (→ value unused)."""
+
+    def __init__(self, value=None):
+        self._value = value
+
     async def __aenter__(self):
-        return self
+        return self._value
 
     async def __aexit__(self, *exc):
         return False
@@ -33,23 +40,14 @@ class _FakeConn:
         self._vault_name = vault_name
 
     def transaction(self):
-        return _FakeTx()
+        return _AsyncCtx()
 
     async def fetchrow(self, sql: str, *params):
         if "FROM vaults" in sql:
             return {"name": self._vault_name}
+        # find_by_name's "FROM vault_tables" lookup → no existing table,
+        # so create_table proceeds to the length guard (no ConflictError).
         return None
-
-
-class _FakeAcquire:
-    def __init__(self, conn):
-        self._conn = conn
-
-    async def __aenter__(self):
-        return self._conn
-
-    async def __aexit__(self, *exc):
-        return False
 
 
 class _FakePool:
@@ -57,7 +55,7 @@ class _FakePool:
         self._conn = conn
 
     def acquire(self):
-        return _FakeAcquire(self._conn)
+        return _AsyncCtx(self._conn)
 
 
 async def test_create_table_rejects_overlong_pg_name(monkeypatch):
@@ -66,17 +64,10 @@ async def test_create_table_rejects_overlong_pg_name(monkeypatch):
     table_name = "report_metrics_1780908249_8ml717"   # 32 chars
     assert len(table_service.table_data_repo.pg_table_name(vault_name, table_name)) == 64
 
-    conn = _FakeConn(vault_name)
-
     async def _fake_get_pool():
-        return _FakePool(conn)
+        return _FakePool(_FakeConn(vault_name))
 
     monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
-
-    async def _no_existing(*a, **k):
-        return None
-
-    monkeypatch.setattr(table_service.table_registry_repo, "find_by_name", _no_existing)
 
     async def _must_not_run(*a, **k):
         raise AssertionError("create_dynamic_table must not run for an over-long name")
@@ -96,9 +87,10 @@ async def test_create_table_rejects_overlong_pg_name(monkeypatch):
     assert str(table_service.table_data_repo.PG_IDENT_MAX_LEN) in ei.value.message
 
 
-async def test_create_table_invalid_name_is_422_not_500(monkeypatch):
-    """The sibling name-shape check now also raises ValidationError, so a
-    malformed name is a clean 422 rather than an uncaught ValueError 500."""
+async def test_create_table_invalid_name_is_422_not_500():
+    """The sibling name-shape check raises ValidationError synchronously
+    (before `get_pool`), so a malformed name is a clean 422 rather than an
+    uncaught ValueError 500 — no pool fixture needed."""
     with pytest.raises(ValidationError) as ei:
         await table_service.create_table(
             uuid.uuid4(),

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -1,0 +1,109 @@
+"""Regression test for E08: `create_table` must refuse a vault+table
+name combination whose PG identifier (`vt_<vault>__<table>`) overflows
+NAMEDATALEN, returning a clean ``ValidationError`` (HTTP 422) *before*
+any DDL — instead of letting ``role_sync`` raise deep in the GRANT path
+and surface as an opaque 500.
+
+DB-free: a minimal fake pool/conn carries the create path as far as the
+length guard. ``create_dynamic_table`` is stubbed to blow up so the test
+also proves the guard short-circuits before touching PG.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services import table_service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeTx:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, vault_name: str):
+        self._vault_name = vault_name
+
+    def transaction(self):
+        return _FakeTx()
+
+    async def fetchrow(self, sql: str, *params):
+        if "FROM vaults" in sql:
+            return {"name": self._vault_name}
+        return None
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+async def test_create_table_rejects_overlong_pg_name(monkeypatch):
+    """The exact E08 trigger: vault(27) + table(32) → 64-char identifier."""
+    vault_name = "prod-conc-1780908249-8ml717"        # 27 chars
+    table_name = "report_metrics_1780908249_8ml717"   # 32 chars
+    assert len(table_service.table_data_repo.pg_table_name(vault_name, table_name)) == 64
+
+    conn = _FakeConn(vault_name)
+
+    async def _fake_get_pool():
+        return _FakePool(conn)
+
+    monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
+
+    async def _no_existing(*a, **k):
+        return None
+
+    monkeypatch.setattr(table_service.table_registry_repo, "find_by_name", _no_existing)
+
+    async def _must_not_run(*a, **k):
+        raise AssertionError("create_dynamic_table must not run for an over-long name")
+
+    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _must_not_run)
+
+    with pytest.raises(ValidationError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(),
+            table_name,
+            [{"name": "amount", "type": "integer"}],
+            actor_id="tester",
+        )
+
+    assert ei.value.status_code == 422
+    assert "too long" in ei.value.message.lower()
+    assert str(table_service.table_data_repo.PG_IDENT_MAX_LEN) in ei.value.message
+
+
+async def test_create_table_invalid_name_is_422_not_500(monkeypatch):
+    """The sibling name-shape check now also raises ValidationError, so a
+    malformed name is a clean 422 rather than an uncaught ValueError 500."""
+    with pytest.raises(ValidationError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(),
+            "Bad Name!",  # spaces + caps + punctuation
+            [{"name": "amount", "type": "integer"}],
+            actor_id="tester",
+        )
+    assert ei.value.status_code == 422


### PR DESCRIPTION
## 무엇을 / 왜

테이블 생성 시 PG 식별자 `vt_<vault>__<table>` 가 PostgreSQL의 63바이트 `NAMEDATALEN` 한계를 넘으면 **불투명한 HTTP 500** 으로 실패했습니다. 긴 이름이 생성 단계는 통과했지만 트랜잭션 내 `GRANT` 시점에 `role_sync._is_safe_pg_table_name` 가드를 건드려, 스택 깊은 곳에서 `ValueError("unsafe pg_table_name … refusing grant")` 가 raise → 500.

동시성 테스트 **E08** 에서 발견: 긴 ephemeral vault명(`prod-conc-…` 27자) + 긴 테이블명(32자) = **64자** 식별자, 한계를 딱 1자 초과.

## 설계 판단 — 안전검사는 유지

PG는 63바이트 초과 식별자를 **조용히 truncate** 합니다. truncate된 `vt_*` 이름에 GRANT 하면 권한이 엉뚱한 테이블로 가는 **truncation-collision** 위험이 있어, 거부가 맞습니다. **약화하지 않습니다.** 바뀐 건 *어디서 / 어떻게 보고하느냐* 뿐:

- `table_service.create_table` 가 `pg_table_name(...)` 산출 직후, **DDL 이전에** 길이를 사전검증 → `ValidationError`(HTTP **422**). 메시지에 문제의 식별자·길이·한계·줄여야 할 이름(vault/table)을 명시.
- 형제 격인 이름 형식 검사(`_TABLE_NAME_RE`)도 bare `ValueError` → 500 이었던 것을 `ValidationError`(422)로 통일 — 잘못된 이름 거부가 전부 깔끔한 4xx.
- 63바이트 한계를 단일 상수 `table_data_repo.PG_IDENT_MAX_LEN` 로 모음. 사전검사 + `role_sync` 방어선이 같은 상수를 사용(매직 `63` 중복 제거).

## 테스트 (CI, DB 불필요)

- `tests/test_table_identifier_unit.py` — 상수 + 63/64 바이트 경계 산식 고정.
- `tests/test_table_name_length_unit.py` (신규) — fake pool로 `create_table` 구동: E08 트리거 → **422 이고 `create_dynamic_table` 에 도달조차 안 함**, 잘못된 이름 → 422.

로컬: `test_table_identifier_unit` 7 passed, `test_table_name_length_unit` 2 passed, `test_role_sync` 회귀 없음(15 passed / 8 skipped).

## 범위 밖 (별건)

같은 조사에서 나온 **E03**(25-way 동시 update 후 `body ↔ current_commit` 불일치)은 read-path 가설이 코드와 맞지 않아(`_get_repo` 무캐싱 + 워크트리/bare가 동일 브랜치 ref) 근본원인 미확정 — speculative fix 대신 계측/재현으로 분리 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)