### PR TITLE
fix(frontend/document): relations never loaded (nonexistent id) + summary width

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -5211,10 +5211,10 @@
         "filename": "frontend/src/pages/__tests__/document-view-toggle.test.tsx",
         "hashed_secret": "6c688927eafd673c7d9194b46b2b88e096e6c9f7",
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 39,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-08T10:46:47Z"
+  "generated_at": "2026-06-08T11:17:21Z"
 }

--- a/frontend/src/components/summary-fold.tsx
+++ b/frontend/src/components/summary-fold.tsx
@@ -32,9 +32,12 @@ export function SummaryFold({ summary, prominent = false, className = "my-4" }: 
   if (!summary) return null;
   const needsFold = summary.length > FOLD_THRESHOLD;
 
+  // Non-prominent (document page): span the full column so the summary's
+  // right edge lines up with the title / FrontmatterCard above it, which
+  // fill the column. The prominent (public-share hero) keeps a prose measure.
   const textCls = prominent
     ? "font-serif-italic text-foreground-muted text-[15px] leading-[1.6] max-w-prose"
-    : "font-serif-italic text-foreground-muted text-sm leading-[1.55] max-w-prose";
+    : "font-serif-italic text-foreground-muted text-sm leading-[1.55]";
 
   if (!needsFold) {
     return (

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -28,8 +28,11 @@ const getRelationsMock = getRelations as unknown as ReturnType<typeof vi.fn>;
 const SAMPLE_CONTENT = "# BodyHeading\n\nworld";
 
 function makeDoc(overrides: Record<string, unknown> = {}) {
+  // NB: the real GET /documents response exposes NO internal `id` — `uri`/
+  // `path` is the sole identifier (see DocumentResponse). The mock must
+  // mirror that, or guards keyed off `d.id` look fine in tests yet are
+  // always-false in production.
   return {
-    id: "0c37e906-6db0-48c2-ac5d-576d0797b3f7",
     path: "notes/hello.md",
     title: "DocTitle",
     content: SAMPLE_CONTENT,
@@ -99,6 +102,16 @@ describe("DocumentPage view toggle", () => {
     ).toBeInTheDocument();
     // The raw <pre> should NOT be present.
     expect(screen.queryByTestId("doc-raw")).not.toBeInTheDocument();
+  });
+
+  it("loads relations keyed by the document path (not a nonexistent id)", async () => {
+    // Regression: the panel used to fetch via `d.id`, which the API never
+    // returns, so relations silently never loaded ("No relations yet.").
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+    await screen.findByRole("heading", { level: 1, name: "BodyHeading" });
+    await waitFor(() =>
+      expect(getRelationsMock).toHaveBeenCalledWith("v", "notes/hello.md"),
+    );
   });
 
   it("?view=raw renders the raw markdown inside <pre>", async () => {

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -147,8 +147,12 @@ export default function DocumentPage() {
     if (d.path && d.path !== docId) {
       navigate(`/vault/${name}/doc/${encodeURIComponent(d.path)}`, { replace: true });
     }
-    if (d.id) {
-      getRelations(name!, d.id).then((r) => setRelations(r.relations || [])).catch(() => {});
+    if (d.path) {
+      // getRelations builds the canonical akb:// URI from the vault-relative
+      // *path* (docUri). The GET response exposes no internal `id` — `uri`/
+      // `path` is the sole identifier — so keying this off `d.id` (always
+      // undefined) meant relations never loaded on the document page.
+      getRelations(name!, d.path).then((r) => setRelations(r.relations || [])).catch(() => {});
     }
     if (d.path) {
       loadHistory(name!, d.path);
@@ -703,7 +707,7 @@ export default function DocumentPage() {
                   })}
                 </ol>
                 <Link
-                  to={`/vault/${name}/graph?focus=${encodeURIComponent(doc.id ? docUri(name!, doc.path) : "")}`}
+                  to={`/vault/${name}/graph?focus=${encodeURIComponent(doc.path ? docUri(name!, doc.path) : "")}`}
                   className="mt-3 inline-flex items-center gap-1 text-xs text-accent hover:underline"
                 >
                   <GitGraph className="h-3 w-3" aria-hidden /> Open in graph →


### PR DESCRIPTION
문서 상세 페이지 2건.

## 1. Relations 탭이 항상 "No relations yet"

관계 패칭이 `d.id`로 게이트돼 있었고 `getRelations(name, d.id)`를 호출했는데, **GET /documents는 내부 id를 안 내려줍니다**(`uri`/`path`가 유일 식별자 — `DocumentResponse` 주석 "Internal IDs are never exposed"). → `d.id`는 항상 `undefined` → `getRelations`가 **한 번도 호출되지 않음** → 관계가 다 있어도(akb_relations로 확인됨) 화면엔 "No relations yet".

같은 죽은 `doc.id` 가드가 "Open in graph" 링크의 `focus` 파라미터도 항상 빈 값으로 만들고 있었음.

→ 둘 다 `d.path` 기준으로 변경(`getRelations`/`docUri`가 실제로 소비하는 값 = 저장된 엣지 URI와 매칭되는 canonical `akb://` 생성). 테스트 mock이 **실 API엔 없는 가짜 `id`**를 들고 있어서 CI는 통과하고 prod만 깨졌던 것 → mock에서 제거 + `getRelations`가 path로 호출되는지 회귀 단언 추가.

## 2. Summary 텍스트 width가 위 요소와 안 맞음

`SummaryFold`가 문서 페이지 summary를 `max-w-prose`(~65ch)로 클램프하는데, 위의 제목/`FrontmatterCard`는 컬럼 전체 폭을 채워서 summary 우측 끝이 위 요소보다 짧게 끝남. → 비-prominent(문서) 변형에서 `max-w-prose` 제거(공개공유 hero는 유지).

## 검증
- vitest 5/5(신규 회귀 포함), eslint 0 errors, 변경 파일 tsc clean.
- 백엔드 관계는 정상(akb_relations 조회됨) — 순수 프론트 패칭 버그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)