### PR TITLE
fix(frontend): self-heal stale-deploy chunk errors (nginx 404 + preloadError reload)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,16 +16,10 @@ RUN npx vite build
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# SPA fallback. /api and /mcp are proxied to the backend service in k8s.
-# If BACKEND_URL env is unset, falls back to expecting an external ingress.
-RUN echo 'server { \
-  listen 3000; \
-  root /usr/share/nginx/html; \
-  location / { try_files $uri $uri/ /index.html; } \
-  location /api/ { proxy_pass http://backend:8000/api/; proxy_set_header Host $host; proxy_set_header X-Forwarded-Proto $scheme; } \
-  location /mcp/ { proxy_pass http://backend:8000/mcp/; proxy_set_header Host $host; } \
-  location /health { proxy_pass http://backend:8000/health; } \
-}' > /etc/nginx/conf.d/default.conf
+# nginx config lives in a tracked file (frontend/nginx.conf) — it carries
+# the SPA fallback, the backend proxies, and the asset cache/404 rules
+# (missing hashed chunks must 404, not fall back to index.html).
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,32 @@
+server {
+  listen 3000;
+  root /usr/share/nginx/html;
+
+  # Hashed build assets (JS/CSS/fonts under /assets/) are content-addressed
+  # and therefore immutable — cache them hard. Critically, a MISSING asset
+  # must 404 honestly rather than fall through to the SPA index.html: when a
+  # client holding a stale index.html requests an old chunk hash that a newer
+  # deploy has removed, the old `try_files ... /index.html` returned the HTML
+  # body with a 200, and the browser then failed to import that HTML as an ES
+  # module ("Failed to fetch dynamically imported module"). Returning a real
+  # 404 lets the app's `vite:preloadError` handler reload onto the fresh build.
+  location /assets/ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
+  # index.html is the version pointer (it names the current asset hashes).
+  # Never cache it, so every navigation after a deploy picks up new hashes.
+  location = /index.html {
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+  }
+
+  # SPA fallback for application routes.
+  location / { try_files $uri $uri/ /index.html; }
+
+  # Backend proxies (k8s service names). Mirror the prod ingress so local
+  # docker-compose and the cluster behave identically.
+  location /api/ { proxy_pass http://backend:8000/api/; proxy_set_header Host $host; proxy_set_header X-Forwarded-Proto $scheme; }
+  location /mcp/ { proxy_pass http://backend:8000/mcp/; proxy_set_header Host $host; }
+  location /health { proxy_pass http://backend:8000/health; }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,6 +25,24 @@ import VaultSettingsPage from "@/pages/vault-settings";
 import VaultActivityPage from "@/pages/vault-activity";
 import "./index.css";
 
+// Vite dispatches `vite:preloadError` on window when a dynamically-imported
+// chunk fails to load — the classic stale-deploy symptom: a client holding
+// an old index.html requests a chunk hash a newer build has removed, so the
+// fetch 404s (or, with the old nginx config, returned index.html and failed
+// to parse as a module). Recover by reloading once onto the fresh build.
+// (The event type ships with vite/client.)
+const PRELOAD_RELOAD_AT = "akb.preloadReloadAt";
+window.addEventListener("vite:preloadError", (event) => {
+  // Loop guard: if we already reloaded for this in the last 10s, the chunk
+  // is genuinely broken (not merely stale) — let the error surface to the
+  // ErrorBoundary instead of reloading forever.
+  const last = Number(sessionStorage.getItem(PRELOAD_RELOAD_AT) || 0);
+  if (Date.now() - last < 10_000) return;
+  sessionStorage.setItem(PRELOAD_RELOAD_AT, String(Date.now()));
+  event.preventDefault(); // we're handling it — suppress the default throw
+  window.location.reload();
+});
+
 // Old /vault/:name/skill URLs now redirect to the underlying guide doc;
 // removed the dedicated page because it duplicated DocumentPage.
 function SkillRedirect() {


### PR DESCRIPTION
## Symptom
After a frontend redeploy, clicking **edit document** (or any lazy route) threw:

> Failed to fetch dynamically imported module: …/assets/markdown-editor-`<hash>`.js

and dropped the user on the "This view couldn't render" error boundary. A hard refresh fixed it — the tell-tale sign of a stale-deploy chunk mismatch, not a code regression.

## Root cause (two layers)
1. The browser tab held the **previous** `index.html`, which references an old lazy-chunk hash. A newer build removed that hash.
2. nginx's single `try_files $uri $uri/ /index.html` fell the missing `/assets/*.js` request **back to index.html with `200` + `text/html`**. The browser then tried to import an HTML body as an ES module → throw. (Confirmed in prod: the errored chunk URL returned `HTTP 200, content-type: text/html`.)

## Fix
**nginx** (`frontend/Dockerfile` → new tracked `frontend/nginx.conf`):
- `location /assets/` → `try_files $uri =404`: a missing hashed asset returns an honest **404**, never index.html.
- Present assets cached immutably (`Cache-Control: public, max-age=31536000, immutable`).
- `index.html` marked `no-cache` so every load after a deploy re-resolves the current asset hashes.
- Config lifted out of the brittle inline `RUN echo '…'` into a real file.

**frontend** (`main.tsx`):
- Listen for Vite's `vite:preloadError` and `location.reload()` **once** onto the fresh build, with a 10s `sessionStorage` loop-guard so a genuinely broken chunk surfaces to the ErrorBoundary instead of reloading forever.

Together: the 404 makes the failure honest, and the reload makes recovery automatic — the user never sees the error screen on the next deploy.

## Verification
Built the image and probed (`--add-host backend:127.0.0.1` so nginx starts; static routes only):

| case | before | after |
|---|---|---|
| missing `/assets/<gone>.js` | `200` text/html | **`404`** |
| present asset | (no cache hdr) | `Cache-Control: public, max-age=31536000, immutable` |
| `/index.html` | (no cache hdr) | `Cache-Control: no-cache, no-store, must-revalidate` |
| `/vault/foo` (app route) | index.html 200 | index.html 200 (unchanged) |

`bash scripts/check.sh` green (ruff, mypy, bandit, eslint 0 errors, tsc, vitest 246/246, detect-secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)