### PR TITLE
feat(design-system): batch 1 — foundation a11y + legacy residue removal

### DIFF
--- a/frontend/src/components/file-viewer.tsx
+++ b/frontend/src/components/file-viewer.tsx
@@ -110,7 +110,7 @@ function FileBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
 
   if (mime.startsWith("image/")) {
     return (
-      <div className="flex justify-center bg-whisper p-6">
+      <div className="flex justify-center bg-surface-2 p-6">
         <img src={directUrl} alt={name} className="max-w-full max-h-[80vh]" />
       </div>
     );

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -125,7 +125,7 @@ export function GraphDetailPanel({
       ) : (
         <>
       <div className="px-3 py-3 border-b border-border">
-        <h2 className="font-serif text-2xl leading-tight mb-1">{doc?.title || "…"}</h2>
+        <h2 className="font-semibold tracking-[-0.015em] text-2xl leading-tight mb-1">{doc?.title || "…"}</h2>
         <p className="coord text-foreground-muted truncate" title={uri}>{uri}</p>
         <div className="flex flex-wrap gap-1 mt-3">
           <Button size="sm" variant="accent" onClick={openDoc}>

--- a/frontend/src/components/json-tree.tsx
+++ b/frontend/src/components/json-tree.tsx
@@ -10,13 +10,13 @@ interface Props {
 export function JsonTree({ data, name, depth = 0 }: Props) {
   const [open, setOpen] = useState(depth < 2);
 
-  if (data === null) return <span className="text-purple-500">null</span>;
+  if (data === null) return <span className="text-subtle">null</span>;
   if (typeof data === "boolean")
-    return <span className="text-orange-500">{String(data)}</span>;
+    return <span className="text-warning">{String(data)}</span>;
   if (typeof data === "number")
-    return <span className="text-blue-500">{data}</span>;
+    return <span className="text-info">{data}</span>;
   if (typeof data === "string")
-    return <span className="text-green-700 dark:text-green-400">"{data}"</span>;
+    return <span className="text-success">"{data}"</span>;
 
   if (Array.isArray(data)) {
     if (data.length === 0) return <span className="text-muted-foreground">[]</span>;
@@ -59,7 +59,7 @@ export function JsonTree({ data, name, depth = 0 }: Props) {
           <div className="ml-4 border-l border-border pl-3">
             {keys.map((k) => (
               <div key={k} className="text-sm font-mono">
-                <span className="text-blue-600 dark:text-blue-400 mr-2">{k}:</span>
+                <span className="text-primary mr-2">{k}:</span>
                 <JsonTree data={data[k]} name={k} depth={depth + 1} />
               </div>
             ))}

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -232,11 +232,11 @@ const components: Record<string, React.FC<any>> = {
   [ParagraphPlugin.key]: ParagraphElement,
   [H1Plugin.key]: makeHeading(
     "h1",
-    "font-serif text-[32px] leading-[1.15] tracking-[-0.02em] mt-8 mb-4",
+    "font-semibold text-[32px] leading-[1.15] tracking-[-0.02em] mt-8 mb-4",
   ),
   [H2Plugin.key]: makeHeading(
     "h2",
-    "font-serif text-[24px] leading-[1.2] tracking-[-0.015em] mt-7 mb-3",
+    "font-semibold text-[24px] leading-[1.2] tracking-[-0.015em] mt-7 mb-3",
   ),
   [H3Plugin.key]: makeHeading("h3", "font-semibold text-[19px] mt-6 mb-2"),
   [H4Plugin.key]: makeHeading("h4", "font-semibold text-[17px] mt-5 mb-2"),

--- a/frontend/src/components/password-gate.tsx
+++ b/frontend/src/components/password-gate.tsx
@@ -29,7 +29,7 @@ export function PasswordGate({ slug, onSuccess }: Props) {
     <div className="min-h-screen flex items-center justify-center bg-surface px-6">
       <div className="w-full max-w-md fade-up">
         <div className="coord mb-3">§ AKB · PUBLIC · RESTRICTED</div>
-        <div className="border border-border p-8 grain relative">
+        <div className="border border-border p-8 relative">
           <div className="font-display-tight text-5xl text-foreground leading-none">
             Sealed.
           </div>

--- a/frontend/src/components/skill/skill-banner.tsx
+++ b/frontend/src/components/skill/skill-banner.tsx
@@ -47,7 +47,7 @@ export function SkillBanner({ vault, docId }: Props) {
     <div className="flex items-center justify-between h-9 px-3 border-b border-border bg-surface">
       <div className="flex items-center gap-3">
         <SkillBadge defined />
-        <span className="font-serif italic text-[13px] text-foreground-muted">
+        <span className="italic font-semibold tracking-[-0.015em] text-[13px] text-foreground-muted">
           Agents writing into this vault read this first.
         </span>
         {error && (

--- a/frontend/src/components/summary-fold.tsx
+++ b/frontend/src/components/summary-fold.tsx
@@ -36,8 +36,8 @@ export function SummaryFold({ summary, prominent = false, className = "my-4" }: 
   // right edge lines up with the title / FrontmatterCard above it, which
   // fill the column. The prominent (public-share hero) keeps a prose measure.
   const textCls = prominent
-    ? "font-serif-italic text-foreground-muted text-[15px] leading-[1.6] max-w-prose"
-    : "font-serif-italic text-foreground-muted text-sm leading-[1.55]";
+    ? "font-medium tracking-[-0.01em] text-foreground-muted text-[15px] leading-[1.6] max-w-prose"
+    : "font-medium tracking-[-0.01em] text-foreground-muted text-sm leading-[1.55]";
 
   if (!needsFold) {
     return (

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -13,11 +13,13 @@ const badgeVariants = cva(
         outline: "border-border bg-transparent text-foreground-muted",
         destructive: "border-destructive bg-destructive text-destructive-foreground",
         success: "border-success bg-transparent text-success",
-        info: "border-accent bg-transparent text-accent",
-        spark: "border-accent bg-accent text-accent-foreground",
+        // accent badges use accent-STRONG: outline badges need it for the
+        // text (10px → no large-text exemption); filled badges for white-on-bg.
+        info: "border-accent-strong bg-transparent text-accent-strong",
+        spark: "border-accent-strong bg-accent-strong text-accent-strong-foreground",
 
         /* role badges — filled for write-authority, outline for read-only */
-        owner: "border-accent bg-accent text-accent-foreground",
+        owner: "border-accent-strong bg-accent-strong text-accent-strong-foreground",
         admin: "border-primary bg-primary text-primary-foreground",
         writer: "border-primary bg-transparent text-primary",
         reader: "border-border bg-surface-muted text-foreground-muted",
@@ -29,7 +31,7 @@ const badgeVariants = cva(
 
         /* system status */
         pending: "border-warning bg-transparent text-warning",
-        syncing: "border-accent bg-transparent text-accent",
+        syncing: "border-accent-strong bg-transparent text-accent-strong",
         error: "border-destructive bg-transparent text-destructive",
       },
     },

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,5 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
@@ -16,8 +17,10 @@ const buttonVariants = cva(
       variant: {
         default:
           "bg-primary text-primary-foreground border border-primary shadow-sm hover:bg-primary/90",
+        // Filled accent CTA — uses accent-STRONG so white text clears WCAG AA
+        // (4.83:1). The bright --color-accent is reserved for non-text accent.
         accent:
-          "bg-accent text-accent-foreground border border-accent shadow-sm hover:bg-accent/90",
+          "bg-accent-strong text-accent-strong-foreground border border-accent-strong shadow-sm hover:bg-accent-strong/90",
         outline:
           "bg-surface text-foreground border border-border hover:bg-surface-muted hover:border-border-strong",
         secondary:
@@ -27,7 +30,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground border border-destructive shadow-sm hover:bg-destructive/90",
         link:
-          "bg-transparent text-primary underline-offset-4 hover:underline hover:text-accent h-auto px-0",
+          "bg-transparent text-primary underline-offset-4 hover:underline hover:text-primary/80 h-auto px-0",
       },
       size: {
         sm: "h-8 px-3 text-xs",
@@ -45,17 +48,32 @@ export interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /** Show a spinner, disable the button, and announce aria-busy. Ignored when
+   *  `asChild` is set (Slot requires a single child). */
+  loading?: boolean;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, loading = false, disabled, children, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
+    if (asChild) {
+      return (
+        <Comp ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props}>
+          {children}
+        </Comp>
+      );
+    }
     return (
       <Comp
         ref={ref}
         className={cn(buttonVariants({ variant, size, className }))}
+        disabled={disabled || loading}
+        aria-busy={loading || undefined}
         {...props}
-      />
+      >
+        {loading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden />}
+        {children}
+      </Comp>
     );
   },
 );

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -15,7 +15,7 @@ const DialogOverlay = forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-foreground/50",
+      "fixed inset-0 z-50 bg-black/50",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       className,
     )}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -10,6 +10,7 @@ const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>
         "flex h-10 w-full rounded-[var(--radius-md)] border border-border bg-surface px-3 py-2 text-sm text-foreground",
         "placeholder:text-foreground-muted",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "aria-[invalid=true]:border-destructive aria-[invalid=true]:focus-visible:ring-destructive",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         "file:border-0 file:bg-transparent file:text-sm file:font-medium",
         "transition-colors duration-150",

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -8,6 +8,7 @@ const Select = forwardRef<HTMLSelectElement, SelectHTMLAttributes<HTMLSelectElem
       className={cn(
         "flex h-10 w-full appearance-none rounded-[var(--radius-md)] border border-border bg-surface pl-3 pr-9 py-2 text-sm text-foreground",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "aria-[invalid=true]:border-destructive aria-[invalid=true]:focus-visible:ring-destructive",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         "transition-colors duration-150",
         "bg-[right_0.75rem_center] bg-no-repeat cursor-pointer",

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -31,7 +31,7 @@ const TabsTrigger = forwardRef<
       // Active tab — soft raised pill (segmented control), accent coord numerals
       "data-[state=active]:bg-surface data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       "data-[state=active]:[&_.coord]:text-accent",
-      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-2",
       "transition-token cursor-pointer",
       className,
     )}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -9,6 +9,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLText
         "flex min-h-[80px] w-full rounded-[var(--radius-md)] border border-border bg-surface px-3 py-2 text-sm text-foreground",
         "placeholder:text-foreground-muted",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "aria-[invalid=true]:border-destructive aria-[invalid=true]:focus-visible:ring-destructive",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         "transition-colors duration-150",
         "resize-y",

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -14,7 +14,7 @@ const TooltipContent = forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 rounded-[var(--radius-sm)] border border-border bg-foreground px-2 py-1 text-xs text-background font-medium tracking-wide",
+      "z-50 rounded-[var(--radius-sm)] border border-border-strong bg-surface px-2 py-1 text-xs text-foreground font-medium tracking-wide shadow-md",
       "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out",
       className,
     )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,18 +63,9 @@
   --color-popover: #ffffff;
   --color-popover-foreground: #1d1d1f;
 
-  /* legacy primitive aliases (kept so any old utility refs still resolve) */
-  --color-paper: #f6f7f9;
-  --color-ink: #1d1d1f;
-  --color-smoke: #5e6068;
-  --color-whisper: #ebeef2;
-  --color-spark: #e55e2c;
-  --color-ember: #c42424;
-
   /* ── Typography — Pretendard everywhere (family unification) ─────── */
   --font-sans: "Pretendard Variable", "Pretendard", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "Fira Code", ui-monospace, "SF Mono", Menlo, monospace;
-  --font-serif: "Pretendard Variable", "Pretendard", system-ui, sans-serif;
   --font-display: "Pretendard Variable", "Pretendard", system-ui, sans-serif;
 
   /* ── Radius — soft, rounded family look (12px controls, 14px cards,
@@ -143,8 +134,6 @@
   --color-popover: #121821;
   --color-popover-foreground: #e7eaef;
 
-  --color-whisper: #1b2430;
-
   --glass-bg: rgba(18, 24, 33, 0.62);
   --glass-border: rgba(255, 255, 255, 0.08);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
@@ -194,19 +183,6 @@ body {
   font-weight: 400;
   letter-spacing: 0;
   line-height: 1.75;
-}
-
-.font-serif {
-  font-family: var(--font-serif);
-  font-weight: 600;
-  letter-spacing: -0.015em;
-}
-
-.font-serif-italic {
-  font-family: var(--font-serif);
-  font-weight: 500;
-  font-style: normal;
-  letter-spacing: -0.01em;
 }
 
 .font-mono {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,6 +34,12 @@
 
   --color-accent: #e55e2c;
   --color-accent-foreground: #ffffff;
+  /* Filled-accent surfaces (buttons/badges with white text) use the darker
+     `accent-strong`: white-on-#c44a1e = 4.83:1 (WCAG AA). The bright #e55e2c
+     stays for borders, text-accent, dots and highlights where no white text
+     sits on it. One token swap re-skins every filled-accent call site. */
+  --color-accent-strong: #c44a1e;
+  --color-accent-strong-foreground: #ffffff;
   --color-success: #228b54;
   --color-success-foreground: #04200d;
   --color-warning: #b06000;
@@ -113,6 +119,8 @@
 
   --color-accent: #e55e2c;
   --color-accent-foreground: #ffffff;
+  --color-accent-strong: #c44a1e;
+  --color-accent-strong-foreground: #ffffff;
   --color-success: #3fb27a;
   --color-success-foreground: #0a1f12;
   --color-warning: #d9912f;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,6 +23,7 @@ import PublicationPage from "@/pages/public-publication";
 import VaultMembersPage from "@/pages/vault-members";
 import VaultSettingsPage from "@/pages/vault-settings";
 import VaultActivityPage from "@/pages/vault-activity";
+import NotFoundPage from "@/pages/not-found";
 import "./index.css";
 
 // Vite dispatches `vite:preloadError` on window when a dynamically-imported
@@ -91,6 +92,9 @@ createRoot(document.getElementById("root")!).render(
           </Route>
           <Route path="/search" element={<SearchPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          {/* Catch-all: an unmatched URL used to render a blank page with no
+              recovery. Render NotFound inside the shell instead. */}
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -371,7 +371,7 @@ export default function DocumentPage() {
 
         {/* Byline in serif italic */}
         {(doc.created_by || doc.updated_at) && (
-          <div className="font-serif-italic text-[14px] text-foreground-muted mb-7">
+          <div className="font-medium tracking-[-0.01em] text-[14px] text-foreground-muted mb-7">
             {doc.created_by && (
               <>
                 Written by{" "}

--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -77,7 +77,7 @@ export default function FilePage() {
       </header>
 
       {info?.description && (
-        <p className="font-serif-italic text-[17px] leading-[1.55] text-foreground-muted mt-3">
+        <p className="font-medium tracking-[-0.01em] text-[17px] leading-[1.55] text-foreground-muted mt-3">
           {info.description}
         </p>
       )}

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Catch-all for unmatched routes. Without this, an old/typo'd/stale-deploy URL
+ * matched no route and React Router rendered nothing — a fully blank page with
+ * no recovery path. This gives a clear message + a way back.
+ */
+export default function NotFoundPage() {
+  return (
+    <div className="mx-auto flex max-w-[640px] flex-col items-center px-6 py-24 text-center">
+      <p className="coord mb-3">404 · not found</p>
+      <h1 className="font-display text-[40px] leading-[1.1] text-foreground mb-3">
+        Page not found
+      </h1>
+      <p className="text-foreground-muted mb-8">
+        The page you're looking for doesn't exist or may have moved. Check the
+        address, or head back to your workspace.
+      </p>
+      <Button asChild>
+        <Link to="/">Back to workspace</Link>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -84,7 +84,7 @@ export default function TablePage() {
       </header>
 
       {info?.description && (
-        <p className="font-serif-italic text-[17px] leading-[1.55] text-foreground-muted mt-3">
+        <p className="font-medium tracking-[-0.01em] text-[17px] leading-[1.55] text-foreground-muted mt-3">
           {info.description}
         </p>
       )}


### PR DESCRIPTION
디자인 시스템 체계 전환의 **배치 1** — 가장 레버리지 크고 저위험인 *토대 a11y + 레거시 제거*. (후속 배치: .feat 브랜드색·§/aurora 톤다운 → 페이지별 전환)

## Phase 0 — 토대 (전 페이지 전파)
- **토큰**: `--color-accent-strong #c44a1e` 신설 — 채움-accent에 흰 글자 **4.83:1 (WCAG AA)**. 기존 `#e55e2c`(흰글자 3.52:1 실패)는 보더/text-accent/하이라이트 등 비텍스트 전용으로 유지. **토큰 1곳이 25+ 호출처 전파.**
- **Button**: accent→accent-strong, `loading` prop(스피너+disabled+aria-busy), link hover teal化.
- **Badge**: info/spark/owner/syncing accent→accent-strong (10px라 large-text 예외 없음).
- **Tooltip**: `bg-foreground/text-background` 슬랩(다크에서 흰 툴팁으로 반전) → `bg-surface/text-foreground`+shadow.
- **Dialog**: 스크림 `bg-foreground/50`(다크 흰 베일) → `bg-black/50`.
- **Input/Textarea/Select**: `aria-[invalid=true]` destructive 보더/링 훅.
- **Tabs**: TabsTrigger 포커스링 ring-offset 추가.
- **404**: 미매칭 URL이 백지였던 것 → catch-all 라우트 + NotFound 페이지.

## Phase 1a — 레거시 토큰/클래스 제거 (렌더 무변화)
- json-tree 원시 팔레트(앱 유일 잔재)→시맨틱 토큰.
- `bg-whisper`→`bg-surface-2` 후 레거시 색 별칭(paper/ink/smoke/whisper/spark/ember) 삭제.
- editorial-serif 9곳 정밀 마이그레이션(`.font-serif`=Pretendard600→font-semibold, `.font-serif-italic`=Pretendard500/normal→font-medium — 이름이 거짓이었음) 후 정의 삭제.
- dead `grain` 클래스 제거.

## 검증
design-check ✓, tsc clean, **vitest 247/247**, eslint 0 errors. 잔존 레거시 참조 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)