### PR TITLE
feat(design-system): batch 2 — off-brand hues → teal/orange family

### DIFF
--- a/frontend/src/components/graph/cluster.ts
+++ b/frontend/src/components/graph/cluster.ts
@@ -73,14 +73,21 @@ export function isDarkBg(bg: string): boolean {
 
 const colorCache = new Map<string, string>();
 
+// Curated on-brand hue set for cluster rings — cool teals/sage + warm
+// oranges/amber, anchored on the teal/orange brand. Replaces the former
+// full-spectrum 0-360 rainbow (which surfaced off-brand blues/purples/magenta).
+// hashHue() (0-359) buckets a group into one of these, keeping clusters
+// distinguishable without leaving the brand palette.
+const CLUSTER_HUES = [192, 200, 178, 160, 30, 18, 40];
+
 /** Stable, theme-aware ring color for a group key (memoized — called per
  *  visible node every frame). Darker on a light background so it reads. */
 export function groupColor(group: string, dark = true): string {
   const key = `${group}|${dark ? 1 : 0}`;
   const cached = colorCache.get(key);
   if (cached) return cached;
-  const h = hashHue(group);
-  const col = dark ? `hsl(${h}, 65%, 62%)` : `hsl(${h}, 60%, 42%)`;
+  const h = CLUSTER_HUES[hashHue(group) % CLUSTER_HUES.length];
+  const col = dark ? `hsl(${h}, 58%, 60%)` : `hsl(${h}, 52%, 38%)`;
   colorCache.set(key, col);
   return col;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -327,19 +327,24 @@ body::before {
   color: #fff;
   box-shadow: var(--shadow-md);
 }
-.feat-knowledge { background: linear-gradient(135deg, #0a6f86, #14b8a6); }
-.feat-agent     { background: linear-gradient(135deg, #5b6ef5, #8b5cf6); }
+/* Per-capability tiles — curated to the teal↔orange brand family
+   (cool teals + warm ambers/oranges + neutral). No off-brand
+   purple/blue/magenta. Distinguishable via hue+lightness within the
+   brand. Eyebrow labels are neutral-muted (Swiss) — the tile carries
+   the color identity. */
+.feat-knowledge { background: linear-gradient(135deg, #004059, #0a6f86); }
+.feat-agent     { background: linear-gradient(135deg, #0a6f86, #18a0a0); }
 .feat-memory    { background: linear-gradient(135deg, #e8932f, #e55e2c); }
-.feat-collector { background: linear-gradient(135deg, #2f7fe8, #22b8d9); }
-.feat-metering  { background: linear-gradient(135deg, #e55e2c, #d9434f); }
-.feat-members   { background: linear-gradient(135deg, #7c4ddc, #b05cf6); }
+.feat-collector { background: linear-gradient(135deg, #2c5561, #5a8fa0); }
+.feat-metering  { background: linear-gradient(135deg, #e55e2c, #c44a1e); }
+.feat-members   { background: linear-gradient(135deg, #5e6068, #8a8f98); }
 .feat-neutral   { background: linear-gradient(135deg, #5e6068, #8a8f98); }
-.feat-eyebrow-knowledge { color: #14b8a6; }
-.feat-eyebrow-agent     { color: #8b5cf6; }
-.feat-eyebrow-memory    { color: #e8932f; }
-.feat-eyebrow-collector { color: #22b8d9; }
-.feat-eyebrow-metering  { color: #e07a3c; }
-.feat-eyebrow-members   { color: #b05cf6; }
+.feat-eyebrow-knowledge,
+.feat-eyebrow-agent,
+.feat-eyebrow-memory,
+.feat-eyebrow-collector,
+.feat-eyebrow-metering,
+.feat-eyebrow-members,
 .feat-eyebrow-neutral   { color: var(--color-foreground-muted); }
 
 /* ── Motion ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
디자인 시스템 전환 **배치 2** — 브랜드(teal+orange) 밖으로 새던 보라/파랑/마젠타를 브랜드 패밀리로.

- **`.feat-*` 타일**: agent(보라 #5b6ef5/#8b5cf6)→teal, collector(파랑 #2f7fe8)→cool slate, members(보라 #7c4ddc)→neutral, metering(orange→red)→orange→orange-strong. 색+명도로 구분 유지, 브랜드 이탈 0. eyebrow 라벨은 neutral-muted(Swiss).
- **그래프 클러스터 링**: `groupColor()`가 0-360° 전스펙트럼 HSL 레인보우였던 것 → 큐레이션된 on-brand hue 세트(teals/sage + oranges/amber)로, 채도 소폭 하향.

검증: design-check ✓, tsc clean, vitest 247/247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)