### PR TITLE
akb_put: support an optional slug to set the document path/uri filename over MCP

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1096,
         "is_secret": false
       }
     ],
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T08:30:37Z"
+  "generated_at": "2026-06-17T09:38:13Z"
 }

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -650,6 +650,7 @@ akb_help(topic="link-resources")    # Workflow guide
 | vault | ✓ | Target vault name |
 | collection | ✓ | Directory path (e.g. "api-specs", "meeting-notes") |
 | title | ✓ | Document title |
+| slug | | Optional filename slug. When omitted, the path is derived from `title`; pass this to pin a stable URI filename independently of the display title. |
 | content | ✓ | Markdown body |
 | type | | note, report, decision, spec, plan, session, task, reference |
 | tags | | ["auth", "api"] |
@@ -664,6 +665,14 @@ akb_help(topic="link-resources")    # Workflow guide
 ```
 akb_put(vault="eng", collection="notes", title="Meeting Notes 2026-04-03",
   content="## Attendees\\n- Kim, Lee\\n\\n## Discussion\\n...")
+```
+
+**Stable path, friendly title:**
+```
+akb_put(vault="eng", collection="issues", title="Fix login redirect loop",
+  slug="github-issue-123",
+  content="## Context\\n...")
+# uri: akb://eng/coll/issues/doc/github-issue-123.md
 ```
 
 **Decision record with links:**

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -275,6 +275,7 @@ async def _handle_put(args: dict, uid: str, user: _MCPUser) -> dict:
     req = DocumentPutRequest(
         vault=vault,
         collection=collection,
+        slug=args.get("slug"),
         title=args["title"],
         content=args["content"],
         type=args.get("type", "note"),

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -130,6 +130,7 @@ TOOLS = [
                 },
                 "vault": {"type": "string", "description": "Target vault name. Required unless `parent` is given."},
                 "collection": {"type": "string", "description": "Collection (directory) path, e.g. 'api-specs' or 'meeting-notes'. Ignored when `parent` is given."},
+                "slug": {"type": "string", "description": "Optional explicit slug for the document filename. When stored under a collection the URI is `akb://{vault}/coll/{collection}/doc/{slug}.md`; at the vault root it is `akb://{vault}/doc/{slug}.md`. When omitted, the slug is derived from the title. Pass it to keep the path stable and meaningful when the title is friendly, changeable text (e.g. slug `github-issue-123` with a human-readable title)."},
                 "title": {"type": "string", "description": "Document title"},
                 "content": {"type": "string", "description": "Document body in Markdown"},
                 "type": {

--- a/backend/tests/test_akb_put_slug_unit.py
+++ b/backend/tests/test_akb_put_slug_unit.py
@@ -69,6 +69,22 @@ def _akb_put_schema_property_names() -> set[str]:
     return {k.value for k in props.keys if isinstance(k, ast.Constant)}
 
 
+def _help_topic_text(topic: str) -> str:
+    tree = ast.parse((_MCP / "help.py").read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == topic
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                return value.value
+    raise AssertionError(f"help topic {topic!r} not found")
+
+
 def _handle_put_put_request_call() -> ast.Call:
     tree = ast.parse((_MCP / "server.py").read_text())
     fn = next(
@@ -90,6 +106,15 @@ def test_akb_put_schema_exposes_slug() -> None:
         "akb_put inputSchema must advertise `slug` so a caller can set it AND so "
         "the schema-derived arg-validator (_TOOL_ARG_NAMES) accepts it."
     )
+
+
+def test_akb_put_help_documents_slug() -> None:
+    text = _help_topic_text("akb_put")
+    assert "| slug |" in text, (
+        "akb_help(topic='akb_put') must document `slug`; schema-only exposure "
+        "is hard for agents/users to discover."
+    )
+    assert "github-issue-123" in text
 
 
 def test_handle_put_forwards_slug_from_args() -> None:

--- a/backend/tests/test_akb_put_slug_unit.py
+++ b/backend/tests/test_akb_put_slug_unit.py
@@ -1,0 +1,110 @@
+"""Unit tests for the optional ``slug`` argument on ``akb_put`` (MCP).
+
+The backend ``DocumentPutRequest`` model and ``document_service._put`` already
+honor a ``slug`` (``slug = (req.slug and _slugify(req.slug)) or _slugify(req.title)``);
+these tests pin the two MCP-surface seams that expose it to a caller:
+
+  1. ``tools.py`` advertises ``slug`` in the ``akb_put`` ``inputSchema``. Because
+     ``server._TOOL_ARG_NAMES`` is schema-derived, advertising it here is also
+     what makes the ``_dispatch`` arg-validator accept it (otherwise the call is
+     rejected with ``unknown_argument``).
+  2. ``_handle_put`` forwards ``args.get("slug")`` into ``DocumentPutRequest``.
+
+Both are verified by AST instead of importing ``mcp_server.tools`` /
+``mcp_server.server`` — the same dependency-avoidance pattern as
+``test_mcp_tool_validation_unit.py`` (importing the server transitively pulls
+psycopg / kiwipiepy / the MCP SDK).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MCP = Path(__file__).resolve().parents[1] / "mcp_server"
+
+
+def _tool_call(tree: ast.AST, tool_name: str) -> ast.Call:
+    """Return the ``Tool(name="<tool_name>", ...)`` call node from tools.py."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_tool = (isinstance(func, ast.Name) and func.id == "Tool") or (
+            isinstance(func, ast.Attribute) and func.attr == "Tool"
+        )
+        if not is_tool:
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "name"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value == tool_name
+            ):
+                return node
+    raise AssertionError(f"Tool(name={tool_name!r}) not found in tools.py")
+
+
+def _kwarg_value(call: ast.Call, name: str) -> ast.expr:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    raise AssertionError(f"keyword {name!r} not found on call")
+
+
+def _dict_value(node: ast.expr, key: str) -> ast.expr:
+    assert isinstance(node, ast.Dict), f"expected a dict literal for {key!r}"
+    for k, v in zip(node.keys, node.values):
+        if isinstance(k, ast.Constant) and k.value == key:
+            return v
+    raise AssertionError(f"key {key!r} not found in dict literal")
+
+
+def _akb_put_schema_property_names() -> set[str]:
+    tree = ast.parse((_MCP / "tools.py").read_text())
+    call = _tool_call(tree, "akb_put")
+    schema = _kwarg_value(call, "inputSchema")
+    props = _dict_value(schema, "properties")
+    assert isinstance(props, ast.Dict)
+    return {k.value for k in props.keys if isinstance(k, ast.Constant)}
+
+
+def _handle_put_put_request_call() -> ast.Call:
+    tree = ast.parse((_MCP / "server.py").read_text())
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef)) and n.name == "_handle_put"
+    )
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "DocumentPutRequest":
+            return node
+    raise AssertionError("DocumentPutRequest(...) not found in _handle_put")
+
+
+def test_akb_put_schema_exposes_slug() -> None:
+    # Positive control: the schema is the one we think it is.
+    names = _akb_put_schema_property_names()
+    assert "title" in names and "content" in names
+    assert "slug" in names, (
+        "akb_put inputSchema must advertise `slug` so a caller can set it AND so "
+        "the schema-derived arg-validator (_TOOL_ARG_NAMES) accepts it."
+    )
+
+
+def test_handle_put_forwards_slug_from_args() -> None:
+    call = _handle_put_put_request_call()
+    slug_kw = next((kw for kw in call.keywords if kw.arg == "slug"), None)
+    assert slug_kw is not None, "_handle_put must forward `slug` into DocumentPutRequest"
+    # Forwarded from the call args, not hardcoded: args.get("slug").
+    value = slug_kw.value
+    assert (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "get"
+        and isinstance(value.func.value, ast.Name)
+        and value.func.value.id == "args"
+        and value.args
+        and isinstance(value.args[0], ast.Constant)
+        and value.args[0].value == "slug"
+    ), "slug must be forwarded as args.get(\"slug\")"

--- a/backend/tests/test_put_slug_e2e.sh
+++ b/backend/tests/test_put_slug_e2e.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# AKB MCP: akb_put `slug` param E2E Test
+# Tests that an explicit slug controls the document path/uri filename
+# (independent of the title), and that omitting it falls back to the title.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+PASS=0
+FAIL=0
+ERRORS=()
+MSGID=0
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   akb_put slug param E2E                 ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# ── 0. Setup ─────────────────────────────────────────────────
+echo "▸ 0. Setup"
+
+E2E_USER="put-slug-$(date +%s)"
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$E2E_USER\",\"email\":\"$E2E_USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$E2E_USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"put-slug-e2e"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+[ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
+
+# ── Start proxy ──────────────────────────────────────────────
+AKB_MCP_BIN="$(dirname "$0")/../../packages/akb-mcp-client/bin/akb-mcp.mjs"
+if [ ! -f "$AKB_MCP_BIN" ]; then
+  AKB_MCP_BIN="$(which akb-mcp 2>/dev/null || echo "")"
+fi
+[ -z "$AKB_MCP_BIN" ] && { echo "ERROR: akb-mcp not found"; exit 1; }
+
+FIFO_IN=$(mktemp -u /tmp/akb-mcp-slug-in.XXXXXX)
+FIFO_OUT=$(mktemp -u /tmp/akb-mcp-slug-out.XXXXXX)
+mkfifo "$FIFO_IN" "$FIFO_OUT"
+
+NODE_TLS_REJECT_UNAUTHORIZED=0 node "$AKB_MCP_BIN" \
+  --url "$BASE_URL/mcp/" --pat "$PAT" --insecure \
+  < "$FIFO_IN" > "$FIFO_OUT" 2>/dev/null &
+MCP_PID=$!
+
+exec 3>"$FIFO_IN" 4<"$FIFO_OUT"
+
+cleanup() {
+  exec 3>&- 4<&- 2>/dev/null
+  kill $MCP_PID 2>/dev/null; wait $MCP_PID 2>/dev/null
+  rm -f "$FIFO_IN" "$FIFO_OUT"
+}
+trap cleanup EXIT
+
+rpc_call() {
+  MSGID=$((MSGID+1))
+  local msg="{\"jsonrpc\":\"2.0\",\"id\":$MSGID,\"method\":\"$1\",\"params\":$2}"
+  echo "$msg" >&3
+  RESPONSE=""
+  read -r -t 30 RESPONSE <&4 || true
+  echo "$RESPONSE"
+}
+
+tool_result() {
+  echo "$1" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["result"]["content"][0]["text"])' 2>/dev/null
+}
+
+sleep 1
+
+# ── 1. Initialize ────────────────────────────────────────────
+echo ""
+echo "▸ 1. Initialize"
+INIT=$(rpc_call "initialize" '{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"put-slug-e2e","version":"1.0"}}')
+echo "$INIT" | python3 -c 'import sys,json; json.load(sys.stdin)["result"]["protocolVersion"]' >/dev/null 2>&1 && pass "Initialized" || fail "Init" "failed"
+echo '{"jsonrpc":"2.0","method":"notifications/initialized"}' >&3
+
+# ── 2. Verify slug param in akb_put schema ───────────────────
+echo ""
+echo "▸ 2. Verify slug param in akb_put schema"
+TOOLS=$(rpc_call "tools/list" '{}')
+PUT_HAS_SLUG=$(echo "$TOOLS" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+for t in d["result"]["tools"]:
+    if t["name"] == "akb_put":
+        print("slug" in t["inputSchema"]["properties"])
+        break
+' 2>/dev/null)
+[ "$PUT_HAS_SLUG" = "True" ] && pass "akb_put advertises slug param" || fail "akb_put schema" "slug param missing"
+
+# ── 3. Create vault ──────────────────────────────────────────
+echo ""
+echo "▸ 3. Create vault"
+VAULT="put-slug-e2e-$(date +%s)"
+VAULT_RESP=$(rpc_call "tools/call" "{\"name\":\"akb_create_vault\",\"arguments\":{\"name\":\"$VAULT\",\"description\":\"put slug param e2e\"}}")
+VAULT_ID=$(tool_result "$VAULT_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("vault_id",""))' 2>/dev/null)
+[ -n "$VAULT_ID" ] && pass "Created vault $VAULT" || fail "Create vault" "no vault_id"
+
+# ── 4. Explicit slug controls the path filename ──────────────
+echo ""
+echo "▸ 4. Explicit slug controls path (independent of title)"
+# Title slugifies to 'slug-path-probe-title'; the explicit slug must win.
+PUT_RESP=$(rpc_call "tools/call" "{\"name\":\"akb_put\",\"arguments\":{\"vault\":\"$VAULT\",\"collection\":\"probe\",\"title\":\"Slug Path Probe Title\",\"slug\":\"fixed-slug-xyz\",\"content\":\"# body\\n\\nslug probe\"}}")
+DOC_URI=$(tool_result "$PUT_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)
+DOC_PATH=$(tool_result "$PUT_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("path",""))' 2>/dev/null)
+echo "$DOC_URI" | grep -q "/fixed-slug-xyz\.md$" \
+  && pass "slug controls filename: uri=$DOC_URI" \
+  || fail "slug path" "expected uri ending /fixed-slug-xyz.md, got '$DOC_URI' (path='$DOC_PATH')"
+# Negative: the title slug must NOT be the path.
+echo "$DOC_URI" | grep -q "slug-path-probe-title" \
+  && fail "slug overrides title" "path fell back to the title slug: $DOC_URI" \
+  || pass "title slug not used when slug given"
+
+# ── 5. Title is preserved (slug only affects the path) ───────
+echo ""
+echo "▸ 5. Title independent of slug"
+GET_RESP=$(rpc_call "tools/call" "{\"name\":\"akb_get\",\"arguments\":{\"uri\":\"$DOC_URI\"}}")
+GOT_TITLE=$(tool_result "$GET_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("title",""))' 2>/dev/null)
+[ "$GOT_TITLE" = "Slug Path Probe Title" ] \
+  && pass "title preserved: '$GOT_TITLE'" \
+  || fail "title" "expected 'Slug Path Probe Title', got '$GOT_TITLE'"
+
+# ── 6. Omitting slug falls back to the title (control) ───────
+echo ""
+echo "▸ 6. Default — no slug derives the path from the title"
+PUT_RESP2=$(rpc_call "tools/call" "{\"name\":\"akb_put\",\"arguments\":{\"vault\":\"$VAULT\",\"collection\":\"probe\",\"title\":\"Title Derived Path\",\"content\":\"# body\\n\\nno slug\"}}")
+DOC_URI2=$(tool_result "$PUT_RESP2" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)
+echo "$DOC_URI2" | grep -q "/title-derived-path\.md$" \
+  && pass "default path from title: uri=$DOC_URI2" \
+  || fail "default path" "expected uri ending /title-derived-path.md, got '$DOC_URI2'"
+
+# ── Cleanup vault ─────────────────────────────────────────────
+echo ""
+echo "▸ Cleanup"
+rpc_call "tools/call" "{\"name\":\"akb_delete_vault\",\"arguments\":{\"name\":\"$VAULT\"}}" >/dev/null 2>&1
+pass "Vault deleted"
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  for e in "${ERRORS[@]}"; do echo "    - $e"; done
+  echo "════════════════════════════════════════════"
+  exit 1
+fi
+echo "════════════════════════════════════════════"

--- a/backend/tests/test_put_slug_e2e.sh
+++ b/backend/tests/test_put_slug_e2e.sh
@@ -145,8 +145,11 @@ echo "$DOC_URI2" | grep -q "/title-derived-path\.md$" \
 # ── Cleanup vault ─────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"
-rpc_call "tools/call" "{\"name\":\"akb_delete_vault\",\"arguments\":{\"name\":\"$VAULT\"}}" >/dev/null 2>&1
-pass "Vault deleted"
+DELETE_RESP=$(rpc_call "tools/call" "{\"name\":\"akb_delete_vault\",\"arguments\":{\"vault\":\"$VAULT\"}}")
+DELETE_OK=$(tool_result "$DELETE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("deleted") is True)' 2>/dev/null)
+[ "$DELETE_OK" = "True" ] \
+  && pass "Vault deleted" \
+  || fail "Cleanup" "akb_delete_vault did not confirm deletion"
 
 # ── Summary ──────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Closes #176.

## What

Expose an optional `slug` argument on the `akb_put` MCP tool, so an MCP caller can set the document path/uri filename independently of the title.

- `tools.py`: advertise `slug` in the `akb_put` `inputSchema`. The arg-allowlist (`_TOOL_ARG_NAMES`) is schema-derived, so this also makes `_dispatch` accept it (no separate allowlist edit needed).
- `server.py` `_handle_put`: forward `slug=args.get("slug")` into `DocumentPutRequest`.

The model field (`DocumentPutRequest.slug`) and `document_service._put` already honor it (`slug = (req.slug and _slugify(req.slug)) or _slugify(req.title)`), so no downstream change is needed. The frontend "Create from template" and the seed flow already use `slug` via the backend directly — this brings MCP callers to parity.

## Behavior

- Optional and backwards-compatible: when omitted, the path keeps deriving from the title (unchanged).
- `slug` controls the path/uri filename (`akb://{vault}/coll/{collection}/doc/{slug}.md`, or `akb://{vault}/doc/{slug}.md` at the root), not the `d-` id.
- `akb_update` is intentionally left unchanged: a document path is fixed at create, so a slug on update has no meaning.
- Sanitization is the existing `_slugify` (lowercases, strips non-word characters, collapses separators, truncates to 80) — a caller-supplied slug cannot introduce path traversal or injection.

## Tests

`backend/tests/test_akb_put_slug_unit.py` — AST-based, no heavy imports (same dependency-light pattern as `test_mcp_tool_validation_unit.py`):

- `akb_put` advertises `slug` in its `inputSchema` (which also enables the schema-derived validator).
- `_handle_put` forwards `args.get("slug")` into `DocumentPutRequest`.
