### PR TITLE
feat(0.8.7): Keycloak SSO — cross-origin companion-app post-login redirect allowlist (REEF-001)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2569
+        "line_number": 2589
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T11:17:21Z"
+  "generated_at": "2026-06-09T15:02:49Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,26 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.7 — 2026-06-10  *(minor — Keycloak SSO: cross-origin companion-app post-login redirect allowlist)*
+
+A single AKB backend can act as the identity owner for a small family of first-party apps on **different origins** (e.g. reef at `reef-<slug>.<domain>` alongside akb's own `akb-<slug>.<domain>`), each delegating to the *same* tenant Keycloak client instead of registering its own. The blocker was that the SSO post-login redirect was a **single per-instance** `keycloak_post_login_path`: the callback always bounced the one-time code to that one same-site path, and `_safe_redirect_path()` collapsed any cross-origin redirect (open-redirect guard). So akb's own SPA and a companion app could not both complete SSO — they fought over one global path, and pointing `keycloak_post_login_path` at the companion's absolute URL (the earlier workaround) just broke akb's own SPA instead.
+
+New optional setting **`keycloak_post_login_allowed_origins`** (list, default empty) lifts this **per request** without weakening the open-redirect guard:
+
+- A companion app starts SSO via `GET /auth/keycloak/login?redirect=<absolute-URL-on-an-allowlisted-origin>`; the callback delivers the one-time `code` straight to that URL (origin + path + its own query preserved). It then exchanges the code server-side via the existing `POST /auth/keycloak/exchange` — same single-use, ≤60s-TTL guarantees as the akb-SPA path, now delivered to a vetted origin.
+- akb's own SPA (a same-site `redirect` path) is unchanged: code goes to `keycloak_post_login_path?code=&redirect=<safe path>`.
+- **Empty list ⇒ identical to before.** No origin can ever receive the code; behaviour is 100% the pre-existing same-site flow.
+- **Open-redirect protection preserved.** Any redirect whose origin is not explicitly listed — absolute URLs, scheme-relative `//host`, and `https://trusted@evil.com` userinfo spoofs — collapses to the safe same-site path. Origins match as `scheme://host[:port]`.
+- **Re-validated at delivery.** The origin is checked at `begin_login` *and* again in the callback, so a config change during the ≤10-min flow window can only ever tighten where the code goes; flow-state values are never trusted blindly.
+- No new trust in the companion: it still stores no Keycloak client/secret/realm — identity stays owned by AKB.
+
+This is the AKB-side counterpart to the reef SSO-delegation work (reef-test REEF-102 / REEF-112) and supersedes the "point `keycloak_post_login_path` at the companion's absolute URL" workaround, which could satisfy only one origin per instance.
+
+`backend/app/api/routes/auth.py` gains `_normalize_origin` / `_allowed_companion_origin` / `_with_query_param` / `_post_login_target`; `keycloak_login` and `keycloak_callback` route through them. `backend/app/config.py` adds the setting (default empty). `config/app.yaml.example` and `docs/designs/keycloak-oidc/00-overview.md` document it.
+
+### Tests
+`tests/test_keycloak_redirect_unit.py` (new, 21 cases, no DB) pins the allowlist gate and the open-redirect guard: origin normalization (host lowercasing, port retention, non-http rejection), the userinfo-spoof rejection even when the trusted origin is listed, empty-list ⇒ same-site for every input, listed-origin code delivery with existing query preserved, and unlisted/absolute/scheme-relative collapse to the safe path.
+
 ## 0.8.6 — 2026-06-08  *(patch — GET document: read body at the row's current_commit, not floating HEAD (E03 read-side race))*
 
 `GET /documents/{vault}/{id}` (`akb_get`) assembled its response from **two unsynchronized reads**: the body via `git.read_file(vault, path)` — which reads the *floating vault HEAD* — and `current_commit` from the DB row. Under concurrent updates to the **same** document, a writer could advance git HEAD and the DB row between those two reads, so a single response carried a `content` and a `current_commit` belonging to **different writers** (the "E03" symptom: body ↔ current_commit disagree).

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -109,11 +109,98 @@ def _safe_redirect_path(raw: str | None) -> str:
     return raw
 
 
+def _normalize_origin(value: str | None) -> str | None:
+    """Canonical ``scheme://host[:port]`` for an absolute http(s) URL, else None.
+
+    Rejects anything that is not a plain absolute http/https URL: relative
+    paths, scheme-relative ``//host``, non-web schemes, and — crucially —
+    URLs carrying embedded credentials (``https://trusted@evil.com``, whose
+    real host is ``evil.com``), a classic origin-spoofing trick. The host is
+    lowercased so the comparison is case-insensitive.
+    """
+    if not value:
+        return None
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    if "@" in parsed.netloc:  # embedded userinfo — spoof guard
+        return None
+    origin = f"{parsed.scheme}://{parsed.hostname.lower()}"
+    if parsed.port is not None:
+        origin += f":{parsed.port}"
+    return origin
+
+
+def _allowed_companion_origin(raw: str | None) -> str | None:
+    """Origin of ``raw`` iff it is an absolute URL on a configured companion
+    origin (``keycloak_post_login_allowed_origins``); otherwise None.
+
+    This allowlist is the ONLY gate that lets the post-login one-time code
+    leave akb's own origin. An empty list ⇒ always None ⇒ the same-site
+    behaviour that predates the option.
+    """
+    origin = _normalize_origin(raw)
+    if origin is None:
+        return None
+    allowed = {
+        _normalize_origin(o) for o in settings.keycloak_post_login_allowed_origins
+    }
+    return origin if origin in allowed else None
+
+
+def _with_query_param(url: str, key: str, value: str) -> str:
+    """Append ``key=value`` to ``url``'s query, preserving existing query
+    and fragment."""
+    parts = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    query.append((key, value))
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, parts.path,
+         urllib.parse.urlencode(query), parts.fragment)
+    )
+
+
+def _post_login_target(redirect: str | None, one_time_code: str) -> str:
+    """Build the URL the SSO callback bounces the browser to, carrying the
+    one-time code. Two shapes, chosen per request:
+
+    - **Companion app** (cross-origin SSO delegation): ``redirect`` is an
+      absolute URL on an allowlisted origin → deliver the code straight to
+      that URL (origin + path + its own query preserved). This is how a
+      first-party app like reef, riding akb's Keycloak client, gets the code
+      back on *its* origin instead of akb's SPA.
+    - **Default / akb's own SPA**: append the code to the same-site
+      ``keycloak_post_login_path`` and carry the safe in-app path as
+      ``redirect``. Any non-allowlisted absolute / scheme-relative value
+      collapses here (open-redirect protection).
+
+    The allowlist is re-checked here (not just at login time) so the
+    delivery decision always reflects current config, never a value frozen
+    into flow state minutes earlier.
+    """
+    if _allowed_companion_origin(redirect) is not None:
+        return _with_query_param(redirect, "code", one_time_code)  # type: ignore[arg-type]
+    safe = _safe_redirect_path(redirect)
+    return (
+        f"{settings.keycloak_post_login_path}"
+        f"?code={urllib.parse.quote(one_time_code)}"
+        f"&redirect={urllib.parse.quote(safe, safe='')}"
+    )
+
+
 @router.get("/auth/keycloak/login", summary="Begin Keycloak SSO login")
 async def keycloak_login(redirect: str = "/"):
     _require_keycloak()
     from app.services.keycloak_oidc import get_keycloak_oidc
-    url = await get_keycloak_oidc().begin_login(_safe_redirect_path(redirect))
+    # An allowlisted companion-app absolute URL rides through verbatim
+    # (re-validated at callback time); everything else is reduced to a safe
+    # same-site path before it ever enters the flow state.
+    dest = (
+        redirect
+        if _allowed_companion_origin(redirect) is not None
+        else _safe_redirect_path(redirect)
+    )
+    url = await get_keycloak_oidc().begin_login(dest)
     return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
 
 
@@ -153,12 +240,7 @@ async def keycloak_callback(request: Request):
     # Stash the Keycloak id_token too so the SPA can pass it back as
     # id_token_hint on logout (seamless RP-initiated logout, no KC prompt).
     one_time = await issue_exchange_code({**login_response, "kc_id_token": id_token})
-    dest = _safe_redirect_path(flow.get("redirect_path", "/"))
-    target = (
-        f"{settings.keycloak_post_login_path}"
-        f"?code={urllib.parse.quote(one_time)}"
-        f"&redirect={urllib.parse.quote(dest, safe='')}"
-    )
+    target = _post_login_target(flow.get("redirect_path", "/"), one_time)
     return RedirectResponse(target, status_code=status.HTTP_302_FOUND)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -202,6 +202,28 @@ class Settings(BaseModel):
     # Relative → resolves against the request origin (same host the user
     # is already on), so it works for both :3000 dev proxy and prod ingress.
     keycloak_post_login_path: str = "/auth/callback"
+    # Companion-app post-login origins for cross-origin SSO delegation.
+    #
+    # Empty (default) → the post-login one-time code is ALWAYS delivered to
+    # the same-site keycloak_post_login_path (AKB's own SPA). Behaviour is
+    # then 100% identical to before this option existed; no other origin can
+    # ever receive the code.
+    #
+    # When set, a first-party companion app served on a listed origin (e.g.
+    # reef at https://reef-<slug>.<domain>) can ride THIS akb's Keycloak
+    # client without owning its own client/realm/secret. It starts SSO via
+    #   GET /auth/keycloak/login?redirect=<absolute-callback-URL-on-that-origin>
+    # and akb delivers the one-time code to that URL (which the companion
+    # then exchanges server-side via POST /auth/keycloak/exchange). This is
+    # what makes a single per-instance keycloak_post_login_path stop being a
+    # bottleneck: akb's own SPA and the companion can both complete SSO,
+    # selected per request by the redirect target rather than one global path.
+    #
+    # Open-redirect protection is preserved: a redirect whose origin is NOT
+    # in this list collapses to the safe same-site path. Each entry must be a
+    # full origin matched as scheme://host[:port], e.g.
+    #   ["https://reef-acme.example.com"]
+    keycloak_post_login_allowed_origins: list[str] = Field(default_factory=list)
     # One-time exchange-code TTL (seconds). The callback hands the SPA a
     # short-lived opaque code; the SPA trades it for the AKB JWT over a
     # POST so the token never rides in a URL. Keep this small.

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -132,7 +132,13 @@ class KeycloakOIDC:
     # ── Authorization request ────────────────────────────────────────
     async def begin_login(self, redirect_path: str = "/") -> str:
         """Create CSRF state (+PKCE for public clients) and return the
-        Keycloak authorization URL to redirect the browser to."""
+        Keycloak authorization URL to redirect the browser to.
+
+        ``redirect_path`` is the caller-vetted post-login destination carried
+        opaquely through flow state. It is normally a same-site path, but may
+        be an allowlisted companion-app absolute URL (cross-origin SSO); the
+        callback (`_post_login_target`) re-validates it before delivering the
+        one-time code, so this layer just stores it verbatim."""
         state = secrets.token_urlsafe(32)
         payload: dict[str, str] = {"redirect_path": redirect_path}
         params: dict[str, str] = {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.6"
+version = "0.8.7"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_keycloak_redirect_unit.py
+++ b/backend/tests/test_keycloak_redirect_unit.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Keycloak SSO post-login redirect logic.
+
+Pure-function tests (no DB, no Keycloak) covering the cross-origin
+companion-app allowlist and the open-redirect guard. The single security
+invariant under test: the post-login one-time code can leave akb's own
+origin ONLY for an origin explicitly in
+``settings.keycloak_post_login_allowed_origins``; everything else collapses
+to the safe same-site path.
+"""
+from __future__ import annotations
+
+import urllib.parse
+
+import pytest
+
+from app.api.routes import auth
+from app.config import settings
+
+
+@pytest.fixture
+def allow(monkeypatch):
+    """Set the companion-origin allowlist for one test."""
+    def _set(origins: list[str]) -> None:
+        monkeypatch.setattr(
+            settings, "keycloak_post_login_allowed_origins", origins, raising=False
+        )
+    return _set
+
+
+# ── _normalize_origin ────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://reef.example.com", "https://reef.example.com"),
+        ("https://reef.example.com/cb?x=1", "https://reef.example.com"),
+        ("https://Reef.Example.COM/cb", "https://reef.example.com"),  # host lowercased
+        ("http://localhost:5173/cb", "http://localhost:5173"),        # port kept
+        # Not absolute http(s) URLs → None.
+        ("/auth/callback", None),
+        ("//evil.com", None),
+        ("", None),
+        (None, None),
+        ("ftp://reef.example.com", None),
+        ("javascript:alert(1)", None),
+        # Userinfo spoof: real host is evil.com, must NOT normalize to trusted.
+        ("https://reef.example.com@evil.com/cb", None),
+    ],
+)
+def test_normalize_origin(value, expected):
+    assert auth._normalize_origin(value) == expected
+
+
+# ── _allowed_companion_origin ────────────────────────────────────────
+
+def test_empty_allowlist_blocks_everything(allow):
+    allow([])
+    assert auth._allowed_companion_origin("https://reef.example.com/cb") is None
+    assert auth._allowed_companion_origin("/auth/callback") is None
+
+
+def test_listed_origin_allowed(allow):
+    allow(["https://reef.example.com"])
+    assert (
+        auth._allowed_companion_origin("https://reef.example.com/api/auth/cb?next=/x")
+        == "https://reef.example.com"
+    )
+
+
+def test_unlisted_origin_blocked(allow):
+    allow(["https://reef.example.com"])
+    assert auth._allowed_companion_origin("https://evil.com/cb") is None
+
+
+def test_userinfo_spoof_blocked_even_when_prefix_listed(allow):
+    # Listing the trusted origin must not let an attacker smuggle it as
+    # userinfo in front of their own host.
+    allow(["https://reef.example.com"])
+    assert auth._allowed_companion_origin("https://reef.example.com@evil.com/cb") is None
+
+
+def test_allowlist_entries_normalized(allow):
+    # A sloppily-configured entry (trailing path, mixed case) still matches
+    # because both sides go through _normalize_origin.
+    allow(["https://Reef.Example.com/ignored"])
+    assert (
+        auth._allowed_companion_origin("https://reef.example.com/cb")
+        == "https://reef.example.com"
+    )
+
+
+# ── _post_login_target ───────────────────────────────────────────────
+
+def test_target_same_site_default(allow):
+    allow([])
+    target = auth._post_login_target("/dashboard", "CODE123")
+    assert target.startswith(settings.keycloak_post_login_path + "?")
+    q = urllib.parse.parse_qs(urllib.parse.urlsplit(target).query)
+    assert q["code"] == ["CODE123"]
+    assert q["redirect"] == ["/dashboard"]
+
+
+def test_target_open_redirect_collapses(allow):
+    # Absolute URL but NOT allowlisted → must not leave the same-site path.
+    allow([])
+    target = auth._post_login_target("https://evil.com/steal", "CODE123")
+    assert target.startswith(settings.keycloak_post_login_path + "?")
+    q = urllib.parse.parse_qs(urllib.parse.urlsplit(target).query)
+    assert q["redirect"] == ["/"]  # collapsed by _safe_redirect_path
+
+
+def test_target_companion_origin_gets_code(allow):
+    allow(["https://reef.example.com"])
+    target = auth._post_login_target(
+        "https://reef.example.com/api/auth/akb/sso/callback", "CODE123"
+    )
+    parts = urllib.parse.urlsplit(target)
+    assert f"{parts.scheme}://{parts.netloc}" == "https://reef.example.com"
+    assert parts.path == "/api/auth/akb/sso/callback"
+    q = urllib.parse.parse_qs(parts.query)
+    assert q["code"] == ["CODE123"]
+
+
+def test_target_companion_preserves_existing_query(allow):
+    allow(["https://reef.example.com"])
+    target = auth._post_login_target(
+        "https://reef.example.com/cb?next=%2Fdash", "CODE123"
+    )
+    q = urllib.parse.parse_qs(urllib.parse.urlsplit(target).query)
+    assert q["next"] == ["/dash"]
+    assert q["code"] == ["CODE123"]
+
+
+def test_target_unlisted_absolute_collapses_to_root(allow):
+    allow(["https://reef.example.com"])
+    target = auth._post_login_target("https://other.example.com/cb", "CODE123")
+    assert target.startswith(settings.keycloak_post_login_path + "?")
+    q = urllib.parse.parse_qs(urllib.parse.urlsplit(target).query)
+    assert q["redirect"] == ["/"]

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -102,6 +102,11 @@ jwt_expire_hours: 24
 #                                         # Default false = no silent merge (OSS-safe).
 # keycloak_redirect_uri: "https://akb.example.com/api/v1/auth/keycloak/callback"
 # keycloak_post_login_path: "/auth/callback"
+# keycloak_post_login_allowed_origins: []   # companion-app origins allowed to receive the SSO
+#                                           # one-time code, e.g. ["https://reef-acme.example.com"].
+#                                           # Lets a first-party app (reef) ride this akb's Keycloak
+#                                           # client and get the code back on ITS origin. Empty =
+#                                           # akb's own SPA only (open-redirect-safe default).
 # keycloak_exchange_code_ttl_secs: 60
 # keycloak_client_secret lives in secret.yaml (never commit it)
 

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -86,6 +86,59 @@ The `/exchange` response intentionally mirrors the existing
 `/auth/login` response (`{token, user:{id,username,email,display_name,is_admin}}`)
 so the SPA reuses `setToken()` and the rest of the Bearer flow verbatim.
 
+## Cross-origin companion apps (post-login origin allowlist)
+
+A single AKB backend can act as the identity owner for a small ecosystem of
+first-party apps on *different* origins (e.g. reef at `reef-<slug>.<domain>`
+alongside akb's own `akb-<slug>.<domain>`), each delegating to the same
+tenant Keycloak client rather than registering its own. The blocker was
+that the post-login redirect was a **single per-instance**
+`keycloak_post_login_path`: the callback always bounced the one-time code to
+that one same-site path, and `_safe_redirect_path()` collapsed any
+cross-origin redirect. So akb's SPA and a companion app could not both
+complete SSO — they fought over one global path.
+
+`keycloak_post_login_allowed_origins` lifts this **per request** without
+weakening the open-redirect guard:
+
+```
+[reef]  GET {AKB}/api/v1/auth/keycloak/login
+              ?redirect=https://reef-acme.example.com/api/auth/akb/sso/callback
+          → redirect's origin ∈ allowlist → carried through flow state
+          → 302 to Keycloak  (same client, same realm — reef owns none of it)
+
+[callback]  _post_login_target() re-checks the origin against the allowlist:
+              ∈ list  → 302 to {that absolute URL}?code=<one_time>   (reef's origin)
+              ∉ list  → 302 to {keycloak_post_login_path}?code=&redirect=<safe path>
+
+[reef server]  POST {AKB}/api/v1/auth/keycloak/exchange { code } → { token, user }
+               → set its own __reef_session cookie
+```
+
+Properties that keep this safe:
+
+- **Empty allowlist ⇒ identical to before.** `_allowed_companion_origin()`
+  returns None for every input, so the code can only ever reach the
+  same-site `keycloak_post_login_path`. No behavioural change for
+  deployments that don't opt in.
+- **The allowlist is the only escape hatch.** Any redirect whose origin is
+  not explicitly listed — including absolute URLs, scheme-relative `//host`,
+  and `https://trusted@evil.com` userinfo spoofs — collapses to the safe
+  same-site path. Origins are matched as `scheme://host[:port]`.
+- **Re-validated at delivery.** The origin is checked at `begin_login` AND
+  again in `_post_login_target` at callback time, so a config change during
+  the ≤10-min flow window can only ever *tighten* where the code goes.
+- **No new trust in the companion.** reef still stores no Keycloak
+  client/secret/realm; identity stays owned by AKB. The one-time code is
+  single-use, ≤60s TTL, and exchanged server-side — same guarantees as the
+  akb-SPA path, now delivered to a vetted origin instead of only the
+  same host.
+
+This is the AKB-side counterpart to reef-test REEF-102 / REEF-112 (reef SSO
+delegation) and supersedes the earlier "just point
+`keycloak_post_login_path` at reef's absolute URL" workaround, which could
+only satisfy one origin per instance.
+
 ## Token validation (ported from seahorse, AKB deps)
 
 - **Local JWKS, no remote introspection.** Fetch JWKS from
@@ -133,6 +186,9 @@ so the SPA reuses `setToken()` and the rest of the Bearer flow verbatim.
   sentinel. `create_jwt()` / `resolve_token()` **unchanged**.
 - `backend/app/config.py` — flat `keycloak_*` settings + derived-endpoint
   properties (see below). `keycloak_enabled` defaults `false`.
+  `keycloak_post_login_allowed_origins` (list, default empty) gates the
+  cross-origin companion-app post-login redirect (see "Cross-origin
+  companion apps" above).
 - `backend/app/services/lifecycle.py` — fail-fast validation when
   enabled; close the Keycloak httpx client on shutdown.
 


### PR DESCRIPTION
## What

Adds an optional `keycloak_post_login_allowed_origins` setting (list, default empty) so a single AKB backend can be the identity owner for first-party apps on **different origins** (e.g. `reef-<slug>.<domain>` alongside akb's own `akb-<slug>.<domain>`), each delegating to the *same* tenant Keycloak client without registering its own.

## Why

The SSO post-login redirect was a **single per-instance** `keycloak_post_login_path`, and `_safe_redirect_path()` collapsed any cross-origin redirect (open-redirect guard). So akb's own SPA and a companion app fought over one global path — and pointing `keycloak_post_login_path` at the companion's absolute URL (the earlier workaround) just broke akb's own SPA instead. This lifts the limitation **per request**.

## How

- Companion starts SSO via `GET /auth/keycloak/login?redirect=<absolute-URL-on-an-allowlisted-origin>`; the callback delivers the one-time `code` straight to that URL (origin + path + its own query preserved), then it exchanges server-side via the existing `POST /auth/keycloak/exchange`.
- akb's own SPA (same-site `redirect` path) is **unchanged**.
- New helpers in `auth.py`: `_normalize_origin` / `_allowed_companion_origin` / `_with_query_param` / `_post_login_target`; `keycloak_login` + `keycloak_callback` route through them.

## Safety

- **Empty list ⇒ 100% identical to prior behaviour.** No origin can ever receive the code.
- **Open-redirect protection preserved.** Absolute URLs, scheme-relative `//host`, and `https://trusted@evil.com` userinfo spoofs all collapse to the safe same-site path. Origins match as `scheme://host[:port]`.
- **Re-validated at `begin_login` AND at the callback**, so a config change during the ≤10-min flow window can only ever *tighten* where the code goes; flow-state values are never trusted blindly.
- No new trust in the companion: it stores no Keycloak client/secret/realm — identity stays owned by AKB.

## Context

AKB-side counterpart to reef SSO-delegation (reef-test REEF-102 / REEF-112) and the reef-akb PM issue **REEF-001**. Supersedes the "point `keycloak_post_login_path` at the companion's absolute URL" workaround, which could satisfy only one origin per instance.

## Tests

- `backend/tests/test_keycloak_redirect_unit.py` — new, **21 cases, no DB**: origin normalization (host lowercasing, port retention, non-http rejection), userinfo-spoof rejection even when the trusted origin is listed, empty-list ⇒ same-site for every input, listed-origin code delivery with existing query preserved, unlisted/absolute/scheme-relative collapse to the safe path.
- Full `scripts/check.sh` green (ruff / mypy / bandit / eslint / tsc / vitest 247✓ / detect-secrets).
- Deployed to internal cluster (`:latest`) and verified live: begin endpoint 302s a reef redirect to Keycloak, `/readyz` healthy, config loaded. Full end-to-end SSO completion to be validated as an akb-platform integration test (needs reef-web REEF-114).

Docs: `docs/designs/keycloak-oidc/00-overview.md` (new "Cross-origin companion apps" section) + `config/app.yaml.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)