### PR TITLE
fix(akb): literal-aware multi-statement guard for akb_sql

### DIFF
--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -205,6 +205,42 @@ def _scan_dollar_quote(sql: str, start: int) -> int | None:
     return end + len(tag)
 
 
+def count_statement_separators(sql: str) -> int:
+    """Count the ``;`` characters in ``sql`` that act as statement
+    separators — i.e. appear OUTSIDE string literals, quoted
+    identifiers, comments, and dollar-quoted blocks.
+
+    Shares the tokenizer (``_SQL_TOKEN_RE`` + ``_scan_dollar_quote``)
+    with ``rewrite_table_names`` so the multi-statement guard in
+    ``table_service.execute_sql`` classifies semicolons with exactly
+    the same scope-awareness as the rewriter. The previous guard was a
+    literal-blind ``";" in sql`` membership test, which rejected single
+    statements like ``VALUES ('Fix bug; refactor')`` (issue #180).
+
+    Tolerance for trailing semicolons is the caller's policy: this
+    helper reports every separator it sees.
+    """
+    count = 0
+    pos = 0
+    n = len(sql)
+    while pos < n:
+        # Same walk order as `rewrite_table_names`: manual dollar-quote
+        # scan first, then the token regex.
+        end = _scan_dollar_quote(sql, pos)
+        if end is not None:
+            pos = end
+            continue
+        m = _SQL_TOKEN_RE.match(sql, pos)
+        if not m:
+            # Should not happen — `sym` catches any character. Safety net.
+            pos += 1
+            continue
+        if m.lastgroup == "sym" and m.group() == ";":
+            count += 1
+        pos = m.end()
+    return count
+
+
 def rewrite_table_names(sql: str, table_map: dict[str, str]) -> str:
     """Replace short table names in ``sql`` with their pg-qualified
     names, but ONLY for bare identifiers — never inside string literals,

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -49,6 +49,7 @@ from app.util.text import fuzzy_hint
 # `table_data_repo`.
 from app.repositories.table_data_repo import (  # noqa: F401
     build_table_name_map,
+    count_statement_separators,
     rewrite_table_names,
 )
 
@@ -512,8 +513,13 @@ async def execute_sql(
         table_map = await table_data_repo.build_table_name_map(conn, vault_names)
         rewritten = table_data_repo.rewrite_table_names(sql, table_map)
 
+        # Literal-aware single-statement boundary (issue #180): a `;`
+        # only counts as a separator outside string literals, quoted
+        # identifiers, comments, and dollar-quoted blocks — same token
+        # classes the rewriter above already walks. Trailing-semicolon
+        # tolerance (`rstrip(";")`) is preserved as-is.
         sql_check = rewritten.rstrip(";").strip()
-        if ";" in sql_check:
+        if count_statement_separators(sql_check) > 0:
             return err(
                 "Multi-statement SQL is not allowed. Send one statement at a time.",
                 code=MULTI_STATEMENT,

--- a/backend/tests/test_sql_multi_statement_guard_unit.py
+++ b/backend/tests/test_sql_multi_statement_guard_unit.py
@@ -1,0 +1,144 @@
+"""Unit tests for the literal-aware multi-statement guard (issue #180).
+
+``table_service.execute_sql`` used to enforce its single-statement
+boundary with a literal-blind ``";" in sql_check`` test, so a semicolon
+inside a string literal (``VALUES ('Fix bug; refactor')``) was rejected
+as multi-statement. The guard now reuses the rewriter's tokenizer via
+``count_statement_separators``: a ``;`` only counts as a statement
+separator outside string literals, quoted identifiers, comments, and
+dollar-quoted blocks.
+
+Two layers are pinned here:
+
+  1. ``count_statement_separators`` itself — a pure function next to
+     ``rewrite_table_names``, dependency-light (no DB, no pool).
+  2. The wiring in ``execute_sql`` — verified by AST instead of
+     importing ``table_service`` (which transitively pulls chunking /
+     executor machinery), the same dependency-avoidance pattern as
+     ``test_mcp_tool_validation_unit.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from app.repositories.table_data_repo import count_statement_separators
+
+
+# ── 1. separator counting is literal-aware ──────────────────────
+
+
+def test_literal_semicolon_in_string_is_not_a_separator():
+    """The motivating case: real-world text with a `;` must be storable
+    losslessly through a single INSERT (issue #180)."""
+    sql = "INSERT INTO source_github_issues (title) VALUES ('Fix bug; refactor')"
+    assert count_statement_separators(sql) == 0
+
+
+def test_genuine_multi_statement_still_detected():
+    assert count_statement_separators("SELECT 1; SELECT 2") == 1
+    assert count_statement_separators("SELECT 1; SELECT 2; SELECT 3") == 2
+    # Mixed: one literal `;`, one real separator — still multi-statement.
+    assert count_statement_separators("SELECT 'a;b'; SELECT 2") == 1
+
+
+def test_semicolon_inside_dollar_quotes_is_not_a_separator():
+    assert count_statement_separators("SELECT $$a; b$$") == 0
+    assert count_statement_separators("SELECT $tag$one; two; three$tag$") == 0
+
+
+def test_semicolon_inside_comments_is_not_a_separator():
+    assert count_statement_separators("SELECT 1 -- trailing; note") == 0
+    assert count_statement_separators("SELECT /* a; b; c */ 1") == 0
+
+
+def test_semicolon_inside_quoted_identifier_is_not_a_separator():
+    assert count_statement_separators('SELECT "weird;col" FROM pipeline') == 0
+
+
+def test_escaped_quote_inside_string_does_not_desync_the_scan():
+    """PG escapes a quote as '' inside a literal; the `;` after it is
+    still inside the string."""
+    assert count_statement_separators("SELECT 'it''s; fine'") == 0
+
+
+def test_trailing_separator_is_still_counted_by_the_pure_helper():
+    """Tolerance for a trailing `;` is execute_sql's policy (it
+    `rstrip(";")`s before counting — pinned by AST below), not the
+    helper's: the helper reports every separator it sees."""
+    assert count_statement_separators("SELECT 1;") == 1
+    assert count_statement_separators("SELECT 1;".rstrip(";").strip()) == 0
+
+
+# ── 2. execute_sql wiring (AST; no heavy imports) ───────────────
+
+_TABLE_SERVICE = (
+    Path(__file__).resolve().parents[1] / "app" / "services" / "table_service.py"
+)
+
+
+def _execute_sql_fn() -> ast.AsyncFunctionDef:
+    tree = ast.parse(_TABLE_SERVICE.read_text())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "execute_sql"
+        ):
+            return node
+    raise AssertionError("execute_sql not found in table_service.py")
+
+
+def _called_names(fn: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Name):
+                names.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                names.add(f.attr)
+    return names
+
+
+def test_execute_sql_uses_the_literal_aware_guard():
+    fn = _execute_sql_fn()
+    assert "count_statement_separators" in _called_names(fn), (
+        "execute_sql must route the multi-statement check through "
+        "count_statement_separators"
+    )
+
+
+def test_execute_sql_dropped_the_literal_blind_membership_test():
+    """The old guard was `";" in sql_check` — a Compare(In) against the
+    constant ";". It must be gone, or literal semicolons are rejected
+    again."""
+    fn = _execute_sql_fn()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Compare) and any(
+            isinstance(op, ast.In) for op in node.ops
+        ):
+            left = node.left
+            assert not (
+                isinstance(left, ast.Constant) and left.value == ";"
+            ), 'execute_sql still contains the literal-blind `";" in ...` guard'
+
+
+def test_execute_sql_keeps_trailing_semicolon_tolerance():
+    """`SELECT 1;` must keep working: the guard strips trailing
+    semicolons (`rstrip(";")`) before counting separators."""
+    fn = _execute_sql_fn()
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "rstrip"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == ";"
+        ):
+            return
+    raise AssertionError(
+        'execute_sql no longer rstrip(";")s before the separator count — '
+        "trailing-semicolon tolerance lost"
+    )


### PR DESCRIPTION
Closes #180.

## What Changed

`execute_sql`'s multi-statement boundary now classifies semicolons with the same scope-awareness as the table-name rewriter: a new `count_statement_separators()` in `table_data_repo` shares `_SQL_TOKEN_RE` and `_scan_dollar_quote`, so a `;` only counts as a separator outside string literals, quoted identifiers, comments, and dollar-quoted blocks. The guard in `table_service.execute_sql` replaces the literal-blind `";" in sql_check` membership test with it; the `MULTI_STATEMENT` error and trailing-semicolon tolerance are unchanged.

## Why

A single valid statement like `INSERT ... VALUES ('Fix bug; refactor')` was rejected as multi-statement, so callers syncing real-world text could not store a semicolon losslessly — the OSS akb-collector currently substitutes a fullwidth `；` before writing, which silently corrupts source-origin content. Statement-boundary classification is AKB's contract to own; the tokenizer that already understands these token classes was one import away.

## Not Included

No change to the allowed-statement keyword check or archived-vault gating. No relaxation for genuine multi-statement input — `SELECT 1; SELECT 2` still fails with the same error.

## Validation

- `cd backend && uv run pytest tests/test_sql_multi_statement_guard_unit.py tests/test_table_identifier_unit.py tests/test_table_name_length_unit.py` — 20 passed.
- Full non-e2e backend suite: 167 passed, 61 skipped (infra-gated skips unchanged).
- New tests cover: literal `;` in a single statement passes; `SELECT 1; SELECT 2` fails; `;` inside dollar quotes, line/block comments, and quoted identifiers passes; trailing semicolons tolerated.
