### PR TITLE
fix(akb): certify the canonical parsed-body content_hash on document writes

### DIFF
--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -200,6 +200,22 @@ def _body_content_hash(body: str) -> str:
     return compute_text_content_hash(body)
 
 
+def _certified_content_hash(md_content: str) -> str:
+    """Hash of the body exactly as a later ``get`` will serve it.
+
+    ``get`` parses the stored markdown (``frontmatter.loads``) and hashes
+    the parsed body — and python-frontmatter strips surrounding
+    whitespace on load. Hashing the raw request body instead certified a
+    write-response hash that no later read would ever confirm whenever
+    the body had leading/trailing whitespace (issue #181). Parsing the
+    composed markdown back makes write-response, DB row, and get agree
+    by construction, and turns the read-side ``_ensure_document_hash``
+    self-heal into a no-op for fresh writes.
+    """
+    _, canonical_body = _parse_markdown(md_content)
+    return _body_content_hash(canonical_body)
+
+
 class DocumentService:
     def __init__(self, git: GitService | None = None):
         self.git = git or GitService()
@@ -424,7 +440,7 @@ class DocumentService:
         if agent_id:
             fm_dict["created_by"] = agent_id
         md_content = _compose_markdown(fm_dict, req.content)
-        content_hash = _body_content_hash(req.content)
+        content_hash = _certified_content_hash(md_content)
 
         # Git commit
         commit_msg = f"[put] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: create\nsummary: {req.title}"
@@ -722,7 +738,7 @@ class DocumentService:
         new_body = req.content if req.content is not None else current_body
         new_md = _compose_markdown(current_fm, new_body)
         previous_hash = current_hash
-        content_hash = _body_content_hash(new_body)
+        content_hash = _certified_content_hash(new_md)
 
         message = req.message or f"Update {file_path}"
         commit_msg = f"[update] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: update\nsummary: {message}"

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -1113,7 +1113,7 @@ class DocumentService:
         current_fm["updated_at"] = now.isoformat()
         new_md = _compose_markdown(current_fm, new_body)
         previous_hash = row.get("content_hash") or _body_content_hash(current_body)
-        content_hash = _body_content_hash(new_body)
+        content_hash = _certified_content_hash(new_md)
 
         msg = message or f"Edit {file_path}"
         commit_msg = f"[edit] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: edit\nsummary: {msg}"

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -330,8 +330,9 @@ class _CommittingGit:
     """Records the markdown handed to commit_file and serves it back on
     read_file — i.e. behaves like the real git round-trip."""
 
-    def __init__(self, commit: str):
+    def __init__(self, commit: str, initial_raw: str | None = None):
         self.commit = commit
+        self.initial_raw = initial_raw
         self.committed_md: str | None = None
 
     def commit_file(self, *, vault_name, file_path, content, message, author_name) -> str:
@@ -339,16 +340,22 @@ class _CommittingGit:
         return self.commit
 
     def read_file(self, vault: str, path: str, commit: str | None = None) -> str:
-        assert self.committed_md is not None, "read before any commit"
-        return self.committed_md
+        if self.committed_md is not None:
+            return self.committed_md
+        assert self.initial_raw is not None, "read before any commit"
+        return self.initial_raw
 
 
 def _patch_index_side_effects(monkeypatch) -> None:
     """Neutralize the chunk/relations/event writes that need a live DB."""
+    import app.repositories.document_repo as document_repo
     import app.services.document_service as ds
 
     async def fake_write_source_chunks(conn, kind, doc_id, *, vault_id, chunks):
         return len(chunks)
+
+    async def fake_drop_resource_alias(*args, **kwargs):
+        return None
 
     async def fake_store_document_relations(*args, **kwargs):
         return None
@@ -356,6 +363,7 @@ def _patch_index_side_effects(monkeypatch) -> None:
     async def fake_emit_event(*args, **kwargs):
         return None
 
+    monkeypatch.setattr(document_repo, "drop_resource_alias", fake_drop_resource_alias)
     monkeypatch.setattr(ds, "write_source_chunks", fake_write_source_chunks)
     monkeypatch.setattr(ds, "store_document_relations", fake_store_document_relations)
     monkeypatch.setattr(ds, "emit_event", fake_emit_event)
@@ -382,8 +390,8 @@ async def test_put_certifies_the_canonical_parsed_body_hash(monkeypatch) -> None
     )
 
     resp = await service._put_locked(
-        req=req, agent_id="tester", vault_id=uuid.uuid4(),
-        file_path="specs/trailing.md", slug="trailing",
+        req=req, agent_id="tester", vault_id=uuid.uuid4(), doc_id=uuid.uuid4(),
+        base_path="specs/trailing.md", base_slug="trailing", explicit_slug=True,
         now=datetime.now(timezone.utc), normalized_collection="specs",
         doc_repo=doc_repo, coll_repo=_FakeCollRepo(), conn=None,
     )
@@ -419,8 +427,8 @@ async def test_get_after_put_confirms_hash_and_self_heal_is_noop(monkeypatch) ->
         content="# Heading\n\nBody.\n\n",
     )
     resp = await service._put_locked(
-        req=req, agent_id="tester", vault_id=uuid.uuid4(),
-        file_path="specs/trailing.md", slug="trailing",
+        req=req, agent_id="tester", vault_id=uuid.uuid4(), doc_id=uuid.uuid4(),
+        base_path="specs/trailing.md", base_slug="trailing", explicit_slug=True,
         now=datetime.now(timezone.utc), normalized_collection="specs",
         doc_repo=put_repo, coll_repo=_FakeCollRepo(), conn=None,
     )
@@ -507,6 +515,63 @@ async def test_update_certifies_the_canonical_parsed_body_hash(monkeypatch) -> N
     assert resp.content_hash == expected_hash, (
         "update response certified the raw request body, not the "
         "canonical parsed body"
+    )
+    assert doc_repo.updated is not None
+    assert doc_repo.updated["content_hash"] == expected_hash
+    assert resp.previous_content_hash == current_hash
+
+
+@pytest.mark.asyncio
+async def test_edit_certifies_the_canonical_parsed_body_hash(monkeypatch) -> None:
+    """akb_edit must use the same canonical write hash as put/update.
+
+    Replacing with a string that ends in blank lines exercises the exact
+    frontmatter round-trip that strips body edges before akb_get hashes it.
+    """
+    import frontmatter
+
+    _patch_index_side_effects(monkeypatch)
+    current_body = "Old body."
+    current_hash = sha256(current_body.encode("utf-8")).hexdigest()
+    commit = "7" * 40
+    doc_id = uuid.uuid4()
+    row = {
+        "id": doc_id,
+        "path": "specs/edit.md",
+        "title": "Edit Hash",
+        "doc_type": "note",
+        "summary": None,
+        "current_commit": "6" * 40,
+        "content_hash": current_hash,
+        "hash_algorithm": "sha256",
+        "content_hash_commit": "6" * 40,
+        "tags": [],
+    }
+    git = _CommittingGit(
+        commit,
+        initial_raw=f"---\ntitle: Edit Hash\ntype: note\n---\n{current_body}",
+    )
+    doc_repo = _FakePutDocRepo(row)
+    service = DocumentService(git=git)
+
+    resp = await service._edit_locked(
+        vault="hash-vault",
+        vault_id=uuid.uuid4(),
+        row=row,
+        doc_repo=doc_repo,
+        old_string=current_body,
+        new_string="New body.\n\n",
+        replace_all=False,
+        message="edit hash",
+        agent_id="tester",
+        conn=None,
+    )
+
+    canonical_body = frontmatter.loads(git.committed_md).content
+    expected_hash = sha256(canonical_body.encode("utf-8")).hexdigest()
+    assert canonical_body == "New body."
+    assert resp.content_hash == expected_hash, (
+        "edit response certified the raw edited body, not the canonical parsed body"
     )
     assert doc_repo.updated is not None
     assert doc_repo.updated["content_hash"] == expected_hash

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -276,6 +276,243 @@ async def test_document_get_reads_body_at_current_commit_not_head(monkeypatch) -
     assert result.current_commit == commit
 
 
+# ── write-response / get hash parity (issue #181) ─────────────────
+#
+# put/update used to hash the RAW request body, while get parses the
+# stored markdown (frontmatter.loads strips surrounding whitespace) and
+# hashes the parsed body. Any body with leading/trailing whitespace got
+# a write-response hash no later read would ever confirm. The write
+# path must certify the canonical parsed body — the same value get
+# serves — by construction.
+
+
+class _FakePutDocRepo:
+    """find_by_path/create/update/update_hash fakes for the put and
+    update critical sections; records what would hit the DB."""
+
+    def __init__(self, row: dict | None = None):
+        self.row = row
+        self.created: dict | None = None
+        self.updated: dict | None = None
+        self.hash_update: dict | None = None
+
+    async def find_by_path(self, vault_id: uuid.UUID, path: str, conn=None):
+        return None
+
+    async def find_by_ref(self, vault_id: uuid.UUID, ref: str) -> dict:
+        return dict(self.row or {})
+
+    async def create(self, **kwargs) -> uuid.UUID:
+        self.created = kwargs
+        return uuid.uuid4()
+
+    async def update(self, doc_id: uuid.UUID, **kwargs) -> None:
+        self.updated = {"doc_id": doc_id, **kwargs}
+
+    async def update_hash(self, doc_id: uuid.UUID, *, content_hash, hash_algorithm, content_hash_commit, conn=None) -> None:
+        self.hash_update = {
+            "doc_id": doc_id,
+            "content_hash": content_hash,
+            "hash_algorithm": hash_algorithm,
+            "content_hash_commit": content_hash_commit,
+        }
+
+
+class _FakeCollRepo:
+    async def get_or_create(self, vault_id: uuid.UUID, path: str, conn=None) -> uuid.UUID:
+        return uuid.uuid4()
+
+    async def increment_count(self, collection_id, now, conn=None) -> None:
+        return None
+
+
+class _CommittingGit:
+    """Records the markdown handed to commit_file and serves it back on
+    read_file — i.e. behaves like the real git round-trip."""
+
+    def __init__(self, commit: str):
+        self.commit = commit
+        self.committed_md: str | None = None
+
+    def commit_file(self, *, vault_name, file_path, content, message, author_name) -> str:
+        self.committed_md = content
+        return self.commit
+
+    def read_file(self, vault: str, path: str, commit: str | None = None) -> str:
+        assert self.committed_md is not None, "read before any commit"
+        return self.committed_md
+
+
+def _patch_index_side_effects(monkeypatch) -> None:
+    """Neutralize the chunk/relations/event writes that need a live DB."""
+    import app.services.document_service as ds
+
+    async def fake_write_source_chunks(conn, kind, doc_id, *, vault_id, chunks):
+        return len(chunks)
+
+    async def fake_store_document_relations(*args, **kwargs):
+        return None
+
+    async def fake_emit_event(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(ds, "write_source_chunks", fake_write_source_chunks)
+    monkeypatch.setattr(ds, "store_document_relations", fake_store_document_relations)
+    monkeypatch.setattr(ds, "emit_event", fake_emit_event)
+
+
+@pytest.mark.asyncio
+async def test_put_certifies_the_canonical_parsed_body_hash(monkeypatch) -> None:
+    """A body with trailing newlines (Jira-style sync payloads produce
+    them routinely): the put-response hash must equal the hash of the
+    frontmatter round-tripped body — what a later get will serve — not
+    the raw request body."""
+    import frontmatter
+
+    from app.models.document import DocumentPutRequest
+
+    _patch_index_side_effects(monkeypatch)
+    commit = "e" * 40
+    git = _CommittingGit(commit)
+    doc_repo = _FakePutDocRepo()
+    service = DocumentService(git=git)
+    req = DocumentPutRequest(
+        vault="hash-vault", collection="specs", title="Trailing",
+        content="Body line one.\n\nBody line two.\n\n",
+    )
+
+    resp = await service._put_locked(
+        req=req, agent_id="tester", vault_id=uuid.uuid4(),
+        file_path="specs/trailing.md", slug="trailing",
+        now=datetime.now(timezone.utc), normalized_collection="specs",
+        doc_repo=doc_repo, coll_repo=_FakeCollRepo(), conn=None,
+    )
+
+    # Canonical body = what frontmatter parses back out of the committed
+    # markdown; this is exactly what get() hashes.
+    canonical_body = frontmatter.loads(git.committed_md).content
+    expected_hash = sha256(canonical_body.encode("utf-8")).hexdigest()
+    assert canonical_body != req.content, "fixture must exercise the strip"
+    assert resp.content_hash == expected_hash, (
+        "put response certified the raw request body, not the canonical "
+        "parsed body — no later akb_get will ever confirm this hash"
+    )
+    # The DB row gets the same canonical hash (no read-order-dependent flip).
+    assert doc_repo.created is not None
+    assert doc_repo.created["content_hash"] == expected_hash
+
+
+@pytest.mark.asyncio
+async def test_get_after_put_confirms_hash_and_self_heal_is_noop(monkeypatch) -> None:
+    """End-to-end parity: get() over the row a fresh put persisted must
+    return the same content_hash and never rewrite the row (the
+    _ensure_document_hash self-heal is a no-op for fresh writes)."""
+    from app.models.document import DocumentPutRequest
+
+    _patch_index_side_effects(monkeypatch)
+    commit = "f" * 40
+    git = _CommittingGit(commit)
+    put_repo = _FakePutDocRepo()
+    service = DocumentService(git=git)
+    req = DocumentPutRequest(
+        vault="hash-vault", collection="specs", title="Trailing",
+        content="# Heading\n\nBody.\n\n",
+    )
+    resp = await service._put_locked(
+        req=req, agent_id="tester", vault_id=uuid.uuid4(),
+        file_path="specs/trailing.md", slug="trailing",
+        now=datetime.now(timezone.utc), normalized_collection="specs",
+        doc_repo=put_repo, coll_repo=_FakeCollRepo(), conn=None,
+    )
+
+    # Project the row exactly as the put persisted it.
+    row = {
+        "id": uuid.uuid4(),
+        "vault_name": "hash-vault",
+        "path": "specs/trailing.md",
+        "title": "Trailing",
+        "doc_type": "note",
+        "status": "draft",
+        "summary": None,
+        "domain": None,
+        "created_by": "tester",
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+        "current_commit": commit,
+        "content_hash": put_repo.created["content_hash"],
+        "hash_algorithm": "sha256",
+        "content_hash_commit": commit,
+        "tags": [],
+    }
+    get_repo = _FakeDocRepo(row)
+
+    async def fake_repos():
+        return _FakeVaultRepo(uuid.uuid4()), get_repo, object()
+
+    async def fake_public_slug(vault: str, path: str) -> None:
+        return None
+
+    monkeypatch.setattr(service, "_repos", fake_repos)
+    monkeypatch.setattr(service, "_get_public_slug", fake_public_slug)
+
+    result = await service.get("hash-vault", "specs/trailing.md")
+
+    assert result.content_hash == resp.content_hash, (
+        "get() returned a different hash than the put response certified"
+    )
+    assert get_repo.hash_update is None, (
+        "get() rewrote the row hash on first read — the write certified "
+        "a non-canonical value"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_certifies_the_canonical_parsed_body_hash(monkeypatch) -> None:
+    """Same parity contract on the update path: req.content with trailing
+    newlines must yield a response/DB hash over the canonical parsed body."""
+    import frontmatter
+
+    _patch_index_side_effects(monkeypatch)
+    current_body = "Old body."
+    current_hash = sha256(current_body.encode("utf-8")).hexdigest()
+    commit = "9" * 40
+    doc_id = uuid.uuid4()
+    row = {
+        "id": doc_id,
+        "path": "specs/trailing.md",
+        "title": "Trailing",
+        "doc_type": "note",
+        "status": "draft",
+        "summary": None,
+        "current_commit": "8" * 40,
+        "content_hash": current_hash,
+        "hash_algorithm": "sha256",
+        "content_hash_commit": "8" * 40,
+        "tags": [],
+    }
+    git = _CommittingGit(commit)
+    git.committed_md = f"---\ntitle: Trailing\n---\n{current_body}"
+    doc_repo = _FakePutDocRepo(row)
+    service = DocumentService(git=git)
+    req = DocumentUpdateRequest(content="New body.\n\n")
+
+    resp = await service._update_locked(
+        req=req, agent_id="tester", vault="hash-vault",
+        vault_id=uuid.uuid4(), doc_repo=doc_repo, row=row, conn=None,
+    )
+
+    canonical_body = frontmatter.loads(git.committed_md).content
+    expected_hash = sha256(canonical_body.encode("utf-8")).hexdigest()
+    assert canonical_body == "New body."
+    assert resp.content_hash == expected_hash, (
+        "update response certified the raw request body, not the "
+        "canonical parsed body"
+    )
+    assert doc_repo.updated is not None
+    assert doc_repo.updated["content_hash"] == expected_hash
+    assert resp.previous_content_hash == current_hash
+
+
 # ── akb_put status option ──────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #181.

## What Changed

Document create and update now certify the `content_hash` of the body exactly as a later `get` will serve it. A new `_certified_content_hash(md_content)` parses the composed markdown back (`frontmatter` round-trip) and hashes the parsed body; `_put` and the update path use it instead of hashing the raw request body.

## Why

`get` hashes the frontmatter-parsed body, and python-frontmatter strips surrounding whitespace on load. For any body with leading/trailing whitespace (sync payloads ending in `\n\n` are routine), the write response certified a hash no later read would ever confirm, and the read-side `_ensure_document_hash` self-heal silently flipped the DB row's hash on first read — the certified value was read-order-dependent. Hash-aware consumers (the OSS akb-collector's idempotent-skip ledger among them) cannot build on a write-response hash that disagrees with every subsequent read. Parity is now by construction: write-response, DB row, and `get` agree from the first commit, and the self-heal is a no-op for fresh writes.

## Not Included

- No legacy-row backfill: the read-side self-heal remains and is sufficient for existing rows.
- The edit/replace path still hashes its derived body directly; it operates on the already-canonical parsed body, so divergence would need edge-whitespace replacements. Worth a follow-up only if it shows up.

## Validation

- `cd backend && uv run pytest tests/test_document_hash_contract_unit.py tests/test_document_get_at_commit_unit.py tests/test_resource_hash_unit.py` — 15 passed.
- Full non-e2e backend suite: 160 passed, 61 skipped.
- New tests: put/update response hash equals the frontmatter round-tripped body hash for a `\n\n`-suffixed body; put→get parity with `_ensure_document_hash` asserting no persisted self-heal (`hash_update is None`) for fresh writes.
