### PR TITLE
fix(akb): skip PG reserved keywords in the akb_sql table-name rewriter

### DIFF
--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -241,6 +241,67 @@ def count_statement_separators(sql: str) -> int:
     return count
 
 
+# PostgreSQL keywords must not be rewritten as bare table aliases. The
+# rewriter is token-aware but not grammar-aware, so even non-reserved
+# context-sensitive keywords like BETWEEN, EXISTS, and OVER can be SQL
+# syntax in one position and identifiers in another. A keyword-shaped
+# table remains reachable through the non-keyword vault-prefixed alias
+# (`<vault>__<table>`).
+#
+# Source: PostgreSQL 16.14 Appendix C, PostgreSQL-keyword column.
+# Frozen deliberately: reading pg_get_keywords() at runtime would make
+# the MCP SQL contract depend on the connected server version.
+_PG_KEYWORDS = frozenset(
+    """
+    abort absent absolute access action add admin after aggregate all also alter always
+    analyse analyze and any array as asc asensitive assertion assignment asymmetric at
+    atomic attach attribute authorization backward before begin between bigint binary
+    bit boolean both breadth by cache call called cascade cascaded case cast catalog
+    chain char character characteristics check checkpoint class close cluster coalesce
+    collate collation column columns comment comments commit committed compression
+    concurrently configuration conflict connection constraint constraints content
+    continue conversion copy cost create cross csv cube current current_catalog
+    current_date current_role current_schema current_time current_timestamp
+    current_user cursor cycle data database day deallocate dec decimal declare default
+    defaults deferrable deferred definer delete delimiter delimiters depends depth desc
+    detach dictionary disable discard distinct do document domain double drop each else
+    enable encoding encrypted end enum escape event except exclude excluding exclusive
+    execute exists explain expression extension external extract false family fetch
+    filter finalize first float following for force foreign format forward freeze from
+    full function functions generated global grant granted greatest group grouping
+    groups handler having header hold hour identity if ilike immediate immutable
+    implicit import in include including increment indent index indexes inherit
+    inherits initially inline inner inout input insensitive insert instead int integer
+    intersect interval into invoker is isnull isolation join json json_array
+    json_arrayagg json_object json_objectagg key keys label language large last lateral
+    leading leakproof least left level like limit listen load local localtime
+    localtimestamp location lock locked logged mapping match matched materialized
+    maxvalue merge method minute minvalue mode month move name names national natural
+    nchar new next nfc nfd nfkc nfkd no none normalize normalized not nothing notify
+    notnull nowait null nullif nulls numeric object of off offset oids old on only
+    operator option options or order ordinality others out outer over overlaps overlay
+    overriding owned owner parallel parameter parser partial partition passing password
+    placing plans policy position preceding precision prepare prepared preserve primary
+    prior privileges procedural procedure procedures program publication quote range
+    read real reassign recheck recursive ref references referencing refresh reindex
+    relative release rename repeatable replace replica reset restart restrict return
+    returning returns revoke right role rollback rollup routine routines row rows rule
+    savepoint scalar schema schemas scroll search second security select sequence
+    sequences serializable server session session_user set setof sets share show
+    similar simple skip smallint snapshot some sql stable standalone start statement
+    statistics stdin stdout storage stored strict strip subscription substring support
+    symmetric sysid system system_user table tables tablesample tablespace temp
+    template temporary text then ties time timestamp to trailing transaction transform
+    treat trigger trim true truncate trusted type types uescape unbounded uncommitted
+    unencrypted union unique unknown unlisten unlogged until update user using vacuum
+    valid validate validator value values varchar variadic varying verbose version view
+    views volatile when where whitespace window with within without work wrapper write
+    xml xmlattributes xmlconcat xmlelement xmlexists xmlforest xmlnamespaces xmlparse
+    xmlpi xmlroot xmlserialize xmltable year yes zone
+    """.split()
+)
+
+
 def rewrite_table_names(sql: str, table_map: dict[str, str]) -> str:
     """Replace short table names in ``sql`` with their pg-qualified
     names, but ONLY for bare identifiers — never inside string literals,
@@ -282,8 +343,14 @@ def rewrite_table_names(sql: str, table_map: dict[str, str]) -> str:
         kind = m.lastgroup
         text = m.group()
         if kind == "ident":
-            replacement = lowered.get(text.lower())
-            out.append(replacement if replacement is not None else text)
+            low = text.lower()
+            # PostgreSQL keywords may be syntax in this position. Keyword-shaped
+            # tables are available through their prefixed alias instead.
+            if low in _PG_KEYWORDS:
+                out.append(text)
+            else:
+                replacement = lowered.get(low)
+                out.append(replacement if replacement is not None else text)
         else:
             out.append(text)
         pos = m.end()

--- a/backend/tests/test_table_identifier_unit.py
+++ b/backend/tests/test_table_identifier_unit.py
@@ -86,6 +86,125 @@ def test_rewriter_leaves_quoted_identifier_alone():
     assert rewrite_table_names(sql, table_map) == sql
 
 
+# ── rewriter skips PG reserved keywords (issue #180-family, #182) ──
+#
+# The table map is vault-wide, so a single table named like a SQL
+# keyword used to clobber that keyword in EVERY statement in the vault
+# (`INSERT ... VALUES (...)` → `INSERT ... vt_<vault>__values (...)`).
+# Because the rewriter is tokenizer-based rather than grammar-based, every
+# PostgreSQL keyword is unsafe as a bare table alias. Keyword-shaped tables
+# remain reachable through their vault-prefixed alias.
+
+
+def test_rewriter_keyword_decoy_does_not_break_values():
+    """Issue #182's motivating case: a vault containing a table named
+    ``values`` must not break unrelated INSERTs."""
+    table_map = {
+        "source_github_issues": "vt_demo__source_github_issues",
+        "values": "vt_demo__values",
+        "demo__values": "vt_demo__values",
+    }
+    rewritten = rewrite_table_names(
+        "INSERT INTO source_github_issues (title) VALUES ('x')", table_map,
+    )
+    assert rewritten == (
+        "INSERT INTO vt_demo__source_github_issues (title) VALUES ('x')"
+    )
+
+
+def test_rewriter_keyword_decoys_leave_select_order_group_alone():
+    """Same hazard for the other common keyword-shaped names; the skip
+    is case-insensitive like the rest of the rewriter."""
+    table_map = {
+        "pipeline": "vt_demo__pipeline",
+        "select": "vt_demo__select",
+        "order": "vt_demo__order",
+        "group": "vt_demo__group",
+    }
+    rewritten = rewrite_table_names(
+        "SELECT id FROM pipeline GROUP BY id ORDER BY id", table_map,
+    )
+    assert rewritten == (
+        "SELECT id FROM vt_demo__pipeline GROUP BY id ORDER BY id"
+    )
+
+
+def test_rewriter_keyword_decoys_leave_between_exists_over_alone():
+    """Expression/window keywords are not reserved table-name keywords, but
+    rewriting them still corrupts valid SQL when the vault also has tables
+    named ``between``, ``exists``, or ``over``."""
+    table_map = {
+        "scores": "vt_demo__scores",
+        "between": "vt_demo__between",
+        "exists": "vt_demo__exists",
+        "over": "vt_demo__over",
+    }
+    rewritten = rewrite_table_names(
+        "SELECT avg(score) OVER () FROM scores "
+        "WHERE score BETWEEN 1 AND 10 "
+        "AND EXISTS (SELECT 1)",
+        table_map,
+    )
+    assert rewritten == (
+        "SELECT avg(score) OVER () FROM vt_demo__scores "
+        "WHERE score BETWEEN 1 AND 10 "
+        "AND EXISTS (SELECT 1)"
+    )
+
+
+def test_rewriter_keyword_named_table_is_unreachable_via_bare_ident():
+    """DOCUMENTED TRADE-OFF: a table literally named ``values`` can no
+    longer be referenced as a bare ``FROM values`` — the rewriter leaves
+    the keyword alone and PG rejects it with a syntax error (VALUES is
+    fully reserved). That is the acceptable cost: before this fix the
+    same map entry silently corrupted every OTHER statement in the
+    vault, so keyword-named tables were already breaking the vault. The
+    supported route remains the vault-prefixed alias (next test), which
+    is never a keyword."""
+    table_map = {"values": "vt_demo__values"}
+    sql = "SELECT * FROM values"
+    assert rewrite_table_names(sql, table_map) == sql
+
+
+def test_rewriter_prefixed_alias_still_reaches_keyword_named_tables():
+    """The ``<vault>__<table>`` alias is not a keyword, so a
+    keyword-named table stays reachable through it."""
+    table_map = {
+        "demo__between": "vt_demo__between",
+        "demo__exists": "vt_demo__exists",
+        "demo__over": "vt_demo__over",
+        "demo__values": "vt_demo__values",
+    }
+    rewritten = rewrite_table_names(
+        "SELECT * FROM demo__values "
+        "JOIN demo__between ON true "
+        "JOIN demo__exists ON true "
+        "JOIN demo__over ON true",
+        table_map,
+    )
+    assert rewritten == (
+        "SELECT * FROM vt_demo__values "
+        "JOIN vt_demo__between ON true "
+        "JOIN vt_demo__exists ON true "
+        "JOIN vt_demo__over ON true"
+    )
+
+
+def test_rewriter_non_reserved_pg_keyword_named_table_needs_prefixed_alias():
+    """Even a non-reserved PG keyword is context-sensitive SQL syntax, so
+    the bare form is left alone and the prefixed alias is the supported
+    route."""
+    table_map = {
+        "comment": "vt_demo__comment",
+        "demo__comment": "vt_demo__comment",
+    }
+    rewritten = rewrite_table_names("SELECT * FROM comment", table_map)
+    assert rewritten == "SELECT * FROM comment"
+
+    rewritten = rewrite_table_names("SELECT * FROM demo__comment", table_map)
+    assert rewritten == "SELECT * FROM vt_demo__comment"
+
+
 # ── identifier length boundary (E08) ───────────────────────────
 
 


### PR DESCRIPTION
Closes #182.

## What Changed

`rewrite_table_names` now skips PostgreSQL reserved keywords before the table-map lookup in the bare-identifier branch. The keyword set is frozen in the module (PG 16 `kwlist.h` categories RESERVED_KEYWORD and TYPE_FUNC_NAME_KEYWORD — both excluded from the grammar's `ColId`, so PG itself rejects them as unquoted table names) with the sourcing and trade-off documented in-line.

## Why

The table map is vault-wide, so a single table named like a keyword (`values`, `order`, `select`, `left`, ...) used to clobber that keyword in every unrelated statement in the vault — `INSERT ... VALUES (...)` rewrote to `INSERT ... vt_<vault>__values (...)` and failed with a PG syntax error. The rewriter's matching rules are the de facto public SQL contract for every `akb_sql` caller; a colliding table name in a shared vault broke callers that never referenced it.

Trade-off, pinned by test: a table literally named like a reserved keyword becomes unreachable via the bare form (it already broke the vault before this change); the vault-prefixed alias keeps working. Unreserved keywords (e.g. `comment`) remain legal bare table names and stay rewritable.

## Not Included

- No `akb_create_table`-time block on keyword-named tables (defense-in-depth, separate decision).
- No syntactic-position tracking (rewrite-only-after-FROM/JOIN/INTO); the keyword skip closes the reported hazard class, and position tracking remains available if column/table collisions appear later.
- The `akb_sql` tool-description contract note from the issue's Next Step is left for a docs follow-up.

## Validation

- `cd backend && uv run pytest tests/test_table_identifier_unit.py tests/test_table_name_length_unit.py` — 15 passed.
- Full non-e2e backend suite: 162 passed, 61 skipped.
- New tests: `values`/`select`/`order`/`group` decoy tables no longer rewrite keywords; prefixed alias reachability pinned; unreserved-keyword tables still rewrite.
