### PR TITLE
fix(0.8.8): kg — wikilink-alias edge corruption + implicit-edge existence validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2589
+        "line_number": 2605
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T15:02:49Z"
+  "generated_at": "2026-06-10T02:10:18Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,22 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.8 — 2026-06-10  *(patch — knowledge graph: wikilink-alias edge corruption + implicit-edge existence validation)*
+
+Body-link extraction had **no handling for Obsidian wikilinks** `[[target|alias]]`. The greedy bare-`akb://` scan (`_AKB_URI_RE`) then swallowed the alias's first word onto the target — a References line like `[[akb://v/coll/decisions/doc/x.md|PWC Query Performance Optimization]]` produced the edge target `akb://v/coll/decisions/doc/x.md|PWC` (matching stopped at the first space). One bug, two symptoms:
+
+- **Relations panel / `akb_relations`** returned the malformed URI, so "related to" navigation built a broken `…/x.md%7CPWC` link to a non-existent doc.
+- **Graph drew no edges** — the corrupted target matched no document node, so every body-derived edge was silently un-drawable. A vault whose only relations were wikilinks showed all nodes, zero edges.
+
+Three-part fix:
+
+1. **Parser** (`extract_markdown_links`): added a wikilink matcher `[[target|alias]]` that keeps only the target (alias is display text), and tightened `_AKB_URI_RE` to stop at `|`, `[`, `]` so the bare-URI fallback can no longer absorb an alias or a closing `]]`.
+2. **Existence validation** (`_store_edge`): the implicit extraction path now validates the target **exists** before storing — via the *same* `_resource_exists` primitive the explicit `akb_link` path uses (the two paths differ only in policy: `akb_link` returns `NOT_FOUND`, extraction silently skips). An implicit edge to a non-existent resource can never be drawn and only pollutes the graph; previously the URI branch skipped this check, which is how the malformed targets persisted. *Note:* a frontmatter `depends_on` / `related_to` (or body link) whose target does not yet exist is now dropped rather than stored as a dangling edge — a deliberate forward-reference is re-materialized on the next index after the target is created.
+3. **Migration 035** (`035_fix_wikilink_alias_edges.py`): repairs rows already persisted — for each edge whose `target_uri` contains `|`, strips to the real target and, if that target resolves, re-inserts the corrected edge (ON CONFLICT DO NOTHING) and drops the corrupted row; orphans whose cleaned target doesn't resolve are dropped. Idempotent.
+
+### Tests
+`tests/test_kg_extract_links_unit.py` gains wikilink coverage: akb:// + alias strips to the clean URI (and asserts no alias fragment leaks), path + alias, alias-less `[[…]]`, the exact historical "stopped at the space" failure shape, bare-scan dedup, and a wikilink inside a code span staying ignored.
+
 ## 0.8.7 — 2026-06-10  *(minor — Keycloak SSO: cross-origin companion-app post-login redirect allowlist)*
 
 A single AKB backend can act as the identity owner for a small family of first-party apps on **different origins** (e.g. reef at `reef-<slug>.<domain>` alongside akb's own `akb-<slug>.<domain>`), each delegating to the *same* tenant Keycloak client instead of registering its own. The blocker was that the SSO post-login redirect was a **single per-instance** `keycloak_post_login_path`: the callback always bounced the one-time code to that one same-site path, and `_safe_redirect_path()` collapsed any cross-origin redirect (open-redirect guard). So akb's own SPA and a companion app could not both complete SSO — they fought over one global path, and pointing `keycloak_post_login_path` at the companion's absolute URL (the earlier workaround) just broke akb's own SPA instead.

--- a/backend/app/db/migrations/035_fix_wikilink_alias_edges.py
+++ b/backend/app/db/migrations/035_fix_wikilink_alias_edges.py
@@ -1,0 +1,121 @@
+"""Migration 035: repair edges whose target_uri carries a wikilink alias.
+
+Body-link extraction (`kg_service.extract_markdown_links`) had no handling
+for Obsidian wikilinks `[[target|alias]]`. The greedy bare-`akb://` scan
+then swallowed the alias's first word onto the target — a References line
+like::
+
+    [[akb://v/coll/decisions/doc/x.md|PWC Query Performance Optimization]]
+
+produced the edge target ``akb://v/coll/decisions/doc/x.md|PWC`` (matching
+stopped at the first space). That target matches no document node, so the
+graph drew no edge and the relations panel rendered a ``…%7CPWC`` broken
+link. The parser + `_store_edge` existence check are fixed going forward;
+this migration repairs the rows already persisted.
+
+For each edge whose ``target_uri`` contains ``|``:
+  1. cleaned = everything before the first ``|`` (the real target).
+  2. If a resource exists at the cleaned URI → insert the corrected edge
+     (ON CONFLICT DO NOTHING, so an already-correct twin is kept) and drop
+     the corrupted row.
+  3. Otherwise (cleaned target doesn't resolve) → just drop the corrupted
+     row; it was an orphan that could never be drawn.
+
+Uses the SAME `parse_uri` / `_resource_exists` the runtime path uses, so a
+repaired edge is identical to one re-extracted from the body.
+
+Idempotent: after one pass no ``target_uri`` contains ``|`` (canonical
+akb:// URIs never do), so a re-run finds nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+from app.services.kg_service import _resource_exists
+from app.services.uri_service import parse_uri
+
+logger = logging.getLogger("akb.migration.035")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    rows = await conn.fetch(
+        """
+        SELECT id, vault_id, source_uri, target_uri, relation_type,
+               source_type, target_type, kind
+          FROM edges
+         WHERE target_uri LIKE '%|%'
+        """
+    )
+    if not rows:
+        logger.info("Migration 035: no alias-corrupted edges; skipping")
+        return
+
+    repaired = 0
+    dropped = 0
+    async with conn.transaction():
+        for r in rows:
+            cleaned = r["target_uri"].split("|", 1)[0]
+            keep = False
+            parsed = parse_uri(cleaned)
+            if parsed and parsed.kind in ("doc", "table", "file"):
+                target_vault_id = await conn.fetchval(
+                    "SELECT id FROM vaults WHERE name = $1", parsed.vault,
+                )
+                if target_vault_id is not None and await _resource_exists(
+                    conn, target_vault_id, parsed.kind, parsed.identifier or "",
+                ):
+                    keep = True
+
+            # Always remove the corrupted row.
+            await conn.execute("DELETE FROM edges WHERE id = $1", r["id"])
+
+            if keep:
+                # Re-insert the corrected edge; ON CONFLICT keeps an existing
+                # correct twin (and preserves its kind via DO NOTHING).
+                await conn.execute(
+                    """
+                    INSERT INTO edges (id, vault_id, source_uri, target_uri,
+                                       relation_type, source_type, target_type, kind)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    uuid.uuid4(), r["vault_id"], r["source_uri"], cleaned,
+                    r["relation_type"], r["source_type"], r["target_type"], r["kind"],
+                )
+                repaired += 1
+            else:
+                dropped += 1
+
+    logger.info(
+        "Migration 035: repaired %d alias-corrupted edge(s), "
+        "dropped %d orphan(s) (cleaned target did not resolve)",
+        repaired, dropped,
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -57,8 +57,16 @@ LINK_RELATION_TYPES: tuple[str, ...] = get_args(LinkRelationType)
 
 # Matches markdown links: [text](target)
 _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
-# Matches akb:// URIs anywhere in text
-_AKB_URI_RE = re.compile(r"akb://[^\s\)>`]+")
+# Matches Obsidian-style wikilinks: [[target]] or [[target|alias]]. Only the
+# target (before the first '|') is the link; the rest is display text. The
+# inner run cannot contain '[' or ']'.
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
+# Matches akb:// URIs anywhere in text. Stops at whitespace, ) > ` AND the
+# wikilink/alias delimiters [ ] | — so a bare-URI scan over a wikilink like
+# `[[akb://…/x.md|Label]]` yields `akb://…/x.md`, not `akb://…/x.md|Label`
+# (the bug where the alias's first word got glued onto the target path,
+# producing an edge to a non-existent doc that no graph node could match).
+_AKB_URI_RE = re.compile(r"akb://[^\s\)\]\[\|>`]+")
 # Code spans — fenced blocks (``` / ~~~) and inline (`…`). Anything inside
 # is example/snippet text, NOT a real link: a session report quoting
 # `akb://project-akb/...`, a regex example `akb://\1/coll/\2/doc/\3`, or a
@@ -89,16 +97,18 @@ def extract_markdown_links(content: str) -> list[str]:
     targets: list[str] = []
     seen: set[str] = set()
 
-    for match in _MD_LINK_RE.finditer(content):
-        target = match.group(2).strip()
-        if target.startswith(("http://", "https://", "mailto:", "#")):
-            continue
+    def _add(raw: str) -> None:
+        """Normalize one link target and append it (deduped). Filters
+        external URLs / anchors; keeps akb:// URIs verbatim; strips a
+        leading './' and any '#fragment' from relative paths."""
+        target = raw.strip()
+        if not target or target.startswith(("http://", "https://", "mailto:", "#")):
+            return
         if target.startswith("akb://"):
             if target not in seen:
                 targets.append(target)
                 seen.add(target)
-            continue
-        # Normalize relative paths
+            return
         target = target.lstrip("./")
         if "#" in target:
             target = target.split("#")[0]
@@ -106,7 +116,17 @@ def extract_markdown_links(content: str) -> list[str]:
             targets.append(target)
             seen.add(target)
 
-    # Also find bare akb:// URIs in body (not inside markdown links)
+    # [text](target)
+    for match in _MD_LINK_RE.finditer(content):
+        _add(match.group(2))
+
+    # [[target]] / [[target|alias]] — the alias after '|' is display text,
+    # not part of the link, so keep only the target. Without this the
+    # alias leaked into the target (see _AKB_URI_RE note above).
+    for match in _WIKILINK_RE.finditer(content):
+        _add(match.group(1).split("|", 1)[0])
+
+    # Also find bare akb:// URIs in body (not inside a markdown / wiki link)
     for match in _AKB_URI_RE.finditer(content):
         uri = match.group(0)
         if uri not in seen:
@@ -760,10 +780,34 @@ async def _store_edge(
             )
             return False
         target_type = parsed.kind
-        # Rebuild from parsed parts so surface variants (extra slash,
-        # coll prefix shape) of the same target collapse under the
-        # edges uniqueness convention — otherwise ON CONFLICT can't dedupe.
         ident = parsed.identifier or ""
+        # Resolve the target's vault (edges may cross vaults) so existence
+        # is checked against the right catalog.
+        target_vault_id = await conn.fetchval(
+            "SELECT id FROM vaults WHERE name = $1", parsed.vault,
+        )
+        if target_vault_id is None:
+            logger.debug(
+                "Skipping edge to %r: target vault %r not found",
+                target_ref, parsed.vault,
+            )
+            return False
+        # Validate the target EXISTS before storing — via the SAME
+        # `_resource_exists` primitive the explicit akb_link path uses, so
+        # the two link paths validate identically (they differ only in
+        # policy: akb_link returns NOT_FOUND, extraction silently skips).
+        # An implicit edge to a non-existent resource can never be drawn and
+        # only pollutes the graph — e.g. a wikilink whose alias leaked into
+        # the path (`…/x.md|Label`), or a forward reference to a doc never
+        # created. The extraction path used to skip this check, which is how
+        # the malformed targets got persisted.
+        if not await _resource_exists(conn, target_vault_id, parsed.kind, ident):
+            logger.debug(
+                "Skipping edge to nonexistent %s %r", parsed.kind, target_ref,
+            )
+            return False
+        # Rebuild from parsed parts so surface variants collapse under the
+        # edges uniqueness convention — otherwise ON CONFLICT can't dedupe.
         if parsed.kind == "doc":
             target_uri = doc_uri(parsed.vault, ident)
         elif parsed.kind == "table":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.7"
+version = "0.8.8"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_kg_extract_links_unit.py
+++ b/backend/tests/test_kg_extract_links_unit.py
@@ -45,3 +45,55 @@ def test_strip_code_spans_removes_code_keeps_prose():
     stripped = strip_code_spans("`akb://x/coll/y/doc/z.md` keep-this")
     assert "akb://" not in stripped
     assert "keep-this" in stripped
+
+
+# ── Wikilink extraction ([[target]] / [[target|alias]]) ──────────────
+#
+# Regression: an Obsidian wikilink with an alias used to leak the alias's
+# first word onto the target — `[[akb://…/x.md|PWC Long Title]]` produced
+# the target `akb://…/x.md|PWC` (the greedy bare-URI scan didn't stop at
+# `|`). That target matched no document node, so the graph drew no edge and
+# the relations panel rendered a `…%7CPWC` broken link.
+
+def test_wikilink_akb_uri_with_alias_strips_alias():
+    content = (
+        "## References\n"
+        "- [[akb://v/coll/decisions/doc/x.md|PWC Query Performance Optimization]]"
+    )
+    out = extract_markdown_links(content)
+    assert out == ["akb://v/coll/decisions/doc/x.md"]
+    # The alias (or any fragment of it) must never appear in a target.
+    assert all("|" not in t and "PWC" not in t for t in out)
+
+
+def test_wikilink_path_with_alias_strips_alias():
+    out = extract_markdown_links("see [[decisions/x.md|Some Decision]] here")
+    assert out == ["decisions/x.md"]
+
+
+def test_wikilink_without_alias():
+    out = extract_markdown_links(
+        "[[akb://v/coll/notes/doc/a.md]] and [[guides/b.md]]"
+    )
+    assert "akb://v/coll/notes/doc/a.md" in out
+    assert "guides/b.md" in out
+    assert all("[" not in t and "]" not in t for t in out)
+
+
+def test_wikilink_alias_with_trailing_space_before_close():
+    # The historical failure: matching stopped at the first space, leaving
+    # `…x.md|PWC` (alias's first word glued on). Assert it does NOT happen.
+    out = extract_markdown_links("[[akb://v/coll/d/doc/x.md|PWC Foo]]")
+    assert "akb://v/coll/d/doc/x.md|PWC" not in out
+    assert out == ["akb://v/coll/d/doc/x.md"]
+
+
+def test_wikilink_dedups_with_bare_uri_scan():
+    # The same akb:// inside a wikilink must not be double-counted by the
+    # bare-URI fallback scan (which now also stops at `|`).
+    out = extract_markdown_links("[[akb://v/coll/d/doc/x.md|Label]]")
+    assert out == ["akb://v/coll/d/doc/x.md"]
+
+
+def test_wikilink_inside_code_span_is_not_extracted():
+    assert extract_markdown_links("`[[akb://v/coll/d/doc/x.md|L]]`") == []


### PR DESCRIPTION
## Symptom (reported)

In `seahorse-cloud-saas`, a doc's **"related to"** link navigated to a broken URL `…/decisions/doc/pwc-…active-set-size-limit.md%7CPWC…` (note the `%7CPWC` = `|PWC` glued on), and the **graph drew no edges** (all nodes, zero relationship lines).

## Root cause (one bug, two symptoms)

The body contained a valid Obsidian wikilink:
```
[[akb://…/decisions/doc/pwc-…active-set-size-limit.md|PWC Query Performance Optimization — …]]
```
`extract_markdown_links` had **no wikilink handling**, and its bare-`akb://` scan `_AKB_URI_RE = akb://[^\s\)>`]+` had **no `|` or `]` in its stop set**, so it captured `akb://…limit.md|PWC` (stopping at the first space, after "PWC"). That malformed target:
- was returned verbatim by `akb_relations` → the `%7CPWC` broken "related to" link, **and**
- matched no document node → the graph silently dropped every body-derived edge.

The implicit edge-storage path (`_store_edge`) also **never validated the target exists** (unlike the explicit `akb_link` path), so the malformed target persisted.

## Fix

1. **Parser** (`extract_markdown_links`): added a `[[target|alias]]` matcher that keeps only the target (alias is display text); tightened `_AKB_URI_RE` to stop at `|`, `[`, `]`.
2. **Existence validation** (`_store_edge`): the implicit path now validates the target exists via the **same `_resource_exists` primitive** the explicit `akb_link` path uses — the two link paths now validate identically and differ only in policy (`akb_link` → `NOT_FOUND`; extraction → silently skip). *Behavior note:* a `depends_on`/`related_to`/body-link target that doesn't yet exist is now dropped rather than stored as a dangling edge (re-materialized on the next index after the target is created).
3. **Migration 035** (`035_fix_wikilink_alias_edges.py`): repairs already-persisted rows — strips the alias, re-inserts the corrected edge if the target resolves (ON CONFLICT DO NOTHING), drops orphans. Idempotent. Runs automatically on backend startup.

## Design note (why two paths, not one)

The explicit (`akb_link`) and implicit (`_store_edge`) link paths intentionally stay separate — different policy (reject-with-error + locks + `kind='explicit'` upsert vs. silent-skip + `kind='implicit'` do-nothing). The shared piece is the **validation primitive** (`_resource_exists`), now used by both. Full function-level unification would need a multi-flag helper that's harder to read.

## Tests

- `tests/test_kg_extract_links_unit.py` — wikilink coverage: akb:// + alias strips to clean URI (asserts no alias fragment leaks), path + alias, alias-less `[[…]]`, the exact historical "stopped at the space" failure shape, bare-scan dedup, wikilink inside a code span stays ignored.
- Full `scripts/check.sh` green (ruff / mypy / bandit / eslint / tsc / vitest / detect-secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)