### PR TITLE
fix(0.8.9): register migration 035 in the runtime applier + guard test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2605
+        "line_number": 2611
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-10T02:10:18Z"
+  "generated_at": "2026-06-10T02:21:33Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,12 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.9 — 2026-06-10  *(patch — register migration 035 in the runtime applier + guard test)*
+
+Migrations run from an **explicit hardcoded list** in `_apply_migrations` (`app/db/postgres.py`), not by globbing the directory — a deliberate design so a steady-state boot runs zero DDL. 0.8.8 added `035_fix_wikilink_alias_edges.py` but **not** its entry in that list, so the migration shipped as a **no-op**: the file was in the image but never invoked, and the already-corrupted edges stayed corrupted on deploy.
+
+This registers `035_fix_wikilink_alias_edges.py` so it actually runs, and adds `tests/test_migrations_registered_unit.py` — a guard that fails if any `0NN_*.py` migration file on disk is missing from the applier list (with a tiny documented allowlist for the two applied via init.sql). That guard would have caught the 0.8.8 omission in CI.
+
 ## 0.8.8 — 2026-06-10  *(patch — knowledge graph: wikilink-alias edge corruption + implicit-edge existence validation)*
 
 Body-link extraction had **no handling for Obsidian wikilinks** `[[target|alias]]`. The greedy bare-`akb://` scan (`_AKB_URI_RE`) then swallowed the alias's first word onto the target — a References line like `[[akb://v/coll/decisions/doc/x.md|PWC Query Performance Optimization]]` produced the edge target `akb://v/coll/decisions/doc/x.md|PWC` (matching stopped at the first space). One bug, two symptoms:

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -167,6 +167,7 @@ async def _apply_migrations() -> None:
         "032_drop_supersedes.py",               # drop never-used documents.supersedes column (status leaned to draft/active/archived)
         "033_users_auth_provider.py",           # users.auth_provider ('local' default | 'keycloak' for JIT-provisioned SSO accounts)
         "034_oidc_transients.py",               # oidc_transients: short-lived OIDC state + one-time exchange codes (HA-safe; empty when Keycloak off)
+        "035_fix_wikilink_alias_edges.py",      # repair edges whose target_uri carries a wikilink alias ([[…|label]] → …|label); strip alias, re-validate existence, drop orphans
     ):
         if filename in applied:
             continue

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.8"
+version = "0.8.9"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/test_migrations_registered_unit.py
+++ b/backend/tests/test_migrations_registered_unit.py
@@ -1,0 +1,38 @@
+"""Guard: every migration file on disk is registered in the runtime
+applier (`_apply_migrations` in app/db/postgres.py).
+
+Migrations are run from an explicit hardcoded list, NOT by globbing the
+directory — so a newly-added `0NN_*.py` file silently never runs until it
+is also added to that list. This test fails loudly on that omission (which
+shipped a no-op migration in 0.8.8 before this guard existed).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent
+_MIG_DIR = _BACKEND / "app" / "db" / "migrations"
+_POSTGRES = _BACKEND / "app" / "db" / "postgres.py"
+
+# Files intentionally NOT in the runtime list (applied via init.sql on a
+# fresh DB / superseded). Keep this set tiny and documented.
+_INTENTIONALLY_UNREGISTERED = {
+    "001_relations_to_edges.py",
+    "013_nfc_normalize.py",
+}
+
+
+def test_every_migration_file_is_registered():
+    on_disk = {p.name for p in _MIG_DIR.glob("[0-9][0-9][0-9]_*.py")}
+    src = _POSTGRES.read_text(encoding="utf-8")
+    missing = [
+        name
+        for name in sorted(on_disk - _INTENTIONALLY_UNREGISTERED)
+        if f'"{name}"' not in src
+    ]
+    assert not missing, (
+        "migration file(s) on disk but not registered in "
+        f"_apply_migrations(): {missing} — add them to the list in "
+        "app/db/postgres.py (or to _INTENTIONALLY_UNREGISTERED if applied "
+        "elsewhere)."
+    )


### PR DESCRIPTION
## Why

Migrations run from an **explicit hardcoded list** in `_apply_migrations` (`app/db/postgres.py`), not by globbing the directory (deliberate: a steady-state boot runs zero DDL). PR #186 (0.8.8) added `035_fix_wikilink_alias_edges.py` but **not** its list entry, so the migration shipped as a **no-op** — confirmed on the on-prem deploy: the file was in the image, but `akb_relations` still returned the `…md|PWC` corrupted edges because 035 never ran.

## Fix

- Register `035_fix_wikilink_alias_edges.py` in the applier list.
- Add `tests/test_migrations_registered_unit.py` — a guard that fails if any `0NN_*.py` migration file on disk is missing from the list (with a documented allowlist for `001`/`013`, which are applied via init.sql). This would have caught the 0.8.8 omission in CI.

After this lands + deploy, migration 035 runs on startup and repairs the corrupted edges.

## Tests
- `tests/test_migrations_registered_unit.py` passes (all on-disk migrations registered).
- Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)