### PR TITLE
fix(frontend/graph): render links_to edges (was dropped by relation allowlist)

### DIFF
--- a/frontend/src/components/graph/__tests__/use-graph-data.test.ts
+++ b/frontend/src/components/graph/__tests__/use-graph-data.test.ts
@@ -178,6 +178,40 @@ describe("bfsExpand", () => {
     expect(out.edges.length).toBe(1);
   });
 
+  // Regression: `links_to` (body markdown / wikilink edges) was missing
+  // from normalizeRelation's allowlist, so every body-link edge was
+  // silently dropped — the neighbor node appeared but its edge never did,
+  // leaving floating nodes with no lines in the graph.
+  it("keeps links_to edges (not just the frontmatter relation kinds)", async () => {
+    const fetchRelations = vi.fn(async (_v: string, docId: string) => ({
+      doc_id: docId,
+      uri: `akb://v/doc/${docId}`,
+      relations: [
+        {
+          direction: "outgoing" as const,
+          relation: "links_to",
+          uri: "akb://v/doc/d-2",
+          name: "Linked",
+          resource_type: "document",
+        },
+      ],
+    }));
+    const out = await bfsExpand({ vault: "v", entry: "d-1", hops: 1, fetchRelations });
+    expect(out.edges).toEqual([
+      { source: "akb://v/doc/d-1", target: "akb://v/doc/d-2", relation: "links_to" },
+    ]);
+  });
+
+  it("DEFAULT_VIEW keeps links_to edges through applyFilters", () => {
+    const nodes: GraphNode[] = [
+      { uri: "akb://v/doc/a", name: "A", kind: "document" },
+      { uri: "akb://v/doc/b", name: "B", kind: "document" },
+    ];
+    const edges: GraphEdge[] = [{ source: "akb://v/doc/a", target: "akb://v/doc/b", relation: "links_to" }];
+    const out = applyFilters({ nodes, edges }, DEFAULT_VIEW);
+    expect(out.edges).toEqual(edges);
+  });
+
   it("walks depth-2 by following neighbors discovered in hop 1", async () => {
     const calls: string[] = [];
     const fetchRelations = vi.fn(async (_v: string, docId: string) => {

--- a/frontend/src/components/graph/graph-types.ts
+++ b/frontend/src/components/graph/graph-types.ts
@@ -7,11 +7,16 @@ export type RelationKind =
   | "references"
   | "related_to"
   | "attached_to"
-  | "derived_from";
+  | "derived_from"
+  // Body markdown / wikilink references (`[[…]]`, `[..](..)`) extracted by
+  // the backend as implicit edges. Omitting it here silently dropped every
+  // body-link edge from the graph even when the backend returned it.
+  | "links_to";
 
 export const ALL_NODE_KINDS: ReadonlyArray<NodeKind> = ["document", "table", "file"];
 export const ALL_RELATIONS: ReadonlyArray<RelationKind> = [
   "depends_on", "implements", "references", "related_to", "attached_to", "derived_from",
+  "links_to",
 ];
 
 export interface GraphNode {
@@ -99,4 +104,5 @@ export const RELATION_DASH: Record<RelationKind, number[]> = {
   related_to: [2, 2],
   attached_to: [],
   derived_from: [6, 2],
+  links_to: [1, 3],
 };

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -32,6 +32,7 @@ function normalizeRelation(raw: string | undefined): RelationKind | null {
     case "related_to":
     case "attached_to":
     case "derived_from":
+    case "links_to":
       return raw;
     default:
       return null;


### PR DESCRIPTION
## Symptom

After the backend kg fix (0.8.8/0.8.9) repaired the corrupted edge data, the **graph still drew no `links_to` edges** — "some edges draw, some don't, even though links_to shows in the relations panel."

## Root cause (frontend, separate from the backend data bug)

`links_to` (body markdown / wikilink edges) was **missing from the frontend `RelationKind` allowlist**. `normalizeRelation` returned `null` for it, so `useFullGraph` and `rowToEdge` filtered every `links_to` edge out. The neighbor *node* was still added (rowToNeighbor doesn't filter), leaving floating nodes with no lines. Recognized kinds (`depends_on`/`related_to`/…) rendered fine — hence "some draw, some don't."

So Bug B had **two independent causes**: corrupted edge targets (fixed backend-side in 0.8.8/0.8.9) **and** this frontend relation-allowlist gap.

## Fix

- Add `links_to` to `RelationKind`, `ALL_RELATIONS` (so it's enabled by default + gets a sidebar toggle), and `RELATION_DASH` (fine-dotted `[1,3]` style; `Record<RelationKind>` makes tsc enforce completeness).
- Add the `links_to` case to `normalizeRelation`.

## Tests
- `use-graph-data.test.ts`: bfsExpand keeps a `links_to` edge; `DEFAULT_VIEW` passes it through `applyFilters`.
- Full `scripts/check.sh` green (eslint / tsc / vitest 66✓ + backend gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)