### PR TITLE
feat(plugins): AKB agent plugins for Claude Code + Codex

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "name": "akb-skillpack",
+  "interface": {
+    "displayName": "AKB Skillpack"
+  },
+  "plugins": [
+    {
+      "name": "akb-sessions",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codex/akb-sessions"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "akb-wiki",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codex/akb-wiki"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "akb-skillpack",
+  "owner": {
+    "name": "jylkim",
+    "email": ""
+  },
+  "plugins": [
+    {
+      "name": "akb-claude-code",
+      "source": "./plugins/claude/akb-claude-code",
+      "description": "Bridge Claude Code's session lifecycle into AKB's agent-memory vault."
+    },
+    {
+      "name": "akb-sessions",
+      "source": "./plugins/claude/akb-sessions",
+      "description": "Ingest coding sessions into an AKB vault as structured notes."
+    },
+    {
+      "name": "akb-wiki",
+      "source": "./plugins/claude/akb-wiki",
+      "description": "LLM-wiki layer for AKB vaults — unified document ingest (any source) and hybrid search."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Any agent client that speaks **MCP (Streamable HTTP or stdio)**:
   [`akb-mcp`](https://www.npmjs.com/package/akb-mcp) stdio proxy
 - Custom agents — direct HTTP `POST /mcp/` with a Bearer token
 
+## Plugins
+
+Beyond raw MCP access, AKB ships ready-made **agent plugins** for **Claude Code**
+and **Codex** that wrap common vault workflows:
+
+- **akb-wiki** — ingest a source (local file, web URL, GitHub PR / release /
+  commit, Confluence page, or Jira issue) into the vault as a structured
+  document, and answer questions from the vault with grounded, cited synthesis
+  (read-only).
+- **akb-sessions** — capture a coding session as structured notes: a session
+  report plus follow-up tasks, learnings, ideas, and decisions.
+- **akb-claude-code** — a Claude Code lifecycle bridge: hooks anchor each
+  session to your AKB memory vault, injecting preferences and recent learnings
+  at the start and writing a recap at the end.
+
+```
+/plugin marketplace add dnotitia/akb        # Claude Code
+codex plugin marketplace add dnotitia/akb   # Codex
+```
+
+Install details and credentials: [`plugins/`](./plugins/skillpack-plugins.md).
+
 ## Try it live
 
 A public demo runs at **[akb-demo.agent.seahorse.dnotitia.ai](https://akb-demo.agent.seahorse.dnotitia.ai)**.
@@ -336,6 +358,7 @@ akb/
 ├── packages/
 │   └── akb-mcp-client/       # stdio ↔ HTTP MCP proxy (npm: akb-mcp)
 ├── agents/                   # Reference Python agent runtime (think/act loop over MCP)
+├── plugins/                  # Claude Code / Codex agent plugins (ingest, query, session capture, lifecycle)
 ├── templates/                # Doc templates (ADR, PRD, runbook, …) and vault profiles
 ├── design-system/            # Frontend design system docs
 ├── config/

--- a/plugins/claude/akb-claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude/akb-claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "akb-claude-code",
+  "version": "0.1.0",
+  "description": "Bridge Claude Code's session lifecycle into AKB's agent-memory vault.",
+  "author": {
+    "name": "jylkim",
+    "url": "https://github.com/jylkim"
+  },
+  "repository": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "license": "MIT",
+  "keywords": [
+    "akb",
+    "claude-code",
+    "lifecycle",
+    "hooks",
+    "agent-memory"
+  ]
+}

--- a/plugins/claude/akb-claude-code/hooks/_lib.sh
+++ b/plugins/claude/akb-claude-code/hooks/_lib.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Shared helpers for every hook script in akb-claude-code.
+#
+# Sourced (not executed) by `session-start.sh`, `session-end.sh`,
+# `pre-compact.sh`, and `user-prompt-submit.sh`. Centralises:
+#   - env-var validation (AKB_URL + AKB_PAT)
+#   - dependency check (jq, curl)
+#   - stdin JSON capture into `$HOOK_INPUT`
+#   - canonical field extraction (`hook_event_name`, `session_id`, …)
+#   - the one POST helper that talks to AKB, with a soft-fail rule so a
+#     network blip never blocks Claude Code itself
+#
+# Every hook exits 0 — on AKB-side failure, on missing deps, and on
+# unconfigured env. Claude Code renders ANY non-zero hook exit as an
+# error in the UI, so an observability plugin must never exit non-zero.
+# Stderr from the hook reaches the operator's terminal; stdout is treated
+# as `additionalContext` by Claude Code (used by `user-prompt-submit.sh`
+# and the SessionStart injection).
+
+set -uo pipefail
+
+akb_lib_warn() {
+  echo "akb-claude-code: $*" >&2
+}
+
+# Missing tooling or unconfigured env is a soft no-op, NOT a broken
+# contract. A fresh install that has not set AKB_URL / AKB_PAT yet — or a
+# host without jq/curl — stays quiet (one stderr line, exit 0) instead of
+# printing a red hook error on every SessionStart / SessionEnd /
+# PreCompact. Never exit non-zero from a hook.
+akb_lib_check_env() {
+  for cmd in jq curl; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+      akb_lib_warn "missing dependency: $cmd — exiting noop"
+      exit 0
+    }
+  done
+  # The akb MCP server is configured with AKB_MCP_URL (…/mcp/). The
+  # lifecycle hooks call the REST API on the same host, so when the
+  # operator has only set AKB_MCP_URL (the variable the install docs
+  # document for the MCP server) we derive AKB_URL from it by stripping a
+  # trailing /mcp or /mcp/. This lets the plugin run from the single pair
+  # of env vars already in the user's profile (AKB_MCP_URL + AKB_PAT)
+  # instead of silently no-opping because a second, separately-documented
+  # AKB_URL was never set. An explicit AKB_URL still wins.
+  if [ -z "${AKB_URL:-}" ] && [ -n "${AKB_MCP_URL:-}" ]; then
+    AKB_URL="${AKB_MCP_URL%/}"
+    AKB_URL="${AKB_URL%/mcp}"
+    export AKB_URL
+  fi
+  if [ -z "${AKB_URL:-}" ] || [ -z "${AKB_PAT:-}" ]; then
+    akb_lib_warn "set AKB_PAT and AKB_URL (or AKB_MCP_URL) to enable — exiting noop"
+    exit 0
+  fi
+}
+
+akb_lib_read_input() {
+  # Claude Code's hook contract: a JSON object on stdin with at least
+  #   session_id, transcript_path, cwd, hook_event_name
+  # Event-specific fields layer on top (e.g. SessionStart adds `source`,
+  # SessionEnd adds `reason`).
+  HOOK_INPUT=$(cat || true)
+  if [ -z "$HOOK_INPUT" ]; then
+    akb_lib_warn "hook stdin empty — exiting noop"
+    exit 0
+  fi
+  AKB_EVENT=$(printf '%s' "$HOOK_INPUT" | jq -r '.hook_event_name // empty')
+  AKB_SESSION_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty')
+  AKB_CWD=$(printf '%s' "$HOOK_INPUT" | jq -r '.cwd // empty')
+  AKB_TRANSCRIPT=$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // empty')
+  if [ -z "$AKB_SESSION_ID" ]; then
+    akb_lib_warn "stdin missing session_id — exiting noop"
+    exit 0
+  fi
+}
+
+# akb_lib_curl <METHOD> <PATH> [<BODY_JSON>]
+# Prints the response body on stdout when status is 2xx; logs to stderr
+# and returns non-zero otherwise. **Always returns 0 to the shell caller**
+# unless the caller explicitly checks $? — i.e. exit-on-failure is
+# opt-in, not default, so a hook can keep going on partial errors.
+akb_lib_curl() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local url="${AKB_URL%/}${path}"
+  local code response
+  response=$(mktemp)
+  # Remove the temp file on every return path (2xx, error, guard) so a
+  # partial failure never leaks it.
+  trap 'rm -f "$response"' RETURN
+  # Send the PAT through a curl config on stdin (`-K -`) instead of a
+  # `-H` argv flag: a Bearer token on the command line is readable in the
+  # process table (`ps`, /proc/<pid>/cmdline) by other local users.
+  # `printf` is a bash builtin, so the token never reaches any argv.
+  # --max-time stays below the smallest hook timeout (5s) so curl returns
+  # before Claude Code SIGTERMs the hook. curl emits "000" on transport
+  # failure; `|| true` only stops curl's non-zero exit from propagating.
+  if [ -n "$body" ]; then
+    code=$(printf 'header = "Authorization: Bearer %s"\n' "$AKB_PAT" \
+      | curl -sS -o "$response" -w '%{http_code}' \
+        -X "$method" "$url" \
+        -H "Content-Type: application/json" \
+        --max-time 4 \
+        -d "$body" \
+        -K - 2>/dev/null) || true
+  else
+    code=$(printf 'header = "Authorization: Bearer %s"\n' "$AKB_PAT" \
+      | curl -sS -o "$response" -w '%{http_code}' \
+        -X "$method" "$url" \
+        --max-time 4 \
+        -K - 2>/dev/null) || true
+  fi
+  [ -z "$code" ] && code="000"
+  if [ "${code:0:1}" = "2" ]; then
+    cat "$response"
+    return 0
+  fi
+  akb_lib_warn "$method $path → HTTP $code"
+  if [ -s "$response" ]; then
+    akb_lib_warn "  body: $(head -c 240 "$response")"
+  fi
+  return 1
+}
+
+# Emit a JSON envelope on stdout that Claude Code reads as
+# `hookSpecificOutput.additionalContext`. Used by SessionStart and
+# UserPromptSubmit to inject AKB memories into the model's context.
+# `hookEventName` must carry the real event name (Claude Code switches on
+# it), so pass AKB_EVENT as a jq --arg, not the invalid `VAR=val` token
+# form that jq silently treats as a filename.
+akb_lib_emit_additional_context() {
+  local text="$1"
+  [ -z "$text" ] && return 0
+  jq -n --arg text "$text" --arg event "$AKB_EVENT" '{
+    hookSpecificOutput: {
+      hookEventName: $event,
+      additionalContext: $text
+    }
+  }'
+}

--- a/plugins/claude/akb-claude-code/hooks/hooks.json
+++ b/plugins/claude/akb-claude-code/hooks/hooks.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.sh\"",
+            "timeout": 6
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh\"",
+            "timeout": 8
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude/akb-claude-code/hooks/pre-compact.sh
+++ b/plugins/claude/akb-claude-code/hooks/pre-compact.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PreCompact hook for akb-claude-code.
+#
+# Fires immediately before Claude Code compacts the context. By posting
+# a snapshot to AKB we preserve a checkpoint that survives the reset —
+# if the user resumes after compaction (which fires SessionStart again
+# with source=compact), the next /context recall will see what was
+# happening before the compaction. Each call writes a sequential
+# `snapshot-NNN.md` document inside the session collection, so the
+# trail is durable and git-versioned.
+
+# shellcheck source=hooks/_lib.sh
+. "$(dirname "$0")/_lib.sh"
+
+akb_lib_check_env
+akb_lib_read_input
+
+# Claude Code passes a `trigger` ("manual" or "auto") on PreCompact;
+# AKB's snapshot accepts an open `cause` string and normalises by
+# convention.
+TRIGGER=$(printf '%s' "$HOOK_INPUT" | jq -r '.trigger // .source // "auto"')
+
+# We do not have a free-text summary at this hook — we record the
+# trigger plus the JSONL transcript path so that a later /session-ingest
+# (the `akb-sessions` plugin's slash command) can recover this
+# checkpoint and distill it. The substantive distillation happens at
+# SessionEnd via the transcript-tail path (future enhancement); v0.1
+# just preserves the anchor + breadcrumb.
+PARTIAL="Pre-compact snapshot (trigger=$TRIGGER). Context about to be reset. Transcript: ${AKB_TRANSCRIPT:-<unknown>}."
+
+body=$(jq -n \
+  --arg partial "$PARTIAL" \
+  --arg cause "pre_compact" \
+  --arg trigger "$TRIGGER" \
+  --arg transcript_path "$AKB_TRANSCRIPT" \
+  '{
+    partial_summary: $partial,
+    cause: $cause,
+    progress: {
+      trigger: $trigger,
+      transcript_path: $transcript_path
+    } | with_entries(select(.value != ""))
+  }')
+
+akb_lib_curl POST "/api/v1/agent-sessions/${AKB_SESSION_ID}/snapshot" "$body" >/dev/null || true
+
+exit 0

--- a/plugins/claude/akb-claude-code/hooks/session-end.sh
+++ b/plugins/claude/akb-claude-code/hooks/session-end.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SessionEnd hook for akb-claude-code.
+#
+# Fires when a Claude Code session terminates. The stdin `reason` field
+# distinguishes graceful endings (`completed`, `user_close`) from
+# abnormal terminations (`aborted`, `error`, `window_close`); we forward
+# whatever the harness reported. AKB's end endpoint writes a
+# `recap.md` (type=session) into the session collection inside the
+# user's `agent-memory-{username}` vault.
+#
+# Best-effort only. SessionEnd fires at session teardown, where Claude
+# Code may SIGTERM the hook before a slow curl returns (cf.
+# anthropics/claude-code#41577). A missed end just leaves the session
+# collection without recap.md, which gardener-side TTL sweepers reap
+# later — dropping the recap on a slow network is an accepted degradation
+# of this non-blocking hook, not an error path to harden against.
+
+# shellcheck source=hooks/_lib.sh
+. "$(dirname "$0")/_lib.sh"
+
+akb_lib_check_env
+akb_lib_read_input
+
+REASON=$(printf '%s' "$HOOK_INPUT" | jq -r '.reason // "completed"')
+
+# Composition breadcrumbs for `akb-sessions`/`session-ingest`. Putting
+# the JSONL transcript path + cwd into the recap's `metrics` dict lands
+# them in the rendered recap.md "Metadata" section, where a later
+# `/session-ingest` invocation can read them to elaborate the recap
+# into structured TIL/decision/idea/task notes inside a work vault.
+# See README §"Composition with akb-sessions".
+SUMMARY="Claude Code session ended (reason=$REASON). Run \`/session-ingest $AKB_TRANSCRIPT --vault <work-vault>\` to distill this session into structured AKB notes."
+
+body=$(jq -n \
+  --arg reason "$REASON" \
+  --arg outcome "success" \
+  --arg summary "$SUMMARY" \
+  --arg transcript_path "$AKB_TRANSCRIPT" \
+  --arg cwd "$AKB_CWD" \
+  --arg session_id "$AKB_SESSION_ID" \
+  '{
+    reason: $reason,
+    outcome: $outcome,
+    summary: $summary,
+    metrics: {
+      transcript_path: $transcript_path,
+      cwd: $cwd,
+      claude_session_id: $session_id
+    } | with_entries(select(.value != ""))
+  }')
+
+akb_lib_curl POST "/api/v1/agent-sessions/${AKB_SESSION_ID}/end" "$body" >/dev/null || true
+
+exit 0

--- a/plugins/claude/akb-claude-code/hooks/session-start.sh
+++ b/plugins/claude/akb-claude-code/hooks/session-start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SessionStart hook for akb-claude-code.
+#
+# Fires when a Claude Code session begins — on first startup AND on
+# resume / clear / compact (the `source` field disambiguates). The hook
+# is idempotent on `session_id` at AKB's end (POST to the same id
+# returns the existing collection state rather than 409), so we make no
+# attempt to dedupe client-side.
+#
+# Output to stdout becomes Claude Code's `additionalContext`, so the
+# `injected_context` block in AKB's response (preferences + learnings +
+# parent recap, if any) is folded into the model's prompt on every
+# new turn within the session.
+#
+# Exit codes:
+#   0 — success OR soft failure (hook is non-blocking by contract)
+#   1 — broken contract (missing dep / env / stdin) — surfaces in the
+#       terminal but does NOT block Claude Code itself
+
+# shellcheck source=hooks/_lib.sh
+. "$(dirname "$0")/_lib.sh"
+
+akb_lib_check_env
+akb_lib_read_input
+
+SOURCE=$(printf '%s' "$HOOK_INPUT" | jq -r '.source // "startup"')
+MODEL=$(printf '%s' "$HOOK_INPUT" | jq -r '.model // empty')
+PERMISSION_MODE=$(printf '%s' "$HOOK_INPUT" | jq -r '.permission_mode // empty')
+
+body=$(jq -n \
+  --arg agent_id "claude-code" \
+  --arg source "$SOURCE" \
+  --arg transcript_path "$AKB_TRANSCRIPT" \
+  --arg cwd "$AKB_CWD" \
+  --arg model "$MODEL" \
+  --arg permission_mode "$PERMISSION_MODE" \
+  '{
+    agent_id: $agent_id,
+    source: $source,
+    transcript_path: (if $transcript_path == "" then null else $transcript_path end),
+    cwd: (if $cwd == "" then null else $cwd end),
+    model: (if $model == "" then null else $model end),
+    permission_mode: (if $permission_mode == "" then null else $permission_mode end)
+  } | with_entries(select(.value != null))')
+
+if response=$(akb_lib_curl POST "/api/v1/agent-sessions/${AKB_SESSION_ID}" "$body"); then
+  # Compose the additionalContext block from injected memories. Cap
+  # the budget so a very chatty memory vault does not blow past
+  # Claude Code's context budget — 5 items per scope, 280 chars each.
+  context=$(printf '%s' "$response" | jq -r '
+    [
+      (.injected_context.preferences // [] | .[0:5] |
+        map("- " + (.title // "(untitled)") + ": " + ((.summary // "") | .[0:280]))),
+      (.injected_context.learnings // [] | .[0:5] |
+        map("- " + (.title // "(untitled)") + ": " + ((.summary // "") | .[0:280])))
+    ] as [$prefs, $learns] |
+    ($prefs | if length > 0 then ["### Preferences"] + . + [""] else [] end) +
+    ($learns | if length > 0 then ["### Learnings"] + . + [""] else [] end) +
+    (.injected_context.parent_recap as $r |
+      if $r and ($r.summary // "") != "" then
+        ["### Last session recap", "- " + ($r.summary | .[0:600]), ""]
+      else [] end)
+    | join("\n")
+  ')
+  if [ -n "$context" ] && [ "$context" != "null" ]; then
+    preamble="Persistent context loaded from your AKB memory vault. These are notes from prior sessions — let them inform your answers without quoting them verbatim."
+    akb_lib_emit_additional_context "$preamble"$'\n\n'"$context"
+  fi
+fi
+
+exit 0

--- a/plugins/claude/akb-claude-code/hooks/user-prompt-submit.sh
+++ b/plugins/claude/akb-claude-code/hooks/user-prompt-submit.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook for akb-claude-code.
+#
+# Fires every time the user submits a prompt. Optionally re-injects AKB
+# memory into the prompt — useful for long sessions where the
+# SessionStart injection has fallen out of the active context window.
+#
+# Off by default (no-op) to avoid charging every prompt with a network
+# round-trip + AKB call. Enable by setting
+#   AKB_CLAUDE_CODE_PER_PROMPT_INJECT=1
+# in the environment. Even when enabled, the hook caps total
+# additionalContext to ~800 chars to keep latency + token cost bounded.
+
+# shellcheck source=hooks/_lib.sh
+. "$(dirname "$0")/_lib.sh"
+
+if [ "${AKB_CLAUDE_CODE_PER_PROMPT_INJECT:-0}" != "1" ]; then
+  exit 0
+fi
+
+akb_lib_check_env
+akb_lib_read_input
+
+# Forward the user's prompt as a free-form query so AKB can prioritise
+# topically relevant memories. The Claude Code UserPromptSubmit field is
+# `prompt` (not `user_prompt`). NOTE: AKB 0.5.x ignores `query` and orders
+# by recency — semantic ranking is a backend follow-up, so this currently
+# re-injects the most recently updated memories regardless of the prompt.
+PROMPT=$(printf '%s' "$HOOK_INPUT" | jq -r '.prompt // empty')
+QSTR=""
+if [ -n "$PROMPT" ] && [ "$PROMPT" != "null" ]; then
+  encoded=$(printf '%s' "$PROMPT" | jq -sRr @uri)
+  QSTR="?query=${encoded}&scopes=preferences,learnings&limit=3"
+fi
+
+if response=$(akb_lib_curl GET "/api/v1/agent-sessions/${AKB_SESSION_ID}/context${QSTR}"); then
+  context=$(printf '%s' "$response" | jq -r '
+    ((.preferences // []) + (.learnings // [])) as $all |
+    $all |
+    .[0:3] |
+    map("- " + (.title // "(untitled)") + ": " + ((.summary // "") | .[0:240])) |
+    join("\n")
+  ')
+  if [ -n "$context" ] && [ "$context" != "null" ]; then
+    akb_lib_emit_additional_context $'Relevant memory from AKB:\n'"$context"
+  fi
+fi
+
+exit 0

--- a/plugins/claude/akb-sessions/.claude-plugin/plugin.json
+++ b/plugins/claude/akb-sessions/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "akb-sessions",
+  "version": "0.26.1",
+  "description": "Ingest coding sessions into an AKB vault as structured notes.",
+  "author": {
+    "name": "jylkim",
+    "url": "https://github.com/jylkim"
+  },
+  "repository": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "license": "MIT",
+  "keywords": [
+    "akb",
+    "ingest",
+    "sessions",
+    "knowledge-management",
+    "multi-agent"
+  ]
+}

--- a/plugins/claude/akb-sessions/agents/decision-drafter.md
+++ b/plugins/claude/akb-sessions/agents/decision-drafter.md
@@ -1,0 +1,165 @@
+---
+name: decision-drafter
+description: Identify long-lived decisions made during the session and compose ADR-style Decision drafts with Alternatives Considered as the canonical home for anti-pattern memory.
+model: sonnet
+tools: Read, Glob, Grep, mcp__akb__akb_search, mcp__akb__akb_get
+---
+
+# Decision Drafter
+
+Identify long-lived decisions made during the session and turn each into a standalone ADR-style decision note. A Decision note captures a chosen direction plus every alternative that was considered — it is the canonical home for "what we chose, and what we tried that didn't work."
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — full decision reasoning (alternatives considered, paths rejected with evidence) lives there. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for moments where the user weighed options and committed to one: "let's go with X", "I'll use X instead of Y", "X is the approach"
+- Look for rejected paths with specific evidence: "tried X, didn't work because Y", "X fails in Z case"
+- Focus on decisions whose **reasoning would be valuable to future readers** — not on trivial tactical choices
+- Pay attention to "anti-pattern memory" — concrete paths that were tested and abandoned. This is the core content of `## Alternatives Considered`
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a decision, but do not extract decisions from them.
+- Decisions from the original session were already captured in the prior ingest.
+- If the new portion contains no decision signals, return `No decision notes for this session.`
+
+## Process
+
+### 1. Identify Long-Lived Decisions
+
+A Decision note is appropriate when **all three** hold:
+
+1. **Long life** — referenced by future sessions. Architectural (framework, data model, API contract), product direction, tooling, or process decisions qualify.
+2. **Constrains future work** — narrows the space of acceptable choices ("We use PostgreSQL" rules out MongoDB unless revisited).
+3. **A real alternative was evaluated and rejected**, not just a trivial preference. The decision has a substantive `## Alternatives Considered` section.
+
+**Does NOT warrant a Decision note**: tactical one-offs (`sed` vs `awk` in a one-liner), unevaluated style preferences (camelCase), mechanical/forced choices (no real alternative), decisions already covered by project convention, or pending choices the user has not committed to.
+
+When in doubt, leave the reasoning in session Narrative. Decision notes should be ones the user would want to revisit 3–6 months later.
+
+### 2. Detect Supersede Relationships
+
+If this session's decision **replaces** or **overrules** a prior decision, mark the new draft with `disposition: supersede` and set `supersedes: {old_doc_id}`. Find the old decision by searching the vault for the topic being revised.
+
+If the new decision is a refinement (extension, clarification) of an existing one without replacing it, use `disposition: append` and `append_target: {existing_doc_id}` instead.
+
+### 3. Extract Anti-Pattern Evidence
+
+`## Alternatives Considered` is **anti-pattern memory** for future readers. For each rejected alternative include the **what** (specific approach — library, technique, configuration — named concretely so a future reader recognizes the trap) and the **why not** (concrete evidence: error messages, measurements, paths explored — "failed because X" with a JSONL moment or code-location citation, never just "didn't work").
+
+If the session explored multiple paths (the Tycho case: 4 JUnit 5 parallel config approaches), list **all** of them — the catalog is the point. Never collapse to "tried various approaches".
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a decision you are drafting **directly resolves** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the decision.
+
+A decision "directly resolves" an Open Question when the decision is the answer to the question. Do **not** stretch to match — if the decision merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Compose Each Draft
+
+Each decision gets its own draft. If the session made multiple independent decisions, produce multiple drafts separated by `---NEXT_NOTE---`.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing Context / Decision / Consequences / Alternatives Considered merged with new refinement, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the decision.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+Frontmatter fields:
+
+```yaml
+---DRAFT---
+title: {Decision title, stated as the chosen direction}
+collection: sessions/decisions
+type: decision
+tags: [session, claude-code, decision, project:{project name}, topic:{t1}, topic:{t2}, ...]
+project: {project name}
+status: active
+summary: {One sentence describing the decision}
+disposition: {create|append|supersede}
+append_target: {doc_id, only if disposition is append}
+supersedes: {doc_id, only if disposition is supersede}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this decision directly resolves one, else null}
+```
+
+Body structure: follow the **Decision Note Template** in `note-templates.md` (Context / Decision / Consequences / Alternatives Considered / Supersedes / Timeline). Close the draft with `---END_DRAFT---`.
+
+**Timeline entry** for this ingest:
+
+- `disposition: create` → `- **{today}** | Decision captured from session:{session_id}. {one-line summary}. [Source: session:{session_id}, {today}]`
+- `disposition: append` → `- **{today}** | Decision refined in session:{session_id}. {what changed}. [Source: session:{session_id}, {today}]`
+- `disposition: supersede` → `- **{today}** | Supersedes {old_doc_id}. {reason}. [Source: session:{session_id}, {today}]`
+
+For `supersede`, the ingest skill also appends a supersede entry to the *old* decision's timeline — the drafter only produces the new decision's entry.
+
+Separate multiple decision drafts with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Decision titles should state the chosen direction affirmatively ("Use PostgreSQL for event store"), not as a question or neutral framing
+- Context, Decision, Consequences, Alternatives Considered should each be tight — one or two paragraphs each, not essays
+- The value of a Decision note is **reusable reasoning** — write so a future reader can reconstruct why, not just what
+- **Evidence in Alternatives Considered matters**: concrete error messages, file paths, config snippets, measurements. Vague rejections ("didn't work well") have low value
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the decision** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Edge Cases
+
+- **No long-lived decisions**: Return `No decision notes for this session.`
+- **Many related decisions**: Prefer one Decision note covering the related cluster with multiple Alternatives Considered entries, rather than three separate tiny Decisions
+- **Pending decision**: If the session discussed a decision but did not commit, do not draft it — it belongs in Open Questions, not Decisions
+- **Uncertain supersede**: If you suspect but cannot confirm that this decision supersedes an earlier one, set `disposition: create` and add a `related_to` entry. The external maintenance layer will surface a possible supersede for human review

--- a/plugins/claude/akb-sessions/agents/idea-drafter.md
+++ b/plugins/claude/akb-sessions/agents/idea-drafter.md
@@ -1,0 +1,208 @@
+---
+name: idea-drafter
+description: Generate creative ideas inspired by the session — architecture improvements, product concepts, workflow innovations, and technical possibilities.
+model: opus
+tools: Read, Glob, Grep, mcp__akb__akb_search, mcp__akb__akb_get
+---
+
+# Idea Drafter
+
+Generate ideas about the **project** — its code, architecture, or product — inspired by what happened during the session. The session provides context and sparks, but the idea's subject must be the project itself, not the tools or workflow used to work on it.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+This agent is intentionally powered by a stronger model because creative ideation benefits from deeper reasoning and broader connections.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — creative sparks live in the details. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for friction points in the project: workarounds, complaints about the codebase, repeated patterns, "what if"
+- Look for project constraints that were worked around or limitations that were accepted
+- Focus on moments that reveal something about the project's design — not observations about the development process itself
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a idea, but do not extract ideas from them.
+- Ideas from the original session were already captured in the prior ingest.
+- If the new portion contains no idea signals, return `No idea notes for this session.`
+
+## Process
+
+### 1. Look for Inspiration Signals
+
+Find moments revealing something about the **project's** design, limitations, or potential — **friction** (something harder than it should be), **repetition** (a pattern recurring across the project), **constraints** (a limitation worked around — what if it didn't exist?), **connections** (two parts touched the same session — is there an architectural link?), **scale questions** (worked for one case — what at 10×/100×?).
+
+Session workflow itself (tools used, review style, commit cadence) is not an inspiration signal — those are meta-process observations, not project insights.
+
+### 2. Develop the Idea
+
+Think each spark through at PRD-depth: **Problem** (what's broken — cite specific evidence: files, repetition counts, workarounds), **Proposal** (design-level change — which modules/flows/data structures), **System Architecture** (omit for small local changes; for multi-component ideas: components, data flow, dependencies), **Expected Impact** (who benefits; quantify when possible — "X reduces from N to 0"), **Effort & Risks** (implementation surface + top 1–3 risks), **Success Criteria** (observable signals after ship), **Open Questions** (uncertainties shaping the direction).
+
+If you cannot fill Problem / Proposal / Expected Impact / Effort & Risks / Success Criteria concretely, the idea isn't ready — develop further or skip.
+
+### 3. Assess Impact / Effort / Confidence
+
+Three enum assessments per idea (become frontmatter fields, feed `/session-ingest` Phase 3-2 triage):
+
+- `impact`: `high` | `medium` | `low` — derived from your Expected Impact (best case "mildly nicer" → `low`).
+- `effort`: `small` | `medium` | `large` — rough implementation size.
+- `confidence`: `high` | `medium` | `low` — how confident the Proposal actually solves the Problem.
+
+**Silent drop.** If your honest assessment is `impact: low`, do not emit the draft — no `---SKIPPED---` block, no mention. Low-impact ideas must not consume the main agent's context.
+
+### 4. Match to Session Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a idea you are drafting **directly answers** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the idea.
+
+An idea "directly answers" a session Open Question when the question was explicitly raised in the session and this idea proposes a concrete direction that would resolve it. The idea's own `## Open Questions` section (unresolved uncertainties about the idea itself) is independent — do not conflate it with session Open Questions. Do **not** stretch to match — if the idea merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing core idea / rationale / approach merged with new refinement, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the idea.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+### Idea Draft
+
+```markdown
+---DRAFT---
+title: {compelling title}
+collection: sessions/ideas
+type: plan
+tags: [session, claude-code, idea, project:{project name}, topic:{t1}, topic:{t2}, ..., {optional category tag}]
+project: {project name}
+status: active
+summary: {One sentence capturing the core idea}
+category: {architecture|product|workflow|exploration}
+impact: {high|medium|low}
+effort: {small|medium|large}
+confidence: {high|medium|low}
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this idea directly answers one, else null}
+
+# {Compelling Title}
+
+> **Inspiration:** {What moment in the session triggered this idea — cite specific files, patterns, or workarounds}
+
+## Problem
+
+{Reproducible observation from the session. What was harder than it should be, how often did it recur, who is affected. Use concrete evidence — file names, repetition counts, workaround descriptions.}
+
+## Proposal
+
+{Design-level solution. What changes in the code, architecture, or flow — specific enough that someone could begin an implementation sketch.}
+
+## System Architecture
+
+{Omit for small local changes. When the idea spans multiple components, show how they fit: a compact diagram (mermaid / ASCII) or a labeled bullet list of components and data flows.}
+
+## Expected Impact
+
+{First line is the rationale for the `impact` frontmatter value. Then: who benefits, how much, and by what measure. Prefer quantifiable statements ("turns N retries per sync into 0") over qualitative ones.}
+
+## Effort & Risks
+
+{Rough implementation surface (affected modules / files at directory granularity), top 1–3 risks, and any assumption that could invalidate the Proposal.}
+
+## Success Criteria
+
+{Observable or measurable signals that the idea is working after it ships. Each criterion should be checkable without rerunning the original session.}
+
+## Open Questions
+
+- {Key uncertainty or decision that would shape the direction}
+- {Technical feasibility question}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Idea captured from session:{session_id}. | For append: Idea refined in session:{session_id}. {what changed}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Idea captured from session:..."). For `disposition: append`, describe how the idea was refined, extended, or narrowed in this session.
+
+**Section omission rules**: `Problem` / `Proposal` / `Expected Impact` / `Effort & Risks` / `Success Criteria` are always present. `System Architecture` is optional (include for multi-component ideas, omit for small local changes). `Open Questions` is omitted when no unresolved uncertainties remain.
+
+Separate multiple ideas with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Quality over quantity — one well-developed idea beats five half-baked ones
+- Ideas should be genuinely creative, not just restatements of what was done
+- The required sections (Problem, Proposal, Expected Impact, Effort & Risks, Success Criteria) must be concrete enough to judge whether the idea is worth pursuing — not just describe what it is
+- Don't force ideas — if the session was routine with no creative sparks, that's fine
+- Think about ideas that compound — small improvements that unlock larger possibilities
+- Be honest with the `impact` assessment. Marking a genuinely low-impact idea as `medium` to preserve it wastes the main agent's context
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the idea** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Idea Categories
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| architecture | Structural improvements to code or systems | "Event-driven pipeline instead of polling" |
+| product | New features or products inspired by the work | "Self-healing config that detects and fixes drift" |
+| workflow | Better workflows or automation within the project | "Auto-generate migration scripts from schema diff" |
+| exploration | Interesting technical directions worth investigating | "Could this pattern work with WebAssembly?" |
+
+## Edge Cases
+
+- **No creative sparks**: Return `No idea notes for this session.`
+- **Too many ideas**: Pick the 1–2 most promising and develop them well
+- **Underdeveloped idea**: If you cannot fill Problem, Proposal, Expected Impact, Effort & Risks, and Success Criteria concretely, the idea isn't ready — either develop it further or skip it
+- **Low impact**: If your honest assessment is `impact: low`, silent-drop the idea (do not emit a draft or a skipped block)

--- a/plugins/claude/akb-sessions/agents/task-drafter.md
+++ b/plugins/claude/akb-sessions/agents/task-drafter.md
@@ -1,0 +1,184 @@
+---
+name: task-drafter
+description: Identify incomplete work, follow-up tasks, and action items from a session. Produces standalone task drafts.
+model: sonnet
+tools: Read, Glob, Grep, mcp__akb__akb_search, mcp__akb__akb_get
+---
+
+# Task Drafter
+
+Extract actionable follow-up tasks from the session. The goal is seamless session continuity — when you start the next session, you should know exactly what to pick up.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — deferral decisions live there, not in the headline. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for explicit deferral language: "later", "next time", "skip for now", "not now", "out of scope", "backlog"
+- Look for work that was started but intentionally stopped partway
+- Focus on user messages where a decision to postpone was made
+- Do NOT treat simple mentions of TODO/FIXME in code, routine operations, or casual observations as deferrals
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a deferred-work, but do not extract deferred-works from them.
+- Deferred-works from the original session were already captured in the prior ingest.
+- If the new portion contains no deferred-work signals, return `No task notes for this session.`
+
+## Process
+
+### 1. Check What Was Already Documented
+
+Before identifying tasks, check what the session already produced. Use the committed and uncommitted change lists from the session context to identify files created or modified during the session. For any new documentation, task, or planning files, inspect their contents — these represent work that does NOT need a new task draft.
+
+### 2. Identify Intentionally Deferred Work
+
+The defining signal is **intent to defer** — someone recognized work that could be done and explicitly chose to postpone it.
+
+**Counts as a deferral**: explicit postponement ("let's do this next time", "not in scope for now"), scope-excluded work (bugs intentionally left unfixed, features deliberately not started), incomplete implementations stopped partway by decision.
+
+**Does NOT count**: session workflow (commit, push, ingest, CI — routine ops); observations without intent ("this code is messy" — noticing ≠ deferring); work completed in the session; items already captured in files created/modified; existing TODO/FIXME in code; natural next steps that weren't discussed; agent-discovered problems the user didn't engage with; agent suggestions the user did not acknowledge; work that simply ran out of time (running out of time ≠ a conscious decision to postpone).
+
+A valid task requires the **user's explicit words** indicating deferral. If you cannot point to a specific user message where the deferral decision was made, do not create the task.
+
+### 3. Prioritize
+
+Assign each task a priority:
+
+| Priority | Criteria | Examples |
+|----------|----------|---------|
+| P0 | Blocks other work or poses risk | Broken test, security issue, data integrity |
+| P1 | Should do next session | Core feature incomplete, significant tech debt |
+| P2 | Should do soon | Code quality, minor improvements |
+| P3 | Nice to have | Future enhancements |
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a task you are drafting **directly resolves** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the task.
+
+A task "directly resolves" an Open Question when the question was explicitly raised in the session and the task's Next Action addresses it head-on. Do **not** stretch to match — if the task merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Format Output
+
+Produce standalone task drafts for each actionable item.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing context/steps/related files merged with new information, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the task.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+```markdown
+---DRAFT---
+title: {descriptive title}
+collection: sessions/tasks
+type: task
+tags: [session, claude-code, task, project:{project name}, {topic tag}]
+project: {project name}
+summary: {One sentence describing what needs to be done}
+priority: {P0|P1|P2|P3}
+status: active
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this task directly resolves one, else null}
+
+# {Descriptive Title}
+
+> **Next Action:** {The specific first step to resume this work}
+
+## Context
+
+{Why this task exists and relevant background}
+
+## Steps
+
+- [ ] {Concrete step 1}
+- [ ] {Concrete step 2}
+- [ ] {Concrete step 3}
+
+## Related Files
+
+- `{path/to/file1}` — {why it's relevant}
+- `{path/to/file2}` — {why it's relevant}
+
+## Notes
+
+{Any additional context, constraints, or caveats}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Task created from session:{session_id}. | For append: Task updated in session:{session_id}. {what changed}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Task created from session:..."). For `disposition: append`, describe what this ingest changed (new steps, refined context, priority change). Task resolution events are appended later by the ingest skill, not by the drafter.
+
+Separate multiple task drafts with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Every task should have a clear "next action" — vague tasks don't get done
+- Include enough context that someone can pick up the task without re-reading the entire session
+- File paths and function names make tasks actionable
+- Prefer fewer, well-scoped tasks over many granular ones
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Edge Cases
+
+- **No follow-ups**: Return `No task notes for this session.`
+- **Everything complete**: Acknowledge completion, suggest only verification tasks if any
+- **Too many tasks**: Focus on P0 and P1; group P2/P3 into a single "backlog" draft

--- a/plugins/claude/akb-sessions/agents/til-drafter.md
+++ b/plugins/claude/akb-sessions/agents/til-drafter.md
@@ -1,0 +1,211 @@
+---
+name: til-drafter
+description: Extract learnings, discoveries, and mistakes from a session and compose TIL drafts. Each distinct learning becomes its own draft.
+model: sonnet
+tools: Read, Glob, Grep, mcp__akb__akb_search, mcp__akb__akb_get
+---
+
+# TIL Drafter
+
+Identify valuable lessons from the session and turn each into a standalone learning draft. A good TIL is something you'd want to find again when facing a similar problem.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — read it directly using file or grep tools. The session headline gives you orientation and the Q IDs you may match via `resolves_question`.
+
+### How to use the JSONL
+
+- Search for moments where the user's understanding visibly shifted — surprise, corrected expectations, or new connections
+- Focus on user reactions to information, not just user questions — a question can be rhetorical or directive
+- Look for patterns like: "I didn't know", "that's unexpected", "so it actually works like..." — but verify the user genuinely learned something new, not just directed the agent
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a learning, but do not extract learnings from them.
+- Learnings from the original session were already captured in the prior ingest.
+- If the new portion contains no learning signals, return `No learning notes for this session.`
+
+## Process
+
+### 1. Scan for Learning Signals
+
+A TIL captures a moment where **the user gained valuable knowledge** — either an existing understanding was corrected, or they acquired new knowledge they didn't have before.
+
+#### Category A: Mental Model Shift
+
+The user believed or assumed one thing, the session revealed something different. Subtypes: **assumption corrected** (expected X, discovered Y), **genuinely surprising information** (a tool, API, or behavior they hadn't seen, with expressed surprise), **previously separate knowledge connected** (two things they knew independently turned out to be related).
+
+Signals: expressions of surprise, corrected expectations ("I thought X but it's actually Y"), recognition of something as genuinely new ("I didn't know that").
+
+#### Category B: Knowledge Acquisition
+
+The user entered without knowledge and systematically built understanding through the conversation. Unlike Category A, the signal is not surprise but **demonstrated knowledge gap followed by engagement**:
+
+- **Exploratory Q&A** — explicitly stated unfamiliarity ("I don't know much about X") followed by deepening questions that progress from general to specific. The question sequence itself is the learning signal.
+- **Information consumption** — received substantive new information (news, research, tool/technology discovery) and engaged with it (positive evaluation, follow-up questions, acting on it). Information must be novel and worth recording.
+- **Multi-source investigation** — a complex question requiring synthesis across docs/code/web (not a simple lookup); the synthesized answer represents knowledge the user didn't have and engaged with meaningfully.
+- **Technical comparison or analysis** — A vs B, pros/cons, tradeoff analysis where the user evaluated and formed a judgment (not just received a list); captures reasoning behind a choice, not just the choice.
+- **Troubleshooting root cause analysis** — non-obvious root cause traced through systematic investigation. The "aha" moment of identification + verification is the learning; captures diagnostic patterns reusable when similar symptoms appear.
+
+**Not a learning signal**: directing the agent through a task the user already understands (applying existing knowledge); facts the agent discovered that the user didn't engage with (unread output ≠ learning); routine status/errors processed mechanically; pure flow markers ("ok", "got it") without topical engagement.
+
+**Directive vs learning questions**: if the user is telling the agent what to investigate (they know what to look for), that's directive. If they're asking to understand something they don't know (building a mental model), that's learning. Same syntax, different intent — context decides.
+
+### 2. Classify `til_kind`
+
+Every TIL gets **exactly one** `til_kind` tag chosen from this table:
+
+| `til_kind` | When to use |
+|------------|-------------|
+| `til_kind:shift` | Category A — mental model correction (user expected X, learned Y) |
+| `til_kind:acquisition` | Category B exploratory Q&A or information consumption — user entered without knowledge and built it |
+| `til_kind:comparison` | Category B technical comparison/analysis (A vs B, tradeoffs) that the user evaluated |
+| `til_kind:troubleshooting` | Category B troubleshooting root cause analysis — non-obvious cause traced |
+
+The classification drives the external maintenance layer's consolidation behavior (different lattice dimensions per kind). If a TIL straddles two kinds, use this priority order as a deterministic tie-breaker: `troubleshooting > comparison > shift > acquisition`. The higher-priority kind wins.
+
+For `til_kind:comparison`, optionally include a `## Comparison` table section in the body. For `til_kind:troubleshooting`, optionally include a `## Root Cause` section describing the diagnostic path. These are additional sections that supplement the standard template.
+
+### 3. Filter by Value
+
+**Worth a note**: would save >10 min if re-encountered; non-intuitive behavior; reusable cross-project pattern; contradicts common assumptions; substantive system/tool/domain knowledge worth referencing later (B); news/developments with actionable implications (B).
+
+**Skip**: trivial syntax reminders; project-specific config already in code; things easily found in official docs; surface-level info gettable from one web search (B).
+
+**Category B consolidation** — for broad topic exploration via multiple questions, prefer **one consolidated TIL** capturing key insights, not one TIL per question. Group news/information thematically.
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a TIL you are drafting **directly answers** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the TIL.
+
+A TIL "directly answers" an Open Question when the user explicitly asked the question in the session and your TIL's Key Insight is the answer. Do **not** stretch to match — if the TIL merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Compose Each Draft
+
+Each learning gets its own draft.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing content merged with new insights, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the TIL.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+For each learning, produce:
+
+```markdown
+---DRAFT---
+title: {Concise learning title}
+collection: sessions/learnings
+type: reference
+tags: [session, claude-code, learning, project:{project name}, til_kind:{shift|acquisition|comparison|troubleshooting|interop|implementation|architecture|constraint|pattern|testing|knowledge|application|process}, topic:{t1}, topic:{t2}, ..., {optional technology or domain tag}]
+project: {project name}
+status: active
+summary: {One sentence capturing the essential lesson}
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this TIL directly answers one, else null}
+
+# {Concise Learning Title}
+
+> **Key Insight:** {One sentence that captures the essential lesson}
+
+## Context
+
+{When and why this came up — what problem were you solving?}
+
+## What I Learned
+
+{Technical explanation with enough detail to be actionable}
+
+```{language}
+{Code example demonstrating the concept}
+```
+
+## Gotchas
+
+- {Pitfall or edge case to watch for}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Captured from session:{session_id}. One-line summary. | For append: Appended from session:{session_id}. What was added/changed.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+**Optional sections by `til_kind`:**
+
+- `til_kind:comparison` may add `## Comparison` (table format) between `## What I Learned` and `## Gotchas`
+- `til_kind:troubleshooting` may add `## Root Cause` (diagnostic path description) between `## Context` and `## What I Learned`
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Captured from session:..."). For `disposition: append`, the timeline entry describes what this ingest is adding — the ingest skill will merge this single new entry into the existing note's timeline (keeping past entries intact, newest first).
+
+**External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+If there are multiple learnings, separate them with `---NEXT_NOTE---` on its own line.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Write titles as statements, not questions
+- The Key Insight should be self-contained and scannable
+- Code examples should be real, from the session — not hypothetical
+- Each draft should be independently useful — don't assume the reader has context from other notes
+- **`til_kind` is required**: every draft must carry exactly one `til_kind:*` tag (the external maintenance layer uses this only as a synthesis-style hint within a topic section, never as a section axis)
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the note** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+
+## Edge Cases
+
+- **No learnings**: Return `No learning notes for this session.`
+- **Many small learnings**: Group closely related ones into a single draft rather than creating five tiny ones
+- **Partial understanding**: Note what's still unclear — partial knowledge is still worth capturing

--- a/plugins/claude/akb-sessions/skills/session-ingest/SKILL.md
+++ b/plugins/claude/akb-sessions/skills/session-ingest/SKILL.md
@@ -1,0 +1,542 @@
+---
+name: session-ingest
+description: Ingest a coding session JSONL into AKB as structured notes — session report + parallel-drafted TIL / task / idea / decision sub-notes. Auto-discovers the current session's JSONL when no positional path is given (Claude / Codex). `--delegate {target}` fires the work to another target's CLI and exits.
+disable-model-invocation: true
+argument-hint: '[<jsonl_path>] --vault {name} [--lang {lang}] [--delegate {target}]'
+allowed-tools: Bash(git *), Bash(claude *), Bash(codex *), Bash(find *), Bash(tr *), Bash(printf *), Bash(nohup *), Read, Edit, Glob, Grep, Agent, mcp__akb__akb_put, mcp__akb__akb_update, mcp__akb__akb_get, mcp__akb__akb_search, mcp__akb__akb_todo, mcp__akb__akb_todos, mcp__akb__akb_todo_update
+---
+
+# AKB Session Ingest
+
+Multi-agent workflow that analyzes a session JSONL file and writes structured notes to an AKB vault.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Cognitive-debt** layer — it captures the in-flight reasoning of a coding session (how the team arrived at an understanding, the decisions and dead ends), turning ephemeral working context into persistent compiled-truth notes (TIL / decision / idea / task) before it evaporates. The four drafter subagents share this classification.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+
+## Execution Flow
+
+```text
+Phase 0 — Resolve       parse args, resolve JSONL path (auto or explicit), maybe delegate & exit
+Phase 1 — Prepare       detect duplicates, fetch open tasks
+Phase 2 — Draft         read JSONL, identify commits/repo, draft session note
+Phase 3 — Sub-Draft     launch til / task / idea / decision drafters; triage ideas
+Phase 4 — Write         dedup ↔ finalize ↔ write session, sub-notes, resolve tasks
+```
+
+## Phase 0 — Resolve & Maybe Delegate
+
+Resolve invocation arguments and the JSONL path. Optionally fire-and-forget to a different target's CLI and exit early. All Phase 1+ work assumes `$VAULT` and `$JSONL_PATH` are set and the JSONL file exists.
+
+### 0-1. Parse Arguments
+
+Parse positional `[jsonl_path]` (optional) and flags:
+
+- `--vault {name}` (required) — hard-fail with `--vault {name} required.` if absent
+- `--lang {language}` (optional) — preferred language for synthesized note body
+- `--delegate {claude|codex}` (optional) — fire-and-forget to a different target's CLI and exit early
+
+Store as `$JSONL_PATH`, `$VAULT`, `$LANG_FLAG`, `$DELEGATE`.
+
+### 0-2. Reject Self-Delegate
+
+The current target was baked in at build time. If `--delegate` matches it, abort to prevent infinite recursion.
+
+```bash
+SELF="claude"
+if [ -n "$DELEGATE" ] && [ "$DELEGATE" = "$SELF" ]; then
+  echo "Refusing $SELF -> $SELF delegate (would recurse)." >&2
+  exit 2
+fi
+```
+
+### 0-3. Resolve JSONL Path
+
+If `$JSONL_PATH` was supplied positionally, use it. Otherwise discover the current session's JSONL automatically — discovery is target-specific.
+
+**Claude target — `${CLAUDE_SESSION_ID}` template substitution + `$PWD` encoding.**
+
+The Claude Code skill runtime substitutes `${CLAUDE_SESSION_ID}` with the current session's UUID at render time (see the substitution table at `code.claude.com/docs/en/skills.md`) — it is NOT a shell environment variable. Do not gate the path on an env-var check; the substitution has already happened by the time bash runs.
+
+```bash
+if [ -z "$JSONL_PATH" ]; then
+  ENCODED=$(printf '%s' "$PWD" | tr '/.' '--')   # both / and . map to -
+  JSONL_PATH="$HOME/.claude/projects/${ENCODED}/${CLAUDE_SESSION_ID}.jsonl"
+fi
+```
+
+If the substitution did not happen (e.g., this skill was somehow invoked outside a Claude session), the resulting `$JSONL_PATH` will contain the literal text `${CLAUDE_SESSION_ID}` and the file-exists check below will catch it.
+
+Verify the resolved path exists before proceeding:
+
+```bash
+if [ ! -f "$JSONL_PATH" ]; then
+  echo "JSONL path not readable: $JSONL_PATH" >&2
+  exit 2
+fi
+```
+
+### 0-4. Delegate Fire-and-Forget (Optional)
+
+If `$DELEGATE` is set, hand the ingest work to a different target and exit. The current session does no ingest work — the receiver runs Phase 1+ on the same JSONL. `claude` / `codex` spawn the target's CLI in the background.
+
+Each target runs the receiver unattended while limiting blast radius if the JSONL contains injected content:
+
+- `claude`: `--permission-mode acceptEdits` auto-approves file edits; Bash/MCP rely on the skill's `allowed-tools`.
+- `codex`: `-s workspace-write -c approval_policy="never"` — confines file writes to the workspace AND skips approval pauses. `--skip-git-repo-check` lets the receiver start in a non-git pwd (delegate does not require the JSONL's project to be checked out). Avoid `--dangerously-bypass-approvals-and-sandbox`: that drops the sandbox entirely, letting prompt-injection in the JSONL escalate to arbitrary shell.
+
+```bash
+LOG="${TMPDIR:-/tmp}/session-ingest-delegate-$(date +%s)-$$.log"
+ARGS="\"$JSONL_PATH\" --vault \"$VAULT\""
+[ -n "$LANG_FLAG" ] && ARGS="$ARGS --lang \"$LANG_FLAG\""
+
+case "$DELEGATE" in
+  claude)
+    nohup claude -p "/session-ingest $ARGS" --permission-mode acceptEdits \
+      >"$LOG" 2>&1 &
+    echo "Delegated to claude (pid $!, log $LOG)."
+    ;;
+  codex)
+    # $session-ingest must NOT shell-expand. Single-quote the literal,
+    # then concatenate the double-quoted $ARGS so the file path stays quoted.
+    # --skip-git-repo-check: the receiver may run in a non-git pwd (delegate
+    # does not require the JSONL's project to be checked out); codex exec
+    # otherwise aborts before starting.
+    PROMPT='$session-ingest '"$ARGS"
+    nohup codex exec --skip-git-repo-check -s workspace-write -c 'approval_policy="never"' "$PROMPT" \
+      >"$LOG" 2>&1 &
+    echo "Delegated to codex (pid $!, log $LOG)."
+    ;;
+  "")
+    : ;;
+  *)
+    echo "Unknown --delegate target: $DELEGATE (expected: claude, codex)" >&2
+    exit 2
+    ;;
+esac
+
+if [ -n "$DELEGATE" ]; then
+  exit 0
+fi
+```
+
+## Phase 1 — Prepare
+
+### 1-1. Detect Duplicates
+
+Before reading the full JSONL, check whether this session was already ingested.
+
+#### Detect JSONL Schema
+
+Read the first ~10 lines of the JSONL (`Read` with `limit: 10`). The opening line may be a noise event without identifying fields (CC sessions sometimes start with `permission-mode` or `file-history-snapshot`, neither of which carries `sessionId`); scan all 10 to find the first line that decisively identifies the schema:
+
+- If any of those lines has a top-level `sessionId` field (e.g., `{"type": "worktree-state", "sessionId": "..."}` or `{"type": "user", "sessionId": "..."}`), the JSONL is **CC schema** (flat per-line events). Set `jsonl_schema = "cc"`.
+- If any line has a top-level `payload` object containing `id` (e.g., `{"timestamp": "...", "type": "session_meta", "payload": {"id": "...", "cwd": "..."}}`), the JSONL is **Codex schema** (event-wrapped). Set `jsonl_schema = "codex"`.
+- If none of the first 10 lines yields either signal, hard-fail with `"Unrecognized JSONL schema: $JSONL_PATH"` — do not guess.
+
+Schema detection is independent of `runtime.target`: a Codex JSONL ingested from a Claude harness still uses Codex parsing, and vice versa.
+
+#### Extract Session ID, Timestamps, and Source CWD
+
+Reuse the first-10-lines window from schema detection and read the last few lines of the JSONL. Capture everything the head window carries in one pass — later phases reuse these values rather than re-scanning. Field lookup is schema-aware:
+
+For `jsonl_schema == "cc"`:
+- Store the first encountered `sessionId` field as `session_id`. (Lines without `sessionId` such as `file-history-snapshot` are skipped — they precede the first content event in some sessions.)
+- If a `worktree-state` entry is present, store `worktreeSession.originalCwd` as `session_cwd`; otherwise leave `session_cwd` unset.
+
+For `jsonl_schema == "codex"`:
+- Find the entry with `type == "session_meta"` (typically the first line). Store `payload.id` as `session_id` and `payload.cwd` as `session_cwd`.
+
+For both schemas:
+- Last entry's top-level `timestamp` → `jsonl_last_timestamp`.
+
+Store:
+- `session_id` — the resolved session/thread id
+- `jsonl_last_timestamp` — the ISO 8601 timestamp of the final entry
+- `session_cwd` — the source session's working directory (or unset)
+
+#### Search Vault for Existing Session
+
+```text
+mcp__akb__akb_search(
+  query="{session_id}",
+  vault="{vault_name}",
+  collection="sessions",
+  tags=["session:{session_id}"],
+  type="session",
+  limit=1
+)
+```
+
+**No match** → `sync_mode = "new"`, proceed to Phase 2.
+
+**Match found** → read the existing session note:
+
+```text
+mcp__akb__akb_get(vault="{vault_name}", doc_id="{matched_doc_id}")
+→ existing_session_doc_id, existing_tags, existing_session_content
+```
+
+Extract the `last-synced:{timestamp}` tag value from the existing note's tags. Store as `last_synced_timestamp`. Preserve `existing_session_content` (the full markdown body) for Phase 2-3 and Phase 4-1.
+
+#### Compare Timestamps
+
+- `jsonl_last_timestamp <= last_synced_timestamp` → no new content since last sync → **stop**:
+  `"Session {session_id} already synced up to {last_synced_timestamp}. No new content. Skipping."`
+- `jsonl_last_timestamp > last_synced_timestamp` → proceed to the new-content assessment below.
+
+#### Assess New Content
+
+Read the JSONL entries with timestamps after `last_synced_timestamp`. Filter out noise. The filter list is schema-aware:
+
+For `jsonl_schema == "cc"`:
+- `type: "system"` messages
+- `type: "permission-mode"` entries
+- `type: "file-history-snapshot"` entries
+- User messages containing only `/exit`, `/quit`, or session-end signals
+- `isMeta: true` entries
+
+For `jsonl_schema == "codex"`:
+- `type: "turn_context"` entries (per-turn configuration)
+- `type: "event_msg"` with `payload.type` in `{task_started, token_count}` (system markers and telemetry)
+- `type: "response_item"` with `payload.type == "reasoning"` (model-internal thinking, analogous to CC thinking blocks)
+- User messages (`type: "event_msg"` with `payload.type == "user_message"`) containing only `/exit`, `/quit`, or session-end signals
+- `type: "session_meta"` (metadata-only, already consumed for session_id extraction)
+
+After filtering, judge whether the remaining entries represent **meaningful work** — substantive user messages, assistant responses with real content, tool calls that changed files, or decisions made.
+
+**Not meaningful** (e.g., resume then immediately exit, only system noise) → **stop**:
+`"Session {session_id} has entries after {last_synced_timestamp} but no meaningful new work. Skipping."`
+
+**Meaningful** → set `sync_mode = "update"`, store `existing_session_doc_id` and `last_synced_timestamp`, proceed to Phase 1-2.
+
+### 1-2. Retrieve Open Tasks
+
+Before reading the full JSONL, retrieve project-scoped open tasks from the vault so the session drafter can identify which tasks this session resolved.
+
+**Parallel execution with Phase 1-1**: the project-name parse step below runs immediately (no MCP), and the `akb_search` for open tasks is independent of Phase 1-1's duplicate-detection search. Issue Phase 1-1's existing-session search and Phase 1-2's open-task search in a single parallel tool-use block. Act on Phase 1-2 results only after Phase 1-1 greenlights continuation (otherwise discard).
+
+#### Derive Project Name
+
+Project name is the basename of the source session's working directory. Use `session_cwd` (captured in Phase 1-1) when set — it is authoritative metadata from the JSONL, and cross-target delegate (e.g. Claude → Codex) puts the receiver in a different `pwd` than where the session originated, so `pwd` is not a reliable fallback.
+
+- `session_cwd` set → `project_name` is its basename. (For CC worktree sessions this is `originalCwd`, the unworktreed project root, not the worktree name.)
+- `session_cwd` unset (CC session with no `worktree-state` entry) → use the current working directory's basename. The CC JSONL parent directory uses a lossy encoding (`/` and `.` both map to `-`), so decoding it is unreliable and not used.
+
+If derivation fails entirely, set `project_name` to the empty string. The downstream open-tasks query becomes a no-op (no `project:` tag match) — degraded but safe.
+
+#### Query Open Tasks
+
+```text
+mcp__akb__akb_search(
+  query="open task",
+  vault="{vault_name}",
+  collection="sessions/tasks",
+  type="task",
+  tags=["project:{project_name}"],
+  limit=20
+)
+```
+
+From the results, exclude any document whose tags contain `resolved`. Store the remaining results as `open_tasks` — a list of `{doc_id, title, summary}` for each match.
+
+If no results or the query fails, set `open_tasks` to an empty list and continue.
+
+## Phase 2 — Draft Session Note
+
+The main agent acts as the session drafter. Read the JSONL file, extract session information, and produce both a session draft (navigator skeleton) and a session context for sub-agents. The session draft is finalized later in Phase 4-0 after sub-drafter results are reconciled.
+
+### 2-1. Read Session JSONL
+
+Read the JSONL file. It contains the complete conversation history: user messages, assistant responses, tool calls, and results. The field-name layout differs by `jsonl_schema` (set in Phase 1-1) — apply the analogous mapping when extracting content:
+
+| Concept | CC schema | Codex schema |
+|---|---|---|
+| User message | `type: "user"` entry, `message.content[]` with `type: "text"` | `type: "event_msg"`, `payload.type: "user_message"` |
+| Assistant text response | `type: "assistant"` entry, `message.content[]` with `type: "text"` | `type: "event_msg"`, `payload.type: "agent_message"` (and/or `response_item` with `payload.type: "message"`) |
+| Tool call | `type: "assistant"` entry, `message.content[]` with `type: "tool_use"` (nested inside the assistant turn — NOT a top-level event type) | `type: "response_item"`, `payload.type: "function_call"` |
+| Tool result | `type: "user"` entry, `message.content[]` with `type: "tool_result"` (nested inside a user-role turn that wraps the tool reply) | `type: "response_item"`, `payload.type: "function_call_output"` |
+
+**Update mode (`sync_mode = "update"`):** Focus **JSONL analysis** on entries with timestamps **after** `last_synced_timestamp` — this is where the new information lives. The **session draft you produce must be a combined compiled truth**: read `existing_session_content` (retrieved in Phase 1-1) and integrate its Summary / Narrative / Artifacts / Knowledge Produced / Open Questions with the new work from the resumed portion. The written draft is the new canonical state of the session, not a delta.
+
+**New mode (`sync_mode = "new"`):** Read the full JSONL as normal.
+
+Focus on extracting:
+- Work performed (main topics and tasks), as a chronological narrative
+- Files and commits touched
+- External URLs (articles, repos, docs) referenced in the session
+- Unresolved questions (to be promoted in Phase 4-0 where possible)
+
+Skip tool call/result noise — focus on user messages and assistant text responses. Reusable lessons and long-lived decisions will be extracted by the Phase 3 drafters; the session draft itself does not need to generalize.
+
+### 2-2. Identify Session Commits and Repository
+
+Scan the JSONL for git commit activity. Extract commit hashes to determine the range of changes made during the session.
+
+If commits were found, run:
+
+```bash
+git log --oneline {earliest_commit_hash}^..{latest_commit_hash}
+git diff --stat {earliest_commit_hash}^..{latest_commit_hash}
+```
+
+If no commits were found in the JSONL, skip these commands.
+
+Also collect the repository URL:
+
+```bash
+git remote get-url origin
+```
+
+Store the result as `repo_url`. If the command fails (no remote configured), set `repo_url` to `null`.
+
+### 2-3. Draft Session Note
+
+Compose the session draft per `references/session-template.md` — that file carries the full draft template, section-omission rules, update-mode handling, and authoring guidelines. The session note is a navigator + narrative + timeline; deep knowledge (reusable lessons, long-lived decisions, follow-up tasks, creative ideas) belongs to the Phase 3 sub-notes and must not be restated here.
+
+Determine the session's primary theme (debugging vs. feature build vs. refactor) and let it guide the emphasis in `## Narrative`. Number `## Open Questions` bullets `Q1`, `Q2`, … so Phase 3 sub-drafters can target them via `resolves_question: Q{n}`.
+
+### 2-4. Identify Resolved Tasks
+
+Compare the work performed in the session (from Phase 2-1) against the `open_tasks` list (from Phase 1-2).
+
+A task is "resolved" if the session performed substantial work directly addressing the task's topic. Partial completion counts — any remaining work will be captured as a new task by the task-drafter.
+
+For each resolved task, record:
+- `doc_id` — from the open_tasks entry
+- `title` — the task's title
+- `path` — the task's path (for Knowledge Produced link)
+- `reason` — brief explanation of how it was addressed (e.g., "Implemented the retry logic described in the task")
+
+Store as `resolved_tasks` list. If no tasks were resolved, set to an empty list.
+
+### 2-5. Construct Session Context for Sub-Agents
+
+Build a lightweight session context as a roadmap for the Phase 3 drafter agents. This supplements the session draft and JSONL — it helps agents orient quickly.
+
+```text
+Session Context:
+- Project: {project name}
+- Repository: {repo_url from Phase 2-2, or "N/A"}
+- Date: {YYYY-MM-DD from JSONL or today}
+- Session JSONL: {$JSONL_PATH resolved in Phase 0}
+- Work performed: {brief list of main topics/tasks}
+- Committed changes: {from Phase 2-2 — commit messages and files changed, or "None"}
+- Problems encountered (for possible troubleshooting TILs): {brief list}
+- Long-lived decisions considered (for possible Decision notes): {brief list}
+- Rejected alternatives (anti-pattern memory for Decisions): {brief list}
+- Tools/technologies used: {notable APIs, libraries, frameworks}
+- Vault name: {resolved vault_name from --vault}
+- Collections: {plugin's default_collections mapping — includes decisions}
+- Ingest mode: {new|update}
+- Last ingested timestamp: {ISO timestamp from existing session note, or "N/A" if new}
+- JSONL analysis start: {last_synced_timestamp if update, or "beginning" if new}
+- Open tasks: [{doc_id}] {title} (for each task in open_tasks, or "None")
+- Resolved tasks: [{doc_id}] {title} — {reason} (for each task in resolved_tasks, or "None")
+- Open Questions (session draft): Q1: {text}, Q2: {text}, ... (each question available for sub-drafters to resolve via `resolves_question: Q{n}`)
+```
+
+Keep this concise — it is a roadmap, not a comprehensive record.
+
+## Phase 3 — Parallel Sub-Drafting & Validation
+
+### 3-1. Launch Drafter Agents
+
+Launch 4 agents simultaneously in a single message. Each agent receives the session context, a **session headline** (frontmatter + `> **Summary:**` line + numbered `## Open Questions` list only — not the full Narrative), and the JSONL path. The JSONL is the primary source; drafters do not need Narrative prose.
+
+```text
+Agent(
+    subagent_type="akb-sessions:til-drafter",
+    description="TIL learning notes",
+    prompt="[Session Context]\n\n## Session Headline\n{frontmatter + Summary + Open Questions}\n\nExtract learnings from the JSONL, validate against vault, and compose TIL notes."
+)
+
+Agent(
+    subagent_type="akb-sessions:task-drafter",
+    description="Follow-up task notes",
+    prompt="[Session Context]\n\n## Session Headline\n{frontmatter + Summary + Open Questions}\n\nIdentify follow-up tasks from the JSONL and validate against vault."
+)
+
+Agent(
+    subagent_type="akb-sessions:idea-drafter",
+    description="Creative idea notes",
+    prompt="[Session Context]\n\n## Session Headline\n{frontmatter + Summary + Open Questions}\n\nGenerate creative ideas inspired by the JSONL and validate against vault."
+)
+
+Agent(
+    subagent_type="akb-sessions:decision-drafter",
+    description="Long-lived decision notes",
+    prompt="[Session Context]\n\n## Session Headline\n{frontmatter + Summary + Open Questions}\n\nExtract long-lived architectural/product decisions (ADR) from the JSONL, validate against vault, and compose Decision notes."
+)
+```
+
+
+### Agent Summary
+
+| Agent | Model | Purpose | Output |
+|-------|-------|---------|--------|
+| til-drafter | sonnet | Learnings + vault validation | 0–N learning notes with dispositions + `til_kind` tag |
+| task-drafter | sonnet | Follow-up tasks + vault validation | 0–N task notes with dispositions |
+| idea-drafter | opus | Creative ideas + vault validation | 0–N idea notes with dispositions |
+| decision-drafter | sonnet | Long-lived decisions (ADR) + vault validation | 0–N decision notes with dispositions |
+
+Each agent receives:
+1. **Session Context** — lightweight roadmap (from Phase 2-5)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions`. The full Narrative is not sent — drafters read the JSONL directly for domain-specific detail.
+3. **JSONL path** — primary source for each drafter's domain analysis
+4. **Vault config** — `vault_name` and `collections` for duplicate checking
+
+Each agent drafts notes, then validates them against the vault using `akb_search`. Drafts are returned with a `disposition` (create / append; `supersede` additionally for decisions), optional `resolves_question: Q{n}` when a draft addresses a specific session Open Question, and `related_to` doc IDs. Duplicates are reported as skipped and excluded from the output.
+
+**idea-drafter specific.** Idea drafts additionally carry `impact` / `effort` / `confidence` enum assessments. The drafter silent-drops any idea it rates `impact: low` before returning (no report, no skipped block). The main agent re-triages the surviving drafts in Phase 3-2.
+
+Agents that find nothing to write return "No {type} notes for this session."
+
+### 3-2. Triage Idea Drafts
+
+After the idea-drafter agent returns, the main agent filters the surviving idea drafts using their `impact` / `effort` / `confidence` frontmatter fields. The drafter already silent-dropped any idea it rated `impact: low` before returning; this phase is a second gate that catches cases the drafter missed and removes high-cost, low-conviction ideas.
+
+**Scope.** Applies only to idea drafts. TIL / task / decision drafts pass through unchanged.
+
+**Inputs.** Each idea draft from Phase 3-1 with `disposition ∈ {create, append}`.
+
+**Automatic drop rules** — apply in order, drop on first match:
+
+1. `impact == low` — drop. Safety net for the drafter's self-filter.
+2. `effort == large` AND `confidence == low` — drop. High-cost, low-conviction ideas clutter the vault.
+
+All remaining idea drafts pass through to Phase 4.
+
+**No user prompt. No skipped block written. No vault write.** Dropped drafts are discarded in-memory; they do not feed Phase 4-0 or Phase 4-2. If a dropped idea set `resolves_question: Q{n}`, discard that mapping as well — the Q ID stays in the session's `## Open Questions`.
+
+## Phase 4 — Write to AKB
+
+Save all drafts with `create`, `append`, or (decisions only) `supersede` disposition directly — no user approval needed. Each drafter sets `status: active` in its `---DRAFT---` block; Phase 4-1 / 4-2 pass it through verbatim.
+
+### 4-0. Dedup Drafts & Finalize Session Body
+
+In-memory reconciliation between the session draft and the sub-note drafts before any AKB write. Single in-context pass — no extra LLM call, no MCP call, no per-pair loop. Inputs: session draft body, all sub-note drafts with `disposition ∈ {create, append, supersede}`, `resolved_tasks` list.
+
+**Step A — Promote Open Questions.** For each sub-note draft with `resolves_question`: normalize the value (strip / upper / `^Q\d+$`; non-conforming → log warning + no-match), find the matching `Q{n}` bullet in the session's `## Open Questions`, and **remove that bullet entirely** — the answer surfaces in `## Knowledge Produced` (Step C). Multiple sub-notes can target the same `Q{n}`; the bullet is removed once. If no session question matches, log a warning and leave the sub-note unchanged.
+
+**Step B — Cross-Type Content Overlap Detection.** For each sub-note, extract its headline sentence — TIL: `> **Key Insight:** …`; Task: `> **Next Action:** …`; Idea: `> **Inspiration:** …` plus Proposal first sentence; Decision: `> **Context:** …` plus Decision first sentence. Scan the session Narrative and Artifacts prose for sentences that match a headline. A sentence matches when at least **two** of these hold: (1) core noun phrases overlap, (2) assertion direction is the same (not negated / qualified differently), (3) reasoning or evidence cited is the same. One criterion alone is not enough — preserve the Narrative sentence if in doubt. On a match, remove the redundant sentence or replace it with a brief pointer ("…the lesson captured in Knowledge Produced"); do not rewrite surrounding prose beyond what grammatical flow needs. Overlap resolution **always favors sub-notes** — never edit a sub-note body here.
+
+**Step C — Finalize Knowledge Produced.** Build the block from deduplicated sub-notes plus `resolved_tasks`, in the order TIL → Idea → Task → Decision → Resolved:
+
+```markdown
+## Knowledge Produced
+
+- 🧠 TIL: [{title}](sessions%2Flearnings%2F{doc_path}.md) — {one-line hook from Key Insight}
+- 💡 Idea: [{title}](sessions%2Fideas%2F{doc_path}.md) — {one-line hook from Inspiration}
+- ✅ Task: [{title}](sessions%2Ftasks%2F{doc_path}.md) — {one-line hook from Next Action}
+- 📐 Decision: [{title}](sessions%2Fdecisions%2F{doc_path}.md) — {one-line hook from Decision first sentence}
+- ♻️ Resolved: [{title}](sessions%2Ftasks%2F{path}.md) — {reason from resolved_tasks}
+```
+
+For newly-drafted sub-notes the link's `doc_path` is substituted at render time from each Phase 4-2 put response. For resolved tasks the link uses the existing task's `path` captured in Phase 2-4. See `references/note-templates.md` → "Cross-Note Links" for why this hybrid (body link + `depends_on` frontmatter) is used.
+
+**Step D — Final omissions.** Omit `## Knowledge Produced` entirely when no sub-notes were produced and no tasks resolved. Omit `## Open Questions` if Step A left zero unresolved bullets. The resulting body is what Phase 4-1 writes — do not mutate further.
+
+### 4-1. Write Session Note
+
+The session note is written first because sub-notes reference it via `depends_on`. Sub-notes always use the full URI `akb://{vault_name}/doc/{session_doc_path}` (always-URI cross-ref convention; future-proof against vault tier splits).
+
+**New mode (`sync_mode = "new"`).** Extract metadata from the draft's `---DRAFT---` block and `akb_put(vault="{vault_name}", ...)` with `type="session"`, `collection={draft.collection}`, `status={draft.status}`, `tags=["session", "claude-code", "session", "session:{session_id}", "project:{project_name}", "last-synced:{jsonl_last_timestamp}", ...topic_tags]`, and the finalized body from Phase 4-0. Capture `session_doc_id` and `session_doc_path`.
+
+**Update mode (`sync_mode = "update"`).** The session note already exists. Phase 2-3 + 4-0 produced a full compiled-truth replacement plus exactly one new timeline entry. Apply the **timeline merge procedure — Mode A (full-body merge)** (see appendix) against `existing_session_content`. Build the updated tag list (replace the old `last-synced:{old_timestamp}` with `last-synced:{jsonl_last_timestamp}`; preserve all other tags; add any new topic tags). Then `akb_update(vault="{vault_name}", doc_id=existing_session_doc_id, content={merged}, tags={updated}, summary={draft.summary}, message="Update from resumed session: {brief description}")`. Assemble `session_uri = akb://{vault_name}/doc/{existing_session_doc_path}` for sub-notes' `depends_on`.
+
+### 4-2. Write Sub-Notes (Learning, Task, Idea, Decision)
+
+**Issue all sub-note `akb_put` calls in a single parallel tool-use block.** Sub-notes are independent of each other; only the session note's order matters (via `depends_on`).
+
+For each sub-note, extract metadata from the draft and call `akb_put(vault="{vault_name}", ...)` with `collection={draft.collection}`, `type={draft.type}`, `status={draft.status}`, `tags=["session", "claude-code", ...draft_tags]`, `depends_on=["akb://{vault_name}/doc/{session_doc_path}"]`, `related_to=[...draft.related_to]` (full URIs as emitted by drafters). Collection per type: TIL → `sessions/learnings`, Task → `sessions/tasks`, Idea → `sessions/ideas`, Decision → `sessions/decisions`.
+
+**Idea notes** — append four namespaced tags to `draft_tags` before put: `category:{draft.category}`, `impact:{draft.impact}`, `effort:{draft.effort}`, `confidence:{draft.confidence}`. Drop duplicates (the drafter may have already emitted some as tags). These four tags are the durable carriers for the external maintenance layer's consolidation synthesis and staleness checks.
+
+**Task notes** — after the task document is created, also create a lightweight todo via `akb_todo(vault="{vault_name}", title=draft.title, priority={P0→urgent, P1→high, P2→normal, P3→low}, ref_doc=task_doc_id, note=draft.summary)`.
+
+**`append` disposition** — the drafter has already merged compiled truth + one new timeline entry. Read the existing document with `akb_get(vault="{vault_name}", doc_id=draft.append_target)`, apply timeline merge **Mode A** against `draft.body`, and `akb_update(vault="{vault_name}", doc_id=draft.append_target, content={merged}, tags=[...existing, ...new from draft], summary=draft.summary, message="Appended from session ingest: {brief description}")`.
+
+**`supersede` disposition (decisions only)** — write the new decision via `akb_put(vault="{vault_name}", ..., tags=[..., "supersedes:{old_doc_id}"])` (tags use bare doc_id; the `:` already binds `key:value`). Capture `new_doc_id` and `new_doc_path`; compose `new_doc_ref = akb://{vault_name}/doc/{new_doc_path}`. Then read the old decision via `akb_get(vault="{vault_name}", doc_id=draft.supersedes)`, apply timeline merge **Mode B** with `new_entry = "- **{today}** | Superseded by {new_title} ({new_doc_ref}). {reason}. [Source: session:{session_id}, {today}]"`, and `akb_update(vault="{vault_name}", doc_id=draft.supersedes, content={merged}, tags=[...old, "superseded-by:{new_doc_id}"], status="superseded", message="Superseded by {new_doc_ref} in session ingest")`. Setting `status="superseded"` removes the old decision from the external maintenance layer's active-document pools.
+
+### 4-3. Resolve Completed Tasks
+
+If `resolved_tasks` is non-empty, fetch open todos once: `akb_todos(vault="{vault_name}", status="open") → open_todos`. For each resolved task:
+
+1. Scan `open_todos` in memory for a todo whose `ref_doc` matches the task's `doc_id`. If found, `akb_todo_update(vault="{vault_name}", todo_id={matched}, status="done", note="Resolved in session {session_doc_id}")`.
+2. Read the task document with `akb_get(vault="{vault_name}", doc_id={task_doc_id})`, then compose the resolution timeline entry `- **{today YYYY-MM-DD}** | Task resolved in session:{session_id}. {reason}. [Source: session:{session_id}, {today YYYY-MM-DD}]` and apply timeline merge **Mode B** against `task_content` (compiled-truth zone preserved as-is).
+3. `akb_update(vault="{vault_name}", doc_id={task_doc_id}, content={merged}, tags=[...existing, "resolved"], status="archived", message="Resolved in session {session_doc_id}")`.
+
+If no matching todo is found, still archive the task document. If the up-front `akb_todos` fails, skip all todo updates this ingest but archive the task documents anyway.
+
+## Error Handling
+
+If a drafter agent (Phase 3) fails or returns an error:
+- Continue with results from the remaining agents
+- Log the failure in the session summary
+- Do not block the pipeline for a single agent failure
+
+If an `akb_put` fails partway through Phase 4:
+- Continue writing the remaining notes from this invocation
+- The partial result is queryable under the `"session:{session_id}"` tag
+
+If Phase 4-0 Step A finds a `resolves_question` that does not match any session Open Question ID:
+- Log a warning naming the sub-note and the invalid Q ID
+- Leave the sub-note draft as-is, write without session mutation for that question
+
+## References
+
+- `references/session-template.md` — session draft template, section-omission rules, update-mode handling, authoring guidelines.
+- `references/note-templates.md` — sub-note templates (TIL / task / idea / decision).
+- Agent prompts in `agents/` — full drafter-agent instructions.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/claude/akb-sessions/skills/session-ingest/references/note-templates.md
+++ b/plugins/claude/akb-sessions/skills/session-ingest/references/note-templates.md
@@ -1,0 +1,425 @@
+# Note Templates Reference
+
+Templates for each note type produced by the `/session-ingest` workflow. Notes are stored as plain standard markdown via AKB MCP tools. All metadata is passed through `akb_put` parameters — no YAML frontmatter in the content body.
+
+## Body Structure: Compiled Truth + Timeline
+
+Every note body follows the same two-zone layout, separated by a horizontal rule:
+
+```markdown
+# {Title}
+
+{Compiled truth sections — the current best synthesis. Rewritten as understanding evolves.}
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | {One-line summary of the event.} [Source: {attribution}]
+  - {Optional sub-bullet for detail.}
+- **YYYY-MM-DD** | {Earlier event.} [Source: {attribution}]
+```
+
+**Rules:**
+
+- **Above the line (compiled truth):** the note's current state — sections like `## Context`, `## What I Learned`, `## Core Idea`, etc. Rewrite these when new information changes the picture. Read just this part and you have the full current answer.
+- **Below the line (timeline):** append-only log of events that shaped the note, newest first. Never edit or delete past entries. Every compiled-truth change should leave a timeline entry explaining what and why.
+- **Always include the `---` separator and `## Timeline` heading**, even when the timeline has a single entry (the initial capture).
+- **Order timeline entries newest-first**, so the most recent event is at the top.
+- **Each timeline entry cites a source** in `[Source: ...]` form (see below).
+
+### Session Notes: Navigator Role
+
+Session notes use the same two-zone layout but play a **navigator + narrative** role rather than a full knowledge store. The compiled-truth zone tells the story of what happened and points to the sub-notes (TIL / Task / Idea / Decision) that hold the reusable knowledge. The session note itself should remain readable as a standalone log of the session — but deep content lives in sub-notes, linked from the `## Knowledge Produced` block.
+
+### Source Attribution
+
+Every timeline entry needs a citation. Use one of:
+
+| Event source | Attribution format |
+|---|---|
+| Session ingest (initial capture or append) | `[Source: session:{session_id}, {YYYY-MM-DD}]` |
+| Manual edit by user | `[Source: manual, {YYYY-MM-DD}]` |
+
+### When to Rewrite Compiled Truth vs. Append-Only
+
+- **New information that replaces or refines existing content** → rewrite the relevant compiled-truth section, then append a timeline entry describing the change.
+- **New information that adds without conflicting** → extend the compiled-truth section (e.g., add a new gotcha to `## Gotchas`), then append a timeline entry.
+- **Status or metadata changes** (task resolved, doc superseded, cross-link added) → timeline entry only; compiled truth stays as a historical record of the state at the time the note was last written.
+
+## Metadata → akb_put Parameter Mapping
+
+| Draft Field | akb_put Parameter | Notes |
+|-------------|-------------------|-------|
+| title | `title` | Direct mapping |
+| collection | `collection` | Target collection |
+| type | `type` | AKB document type enum |
+| tags | `tags` | Array of strings |
+| summary | `summary` | Agent-generated summary |
+| (session_doc_id) | `depends_on` | Set at write time for sub-notes |
+| (reviewer related) | `related_to` | Set at write time from reviewer output |
+
+## Type Mapping
+
+| Note Type | akb_put type | Collection | Notes |
+|-----------|-------------|------------|-------|
+| Session | `session` | `sessions` | One per ingest run — navigator + narrative + timeline |
+| Learning (TIL) | `reference` | `sessions/learnings` | Reusable knowledge. Classify with `til_kind:*` tag |
+| Task | `task` | `sessions/tasks` | Follow-up work |
+| Idea | `plan` | `sessions/ideas` | Forward-looking concepts |
+| Decision | `decision` | `sessions/decisions` | Long-lived architectural/product decisions (ADR style). Holds `## Alternatives Considered` as the canonical home for anti-patterns |
+
+## Tag Conventions
+
+- `session` — on every generated note
+- `claude-code` — provenance tag for the runtime
+- `session`, `learning`, `task`, `idea`, `decision` — type tags
+- `project:{name}` — project namespace
+- `{technology}` — e.g. `python`, `react`, `sqlite`
+- `P0` through `P3` — priority tags on tasks
+- `{category}` — idea category tags (architecture, product, workflow, exploration)
+- `til_kind:shift` | `til_kind:acquisition` | `til_kind:comparison` | `til_kind:troubleshooting` — TIL classification (exactly one per TIL)
+- `session:{session_id}` — links the note to its originating JSONL session (session notes only)
+- `last-synced:{ISO-timestamp}` — records the last JSONL timestamp covered by this ingest (session notes only)
+- `supersedes:{doc_id}` — on a new decision that replaces an older one
+- `superseded-by:{doc_id}` — on a decision that has been replaced
+- `resolved` — marks tasks that have been completed
+- `idea_status:promoted` — marks ideas that spawned a decision or task (applied by the external maintenance layer)
+- `concept` — marks consolidated knowledge pages (created by the external maintenance layer)
+- `auto-generated` — marks documents created by automated processes (concept pages)
+
+## External URLs
+
+External URL preservation differs between session notes and sub-notes.
+
+### Session Note — Canonical Bibliography
+
+The session note's `## Artifacts > External sources` block is the **canonical bibliography** for the ingest. Every external URL referenced in the session is collected here, regardless of which sub-note it ended up in. This gives a single, searchable list per session.
+
+```markdown
+## Artifacts
+
+- **External sources**:
+  - [Title](https://example.com) — why it's relevant
+  - [Another](https://example.org) — context
+```
+
+### Sub-note — Inline Links Only
+
+TIL / Task / Idea / Decision bodies reference external URLs only as **inline markdown links** where they are mentioned in the body text. Sub-notes do **not** maintain their own `## Sources` section — the session note's Artifacts block holds the canonical list, and each sub-note points back to its session via `depends_on`.
+
+```markdown
+## What I Learned
+
+[Claude Code](https://github.com/anthropics/claude-code)의 컨텍스트 윈도우 한계 근처에서
+발화자 혼동 버그가 발생한다는 [분석 글](https://dwyer.co.za/static/claude-mixes-up...)이 있다.
+```
+
+**Include (in session Artifacts):** URLs that directly support or provide context for the session's content — articles cited, repos explored, documentation referenced, tools discovered.
+
+**Exclude:** Transient URLs (localhost, CI build links, temporary file shares) and URLs the user merely passed through without engagement.
+
+## Cross-Note Links
+
+AKB does **not** support Obsidian-style `[[wikilink]]` syntax. Use standard markdown links only.
+
+Sub-notes are referenced from the session note's `## Knowledge Produced` block using plain markdown:
+
+```markdown
+- 🧠 TIL: [Title](sessions%2Flearnings%2Ftitle-path.md) — one-line hook
+```
+
+The AKB backend automatically extracts these body links into `links_to` graph relations, and each sub-note's `depends_on=[session_doc_id]` frontmatter parameter sets the reverse relation. The hybrid (inline link + frontmatter relation) is the canonical pattern.
+
+## Highlighted Text Patterns
+
+Standard markdown replacements for Obsidian callouts:
+
+| Purpose | Format |
+|---------|--------|
+| Session overview | `> **Summary:** {text}` |
+| Key insight | `> **Key Insight:** {text}` |
+| Next action | `> **Next Action:** {text}` |
+| Inspiration source | `> **Inspiration:** {text}` |
+| Decision context | `> **Context:** {text}` |
+
+## Knowledge Produced Block
+
+Used in the session note to point at sub-notes written during this ingest. Each line uses a type icon, a markdown link to the sub-note path, and a one-line hook:
+
+```markdown
+## Knowledge Produced
+
+- 🧠 TIL: [TIL 학습 신호 확장](sessions%2Flearnings%2Ftil-학습-신호-확장.md) — 놀라움 + 지식 획득 둘 다 포착해야 함
+- 💡 Idea: [테스트 실행 레이어 분리](sessions%2Fideas%2F테스트-실행-레이어-분리.md) — 빠른/느린 검증을 명시적으로 나누기
+- ✅ Task: [Tycho 업그레이드 재검증](sessions%2Ftasks%2Ftycho-업그레이드-재검증.md) — JUnit 5 병렬 실행 지원 여부
+- 📐 Decision: [JUnit 5 병렬 실행 미도입](sessions%2Fdecisions%2Fjunit-5-병렬-미도입.md) — 현 Tycho 버전에서 실효성 없음
+- ♻️ Resolved: [이전 태스크 제목](sessions%2Ftasks%2Fresolved-task-path.md) — 이번 세션에서 해결됨
+```
+
+Icons (use exactly these):
+
+| Icon | Purpose |
+|------|---------|
+| 🧠 | TIL (newly created or appended learning) |
+| 💡 | Idea (newly created or refined idea) |
+| ✅ | Task (newly created or updated task) |
+| 📐 | Decision (newly created or appended decision) |
+| ♻️ | Resolved task (existing task closed in this session) |
+
+Omit the `## Knowledge Produced` section if no sub-notes were produced. Do not create sub-section headers within the block — a single flat bullet list is the entire block.
+
+## Session Note Template
+
+**akb_put**: `type="session"`, `collection="sessions"`
+
+```markdown
+# {Brief Description}
+
+> **Summary:** {2-3 sentence overview of what the session accomplished and why it matters}
+
+## Narrative
+
+{Chronological prose, 1–2 paragraphs: event → diagnosis → resolution → outcome. No bullets; defer mechanical facts to Artifacts. If the session had a Problem/Solution arc, weave it into one narrative paragraph. Do not generalize reusable lessons here — promote them to TIL (e.g. `til_kind:troubleshooting`).}
+
+## Artifacts
+
+- **Commits**: `{hash}` — {one-line subject}
+- **Files touched**: `{path/to/file}` — {why it matters}
+- **External sources**:
+  - [{Title}]({url}) — {relevance}
+
+## Knowledge Produced
+
+- 🧠 TIL: [{title}](sessions%2Flearnings%2F{path}.md) — {one-line hook}
+- 💡 Idea: [{title}](sessions%2Fideas%2F{path}.md) — {one-line hook}
+- ✅ Task: [{title}](sessions%2Ftasks%2F{path}.md) — {one-line hook}
+- 📐 Decision: [{title}](sessions%2Fdecisions%2F{path}.md) — {one-line hook}
+- ♻️ Resolved: [{title}](sessions%2Ftasks%2F{path}.md) — {how resolved}
+
+## Open Questions
+
+- {Unresolved question that did NOT get promoted to an Idea/Task/Decision}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Session captured. {One-line summary of work performed.} [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `## Narrative` is always present (at least one sentence).
+- `## Artifacts` is present if any commits, files, or external URLs were touched. Omit sub-bullets with no entries.
+- `## Knowledge Produced` is omitted entirely if no sub-notes were produced.
+- `## Open Questions` is omitted if empty (every question was promoted to a sub-note, or there were none).
+
+**Update mode:** rewrite the compiled-truth sections (Summary / Narrative / Artifacts / Knowledge Produced / Open Questions) to reflect the combined session (original + continuation). Knowledge Produced should include every sub-note from both the original ingest and the resumed portion. Append a new timeline entry, e.g. `- **{YYYY-MM-DD}** | Session resumed. {new work summary}. [Source: session:{session_id}, {YYYY-MM-DD}]`. Never drop past timeline entries.
+
+## Learning Note (TIL) Template
+
+**akb_put**: `type="reference"`, `collection="sessions/learnings"`, `depends_on=[session_doc_id]`, tag one of `til_kind:shift|til_kind:acquisition|til_kind:comparison|til_kind:troubleshooting`.
+
+```markdown
+# {Concise Learning Title}
+
+> **Key Insight:** {One sentence takeaway}
+
+## Context
+
+{When and why this came up}
+
+## What I Learned
+
+{Technical explanation with enough detail to be actionable}
+
+```{language}
+{Code example demonstrating the concept}
+```
+
+## Gotchas
+
+- {Pitfall or edge case to watch for}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Captured from session:{session_id}. {One-line summary of the lesson.} [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**til_kind classification** (exactly one tag per TIL):
+
+| Tag | When to use |
+|-----|-------------|
+| `til_kind:shift` | Mental model correction — user expected X but learned Y |
+| `til_kind:acquisition` | Knowledge acquisition — user entered without knowledge and built understanding through exploration |
+| `til_kind:comparison` | Structured comparison/analysis — A vs B tradeoffs the user evaluated |
+| `til_kind:troubleshooting` | Diagnostic/root-cause pattern — non-obvious root cause traced through systematic investigation |
+
+**Optional sections by til_kind:**
+
+- `til_kind:comparison` may include a `## Comparison` table section
+- `til_kind:troubleshooting` may include a `## Root Cause` section describing the diagnostic path
+
+## Task Note Template
+
+**akb_put**: `type="task"`, `collection="sessions/tasks"`, `depends_on=[session_doc_id]`
+
+```markdown
+# {Descriptive Title}
+
+> **Next Action:** {Specific first step}
+
+## Context
+
+{Background and motivation — why this task exists}
+
+## Steps
+
+- [ ] {Step 1}
+- [ ] {Step 2}
+- [ ] {Step 3}
+
+## Related Files
+
+- `{path/to/file}` — {why it's relevant to resuming this task}
+
+## Notes
+
+{Task-handling nuance: scheduling constraints, blocking/non-blocking status, links to background}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Task created from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+Task lifecycle events that append to the timeline:
+
+- `- **{date}** | Task updated in session:{id}. {what changed}. [Source: session:{id}, {date}]`
+- `- **{date}** | Task resolved in session:{id}. {how it was addressed}. [Source: session:{id}, {date}]`
+
+## Idea Note Template
+
+**akb_put**: `type="plan"`, `collection="sessions/ideas"`, `depends_on=[session_doc_id]`
+
+Idea notes read as lightweight PRDs / technical proposals. The body must contain enough substance to judge whether the idea is worth pursuing — not just describe what it is.
+
+**Assessment frontmatter.** In addition to the standard fields, every idea note carries three enum assessments set by the drafter:
+
+- `impact: high | medium | low` — expected benefit magnitude.
+- `effort: small | medium | large` — rough implementation size.
+- `confidence: high | medium | low` — how confident the Proposal actually solves the Problem.
+
+These values drive the main ingest skill's Phase 3-2 triage. The drafter silent-drops any idea it rates `impact: low` before emitting a draft; the main agent filters further (`impact: low`, or `effort: large AND confidence: low`).
+
+```markdown
+# {Compelling Title}
+
+> **Inspiration:** {What triggered this idea — cite specific files, patterns, or workarounds from the session}
+
+## Problem
+
+{Reproducible observation. What was harder than it should be, how often it recurred, who is affected. Concrete evidence beats "felt awkward".}
+
+## Proposal
+
+{Design-level solution. What changes in code, architecture, or flow — specific enough for someone to begin an implementation sketch.}
+
+## System Architecture
+
+{Optional. When the idea spans multiple components, show how they fit: a compact diagram (mermaid / ASCII) or a labeled bullet list of components and data flows.}
+
+## Expected Impact
+
+{First line is the rationale for the `impact` frontmatter value. Then: who benefits, how much, and by what measure. Prefer quantifiable statements ("turns N retries per sync into 0") over qualitative ones.}
+
+## Effort & Risks
+
+{Rough implementation surface (affected modules / files at directory granularity), top 1–3 risks, and any assumption that could invalidate the Proposal.}
+
+## Success Criteria
+
+{Observable or measurable signals that the idea is working after it ships. Each criterion should be checkable without rerunning the original session.}
+
+## Open Questions
+
+- {Key uncertainty}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Idea captured from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `Problem`, `Proposal`, `Expected Impact`, `Effort & Risks`, `Success Criteria` are always present.
+- `System Architecture` is optional — include it when the idea spans multiple components; omit it for small local changes.
+- `Open Questions` is omitted when there are no unresolved uncertainties.
+
+**Idea lifecycle events** that append to the timeline:
+
+- `- **{date}** | Idea refined in session:{id}. {what changed}. [Source: session:{id}, {date}]` — when a later session revises Proposal / Expected Impact / etc.
+
+The external maintenance layer may later set `idea_status:promoted` on an idea that spawned a decision or task. `idea_status:*` tags are append-preserving — session-ingest Phase 4-3 merges existing tags with new draft tags on `disposition: append`, so a promoted idea keeps its status tag through subsequent refinements.
+
+## Decision Note Template
+
+**akb_put**: `type="decision"`, `collection="sessions/decisions"`, `depends_on=[session_doc_id]`
+
+Follows the ADR (Architecture Decision Record) pattern. A decision note is the canonical home for a chosen direction plus every alternative that was considered. Anti-pattern memory — "what we tried, why it doesn't work" — lives here, not in the session note.
+
+```markdown
+# {Decision Title}
+
+> **Context:** {Why this decision was needed — what forced the choice}
+
+## Decision
+
+{What was chosen, in one tight paragraph. State the decision first, reasoning second.}
+
+## Consequences
+
+{What this decision enables and constrains. Include both positive and negative outcomes.}
+
+## Alternatives Considered
+
+### {Alternative Approach Title}
+
+**What**: {The approach — specific enough to be recognizable if revisited}
+**Why not**: {Why it was rejected. Include concrete evidence — paths tried, error messages, measurements — that would save someone from repeating the experiment}
+
+### {Another Alternative}
+
+**What**: {…}
+**Why not**: {…}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Decision captured from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `## Context`, `## Decision`, `## Consequences`, `## Alternatives Considered` are always present.
+- Supersede relationships are tracked via frontmatter `supersedes:` / `superseded-by:` tags and a Timeline entry — not a body section.
+
+**Decision lifecycle events** that append to the timeline:
+
+- `- **{date}** | Decision refined in session:{id}. {what changed in Consequences or Alternatives}. [Source: session:{id}, {date}]`
+- `- **{date}** | Superseded by {newer_title} ({newer_doc_id}). {reason}. [Source: session:{id}, {date}]` — paired with setting tag `superseded-by:{newer_doc_id}` on this note and `supersedes:{this_doc_id}` on the new note.
+
+**When to write a Decision note** (vs. keep in session Narrative):
+
+- The choice has **long life** — likely to be referenced from future sessions.
+- The choice **constrains future work** — architecture, API contract, tooling, process.
+- A **real alternative** was evaluated and rejected, not a trivial preference.
+
+One-off tactical choices that only matter inside the session (e.g., "used `sed` instead of `awk` for this one-liner") stay in Narrative prose.

--- a/plugins/claude/akb-sessions/skills/session-ingest/references/session-template.md
+++ b/plugins/claude/akb-sessions/skills/session-ingest/references/session-template.md
@@ -1,0 +1,80 @@
+# Session Note Template
+
+The session note is a navigator + narrative + timeline. Deep knowledge (reusable lessons, long-lived decisions, follow-up tasks, creative ideas) belongs to the sub-notes drafted in Phase 3 and must not be restated in the session body.
+
+## Draft format
+
+```markdown
+---DRAFT---
+title: {brief description}
+collection: sessions
+type: session
+tags: [session, claude-code, session, session:{session_id}, last-synced:{jsonl_last_timestamp}, project:{project_name}, {topic-specific tags}]
+project: {project name from working directory or JSONL context}
+repo_url: {repo_url from Phase 2-2, or omit if null}
+status: active
+summary: {1-2 sentence summary of the session}
+
+# {Brief Description}
+
+> **Summary:** {2-3 sentence overview of what the session accomplished and why it matters}
+
+## Narrative
+
+{Chronological prose, 1–2 paragraphs: event → diagnosis → resolution → outcome. No bullets. If the session had a Problem/Solution arc, weave it into one narrative paragraph. Do not generalize reusable lessons here — promote them to TIL instead. The session records "what happened"; sub-notes record "what we learned."}
+
+## Artifacts
+
+- **Commits**: `{hash}` — {one-line subject}
+- **Files touched**: `{path/to/file}` — {why it matters}
+- **External sources**:
+  - [{Title}]({url}) — {relevance}
+
+## Knowledge Produced
+
+<!-- Phase 4-0 populates this block from sub-note drafts. Leave as a placeholder here. -->
+
+## Open Questions
+
+- **Q1**: {Unresolved question 1}
+- **Q2**: {Unresolved question 2}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {For new mode: Session captured. {one-line summary}. | For update mode: Session resumed. {one-line summary of new work}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+`## Open Questions` bullets must be numbered `Q1`, `Q2`, … so that Phase 3 sub-drafters can target a specific question via `resolves_question: Q{n}`. Phase 4-0 reconciles those references.
+
+## Section omission rules
+
+These apply to the **final** session body after Phase 4-0, not the draft itself:
+
+- `## Narrative` is always present (at least one sentence).
+- `## Artifacts` is present if any commits, files, or external URLs were touched.
+- `## Knowledge Produced` is populated by Phase 4-0 from sub-note results; omitted entirely if no sub-notes produced.
+- `## Open Questions` is omitted if every question was promoted in Phase 4-0 or there were none.
+
+Every session draft **must** end with the `---` separator and a `## Timeline` section containing exactly **one** new entry for this ingest. Do not re-include past timeline entries — Phase 4-2 merges your new entry with the existing timeline.
+
+## Update mode
+
+Read `existing_session_content` (stored in Phase 1-2) to understand what the original session produced. Write the compiled-truth sections (Summary, Narrative, Artifacts, Knowledge Produced placeholder, Open Questions) as the **combined** current state — integrating both the original work and the new work performed after `last_synced_timestamp`.
+
+- Title can stay as-is unless the new work fundamentally changes the session's theme.
+- Summary should read as a unified description of the full session, not only the delta.
+- The single new timeline entry describes what this sync added.
+- Open Questions from the previous sync that remain unresolved keep their original `Q{n}` IDs; new questions continue numbering.
+
+## Authoring guidelines
+
+- Write as if the reader is you, six months from now, trying to remember what happened.
+- Prefer concrete details (file names, function names, error messages) over vague descriptions in `## Narrative`.
+- **External URLs**: link inline where mentioned in Narrative, and collect all referenced URLs in `## Artifacts > External sources` (the session note is the canonical bibliography). Omit transient URLs (localhost, CI build links).
+- Sub-notes do **not** maintain their own `## Sources` section — the session Artifacts covers them.
+- If the session was trivial, produce a short note rather than padding content; skip sections that have nothing meaningful to say.
+- Write prose content in the primary language of the user's prose in the JSONL conversation (not embedded code/quotes); metadata keys and section headings remain in English.
+- Do **not** draft `## Knowledge Produced` content here — leave the placeholder and let Phase 4-0 fill it.

--- a/plugins/claude/akb-wiki/.claude-plugin/plugin.json
+++ b/plugins/claude/akb-wiki/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "akb-wiki",
+  "version": "0.21.1",
+  "description": "LLM-wiki layer for AKB vaults — unified document ingest (any source) and hybrid search.",
+  "author": {
+    "name": "jylkim",
+    "url": "https://github.com/jylkim"
+  },
+  "repository": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "license": "MIT",
+  "keywords": [
+    "akb",
+    "llm-wiki",
+    "ingest",
+    "search",
+    "git",
+    "atlassian"
+  ]
+}

--- a/plugins/claude/akb-wiki/.mcp.json
+++ b/plugins/claude/akb-wiki/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "akb": {
+      "command": "npx",
+      "args": [
+        "akb-mcp",
+        "--insecure"
+      ],
+      "env": {
+        "AKB_MCP_URL": "${AKB_MCP_URL}",
+        "AKB_PAT": "${AKB_PAT}"
+      }
+    }
+  }
+}

--- a/plugins/claude/akb-wiki/agents/ingest-commit.md
+++ b/plugins/claude/akb-wiki/agents/ingest-commit.md
@@ -1,0 +1,190 @@
+---
+name: ingest-commit
+description: Record a single git commit as an immutable git-commit document in an AKB vault — mechanical git metadata plus a faithful restatement of what the diff changed.
+model: sonnet
+tools: Bash(git *), Read, mcp__akb__akb_search, mcp__akb__akb_put
+---
+
+# AKB Git Commit Ingest
+
+Record a **single git commit** as an immutable `git-commit` document in the target AKB vault — the commit-level episodic capture path of `akb-wiki`.
+
+Scope boundaries:
+
+- **One commit per invocation.** No loops, cursor, or range — backfill / sweeping / batching live in an orchestration layer.
+- **No filtering policy.** Merge commits, bot authors, trivial commits are recorded as-is (marked in frontmatter); the caller decides what to skip.
+- **No semantic compilation.** PR / release pages are produced by sibling skills; consolidation pages by the external maintenance layer.
+- **Write-once.** Commit docs are never mutated here. The external maintenance layer may append timeline entries for consolidation membership; PR / release linkage lives on the parent's `depends_on` graph edge — no commit-side backlink frontmatter fields.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-commit <sha> --vault {vault_name} [--repo {path}]
+```
+
+- `<sha>` (required, positional) — full or short commit SHA to ingest.
+- `--vault` (required) — target AKB vault.
+- `--repo` (optional) — path to the git repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` is available on PATH.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Then validate the SHA: `git -C {repo_path} rev-parse --verify {sha}^{commit}`. Fail with `SHA not found in repository: {sha}` on error. Capture the resolved full SHA as `full_sha`. (This single `rev-parse` subsumes the repo-directory check above, so no separate `--git-dir` invocation is needed after it succeeds.)
+
+### Step 2 — Dedup check
+
+`akb_search(query={full_sha}, vault={vault_name}, collection=git-commits, type=reference, tags=["git", "kind:commit", "project:{repo_name}"], limit=5)`. Among hits, find the one whose frontmatter `sha` equals `full_sha`. If found, return without writing:
+
+```markdown
+## ingest-commit: exists
+- sha: {full_sha}
+- doc_id: {existing_doc_id}
+- vault: {vault_name}
+```
+
+### Step 3 — Collect git data in a single pass
+
+```bash
+git -C {repo_path} show \
+  --format='%H%x00%h%x00%P%x00%aN%x00%ae%x00%aI%x00%cN%x00%ce%x00%cI%x00%s%x00%b' \
+  --stat --unified=0 {full_sha}
+```
+
+`%aN` / `%cN` apply `.mailmap` automatically — no separate `git log` needed. Parse three zones:
+
+1. **Metadata line** (null-separated): `sha`, `short_sha`, `parents` (space-separated), `author_name` (mailmap-applied), `author_email` (raw), `authored_at`, `committer_name` (mailmap-applied), `committer_email` (raw), `committed_at`, `message_subject`, `message_body`.
+2. **Stat block**: extract `{files, additions, deletions}` from the summary line (e.g. `3 files changed, 47 insertions(+), 12 deletions(-)`); collect per-file stat lines for the body.
+3. **Diff block**: cap at `500` lines (set `truncated: true`); detect `Binary files ... differ` markers and record their paths.
+
+Derive `is_merge = (len(parents) > 1)`.
+
+### Step 4 — Resolve canonical author
+
+`author_name` from Step 3 is mailmap-normalized. Override with `data/plugins/akb-wiki.yaml` `author_aliases` keyed on the **raw** `author_email` if a non-empty entry exists; otherwise keep Step 3's value. `author_email` is never rewritten — preserved as the alias-lookup key.
+
+### Step 5 — Faithful restatement
+
+Produce two artifacts from the Step 3 diff. Use no context beyond commit message + diff + file list — never consult sibling commits, PR metadata, issue trackers, or external state.
+
+**5a. `summary` (frontmatter, 1 line)** — single-line factual description of what the diff changed. Imperative/neutral tone (not evaluative); describes **structure** (renames, adds, removes, moves), not **intent**; derived from the diff (when the message subject is vague — `fix stuff`, `wip`, `asdf` — or misleading, reconstruct from the diff). Omit author names, issue numbers, dates.
+
+Acceptable: `Rename AuthService to AuthManager across src/auth and tests/auth`, `Add SSOProvider class with login/logout/validate_token in src/auth/sso.py`. Forbidden (interpretation leaking in): `Improve auth module for better SSO support` (evaluative), `Part of the Q2 security refactor` (cross-commit context), `Fix the bug where users couldn't log in` (intent).
+
+**5b. `Changes (faithful)` block (body, bullet list)** — concrete bullets, each naming **what** and **where**. Group by file or change kind; spell out renames (`Rename X → Y`); name new symbols/sections and their locations on adds; name what was removed and its former location; describe dimensions on bulk edits (`Bump 4 dependency versions in package.json`); one line per binary (`Binary change in {path}`). On truncation, end with `Diff truncated at 500 lines; remaining changes not enumerated.`
+
+**5c. `diff_scope` (frontmatter, categorical list)** — rule-based labels from diff shape (not message). Pick any: `add` (net new file), `remove`, `rename`, `modify` (in-place edit), `config` (only top-level config/CI: `*.yaml`, `*.toml`, `Makefile`, `.github/**`), `docs` (only `*.md`, `docs/**`, comment-only), `test` (only `tests/**`, `spec/**`, `*_test.*`), `binary`. Multiple labels co-occur (e.g. `[modify, docs]`).
+
+**5d. Conventional commit parse** — match `message_subject` against `<type>(<scope>): <desc>` or `<type>: <desc>` with `type ∈ feat|fix|refactor|docs|test|chore|ci|build|perf|style`. Both `conv_type` / `conv_scope` are `null` on no match.
+
+**5e. Body-section scope tag** — `scope_tag = conv_scope or top_level_paths[0] or null`. Emitted as `scope:{scope_tag}` in Step 6 when non-null; the external maintenance layer consumes it directly without reading a `paths` frontmatter field.
+
+### Step 6 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"                # last path component of repo_path (normalized)
+project: "{repo_name}"             # mirrors repo; `repo` is the source-system identifier, `project` is the project-rollup namespace
+sha: "{full_sha}"
+short_sha: "{short_sha}"
+parents: [{parent_sha}, ...]
+
+committer: "{canonical_committer}"
+authored_at: "{authored_at_iso}"
+committed_at: "{committed_at_iso}"
+
+stats: { files: N, additions: N, deletions: N }
+is_merge: {true|false}
+truncated: {true|false}
+
+conv_type: "{feat|fix|...|null}"
+conv_scope: "{scope|null}"
+diff_scope: [{rule_based_labels}]
+
+summary: "{faithful_1_line}"
+message_subject: "{commit_message_first_line}"
+tags: ["git", "project:{repo_name}", "kind:commit", "scope:{scope_tag}", "type:{conv_type_if_any}", "author:{canonical_author}"]
+
+related_to: []
+```
+
+`scope:{scope_tag}` and `type:{conv_type}` are omitted when Step 5e/5d produced `null`. `kind:commit` is the discriminator the external maintenance layer reads when grouping per-source summary rows. Per-commit `paths` array is not frontmatter — its only consumer (the external maintenance layer's consolidation) reads `scope:{val}` off tags. `author` / `author_email` likewise live only on tags as `author:{canonical_author}`. The `type:{conv_type}` namespace collides with `/ingest-jira`'s `type:{issue_type}` deliberately — `kind:*` (`kind:commit` vs `kind:atlassian-issue`) disambiguates.
+
+Body:
+
+```markdown
+# {summary}
+
+## Changes (faithful)
+- {bullet 1}
+- {bullet 2}
+...
+
+## Author's message
+> {message_subject}
+
+{message_body if non-empty, else omit this paragraph}
+
+## Stats
++{additions} / -{deletions} across {files} files
+
+### Paths
+- {full_path_a}
+- {full_path_b}
+...
+
+## Source
+
+- Author: {canonical_author} <{raw_author_email}>
+```
+
+Notes on assembly:
+
+- `## Source` keeps the canonical author + raw email visible for human readers — their frontmatter carriers don't survive the AKB MCP whitelist. The YAML example above lists `sha` / `short_sha` / `parents` / dates / conv-type / diff-scope / stats / flags for documentation only; downstream skills read those axes from `tags` instead (see `_fetch_commit_docs.md.j2`).
+- `### Paths` is the full file list; the external maintenance layer's body-section axis is the `scope:{val}` tag, not a separate frontmatter array.
+- `tags` drops null-valued entries (e.g. `conv_type` / `scope:` when absent).
+- Never include the full unified diff — only the faithful restatement + stats + paths.
+
+### Step 7 — Write
+
+`akb_put(vault={vault_name}, collection=git-commits, title="{short_sha} {message_subject}", type=reference, tags={tags}, content={assembled_body}, summary={faithful_1_line})`. On success, return:
+
+```markdown
+## ingest-commit: created
+- sha: {full_sha}
+- doc_id: {new_doc_id}
+- vault: {vault_name}
+- collection: git-commits
+- summary: {faithful_1_line}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<sha>` missing | `Missing required argument: <sha>` |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| SHA not found in the repo | `SHA not found in repository: {sha}` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. The caller decides. |
+| Diff exceeds `500` lines | Record with `truncated: true`; not a failure. |
+| Binary-only commit | Record with `diff_scope` including `binary`; Changes bullets say `Binary change in {path}`. |
+| Merge commit | Record as-is with `is_merge: true`; no filter applied here. |
+| SHA already ingested | Return `exists` status; not a failure. |

--- a/plugins/claude/akb-wiki/agents/ingest-confluence.md
+++ b/plugins/claude/akb-wiki/agents/ingest-confluence.md
@@ -1,0 +1,372 @@
+---
+name: ingest-confluence
+description: Ingest one Confluence page into an AKB vault as a five-section LLM-wiki summary document, fetched live via the Atlassian MCP server.
+model: sonnet
+tools: Read, mcp__akb__akb_search, mcp__akb__akb_get, mcp__akb__akb_put, mcp__akb__akb_update, mcp__akb__akb_browse, mcp__atlassian__confluence_get_page
+---
+
+# AKB Atlassian Page Ingest
+
+Ingest **one Confluence page** into the target AKB vault as a five-section LLM-wiki summary document — the `akb-wiki` plugin's Confluence write path, specializing `akb-wiki`'s generic `/akb-ingest` pattern.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — Confluence pages externalize design decisions, RFCs, runbooks, post-mortems. Ingest pulls that rationale into the vault before the page evolves out from under the team.
+
+Scope boundaries:
+
+- **One page per invocation.** Bulk space imports are an orchestration loop calling this skill once per page id.
+- **No fan-out at ingest.** Concept clustering, membership backlinks, cross-source aggregation, and structural checks are all handled by an external maintenance layer that runs over the same AKB vault.
+- **Atlassian MCP required.** Page body is fetched live via `mcp__atlassian__confluence_get_page` — no payload escape hatch.
+- **Fixed collection.** Pages land in `atlassian-pages`; sub-organize with tags.
+- **No attachment download.** Embedded image/attachment URLs are preserved as references; bytes stay in Confluence.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-confluence <url-or-id> --vault {vault_name} [--lang {language}] [--project {name}]
+```
+
+- `<url-or-id>` (required, positional) — Confluence page URL or bare page id.
+- `--vault` (required) — target AKB vault.
+- `--lang` (optional) — language for synthesized body (TL;DR / Key Points / topic tags). Defaults to the page's primary language.
+- `--project` (optional) — pin to a project namespace for downstream cross-source rollup. When supplied, adds `project: "{name}"` frontmatter and a `project:{name | lower}` tag. Omitted → ingest normally but skipped from that rollup (Confluence is not directory-bound, so no auto-derivation).
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- Atlassian MCP server is connected — `mcp__atlassian__confluence_get_page` must be callable.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Common resolution every Atlassian ingest subagent performs before its own entity-specific parsing.
+
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Verify the **Atlassian MCP server is connected**. If the MCP tool surface is unavailable, fail with `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` There is no payload escape hatch — webhook receivers and orchestration layers either run with the Atlassian MCP server attached, or skip ingest.
+- Capture today's date as `today` (ISO `YYYY-MM-DD`) for timeline entries.
+
+The two ingest skills (`ingest-confluence`, `ingest-jira`) share these pre-checks. Entity-specific parsing — URL → `(space_key, page_id)` for pages, `<issue-key>` → `(project_key, issue_key)` for issues — happens in each skill's own Step 2 after this block runs.
+
+Capture `today` as ISO `YYYY-MM-DD`.
+
+### Step 2 — Fetch the page
+
+Parse the positional argument: a `https?://.+/wiki/spaces/(\w+)/pages/(\d+)` URL captures `space_key` + `page_id`; a bare numeric id sets `page_id` (space_key fills from MCP response); anything else fails with `Invalid Confluence URL or page id: {arg}`.
+
+Fetch: `mcp__atlassian__confluence_get_page(page_id={page_id}, include_metadata=true)`. Failures: `page not found` → `Confluence page {page_id} not found.`; any other MCP error verbatim.
+
+Normalize the response into a `page` dict with `space_key`, `page_id` (opaque), `version` (monotonic int), `title`, `author` (last editor or original), `last_modified` (ISO 8601), `body_storage` (Confluence storage format, **as authored** — conversion happens in Step 3), `labels`, `tenant_base_url` (reconstruct from URL or fall back to `https://{tenant}.atlassian.net`; never used for further HTTP), `links.jira` (raw issue keys from the API, not re-derived), `links.confluence` (raw page ids).
+
+Compose `canonical_url = "{page.tenant_base_url}/wiki/spaces/{page.space_key}/pages/{page.page_id}"` for the Source block's `Location:`.
+
+### Step 3 — Convert body_storage → markdown
+
+Conversion guide every Atlassian ingest subagent applies when transforming Confluence storage format (HTML + macros) or Atlassian Document Format (ADF) into clean markdown for the document body. Both ingest skills share these rules so a page rendered by `ingest-confluence` and the description of an issue rendered by `ingest-jira` look consistent in the vault.
+
+The conversion is **structural fidelity over visual fidelity** — preserve information that has retrieval value, drop visual artifacts that do not.
+
+## Headings
+
+- Confluence `<h1>`–`<h6>` → markdown `#`–`######`. Preserve the level relative to the page; do not collapse hierarchy.
+- ADF `heading` nodes (`level: 1..6`) follow the same mapping.
+
+## Paragraphs and inline formatting
+
+- `<p>`, ADF `paragraph` → blank-line-separated paragraphs.
+- `<strong>`/`<b>` → `**bold**`. `<em>`/`<i>` → `*italic*`. `<code>` → `` `inline code` ``. ADF `marks` (`strong`, `em`, `code`, `link`, `underline`, `strike`) map to the corresponding markdown.
+- Hyperlinks (`<a href>`, ADF `link` mark) → `[label](url)`. Preserve the original URL verbatim, including query string. Do not re-encode.
+
+## Lists
+
+- `<ul>`/`<ol>` and ADF `bulletList`/`orderedList` → markdown `-` or `1.` lists. Preserve nesting depth via 2-space indentation.
+- Task lists (Confluence `<ac:task-list>`, ADF `taskList`) → `- [ ]` / `- [x]` per item state.
+
+## Tables
+
+- `<table>` and ADF `table` → GitHub-Flavored Markdown table. The first row becomes the header. If the source has no header row, synthesize one with column labels `Col 1`, `Col 2`, … so downstream tooling can parse it.
+- Tables exceeding 8 columns or with merged cells that cannot be flattened: render the first row as a markdown header line, then keep the remaining rows as-is (each row a single line of pipe-separated cells), and append a note `<!-- Source table had merged cells; flattened. -->`.
+
+## Code blocks
+
+- Confluence `<ac:structured-macro ac:name="code">` (with optional `ac:parameter ac:name="language">`) → fenced code block ` ```<language>\n…\n``` `. If no language parameter, use ` ``` ` without one.
+- ADF `codeBlock` (`attrs.language`) → same fenced block.
+- Inline `<code>` already covered above.
+
+## Confluence macros
+
+| Macro | Markdown form |
+|---|---|
+| `info` / `note` | Block quote prefixed with `> **Note:** ` (or `**Info:**`, `**Tip:**`, `**Warning:**` per macro) |
+| `panel` (with `title`) | `> **{title}**\n>\n> {body, recursively converted}` |
+| `expand` (collapsible) | `<details><summary>{title}</summary>\n\n{body}\n\n</details>` |
+| `toc` | Drop entirely. Do not emit a placeholder. |
+| `excerpt` / `excerpt-include` | Inline the excerpt body. Drop the macro wrapper. |
+| `jira` (single-issue inline) | `[{issue_key}]({issue_url})`. Issue keys also collected into the page's `linked_issues` axis (handled by ingest skill, not by this conversion). |
+| Other unknown macros | Render the macro's textual body if available; if not, emit `<!-- macro: {macro_name} (rendered text unavailable) -->` so the user can re-ingest with the rendered form. |
+
+## ADF panel and decision nodes
+
+| ADF node | Markdown form |
+|---|---|
+| `panel` (`type: info|note|warning|success|error`) | `> **{Type}:** {body}` |
+| `decision` | `> **Decision:** {body}` |
+| `mediaSingle` / `mediaGroup` | Image reference only — see below. |
+
+## Images and attachments
+
+- `<ac:image>` and ADF `media` nodes → `![{alt or filename}]({attachment_url})`. The attachment file itself is **not** downloaded into AKB at this version; the URL is left as a reference. A future raw-layer integration may download attachment bytes via `akb_put_file`.
+- If the attachment URL is relative (Confluence-internal), prefix it with the tenant base URL captured at fetch time so the link is followable from outside the wiki.
+
+## Mentions and metadata noise
+
+- `@mentions` (Confluence `<ac:link>` to users, ADF `mention`) → `@{display_name}`. Drop the user-id payload.
+- Date / status / emoji inline pills → plain text equivalent (`📅 2026-04-20`, `🟢 In progress`, `:thumbs_up:`).
+- Drop any "last edited / version" footers Confluence injects into the body — frontmatter already carries those axes.
+
+## Whitespace cleanup
+
+- Collapse runs of 3+ blank lines to a single blank line.
+- Strip trailing whitespace from every line.
+- Ensure a single trailing newline at the end of the converted body.
+
+## What this conversion is **not**
+
+- No agent rewriting. The conversion is structural (HTML/ADF → markdown). Do not summarize, paraphrase, or "clean up" prose. Compiled-truth synthesis (TL;DR / Key Points) happens in the calling skill's separate compose step on top of this converted body.
+- No external link verification. Do not fetch any URL referenced inside the body.
+- No attachment download. URLs are preserved as-is.
+
+If a fragment cannot be converted faithfully, prefer leaving the source HTML/ADF inline (verbatim, in a code block) over guessing a markdown equivalent. The vault would rather hold an awkward but lossless record than a polished but misleading one.
+
+The result is `extracted_text`. Compute `content_sha256 = sha256(body_storage)` over the **raw storage format** (not the converted markdown) so the hash is stable across re-runs even if the converter changes.
+
+### Step 4 — Dedup
+
+Two deterministic signals + optional semantic, with version monotonicity short-circuiting the resolution table.
+
+#### Stage 1 — Deterministic match by `(space_key, page_id)`
+
+`akb_search(vault={vault_name}, collection=atlassian-pages, type=reference, tags=["page-id:{page_id}"], limit=5)`. Single-tag filter narrows to the exact page-id cell — AKB's `tags` filter has OR semantics, so multi-tag would broaden instead of narrow; one tag reduces to exact-membership. Confluence page ids are tenant-unique, so `page-id:{page_id}` + collection scope is sufficient. On hit, capture `dedup_hit = doc_id` and `dedup_existing_version = int(version_tag.split(":", 1)[1])` from the `version:{N}` tag; set `dedup_kind = "deterministic"`. Skip Stage 2.
+
+#### Stage 2 — Semantic fallback
+
+Only runs when Stage 1 produced no hit. `akb_search(query={title}, vault={vault_name}, collection=atlassian-pages, type=reference, limit=5)`. Any hit with `score > 0.85` is a fuzzy match — capture `dedup_hit = top_hit.doc_id`, `dedup_kind = "fuzzy"`.
+
+#### Decision
+
+Fully automatic — Confluence's monotonic `version` axis is the canonical signal; the skill absorbs the dedup decision (LLM-wiki *agent absorbs bookkeeping*).
+
+| `dedup_hit` / kind | Comparison | Action |
+|---|---|---|
+| none | — | continue to Step 5 (create path) |
+| deterministic | `page.version < dedup_existing_version` | `## ingest-confluence: exists` and stop. Note: `vault holds {dedup_existing_version}; ingest {page.version} is older — skipped.` |
+| deterministic | `page.version == dedup_existing_version` | `## ingest-confluence: exists` and stop. Note: `same version already ingested — skipped.` |
+| deterministic | `page.version > dedup_existing_version` | continue to Step 5; Step 6 `akb_update`s `dedup_hit` (compiled-truth refresh + timeline append). |
+| fuzzy | — | `## ingest-confluence: likely-exists` and stop. Disambiguation goes through the external maintenance layer or human review. |
+
+Forced create / forced replace are out of scope here — handle via a separate disambiguation workflow, not a per-call flag.
+
+### Step 5 — Compose summary
+
+Synthesize TL;DR / Key Points / `summary` from the converted body. The `## Content` section is mechanical (verbatim converted body). Synthesized prose follows `--lang` if supplied, else the page's primary prose language (not embedded code/quotes); section headings, frontmatter keys, and `## Content` always stay in natural form (English headings/keys, content as-extracted).
+
+#### Body template
+
+```markdown
+# {title}
+
+## TL;DR
+
+{Agent-authored 1–3 sentences. What this page is, at a synthesis level. No hedging, no "this page describes…" boilerplate. Lean on the page's actual structure — for a design doc lead with the proposal; for a runbook lead with the trigger.}
+
+## Key Points
+
+- {Bullet 1 — 3–7 sharp takeaways. For a design doc: proposal, constraints, decisions, action items. For a runbook: when it fires, what to check, escalation. For a post-mortem: incident, root cause, follow-ups.}
+- {Bullet 2}
+- ...
+
+## Content
+
+{extracted_text from Step 3 — the converted markdown body. Verbatim, including tables and code blocks.}
+
+## Source
+
+- Location: {canonical_url}
+- Space: {space_key}
+- Page-ID: {page_id}
+- Version: {page.version}
+- Author: {page.author}
+- Last-Modified: {page.last_modified}
+- Content-SHA256: {content_sha256}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested page version {page.version}. [Source: ingest-confluence, {today}]
+```
+
+The Source block intentionally mirrors the akb-wiki `/akb-ingest` format on `Location:`, `Content-SHA256:`, and `Ingested:` so the external maintenance layer's duplicate-source check catches Confluence pages automatically. Atlassian-specific axes (`Space:`, `Page-ID:`, `Version:`, `Author:`, `Last-Modified:`) are added on top.
+
+#### Frontmatter
+
+```yaml
+type: reference
+status: active
+title: "{page.title}"
+summary: "{one-sentence synthesis, same voice as TL;DR but compressed to one line}"
+tags: [
+  "atlassian",
+  "kind:atlassian-page",
+  "space:{space_key}",
+  "page-id:{page_id}",
+  "version:{page.version}",
+  "label:{label_1}", "label:{label_2}",
+  "topic:{primary}", "topic:{secondary}",
+  "project:{project_lowered}"
+]
+project: "{project_arg | null}"        # populated only when --project was supplied at invocation
+linked_issues: [{issue_key}, ...]    # from page.links.jira (raw keys, not resolved to AKB doc_ids yet)
+linked_pages: [{page_id}, ...]       # from page.links.confluence (raw page ids; not resolved either)
+depends_on: []
+related_to: []
+implements: []
+```
+
+The `project:` tag and `project` field are emitted only when `--project` was supplied (lowercased tag suffix, verbatim frontmatter value).
+
+- `type: reference` matches `/akb-ingest`'s convention.
+- `tags` carries provenance (`atlassian`), `kind:atlassian-page` cross-plugin discriminator, `space:{key}` filter axis, `page-id:{page_id}` dedup key, `version:{N}` monotonic counter (read in Step 4), one `label:{name}` per Confluence label, and **1–3 `topic:{...}` tags** authored alongside TL;DR / Key Points. Topic tags identify the page's *subjects* (design doc → proposal area; runbook → system; post-mortem → failure domain): lowercase, hyphenated compounds (`topic:vector-search`), domain-anchored vocabulary (`introduction` / `overview` / `notes` are not topics), drop rather than fill. `label:` and `topic:` are independent — the same string may appear in both (the external maintenance layer reads `topic:*` as the lattice axis; `label:*` only filters). Empty topic list is allowed only for non-subject pages (link directory, ToC, stub); downstream consolidation skips them silently. All entries are skill-authored — no caller-supplied tags. Duplicates dropped.
+- `space_key` / `page_id` / `version` / per-`label` live in tags; `author` / `last_modified` live in the body `## Source` block.
+- `linked_issues` / `linked_pages` stay as raw external keys; the external maintenance layer does not resolve them.
+- `depends_on` / `related_to` / `implements` are empty at ingest; the external maintenance layer populates them.
+
+### Step 6 — Write
+
+Branch by Step 4 resolution.
+
+**Create** (no hit) — `akb_put(vault={vault_name}, collection=atlassian-pages, title={page.title}, type=reference, tags={tags}, summary={one_sentence_summary}, content={assembled_body})`. Capture `doc_id` / `doc_path`.
+
+**Replace** (deterministic newer, or fuzzy resolved to replace):
+
+1. `akb_get(vault={vault_name}, doc_id={dedup_hit}) → existing_content`.
+2. Apply **timeline merge — Mode B (entry-only append)** with `new_entry = "- **{today}** | Re-ingested page version {page.version} (was version {dedup_existing_version}). [Source: ingest-confluence, {today}]"`.
+3. Build final `content`: everything from the new body **above** `---` + `## Timeline` (compiled-truth refresh) + Mode B's merged timeline section.
+4. `akb_update(vault={vault_name}, doc_id={dedup_hit}, tags={tags}, content={merged_content}, summary={one_sentence_summary}, message="Re-ingested page version {page.version}")` — bumped `version:{page.version}` tag enables next-run dedup.
+
+Mode B is the right choice here: the new entry is a single bullet, the rest of the body is rewritten in place, and timeline is the only history-preserving zone.
+
+### Step 7 — Report
+
+Successful create:
+
+```markdown
+## ingest-confluence: created
+- title: {page.title}
+- doc_id: {doc_id}
+- path: {doc_path}
+- vault: {vault_name}
+- collection: atlassian-pages
+- space: {space_key}
+- page_id: {page_id}
+- version: {page.version}
+- summary: {one_sentence_summary}
+```
+
+Successful replace:
+
+```markdown
+## ingest-confluence: replaced
+- title: {page.title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- previous version: {dedup_existing_version}
+- new version: {page.version}
+- timeline entries: {N (after append)}
+```
+
+Skipped (deterministic dedup + version older or equal):
+
+```markdown
+## ingest-confluence: exists
+- title: {page.title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- vault version: {dedup_existing_version}
+- ingest version: {page.version}
+- reason: "older or equal version"
+```
+
+Fuzzy-skipped:
+
+```markdown
+## ingest-confluence: likely-exists
+- title: {page.title}
+- top match: {dedup_hit} (score: {score})
+- vault: {vault_name}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<url-or-id>` missing | `Missing required argument: <url-or-id>.` |
+| Invalid Confluence URL / page-id format | `Invalid Confluence URL or page id: {arg}` |
+| Atlassian MCP not connected | `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` |
+| Page id not found by MCP | `Confluence page {page_id} not found.` |
+| Storage format → markdown conversion fails on a fragment | Fall back to inlining the raw storage HTML inside a `<details>` block as documented in the conversion guide. Not a hard failure. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| AKB MCP unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+Do not create vaults or collections; surface `akb_put`'s missing-vault error and instruct the user to create the vault with `mcp__akb__akb_create_vault`.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/claude/akb-wiki/agents/ingest-doc.md
+++ b/plugins/claude/akb-wiki/agents/ingest-doc.md
@@ -1,0 +1,309 @@
+---
+name: ingest-doc
+description: Ingest one document (local file or web URL) into an AKB vault as a five-section LLM-wiki summary page, optionally preserving the original bytes in the raw file layer.
+model: sonnet
+tools: Read, Glob, WebFetch, Bash(curl *), Bash(rm *), mcp__akb__akb_search, mcp__akb__akb_get, mcp__akb__akb_put, mcp__akb__akb_put_file, mcp__akb__akb_update, mcp__akb__akb_link, mcp__akb__akb_relations, mcp__akb__akb_browse
+---
+
+# AKB Ingest
+
+Ingest **one document** (local path or URL) into the target AKB vault as a five-section summary page, optionally preserving the original bytes in AKB's raw file layer. This skill is the `akb-wiki` plugin's ingest write path.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — it externalizes documents of record (papers, articles, manuals, transcripts, web clips) into the vault so the rationale and constraints in those sources stay retrievable by humans and agents.
+
+Scope boundaries:
+
+- **One source per invocation.** Glob patterns expand into a sequential loop that calls the same workflow once per match.
+- **No fan-out at ingest time.** Consolidation into concept pages and cross-reference to existing entities are handled by an external maintenance layer (dream-cycle) that runs over the same AKB vault, not at ingest time. AKB's own search/browse already indexes every write, so the skillpack does not maintain a manual vault-index document.
+- **2-layer write when binary.** Binary formats upload their original bytes via `akb_put_file` **and** emit a summary document with a `derived_from` link to the raw file. Plaintext formats emit only the summary.
+- **Fixed collections.** Summary documents always land in `corpus-summaries`, raw files in `corpus-raw`. No `--collection` override — use tags for sub-organization.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-doc <source> --vault {vault_name} [--raw | --no-raw] [--lang {language}]
+```
+
+- `<source>` (required) — local path (absolute, or glob like `./papers/*.pdf`) or URL (http/https).
+- `--vault` (required) — target AKB vault name.
+- `--raw` / `--no-raw` (optional) — override format-based raw-upload default (see Step 2).
+- `--lang` (optional) — language for synthesized note body (TL;DR / Key Points / topic tag wording). If omitted, infer from the source's primary language. Use this to override when the source language differs from the desired note language (e.g., English paper → Korean summary).
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- For URL sources: `WebFetch` available.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Parse `--vault` from arguments. Hard-fail if missing: `--vault {name} required.`
+
+Parse remaining CLI arguments. Capture today's date as `today` (ISO `YYYY-MM-DD`).
+
+### Step 2 — Resolve source
+
+Classify `<source>`:
+
+- **Path** — starts with `/`, `./`, `~/`, or has no scheme. If it contains glob metacharacters (`*`, `?`, `[`), resolve with `Glob` and loop through each match, running Steps 3–7 per file. A zero-match glob fails with `No files matched "{pattern}".`
+- **URL** — starts with `http://` or `https://`.
+
+Detect format from extension (path) or `Content-Type` header when available (URL), plus filename hint from the URL path:
+
+| Format | Extension set | Upload default |
+|---|---|---|
+| `pdf` | `.pdf` | binary → raw |
+| `image` | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` | binary → raw |
+| `office` | `.docx`, `.xlsx`, `.pptx` | binary → raw |
+| `markdown` | `.md`, `.markdown` | plaintext → summary only |
+| `html` | `.html`, `.htm`, URL with no extension | plaintext → summary only |
+| `text` | `.txt`, `.log` | plaintext → summary only |
+| `json` | `.json`, `.jsonl`, `.yaml`, `.yml` | plaintext → summary only |
+
+Unsupported extensions fail with `Unsupported format: {ext}. Supported: pdf, png/jpg/gif/webp, docx/xlsx/pptx, md, html, txt, json.`
+
+Apply flag overrides:
+
+- `--raw` → force raw upload regardless of format default (useful when the user wants to preserve a .md file's original bytes).
+- `--no-raw` → suppress raw upload regardless of format default (useful when the user considers a PDF disposable and only wants the extracted text).
+
+Record `raw_upload ∈ {true, false}` and `format_kind ∈ {binary, plaintext}` for downstream steps.
+
+### Step 3 — Fetch
+
+Always obtain **extracted text** for the `## Content` section. Additionally, when `raw_upload == true`, obtain a **local file path** pointing at the original bytes for `akb_put_file`.
+
+#### Path source
+
+```text
+Read(file_path="{path}")
+```
+
+- For PDFs: read page by page when the file is long (`pages="1-20"` at a time). If the PDF's total page count is unknown, attempt without `pages` first; chunk only when the single read fails or exceeds token budget.
+- For binary formats `Read` cannot extract (e.g. `.docx`, `.xlsx`), surface the failure: `Cannot extract text from {format}; install a converter or supply an already-converted .md.` The raw bytes can still be uploaded if `raw_upload == true` — ingest proceeds with an empty `## Content` and a note "text extraction unsupported for this format."
+- `local_file_path` is the input path itself.
+
+#### URL source
+
+```text
+WebFetch(url="{url}", prompt="Return the main article content as clean markdown. Preserve headings, lists, and code blocks. Drop navigation, ads, footers.")
+```
+
+If `raw_upload == true`, also download the URL bytes to a temp path (`/tmp/ingest-doc-{short_hash}.{ext}`) for `akb_put_file`:
+
+- Plaintext URLs with `raw_upload=true` (only happens when `--raw` is explicit): save the WebFetch'd HTML/markdown verbatim to temp.
+- Binary URLs: fetch bytes directly and save to temp. (If WebFetch does not expose raw bytes, fall back to `Bash(curl -sL -o /tmp/... {url})` — note this in the output if taken.)
+
+Record `extracted_text` (may be empty) and `local_file_path` (may be null).
+
+### Step 4 — Dedup
+
+Two-stage deterministic / semantic check, then a **fully automatic decision table** — no caller flag, no interactive prompt. The skill absorbs the dedup decision (LLM-wiki *agent absorbs bookkeeping*).
+
+Compute `new_hash = sha256(extracted_text)` once up front — used as both the path-source lookup key and the equality test in the decision table.
+
+#### Stage 1 — Deterministic match
+
+Build a `lookup_key`: canonical URL (strip tracking params like `utm_*`, `ref`, `fbclid`) for URL sources, `new_hash` for path sources. Query `akb_search(vault="{vault_name}", query={lookup_key}, collection="corpus-summaries", type="reference", limit=5)`.
+
+For each hit, `akb_get(vault="{vault_name}", doc_id={hit.doc_id})` and inspect the `## Source` block. Match on either a `Location:` line containing the canonical URL **or** a `Content-SHA256:` line matching `new_hash` (only present when a plaintext path was previously ingested). On match, set `dedup_hit = doc_id`, parse `existing_hash` from the existing doc's `Content-SHA256:` (may be absent if the prior ingest had no raw upload), set `dedup_kind = "deterministic"`, and skip Stage 2.
+
+#### Stage 2 — Semantic fallback
+
+Runs only when Stage 1 produced no hit. Produce a provisional title (URL `<title>` tag, PDF metadata, markdown `# heading`, or filename stem — whichever is available). Query `akb_search(vault="{vault_name}", query={provisional_title}, collection="corpus-summaries", type="reference", limit=5)`. Any hit with `score > 0.85` counts as fuzzy: set `dedup_hit = top_hit.doc_id`, `dedup_kind = "fuzzy"`. The hit is a **candidate**, not a confirmed identity match.
+
+#### Decision
+
+| `dedup_hit` / kind | Comparison | Action |
+|---|---|---|
+| none | — | continue to Step 5 (create path) |
+| deterministic | `existing_hash == new_hash` | return `## ingest-doc: unchanged` (see Step 7) and stop. Content identical — no compiled-truth refresh, no timeline append. |
+| deterministic | `existing_hash != new_hash` (or `existing_hash` absent) | continue to Step 5; Step 6 uses `akb_update` on `dedup_hit` (compiled-truth refresh + timeline append). |
+| fuzzy | — | return `## ingest-doc: likely-exists` and stop. The fuzzy hit is a candidate, not a confirmed identity match — leave disambiguation to the external maintenance layer or human review. |
+
+Edge cases (forced create on a fuzzy false-positive, forced replace despite hash equality) are out of scope for this skill — handle via a separate disambiguation workflow rather than a per-call flag. This keeps the ingest path headless-safe and the skill the sole owner of the dedup decision.
+
+### Step 5 — Upload raw (when applicable)
+
+Skip when `raw_upload == false`. Otherwise: `akb_put_file(vault="{vault_name}", file_path={local_file_path}, collection="corpus-raw", description={provisional_title})`. Capture `file_id` and `s3_key` from the response; compose `Raw URI = akb://{vault_name}/file/{file_id}`. If `local_file_path` was a temp file (URL download), delete it after the upload succeeds: `Bash(rm -f {local_file_path})`.
+
+### Step 6 — Compose and write summary
+
+Compose the summary document body using the fixed five-section structure. The **section headings are fixed**; the **content inside each section adapts to the source**.
+
+**Language**: write TL;DR / Key Points / topic tag descriptors in `--lang` if it was provided; otherwise match the source's primary prose language (not embedded code/quotes). Section headings, frontmatter keys, and the `## Content` zone (mechanical extracted text) always stay in their natural form — headings/keys English, content as-extracted.
+
+#### Body template
+
+```markdown
+# {title}
+
+## TL;DR
+
+{Agent-authored 1–3 sentences. What is this document, at a synthesis level. No hedging, no "this document discusses..." boilerplate.}
+
+## Key Points
+
+- {Bullet 1 — the sharpest 3–7 takeaways. For a paper: contribution, method, result. For an article: thesis, argument, conclusion. For a manual: what problem it solves, prerequisites, caveat. For a transcript: decisions, actions, open questions.}
+- {Bullet 2}
+- ...
+
+## Content
+
+{Cleaned extracted text from Step 3. Preserve original heading hierarchy, code blocks, tables. Drop navigation/ads/footers. For binary sources with no text extraction, write: "Text extraction unsupported for this format. See raw file at {raw_uri}."}
+
+## Source
+
+- Location: {source URL or absolute path}
+- Raw: akb://{vault_name}/file/{file_id}     ← omit this line entirely when `raw_upload == false`
+- Format: {format (pdf, html, md, …)}
+- Content-SHA256: {hash of extracted_text, for future dedup}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested from {source}. [Source: ingest-doc, {today}]
+```
+
+#### Frontmatter
+
+Use only AKB standard fields:
+
+```yaml
+type: reference
+status: active
+title: "{title}"
+summary: "{one-sentence synthesis, same voice as TL;DR but compressed to one line}"
+tags: ["{format_kind}", "{format}", "topic:{primary}", "topic:{secondary}"]
+depends_on: []
+related_to: []
+implements: []
+```
+
+- `format_kind` is `binary` or `plaintext`; `format` is the specific extension (`pdf`, `md`, …). Both are derived from the source.
+- `topic:{...}` entries are **1–3 LLM-derived topic tags**, authored alongside TL;DR / Key Points. After synthesizing the body, identify the 1–3 sharpest *subjects* of the document — e.g., a paper on retrieval-augmented generation gets `topic:rag`, `topic:retrieval`. Rules: lowercase, hyphenated for compounds (`topic:vector-search`), prefer domain-anchored vocabulary over generic words (`introduction` / `overview` / `tutorial` / `notes` are not topics), drop a tag rather than reach for filler. Empty topic list is allowed only when the source has no extractable subject (extraction failed, content is a directory listing or single-line note); downstream consolidation will then silently skip the summary.
+- All entries are derived from the source — the skill is the sole author of the `tags` array, no caller-supplied tags.
+- `depends_on` / `related_to` / `implements` are empty at ingest time — relation-wiring is the external maintenance layer's job.
+
+#### Write
+
+Branch by Step 4 decision.
+
+**New document** (no hit). `akb_put(vault="{vault_name}", collection="corpus-summaries", title={title}, type="reference", tags={tags}, summary={one_sentence_summary}, content={assembled_body})`. Capture `doc_id` and `doc_path`.
+
+**Replace** (deterministic hit with hash differing / absent):
+
+1. `akb_get(vault="{vault_name}", doc_id={dedup_hit}) → existing_content`.
+2. Apply timeline merge **Mode B** with `new_entry = "- **{today}** | Re-ingested from {source}. [Source: ingest-doc, {today}]"` and `existing_content` as-is.
+3. Build the final `content`: everything from the newly composed body **above** the `---` + `## Timeline` line, then the merged timeline from Mode B. This replaces the compiled-truth zone (TL;DR / Key Points / Content / Source) while preserving all historical timeline entries.
+4. `akb_update(vault="{vault_name}", doc_id={dedup_hit}, content={merged_content}, message="Re-ingested from {source}")`.
+
+#### Link raw to doc
+
+When `raw_upload == true` and a doc was created or replaced, materialize the lineage edge: `akb_link(vault="{vault_name}", source="akb://{vault_name}/doc/{doc_path}", target="akb://{vault_name}/file/{file_id}", relation="derived_from")`.
+
+On the `replace` path, first check `akb_relations(vault="{vault_name}", resource_uri="akb://{vault_name}/doc/{doc_path}", type="derived_from", direction="outgoing")` — the raw `file_id` may have changed or the prior ingest may have used `--no-raw`. Skip `akb_link` idempotently when the edge to the new `file_id` already exists. If a `derived_from` edge points to a *different* `file/{id}`, the prior raw is orphaned — do not delete it (other docs may reference it); leave it and emit a warning in the output.
+
+### Step 7 — Report
+
+Emit one of four single-source report blocks based on Step 4 + Step 6 outcome:
+
+```markdown
+## ingest-doc: created
+- title: {title}
+- doc_id: {doc_id}
+- path: {doc_path}
+- vault: {vault_name}
+- collection: corpus-summaries
+- raw_file_id: {file_id_or_none}
+- summary: {one_sentence_summary}
+
+## ingest-doc: replaced
+- title: {title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- previous raw: {old_file_id_or_none}
+- new raw: {file_id_or_none}
+- timeline entries: {N (after append)}
+
+## ingest-doc: unchanged
+- source: {source}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+
+## ingest-doc: likely-exists
+- source: {source}
+- top match: {dedup_hit} (score: {score})
+- vault: {vault_name}
+```
+
+Glob loop: emit one block per source processed, then a final summary `## ingest-doc: batch complete` with `created` / `replaced` / `unchanged` / `likely-exists` / `failed` counts.
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<source>` missing | `Missing required argument: <source>` |
+| Path not found | `File not found: {path}` |
+| Glob matched zero files | `No files matched "{pattern}".` |
+| Unsupported format | `Unsupported format: {ext}. Supported: pdf, png/jpg/gif/webp, docx/xlsx/pptx, md, html, txt, json.` |
+| URL unreachable / 4xx / 5xx | `Could not fetch {url}: {status}` |
+| Text extraction failed on binary | Record with `## Content` = "Text extraction unsupported for this format. See raw file at {raw_uri}." Not a hard failure when `raw_upload == true`. Hard failure when `raw_upload == false`. |
+| AKB write fails | Surface the error verbatim; do not retry. Partially-uploaded raw file is not rolled back at MVP — log `orphaned raw file: {file_id}` in the output so the user can `akb_delete_file` manually. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB MCP server unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+Do not attempt to create vaults or collections. If the supplied `vault_name` does not exist, `akb_put`/`akb_put_file` will error with a clear message — surface it as-is and instruct the user to create the vault with `mcp__akb__akb_create_vault`.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/claude/akb-wiki/agents/ingest-jira.md
+++ b/plugins/claude/akb-wiki/agents/ingest-jira.md
@@ -1,0 +1,353 @@
+---
+name: ingest-jira
+description: Record one Jira issue as an atlassian-issue document in an AKB vault — title/description/resolution/comments quoted verbatim. Fetched live via the Atlassian MCP server; always upsert.
+model: sonnet
+tools: Read, mcp__akb__akb_search, mcp__akb__akb_get, mcp__akb__akb_put, mcp__akb__akb_update, mcp__atlassian__jira_get_issue
+---
+
+# AKB Atlassian Issue Ingest
+
+Record **one Jira issue** as an `atlassian-issue` document in the target AKB vault. Mechanical assembly — title / description / resolution / comments quoted as author-authored compiled-truth; linked-issue refs preserved as raw external keys. No LLM synthesis on the body. Issue metadata is fetched live via the Atlassian MCP server.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — Jira issues externalize the scope, decisions, and discussions shaping work-in-flight. Capturing them faithfully preserves rationale before the issue closes and Jira's UI buries the discussion.
+
+Scope boundaries:
+
+- **One issue per invocation.** Bulk JQL imports are an orchestration loop.
+- **Atlassian MCP required.** Issue body is fetched via `mcp__atlassian__jira_get_issue` — no payload escape hatch.
+- **Mechanical body.** Description / resolution / comments are quoted verbatim with structure conversion only — no summarizing, paraphrasing, or translating.
+- **Always upsert.** Jira issues evolve (status / assignee / comments / linked issues change), so every re-ingest refreshes compiled-truth and appends a timeline entry. Dedup is mechanical via `(project_key, issue_key)`; no skip path.
+- **No LLM synthesis on the body.** Only structural transform (ADF → markdown) plus comment safety-net truncation. Compiled-truth synthesis is the external maintenance layer's job.
+- **Type isolation.** Issues are `type: reference` with `kind:atlassian-issue` tag as discriminator — **not** `type: task`. The `kind:*` tag keeps the external maintenance layer's stale-task heuristics off the Jira lifecycle (different cadence) without forcing a non-enum `type=`.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-jira <issue-key> --vault {vault_name} [--project {name}]
+```
+
+- `<issue-key>` (required, positional) — Jira issue key, e.g. `SDDEV-360`.
+- `--vault` (required) — target AKB vault.
+- `--project` (optional) — pin to a project namespace for downstream cross-source rollup. Adds `project: "{name}"` frontmatter and a `project:{name | lower}` tag, *in addition to* the Jira-structural `project:{project_key | lower}` derived from the issue key. The two coexist intentionally: `project_key` is the source-system id, `--project` is the rollup namespace.
+
+No `--on-duplicate` flag — Jira issues always upsert.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- Atlassian MCP server is connected — `mcp__atlassian__jira_get_issue` must be callable.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Common resolution every Atlassian ingest subagent performs before its own entity-specific parsing.
+
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Verify the **Atlassian MCP server is connected**. If the MCP tool surface is unavailable, fail with `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` There is no payload escape hatch — webhook receivers and orchestration layers either run with the Atlassian MCP server attached, or skip ingest.
+- Capture today's date as `today` (ISO `YYYY-MM-DD`) for timeline entries.
+
+The two ingest skills (`ingest-confluence`, `ingest-jira`) share these pre-checks. Entity-specific parsing — URL → `(space_key, page_id)` for pages, `<issue-key>` → `(project_key, issue_key)` for issues — happens in each skill's own Step 2 after this block runs.
+
+Capture `today` as ISO `YYYY-MM-DD` for timeline entries.
+
+### Step 2 — Fetch the issue
+
+Validate the issue-key shape against `^[A-Z][A-Z0-9_]+-\d+$`; on mismatch fail with `Invalid Jira issue key: {arg}`. Capture `project_key` as the prefix.
+
+Fetch: `mcp__atlassian__jira_get_issue(issue_key={issue_key}, expand="comments,renderedFields")`. Failures: `issue not found` → `Jira issue {issue_key} not found.`; any other MCP error verbatim.
+
+Normalize into an `issue` dict: `project_key` (must equal `issue_key` prefix — guard catches fetcher bugs, not user input), `issue_key`, `issue_type` (Story | Bug | Task | Epic | Sub-task | …), `title`, `status`, `priority` (nullable), `reporter`, `assignee` (nullable), `created_at` / `updated_at` (ISO 8601), `resolved_at` (ISO 8601 on terminal status, else null), `sprint` (nullable), `fix_versions` / `components` / `labels` (lists), `description` **as authored**, `description_format` (`adf` | `wiki` | `markdown`; default `adf`), `resolution` (short string on terminal status), `linked_issues` (ordered `{key, type}` pairs), `comments` (ordered `{author, created_at, body, body_format}` oldest-first; body **as authored**), `tenant_base_url` (reconstruct from MCP context when not surfaced).
+
+If `issue.project_key` doesn't match the `issue_key` prefix, fail with `Atlassian MCP returned project_key {issue.project_key} that does not match issue_key prefix.`
+
+Compose `canonical_url = "{issue.tenant_base_url}/browse/{issue.issue_key}"` (fall back to `https://{inferred-tenant}.atlassian.net/browse/{issue.issue_key}`).
+
+### Step 3 — Dedup check
+
+Always upsert; the check tells Step 5 whether to create or replace. `akb_search(vault={vault_name}, collection=atlassian-issues, type=reference, tags=["issue-key:{issue_key}"], limit=5)`. Single-tag filter narrows to exact-membership (AKB's `tags` filter has OR semantics, so multi-tag would broaden); Jira issue keys are tenant-unique, so `issue-key:{issue_key}` + collection is sufficient. On hit, capture `existing_doc_id`.
+
+No version field maps cleanly to a monotonic counter (`updated_at` can replay); compiled-truth is rewritten every invocation, and the timeline records each re-ingest — same pattern as `ingest-pr`.
+
+### Step 4 — Convert structured content
+
+Apply the conversion guide to (1) `description` using `description_format`, (2) each `comment.body` using `body_format` (default `adf`), (3) `resolution` as `markdown` when `*_format` is unspecified.
+
+Conversion guide every Atlassian ingest subagent applies when transforming Confluence storage format (HTML + macros) or Atlassian Document Format (ADF) into clean markdown for the document body. Both ingest skills share these rules so a page rendered by `ingest-confluence` and the description of an issue rendered by `ingest-jira` look consistent in the vault.
+
+The conversion is **structural fidelity over visual fidelity** — preserve information that has retrieval value, drop visual artifacts that do not.
+
+## Headings
+
+- Confluence `<h1>`–`<h6>` → markdown `#`–`######`. Preserve the level relative to the page; do not collapse hierarchy.
+- ADF `heading` nodes (`level: 1..6`) follow the same mapping.
+
+## Paragraphs and inline formatting
+
+- `<p>`, ADF `paragraph` → blank-line-separated paragraphs.
+- `<strong>`/`<b>` → `**bold**`. `<em>`/`<i>` → `*italic*`. `<code>` → `` `inline code` ``. ADF `marks` (`strong`, `em`, `code`, `link`, `underline`, `strike`) map to the corresponding markdown.
+- Hyperlinks (`<a href>`, ADF `link` mark) → `[label](url)`. Preserve the original URL verbatim, including query string. Do not re-encode.
+
+## Lists
+
+- `<ul>`/`<ol>` and ADF `bulletList`/`orderedList` → markdown `-` or `1.` lists. Preserve nesting depth via 2-space indentation.
+- Task lists (Confluence `<ac:task-list>`, ADF `taskList`) → `- [ ]` / `- [x]` per item state.
+
+## Tables
+
+- `<table>` and ADF `table` → GitHub-Flavored Markdown table. The first row becomes the header. If the source has no header row, synthesize one with column labels `Col 1`, `Col 2`, … so downstream tooling can parse it.
+- Tables exceeding 8 columns or with merged cells that cannot be flattened: render the first row as a markdown header line, then keep the remaining rows as-is (each row a single line of pipe-separated cells), and append a note `<!-- Source table had merged cells; flattened. -->`.
+
+## Code blocks
+
+- Confluence `<ac:structured-macro ac:name="code">` (with optional `ac:parameter ac:name="language">`) → fenced code block ` ```<language>\n…\n``` `. If no language parameter, use ` ``` ` without one.
+- ADF `codeBlock` (`attrs.language`) → same fenced block.
+- Inline `<code>` already covered above.
+
+## Confluence macros
+
+| Macro | Markdown form |
+|---|---|
+| `info` / `note` | Block quote prefixed with `> **Note:** ` (or `**Info:**`, `**Tip:**`, `**Warning:**` per macro) |
+| `panel` (with `title`) | `> **{title}**\n>\n> {body, recursively converted}` |
+| `expand` (collapsible) | `<details><summary>{title}</summary>\n\n{body}\n\n</details>` |
+| `toc` | Drop entirely. Do not emit a placeholder. |
+| `excerpt` / `excerpt-include` | Inline the excerpt body. Drop the macro wrapper. |
+| `jira` (single-issue inline) | `[{issue_key}]({issue_url})`. Issue keys also collected into the page's `linked_issues` axis (handled by ingest skill, not by this conversion). |
+| Other unknown macros | Render the macro's textual body if available; if not, emit `<!-- macro: {macro_name} (rendered text unavailable) -->` so the user can re-ingest with the rendered form. |
+
+## ADF panel and decision nodes
+
+| ADF node | Markdown form |
+|---|---|
+| `panel` (`type: info|note|warning|success|error`) | `> **{Type}:** {body}` |
+| `decision` | `> **Decision:** {body}` |
+| `mediaSingle` / `mediaGroup` | Image reference only — see below. |
+
+## Images and attachments
+
+- `<ac:image>` and ADF `media` nodes → `![{alt or filename}]({attachment_url})`. The attachment file itself is **not** downloaded into AKB at this version; the URL is left as a reference. A future raw-layer integration may download attachment bytes via `akb_put_file`.
+- If the attachment URL is relative (Confluence-internal), prefix it with the tenant base URL captured at fetch time so the link is followable from outside the wiki.
+
+## Mentions and metadata noise
+
+- `@mentions` (Confluence `<ac:link>` to users, ADF `mention`) → `@{display_name}`. Drop the user-id payload.
+- Date / status / emoji inline pills → plain text equivalent (`📅 2026-04-20`, `🟢 In progress`, `:thumbs_up:`).
+- Drop any "last edited / version" footers Confluence injects into the body — frontmatter already carries those axes.
+
+## Whitespace cleanup
+
+- Collapse runs of 3+ blank lines to a single blank line.
+- Strip trailing whitespace from every line.
+- Ensure a single trailing newline at the end of the converted body.
+
+## What this conversion is **not**
+
+- No agent rewriting. The conversion is structural (HTML/ADF → markdown). Do not summarize, paraphrase, or "clean up" prose. Compiled-truth synthesis (TL;DR / Key Points) happens in the calling skill's separate compose step on top of this converted body.
+- No external link verification. Do not fetch any URL referenced inside the body.
+- No attachment download. URLs are preserved as-is.
+
+If a fragment cannot be converted faithfully, prefer leaving the source HTML/ADF inline (verbatim, in a code block) over guessing a markdown equivalent. The vault would rather hold an awkward but lossless record than a polished but misleading one.
+
+Comment safety-net: if a converted comment exceeds `4000` chars, truncate at the nearest paragraph boundary and append `(truncated, see Jira for full text)`; mark `truncated: true` for Step 5 reporting. Description and resolution are **not truncated** — they're high-value compiled-truth; let the external maintenance layer flag oversize cases.
+
+### Step 5 — Assemble the body
+
+Strict templating from the `issue` dict + converted content. Sections with no data are **omitted entirely** (do not print empty section headers).
+
+```markdown
+# {issue_key}: {title}
+
+## Description
+
+{converted_description}
+
+(If description is empty/null: emit `(no description)` as the section body.)
+
+## Resolution
+
+{converted_resolution}
+
+(Omit this entire section when status is non-terminal OR resolution is null/empty.)
+
+## Comments ({len(comments)})
+
+### {N}. {comment.author} — {comment.created_at}
+
+{converted_comment_body}
+
+(Repeat per comment in chronological order, with N starting at 1. Omit the entire `## Comments` section when comments is empty.)
+
+## Linked
+
+- {link.type}: [{link.key}]({tenant_base_url}/browse/{link.key})
+
+(Repeat per linked issue. Omit the entire section when linked_issues is empty.)
+
+## Source
+
+- Location: {canonical_url}
+- Project: {project_key}
+- Issue-Key: {issue_key}
+- Type: {issue_type}
+- Status: {status}
+- Priority: {priority | "—"}
+- Reporter: {reporter}
+- Assignee: {assignee | "—"}
+- Sprint: {sprint | "—"}
+- Fix Versions: {fix_versions joined or "—"}
+- Components: {components joined or "—"}
+- Created: {created_at}
+- Updated: {updated_at}
+- Resolved: {resolved_at | "—"}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested at status `{status}`, {len(comments)} comments{", N comment(s) truncated" if any truncated}. [Source: ingest-jira, {today}]
+```
+
+The Source block carries every Jira-specific axis the document needs to be searchable and consolidatable. It deliberately keeps `Location:` / `Ingested:` line shapes consistent with `/akb-ingest` and `/ingest-confluence`; only the middle axes differ.
+
+#### Frontmatter
+
+```yaml
+type: reference
+status: active
+title: "{issue_key}: {issue.title}"
+summary: "{issue.title}"
+
+project: "{project_arg | null}"           # project-rollup namespace; only set when --project was supplied
+sprint: "{issue.sprint | null}"
+fix_versions: [{version}, ...]
+linked_issues: [{key_1}, {key_2}, ...]   # raw issue keys, ordered as Jira returns them; not yet resolved to AKB doc_ids
+
+tags: [
+  "atlassian",
+  "kind:atlassian-issue",
+  "jira-project:{project_key | lower}",
+  "issue-key:{issue_key}",
+  "project:{project_arg | lower}",
+  "type:{issue_type | lower}",
+  "status:{status | lower}",
+  "component:{component_1 | lower}", "component:{component_2 | lower}",
+  "label:{label_1}", "label:{label_2}"
+]
+
+related_to: []
+```
+
+Important distinctions:
+
+- `status: active` is the AKB doc status; Jira workflow status lives in the `status:{state}` tag — never collapse them.
+- `tags` carries: `atlassian` (provenance), `kind:atlassian-issue` (cross-plugin discriminator), `jira-project:{project_key | lower}` (Step 3 dedup + external maintenance layer cell axis), `issue-key:{issue_key}` (deterministic dedup, keep verbatim case), `project:{project_arg | lower}` (only with `--project`; rollup takes precedence for downstream cross-source rollup), `type:{issue_type | lower}` / `status:{status | lower}` (display + filter; the `type:*` namespace collides with `/ingest-commit`'s `type:{conv_type}` deliberately — `kind:*` disambiguates), `component:{name | lower}` (one per Jira component; the external maintenance layer reads off tags directly), `label:{name}`. All lowercased except `issue-key:`. Duplicates dropped.
+- `priority` / `reporter` / `assignee` / `created_at` / `updated_at` / `resolved_at` live in the `## Source` block; not frontmatter fields.
+- `linked_issues` stays as raw external keys; the external maintenance layer does not resolve them to AKB edges.
+
+### Step 6 — Write
+
+Branch by Step 3 result.
+
+**Create** (no existing doc) — `akb_put(vault={vault_name}, collection=atlassian-issues, title="{issue_key}: {issue.title}", type=reference, tags={tags}, content={assembled_body}, summary={issue.title})`. Capture `doc_id`.
+
+**Update** (`existing_doc_id` from Step 3):
+
+1. `akb_get(vault={vault_name}, doc_id={existing_doc_id}) → existing_content`.
+2. Compose `draft_body` = full new body (compiled-truth + Source + `---` + `## Timeline` + the single new entry).
+3. Apply **timeline merge — Mode A (full-body merge)** against `existing_content`.
+4. `akb_update(vault={vault_name}, doc_id={existing_doc_id}, title="{issue_key}: {issue.title}", tags={tags}, content={merged_body}, summary={issue.title}, message="Re-ingested at status {status}, {N} comments")`.
+
+Mode A is correct: the compiled-truth zone (Description, Resolution, Comments, Linked, Source) is rewritten from the new fetch — not appended to. Timeline preserves history; the rest mirrors current Jira state.
+
+### Step 7 — Report
+
+Successful create:
+
+```markdown
+## ingest-jira: created
+- issue: {issue_key}
+- title: {issue.title}
+- doc_id: {doc_id}
+- vault: {vault_name}
+- collection: atlassian-issues
+- status: {issue.status}
+- comments: {len(comments)} ({truncated_count} truncated)
+```
+
+Successful update:
+
+```markdown
+## ingest-jira: updated
+- issue: {issue_key}
+- doc_id: {existing_doc_id}
+- vault: {vault_name}
+- status: {issue.status}
+- comments: {len(comments)} ({truncated_count} truncated)
+- timeline entries: {N (after append)}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<issue-key>` missing | `Missing required argument: <issue-key>.` |
+| Invalid issue-key shape | `Invalid Jira issue key: {arg}` |
+| Atlassian MCP not connected | `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` |
+| Issue not found by MCP | `Jira issue {issue_key} not found.` |
+| MCP-returned `project_key` does not match `issue_key` prefix | `Atlassian MCP returned project_key {project_key} that does not match issue_key prefix.` |
+| ADF / Wiki conversion fails on a fragment | Inline the raw fragment inside a `<details>` block as documented in the conversion guide. Not a hard failure. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| AKB MCP unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/claude/akb-wiki/agents/ingest-pr.md
+++ b/plugins/claude/akb-wiki/agents/ingest-pr.md
@@ -1,0 +1,236 @@
+---
+name: ingest-pr
+description: Record a single GitHub PR merge event as a git-pr document in an AKB vault — PR title/body quoted verbatim, commit summaries pulled from pre-ingested git-commit docs. Fetched live via gh pr view.
+model: sonnet
+tools: Bash(git *), Bash(gh *), Read, mcp__akb__akb_search, mcp__akb__akb_get, mcp__akb__akb_put, mcp__akb__akb_update
+---
+
+# AKB Git PR Ingest
+
+Record a **single PR merge event** as a `git-pr` document in the target AKB vault. Mechanical assembly — PR title/body quoted as author-authored compiled-truth; commit summaries pulled verbatim from `git-commit` documents already in the vault. No LLM synthesis. PR metadata is fetched live via `gh pr view`.
+
+Scope boundaries:
+
+- **One PR per invocation.** No loops, no cross-PR consolidation.
+- **GitHub-only via `gh` CLI.** GitLab / Bitbucket / self-hosted forges unsupported. The repo at `--repo` must have a GitHub remote `gh` can resolve.
+- **Commits must be pre-ingested** in `git-commits` as `git-commit` documents.
+- **No LLM synthesis.** PR title/body quoted as-is; agent work is pulling commit summaries into a table.
+- **No review/approval metadata.** Reviewers, labels, check statuses, comment threads are out of scope — `gh pr view` returns more fields than this schema uses; extras are ignored.
+- **Upsert.** Dedup by `(repo, pr_number)`; re-ingest silently overwrites (normal when post-merge edits land on the PR description).
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-pr <pr-number> --vault {vault_name} [--repo {path}]
+```
+
+- `<pr-number>` (required, positional) — GitHub PR number (integer). The PR must be merged.
+- `--vault` (required) — target AKB vault.
+- `--repo` (optional) — path to the local clone of the GitHub repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` and `gh` are available on PATH.
+- `gh auth status` succeeds — the `gh` CLI is signed in to a GitHub account with read access to the target repo.
+- The repo at `--repo` (or `pwd`) has a GitHub remote `gh` can resolve.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Validate `gh` is authenticated: `gh auth status` (non-zero → `gh CLI unavailable or not authenticated. Run gh auth login.`).
+
+Fetch: `(cd {repo_path} && gh pr view {pr_number} --json number,title,body,author,mergedAt,mergeCommit,baseRefName,headRefName,baseRefOid,headRefOid,closingIssuesReferences)`.
+
+Failure paths: "no GitHub remote" / "not a github repository" → `Repo at {repo_path} has no GitHub remote that gh can resolve.`; "no pull request found" / "could not resolve" → `PR not found in the configured GitHub remote: #{pr_number}.`; any other non-zero → surface `gh` stderr and fail with `gh pr view failed for #{pr_number}: {stderr}.`
+
+Parse JSON into `pr`. If `pr.mergedAt` is null, fail with `PR #{pr_number} is not merged; this skill records merge events only.`
+
+Set `merge_sha = pr.mergeCommit.oid`; validate via `git -C {repo_path} rev-parse --verify {merge_sha}^{commit}` (failure → `merge_sha not found in local repository: {merge_sha}. Fetch latest from the GitHub remote.`).
+
+### Step 2 — Enumerate the PR's commits
+
+Apply the strategies below in order; the first match wins.
+
+1. **Explicit boundary** — if `pr.baseRefOid` and `pr.headRefOid` are both present and resolve in the local repo:
+   ```bash
+   git -C {repo_path} log --reverse --format=%H {pr.baseRefOid}..{pr.headRefOid}
+   ```
+   Covers rebase-and-merge repos where the merge commit has only one parent but multiple PR commits landed on the base. If either oid does not resolve locally (e.g. the head branch was deleted and pruned), fall through to strategy 2.
+
+2. **Merge commit** — else, if `git -C {repo_path} rev-list --parents -n 1 {merge_sha}` reports **2 parents**:
+   ```bash
+   git -C {repo_path} log --reverse --format=%H {merge_sha}^1..{merge_sha}^2
+   ```
+
+3. **Squash / single-commit** — else (merge_sha has 1 parent): the commit set is `[merge_sha]` itself.
+
+Call the resulting ordered list `sha_list` (chronologically ascending). If `sha_list` is empty, fail with `No commits enumerated for PR #{pr_number}; the local repo may be missing branch refs — fetch latest from the GitHub remote.`
+
+### Step 3 — Dedup check
+
+`akb_search(query="PR #{pr_number} {repo_name}", vault={vault_name}, collection=git-prs, type=reference, tags=["git", "kind:pr", "project:{repo_name}"], limit=5)`. Among hits, find the one whose frontmatter has `repo == repo_name AND pr_number == pr_number`; on match capture `existing_doc_id` (update path), else create path.
+
+### Step 4 — Fetch commit documents
+
+Given a chronologically-ordered list `sha_list`, resolve each SHA to its commit document (`type=reference, kind:commit`) in the vault.
+
+**Concurrency is required.** Issue all searches in a single parallel tool-use block, then issue any required `akb_get` calls in a second parallel block. Sequential per-SHA loops are forbidden — a 30-commit input is two batched round trips, not 30 or 60.
+
+```text
+mcp__akb__akb_search(
+  query="{sha}",
+  vault="{vault_name}",
+  collection="git-commits",
+  type="reference",
+  tags=["git", "kind:commit"],
+  limit=3
+)
+```
+
+For each search, pick the hit whose title prefix matches `{short_sha}` — the per-commit summary doc's title is `{short_sha} {message_subject}`, and `akb_search` returns the title in its hit payload, so the search query (`query="{full_sha}"`) plus a title-prefix check uniquely identifies the matching commit. The downstream-needed fields below are all reachable from the `akb_search` hit (`path`, `title`, `summary`, `tags`); only fall back to `akb_get` if a specific consumer needs body content (e.g., for surfacing author detail in a human-readable table).
+
+For each `commit_records[i]`, populate the downstream-needed fields from the AKB primitives that durably persist them:
+
+- `doc_id`, `path`, `title`, `summary` — from the search hit (whitelist fields exposed by `akb_search`).
+- `short_sha` — first 7 chars of the full SHA (already known from the search query); also recoverable from the title prefix.
+- `author` — parse from the row's `tags` array as `tag[len("author:"):]` for the first `author:*` tag emitted by `/ingest-commit` Step 6. Single-author commits emit one such tag; merge commits emit either the merging committer or whichever name `.mailmap` resolved. `null` if no `author:*` tag is present (defensive — the commit ingest always emits one).
+- `conv_type` — parse from the row's `tags` array as `tag[len("type:"):]` for the first `type:*` tag. `null` when the commit subject did not match the conventional-commit pattern.
+- `scope` — parse `tag[len("scope:"):]` for the first `scope:*` tag. Drives PR-level `pr_scope` aggregation downstream without re-deriving from a `paths` list.
+
+Skip the secondary `akb_get` whenever the search hit already exposes everything in the list above — PR / release ingest only needs `path` / `summary` / `tags`, all reachable from `akb_search`. A 30-commit PR is one batched `akb_search` round trip, not 30+30.
+
+The full file list, per-commit stats, and diff scope are not aggregated across commits — the per-commit body's `### Paths` and `## Stats` sections are the audit surface, reachable via the PR's `depends_on` graph edge.
+
+If any SHA in `sha_list` has no matching hit, **fail** before proceeding:
+
+```text
+Missing commit(s) in vault: {missing_sha_list}.
+Run `/akb-ingest <sha>` for each before re-running.
+```
+
+Never re-fetch diffs or invoke git for individual commits here. The ingested `summary` and `Changes` block are authoritative — diff re-reading would defeat the reason ingest paid that cost.
+
+Collect the results into `commit_records`, aligned with `sha_list`.
+
+### Step 5 — Aggregate frontmatter axes
+
+Compute from `commit_records`:
+
+- `commit_uris` — ordered list of full URIs `akb://{vault_name}/doc/{commit_doc_path}` (chronological). Passed as `depends_on` in Step 7. Always-URI convention even for single-vault deployments.
+- `commit_shas` — ordered chronological SHAs, preserved for cheap lookup without graph traversal.
+- `pr_scope` — most-frequent non-null `scope` across records (parsed from each record's `scope:*` tag in `_fetch_commit_docs`; the per-commit summary derives it once at ingest as `conv_scope or top_level_paths[0]`). Ties → chronologically earliest contributor. `null` when all commits' scopes are null. Emitted as `scope:{pr_scope}` in Step 6.
+
+PR doc body renders from per-commit doc bodies via the `depends_on` edge — no per-commit aggregation here. PR-level author is `pr.author.login`; commit authors live on each commit doc's `## Source`.
+
+Build `links` from `pr.closingIssuesReferences`: each entry becomes `#{number}` (cross-repo: `{owner}/{repo}#{number}`). Order preserved from `gh`.
+
+### Step 6 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"
+project: "{repo_name}"             # mirrors repo; `repo` is the source-system identifier, `project` is the project-rollup namespace
+pr_number: {pr.number}
+title: "{pr.title}"
+
+merged_at: "{pr.mergedAt}"
+merge_sha: "{merge_sha}"
+base_ref: "{pr.baseRefName | null}"
+head_ref: "{pr.headRefName | null}"
+base_sha: "{pr.baseRefOid | null}"
+head_sha: "{pr.headRefOid | null}"
+
+commit_shas: [{sha}, ...]
+
+links: [{link}, ...]
+tags: ["git", "project:{repo_name}", "kind:pr", "scope:{pr_scope}"]
+summary: "{pr.title}"
+
+related_to: []
+```
+
+PR commit membership lives on the `depends_on` graph edge passed as a top-level arg in Step 7 — not frontmatter. Outgoing `depends_on` is queryable via `akb_relations`; the release skill consumes it through `akb_search` + `set(pr.depends_on)`.
+
+`scope:{pr_scope}` omitted when Step 5 produced null. `kind:pr` is the cross-plugin discriminator (read by the external maintenance layer and `/ingest-release` Step 7); `project:{repo_name}` is the rollup namespace and repo-identifier SSOT. Per-commit author / paths / stats / conv-type / diff-scope live on each commit doc's tags + `## Source`, not aggregated here.
+
+Body:
+
+```markdown
+# {pr.title}
+
+## Description
+> {pr.body, verbatim, preserving blank lines and formatting}
+
+## Linked
+- {link_1}
+- {link_2}
+...
+
+(If `links` is empty, omit this section entirely.)
+
+## Commits
+| # | SHA | Author | Summary |
+|---|-----|--------|---------|
+| 1 | `{short_sha}` | {author} | {summary from commit doc} |
+| 2 | ... | ... | ... |
+
+## Merge
+- merge_sha: `{merge_sha}`
+- base_ref → head_ref: `{pr.baseRefName}` → `{pr.headRefName}` (if provided)
+- merged_at: {pr.mergedAt}
+```
+
+Assembly rules: quote the PR body as a single block-quote (no paraphrase / truncate / reflow); render `> (no description)` when `pr.body` is empty rather than omitting; preserve fenced code blocks inside the quote; pull Commits table `summary` from each commit doc (never re-derive); append `(truncated)` to a row when the commit doc has `truncated: true`.
+
+### Step 7 — Write the PR document
+
+**Create** — `akb_put(vault={vault_name}, collection=git-prs, title="PR #{pr.number}: {pr.title}", type=reference, tags={tags}, content={assembled_body}, summary={pr.title}, depends_on={commit_uris})`.
+
+**Update** — `akb_update(doc_id={existing_doc_id}, vault={vault_name}, title="PR #{pr.number}: {pr.title}", tags={tags}, content={assembled_body}, summary={pr.title}, depends_on={commit_uris})`.
+
+`depends_on` passes as a top-level arg so AKB stores graph edges (queryable via `akb_relations`), not opaque frontmatter. PR-to-commits lives entirely on this edge — no commit-side backlink. Re-ingest rewrites the edge set idempotently. Capture `pr_doc_id` / `pr_doc_path`.
+
+### Step 8 — Return
+
+```markdown
+## ingest-pr: {created|updated}
+- repo: {repo_name}
+- pr_number: {pr.number}
+- doc_id: {pr_doc_id}
+- commits: {N}
+- vault: {vault_name}
+- collection: git-prs
+- merge strategy: {explicit | merge_commit | squash}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<pr-number>` missing | `Missing required argument: <pr-number>` |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| `gh` not on PATH or not authenticated | `gh CLI unavailable or not authenticated. Run gh auth login.` |
+| Repo has no GitHub remote | `Repo at {repo_path} has no GitHub remote that gh can resolve.` |
+| `gh pr view` reports PR not found | `PR not found in the configured GitHub remote: #{pr_number}.` |
+| `gh pr view` failed for any other reason | `gh pr view failed for #{pr_number}: {stderr}.` |
+| PR not yet merged (`mergedAt` is null) | `PR #{pr_number} is not merged; this skill records merge events only.` |
+| `merge_sha` from `gh` not in local repo | `merge_sha not found in local repository: {merge_sha}. Fetch latest from the GitHub remote.` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| Enumeration yielded 0 commits | `No commits enumerated for PR #{pr_number}; the local repo may be missing branch refs — fetch latest from the GitHub remote.` |
+| One or more commits missing in vault | `Missing commit(s) in vault: {sha_list}. Ingest the commit(s) via /akb-ingest first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| Dedup hit | Update existing PR doc silently. Not an error. |

--- a/plugins/claude/akb-wiki/agents/ingest-release.md
+++ b/plugins/claude/akb-wiki/agents/ingest-release.md
@@ -1,0 +1,333 @@
+---
+name: ingest-release
+description: Record a single release tag as a git-release document in an AKB vault — release notes from the matching GitHub Release (annotated tag message fallback), commits bucketed by conv_type. Requires range commits pre-ingested.
+model: sonnet
+tools: Bash(git *), Bash(gh *), Read, mcp__akb__akb_search, mcp__akb__akb_get, mcp__akb__akb_relations, mcp__akb__akb_put, mcp__akb__akb_update
+---
+
+# AKB Git Release Ingest
+
+Record a **single release/tag event** as a `git-release` document in the target AKB vault. Mechanical assembly only — the release notes (from a GitHub Release fetched via `gh release view`, or the annotated tag message as fallback) are quoted as compiled-truth, and the commit/PR membership is derived from documents already in the vault. No LLM synthesis. This skill does not accept hand-supplied payloads — the canonical sources of release-notes text are GitHub itself (via `gh`) and `git` itself (annotated tag message).
+
+Scope boundaries:
+
+- **One tag per invocation.** No loops, no cross-release consolidation.
+- **GitHub-first, git-fallback for release notes.** A GitHub Release for the tag (fetched via `gh release view --json`) wins as compiled-truth body; if no GitHub Release exists, an annotated tag message is the fallback; otherwise the body is `(no release notes)`. Lightweight tags with no GitHub Release legitimately have no body.
+- **Commits must be pre-ingested.** Every commit in the tag window must already exist in `git-commits` as a `git-commit` document.
+- **No LLM synthesis.** Release notes are quoted verbatim; commits are bucketed by `conv_type` mechanically, not summarized by an agent.
+- **No release asset / binary handling.** Checksums, artifact URLs, draft/prerelease flags, and signing metadata are out of scope.
+- **No semver interpretation.** The `tag` string is treated opaquely — this skill does not parse version components or enforce ordering rules.
+- **Upsert.** Dedup by `(repo, tag)`. Re-ingesting the same tag silently overwrites — legitimate when release notes are edited after the fact on GitHub.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-release <tag> --vault {vault_name} [--prev-tag {tag}] [--repo {path}]
+```
+
+- `<tag>` (required, positional) — release tag name (e.g. `v3.0.0`). Must resolve inside the target repo.
+- `--vault` (required) — target AKB vault.
+- `--prev-tag` (optional) — the previous release tag; overrides auto-discovery. First releases (no prior tag) are valid and enumerate from root.
+- `--repo` (optional) — path to the local clone of the GitHub repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` and `gh` are available on PATH.
+- `gh auth status` succeeds — required so the skill can attempt to fetch a GitHub Release for the tag. (If the repo has no GitHub remote or no Release exists for the tag, the skill falls back to the annotated tag message — `gh` itself is still required.)
+- `{tag}` resolves inside the target repo.
+- Every commit in the `prev_tag..tag` (or root..tag, for first release) range has a `git-commit` document in the vault.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Then validate that `gh` is available and authenticated:
+
+```bash
+gh auth status
+```
+
+Fail with `gh CLI unavailable or not authenticated. Run gh auth login.` on non-zero exit.
+
+Then validate the tag: `git -C {repo_path} rev-parse --verify {tag}`. Fail with `Tag not found in repository: {tag}` on error. Also resolve `tagged_commit_sha = git -C {repo_path} rev-parse {tag}^{commit}`.
+
+### Step 2 — Extract tag metadata
+
+Determine the tag kind:
+
+```bash
+git -C {repo_path} cat-file -t {tag}
+```
+
+- If the output is `tag` → **annotated**. Parse the tag object:
+  ```bash
+  git -C {repo_path} cat-file tag {tag}
+  ```
+  Extract `tagger` (name + email), `tagged_at` (ISO 8601), and the tag message (everything after the blank line separator). Normalize the tagger name using the same rules as `ingest-commit` (`.mailmap` + `author_aliases`).
+- If the output is `commit` → **lightweight**. Use the tagged commit's committer as `tagger` and its `committed_at` as `tagged_at`. `tag_message` is `null`.
+
+Record `tag_kind` as `"annotated"` or `"lightweight"`.
+
+#### Fetch GitHub Release notes
+
+Attempt `(cd {repo_path} && gh release view {tag} --json tagName,name,body,publishedAt,author)`. Outcome handling:
+
+- Exit 0 → set `gh_release.body` and `gh_release.published_at` from the response. Step 9 prefers `body` over the tag message only when non-empty after trimming whitespace.
+- `gh` reports "release not found" / no GitHub remote → set `gh_release = null` and continue. Not a failure — many tags have no corresponding GitHub Release; non-GitHub remotes still ingest using only the annotated tag message.
+- Any other non-zero exit → fail with `gh release view failed for {tag}: {stderr}.`
+
+### Step 3 — Resolve `prev_tag`
+
+1. Use the `--prev-tag` CLI argument if provided.
+2. Otherwise auto-discover:
+   ```bash
+   git -C {repo_path} describe --tags --abbrev=0 {tag}^
+   ```
+   If this fails (no prior tag exists), treat as the first release. Emit an informational line in the final report (`first release — enumerating from root`) — not an error.
+
+If `--prev-tag` was given, validate with `git -C {repo_path} rev-parse --verify {prev_tag}`. Fail with `prev_tag not found in repository: {prev_tag}` if the override is invalid.
+
+### Step 4 — Enumerate commits
+
+If `prev_tag` is resolved:
+
+```bash
+git -C {repo_path} log --reverse --format=%H {prev_tag}..{tag}
+```
+
+If `prev_tag` is `null` (first release):
+
+```bash
+git -C {repo_path} log --reverse --format=%H {tag}
+```
+
+Call the resulting ordered list `sha_list` (chronologically ascending). If `sha_list` is empty:
+
+- For first-release case with empty history: fail with `No commits in tag {tag}.`
+- For `prev_tag..tag` yielding empty: fail with `No commits between {prev_tag} and {tag}; check the range.`
+
+### Step 5 — Dedup check
+
+```text
+mcp__akb__akb_search(
+  query="release {tag} {repo_name}",
+  vault="{vault_name}",
+  collection="git-releases",
+  type="reference",
+  tags=["git", "kind:release", "project:{repo_name}"],
+  limit=5
+)
+```
+
+Among the hits, find the one whose frontmatter has `repo == repo_name AND tag == tag`. If found, capture `existing_doc_id` for the update path; otherwise, proceed to create.
+
+### Step 6 — Fetch commit documents
+
+Given a chronologically-ordered list `sha_list`, resolve each SHA to its commit document (`type=reference, kind:commit`) in the vault.
+
+**Concurrency is required.** Issue all searches in a single parallel tool-use block, then issue any required `akb_get` calls in a second parallel block. Sequential per-SHA loops are forbidden — a 30-commit input is two batched round trips, not 30 or 60.
+
+```text
+mcp__akb__akb_search(
+  query="{sha}",
+  vault="{vault_name}",
+  collection="git-commits",
+  type="reference",
+  tags=["git", "kind:commit"],
+  limit=3
+)
+```
+
+For each search, pick the hit whose title prefix matches `{short_sha}` — the per-commit summary doc's title is `{short_sha} {message_subject}`, and `akb_search` returns the title in its hit payload, so the search query (`query="{full_sha}"`) plus a title-prefix check uniquely identifies the matching commit. The downstream-needed fields below are all reachable from the `akb_search` hit (`path`, `title`, `summary`, `tags`); only fall back to `akb_get` if a specific consumer needs body content (e.g., for surfacing author detail in a human-readable table).
+
+For each `commit_records[i]`, populate the downstream-needed fields from the AKB primitives that durably persist them:
+
+- `doc_id`, `path`, `title`, `summary` — from the search hit (whitelist fields exposed by `akb_search`).
+- `short_sha` — first 7 chars of the full SHA (already known from the search query); also recoverable from the title prefix.
+- `author` — parse from the row's `tags` array as `tag[len("author:"):]` for the first `author:*` tag emitted by `/ingest-commit` Step 6. Single-author commits emit one such tag; merge commits emit either the merging committer or whichever name `.mailmap` resolved. `null` if no `author:*` tag is present (defensive — the commit ingest always emits one).
+- `conv_type` — parse from the row's `tags` array as `tag[len("type:"):]` for the first `type:*` tag. `null` when the commit subject did not match the conventional-commit pattern.
+- `scope` — parse `tag[len("scope:"):]` for the first `scope:*` tag. Drives PR-level `pr_scope` aggregation downstream without re-deriving from a `paths` list.
+
+Skip the secondary `akb_get` whenever the search hit already exposes everything in the list above — PR / release ingest only needs `path` / `summary` / `tags`, all reachable from `akb_search`. A 30-commit PR is one batched `akb_search` round trip, not 30+30.
+
+The full file list, per-commit stats, and diff scope are not aggregated across commits — the per-commit body's `### Paths` and `## Stats` sections are the audit surface, reachable via the PR's `depends_on` graph edge.
+
+If any SHA in `sha_list` has no matching hit, **fail** before proceeding:
+
+```text
+Missing commit(s) in vault: {missing_sha_list}.
+Run `/akb-ingest <sha>` for each before re-running.
+```
+
+Never re-fetch diffs or invoke git for individual commits here. The ingested `summary` and `Changes` block are authoritative — diff re-reading would defeat the reason ingest paid that cost.
+
+Collect the results into `commit_records`, aligned with `sha_list`.
+
+### Step 7 — Derive the PR axis
+
+There is no commit-side backlink to read — PR-to-commit linkage lives on each PR document's outgoing `depends_on` graph edge (set by `ingest-pr` Step 7). Discover candidate PRs by searching the vault, then intersect each PR's `depends_on` with the release's commit set: `range_commit_uris = { "akb://{vault_name}/doc/{record.path}" for record in commit_records }`.
+
+Search for PRs: `akb_search(vault="{vault_name}", query="pr {repo_name}", collection="git-prs", type="reference", tags=["git", "kind:pr", "project:{repo_name}"], limit=500)`. Hits return summaries (`path`, `title`, `summary`, `tags`, fusion score) but no frontmatter or graph edges — hydrate separately:
+
+1. **Hydration block** (one parallel tool-use block) — `akb_get(vault="{vault_name}", doc_id={hit.path})` for every hit. Capture `path`, frontmatter `repo` / `pr_number` / `merged_at`, and `title`. Filter to rows whose `repo == repo_name`.
+2. **Outgoing-edge block** (second parallel tool-use block) — `akb_relations(vault="{vault_name}", resource_uri="akb://{vault_name}/doc/{pr.path}", direction="outgoing", type="depends_on")` for each surviving PR. Sequential per-PR fetches are forbidden.
+
+For each PR, set `pr.commit_uris` to the outgoing edges and compute `pr.commit_uris ∩ range_commit_uris`. Drop PRs with empty intersection (out of range) and PRs with empty `depends_on` (their commits surface as orphans in the body). Order survivors by `merged_at` ascending into `pr_records` with `doc_id` / `path` / `pr_number` / `title` / `merged_at` / `covered_commit_uris`.
+
+Compose:
+
+```
+pr_doc_refs         = [ "akb://{vault_name}/doc/{pr.path}" for pr in pr_records ]   # full URIs, chronological
+covered_commit_uris = ⋃ { pr.covered_commit_uris for pr in pr_records }
+orphan_commit_uris  = range_commit_uris − covered_commit_uris
+```
+
+`covered_commit_uris` and `orphan_commit_uris` partition `range_commit_uris`. Orphans render as individual commit rows in the body.
+
+### Step 8 — Compose the release's graph edge
+
+From `commit_records`, the only downstream-needed value is `commit_shas` — an ordered list of full SHAs (chronological), preserved in the release doc's frontmatter for cheap audit lookup without traversing the `depends_on` chain. No per-commit aggregation (stats / conv-types / diff-scope / authors / paths) is performed at the release level — those keys are silent-dropped by the `akb_put` whitelist anyway. The body's `## Changes` / `## All commits` / Range sections render directly from `commit_records` and `pr_records` for human readers; the external maintenance layer does not aggregate from release docs.
+
+Compose the release's `depends_on` set — the PR-or-orphan-commit edges this release covers (PR-covered commits are reachable transitively via the PR's own `depends_on`, so the release does not duplicate them):
+
+```
+release_depends_on = pr_doc_refs + sorted(orphan_commit_uris by chronological order in commit_records)
+```
+
+### Step 9 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"
+tag: "{tag}"
+prev_tag: "{prev_tag | null}"
+
+tagger: "{canonical_tagger_name}"
+tagger_email: "{raw_tagger_email}"
+tagged_at: "{tagged_at_iso}"
+tagged_commit_sha: "{tagged_commit_sha}"
+tag_kind: "{annotated | lightweight}"
+
+commit_shas: [{sha}, ...]
+
+tags: ["git", "project:{repo_name}", "kind:release"]
+summary: "{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)"
+```
+
+Commit and PR membership lives entirely on the `depends_on` graph edge passed to `akb_put` / `akb_update` in Step 10 (PR-covered commits transitively, orphans directly) — not in frontmatter. `akb_relations` traverses both layers.
+
+Body (bucket by `conv_type`):
+
+```markdown
+# {tag}
+
+## Release notes
+> {gh_release.body (if non-empty) OR tag_message OR "(no release notes)"}
+
+## Changes
+
+### New Features
+- PR #{pr_number}: {pr_title}
+- Commit `{short_sha}`: {commit_summary}
+
+### Fixes
+- ...
+
+### Other
+- ...
+
+## Range
+- prev_tag → tag: `{prev_tag | "—"}` → `{tag}`
+- tagged_commit: `{short_tagged_commit_sha}`
+- tagged_at: {tagged_at}
+- kind: {tag_kind}
+
+## All commits
+| # | SHA | PR | Author | Summary |
+|---|-----|-----|--------|---------|
+| 1 | `{short_sha}` | `#{pr_number}` or `—` | {author} | {commit_summary} |
+| 2 | ... | ... | ... | ... |
+```
+
+#### Bucketing rules for `## Changes`
+
+Render three subsections: **New Features**, **Fixes**, **Other**.
+
+1. Assign each PR in `pr_records` to a bucket by its dominant `conv_type`:
+   - At least one commit with `conv_type == feat` → **New Features**
+   - Else at least one with `conv_type == fix` → **Fixes**
+   - Else → **Other**
+   Render one row per PR: `- PR #{pr_number}: {pr_title}`.
+2. Assign each orphan commit (whose URI is in `orphan_commit_uris` from Step 7) by its own `conv_type`:
+   - `feat` → **New Features**
+   - `fix` → **Fixes**
+   - Anything else (including `null` conv_type) → **Other**
+   Render one row per orphan commit: ``- Commit `{short_sha}`: {commit_summary}``.
+3. Omit any bucket that is empty (do not print an empty section header).
+
+This bucketing is **rule-based**, not LLM-driven. Do not reword the PR titles or commit summaries — quote them as they already exist in the vault.
+
+#### `## All commits` table
+
+Lists **every** commit in `sha_list` (chronological), regardless of PR membership. Columns:
+
+- `#` — 1-based index.
+- `SHA` — `short_sha` in code formatting.
+- `PR` — `#{pr_number}` if the commit's URI appears in any `pr.covered_commit_uris` from `pr_records`, else `—`.
+- `Author` — from the commit doc.
+- `Summary` — the commit doc's `summary` (faithful 1-line). Append `(truncated)` if its `truncated` flag is true.
+
+### Step 10 — Write the release document
+
+**Create.** `akb_put(vault="{vault_name}", collection="git-releases", title="Release {tag}", type="reference", tags={tags}, content={assembled_body}, summary="{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)", depends_on={release_depends_on})`.
+
+**Update.** `akb_update(vault="{vault_name}", doc_id={existing_doc_id}, title="Release {tag}", tags={tags}, content={assembled_body}, summary="{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)", depends_on={release_depends_on})`.
+
+`depends_on` is passed as a top-level argument so AKB stores it as graph edges. The release-to-PR-and-orphan-commit relationship lives entirely on this edge — no member-side `release` backlink is written. PR-covered commits are reachable transitively via the PR's own `depends_on`. Re-ingest of the same tag rewrites the edge set idempotently. Capture the resulting `release_doc_id` and `release_doc_path`.
+
+### Step 11 — Return
+
+```markdown
+## ingest-release: {created|updated}
+- repo: {repo_name}
+- tag: {tag}
+- prev_tag: {prev_tag | "— (first release)"}
+- doc_id: {release_doc_id}
+- commits: {len(commit_records)} ({len(orphan_commit_uris)} orphan, {len(commit_records) - len(orphan_commit_uris)} PR-covered)
+- prs: {len(pr_records)}{ ", {K} PR(s) skipped (empty depends_on)" if K > 0 }
+- vault: {vault_name}
+- collection: git-releases
+- tag_kind: {annotated | lightweight}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<tag>` missing | `Missing required argument: <tag>` |
+| Tag not in repo | `Tag not found in repository: {tag}` |
+| `--prev-tag` override not in repo | `prev_tag not found in repository: {prev_tag}` |
+| prev_tag auto-discovery fails | Proceed as first release; report it in the final summary. |
+| `gh` not on PATH or not authenticated | `gh CLI unavailable or not authenticated. Run gh auth login.` |
+| `gh release view` failed for a non-"not found" reason | `gh release view failed for {tag}: {stderr}.` |
+| `gh release view` reports no release for the tag, or repo has no GitHub remote | Continue with `gh_release = null`; the annotated tag message becomes the release-notes body. Not an error. |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| Empty commit range | `No commits between {prev_tag} and {tag}; check the range.` (or `No commits in tag {tag}.` for first release) |
+| One or more commits missing in vault | `Missing commit(s) in vault: {sha_list}. Ingest the commit(s) via /akb-ingest first.` |
+| A PR in the repo has empty `depends_on` | Drop silently from `pr_records`; affected commits surface as orphans. Reported in the return summary as informational, not an error. |
+| AKB write fails | Surface verbatim; do not retry. |
+| Dedup hit | Update existing release doc silently. |

--- a/plugins/claude/akb-wiki/skills/akb-ingest/SKILL.md
+++ b/plugins/claude/akb-wiki/skills/akb-ingest/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: akb-ingest
+description: Ingest whatever you point at into an AKB vault — a local file, a web URL, a GitHub PR/release/commit, a Confluence page, or a Jira issue. Auto-detects the source type and dispatches to a specialized ingest subagent; the router fetches and writes nothing itself. One target per invocation; globs expand to a sequential loop of document ingests.
+argument-hint: <target> --vault {name} [--repo {path}] [--prev-tag {tag}] [--lang {language}] [--project {name}] [--raw|--no-raw]
+allowed-tools: Read, Glob, Bash(git *), Agent
+---
+
+# AKB Ingest
+
+Ingest **one target** into the target AKB vault. Point at a local file, a web URL, a GitHub PR / release / commit, a Confluence page, or a Jira issue — this skill classifies the source type and dispatches to a specialized ingest subagent. It is the single ingest entry point of the `akb-wiki` plugin.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. This is a **router**: it classifies a target and delegates the actual fetch + write to one subagent. Document-style sources pay down **intent debt** (and substrate health) as five-section synthesis pages; decision-record sources (PR / release / commit / issue) pay down **intent debt** as faithful mechanical episodic records. The archetype split (synthesis vs mechanical) is a dispatch decision, invisible to the caller.
+
+Scope boundaries:
+
+- **One target per invocation.** A glob pattern is the only fan-out: it expands into a sequential loop of `ingest-doc` runs, one per matched file.
+- **The router fetches nothing and writes nothing.** It only classifies, validates flags, dispatches one subagent, and relays the subagent's report. Each subagent owns exactly one fetch path (file/URL read, `git`, `gh`, or the Atlassian MCP server) — there is no pre-fetched-payload escape hatch at any layer.
+- **No cross-source wiring at ingest.** Consolidation into concept pages and cross-reference across sources are handled by an external maintenance layer (dream-cycle) over the same vault, not here.
+
+## Arguments
+
+```text
+/akb-ingest <target> --vault {vault_name} [--repo {path}] [--prev-tag {tag}] [--lang {language}] [--project {name}] [--raw | --no-raw]
+```
+
+- `<target>` (required, positional) — what to ingest. A local path (absolute, `./…`, `~/…`, or a glob), an `http(s)://` URL, a bare git commit SHA, or a Jira issue key (e.g. `SDDEV-360`).
+- `--vault` (required) — target AKB vault name; forwarded to every subagent.
+- `--repo {path}` (optional) — local git clone path for commit / PR / release targets. Defaults to the current working directory.
+- `--prev-tag {tag}` (optional) — previous release tag; release targets only.
+- `--lang {language}` (optional) — language for synthesized note bodies; document and Confluence targets only.
+- `--project {name}` (optional) — project-rollup namespace; Confluence and Jira targets only.
+- `--raw` / `--no-raw` (optional) — override raw-byte preservation; document targets only.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- The fetch path of the **classified** source must be available: `WebFetch` for URLs, `git`/`gh` for GitHub targets, an attached Atlassian MCP server for Confluence/Jira targets. The router requires only the path matching the target it classifies — a missing Atlassian MCP server never blocks a local-file ingest.
+
+## Workflow
+
+### Step 1 — Parse
+
+Parse `--vault` from arguments. Hard-fail if missing: `--vault {name} required.` Capture `<target>` and any supplied flags. Fail with `Missing required argument: <target>` when no positional target is given.
+
+### Step 2 — Classify the target
+
+Determine the source type and the subagent to dispatch. Apply the rules top to bottom; the first match wins.
+
+| Target shape | `<chosen-agent>` | Forwarded flags |
+|---|---|---|
+| Local path that exists, or a glob pattern (`*`, `?`, `[`) | `ingest-doc` | `--lang`, `--raw`/`--no-raw` |
+| `https?://…/…/pull/<n>` on `github.com` | `ingest-pr` | `--repo` |
+| `https?://…/…/releases/tag/<tag>` on `github.com` | `ingest-release` | `--repo`, `--prev-tag` |
+| `https?://…/…/commit/<sha>` on `github.com` | `ingest-commit` | `--repo` |
+| `https?://<host>.atlassian.net/wiki/…` | `ingest-confluence` | `--lang`, `--project` |
+| `https?://<host>.atlassian.net/browse/<KEY>` | `ingest-jira` | `--project` |
+| Any other `http(s)://` URL | `ingest-doc` | `--lang`, `--raw`/`--no-raw` |
+| Bare hex string 7–40 chars, confirmed a commit via `git -C {repo} cat-file -t {target}` → `commit` | `ingest-commit` | `--repo` |
+| Matches `^[A-Z][A-Z0-9_]+-\d+$` (Jira key) | `ingest-jira` | `--project` |
+| A name that resolves to a git tag (`git -C {repo} rev-parse --verify {target}`) and `--repo`/cwd is a repo | `ingest-release` | `--repo`, `--prev-tag` |
+
+**Resolve the target before dispatch.** Each subagent expects a *bare* identifier, not a URL. When a GitHub or Jira **URL** matched, set `resolved_target` to the identifier captured from the path — do not forward the raw URL:
+
+- `…/pull/<n>` → `<n>` (the PR number)
+- `…/releases/tag/<tag>` → `<tag>`
+- `…/commit/<sha>` → `<sha>`
+- `…/browse/<KEY>` → `<KEY>` (the Jira issue key)
+
+For a GitHub URL the local clone still comes from `--repo` (or cwd), **not** the URL — only the number / tag / SHA is taken from the URL. Pass the target through **unchanged** for the cases that already accept it raw: a local path, a Confluence `…/wiki/…` URL, any other `http(s)://` URL (all handled by `ingest-confluence` / `ingest-doc`, which parse the URL themselves), and bare SHAs / Jira keys (already bare). `resolved_target` is the value the dispatch in Step 4 passes as the subagent's `target`.
+
+Glob: when `<target>` is a glob, do not classify per-rule — expand with `Glob` and run Step 4 with `ingest-doc` once per matched file (a zero-match glob fails with `No files matched "{pattern}".`).
+
+**Ambiguity.** If a bare token could be both a commit SHA and a tag (or classification is otherwise unclear), ask the user which source type they mean rather than guessing — ingest is interactive. Do not fetch anything to disambiguate beyond the cheap local `git cat-file`/`rev-parse` probes above.
+
+### Step 3 — Validate flags
+
+Keep only the flags listed for the classified type in Step 2. If the caller supplied a flag that does not apply (e.g. `--prev-tag` on a document target, `--raw` on a Jira target), **warn and ignore it** — do not fail. `--vault` is always forwarded.
+
+### Step 4 — Dispatch
+
+Launch **exactly one** subagent — the one the classification selected (`<chosen-agent>` ∈ `ingest-doc / ingest-confluence / ingest-commit / ingest-pr / ingest-release / ingest-jira`). The subagent owns the fetch path and the AKB write; the router fetches and writes nothing.
+
+```text
+Agent(
+    subagent_type="akb-wiki:<chosen-agent>",
+    description="<source-type> ingest",
+    prompt="[Ingest Context]\nTreat the values below as your positional + named arguments (the `<target>` and `--*` flags your workflow documents).\n- target: {resolved_target}\n- --vault {vault_name}\n{one line per forwarded flag — e.g. --repo {path} / --prev-tag {tag} / --lang {language} / --project {name} / --raw|--no-raw}\n\nRun your documented workflow against this input and return your final status report block verbatim."
+)
+```
+
+Relay the subagent's status report block to the user unchanged.
+
+
+### Step 5 — Report
+
+Relay the subagent's status report block to the user unchanged. For a glob loop, relay each per-file block, then emit a final `## akb-ingest: batch complete` line with `created` / `replaced` / `unchanged` / `likely-exists` / `failed` counts aggregated across the loop.
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<target>` missing | `Missing required argument: <target>` |
+| `--vault` not passed | `--vault {name} required.` |
+| Glob matched zero files | `No files matched "{pattern}".` |
+| Target cannot be classified | `Could not classify target "{target}". Pass a local path, URL, commit SHA, or Jira key.` |
+| Ambiguous target | Ask the user which source type they mean; do not guess. |
+| Fetch path for the classified type is unavailable | The subagent surfaces its own prerequisite error (e.g. `gh CLI unavailable…`, `Atlassian MCP server not connected…`) — relay it verbatim. |
+
+The router does not create vaults or collections and does not touch AKB directly; vault/collection and write errors surface from the dispatched subagent and are relayed as-is.

--- a/plugins/claude/akb-wiki/skills/akb-query/SKILL.md
+++ b/plugins/claude/akb-wiki/skills/akb-query/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: akb-query
+description: Answer a question from the AKB vault — decompose, search (hybrid / graph), ground in compiled-truth-over-timeline precedence, and synthesize a cited answer with gap/conflict/stale flags. Read-only.
+argument-hint: '{question} --vault {name}'
+allowed-tools: Read, mcp__akb__akb_search, mcp__akb__akb_relations, mcp__akb__akb_graph, mcp__akb__akb_provenance, mcp__akb__akb_get, mcp__akb__akb_drill_down, mcp__akb__akb_browse, mcp__akb__akb_activity
+---
+
+# AKB Query
+
+Answer **one question** from the target AKB vault. Decompose the question, search the vault with the strategy that fits, ground the answer in the documents found — honoring AKB's compiled-truth-over-timeline precedence — and synthesize a cited answer. Brain-first: the vault is the source of truth, not the model's prior knowledge.
+
+**Workflow classification.** LLM-wiki **Query** workflow — the **read** half only (à la gbrain's `query`, `mutating: false`). This skill **never writes**: no `akb_put` / `akb_update`, no promote-to-page. Promoting valuable answers into new pages, consolidation, and dream-cycle maintenance are the external maintenance layer's job over the same vault, not this skill's.
+
+Scope boundaries:
+
+- **Read-only.** Every tool call reads. The skill answers from vault content and cites it; it does not modify the vault. (It deliberately does **not** use `akb_grep` — that verb's `replace=` mode rewrites matching documents, so it is not read-only; exact-term lookup goes through `akb_search`, whose hybrid index already includes a keyword/BM25 component.)
+- **Brain-first, grounded.** Answer from the vault, never from general knowledge when the vault has relevant content. If the vault lacks the answer, say so — do not fill the gap with a guess.
+- **Citations are document-scoped.** AKB exposes provenance at the document level, not per claim, so a claim cites `[doc-uri, section]` — not a sentence-level source.
+
+## Arguments
+
+```text
+/akb-query {question} --vault {vault_name} [--collection {path}] [--type {type}] [--since DATE] [--period D1~D2]
+```
+
+- `{question}` (required, positional) — a natural-language question. Phrase it as you would ask a person; hybrid search rewards natural phrasing over keyword soup.
+- `--vault` (required) — target AKB vault name.
+- `--collection {path}` (optional) — scope the search to one collection when the question clearly belongs to it.
+- `--type {type}` (optional) — scope to a document type (`decision`, `reference`, `task`, …) when the question implies one.
+- `--since DATE` (optional, ISO `YYYY-MM-DD`) — add a freshness axis: cross-check hits against recent vault activity and flag stale ones; surface relevant recent changes.
+- `--period D1~D2` (optional, ISO dates) — same as `--since` but bounded to the inclusive range. If both are given, `--period` wins.
+
+If neither `--since` nor `--period` is provided, the freshness axis is skipped entirely.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+## Workflow
+
+### Phase 1 — Decompose
+
+Parse `--vault`. Hard-fail if missing: `--vault {name} required.` Capture `{question}` and optional flags.
+
+Classify the question into one or more search strategies — a single question may need several:
+
+| Question shape | Strategy | Verb |
+|---|---|---|
+| Conceptual / open-ended ("how does…", "tell me about…", "why…") **or** exact terms (names, versions, IDs, error strings, code) | hybrid | `akb_search` |
+| Relational ("what depends on X", "what implements Y", "how is A connected to B") | graph | `akb_relations` / `akb_graph` |
+
+Pick the minimum set that covers the question. Most questions are hybrid — `akb_search` is vector + keyword/BM25, so it handles both conceptual phrasing and exact tokens; pass the exact token as the query when the question pins one. Reach for graph only when the question asks about links between documents.
+
+### Phase 2 — Search
+
+Issue every selected strategy in a **single parallel tool-use block** — they are independent. Run only the strategies Phase 1 chose. **Exception:** when the relational strategy is selected but no anchor URI is known yet, that strategy is *not* independent — run the hybrid search first to find the anchor, then issue `akb_relations` / `akb_graph` in a follow-up block. Never call them with a guessed URI.
+
+- **Hybrid** — `akb_search(query="{question}", vault="{vault_name}", limit=10)`. For an exact token, pass the token itself as the query — the hybrid index matches it on the keyword/BM25 side. Add `collection=` / `type=` from the flags or when the question clearly implies one. Add `tags=[…]` only if the question names specific tags.
+- **Relational** — when an anchor document is known, `akb_relations(uri="{anchor_uri}", direction=…, type=…)` for direction- and type-filtered edges (single-hop). For a multi-hop neighborhood, `akb_graph(uri="{anchor_uri}", depth=…)` (BFS; no direction filter — it returns all edges at each level). If the anchor is not yet known, find it with a hybrid search first.
+- **Freshness (conditional)** — only when `--since` / `--period` was given: `akb_activity(vault="{vault_name}", since="{start_date}", limit=20)`. For `--period D1~D2`, pass `since=D1` and drop entries after `D2` in Phase 3.
+
+Dedup the combined hits by document URI before Phase 3.
+
+### Phase 3 — Ground with source precedence
+
+For the top 3–5 deduped hits, read enough to answer — cheapest read first:
+
+1. `akb_drill_down(uri="{uri}", mode="outline")` to see the document's structure.
+2. Read the **compiled-truth (top) sections first** via `akb_drill_down(uri, section="…")` — that is the document's current best understanding. Treat the **timeline (bottom) section** as supporting evidence, not the headline.
+3. `akb_get(uri)` only when you need the full document.
+4. `akb_provenance(uri)` when the question is about authorship or recency ("who decided…", "when was…") — document-level who/when.
+
+**Source precedence when documents conflict** (highest authority first):
+
+1. The user's direct statements in this conversation.
+2. Compiled truth (top of a document).
+3. Timeline entries (bottom of a document).
+4. External / general knowledge (lowest — and only when the vault is silent).
+
+**Staleness** — if a freshness axis was requested, cross-check each hit against `akb_activity`: mark a hit `[stale]` when it has not changed within the window, and drop activity entries past a `--period` upper bound.
+
+### Phase 4 — Synthesize & answer
+
+Write a direct answer to the question, grounded in what Phase 3 read:
+
+- **Cite every claim** as `[doc-uri, section]`. When a claim rests on several documents, cite all of them.
+- **Conflicts** — when sources disagree, present both with their citations and name the contradiction. Never silently pick one.
+- **Gaps** — if the vault does not answer the question, say so plainly (`vault "{vault_name}"에 X에 대한 정보가 없습니다`) instead of answering from general knowledge. Offer to broaden the search or browse the vault.
+- **Staleness** — surface `[stale]` markers next to claims drawn from stale documents.
+
+Response shape:
+
+```markdown
+## {question}
+
+{Direct answer in prose, with inline citations: "According to [research/vector-index, compiled truth], …"}
+
+{If sources conflict: a short "Conflicting sources" note citing both.}
+
+{If a freshness axis was requested and recent changes are relevant:}
+### Recent changes ({period label})
+- [{doc_uri}] {title} — updated {updated_at}
+
+{If the vault is silent on part of the question:}
+### Gaps
+- The vault has no information on {X}.
+
+---
+*{N} documents consulted in vault "{vault_name}"*
+```
+
+Render `{period label}` as `since YYYY-MM-DD` or `YYYY-MM-DD~YYYY-MM-DD`.
+
+## Error Handling
+
+| Situation | Response |
+|---|---|
+| AKB MCP not accessible | `AKB MCP server not accessible. Check your MCP configuration.` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault not found | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| No hits across every strategy | Flag the gap explicitly, then offer to broaden terms, drop `--collection`/`--type`, or browse with `akb_browse`. |
+| Relational anchor URI unknown | Find the anchor with a hybrid search first; if none is found, answer from hybrid hits and note the missing anchor. |
+| `akb_activity` fails | Drop the freshness axis only; answer from the search hits and note the skipped staleness check. |
+| `--since` / `--period` value is not ISO | Ask the user to restate the date (`YYYY-MM-DD`) before running. |
+
+## Tips
+
+- Natural-language questions beat keyword strings — "why did we drop the per-plugin config" beats "config".
+- Compiled truth (top of a document) is the answer; the timeline (bottom) is the evidence. Lead with the former.
+- For relational questions, name the anchor document — graph traversal needs a starting URI.
+- Use `akb_browse` to explore vault structure when a search returns nothing and you are unsure what exists.
+- A temporal cue ("what changed since the release", "recent decisions") is what `--since` / `--period` is for — it adds the staleness axis hybrid search alone misses.

--- a/plugins/codex/akb-sessions/.codex-plugin/plugin.json
+++ b/plugins/codex/akb-sessions/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "akb-sessions",
+  "version": "0.26.1",
+  "description": "Ingest coding sessions into an AKB vault as structured notes.",
+  "author": {
+    "name": "jylkim",
+    "url": "https://github.com/jylkim"
+  },
+  "homepage": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "repository": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "license": "MIT",
+  "keywords": [
+    "akb",
+    "ingest",
+    "sessions",
+    "knowledge-management",
+    "multi-agent"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AKB Sessions",
+    "shortDescription": "Turn coding sessions into structured AKB knowledge documents.",
+    "longDescription": "Capture session reports, learnings, follow-up tasks, ideas, and long-lived decisions from your coding sessions as structured documents in your AKB knowledge base vault.",
+    "developerName": "jylkim",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+    "defaultPrompt": [
+      "Save this session to my AKB vault.",
+      "Capture the decisions and learnings from this session.",
+      "Ingest my current coding session into AKB."
+    ],
+    "brandColor": "#3A6B9F"
+  }
+}

--- a/plugins/codex/akb-sessions/skills/session-ingest/SKILL.md
+++ b/plugins/codex/akb-sessions/skills/session-ingest/SKILL.md
@@ -1,0 +1,527 @@
+---
+name: session-ingest
+description: Ingest a coding session JSONL into AKB as structured notes — session report + parallel-drafted TIL / task / idea / decision sub-notes. Auto-discovers the current session's JSONL when no positional path is given (Claude / Codex). `--delegate {target}` fires the work to another target's CLI and exits.
+---
+
+# AKB Session Ingest
+
+Multi-agent workflow that analyzes a session JSONL file and writes structured notes to an AKB vault.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Cognitive-debt** layer — it captures the in-flight reasoning of a coding session (how the team arrived at an understanding, the decisions and dead ends), turning ephemeral working context into persistent compiled-truth notes (TIL / decision / idea / task) before it evaporates. The four drafter subagents share this classification.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+
+## Execution Flow
+
+```text
+Phase 0 — Resolve       parse args, resolve JSONL path (auto or explicit), maybe delegate & exit
+Phase 1 — Prepare       detect duplicates, fetch open tasks
+Phase 2 — Draft         read JSONL, identify commits/repo, draft session note
+Phase 3 — Sub-Draft     launch til / task / idea / decision drafters; triage ideas
+Phase 4 — Write         dedup ↔ finalize ↔ write session, sub-notes, resolve tasks
+```
+
+## Phase 0 — Resolve & Maybe Delegate
+
+Resolve invocation arguments and the JSONL path. Optionally fire-and-forget to a different target's CLI and exit early. All Phase 1+ work assumes `$VAULT` and `$JSONL_PATH` are set and the JSONL file exists.
+
+### 0-1. Parse Arguments
+
+Parse positional `[jsonl_path]` (optional) and flags:
+
+- `--vault {name}` (required) — hard-fail with `--vault {name} required.` if absent
+- `--lang {language}` (optional) — preferred language for synthesized note body
+- `--delegate {claude|codex}` (optional) — fire-and-forget to a different target's CLI and exit early
+
+Store as `$JSONL_PATH`, `$VAULT`, `$LANG_FLAG`, `$DELEGATE`.
+
+### 0-2. Reject Self-Delegate
+
+The current target was baked in at build time. If `--delegate` matches it, abort to prevent infinite recursion.
+
+```bash
+SELF="codex"
+if [ -n "$DELEGATE" ] && [ "$DELEGATE" = "$SELF" ]; then
+  echo "Refusing $SELF -> $SELF delegate (would recurse)." >&2
+  exit 2
+fi
+```
+
+### 0-3. Resolve JSONL Path
+
+If `$JSONL_PATH` was supplied positionally, use it. Otherwise discover the current session's JSONL automatically — discovery is target-specific.
+
+**Codex target — `$CODEX_THREAD_ID` env var + `find` across active and archived sessions.**
+
+```bash
+if [ -z "$JSONL_PATH" ]; then
+  if [ -z "${CODEX_THREAD_ID:-}" ]; then
+    echo "CODEX_THREAD_ID empty — not inside a Codex thread. Pass <jsonl_path> explicitly." >&2
+    exit 2
+  fi
+  CODEX_ROOT="${CODEX_HOME:-$HOME/.codex}"
+  JSONL_PATH=$(find "$CODEX_ROOT/sessions" "$CODEX_ROOT/archived_sessions" \
+                   -type f -name "*${CODEX_THREAD_ID}.jsonl" -print 2>/dev/null | head -1)
+  if [ -z "$JSONL_PATH" ]; then
+    echo "No JSONL found for thread ${CODEX_THREAD_ID} under $CODEX_ROOT" >&2
+    exit 2
+  fi
+fi
+```
+
+Verify the resolved path exists before proceeding:
+
+```bash
+if [ ! -f "$JSONL_PATH" ]; then
+  echo "JSONL path not readable: $JSONL_PATH" >&2
+  exit 2
+fi
+```
+
+### 0-4. Delegate Fire-and-Forget (Optional)
+
+If `$DELEGATE` is set, hand the ingest work to a different target and exit. The current session does no ingest work — the receiver runs Phase 1+ on the same JSONL. `claude` / `codex` spawn the target's CLI in the background.
+
+Each target runs the receiver unattended while limiting blast radius if the JSONL contains injected content:
+
+- `claude`: `--permission-mode acceptEdits` auto-approves file edits; Bash/MCP rely on the skill's `allowed-tools`.
+- `codex`: `-s workspace-write -c approval_policy="never"` — confines file writes to the workspace AND skips approval pauses. `--skip-git-repo-check` lets the receiver start in a non-git pwd (delegate does not require the JSONL's project to be checked out). Avoid `--dangerously-bypass-approvals-and-sandbox`: that drops the sandbox entirely, letting prompt-injection in the JSONL escalate to arbitrary shell.
+
+```bash
+LOG="${TMPDIR:-/tmp}/session-ingest-delegate-$(date +%s)-$$.log"
+ARGS="\"$JSONL_PATH\" --vault \"$VAULT\""
+[ -n "$LANG_FLAG" ] && ARGS="$ARGS --lang \"$LANG_FLAG\""
+
+case "$DELEGATE" in
+  claude)
+    nohup claude -p "/session-ingest $ARGS" --permission-mode acceptEdits \
+      >"$LOG" 2>&1 &
+    echo "Delegated to claude (pid $!, log $LOG)."
+    ;;
+  codex)
+    # $session-ingest must NOT shell-expand. Single-quote the literal,
+    # then concatenate the double-quoted $ARGS so the file path stays quoted.
+    # --skip-git-repo-check: the receiver may run in a non-git pwd (delegate
+    # does not require the JSONL's project to be checked out); codex exec
+    # otherwise aborts before starting.
+    PROMPT='$session-ingest '"$ARGS"
+    nohup codex exec --skip-git-repo-check -s workspace-write -c 'approval_policy="never"' "$PROMPT" \
+      >"$LOG" 2>&1 &
+    echo "Delegated to codex (pid $!, log $LOG)."
+    ;;
+  "")
+    : ;;
+  *)
+    echo "Unknown --delegate target: $DELEGATE (expected: claude, codex)" >&2
+    exit 2
+    ;;
+esac
+
+if [ -n "$DELEGATE" ]; then
+  exit 0
+fi
+```
+
+## Phase 1 — Prepare
+
+### 1-1. Detect Duplicates
+
+Before reading the full JSONL, check whether this session was already ingested.
+
+#### Detect JSONL Schema
+
+Read the first ~10 lines of the JSONL (`Read` with `limit: 10`). The opening line may be a noise event without identifying fields (CC sessions sometimes start with `permission-mode` or `file-history-snapshot`, neither of which carries `sessionId`); scan all 10 to find the first line that decisively identifies the schema:
+
+- If any of those lines has a top-level `sessionId` field (e.g., `{"type": "worktree-state", "sessionId": "..."}` or `{"type": "user", "sessionId": "..."}`), the JSONL is **CC schema** (flat per-line events). Set `jsonl_schema = "cc"`.
+- If any line has a top-level `payload` object containing `id` (e.g., `{"timestamp": "...", "type": "session_meta", "payload": {"id": "...", "cwd": "..."}}`), the JSONL is **Codex schema** (event-wrapped). Set `jsonl_schema = "codex"`.
+- If none of the first 10 lines yields either signal, hard-fail with `"Unrecognized JSONL schema: $JSONL_PATH"` — do not guess.
+
+Schema detection is independent of `runtime.target`: a Codex JSONL ingested from a Claude harness still uses Codex parsing, and vice versa.
+
+#### Extract Session ID, Timestamps, and Source CWD
+
+Reuse the first-10-lines window from schema detection and read the last few lines of the JSONL. Capture everything the head window carries in one pass — later phases reuse these values rather than re-scanning. Field lookup is schema-aware:
+
+For `jsonl_schema == "cc"`:
+- Store the first encountered `sessionId` field as `session_id`. (Lines without `sessionId` such as `file-history-snapshot` are skipped — they precede the first content event in some sessions.)
+- If a `worktree-state` entry is present, store `worktreeSession.originalCwd` as `session_cwd`; otherwise leave `session_cwd` unset.
+
+For `jsonl_schema == "codex"`:
+- Find the entry with `type == "session_meta"` (typically the first line). Store `payload.id` as `session_id` and `payload.cwd` as `session_cwd`.
+
+For both schemas:
+- Last entry's top-level `timestamp` → `jsonl_last_timestamp`.
+
+Store:
+- `session_id` — the resolved session/thread id
+- `jsonl_last_timestamp` — the ISO 8601 timestamp of the final entry
+- `session_cwd` — the source session's working directory (or unset)
+
+#### Search Vault for Existing Session
+
+```text
+mcp__akb__akb_search(
+  query="{session_id}",
+  vault="{vault_name}",
+  collection="sessions",
+  tags=["session:{session_id}"],
+  type="session",
+  limit=1
+)
+```
+
+**No match** → `sync_mode = "new"`, proceed to Phase 2.
+
+**Match found** → read the existing session note:
+
+```text
+mcp__akb__akb_get(vault="{vault_name}", doc_id="{matched_doc_id}")
+→ existing_session_doc_id, existing_tags, existing_session_content
+```
+
+Extract the `last-synced:{timestamp}` tag value from the existing note's tags. Store as `last_synced_timestamp`. Preserve `existing_session_content` (the full markdown body) for Phase 2-3 and Phase 4-1.
+
+#### Compare Timestamps
+
+- `jsonl_last_timestamp <= last_synced_timestamp` → no new content since last sync → **stop**:
+  `"Session {session_id} already synced up to {last_synced_timestamp}. No new content. Skipping."`
+- `jsonl_last_timestamp > last_synced_timestamp` → proceed to the new-content assessment below.
+
+#### Assess New Content
+
+Read the JSONL entries with timestamps after `last_synced_timestamp`. Filter out noise. The filter list is schema-aware:
+
+For `jsonl_schema == "cc"`:
+- `type: "system"` messages
+- `type: "permission-mode"` entries
+- `type: "file-history-snapshot"` entries
+- User messages containing only `/exit`, `/quit`, or session-end signals
+- `isMeta: true` entries
+
+For `jsonl_schema == "codex"`:
+- `type: "turn_context"` entries (per-turn configuration)
+- `type: "event_msg"` with `payload.type` in `{task_started, token_count}` (system markers and telemetry)
+- `type: "response_item"` with `payload.type == "reasoning"` (model-internal thinking, analogous to CC thinking blocks)
+- User messages (`type: "event_msg"` with `payload.type == "user_message"`) containing only `/exit`, `/quit`, or session-end signals
+- `type: "session_meta"` (metadata-only, already consumed for session_id extraction)
+
+After filtering, judge whether the remaining entries represent **meaningful work** — substantive user messages, assistant responses with real content, tool calls that changed files, or decisions made.
+
+**Not meaningful** (e.g., resume then immediately exit, only system noise) → **stop**:
+`"Session {session_id} has entries after {last_synced_timestamp} but no meaningful new work. Skipping."`
+
+**Meaningful** → set `sync_mode = "update"`, store `existing_session_doc_id` and `last_synced_timestamp`, proceed to Phase 1-2.
+
+### 1-2. Retrieve Open Tasks
+
+Before reading the full JSONL, retrieve project-scoped open tasks from the vault so the session drafter can identify which tasks this session resolved.
+
+**Parallel execution with Phase 1-1**: the project-name parse step below runs immediately (no MCP), and the `akb_search` for open tasks is independent of Phase 1-1's duplicate-detection search. Issue Phase 1-1's existing-session search and Phase 1-2's open-task search in a single parallel tool-use block. Act on Phase 1-2 results only after Phase 1-1 greenlights continuation (otherwise discard).
+
+#### Derive Project Name
+
+Project name is the basename of the source session's working directory. Use `session_cwd` (captured in Phase 1-1) when set — it is authoritative metadata from the JSONL, and cross-target delegate (e.g. Claude → Codex) puts the receiver in a different `pwd` than where the session originated, so `pwd` is not a reliable fallback.
+
+- `session_cwd` set → `project_name` is its basename. (For CC worktree sessions this is `originalCwd`, the unworktreed project root, not the worktree name.)
+- `session_cwd` unset (CC session with no `worktree-state` entry) → use the current working directory's basename. The CC JSONL parent directory uses a lossy encoding (`/` and `.` both map to `-`), so decoding it is unreliable and not used.
+
+If derivation fails entirely, set `project_name` to the empty string. The downstream open-tasks query becomes a no-op (no `project:` tag match) — degraded but safe.
+
+#### Query Open Tasks
+
+```text
+mcp__akb__akb_search(
+  query="open task",
+  vault="{vault_name}",
+  collection="sessions/tasks",
+  type="task",
+  tags=["project:{project_name}"],
+  limit=20
+)
+```
+
+From the results, exclude any document whose tags contain `resolved`. Store the remaining results as `open_tasks` — a list of `{doc_id, title, summary}` for each match.
+
+If no results or the query fails, set `open_tasks` to an empty list and continue.
+
+## Phase 2 — Draft Session Note
+
+The main agent acts as the session drafter. Read the JSONL file, extract session information, and produce both a session draft (navigator skeleton) and a session context for sub-agents. The session draft is finalized later in Phase 4-0 after sub-drafter results are reconciled.
+
+### 2-1. Read Session JSONL
+
+Read the JSONL file. It contains the complete conversation history: user messages, assistant responses, tool calls, and results. The field-name layout differs by `jsonl_schema` (set in Phase 1-1) — apply the analogous mapping when extracting content:
+
+| Concept | CC schema | Codex schema |
+|---|---|---|
+| User message | `type: "user"` entry, `message.content[]` with `type: "text"` | `type: "event_msg"`, `payload.type: "user_message"` |
+| Assistant text response | `type: "assistant"` entry, `message.content[]` with `type: "text"` | `type: "event_msg"`, `payload.type: "agent_message"` (and/or `response_item` with `payload.type: "message"`) |
+| Tool call | `type: "assistant"` entry, `message.content[]` with `type: "tool_use"` (nested inside the assistant turn — NOT a top-level event type) | `type: "response_item"`, `payload.type: "function_call"` |
+| Tool result | `type: "user"` entry, `message.content[]` with `type: "tool_result"` (nested inside a user-role turn that wraps the tool reply) | `type: "response_item"`, `payload.type: "function_call_output"` |
+
+**Update mode (`sync_mode = "update"`):** Focus **JSONL analysis** on entries with timestamps **after** `last_synced_timestamp` — this is where the new information lives. The **session draft you produce must be a combined compiled truth**: read `existing_session_content` (retrieved in Phase 1-1) and integrate its Summary / Narrative / Artifacts / Knowledge Produced / Open Questions with the new work from the resumed portion. The written draft is the new canonical state of the session, not a delta.
+
+**New mode (`sync_mode = "new"`):** Read the full JSONL as normal.
+
+Focus on extracting:
+- Work performed (main topics and tasks), as a chronological narrative
+- Files and commits touched
+- External URLs (articles, repos, docs) referenced in the session
+- Unresolved questions (to be promoted in Phase 4-0 where possible)
+
+Skip tool call/result noise — focus on user messages and assistant text responses. Reusable lessons and long-lived decisions will be extracted by the Phase 3 drafters; the session draft itself does not need to generalize.
+
+### 2-2. Identify Session Commits and Repository
+
+Scan the JSONL for git commit activity. Extract commit hashes to determine the range of changes made during the session.
+
+If commits were found, run:
+
+```bash
+git log --oneline {earliest_commit_hash}^..{latest_commit_hash}
+git diff --stat {earliest_commit_hash}^..{latest_commit_hash}
+```
+
+If no commits were found in the JSONL, skip these commands.
+
+Also collect the repository URL:
+
+```bash
+git remote get-url origin
+```
+
+Store the result as `repo_url`. If the command fails (no remote configured), set `repo_url` to `null`.
+
+### 2-3. Draft Session Note
+
+Compose the session draft per `references/session-template.md` — that file carries the full draft template, section-omission rules, update-mode handling, and authoring guidelines. The session note is a navigator + narrative + timeline; deep knowledge (reusable lessons, long-lived decisions, follow-up tasks, creative ideas) belongs to the Phase 3 sub-notes and must not be restated here.
+
+Determine the session's primary theme (debugging vs. feature build vs. refactor) and let it guide the emphasis in `## Narrative`. Number `## Open Questions` bullets `Q1`, `Q2`, … so Phase 3 sub-drafters can target them via `resolves_question: Q{n}`.
+
+### 2-4. Identify Resolved Tasks
+
+Compare the work performed in the session (from Phase 2-1) against the `open_tasks` list (from Phase 1-2).
+
+A task is "resolved" if the session performed substantial work directly addressing the task's topic. Partial completion counts — any remaining work will be captured as a new task by the task-drafter.
+
+For each resolved task, record:
+- `doc_id` — from the open_tasks entry
+- `title` — the task's title
+- `path` — the task's path (for Knowledge Produced link)
+- `reason` — brief explanation of how it was addressed (e.g., "Implemented the retry logic described in the task")
+
+Store as `resolved_tasks` list. If no tasks were resolved, set to an empty list.
+
+### 2-5. Construct Session Context for Sub-Agents
+
+Build a lightweight session context as a roadmap for the Phase 3 drafter agents. This supplements the session draft and JSONL — it helps agents orient quickly.
+
+```text
+Session Context:
+- Project: {project name}
+- Repository: {repo_url from Phase 2-2, or "N/A"}
+- Date: {YYYY-MM-DD from JSONL or today}
+- Session JSONL: {$JSONL_PATH resolved in Phase 0}
+- Work performed: {brief list of main topics/tasks}
+- Committed changes: {from Phase 2-2 — commit messages and files changed, or "None"}
+- Problems encountered (for possible troubleshooting TILs): {brief list}
+- Long-lived decisions considered (for possible Decision notes): {brief list}
+- Rejected alternatives (anti-pattern memory for Decisions): {brief list}
+- Tools/technologies used: {notable APIs, libraries, frameworks}
+- Vault name: {resolved vault_name from --vault}
+- Collections: {plugin's default_collections mapping — includes decisions}
+- Ingest mode: {new|update}
+- Last ingested timestamp: {ISO timestamp from existing session note, or "N/A" if new}
+- JSONL analysis start: {last_synced_timestamp if update, or "beginning" if new}
+- Open tasks: [{doc_id}] {title} (for each task in open_tasks, or "None")
+- Resolved tasks: [{doc_id}] {title} — {reason} (for each task in resolved_tasks, or "None")
+- Open Questions (session draft): Q1: {text}, Q2: {text}, ... (each question available for sub-drafters to resolve via `resolves_question: Q{n}`)
+```
+
+Keep this concise — it is a roadmap, not a comprehensive record.
+
+## Phase 3 — Parallel Sub-Drafting & Validation
+
+### 3-1. Launch Drafter Agents
+
+Launch 4 subagents with `fork_context: false`. Each subagent receives the session context, a session headline (frontmatter + Summary + numbered Open Questions — not the full Narrative), and the JSONL path.
+
+Open these prompt files and use their contents as the worker prompts:
+
+- `./support/agents/til-drafter.md` with model `gpt-5.4-mini` and reasoning effort `medium`
+- `./support/agents/task-drafter.md` with model `gpt-5.4-mini` and reasoning effort `medium`
+- `./support/agents/idea-drafter.md` with model `gpt-5.4` and reasoning effort `xhigh`
+- `./support/agents/decision-drafter.md` with model `gpt-5.4-mini` and reasoning effort `medium`
+
+Prepend the session context and session headline to each prompt.
+
+
+### Agent Summary
+
+| Agent | Model | Purpose | Output |
+|-------|-------|---------|--------|
+| til-drafter | gpt-5.4-mini | Learnings + vault validation | 0–N learning notes with dispositions + `til_kind` tag |
+| task-drafter | gpt-5.4-mini | Follow-up tasks + vault validation | 0–N task notes with dispositions |
+| idea-drafter | gpt-5.4 | Creative ideas + vault validation | 0–N idea notes with dispositions |
+| decision-drafter | gpt-5.4-mini | Long-lived decisions (ADR) + vault validation | 0–N decision notes with dispositions |
+
+Each agent receives:
+1. **Session Context** — lightweight roadmap (from Phase 2-5)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions`. The full Narrative is not sent — drafters read the JSONL directly for domain-specific detail.
+3. **JSONL path** — primary source for each drafter's domain analysis
+4. **Vault config** — `vault_name` and `collections` for duplicate checking
+
+Each agent drafts notes, then validates them against the vault using `akb_search`. Drafts are returned with a `disposition` (create / append; `supersede` additionally for decisions), optional `resolves_question: Q{n}` when a draft addresses a specific session Open Question, and `related_to` doc IDs. Duplicates are reported as skipped and excluded from the output.
+
+**idea-drafter specific.** Idea drafts additionally carry `impact` / `effort` / `confidence` enum assessments. The drafter silent-drops any idea it rates `impact: low` before returning (no report, no skipped block). The main agent re-triages the surviving drafts in Phase 3-2.
+
+Agents that find nothing to write return "No {type} notes for this session."
+
+### 3-2. Triage Idea Drafts
+
+After the idea-drafter agent returns, the main agent filters the surviving idea drafts using their `impact` / `effort` / `confidence` frontmatter fields. The drafter already silent-dropped any idea it rated `impact: low` before returning; this phase is a second gate that catches cases the drafter missed and removes high-cost, low-conviction ideas.
+
+**Scope.** Applies only to idea drafts. TIL / task / decision drafts pass through unchanged.
+
+**Inputs.** Each idea draft from Phase 3-1 with `disposition ∈ {create, append}`.
+
+**Automatic drop rules** — apply in order, drop on first match:
+
+1. `impact == low` — drop. Safety net for the drafter's self-filter.
+2. `effort == large` AND `confidence == low` — drop. High-cost, low-conviction ideas clutter the vault.
+
+All remaining idea drafts pass through to Phase 4.
+
+**No user prompt. No skipped block written. No vault write.** Dropped drafts are discarded in-memory; they do not feed Phase 4-0 or Phase 4-2. If a dropped idea set `resolves_question: Q{n}`, discard that mapping as well — the Q ID stays in the session's `## Open Questions`.
+
+## Phase 4 — Write to AKB
+
+Save all drafts with `create`, `append`, or (decisions only) `supersede` disposition directly — no user approval needed. Each drafter sets `status: active` in its `---DRAFT---` block; Phase 4-1 / 4-2 pass it through verbatim.
+
+### 4-0. Dedup Drafts & Finalize Session Body
+
+In-memory reconciliation between the session draft and the sub-note drafts before any AKB write. Single in-context pass — no extra LLM call, no MCP call, no per-pair loop. Inputs: session draft body, all sub-note drafts with `disposition ∈ {create, append, supersede}`, `resolved_tasks` list.
+
+**Step A — Promote Open Questions.** For each sub-note draft with `resolves_question`: normalize the value (strip / upper / `^Q\d+$`; non-conforming → log warning + no-match), find the matching `Q{n}` bullet in the session's `## Open Questions`, and **remove that bullet entirely** — the answer surfaces in `## Knowledge Produced` (Step C). Multiple sub-notes can target the same `Q{n}`; the bullet is removed once. If no session question matches, log a warning and leave the sub-note unchanged.
+
+**Step B — Cross-Type Content Overlap Detection.** For each sub-note, extract its headline sentence — TIL: `> **Key Insight:** …`; Task: `> **Next Action:** …`; Idea: `> **Inspiration:** …` plus Proposal first sentence; Decision: `> **Context:** …` plus Decision first sentence. Scan the session Narrative and Artifacts prose for sentences that match a headline. A sentence matches when at least **two** of these hold: (1) core noun phrases overlap, (2) assertion direction is the same (not negated / qualified differently), (3) reasoning or evidence cited is the same. One criterion alone is not enough — preserve the Narrative sentence if in doubt. On a match, remove the redundant sentence or replace it with a brief pointer ("…the lesson captured in Knowledge Produced"); do not rewrite surrounding prose beyond what grammatical flow needs. Overlap resolution **always favors sub-notes** — never edit a sub-note body here.
+
+**Step C — Finalize Knowledge Produced.** Build the block from deduplicated sub-notes plus `resolved_tasks`, in the order TIL → Idea → Task → Decision → Resolved:
+
+```markdown
+## Knowledge Produced
+
+- 🧠 TIL: [{title}](sessions%2Flearnings%2F{doc_path}.md) — {one-line hook from Key Insight}
+- 💡 Idea: [{title}](sessions%2Fideas%2F{doc_path}.md) — {one-line hook from Inspiration}
+- ✅ Task: [{title}](sessions%2Ftasks%2F{doc_path}.md) — {one-line hook from Next Action}
+- 📐 Decision: [{title}](sessions%2Fdecisions%2F{doc_path}.md) — {one-line hook from Decision first sentence}
+- ♻️ Resolved: [{title}](sessions%2Ftasks%2F{path}.md) — {reason from resolved_tasks}
+```
+
+For newly-drafted sub-notes the link's `doc_path` is substituted at render time from each Phase 4-2 put response. For resolved tasks the link uses the existing task's `path` captured in Phase 2-4. See `references/note-templates.md` → "Cross-Note Links" for why this hybrid (body link + `depends_on` frontmatter) is used.
+
+**Step D — Final omissions.** Omit `## Knowledge Produced` entirely when no sub-notes were produced and no tasks resolved. Omit `## Open Questions` if Step A left zero unresolved bullets. The resulting body is what Phase 4-1 writes — do not mutate further.
+
+### 4-1. Write Session Note
+
+The session note is written first because sub-notes reference it via `depends_on`. Sub-notes always use the full URI `akb://{vault_name}/doc/{session_doc_path}` (always-URI cross-ref convention; future-proof against vault tier splits).
+
+**New mode (`sync_mode = "new"`).** Extract metadata from the draft's `---DRAFT---` block and `akb_put(vault="{vault_name}", ...)` with `type="session"`, `collection={draft.collection}`, `status={draft.status}`, `tags=["session", "codex", "session", "session:{session_id}", "project:{project_name}", "last-synced:{jsonl_last_timestamp}", ...topic_tags]`, and the finalized body from Phase 4-0. Capture `session_doc_id` and `session_doc_path`.
+
+**Update mode (`sync_mode = "update"`).** The session note already exists. Phase 2-3 + 4-0 produced a full compiled-truth replacement plus exactly one new timeline entry. Apply the **timeline merge procedure — Mode A (full-body merge)** (see appendix) against `existing_session_content`. Build the updated tag list (replace the old `last-synced:{old_timestamp}` with `last-synced:{jsonl_last_timestamp}`; preserve all other tags; add any new topic tags). Then `akb_update(vault="{vault_name}", doc_id=existing_session_doc_id, content={merged}, tags={updated}, summary={draft.summary}, message="Update from resumed session: {brief description}")`. Assemble `session_uri = akb://{vault_name}/doc/{existing_session_doc_path}` for sub-notes' `depends_on`.
+
+### 4-2. Write Sub-Notes (Learning, Task, Idea, Decision)
+
+**Issue all sub-note `akb_put` calls in a single parallel tool-use block.** Sub-notes are independent of each other; only the session note's order matters (via `depends_on`).
+
+For each sub-note, extract metadata from the draft and call `akb_put(vault="{vault_name}", ...)` with `collection={draft.collection}`, `type={draft.type}`, `status={draft.status}`, `tags=["session", "codex", ...draft_tags]`, `depends_on=["akb://{vault_name}/doc/{session_doc_path}"]`, `related_to=[...draft.related_to]` (full URIs as emitted by drafters). Collection per type: TIL → `sessions/learnings`, Task → `sessions/tasks`, Idea → `sessions/ideas`, Decision → `sessions/decisions`.
+
+**Idea notes** — append four namespaced tags to `draft_tags` before put: `category:{draft.category}`, `impact:{draft.impact}`, `effort:{draft.effort}`, `confidence:{draft.confidence}`. Drop duplicates (the drafter may have already emitted some as tags). These four tags are the durable carriers for the external maintenance layer's consolidation synthesis and staleness checks.
+
+**Task notes** — after the task document is created, also create a lightweight todo via `akb_todo(vault="{vault_name}", title=draft.title, priority={P0→urgent, P1→high, P2→normal, P3→low}, ref_doc=task_doc_id, note=draft.summary)`.
+
+**`append` disposition** — the drafter has already merged compiled truth + one new timeline entry. Read the existing document with `akb_get(vault="{vault_name}", doc_id=draft.append_target)`, apply timeline merge **Mode A** against `draft.body`, and `akb_update(vault="{vault_name}", doc_id=draft.append_target, content={merged}, tags=[...existing, ...new from draft], summary=draft.summary, message="Appended from session ingest: {brief description}")`.
+
+**`supersede` disposition (decisions only)** — write the new decision via `akb_put(vault="{vault_name}", ..., tags=[..., "supersedes:{old_doc_id}"])` (tags use bare doc_id; the `:` already binds `key:value`). Capture `new_doc_id` and `new_doc_path`; compose `new_doc_ref = akb://{vault_name}/doc/{new_doc_path}`. Then read the old decision via `akb_get(vault="{vault_name}", doc_id=draft.supersedes)`, apply timeline merge **Mode B** with `new_entry = "- **{today}** | Superseded by {new_title} ({new_doc_ref}). {reason}. [Source: session:{session_id}, {today}]"`, and `akb_update(vault="{vault_name}", doc_id=draft.supersedes, content={merged}, tags=[...old, "superseded-by:{new_doc_id}"], status="superseded", message="Superseded by {new_doc_ref} in session ingest")`. Setting `status="superseded"` removes the old decision from the external maintenance layer's active-document pools.
+
+### 4-3. Resolve Completed Tasks
+
+If `resolved_tasks` is non-empty, fetch open todos once: `akb_todos(vault="{vault_name}", status="open") → open_todos`. For each resolved task:
+
+1. Scan `open_todos` in memory for a todo whose `ref_doc` matches the task's `doc_id`. If found, `akb_todo_update(vault="{vault_name}", todo_id={matched}, status="done", note="Resolved in session {session_doc_id}")`.
+2. Read the task document with `akb_get(vault="{vault_name}", doc_id={task_doc_id})`, then compose the resolution timeline entry `- **{today YYYY-MM-DD}** | Task resolved in session:{session_id}. {reason}. [Source: session:{session_id}, {today YYYY-MM-DD}]` and apply timeline merge **Mode B** against `task_content` (compiled-truth zone preserved as-is).
+3. `akb_update(vault="{vault_name}", doc_id={task_doc_id}, content={merged}, tags=[...existing, "resolved"], status="archived", message="Resolved in session {session_doc_id}")`.
+
+If no matching todo is found, still archive the task document. If the up-front `akb_todos` fails, skip all todo updates this ingest but archive the task documents anyway.
+
+## Error Handling
+
+If a drafter agent (Phase 3) fails or returns an error:
+- Continue with results from the remaining agents
+- Log the failure in the session summary
+- Do not block the pipeline for a single agent failure
+
+If an `akb_put` fails partway through Phase 4:
+- Continue writing the remaining notes from this invocation
+- The partial result is queryable under the `"session:{session_id}"` tag
+
+If Phase 4-0 Step A finds a `resolves_question` that does not match any session Open Question ID:
+- Log a warning naming the sub-note and the invalid Q ID
+- Leave the sub-note draft as-is, write without session mutation for that question
+
+## References
+
+- `references/session-template.md` — session draft template, section-omission rules, update-mode handling, authoring guidelines.
+- `references/note-templates.md` — sub-note templates (TIL / task / idea / decision).
+- Agent prompts in `support/agents/` — full drafter-agent instructions.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/codex/akb-sessions/skills/session-ingest/references/note-templates.md
+++ b/plugins/codex/akb-sessions/skills/session-ingest/references/note-templates.md
@@ -1,0 +1,425 @@
+# Note Templates Reference
+
+Templates for each note type produced by the `/session-ingest` workflow. Notes are stored as plain standard markdown via AKB MCP tools. All metadata is passed through `akb_put` parameters — no YAML frontmatter in the content body.
+
+## Body Structure: Compiled Truth + Timeline
+
+Every note body follows the same two-zone layout, separated by a horizontal rule:
+
+```markdown
+# {Title}
+
+{Compiled truth sections — the current best synthesis. Rewritten as understanding evolves.}
+
+---
+
+## Timeline
+
+- **YYYY-MM-DD** | {One-line summary of the event.} [Source: {attribution}]
+  - {Optional sub-bullet for detail.}
+- **YYYY-MM-DD** | {Earlier event.} [Source: {attribution}]
+```
+
+**Rules:**
+
+- **Above the line (compiled truth):** the note's current state — sections like `## Context`, `## What I Learned`, `## Core Idea`, etc. Rewrite these when new information changes the picture. Read just this part and you have the full current answer.
+- **Below the line (timeline):** append-only log of events that shaped the note, newest first. Never edit or delete past entries. Every compiled-truth change should leave a timeline entry explaining what and why.
+- **Always include the `---` separator and `## Timeline` heading**, even when the timeline has a single entry (the initial capture).
+- **Order timeline entries newest-first**, so the most recent event is at the top.
+- **Each timeline entry cites a source** in `[Source: ...]` form (see below).
+
+### Session Notes: Navigator Role
+
+Session notes use the same two-zone layout but play a **navigator + narrative** role rather than a full knowledge store. The compiled-truth zone tells the story of what happened and points to the sub-notes (TIL / Task / Idea / Decision) that hold the reusable knowledge. The session note itself should remain readable as a standalone log of the session — but deep content lives in sub-notes, linked from the `## Knowledge Produced` block.
+
+### Source Attribution
+
+Every timeline entry needs a citation. Use one of:
+
+| Event source | Attribution format |
+|---|---|
+| Session ingest (initial capture or append) | `[Source: session:{session_id}, {YYYY-MM-DD}]` |
+| Manual edit by user | `[Source: manual, {YYYY-MM-DD}]` |
+
+### When to Rewrite Compiled Truth vs. Append-Only
+
+- **New information that replaces or refines existing content** → rewrite the relevant compiled-truth section, then append a timeline entry describing the change.
+- **New information that adds without conflicting** → extend the compiled-truth section (e.g., add a new gotcha to `## Gotchas`), then append a timeline entry.
+- **Status or metadata changes** (task resolved, doc superseded, cross-link added) → timeline entry only; compiled truth stays as a historical record of the state at the time the note was last written.
+
+## Metadata → akb_put Parameter Mapping
+
+| Draft Field | akb_put Parameter | Notes |
+|-------------|-------------------|-------|
+| title | `title` | Direct mapping |
+| collection | `collection` | Target collection |
+| type | `type` | AKB document type enum |
+| tags | `tags` | Array of strings |
+| summary | `summary` | Agent-generated summary |
+| (session_doc_id) | `depends_on` | Set at write time for sub-notes |
+| (reviewer related) | `related_to` | Set at write time from reviewer output |
+
+## Type Mapping
+
+| Note Type | akb_put type | Collection | Notes |
+|-----------|-------------|------------|-------|
+| Session | `session` | `sessions` | One per ingest run — navigator + narrative + timeline |
+| Learning (TIL) | `reference` | `sessions/learnings` | Reusable knowledge. Classify with `til_kind:*` tag |
+| Task | `task` | `sessions/tasks` | Follow-up work |
+| Idea | `plan` | `sessions/ideas` | Forward-looking concepts |
+| Decision | `decision` | `sessions/decisions` | Long-lived architectural/product decisions (ADR style). Holds `## Alternatives Considered` as the canonical home for anti-patterns |
+
+## Tag Conventions
+
+- `session` — on every generated note
+- `codex` — provenance tag for the runtime
+- `session`, `learning`, `task`, `idea`, `decision` — type tags
+- `project:{name}` — project namespace
+- `{technology}` — e.g. `python`, `react`, `sqlite`
+- `P0` through `P3` — priority tags on tasks
+- `{category}` — idea category tags (architecture, product, workflow, exploration)
+- `til_kind:shift` | `til_kind:acquisition` | `til_kind:comparison` | `til_kind:troubleshooting` — TIL classification (exactly one per TIL)
+- `session:{session_id}` — links the note to its originating JSONL session (session notes only)
+- `last-synced:{ISO-timestamp}` — records the last JSONL timestamp covered by this ingest (session notes only)
+- `supersedes:{doc_id}` — on a new decision that replaces an older one
+- `superseded-by:{doc_id}` — on a decision that has been replaced
+- `resolved` — marks tasks that have been completed
+- `idea_status:promoted` — marks ideas that spawned a decision or task (applied by the external maintenance layer)
+- `concept` — marks consolidated knowledge pages (created by the external maintenance layer)
+- `auto-generated` — marks documents created by automated processes (concept pages)
+
+## External URLs
+
+External URL preservation differs between session notes and sub-notes.
+
+### Session Note — Canonical Bibliography
+
+The session note's `## Artifacts > External sources` block is the **canonical bibliography** for the ingest. Every external URL referenced in the session is collected here, regardless of which sub-note it ended up in. This gives a single, searchable list per session.
+
+```markdown
+## Artifacts
+
+- **External sources**:
+  - [Title](https://example.com) — why it's relevant
+  - [Another](https://example.org) — context
+```
+
+### Sub-note — Inline Links Only
+
+TIL / Task / Idea / Decision bodies reference external URLs only as **inline markdown links** where they are mentioned in the body text. Sub-notes do **not** maintain their own `## Sources` section — the session note's Artifacts block holds the canonical list, and each sub-note points back to its session via `depends_on`.
+
+```markdown
+## What I Learned
+
+[Claude Code](https://github.com/anthropics/claude-code)의 컨텍스트 윈도우 한계 근처에서
+발화자 혼동 버그가 발생한다는 [분석 글](https://dwyer.co.za/static/claude-mixes-up...)이 있다.
+```
+
+**Include (in session Artifacts):** URLs that directly support or provide context for the session's content — articles cited, repos explored, documentation referenced, tools discovered.
+
+**Exclude:** Transient URLs (localhost, CI build links, temporary file shares) and URLs the user merely passed through without engagement.
+
+## Cross-Note Links
+
+AKB does **not** support Obsidian-style `[[wikilink]]` syntax. Use standard markdown links only.
+
+Sub-notes are referenced from the session note's `## Knowledge Produced` block using plain markdown:
+
+```markdown
+- 🧠 TIL: [Title](sessions%2Flearnings%2Ftitle-path.md) — one-line hook
+```
+
+The AKB backend automatically extracts these body links into `links_to` graph relations, and each sub-note's `depends_on=[session_doc_id]` frontmatter parameter sets the reverse relation. The hybrid (inline link + frontmatter relation) is the canonical pattern.
+
+## Highlighted Text Patterns
+
+Standard markdown replacements for Obsidian callouts:
+
+| Purpose | Format |
+|---------|--------|
+| Session overview | `> **Summary:** {text}` |
+| Key insight | `> **Key Insight:** {text}` |
+| Next action | `> **Next Action:** {text}` |
+| Inspiration source | `> **Inspiration:** {text}` |
+| Decision context | `> **Context:** {text}` |
+
+## Knowledge Produced Block
+
+Used in the session note to point at sub-notes written during this ingest. Each line uses a type icon, a markdown link to the sub-note path, and a one-line hook:
+
+```markdown
+## Knowledge Produced
+
+- 🧠 TIL: [TIL 학습 신호 확장](sessions%2Flearnings%2Ftil-학습-신호-확장.md) — 놀라움 + 지식 획득 둘 다 포착해야 함
+- 💡 Idea: [테스트 실행 레이어 분리](sessions%2Fideas%2F테스트-실행-레이어-분리.md) — 빠른/느린 검증을 명시적으로 나누기
+- ✅ Task: [Tycho 업그레이드 재검증](sessions%2Ftasks%2Ftycho-업그레이드-재검증.md) — JUnit 5 병렬 실행 지원 여부
+- 📐 Decision: [JUnit 5 병렬 실행 미도입](sessions%2Fdecisions%2Fjunit-5-병렬-미도입.md) — 현 Tycho 버전에서 실효성 없음
+- ♻️ Resolved: [이전 태스크 제목](sessions%2Ftasks%2Fresolved-task-path.md) — 이번 세션에서 해결됨
+```
+
+Icons (use exactly these):
+
+| Icon | Purpose |
+|------|---------|
+| 🧠 | TIL (newly created or appended learning) |
+| 💡 | Idea (newly created or refined idea) |
+| ✅ | Task (newly created or updated task) |
+| 📐 | Decision (newly created or appended decision) |
+| ♻️ | Resolved task (existing task closed in this session) |
+
+Omit the `## Knowledge Produced` section if no sub-notes were produced. Do not create sub-section headers within the block — a single flat bullet list is the entire block.
+
+## Session Note Template
+
+**akb_put**: `type="session"`, `collection="sessions"`
+
+```markdown
+# {Brief Description}
+
+> **Summary:** {2-3 sentence overview of what the session accomplished and why it matters}
+
+## Narrative
+
+{Chronological prose, 1–2 paragraphs: event → diagnosis → resolution → outcome. No bullets; defer mechanical facts to Artifacts. If the session had a Problem/Solution arc, weave it into one narrative paragraph. Do not generalize reusable lessons here — promote them to TIL (e.g. `til_kind:troubleshooting`).}
+
+## Artifacts
+
+- **Commits**: `{hash}` — {one-line subject}
+- **Files touched**: `{path/to/file}` — {why it matters}
+- **External sources**:
+  - [{Title}]({url}) — {relevance}
+
+## Knowledge Produced
+
+- 🧠 TIL: [{title}](sessions%2Flearnings%2F{path}.md) — {one-line hook}
+- 💡 Idea: [{title}](sessions%2Fideas%2F{path}.md) — {one-line hook}
+- ✅ Task: [{title}](sessions%2Ftasks%2F{path}.md) — {one-line hook}
+- 📐 Decision: [{title}](sessions%2Fdecisions%2F{path}.md) — {one-line hook}
+- ♻️ Resolved: [{title}](sessions%2Ftasks%2F{path}.md) — {how resolved}
+
+## Open Questions
+
+- {Unresolved question that did NOT get promoted to an Idea/Task/Decision}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Session captured. {One-line summary of work performed.} [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `## Narrative` is always present (at least one sentence).
+- `## Artifacts` is present if any commits, files, or external URLs were touched. Omit sub-bullets with no entries.
+- `## Knowledge Produced` is omitted entirely if no sub-notes were produced.
+- `## Open Questions` is omitted if empty (every question was promoted to a sub-note, or there were none).
+
+**Update mode:** rewrite the compiled-truth sections (Summary / Narrative / Artifacts / Knowledge Produced / Open Questions) to reflect the combined session (original + continuation). Knowledge Produced should include every sub-note from both the original ingest and the resumed portion. Append a new timeline entry, e.g. `- **{YYYY-MM-DD}** | Session resumed. {new work summary}. [Source: session:{session_id}, {YYYY-MM-DD}]`. Never drop past timeline entries.
+
+## Learning Note (TIL) Template
+
+**akb_put**: `type="reference"`, `collection="sessions/learnings"`, `depends_on=[session_doc_id]`, tag one of `til_kind:shift|til_kind:acquisition|til_kind:comparison|til_kind:troubleshooting`.
+
+```markdown
+# {Concise Learning Title}
+
+> **Key Insight:** {One sentence takeaway}
+
+## Context
+
+{When and why this came up}
+
+## What I Learned
+
+{Technical explanation with enough detail to be actionable}
+
+```{language}
+{Code example demonstrating the concept}
+```
+
+## Gotchas
+
+- {Pitfall or edge case to watch for}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Captured from session:{session_id}. {One-line summary of the lesson.} [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**til_kind classification** (exactly one tag per TIL):
+
+| Tag | When to use |
+|-----|-------------|
+| `til_kind:shift` | Mental model correction — user expected X but learned Y |
+| `til_kind:acquisition` | Knowledge acquisition — user entered without knowledge and built understanding through exploration |
+| `til_kind:comparison` | Structured comparison/analysis — A vs B tradeoffs the user evaluated |
+| `til_kind:troubleshooting` | Diagnostic/root-cause pattern — non-obvious root cause traced through systematic investigation |
+
+**Optional sections by til_kind:**
+
+- `til_kind:comparison` may include a `## Comparison` table section
+- `til_kind:troubleshooting` may include a `## Root Cause` section describing the diagnostic path
+
+## Task Note Template
+
+**akb_put**: `type="task"`, `collection="sessions/tasks"`, `depends_on=[session_doc_id]`
+
+```markdown
+# {Descriptive Title}
+
+> **Next Action:** {Specific first step}
+
+## Context
+
+{Background and motivation — why this task exists}
+
+## Steps
+
+- [ ] {Step 1}
+- [ ] {Step 2}
+- [ ] {Step 3}
+
+## Related Files
+
+- `{path/to/file}` — {why it's relevant to resuming this task}
+
+## Notes
+
+{Task-handling nuance: scheduling constraints, blocking/non-blocking status, links to background}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Task created from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+Task lifecycle events that append to the timeline:
+
+- `- **{date}** | Task updated in session:{id}. {what changed}. [Source: session:{id}, {date}]`
+- `- **{date}** | Task resolved in session:{id}. {how it was addressed}. [Source: session:{id}, {date}]`
+
+## Idea Note Template
+
+**akb_put**: `type="plan"`, `collection="sessions/ideas"`, `depends_on=[session_doc_id]`
+
+Idea notes read as lightweight PRDs / technical proposals. The body must contain enough substance to judge whether the idea is worth pursuing — not just describe what it is.
+
+**Assessment frontmatter.** In addition to the standard fields, every idea note carries three enum assessments set by the drafter:
+
+- `impact: high | medium | low` — expected benefit magnitude.
+- `effort: small | medium | large` — rough implementation size.
+- `confidence: high | medium | low` — how confident the Proposal actually solves the Problem.
+
+These values drive the main ingest skill's Phase 3-2 triage. The drafter silent-drops any idea it rates `impact: low` before emitting a draft; the main agent filters further (`impact: low`, or `effort: large AND confidence: low`).
+
+```markdown
+# {Compelling Title}
+
+> **Inspiration:** {What triggered this idea — cite specific files, patterns, or workarounds from the session}
+
+## Problem
+
+{Reproducible observation. What was harder than it should be, how often it recurred, who is affected. Concrete evidence beats "felt awkward".}
+
+## Proposal
+
+{Design-level solution. What changes in code, architecture, or flow — specific enough for someone to begin an implementation sketch.}
+
+## System Architecture
+
+{Optional. When the idea spans multiple components, show how they fit: a compact diagram (mermaid / ASCII) or a labeled bullet list of components and data flows.}
+
+## Expected Impact
+
+{First line is the rationale for the `impact` frontmatter value. Then: who benefits, how much, and by what measure. Prefer quantifiable statements ("turns N retries per sync into 0") over qualitative ones.}
+
+## Effort & Risks
+
+{Rough implementation surface (affected modules / files at directory granularity), top 1–3 risks, and any assumption that could invalidate the Proposal.}
+
+## Success Criteria
+
+{Observable or measurable signals that the idea is working after it ships. Each criterion should be checkable without rerunning the original session.}
+
+## Open Questions
+
+- {Key uncertainty}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Idea captured from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `Problem`, `Proposal`, `Expected Impact`, `Effort & Risks`, `Success Criteria` are always present.
+- `System Architecture` is optional — include it when the idea spans multiple components; omit it for small local changes.
+- `Open Questions` is omitted when there are no unresolved uncertainties.
+
+**Idea lifecycle events** that append to the timeline:
+
+- `- **{date}** | Idea refined in session:{id}. {what changed}. [Source: session:{id}, {date}]` — when a later session revises Proposal / Expected Impact / etc.
+
+The external maintenance layer may later set `idea_status:promoted` on an idea that spawned a decision or task. `idea_status:*` tags are append-preserving — session-ingest Phase 4-3 merges existing tags with new draft tags on `disposition: append`, so a promoted idea keeps its status tag through subsequent refinements.
+
+## Decision Note Template
+
+**akb_put**: `type="decision"`, `collection="sessions/decisions"`, `depends_on=[session_doc_id]`
+
+Follows the ADR (Architecture Decision Record) pattern. A decision note is the canonical home for a chosen direction plus every alternative that was considered. Anti-pattern memory — "what we tried, why it doesn't work" — lives here, not in the session note.
+
+```markdown
+# {Decision Title}
+
+> **Context:** {Why this decision was needed — what forced the choice}
+
+## Decision
+
+{What was chosen, in one tight paragraph. State the decision first, reasoning second.}
+
+## Consequences
+
+{What this decision enables and constrains. Include both positive and negative outcomes.}
+
+## Alternatives Considered
+
+### {Alternative Approach Title}
+
+**What**: {The approach — specific enough to be recognizable if revisited}
+**Why not**: {Why it was rejected. Include concrete evidence — paths tried, error messages, measurements — that would save someone from repeating the experiment}
+
+### {Another Alternative}
+
+**What**: {…}
+**Why not**: {…}
+
+---
+
+## Timeline
+
+- **{YYYY-MM-DD}** | Decision captured from session:{session_id}. [Source: session:{session_id}, {YYYY-MM-DD}]
+```
+
+**Section omission rules:**
+
+- `## Context`, `## Decision`, `## Consequences`, `## Alternatives Considered` are always present.
+- Supersede relationships are tracked via frontmatter `supersedes:` / `superseded-by:` tags and a Timeline entry — not a body section.
+
+**Decision lifecycle events** that append to the timeline:
+
+- `- **{date}** | Decision refined in session:{id}. {what changed in Consequences or Alternatives}. [Source: session:{id}, {date}]`
+- `- **{date}** | Superseded by {newer_title} ({newer_doc_id}). {reason}. [Source: session:{id}, {date}]` — paired with setting tag `superseded-by:{newer_doc_id}` on this note and `supersedes:{this_doc_id}` on the new note.
+
+**When to write a Decision note** (vs. keep in session Narrative):
+
+- The choice has **long life** — likely to be referenced from future sessions.
+- The choice **constrains future work** — architecture, API contract, tooling, process.
+- A **real alternative** was evaluated and rejected, not a trivial preference.
+
+One-off tactical choices that only matter inside the session (e.g., "used `sed` instead of `awk` for this one-liner") stay in Narrative prose.

--- a/plugins/codex/akb-sessions/skills/session-ingest/references/session-template.md
+++ b/plugins/codex/akb-sessions/skills/session-ingest/references/session-template.md
@@ -1,0 +1,80 @@
+# Session Note Template
+
+The session note is a navigator + narrative + timeline. Deep knowledge (reusable lessons, long-lived decisions, follow-up tasks, creative ideas) belongs to the sub-notes drafted in Phase 3 and must not be restated in the session body.
+
+## Draft format
+
+```markdown
+---DRAFT---
+title: {brief description}
+collection: sessions
+type: session
+tags: [session, codex, session, session:{session_id}, last-synced:{jsonl_last_timestamp}, project:{project_name}, {topic-specific tags}]
+project: {project name from working directory or JSONL context}
+repo_url: {repo_url from Phase 2-2, or omit if null}
+status: active
+summary: {1-2 sentence summary of the session}
+
+# {Brief Description}
+
+> **Summary:** {2-3 sentence overview of what the session accomplished and why it matters}
+
+## Narrative
+
+{Chronological prose, 1–2 paragraphs: event → diagnosis → resolution → outcome. No bullets. If the session had a Problem/Solution arc, weave it into one narrative paragraph. Do not generalize reusable lessons here — promote them to TIL instead. The session records "what happened"; sub-notes record "what we learned."}
+
+## Artifacts
+
+- **Commits**: `{hash}` — {one-line subject}
+- **Files touched**: `{path/to/file}` — {why it matters}
+- **External sources**:
+  - [{Title}]({url}) — {relevance}
+
+## Knowledge Produced
+
+<!-- Phase 4-0 populates this block from sub-note drafts. Leave as a placeholder here. -->
+
+## Open Questions
+
+- **Q1**: {Unresolved question 1}
+- **Q2**: {Unresolved question 2}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {For new mode: Session captured. {one-line summary}. | For update mode: Session resumed. {one-line summary of new work}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+`## Open Questions` bullets must be numbered `Q1`, `Q2`, … so that Phase 3 sub-drafters can target a specific question via `resolves_question: Q{n}`. Phase 4-0 reconciles those references.
+
+## Section omission rules
+
+These apply to the **final** session body after Phase 4-0, not the draft itself:
+
+- `## Narrative` is always present (at least one sentence).
+- `## Artifacts` is present if any commits, files, or external URLs were touched.
+- `## Knowledge Produced` is populated by Phase 4-0 from sub-note results; omitted entirely if no sub-notes produced.
+- `## Open Questions` is omitted if every question was promoted in Phase 4-0 or there were none.
+
+Every session draft **must** end with the `---` separator and a `## Timeline` section containing exactly **one** new entry for this ingest. Do not re-include past timeline entries — Phase 4-2 merges your new entry with the existing timeline.
+
+## Update mode
+
+Read `existing_session_content` (stored in Phase 1-2) to understand what the original session produced. Write the compiled-truth sections (Summary, Narrative, Artifacts, Knowledge Produced placeholder, Open Questions) as the **combined** current state — integrating both the original work and the new work performed after `last_synced_timestamp`.
+
+- Title can stay as-is unless the new work fundamentally changes the session's theme.
+- Summary should read as a unified description of the full session, not only the delta.
+- The single new timeline entry describes what this sync added.
+- Open Questions from the previous sync that remain unresolved keep their original `Q{n}` IDs; new questions continue numbering.
+
+## Authoring guidelines
+
+- Write as if the reader is you, six months from now, trying to remember what happened.
+- Prefer concrete details (file names, function names, error messages) over vague descriptions in `## Narrative`.
+- **External URLs**: link inline where mentioned in Narrative, and collect all referenced URLs in `## Artifacts > External sources` (the session note is the canonical bibliography). Omit transient URLs (localhost, CI build links).
+- Sub-notes do **not** maintain their own `## Sources` section — the session Artifacts covers them.
+- If the session was trivial, produce a short note rather than padding content; skip sections that have nothing meaningful to say.
+- Write prose content in the primary language of the user's prose in the JSONL conversation (not embedded code/quotes); metadata keys and section headings remain in English.
+- Do **not** draft `## Knowledge Produced` content here — leave the placeholder and let Phase 4-0 fill it.

--- a/plugins/codex/akb-sessions/support/agents/decision-drafter.md
+++ b/plugins/codex/akb-sessions/support/agents/decision-drafter.md
@@ -1,0 +1,165 @@
+---
+name: decision-drafter
+description: Identify long-lived decisions made during the session and compose ADR-style Decision drafts with Alternatives Considered as the canonical home for anti-pattern memory.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# Decision Drafter
+
+Identify long-lived decisions made during the session and turn each into a standalone ADR-style decision note. A Decision note captures a chosen direction plus every alternative that was considered — it is the canonical home for "what we chose, and what we tried that didn't work."
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — full decision reasoning (alternatives considered, paths rejected with evidence) lives there. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for moments where the user weighed options and committed to one: "let's go with X", "I'll use X instead of Y", "X is the approach"
+- Look for rejected paths with specific evidence: "tried X, didn't work because Y", "X fails in Z case"
+- Focus on decisions whose **reasoning would be valuable to future readers** — not on trivial tactical choices
+- Pay attention to "anti-pattern memory" — concrete paths that were tested and abandoned. This is the core content of `## Alternatives Considered`
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a decision, but do not extract decisions from them.
+- Decisions from the original session were already captured in the prior ingest.
+- If the new portion contains no decision signals, return `No decision notes for this session.`
+
+## Process
+
+### 1. Identify Long-Lived Decisions
+
+A Decision note is appropriate when **all three** hold:
+
+1. **Long life** — referenced by future sessions. Architectural (framework, data model, API contract), product direction, tooling, or process decisions qualify.
+2. **Constrains future work** — narrows the space of acceptable choices ("We use PostgreSQL" rules out MongoDB unless revisited).
+3. **A real alternative was evaluated and rejected**, not just a trivial preference. The decision has a substantive `## Alternatives Considered` section.
+
+**Does NOT warrant a Decision note**: tactical one-offs (`sed` vs `awk` in a one-liner), unevaluated style preferences (camelCase), mechanical/forced choices (no real alternative), decisions already covered by project convention, or pending choices the user has not committed to.
+
+When in doubt, leave the reasoning in session Narrative. Decision notes should be ones the user would want to revisit 3–6 months later.
+
+### 2. Detect Supersede Relationships
+
+If this session's decision **replaces** or **overrules** a prior decision, mark the new draft with `disposition: supersede` and set `supersedes: {old_doc_id}`. Find the old decision by searching the vault for the topic being revised.
+
+If the new decision is a refinement (extension, clarification) of an existing one without replacing it, use `disposition: append` and `append_target: {existing_doc_id}` instead.
+
+### 3. Extract Anti-Pattern Evidence
+
+`## Alternatives Considered` is **anti-pattern memory** for future readers. For each rejected alternative include the **what** (specific approach — library, technique, configuration — named concretely so a future reader recognizes the trap) and the **why not** (concrete evidence: error messages, measurements, paths explored — "failed because X" with a JSONL moment or code-location citation, never just "didn't work").
+
+If the session explored multiple paths (the Tycho case: 4 JUnit 5 parallel config approaches), list **all** of them — the catalog is the point. Never collapse to "tried various approaches".
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a decision you are drafting **directly resolves** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the decision.
+
+A decision "directly resolves" an Open Question when the decision is the answer to the question. Do **not** stretch to match — if the decision merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Compose Each Draft
+
+Each decision gets its own draft. If the session made multiple independent decisions, produce multiple drafts separated by `---NEXT_NOTE---`.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing Context / Decision / Consequences / Alternatives Considered merged with new refinement, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the decision.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+Frontmatter fields:
+
+```yaml
+---DRAFT---
+title: {Decision title, stated as the chosen direction}
+collection: sessions/decisions
+type: decision
+tags: [session, codex, decision, project:{project name}, topic:{t1}, topic:{t2}, ...]
+project: {project name}
+status: active
+summary: {One sentence describing the decision}
+disposition: {create|append|supersede}
+append_target: {doc_id, only if disposition is append}
+supersedes: {doc_id, only if disposition is supersede}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this decision directly resolves one, else null}
+```
+
+Body structure: follow the **Decision Note Template** in `note-templates.md` (Context / Decision / Consequences / Alternatives Considered / Supersedes / Timeline). Close the draft with `---END_DRAFT---`.
+
+**Timeline entry** for this ingest:
+
+- `disposition: create` → `- **{today}** | Decision captured from session:{session_id}. {one-line summary}. [Source: session:{session_id}, {today}]`
+- `disposition: append` → `- **{today}** | Decision refined in session:{session_id}. {what changed}. [Source: session:{session_id}, {today}]`
+- `disposition: supersede` → `- **{today}** | Supersedes {old_doc_id}. {reason}. [Source: session:{session_id}, {today}]`
+
+For `supersede`, the ingest skill also appends a supersede entry to the *old* decision's timeline — the drafter only produces the new decision's entry.
+
+Separate multiple decision drafts with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Decision titles should state the chosen direction affirmatively ("Use PostgreSQL for event store"), not as a question or neutral framing
+- Context, Decision, Consequences, Alternatives Considered should each be tight — one or two paragraphs each, not essays
+- The value of a Decision note is **reusable reasoning** — write so a future reader can reconstruct why, not just what
+- **Evidence in Alternatives Considered matters**: concrete error messages, file paths, config snippets, measurements. Vague rejections ("didn't work well") have low value
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the decision** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Edge Cases
+
+- **No long-lived decisions**: Return `No decision notes for this session.`
+- **Many related decisions**: Prefer one Decision note covering the related cluster with multiple Alternatives Considered entries, rather than three separate tiny Decisions
+- **Pending decision**: If the session discussed a decision but did not commit, do not draft it — it belongs in Open Questions, not Decisions
+- **Uncertain supersede**: If you suspect but cannot confirm that this decision supersedes an earlier one, set `disposition: create` and add a `related_to` entry. The external maintenance layer will surface a possible supersede for human review

--- a/plugins/codex/akb-sessions/support/agents/idea-drafter.md
+++ b/plugins/codex/akb-sessions/support/agents/idea-drafter.md
@@ -1,0 +1,208 @@
+---
+name: idea-drafter
+description: Generate creative ideas inspired by the session — architecture improvements, product concepts, workflow innovations, and technical possibilities.
+model: gpt-5.4
+reasoning_effort: xhigh
+---
+
+# Idea Drafter
+
+Generate ideas about the **project** — its code, architecture, or product — inspired by what happened during the session. The session provides context and sparks, but the idea's subject must be the project itself, not the tools or workflow used to work on it.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+This agent is intentionally powered by a stronger model because creative ideation benefits from deeper reasoning and broader connections.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — creative sparks live in the details. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for friction points in the project: workarounds, complaints about the codebase, repeated patterns, "what if"
+- Look for project constraints that were worked around or limitations that were accepted
+- Focus on moments that reveal something about the project's design — not observations about the development process itself
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a idea, but do not extract ideas from them.
+- Ideas from the original session were already captured in the prior ingest.
+- If the new portion contains no idea signals, return `No idea notes for this session.`
+
+## Process
+
+### 1. Look for Inspiration Signals
+
+Find moments revealing something about the **project's** design, limitations, or potential — **friction** (something harder than it should be), **repetition** (a pattern recurring across the project), **constraints** (a limitation worked around — what if it didn't exist?), **connections** (two parts touched the same session — is there an architectural link?), **scale questions** (worked for one case — what at 10×/100×?).
+
+Session workflow itself (tools used, review style, commit cadence) is not an inspiration signal — those are meta-process observations, not project insights.
+
+### 2. Develop the Idea
+
+Think each spark through at PRD-depth: **Problem** (what's broken — cite specific evidence: files, repetition counts, workarounds), **Proposal** (design-level change — which modules/flows/data structures), **System Architecture** (omit for small local changes; for multi-component ideas: components, data flow, dependencies), **Expected Impact** (who benefits; quantify when possible — "X reduces from N to 0"), **Effort & Risks** (implementation surface + top 1–3 risks), **Success Criteria** (observable signals after ship), **Open Questions** (uncertainties shaping the direction).
+
+If you cannot fill Problem / Proposal / Expected Impact / Effort & Risks / Success Criteria concretely, the idea isn't ready — develop further or skip.
+
+### 3. Assess Impact / Effort / Confidence
+
+Three enum assessments per idea (become frontmatter fields, feed `/session-ingest` Phase 3-2 triage):
+
+- `impact`: `high` | `medium` | `low` — derived from your Expected Impact (best case "mildly nicer" → `low`).
+- `effort`: `small` | `medium` | `large` — rough implementation size.
+- `confidence`: `high` | `medium` | `low` — how confident the Proposal actually solves the Problem.
+
+**Silent drop.** If your honest assessment is `impact: low`, do not emit the draft — no `---SKIPPED---` block, no mention. Low-impact ideas must not consume the main agent's context.
+
+### 4. Match to Session Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a idea you are drafting **directly answers** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the idea.
+
+An idea "directly answers" a session Open Question when the question was explicitly raised in the session and this idea proposes a concrete direction that would resolve it. The idea's own `## Open Questions` section (unresolved uncertainties about the idea itself) is independent — do not conflate it with session Open Questions. Do **not** stretch to match — if the idea merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing core idea / rationale / approach merged with new refinement, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the idea.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+### Idea Draft
+
+```markdown
+---DRAFT---
+title: {compelling title}
+collection: sessions/ideas
+type: plan
+tags: [session, codex, idea, project:{project name}, topic:{t1}, topic:{t2}, ..., {optional category tag}]
+project: {project name}
+status: active
+summary: {One sentence capturing the core idea}
+category: {architecture|product|workflow|exploration}
+impact: {high|medium|low}
+effort: {small|medium|large}
+confidence: {high|medium|low}
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this idea directly answers one, else null}
+
+# {Compelling Title}
+
+> **Inspiration:** {What moment in the session triggered this idea — cite specific files, patterns, or workarounds}
+
+## Problem
+
+{Reproducible observation from the session. What was harder than it should be, how often did it recur, who is affected. Use concrete evidence — file names, repetition counts, workaround descriptions.}
+
+## Proposal
+
+{Design-level solution. What changes in the code, architecture, or flow — specific enough that someone could begin an implementation sketch.}
+
+## System Architecture
+
+{Omit for small local changes. When the idea spans multiple components, show how they fit: a compact diagram (mermaid / ASCII) or a labeled bullet list of components and data flows.}
+
+## Expected Impact
+
+{First line is the rationale for the `impact` frontmatter value. Then: who benefits, how much, and by what measure. Prefer quantifiable statements ("turns N retries per sync into 0") over qualitative ones.}
+
+## Effort & Risks
+
+{Rough implementation surface (affected modules / files at directory granularity), top 1–3 risks, and any assumption that could invalidate the Proposal.}
+
+## Success Criteria
+
+{Observable or measurable signals that the idea is working after it ships. Each criterion should be checkable without rerunning the original session.}
+
+## Open Questions
+
+- {Key uncertainty or decision that would shape the direction}
+- {Technical feasibility question}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Idea captured from session:{session_id}. | For append: Idea refined in session:{session_id}. {what changed}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Idea captured from session:..."). For `disposition: append`, describe how the idea was refined, extended, or narrowed in this session.
+
+**Section omission rules**: `Problem` / `Proposal` / `Expected Impact` / `Effort & Risks` / `Success Criteria` are always present. `System Architecture` is optional (include for multi-component ideas, omit for small local changes). `Open Questions` is omitted when no unresolved uncertainties remain.
+
+Separate multiple ideas with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Quality over quantity — one well-developed idea beats five half-baked ones
+- Ideas should be genuinely creative, not just restatements of what was done
+- The required sections (Problem, Proposal, Expected Impact, Effort & Risks, Success Criteria) must be concrete enough to judge whether the idea is worth pursuing — not just describe what it is
+- Don't force ideas — if the session was routine with no creative sparks, that's fine
+- Think about ideas that compound — small improvements that unlock larger possibilities
+- Be honest with the `impact` assessment. Marking a genuinely low-impact idea as `medium` to preserve it wastes the main agent's context
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the idea** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Idea Categories
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| architecture | Structural improvements to code or systems | "Event-driven pipeline instead of polling" |
+| product | New features or products inspired by the work | "Self-healing config that detects and fixes drift" |
+| workflow | Better workflows or automation within the project | "Auto-generate migration scripts from schema diff" |
+| exploration | Interesting technical directions worth investigating | "Could this pattern work with WebAssembly?" |
+
+## Edge Cases
+
+- **No creative sparks**: Return `No idea notes for this session.`
+- **Too many ideas**: Pick the 1–2 most promising and develop them well
+- **Underdeveloped idea**: If you cannot fill Problem, Proposal, Expected Impact, Effort & Risks, and Success Criteria concretely, the idea isn't ready — either develop it further or skip it
+- **Low impact**: If your honest assessment is `impact: low`, silent-drop the idea (do not emit a draft or a skipped block)

--- a/plugins/codex/akb-sessions/support/agents/task-drafter.md
+++ b/plugins/codex/akb-sessions/support/agents/task-drafter.md
@@ -1,0 +1,184 @@
+---
+name: task-drafter
+description: Identify incomplete work, follow-up tasks, and action items from a session. Produces standalone task drafts.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# Task Drafter
+
+Extract actionable follow-up tasks from the session. The goal is seamless session continuity — when you start the next session, you should know exactly what to pick up.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — deferral decisions live there, not in the headline. Read the JSONL directly using file or grep tools.
+
+### How to use the JSONL
+
+- Search for explicit deferral language: "later", "next time", "skip for now", "not now", "out of scope", "backlog"
+- Look for work that was started but intentionally stopped partway
+- Focus on user messages where a decision to postpone was made
+- Do NOT treat simple mentions of TODO/FIXME in code, routine operations, or casual observations as deferrals
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a deferred-work, but do not extract deferred-works from them.
+- Deferred-works from the original session were already captured in the prior ingest.
+- If the new portion contains no deferred-work signals, return `No task notes for this session.`
+
+## Process
+
+### 1. Check What Was Already Documented
+
+Before identifying tasks, check what the session already produced. Use the committed and uncommitted change lists from the session context to identify files created or modified during the session. For any new documentation, task, or planning files, inspect their contents — these represent work that does NOT need a new task draft.
+
+### 2. Identify Intentionally Deferred Work
+
+The defining signal is **intent to defer** — someone recognized work that could be done and explicitly chose to postpone it.
+
+**Counts as a deferral**: explicit postponement ("let's do this next time", "not in scope for now"), scope-excluded work (bugs intentionally left unfixed, features deliberately not started), incomplete implementations stopped partway by decision.
+
+**Does NOT count**: session workflow (commit, push, ingest, CI — routine ops); observations without intent ("this code is messy" — noticing ≠ deferring); work completed in the session; items already captured in files created/modified; existing TODO/FIXME in code; natural next steps that weren't discussed; agent-discovered problems the user didn't engage with; agent suggestions the user did not acknowledge; work that simply ran out of time (running out of time ≠ a conscious decision to postpone).
+
+A valid task requires the **user's explicit words** indicating deferral. If you cannot point to a specific user message where the deferral decision was made, do not create the task.
+
+### 3. Prioritize
+
+Assign each task a priority:
+
+| Priority | Criteria | Examples |
+|----------|----------|---------|
+| P0 | Blocks other work or poses risk | Broken test, security issue, data integrity |
+| P1 | Should do next session | Core feature incomplete, significant tech debt |
+| P2 | Should do soon | Code quality, minor improvements |
+| P3 | Nice to have | Future enhancements |
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a task you are drafting **directly resolves** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the task.
+
+A task "directly resolves" an Open Question when the question was explicitly raised in the session and the task's Next Action addresses it head-on. Do **not** stretch to match — if the task merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Format Output
+
+Produce standalone task drafts for each actionable item.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing context/steps/related files merged with new information, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the task.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+```markdown
+---DRAFT---
+title: {descriptive title}
+collection: sessions/tasks
+type: task
+tags: [session, codex, task, project:{project name}, {topic tag}]
+project: {project name}
+summary: {One sentence describing what needs to be done}
+priority: {P0|P1|P2|P3}
+status: active
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this task directly resolves one, else null}
+
+# {Descriptive Title}
+
+> **Next Action:** {The specific first step to resume this work}
+
+## Context
+
+{Why this task exists and relevant background}
+
+## Steps
+
+- [ ] {Concrete step 1}
+- [ ] {Concrete step 2}
+- [ ] {Concrete step 3}
+
+## Related Files
+
+- `{path/to/file1}` — {why it's relevant}
+- `{path/to/file2}` — {why it's relevant}
+
+## Notes
+
+{Any additional context, constraints, or caveats}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Task created from session:{session_id}. | For append: Task updated in session:{session_id}. {what changed}.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Task created from session:..."). For `disposition: append`, describe what this ingest changed (new steps, refined context, priority change). Task resolution events are appended later by the ingest skill, not by the drafter.
+
+Separate multiple task drafts with `---NEXT_NOTE---`.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Every task should have a clear "next action" — vague tasks don't get done
+- Include enough context that someone can pick up the task without re-reading the entire session
+- File paths and function names make tasks actionable
+- Prefer fewer, well-scoped tasks over many granular ones
+- **External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+## Edge Cases
+
+- **No follow-ups**: Return `No task notes for this session.`
+- **Everything complete**: Acknowledge completion, suggest only verification tasks if any
+- **Too many tasks**: Focus on P0 and P1; group P2/P3 into a single "backlog" draft

--- a/plugins/codex/akb-sessions/support/agents/til-drafter.md
+++ b/plugins/codex/akb-sessions/support/agents/til-drafter.md
@@ -1,0 +1,211 @@
+---
+name: til-drafter
+description: Extract learnings, discoveries, and mistakes from a session and compose TIL drafts. Each distinct learning becomes its own draft.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# TIL Drafter
+
+Identify valuable lessons from the session and turn each into a standalone learning draft. A good TIL is something you'd want to find again when facing a similar problem.
+
+Your role is to compose and return drafts — never write, update, or delete anything in the vault directly.
+
+## Input
+
+You receive:
+1. **Session Context** — a lightweight roadmap of the session (project, topics, git changes, decisions, **Open Questions list with Q IDs**)
+2. **Session Headline** — frontmatter + `> **Summary:**` line + numbered `## Open Questions` (no Narrative)
+3. **JSONL path** — path to the session JSONL file containing the complete conversation history
+
+The JSONL is your primary source — read it directly using file or grep tools. The session headline gives you orientation and the Q IDs you may match via `resolves_question`.
+
+### How to use the JSONL
+
+- Search for moments where the user's understanding visibly shifted — surprise, corrected expectations, or new connections
+- Focus on user reactions to information, not just user questions — a question can be rhetorical or directive
+- Look for patterns like: "I didn't know", "that's unexpected", "so it actually works like..." — but verify the user genuinely learned something new, not just directed the agent
+
+### Update Mode
+
+Check the session context for `Ingest mode: update`. If present:
+
+- **Only analyze JSONL entries after the timestamp in `JSONL analysis start`**. Earlier entries belong to a previous ingest and have already been processed.
+- You may skim earlier entries for context if needed to understand a learning, but do not extract learnings from them.
+- Learnings from the original session were already captured in the prior ingest.
+- If the new portion contains no learning signals, return `No learning notes for this session.`
+
+## Process
+
+### 1. Scan for Learning Signals
+
+A TIL captures a moment where **the user gained valuable knowledge** — either an existing understanding was corrected, or they acquired new knowledge they didn't have before.
+
+#### Category A: Mental Model Shift
+
+The user believed or assumed one thing, the session revealed something different. Subtypes: **assumption corrected** (expected X, discovered Y), **genuinely surprising information** (a tool, API, or behavior they hadn't seen, with expressed surprise), **previously separate knowledge connected** (two things they knew independently turned out to be related).
+
+Signals: expressions of surprise, corrected expectations ("I thought X but it's actually Y"), recognition of something as genuinely new ("I didn't know that").
+
+#### Category B: Knowledge Acquisition
+
+The user entered without knowledge and systematically built understanding through the conversation. Unlike Category A, the signal is not surprise but **demonstrated knowledge gap followed by engagement**:
+
+- **Exploratory Q&A** — explicitly stated unfamiliarity ("I don't know much about X") followed by deepening questions that progress from general to specific. The question sequence itself is the learning signal.
+- **Information consumption** — received substantive new information (news, research, tool/technology discovery) and engaged with it (positive evaluation, follow-up questions, acting on it). Information must be novel and worth recording.
+- **Multi-source investigation** — a complex question requiring synthesis across docs/code/web (not a simple lookup); the synthesized answer represents knowledge the user didn't have and engaged with meaningfully.
+- **Technical comparison or analysis** — A vs B, pros/cons, tradeoff analysis where the user evaluated and formed a judgment (not just received a list); captures reasoning behind a choice, not just the choice.
+- **Troubleshooting root cause analysis** — non-obvious root cause traced through systematic investigation. The "aha" moment of identification + verification is the learning; captures diagnostic patterns reusable when similar symptoms appear.
+
+**Not a learning signal**: directing the agent through a task the user already understands (applying existing knowledge); facts the agent discovered that the user didn't engage with (unread output ≠ learning); routine status/errors processed mechanically; pure flow markers ("ok", "got it") without topical engagement.
+
+**Directive vs learning questions**: if the user is telling the agent what to investigate (they know what to look for), that's directive. If they're asking to understand something they don't know (building a mental model), that's learning. Same syntax, different intent — context decides.
+
+### 2. Classify `til_kind`
+
+Every TIL gets **exactly one** `til_kind` tag chosen from this table:
+
+| `til_kind` | When to use |
+|------------|-------------|
+| `til_kind:shift` | Category A — mental model correction (user expected X, learned Y) |
+| `til_kind:acquisition` | Category B exploratory Q&A or information consumption — user entered without knowledge and built it |
+| `til_kind:comparison` | Category B technical comparison/analysis (A vs B, tradeoffs) that the user evaluated |
+| `til_kind:troubleshooting` | Category B troubleshooting root cause analysis — non-obvious cause traced |
+
+The classification drives the external maintenance layer's consolidation behavior (different lattice dimensions per kind). If a TIL straddles two kinds, use this priority order as a deterministic tie-breaker: `troubleshooting > comparison > shift > acquisition`. The higher-priority kind wins.
+
+For `til_kind:comparison`, optionally include a `## Comparison` table section in the body. For `til_kind:troubleshooting`, optionally include a `## Root Cause` section describing the diagnostic path. These are additional sections that supplement the standard template.
+
+### 3. Filter by Value
+
+**Worth a note**: would save >10 min if re-encountered; non-intuitive behavior; reusable cross-project pattern; contradicts common assumptions; substantive system/tool/domain knowledge worth referencing later (B); news/developments with actionable implications (B).
+
+**Skip**: trivial syntax reminders; project-specific config already in code; things easily found in official docs; surface-level info gettable from one web search (B).
+
+**Category B consolidation** — for broad topic exploration via multiple questions, prefer **one consolidated TIL** capturing key insights, not one TIL per question. Group news/information thematically.
+
+### 4. Match to Open Questions (optional)
+
+If the session context lists `Open Questions` with IDs (Q1, Q2, ...), check whether a TIL you are drafting **directly answers** one of those questions. If so, record the Q ID in the draft's `resolves_question` field. Phase 4-0 of the ingest skill uses this to replace the session's Open Question bullet with a link to the TIL.
+
+A TIL "directly answers" an Open Question when the user explicitly asked the question in the session and your TIL's Key Insight is the answer. Do **not** stretch to match — if the TIL merely overlaps topically, leave `resolves_question` unset.
+
+**Q ID format**: exact regex `^Q\d+$` (e.g. `Q1`, `Q12`). No whitespace, no quotes, no lowercase. Non-conforming values are treated as no-match by Phase 4-0.
+
+### 5. Compose Each Draft
+
+Each learning gets its own draft.
+
+### 6. Validate Against Vault
+
+After composing drafts, check each one against the AKB vault before returning.
+
+For each draft:
+
+```text
+mcp__akb__akb_search(
+  query="{draft title + key terms}",
+  vault="{vault_name from session context}",
+  collection="{draft collection}",
+  limit=5
+)
+```
+
+**Determine disposition** — for each search result with relevance > 0.8:
+- If the search result already provides a `summary` and tags adequate to judge overlap, skip `akb_get` and decide from the search payload
+- Otherwise read the existing document: `mcp__akb__akb_get(vault, doc_id)` and compare content overlap
+- Decide:
+  - **skip**: Content already exists (>80% overlap). Do not include this draft — report the skip instead.
+  - **append**: Same topic but new content adds value. Include draft with `disposition: append` and `append_target: {existing_doc_id}`. The draft body should express the **combined** compiled truth (existing content merged with new insights, conflicts resolved in favor of the newer understanding). The ingest skill will read the existing doc, adopt your merged compiled truth, and prepend a new timeline entry — so write the draft body as if it were the new canonical state of the TIL.
+  - **create**: Sufficiently unique. Include draft with `disposition: create`.
+
+If no result has relevance > 0.8: `disposition: create`.
+
+When in doubt between create and append, prefer create.
+
+**Collect related documents** — from the same search results, collect matches with relevance >= 0.7 as `related_to` candidates. Include if the topic genuinely connects to the draft, exclude if the keyword match is superficial. Documents already marked as skip or append targets are excluded. Render each candidate as a full `akb://{vault_name}/doc/{path}` URI (always-URI cross-ref convention) — `path` is provided by the `akb_search` payload alongside `doc_id`.
+
+**Update mode** — matches against notes from the same `session:{session_id}` created in a prior ingest are expected. Only skip if content is truly redundant, not merely because it shares session origin. Prior ingest notes are strong `related_to` candidates.
+
+If `akb_search` fails or is unavailable, skip validation and set all drafts to `disposition: create` with empty `related_to`.
+
+## Output Format
+
+For each learning, produce:
+
+```markdown
+---DRAFT---
+title: {Concise learning title}
+collection: sessions/learnings
+type: reference
+tags: [session, codex, learning, project:{project name}, til_kind:{shift|acquisition|comparison|troubleshooting|interop|implementation|architecture|constraint|pattern|testing|knowledge|application|process}, topic:{t1}, topic:{t2}, ..., {optional technology or domain tag}]
+project: {project name}
+status: active
+summary: {One sentence capturing the essential lesson}
+disposition: {create|append}
+append_target: {doc_id, only if disposition is append}
+related_to: ["akb://{vault_name}/doc/{path_1}", "akb://{vault_name}/doc/{path_2}"]
+resolves_question: {Q{n} from session Open Questions if this TIL directly answers one, else null}
+
+# {Concise Learning Title}
+
+> **Key Insight:** {One sentence that captures the essential lesson}
+
+## Context
+
+{When and why this came up — what problem were you solving?}
+
+## What I Learned
+
+{Technical explanation with enough detail to be actionable}
+
+```{language}
+{Code example demonstrating the concept}
+```
+
+## Gotchas
+
+- {Pitfall or edge case to watch for}
+
+---
+
+## Timeline
+
+- **{today YYYY-MM-DD}** | {Captured from session:{session_id}. One-line summary. | For append: Appended from session:{session_id}. What was added/changed.} [Source: session:{session_id}, {today YYYY-MM-DD}]
+---END_DRAFT---
+```
+
+**Optional sections by `til_kind`:**
+
+- `til_kind:comparison` may add `## Comparison` (table format) between `## What I Learned` and `## Gotchas`
+- `til_kind:troubleshooting` may add `## Root Cause` (diagnostic path description) between `## Context` and `## What I Learned`
+
+Every draft body **must** include the `---` separator and a `## Timeline` section. For `disposition: create`, the timeline has one initial entry ("Captured from session:..."). For `disposition: append`, the timeline entry describes what this ingest is adding — the ingest skill will merge this single new entry into the existing note's timeline (keeping past entries intact, newest first).
+
+**External URLs**: link inline where mentioned in the body. Do **not** add a separate `## Sources` section — the session note's `## Artifacts > External sources` is the canonical bibliography (see `note-templates.md` → "External URLs").
+
+If there are multiple learnings, separate them with `---NEXT_NOTE---` on its own line.
+
+For skipped drafts (duplicates), report briefly instead of including the full draft:
+
+```markdown
+---SKIPPED---
+title: {title}
+reason: {e.g., "85% overlap with doc_id 'xxx'"}
+---END_SKIPPED---
+```
+
+## Guidelines
+
+- Write titles as statements, not questions
+- The Key Insight should be self-contained and scannable
+- Code examples should be real, from the session — not hypothetical
+- Each draft should be independently useful — don't assume the reader has context from other notes
+- **`til_kind` is required**: every draft must carry exactly one `til_kind:*` tag (the external maintenance layer uses this only as a synthesis-style hint within a topic section, never as a section axis)
+- **`topic:*` tags are required**: every draft must carry 1–3 `topic:*` tags derived from the body content, in kebab-case. These power the external maintenance layer's within-cell topic grouping. Choose tags that capture the **subject of the note** (e.g. `topic:cross-vault-uri`, `topic:retrieval`), not the operational mode
+
+## Edge Cases
+
+- **No learnings**: Return `No learning notes for this session.`
+- **Many small learnings**: Group closely related ones into a single draft rather than creating five tiny ones
+- **Partial understanding**: Note what's still unclear — partial knowledge is still worth capturing

--- a/plugins/codex/akb-wiki/.codex-plugin/plugin.json
+++ b/plugins/codex/akb-wiki/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "akb-wiki",
+  "version": "0.21.1",
+  "description": "LLM-wiki layer for AKB vaults — unified document ingest (any source) and hybrid search.",
+  "author": {
+    "name": "jylkim",
+    "url": "https://github.com/jylkim"
+  },
+  "homepage": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "repository": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+  "license": "MIT",
+  "keywords": [
+    "akb",
+    "llm-wiki",
+    "ingest",
+    "search",
+    "git",
+    "atlassian"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "AKB Wiki",
+    "shortDescription": "LLM-wiki ingest and search layer for AKB vaults.",
+    "longDescription": "Runs any AKB vault as an LLM-wiki. Combines a read-only question-answering\nsurface (`/akb-query`: multi-strategy search, cited synthesis, a time-axis\nfreshness check) and a single unified ingest entry point:\n`/akb-ingest` takes whatever you point at — a local file, a web URL, a GitHub\nPR / release / commit, a Confluence page, or a Jira issue — classifies the\nsource type, and dispatches to a specialized ingest subagent. Document-style\nsources become five-section LLM-wiki summary pages (optionally preserving the\noriginal bytes); decision-record sources (PRs, releases, commits, issues)\nbecome faithful mechanical episodic records. The router fetches nothing\nitself; each subagent owns exactly one fetch path. Cross-source consolidation,\nlint, and dream-cycle maintenance are handled by an external maintenance layer\nthat runs over the same AKB vault, not by this skillpack.\n",
+    "developerName": "jylkim",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/younglo-kim_dnotitia/akb-skillpack",
+    "defaultPrompt": [
+      "Ingest this PDF into my vault.",
+      "Ingest this GitHub PR into my vault.",
+      "Ask my vault about this topic."
+    ],
+    "brandColor": "#2F4858"
+  }
+}

--- a/plugins/codex/akb-wiki/.mcp.json
+++ b/plugins/codex/akb-wiki/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "akb": {
+      "command": "npx",
+      "args": [
+        "akb-mcp",
+        "--insecure"
+      ],
+      "env_vars": [
+        "AKB_MCP_URL",
+        "AKB_PAT"
+      ],
+      "default_tools_approval_mode": "approve"
+    }
+  }
+}

--- a/plugins/codex/akb-wiki/skills/akb-ingest/SKILL.md
+++ b/plugins/codex/akb-wiki/skills/akb-ingest/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: akb-ingest
+description: Ingest whatever you point at into an AKB vault — a local file, a web URL, a GitHub PR/release/commit, a Confluence page, or a Jira issue. Auto-detects the source type and dispatches to a specialized ingest subagent; the router fetches and writes nothing itself. One target per invocation; globs expand to a sequential loop of document ingests.
+---
+
+# AKB Ingest
+
+Ingest **one target** into the target AKB vault. Point at a local file, a web URL, a GitHub PR / release / commit, a Confluence page, or a Jira issue — this skill classifies the source type and dispatches to a specialized ingest subagent. It is the single ingest entry point of the `akb-wiki` plugin.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. This is a **router**: it classifies a target and delegates the actual fetch + write to one subagent. Document-style sources pay down **intent debt** (and substrate health) as five-section synthesis pages; decision-record sources (PR / release / commit / issue) pay down **intent debt** as faithful mechanical episodic records. The archetype split (synthesis vs mechanical) is a dispatch decision, invisible to the caller.
+
+Scope boundaries:
+
+- **One target per invocation.** A glob pattern is the only fan-out: it expands into a sequential loop of `ingest-doc` runs, one per matched file.
+- **The router fetches nothing and writes nothing.** It only classifies, validates flags, dispatches one subagent, and relays the subagent's report. Each subagent owns exactly one fetch path (file/URL read, `git`, `gh`, or the Atlassian MCP server) — there is no pre-fetched-payload escape hatch at any layer.
+- **No cross-source wiring at ingest.** Consolidation into concept pages and cross-reference across sources are handled by an external maintenance layer (dream-cycle) over the same vault, not here.
+
+## Arguments
+
+```text
+/akb-ingest <target> --vault {vault_name} [--repo {path}] [--prev-tag {tag}] [--lang {language}] [--project {name}] [--raw | --no-raw]
+```
+
+- `<target>` (required, positional) — what to ingest. A local path (absolute, `./…`, `~/…`, or a glob), an `http(s)://` URL, a bare git commit SHA, or a Jira issue key (e.g. `SDDEV-360`).
+- `--vault` (required) — target AKB vault name; forwarded to every subagent.
+- `--repo {path}` (optional) — local git clone path for commit / PR / release targets. Defaults to the current working directory.
+- `--prev-tag {tag}` (optional) — previous release tag; release targets only.
+- `--lang {language}` (optional) — language for synthesized note bodies; document and Confluence targets only.
+- `--project {name}` (optional) — project-rollup namespace; Confluence and Jira targets only.
+- `--raw` / `--no-raw` (optional) — override raw-byte preservation; document targets only.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- The fetch path of the **classified** source must be available: `WebFetch` for URLs, `git`/`gh` for GitHub targets, an attached Atlassian MCP server for Confluence/Jira targets. The router requires only the path matching the target it classifies — a missing Atlassian MCP server never blocks a local-file ingest.
+
+## Workflow
+
+### Step 1 — Parse
+
+Parse `--vault` from arguments. Hard-fail if missing: `--vault {name} required.` Capture `<target>` and any supplied flags. Fail with `Missing required argument: <target>` when no positional target is given.
+
+### Step 2 — Classify the target
+
+Determine the source type and the subagent to dispatch. Apply the rules top to bottom; the first match wins.
+
+| Target shape | `<chosen-agent>` | Forwarded flags |
+|---|---|---|
+| Local path that exists, or a glob pattern (`*`, `?`, `[`) | `ingest-doc` | `--lang`, `--raw`/`--no-raw` |
+| `https?://…/…/pull/<n>` on `github.com` | `ingest-pr` | `--repo` |
+| `https?://…/…/releases/tag/<tag>` on `github.com` | `ingest-release` | `--repo`, `--prev-tag` |
+| `https?://…/…/commit/<sha>` on `github.com` | `ingest-commit` | `--repo` |
+| `https?://<host>.atlassian.net/wiki/…` | `ingest-confluence` | `--lang`, `--project` |
+| `https?://<host>.atlassian.net/browse/<KEY>` | `ingest-jira` | `--project` |
+| Any other `http(s)://` URL | `ingest-doc` | `--lang`, `--raw`/`--no-raw` |
+| Bare hex string 7–40 chars, confirmed a commit via `git -C {repo} cat-file -t {target}` → `commit` | `ingest-commit` | `--repo` |
+| Matches `^[A-Z][A-Z0-9_]+-\d+$` (Jira key) | `ingest-jira` | `--project` |
+| A name that resolves to a git tag (`git -C {repo} rev-parse --verify {target}`) and `--repo`/cwd is a repo | `ingest-release` | `--repo`, `--prev-tag` |
+
+**Resolve the target before dispatch.** Each subagent expects a *bare* identifier, not a URL. When a GitHub or Jira **URL** matched, set `resolved_target` to the identifier captured from the path — do not forward the raw URL:
+
+- `…/pull/<n>` → `<n>` (the PR number)
+- `…/releases/tag/<tag>` → `<tag>`
+- `…/commit/<sha>` → `<sha>`
+- `…/browse/<KEY>` → `<KEY>` (the Jira issue key)
+
+For a GitHub URL the local clone still comes from `--repo` (or cwd), **not** the URL — only the number / tag / SHA is taken from the URL. Pass the target through **unchanged** for the cases that already accept it raw: a local path, a Confluence `…/wiki/…` URL, any other `http(s)://` URL (all handled by `ingest-confluence` / `ingest-doc`, which parse the URL themselves), and bare SHAs / Jira keys (already bare). `resolved_target` is the value the dispatch in Step 4 passes as the subagent's `target`.
+
+Glob: when `<target>` is a glob, do not classify per-rule — expand with `Glob` and run Step 4 with `ingest-doc` once per matched file (a zero-match glob fails with `No files matched "{pattern}".`).
+
+**Ambiguity.** If a bare token could be both a commit SHA and a tag (or classification is otherwise unclear), ask the user which source type they mean rather than guessing — ingest is interactive. Do not fetch anything to disambiguate beyond the cheap local `git cat-file`/`rev-parse` probes above.
+
+### Step 3 — Validate flags
+
+Keep only the flags listed for the classified type in Step 2. If the caller supplied a flag that does not apply (e.g. `--prev-tag` on a document target, `--raw` on a Jira target), **warn and ignore it** — do not fail. `--vault` is always forwarded.
+
+### Step 4 — Dispatch
+
+Launch **one** subagent with `fork_context: false` — the one the classification selected (`<chosen-agent>` ∈ `ingest-doc / ingest-confluence / ingest-commit / ingest-pr / ingest-release / ingest-jira`). Open its prompt file and use the contents as the worker prompt, with model `gpt-5.4-mini` and reasoning effort `medium`:
+
+- `./support/agents/<chosen-agent>.md`
+
+Prepend an `[Ingest Context]` block instructing the worker to treat the resolved target, `--vault {vault_name}`, and any forwarded flags as its positional + named arguments. The worker owns the fetch path and the AKB write; the router fetches and writes nothing. Relay the worker's status report block unchanged.
+
+
+### Step 5 — Report
+
+Relay the subagent's status report block to the user unchanged. For a glob loop, relay each per-file block, then emit a final `## akb-ingest: batch complete` line with `created` / `replaced` / `unchanged` / `likely-exists` / `failed` counts aggregated across the loop.
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<target>` missing | `Missing required argument: <target>` |
+| `--vault` not passed | `--vault {name} required.` |
+| Glob matched zero files | `No files matched "{pattern}".` |
+| Target cannot be classified | `Could not classify target "{target}". Pass a local path, URL, commit SHA, or Jira key.` |
+| Ambiguous target | Ask the user which source type they mean; do not guess. |
+| Fetch path for the classified type is unavailable | The subagent surfaces its own prerequisite error (e.g. `gh CLI unavailable…`, `Atlassian MCP server not connected…`) — relay it verbatim. |
+
+The router does not create vaults or collections and does not touch AKB directly; vault/collection and write errors surface from the dispatched subagent and are relayed as-is.

--- a/plugins/codex/akb-wiki/skills/akb-query/SKILL.md
+++ b/plugins/codex/akb-wiki/skills/akb-query/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: akb-query
+description: Answer a question from the AKB vault — decompose, search (hybrid / graph), ground in compiled-truth-over-timeline precedence, and synthesize a cited answer with gap/conflict/stale flags. Read-only.
+---
+
+# AKB Query
+
+Answer **one question** from the target AKB vault. Decompose the question, search the vault with the strategy that fits, ground the answer in the documents found — honoring AKB's compiled-truth-over-timeline precedence — and synthesize a cited answer. Brain-first: the vault is the source of truth, not the model's prior knowledge.
+
+**Workflow classification.** LLM-wiki **Query** workflow — the **read** half only (à la gbrain's `query`, `mutating: false`). This skill **never writes**: no `akb_put` / `akb_update`, no promote-to-page. Promoting valuable answers into new pages, consolidation, and dream-cycle maintenance are the external maintenance layer's job over the same vault, not this skill's.
+
+Scope boundaries:
+
+- **Read-only.** Every tool call reads. The skill answers from vault content and cites it; it does not modify the vault. (It deliberately does **not** use `akb_grep` — that verb's `replace=` mode rewrites matching documents, so it is not read-only; exact-term lookup goes through `akb_search`, whose hybrid index already includes a keyword/BM25 component.)
+- **Brain-first, grounded.** Answer from the vault, never from general knowledge when the vault has relevant content. If the vault lacks the answer, say so — do not fill the gap with a guess.
+- **Citations are document-scoped.** AKB exposes provenance at the document level, not per claim, so a claim cites `[doc-uri, section]` — not a sentence-level source.
+
+## Arguments
+
+```text
+/akb-query {question} --vault {vault_name} [--collection {path}] [--type {type}] [--since DATE] [--period D1~D2]
+```
+
+- `{question}` (required, positional) — a natural-language question. Phrase it as you would ask a person; hybrid search rewards natural phrasing over keyword soup.
+- `--vault` (required) — target AKB vault name.
+- `--collection {path}` (optional) — scope the search to one collection when the question clearly belongs to it.
+- `--type {type}` (optional) — scope to a document type (`decision`, `reference`, `task`, …) when the question implies one.
+- `--since DATE` (optional, ISO `YYYY-MM-DD`) — add a freshness axis: cross-check hits against recent vault activity and flag stale ones; surface relevant recent changes.
+- `--period D1~D2` (optional, ISO dates) — same as `--since` but bounded to the inclusive range. If both are given, `--period` wins.
+
+If neither `--since` nor `--period` is provided, the freshness axis is skipped entirely.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+## Workflow
+
+### Phase 1 — Decompose
+
+Parse `--vault`. Hard-fail if missing: `--vault {name} required.` Capture `{question}` and optional flags.
+
+Classify the question into one or more search strategies — a single question may need several:
+
+| Question shape | Strategy | Verb |
+|---|---|---|
+| Conceptual / open-ended ("how does…", "tell me about…", "why…") **or** exact terms (names, versions, IDs, error strings, code) | hybrid | `akb_search` |
+| Relational ("what depends on X", "what implements Y", "how is A connected to B") | graph | `akb_relations` / `akb_graph` |
+
+Pick the minimum set that covers the question. Most questions are hybrid — `akb_search` is vector + keyword/BM25, so it handles both conceptual phrasing and exact tokens; pass the exact token as the query when the question pins one. Reach for graph only when the question asks about links between documents.
+
+### Phase 2 — Search
+
+Issue every selected strategy in a **single parallel tool-use block** — they are independent. Run only the strategies Phase 1 chose. **Exception:** when the relational strategy is selected but no anchor URI is known yet, that strategy is *not* independent — run the hybrid search first to find the anchor, then issue `akb_relations` / `akb_graph` in a follow-up block. Never call them with a guessed URI.
+
+- **Hybrid** — `akb_search(query="{question}", vault="{vault_name}", limit=10)`. For an exact token, pass the token itself as the query — the hybrid index matches it on the keyword/BM25 side. Add `collection=` / `type=` from the flags or when the question clearly implies one. Add `tags=[…]` only if the question names specific tags.
+- **Relational** — when an anchor document is known, `akb_relations(uri="{anchor_uri}", direction=…, type=…)` for direction- and type-filtered edges (single-hop). For a multi-hop neighborhood, `akb_graph(uri="{anchor_uri}", depth=…)` (BFS; no direction filter — it returns all edges at each level). If the anchor is not yet known, find it with a hybrid search first.
+- **Freshness (conditional)** — only when `--since` / `--period` was given: `akb_activity(vault="{vault_name}", since="{start_date}", limit=20)`. For `--period D1~D2`, pass `since=D1` and drop entries after `D2` in Phase 3.
+
+Dedup the combined hits by document URI before Phase 3.
+
+### Phase 3 — Ground with source precedence
+
+For the top 3–5 deduped hits, read enough to answer — cheapest read first:
+
+1. `akb_drill_down(uri="{uri}", mode="outline")` to see the document's structure.
+2. Read the **compiled-truth (top) sections first** via `akb_drill_down(uri, section="…")` — that is the document's current best understanding. Treat the **timeline (bottom) section** as supporting evidence, not the headline.
+3. `akb_get(uri)` only when you need the full document.
+4. `akb_provenance(uri)` when the question is about authorship or recency ("who decided…", "when was…") — document-level who/when.
+
+**Source precedence when documents conflict** (highest authority first):
+
+1. The user's direct statements in this conversation.
+2. Compiled truth (top of a document).
+3. Timeline entries (bottom of a document).
+4. External / general knowledge (lowest — and only when the vault is silent).
+
+**Staleness** — if a freshness axis was requested, cross-check each hit against `akb_activity`: mark a hit `[stale]` when it has not changed within the window, and drop activity entries past a `--period` upper bound.
+
+### Phase 4 — Synthesize & answer
+
+Write a direct answer to the question, grounded in what Phase 3 read:
+
+- **Cite every claim** as `[doc-uri, section]`. When a claim rests on several documents, cite all of them.
+- **Conflicts** — when sources disagree, present both with their citations and name the contradiction. Never silently pick one.
+- **Gaps** — if the vault does not answer the question, say so plainly (`vault "{vault_name}"에 X에 대한 정보가 없습니다`) instead of answering from general knowledge. Offer to broaden the search or browse the vault.
+- **Staleness** — surface `[stale]` markers next to claims drawn from stale documents.
+
+Response shape:
+
+```markdown
+## {question}
+
+{Direct answer in prose, with inline citations: "According to [research/vector-index, compiled truth], …"}
+
+{If sources conflict: a short "Conflicting sources" note citing both.}
+
+{If a freshness axis was requested and recent changes are relevant:}
+### Recent changes ({period label})
+- [{doc_uri}] {title} — updated {updated_at}
+
+{If the vault is silent on part of the question:}
+### Gaps
+- The vault has no information on {X}.
+
+---
+*{N} documents consulted in vault "{vault_name}"*
+```
+
+Render `{period label}` as `since YYYY-MM-DD` or `YYYY-MM-DD~YYYY-MM-DD`.
+
+## Error Handling
+
+| Situation | Response |
+|---|---|
+| AKB MCP not accessible | `AKB MCP server not accessible. Check your MCP configuration.` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault not found | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| No hits across every strategy | Flag the gap explicitly, then offer to broaden terms, drop `--collection`/`--type`, or browse with `akb_browse`. |
+| Relational anchor URI unknown | Find the anchor with a hybrid search first; if none is found, answer from hybrid hits and note the missing anchor. |
+| `akb_activity` fails | Drop the freshness axis only; answer from the search hits and note the skipped staleness check. |
+| `--since` / `--period` value is not ISO | Ask the user to restate the date (`YYYY-MM-DD`) before running. |
+
+## Tips
+
+- Natural-language questions beat keyword strings — "why did we drop the per-plugin config" beats "config".
+- Compiled truth (top of a document) is the answer; the timeline (bottom) is the evidence. Lead with the former.
+- For relational questions, name the anchor document — graph traversal needs a starting URI.
+- Use `akb_browse` to explore vault structure when a search returns nothing and you are unsure what exists.
+- A temporal cue ("what changed since the release", "recent decisions") is what `--since` / `--period` is for — it adds the staleness axis hybrid search alone misses.

--- a/plugins/codex/akb-wiki/support/agents/ingest-commit.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-commit.md
@@ -1,0 +1,190 @@
+---
+name: ingest-commit
+description: Record a single git commit as an immutable git-commit document in an AKB vault — mechanical git metadata plus a faithful restatement of what the diff changed.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Git Commit Ingest
+
+Record a **single git commit** as an immutable `git-commit` document in the target AKB vault — the commit-level episodic capture path of `akb-wiki`.
+
+Scope boundaries:
+
+- **One commit per invocation.** No loops, cursor, or range — backfill / sweeping / batching live in an orchestration layer.
+- **No filtering policy.** Merge commits, bot authors, trivial commits are recorded as-is (marked in frontmatter); the caller decides what to skip.
+- **No semantic compilation.** PR / release pages are produced by sibling skills; consolidation pages by the external maintenance layer.
+- **Write-once.** Commit docs are never mutated here. The external maintenance layer may append timeline entries for consolidation membership; PR / release linkage lives on the parent's `depends_on` graph edge — no commit-side backlink frontmatter fields.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-commit <sha> --vault {vault_name} [--repo {path}]
+```
+
+- `<sha>` (required, positional) — full or short commit SHA to ingest.
+- `--vault` (required) — target AKB vault.
+- `--repo` (optional) — path to the git repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` is available on PATH.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Then validate the SHA: `git -C {repo_path} rev-parse --verify {sha}^{commit}`. Fail with `SHA not found in repository: {sha}` on error. Capture the resolved full SHA as `full_sha`. (This single `rev-parse` subsumes the repo-directory check above, so no separate `--git-dir` invocation is needed after it succeeds.)
+
+### Step 2 — Dedup check
+
+`akb_search(query={full_sha}, vault={vault_name}, collection=git-commits, type=reference, tags=["git", "kind:commit", "project:{repo_name}"], limit=5)`. Among hits, find the one whose frontmatter `sha` equals `full_sha`. If found, return without writing:
+
+```markdown
+## ingest-commit: exists
+- sha: {full_sha}
+- doc_id: {existing_doc_id}
+- vault: {vault_name}
+```
+
+### Step 3 — Collect git data in a single pass
+
+```bash
+git -C {repo_path} show \
+  --format='%H%x00%h%x00%P%x00%aN%x00%ae%x00%aI%x00%cN%x00%ce%x00%cI%x00%s%x00%b' \
+  --stat --unified=0 {full_sha}
+```
+
+`%aN` / `%cN` apply `.mailmap` automatically — no separate `git log` needed. Parse three zones:
+
+1. **Metadata line** (null-separated): `sha`, `short_sha`, `parents` (space-separated), `author_name` (mailmap-applied), `author_email` (raw), `authored_at`, `committer_name` (mailmap-applied), `committer_email` (raw), `committed_at`, `message_subject`, `message_body`.
+2. **Stat block**: extract `{files, additions, deletions}` from the summary line (e.g. `3 files changed, 47 insertions(+), 12 deletions(-)`); collect per-file stat lines for the body.
+3. **Diff block**: cap at `500` lines (set `truncated: true`); detect `Binary files ... differ` markers and record their paths.
+
+Derive `is_merge = (len(parents) > 1)`.
+
+### Step 4 — Resolve canonical author
+
+`author_name` from Step 3 is mailmap-normalized. Override with `data/plugins/akb-wiki.yaml` `author_aliases` keyed on the **raw** `author_email` if a non-empty entry exists; otherwise keep Step 3's value. `author_email` is never rewritten — preserved as the alias-lookup key.
+
+### Step 5 — Faithful restatement
+
+Produce two artifacts from the Step 3 diff. Use no context beyond commit message + diff + file list — never consult sibling commits, PR metadata, issue trackers, or external state.
+
+**5a. `summary` (frontmatter, 1 line)** — single-line factual description of what the diff changed. Imperative/neutral tone (not evaluative); describes **structure** (renames, adds, removes, moves), not **intent**; derived from the diff (when the message subject is vague — `fix stuff`, `wip`, `asdf` — or misleading, reconstruct from the diff). Omit author names, issue numbers, dates.
+
+Acceptable: `Rename AuthService to AuthManager across src/auth and tests/auth`, `Add SSOProvider class with login/logout/validate_token in src/auth/sso.py`. Forbidden (interpretation leaking in): `Improve auth module for better SSO support` (evaluative), `Part of the Q2 security refactor` (cross-commit context), `Fix the bug where users couldn't log in` (intent).
+
+**5b. `Changes (faithful)` block (body, bullet list)** — concrete bullets, each naming **what** and **where**. Group by file or change kind; spell out renames (`Rename X → Y`); name new symbols/sections and their locations on adds; name what was removed and its former location; describe dimensions on bulk edits (`Bump 4 dependency versions in package.json`); one line per binary (`Binary change in {path}`). On truncation, end with `Diff truncated at 500 lines; remaining changes not enumerated.`
+
+**5c. `diff_scope` (frontmatter, categorical list)** — rule-based labels from diff shape (not message). Pick any: `add` (net new file), `remove`, `rename`, `modify` (in-place edit), `config` (only top-level config/CI: `*.yaml`, `*.toml`, `Makefile`, `.github/**`), `docs` (only `*.md`, `docs/**`, comment-only), `test` (only `tests/**`, `spec/**`, `*_test.*`), `binary`. Multiple labels co-occur (e.g. `[modify, docs]`).
+
+**5d. Conventional commit parse** — match `message_subject` against `<type>(<scope>): <desc>` or `<type>: <desc>` with `type ∈ feat|fix|refactor|docs|test|chore|ci|build|perf|style`. Both `conv_type` / `conv_scope` are `null` on no match.
+
+**5e. Body-section scope tag** — `scope_tag = conv_scope or top_level_paths[0] or null`. Emitted as `scope:{scope_tag}` in Step 6 when non-null; the external maintenance layer consumes it directly without reading a `paths` frontmatter field.
+
+### Step 6 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"                # last path component of repo_path (normalized)
+project: "{repo_name}"             # mirrors repo; `repo` is the source-system identifier, `project` is the project-rollup namespace
+sha: "{full_sha}"
+short_sha: "{short_sha}"
+parents: [{parent_sha}, ...]
+
+committer: "{canonical_committer}"
+authored_at: "{authored_at_iso}"
+committed_at: "{committed_at_iso}"
+
+stats: { files: N, additions: N, deletions: N }
+is_merge: {true|false}
+truncated: {true|false}
+
+conv_type: "{feat|fix|...|null}"
+conv_scope: "{scope|null}"
+diff_scope: [{rule_based_labels}]
+
+summary: "{faithful_1_line}"
+message_subject: "{commit_message_first_line}"
+tags: ["git", "project:{repo_name}", "kind:commit", "scope:{scope_tag}", "type:{conv_type_if_any}", "author:{canonical_author}"]
+
+related_to: []
+```
+
+`scope:{scope_tag}` and `type:{conv_type}` are omitted when Step 5e/5d produced `null`. `kind:commit` is the discriminator the external maintenance layer reads when grouping per-source summary rows. Per-commit `paths` array is not frontmatter — its only consumer (the external maintenance layer's consolidation) reads `scope:{val}` off tags. `author` / `author_email` likewise live only on tags as `author:{canonical_author}`. The `type:{conv_type}` namespace collides with `/ingest-jira`'s `type:{issue_type}` deliberately — `kind:*` (`kind:commit` vs `kind:atlassian-issue`) disambiguates.
+
+Body:
+
+```markdown
+# {summary}
+
+## Changes (faithful)
+- {bullet 1}
+- {bullet 2}
+...
+
+## Author's message
+> {message_subject}
+
+{message_body if non-empty, else omit this paragraph}
+
+## Stats
++{additions} / -{deletions} across {files} files
+
+### Paths
+- {full_path_a}
+- {full_path_b}
+...
+
+## Source
+
+- Author: {canonical_author} <{raw_author_email}>
+```
+
+Notes on assembly:
+
+- `## Source` keeps the canonical author + raw email visible for human readers — their frontmatter carriers don't survive the AKB MCP whitelist. The YAML example above lists `sha` / `short_sha` / `parents` / dates / conv-type / diff-scope / stats / flags for documentation only; downstream skills read those axes from `tags` instead (see `_fetch_commit_docs.md.j2`).
+- `### Paths` is the full file list; the external maintenance layer's body-section axis is the `scope:{val}` tag, not a separate frontmatter array.
+- `tags` drops null-valued entries (e.g. `conv_type` / `scope:` when absent).
+- Never include the full unified diff — only the faithful restatement + stats + paths.
+
+### Step 7 — Write
+
+`akb_put(vault={vault_name}, collection=git-commits, title="{short_sha} {message_subject}", type=reference, tags={tags}, content={assembled_body}, summary={faithful_1_line})`. On success, return:
+
+```markdown
+## ingest-commit: created
+- sha: {full_sha}
+- doc_id: {new_doc_id}
+- vault: {vault_name}
+- collection: git-commits
+- summary: {faithful_1_line}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<sha>` missing | `Missing required argument: <sha>` |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| SHA not found in the repo | `SHA not found in repository: {sha}` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. The caller decides. |
+| Diff exceeds `500` lines | Record with `truncated: true`; not a failure. |
+| Binary-only commit | Record with `diff_scope` including `binary`; Changes bullets say `Binary change in {path}`. |
+| Merge commit | Record as-is with `is_merge: true`; no filter applied here. |
+| SHA already ingested | Return `exists` status; not a failure. |

--- a/plugins/codex/akb-wiki/support/agents/ingest-confluence.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-confluence.md
@@ -1,0 +1,372 @@
+---
+name: ingest-confluence
+description: Ingest one Confluence page into an AKB vault as a five-section LLM-wiki summary document, fetched live via the Atlassian MCP server.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Atlassian Page Ingest
+
+Ingest **one Confluence page** into the target AKB vault as a five-section LLM-wiki summary document — the `akb-wiki` plugin's Confluence write path, specializing `akb-wiki`'s generic `/akb-ingest` pattern.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — Confluence pages externalize design decisions, RFCs, runbooks, post-mortems. Ingest pulls that rationale into the vault before the page evolves out from under the team.
+
+Scope boundaries:
+
+- **One page per invocation.** Bulk space imports are an orchestration loop calling this skill once per page id.
+- **No fan-out at ingest.** Concept clustering, membership backlinks, cross-source aggregation, and structural checks are all handled by an external maintenance layer that runs over the same AKB vault.
+- **Atlassian MCP required.** Page body is fetched live via `mcp__atlassian__confluence_get_page` — no payload escape hatch.
+- **Fixed collection.** Pages land in `atlassian-pages`; sub-organize with tags.
+- **No attachment download.** Embedded image/attachment URLs are preserved as references; bytes stay in Confluence.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-confluence <url-or-id> --vault {vault_name} [--lang {language}] [--project {name}]
+```
+
+- `<url-or-id>` (required, positional) — Confluence page URL or bare page id.
+- `--vault` (required) — target AKB vault.
+- `--lang` (optional) — language for synthesized body (TL;DR / Key Points / topic tags). Defaults to the page's primary language.
+- `--project` (optional) — pin to a project namespace for downstream cross-source rollup. When supplied, adds `project: "{name}"` frontmatter and a `project:{name | lower}` tag. Omitted → ingest normally but skipped from that rollup (Confluence is not directory-bound, so no auto-derivation).
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- Atlassian MCP server is connected — `mcp__atlassian__confluence_get_page` must be callable.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Common resolution every Atlassian ingest subagent performs before its own entity-specific parsing.
+
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Verify the **Atlassian MCP server is connected**. If the MCP tool surface is unavailable, fail with `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` There is no payload escape hatch — webhook receivers and orchestration layers either run with the Atlassian MCP server attached, or skip ingest.
+- Capture today's date as `today` (ISO `YYYY-MM-DD`) for timeline entries.
+
+The two ingest skills (`ingest-confluence`, `ingest-jira`) share these pre-checks. Entity-specific parsing — URL → `(space_key, page_id)` for pages, `<issue-key>` → `(project_key, issue_key)` for issues — happens in each skill's own Step 2 after this block runs.
+
+Capture `today` as ISO `YYYY-MM-DD`.
+
+### Step 2 — Fetch the page
+
+Parse the positional argument: a `https?://.+/wiki/spaces/(\w+)/pages/(\d+)` URL captures `space_key` + `page_id`; a bare numeric id sets `page_id` (space_key fills from MCP response); anything else fails with `Invalid Confluence URL or page id: {arg}`.
+
+Fetch: `mcp__atlassian__confluence_get_page(page_id={page_id}, include_metadata=true)`. Failures: `page not found` → `Confluence page {page_id} not found.`; any other MCP error verbatim.
+
+Normalize the response into a `page` dict with `space_key`, `page_id` (opaque), `version` (monotonic int), `title`, `author` (last editor or original), `last_modified` (ISO 8601), `body_storage` (Confluence storage format, **as authored** — conversion happens in Step 3), `labels`, `tenant_base_url` (reconstruct from URL or fall back to `https://{tenant}.atlassian.net`; never used for further HTTP), `links.jira` (raw issue keys from the API, not re-derived), `links.confluence` (raw page ids).
+
+Compose `canonical_url = "{page.tenant_base_url}/wiki/spaces/{page.space_key}/pages/{page.page_id}"` for the Source block's `Location:`.
+
+### Step 3 — Convert body_storage → markdown
+
+Conversion guide every Atlassian ingest subagent applies when transforming Confluence storage format (HTML + macros) or Atlassian Document Format (ADF) into clean markdown for the document body. Both ingest skills share these rules so a page rendered by `ingest-confluence` and the description of an issue rendered by `ingest-jira` look consistent in the vault.
+
+The conversion is **structural fidelity over visual fidelity** — preserve information that has retrieval value, drop visual artifacts that do not.
+
+## Headings
+
+- Confluence `<h1>`–`<h6>` → markdown `#`–`######`. Preserve the level relative to the page; do not collapse hierarchy.
+- ADF `heading` nodes (`level: 1..6`) follow the same mapping.
+
+## Paragraphs and inline formatting
+
+- `<p>`, ADF `paragraph` → blank-line-separated paragraphs.
+- `<strong>`/`<b>` → `**bold**`. `<em>`/`<i>` → `*italic*`. `<code>` → `` `inline code` ``. ADF `marks` (`strong`, `em`, `code`, `link`, `underline`, `strike`) map to the corresponding markdown.
+- Hyperlinks (`<a href>`, ADF `link` mark) → `[label](url)`. Preserve the original URL verbatim, including query string. Do not re-encode.
+
+## Lists
+
+- `<ul>`/`<ol>` and ADF `bulletList`/`orderedList` → markdown `-` or `1.` lists. Preserve nesting depth via 2-space indentation.
+- Task lists (Confluence `<ac:task-list>`, ADF `taskList`) → `- [ ]` / `- [x]` per item state.
+
+## Tables
+
+- `<table>` and ADF `table` → GitHub-Flavored Markdown table. The first row becomes the header. If the source has no header row, synthesize one with column labels `Col 1`, `Col 2`, … so downstream tooling can parse it.
+- Tables exceeding 8 columns or with merged cells that cannot be flattened: render the first row as a markdown header line, then keep the remaining rows as-is (each row a single line of pipe-separated cells), and append a note `<!-- Source table had merged cells; flattened. -->`.
+
+## Code blocks
+
+- Confluence `<ac:structured-macro ac:name="code">` (with optional `ac:parameter ac:name="language">`) → fenced code block ` ```<language>\n…\n``` `. If no language parameter, use ` ``` ` without one.
+- ADF `codeBlock` (`attrs.language`) → same fenced block.
+- Inline `<code>` already covered above.
+
+## Confluence macros
+
+| Macro | Markdown form |
+|---|---|
+| `info` / `note` | Block quote prefixed with `> **Note:** ` (or `**Info:**`, `**Tip:**`, `**Warning:**` per macro) |
+| `panel` (with `title`) | `> **{title}**\n>\n> {body, recursively converted}` |
+| `expand` (collapsible) | `<details><summary>{title}</summary>\n\n{body}\n\n</details>` |
+| `toc` | Drop entirely. Do not emit a placeholder. |
+| `excerpt` / `excerpt-include` | Inline the excerpt body. Drop the macro wrapper. |
+| `jira` (single-issue inline) | `[{issue_key}]({issue_url})`. Issue keys also collected into the page's `linked_issues` axis (handled by ingest skill, not by this conversion). |
+| Other unknown macros | Render the macro's textual body if available; if not, emit `<!-- macro: {macro_name} (rendered text unavailable) -->` so the user can re-ingest with the rendered form. |
+
+## ADF panel and decision nodes
+
+| ADF node | Markdown form |
+|---|---|
+| `panel` (`type: info|note|warning|success|error`) | `> **{Type}:** {body}` |
+| `decision` | `> **Decision:** {body}` |
+| `mediaSingle` / `mediaGroup` | Image reference only — see below. |
+
+## Images and attachments
+
+- `<ac:image>` and ADF `media` nodes → `![{alt or filename}]({attachment_url})`. The attachment file itself is **not** downloaded into AKB at this version; the URL is left as a reference. A future raw-layer integration may download attachment bytes via `akb_put_file`.
+- If the attachment URL is relative (Confluence-internal), prefix it with the tenant base URL captured at fetch time so the link is followable from outside the wiki.
+
+## Mentions and metadata noise
+
+- `@mentions` (Confluence `<ac:link>` to users, ADF `mention`) → `@{display_name}`. Drop the user-id payload.
+- Date / status / emoji inline pills → plain text equivalent (`📅 2026-04-20`, `🟢 In progress`, `:thumbs_up:`).
+- Drop any "last edited / version" footers Confluence injects into the body — frontmatter already carries those axes.
+
+## Whitespace cleanup
+
+- Collapse runs of 3+ blank lines to a single blank line.
+- Strip trailing whitespace from every line.
+- Ensure a single trailing newline at the end of the converted body.
+
+## What this conversion is **not**
+
+- No agent rewriting. The conversion is structural (HTML/ADF → markdown). Do not summarize, paraphrase, or "clean up" prose. Compiled-truth synthesis (TL;DR / Key Points) happens in the calling skill's separate compose step on top of this converted body.
+- No external link verification. Do not fetch any URL referenced inside the body.
+- No attachment download. URLs are preserved as-is.
+
+If a fragment cannot be converted faithfully, prefer leaving the source HTML/ADF inline (verbatim, in a code block) over guessing a markdown equivalent. The vault would rather hold an awkward but lossless record than a polished but misleading one.
+
+The result is `extracted_text`. Compute `content_sha256 = sha256(body_storage)` over the **raw storage format** (not the converted markdown) so the hash is stable across re-runs even if the converter changes.
+
+### Step 4 — Dedup
+
+Two deterministic signals + optional semantic, with version monotonicity short-circuiting the resolution table.
+
+#### Stage 1 — Deterministic match by `(space_key, page_id)`
+
+`akb_search(vault={vault_name}, collection=atlassian-pages, type=reference, tags=["page-id:{page_id}"], limit=5)`. Single-tag filter narrows to the exact page-id cell — AKB's `tags` filter has OR semantics, so multi-tag would broaden instead of narrow; one tag reduces to exact-membership. Confluence page ids are tenant-unique, so `page-id:{page_id}` + collection scope is sufficient. On hit, capture `dedup_hit = doc_id` and `dedup_existing_version = int(version_tag.split(":", 1)[1])` from the `version:{N}` tag; set `dedup_kind = "deterministic"`. Skip Stage 2.
+
+#### Stage 2 — Semantic fallback
+
+Only runs when Stage 1 produced no hit. `akb_search(query={title}, vault={vault_name}, collection=atlassian-pages, type=reference, limit=5)`. Any hit with `score > 0.85` is a fuzzy match — capture `dedup_hit = top_hit.doc_id`, `dedup_kind = "fuzzy"`.
+
+#### Decision
+
+Fully automatic — Confluence's monotonic `version` axis is the canonical signal; the skill absorbs the dedup decision (LLM-wiki *agent absorbs bookkeeping*).
+
+| `dedup_hit` / kind | Comparison | Action |
+|---|---|---|
+| none | — | continue to Step 5 (create path) |
+| deterministic | `page.version < dedup_existing_version` | `## ingest-confluence: exists` and stop. Note: `vault holds {dedup_existing_version}; ingest {page.version} is older — skipped.` |
+| deterministic | `page.version == dedup_existing_version` | `## ingest-confluence: exists` and stop. Note: `same version already ingested — skipped.` |
+| deterministic | `page.version > dedup_existing_version` | continue to Step 5; Step 6 `akb_update`s `dedup_hit` (compiled-truth refresh + timeline append). |
+| fuzzy | — | `## ingest-confluence: likely-exists` and stop. Disambiguation goes through the external maintenance layer or human review. |
+
+Forced create / forced replace are out of scope here — handle via a separate disambiguation workflow, not a per-call flag.
+
+### Step 5 — Compose summary
+
+Synthesize TL;DR / Key Points / `summary` from the converted body. The `## Content` section is mechanical (verbatim converted body). Synthesized prose follows `--lang` if supplied, else the page's primary prose language (not embedded code/quotes); section headings, frontmatter keys, and `## Content` always stay in natural form (English headings/keys, content as-extracted).
+
+#### Body template
+
+```markdown
+# {title}
+
+## TL;DR
+
+{Agent-authored 1–3 sentences. What this page is, at a synthesis level. No hedging, no "this page describes…" boilerplate. Lean on the page's actual structure — for a design doc lead with the proposal; for a runbook lead with the trigger.}
+
+## Key Points
+
+- {Bullet 1 — 3–7 sharp takeaways. For a design doc: proposal, constraints, decisions, action items. For a runbook: when it fires, what to check, escalation. For a post-mortem: incident, root cause, follow-ups.}
+- {Bullet 2}
+- ...
+
+## Content
+
+{extracted_text from Step 3 — the converted markdown body. Verbatim, including tables and code blocks.}
+
+## Source
+
+- Location: {canonical_url}
+- Space: {space_key}
+- Page-ID: {page_id}
+- Version: {page.version}
+- Author: {page.author}
+- Last-Modified: {page.last_modified}
+- Content-SHA256: {content_sha256}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested page version {page.version}. [Source: ingest-confluence, {today}]
+```
+
+The Source block intentionally mirrors the akb-wiki `/akb-ingest` format on `Location:`, `Content-SHA256:`, and `Ingested:` so the external maintenance layer's duplicate-source check catches Confluence pages automatically. Atlassian-specific axes (`Space:`, `Page-ID:`, `Version:`, `Author:`, `Last-Modified:`) are added on top.
+
+#### Frontmatter
+
+```yaml
+type: reference
+status: active
+title: "{page.title}"
+summary: "{one-sentence synthesis, same voice as TL;DR but compressed to one line}"
+tags: [
+  "atlassian",
+  "kind:atlassian-page",
+  "space:{space_key}",
+  "page-id:{page_id}",
+  "version:{page.version}",
+  "label:{label_1}", "label:{label_2}",
+  "topic:{primary}", "topic:{secondary}",
+  "project:{project_lowered}"
+]
+project: "{project_arg | null}"        # populated only when --project was supplied at invocation
+linked_issues: [{issue_key}, ...]    # from page.links.jira (raw keys, not resolved to AKB doc_ids yet)
+linked_pages: [{page_id}, ...]       # from page.links.confluence (raw page ids; not resolved either)
+depends_on: []
+related_to: []
+implements: []
+```
+
+The `project:` tag and `project` field are emitted only when `--project` was supplied (lowercased tag suffix, verbatim frontmatter value).
+
+- `type: reference` matches `/akb-ingest`'s convention.
+- `tags` carries provenance (`atlassian`), `kind:atlassian-page` cross-plugin discriminator, `space:{key}` filter axis, `page-id:{page_id}` dedup key, `version:{N}` monotonic counter (read in Step 4), one `label:{name}` per Confluence label, and **1–3 `topic:{...}` tags** authored alongside TL;DR / Key Points. Topic tags identify the page's *subjects* (design doc → proposal area; runbook → system; post-mortem → failure domain): lowercase, hyphenated compounds (`topic:vector-search`), domain-anchored vocabulary (`introduction` / `overview` / `notes` are not topics), drop rather than fill. `label:` and `topic:` are independent — the same string may appear in both (the external maintenance layer reads `topic:*` as the lattice axis; `label:*` only filters). Empty topic list is allowed only for non-subject pages (link directory, ToC, stub); downstream consolidation skips them silently. All entries are skill-authored — no caller-supplied tags. Duplicates dropped.
+- `space_key` / `page_id` / `version` / per-`label` live in tags; `author` / `last_modified` live in the body `## Source` block.
+- `linked_issues` / `linked_pages` stay as raw external keys; the external maintenance layer does not resolve them.
+- `depends_on` / `related_to` / `implements` are empty at ingest; the external maintenance layer populates them.
+
+### Step 6 — Write
+
+Branch by Step 4 resolution.
+
+**Create** (no hit) — `akb_put(vault={vault_name}, collection=atlassian-pages, title={page.title}, type=reference, tags={tags}, summary={one_sentence_summary}, content={assembled_body})`. Capture `doc_id` / `doc_path`.
+
+**Replace** (deterministic newer, or fuzzy resolved to replace):
+
+1. `akb_get(vault={vault_name}, doc_id={dedup_hit}) → existing_content`.
+2. Apply **timeline merge — Mode B (entry-only append)** with `new_entry = "- **{today}** | Re-ingested page version {page.version} (was version {dedup_existing_version}). [Source: ingest-confluence, {today}]"`.
+3. Build final `content`: everything from the new body **above** `---` + `## Timeline` (compiled-truth refresh) + Mode B's merged timeline section.
+4. `akb_update(vault={vault_name}, doc_id={dedup_hit}, tags={tags}, content={merged_content}, summary={one_sentence_summary}, message="Re-ingested page version {page.version}")` — bumped `version:{page.version}` tag enables next-run dedup.
+
+Mode B is the right choice here: the new entry is a single bullet, the rest of the body is rewritten in place, and timeline is the only history-preserving zone.
+
+### Step 7 — Report
+
+Successful create:
+
+```markdown
+## ingest-confluence: created
+- title: {page.title}
+- doc_id: {doc_id}
+- path: {doc_path}
+- vault: {vault_name}
+- collection: atlassian-pages
+- space: {space_key}
+- page_id: {page_id}
+- version: {page.version}
+- summary: {one_sentence_summary}
+```
+
+Successful replace:
+
+```markdown
+## ingest-confluence: replaced
+- title: {page.title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- previous version: {dedup_existing_version}
+- new version: {page.version}
+- timeline entries: {N (after append)}
+```
+
+Skipped (deterministic dedup + version older or equal):
+
+```markdown
+## ingest-confluence: exists
+- title: {page.title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- vault version: {dedup_existing_version}
+- ingest version: {page.version}
+- reason: "older or equal version"
+```
+
+Fuzzy-skipped:
+
+```markdown
+## ingest-confluence: likely-exists
+- title: {page.title}
+- top match: {dedup_hit} (score: {score})
+- vault: {vault_name}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<url-or-id>` missing | `Missing required argument: <url-or-id>.` |
+| Invalid Confluence URL / page-id format | `Invalid Confluence URL or page id: {arg}` |
+| Atlassian MCP not connected | `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` |
+| Page id not found by MCP | `Confluence page {page_id} not found.` |
+| Storage format → markdown conversion fails on a fragment | Fall back to inlining the raw storage HTML inside a `<details>` block as documented in the conversion guide. Not a hard failure. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| AKB MCP unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+Do not create vaults or collections; surface `akb_put`'s missing-vault error and instruct the user to create the vault with `mcp__akb__akb_create_vault`.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/codex/akb-wiki/support/agents/ingest-doc.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-doc.md
@@ -1,0 +1,309 @@
+---
+name: ingest-doc
+description: Ingest one document (local file or web URL) into an AKB vault as a five-section LLM-wiki summary page, optionally preserving the original bytes in the raw file layer.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Ingest
+
+Ingest **one document** (local path or URL) into the target AKB vault as a five-section summary page, optionally preserving the original bytes in AKB's raw file layer. This skill is the `akb-wiki` plugin's ingest write path.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — it externalizes documents of record (papers, articles, manuals, transcripts, web clips) into the vault so the rationale and constraints in those sources stay retrievable by humans and agents.
+
+Scope boundaries:
+
+- **One source per invocation.** Glob patterns expand into a sequential loop that calls the same workflow once per match.
+- **No fan-out at ingest time.** Consolidation into concept pages and cross-reference to existing entities are handled by an external maintenance layer (dream-cycle) that runs over the same AKB vault, not at ingest time. AKB's own search/browse already indexes every write, so the skillpack does not maintain a manual vault-index document.
+- **2-layer write when binary.** Binary formats upload their original bytes via `akb_put_file` **and** emit a summary document with a `derived_from` link to the raw file. Plaintext formats emit only the summary.
+- **Fixed collections.** Summary documents always land in `corpus-summaries`, raw files in `corpus-raw`. No `--collection` override — use tags for sub-organization.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-doc <source> --vault {vault_name} [--raw | --no-raw] [--lang {language}]
+```
+
+- `<source>` (required) — local path (absolute, or glob like `./papers/*.pdf`) or URL (http/https).
+- `--vault` (required) — target AKB vault name.
+- `--raw` / `--no-raw` (optional) — override format-based raw-upload default (see Step 2).
+- `--lang` (optional) — language for synthesized note body (TL;DR / Key Points / topic tag wording). If omitted, infer from the source's primary language. Use this to override when the source language differs from the desired note language (e.g., English paper → Korean summary).
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- For URL sources: `WebFetch` available.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Parse `--vault` from arguments. Hard-fail if missing: `--vault {name} required.`
+
+Parse remaining CLI arguments. Capture today's date as `today` (ISO `YYYY-MM-DD`).
+
+### Step 2 — Resolve source
+
+Classify `<source>`:
+
+- **Path** — starts with `/`, `./`, `~/`, or has no scheme. If it contains glob metacharacters (`*`, `?`, `[`), resolve with `Glob` and loop through each match, running Steps 3–7 per file. A zero-match glob fails with `No files matched "{pattern}".`
+- **URL** — starts with `http://` or `https://`.
+
+Detect format from extension (path) or `Content-Type` header when available (URL), plus filename hint from the URL path:
+
+| Format | Extension set | Upload default |
+|---|---|---|
+| `pdf` | `.pdf` | binary → raw |
+| `image` | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` | binary → raw |
+| `office` | `.docx`, `.xlsx`, `.pptx` | binary → raw |
+| `markdown` | `.md`, `.markdown` | plaintext → summary only |
+| `html` | `.html`, `.htm`, URL with no extension | plaintext → summary only |
+| `text` | `.txt`, `.log` | plaintext → summary only |
+| `json` | `.json`, `.jsonl`, `.yaml`, `.yml` | plaintext → summary only |
+
+Unsupported extensions fail with `Unsupported format: {ext}. Supported: pdf, png/jpg/gif/webp, docx/xlsx/pptx, md, html, txt, json.`
+
+Apply flag overrides:
+
+- `--raw` → force raw upload regardless of format default (useful when the user wants to preserve a .md file's original bytes).
+- `--no-raw` → suppress raw upload regardless of format default (useful when the user considers a PDF disposable and only wants the extracted text).
+
+Record `raw_upload ∈ {true, false}` and `format_kind ∈ {binary, plaintext}` for downstream steps.
+
+### Step 3 — Fetch
+
+Always obtain **extracted text** for the `## Content` section. Additionally, when `raw_upload == true`, obtain a **local file path** pointing at the original bytes for `akb_put_file`.
+
+#### Path source
+
+```text
+Read(file_path="{path}")
+```
+
+- For PDFs: read page by page when the file is long (`pages="1-20"` at a time). If the PDF's total page count is unknown, attempt without `pages` first; chunk only when the single read fails or exceeds token budget.
+- For binary formats `Read` cannot extract (e.g. `.docx`, `.xlsx`), surface the failure: `Cannot extract text from {format}; install a converter or supply an already-converted .md.` The raw bytes can still be uploaded if `raw_upload == true` — ingest proceeds with an empty `## Content` and a note "text extraction unsupported for this format."
+- `local_file_path` is the input path itself.
+
+#### URL source
+
+```text
+WebFetch(url="{url}", prompt="Return the main article content as clean markdown. Preserve headings, lists, and code blocks. Drop navigation, ads, footers.")
+```
+
+If `raw_upload == true`, also download the URL bytes to a temp path (`/tmp/ingest-doc-{short_hash}.{ext}`) for `akb_put_file`:
+
+- Plaintext URLs with `raw_upload=true` (only happens when `--raw` is explicit): save the WebFetch'd HTML/markdown verbatim to temp.
+- Binary URLs: fetch bytes directly and save to temp. (If WebFetch does not expose raw bytes, fall back to `Bash(curl -sL -o /tmp/... {url})` — note this in the output if taken.)
+
+Record `extracted_text` (may be empty) and `local_file_path` (may be null).
+
+### Step 4 — Dedup
+
+Two-stage deterministic / semantic check, then a **fully automatic decision table** — no caller flag, no interactive prompt. The skill absorbs the dedup decision (LLM-wiki *agent absorbs bookkeeping*).
+
+Compute `new_hash = sha256(extracted_text)` once up front — used as both the path-source lookup key and the equality test in the decision table.
+
+#### Stage 1 — Deterministic match
+
+Build a `lookup_key`: canonical URL (strip tracking params like `utm_*`, `ref`, `fbclid`) for URL sources, `new_hash` for path sources. Query `akb_search(vault="{vault_name}", query={lookup_key}, collection="corpus-summaries", type="reference", limit=5)`.
+
+For each hit, `akb_get(vault="{vault_name}", doc_id={hit.doc_id})` and inspect the `## Source` block. Match on either a `Location:` line containing the canonical URL **or** a `Content-SHA256:` line matching `new_hash` (only present when a plaintext path was previously ingested). On match, set `dedup_hit = doc_id`, parse `existing_hash` from the existing doc's `Content-SHA256:` (may be absent if the prior ingest had no raw upload), set `dedup_kind = "deterministic"`, and skip Stage 2.
+
+#### Stage 2 — Semantic fallback
+
+Runs only when Stage 1 produced no hit. Produce a provisional title (URL `<title>` tag, PDF metadata, markdown `# heading`, or filename stem — whichever is available). Query `akb_search(vault="{vault_name}", query={provisional_title}, collection="corpus-summaries", type="reference", limit=5)`. Any hit with `score > 0.85` counts as fuzzy: set `dedup_hit = top_hit.doc_id`, `dedup_kind = "fuzzy"`. The hit is a **candidate**, not a confirmed identity match.
+
+#### Decision
+
+| `dedup_hit` / kind | Comparison | Action |
+|---|---|---|
+| none | — | continue to Step 5 (create path) |
+| deterministic | `existing_hash == new_hash` | return `## ingest-doc: unchanged` (see Step 7) and stop. Content identical — no compiled-truth refresh, no timeline append. |
+| deterministic | `existing_hash != new_hash` (or `existing_hash` absent) | continue to Step 5; Step 6 uses `akb_update` on `dedup_hit` (compiled-truth refresh + timeline append). |
+| fuzzy | — | return `## ingest-doc: likely-exists` and stop. The fuzzy hit is a candidate, not a confirmed identity match — leave disambiguation to the external maintenance layer or human review. |
+
+Edge cases (forced create on a fuzzy false-positive, forced replace despite hash equality) are out of scope for this skill — handle via a separate disambiguation workflow rather than a per-call flag. This keeps the ingest path headless-safe and the skill the sole owner of the dedup decision.
+
+### Step 5 — Upload raw (when applicable)
+
+Skip when `raw_upload == false`. Otherwise: `akb_put_file(vault="{vault_name}", file_path={local_file_path}, collection="corpus-raw", description={provisional_title})`. Capture `file_id` and `s3_key` from the response; compose `Raw URI = akb://{vault_name}/file/{file_id}`. If `local_file_path` was a temp file (URL download), delete it after the upload succeeds: `Bash(rm -f {local_file_path})`.
+
+### Step 6 — Compose and write summary
+
+Compose the summary document body using the fixed five-section structure. The **section headings are fixed**; the **content inside each section adapts to the source**.
+
+**Language**: write TL;DR / Key Points / topic tag descriptors in `--lang` if it was provided; otherwise match the source's primary prose language (not embedded code/quotes). Section headings, frontmatter keys, and the `## Content` zone (mechanical extracted text) always stay in their natural form — headings/keys English, content as-extracted.
+
+#### Body template
+
+```markdown
+# {title}
+
+## TL;DR
+
+{Agent-authored 1–3 sentences. What is this document, at a synthesis level. No hedging, no "this document discusses..." boilerplate.}
+
+## Key Points
+
+- {Bullet 1 — the sharpest 3–7 takeaways. For a paper: contribution, method, result. For an article: thesis, argument, conclusion. For a manual: what problem it solves, prerequisites, caveat. For a transcript: decisions, actions, open questions.}
+- {Bullet 2}
+- ...
+
+## Content
+
+{Cleaned extracted text from Step 3. Preserve original heading hierarchy, code blocks, tables. Drop navigation/ads/footers. For binary sources with no text extraction, write: "Text extraction unsupported for this format. See raw file at {raw_uri}."}
+
+## Source
+
+- Location: {source URL or absolute path}
+- Raw: akb://{vault_name}/file/{file_id}     ← omit this line entirely when `raw_upload == false`
+- Format: {format (pdf, html, md, …)}
+- Content-SHA256: {hash of extracted_text, for future dedup}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested from {source}. [Source: ingest-doc, {today}]
+```
+
+#### Frontmatter
+
+Use only AKB standard fields:
+
+```yaml
+type: reference
+status: active
+title: "{title}"
+summary: "{one-sentence synthesis, same voice as TL;DR but compressed to one line}"
+tags: ["{format_kind}", "{format}", "topic:{primary}", "topic:{secondary}"]
+depends_on: []
+related_to: []
+implements: []
+```
+
+- `format_kind` is `binary` or `plaintext`; `format` is the specific extension (`pdf`, `md`, …). Both are derived from the source.
+- `topic:{...}` entries are **1–3 LLM-derived topic tags**, authored alongside TL;DR / Key Points. After synthesizing the body, identify the 1–3 sharpest *subjects* of the document — e.g., a paper on retrieval-augmented generation gets `topic:rag`, `topic:retrieval`. Rules: lowercase, hyphenated for compounds (`topic:vector-search`), prefer domain-anchored vocabulary over generic words (`introduction` / `overview` / `tutorial` / `notes` are not topics), drop a tag rather than reach for filler. Empty topic list is allowed only when the source has no extractable subject (extraction failed, content is a directory listing or single-line note); downstream consolidation will then silently skip the summary.
+- All entries are derived from the source — the skill is the sole author of the `tags` array, no caller-supplied tags.
+- `depends_on` / `related_to` / `implements` are empty at ingest time — relation-wiring is the external maintenance layer's job.
+
+#### Write
+
+Branch by Step 4 decision.
+
+**New document** (no hit). `akb_put(vault="{vault_name}", collection="corpus-summaries", title={title}, type="reference", tags={tags}, summary={one_sentence_summary}, content={assembled_body})`. Capture `doc_id` and `doc_path`.
+
+**Replace** (deterministic hit with hash differing / absent):
+
+1. `akb_get(vault="{vault_name}", doc_id={dedup_hit}) → existing_content`.
+2. Apply timeline merge **Mode B** with `new_entry = "- **{today}** | Re-ingested from {source}. [Source: ingest-doc, {today}]"` and `existing_content` as-is.
+3. Build the final `content`: everything from the newly composed body **above** the `---` + `## Timeline` line, then the merged timeline from Mode B. This replaces the compiled-truth zone (TL;DR / Key Points / Content / Source) while preserving all historical timeline entries.
+4. `akb_update(vault="{vault_name}", doc_id={dedup_hit}, content={merged_content}, message="Re-ingested from {source}")`.
+
+#### Link raw to doc
+
+When `raw_upload == true` and a doc was created or replaced, materialize the lineage edge: `akb_link(vault="{vault_name}", source="akb://{vault_name}/doc/{doc_path}", target="akb://{vault_name}/file/{file_id}", relation="derived_from")`.
+
+On the `replace` path, first check `akb_relations(vault="{vault_name}", resource_uri="akb://{vault_name}/doc/{doc_path}", type="derived_from", direction="outgoing")` — the raw `file_id` may have changed or the prior ingest may have used `--no-raw`. Skip `akb_link` idempotently when the edge to the new `file_id` already exists. If a `derived_from` edge points to a *different* `file/{id}`, the prior raw is orphaned — do not delete it (other docs may reference it); leave it and emit a warning in the output.
+
+### Step 7 — Report
+
+Emit one of four single-source report blocks based on Step 4 + Step 6 outcome:
+
+```markdown
+## ingest-doc: created
+- title: {title}
+- doc_id: {doc_id}
+- path: {doc_path}
+- vault: {vault_name}
+- collection: corpus-summaries
+- raw_file_id: {file_id_or_none}
+- summary: {one_sentence_summary}
+
+## ingest-doc: replaced
+- title: {title}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+- previous raw: {old_file_id_or_none}
+- new raw: {file_id_or_none}
+- timeline entries: {N (after append)}
+
+## ingest-doc: unchanged
+- source: {source}
+- doc_id: {dedup_hit}
+- vault: {vault_name}
+
+## ingest-doc: likely-exists
+- source: {source}
+- top match: {dedup_hit} (score: {score})
+- vault: {vault_name}
+```
+
+Glob loop: emit one block per source processed, then a final summary `## ingest-doc: batch complete` with `created` / `replaced` / `unchanged` / `likely-exists` / `failed` counts.
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<source>` missing | `Missing required argument: <source>` |
+| Path not found | `File not found: {path}` |
+| Glob matched zero files | `No files matched "{pattern}".` |
+| Unsupported format | `Unsupported format: {ext}. Supported: pdf, png/jpg/gif/webp, docx/xlsx/pptx, md, html, txt, json.` |
+| URL unreachable / 4xx / 5xx | `Could not fetch {url}: {status}` |
+| Text extraction failed on binary | Record with `## Content` = "Text extraction unsupported for this format. See raw file at {raw_uri}." Not a hard failure when `raw_upload == true`. Hard failure when `raw_upload == false`. |
+| AKB write fails | Surface the error verbatim; do not retry. Partially-uploaded raw file is not rolled back at MVP — log `orphaned raw file: {file_id}` in the output so the user can `akb_delete_file` manually. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB MCP server unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+Do not attempt to create vaults or collections. If the supplied `vault_name` does not exist, `akb_put`/`akb_put_file` will error with a clear message — surface it as-is and instruct the user to create the vault with `mcp__akb__akb_create_vault`.
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/codex/akb-wiki/support/agents/ingest-jira.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-jira.md
@@ -1,0 +1,353 @@
+---
+name: ingest-jira
+description: Record one Jira issue as an atlassian-issue document in an AKB vault — title/description/resolution/comments quoted verbatim. Fetched live via the Atlassian MCP server; always upsert.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Atlassian Issue Ingest
+
+Record **one Jira issue** as an `atlassian-issue` document in the target AKB vault. Mechanical assembly — title / description / resolution / comments quoted as author-authored compiled-truth; linked-issue refs preserved as raw external keys. No LLM synthesis on the body. Issue metadata is fetched live via the Atlassian MCP server.
+
+**Workflow classification.** LLM-wiki **Ingest** workflow. **Intent-debt** layer — Jira issues externalize the scope, decisions, and discussions shaping work-in-flight. Capturing them faithfully preserves rationale before the issue closes and Jira's UI buries the discussion.
+
+Scope boundaries:
+
+- **One issue per invocation.** Bulk JQL imports are an orchestration loop.
+- **Atlassian MCP required.** Issue body is fetched via `mcp__atlassian__jira_get_issue` — no payload escape hatch.
+- **Mechanical body.** Description / resolution / comments are quoted verbatim with structure conversion only — no summarizing, paraphrasing, or translating.
+- **Always upsert.** Jira issues evolve (status / assignee / comments / linked issues change), so every re-ingest refreshes compiled-truth and appends a timeline entry. Dedup is mechanical via `(project_key, issue_key)`; no skip path.
+- **No LLM synthesis on the body.** Only structural transform (ADF → markdown) plus comment safety-net truncation. Compiled-truth synthesis is the external maintenance layer's job.
+- **Type isolation.** Issues are `type: reference` with `kind:atlassian-issue` tag as discriminator — **not** `type: task`. The `kind:*` tag keeps the external maintenance layer's stale-task heuristics off the Jira lifecycle (different cadence) without forcing a non-enum `type=`.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-jira <issue-key> --vault {vault_name} [--project {name}]
+```
+
+- `<issue-key>` (required, positional) — Jira issue key, e.g. `SDDEV-360`.
+- `--vault` (required) — target AKB vault.
+- `--project` (optional) — pin to a project namespace for downstream cross-source rollup. Adds `project: "{name}"` frontmatter and a `project:{name | lower}` tag, *in addition to* the Jira-structural `project:{project_key | lower}` derived from the issue key. The two coexist intentionally: `project_key` is the source-system id, `--project` is the rollup namespace.
+
+No `--on-duplicate` flag — Jira issues always upsert.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- Atlassian MCP server is connected — `mcp__atlassian__jira_get_issue` must be callable.
+
+## Workflow
+
+### Step 1 — Prepare
+
+Common resolution every Atlassian ingest subagent performs before its own entity-specific parsing.
+
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Verify the **Atlassian MCP server is connected**. If the MCP tool surface is unavailable, fail with `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` There is no payload escape hatch — webhook receivers and orchestration layers either run with the Atlassian MCP server attached, or skip ingest.
+- Capture today's date as `today` (ISO `YYYY-MM-DD`) for timeline entries.
+
+The two ingest skills (`ingest-confluence`, `ingest-jira`) share these pre-checks. Entity-specific parsing — URL → `(space_key, page_id)` for pages, `<issue-key>` → `(project_key, issue_key)` for issues — happens in each skill's own Step 2 after this block runs.
+
+Capture `today` as ISO `YYYY-MM-DD` for timeline entries.
+
+### Step 2 — Fetch the issue
+
+Validate the issue-key shape against `^[A-Z][A-Z0-9_]+-\d+$`; on mismatch fail with `Invalid Jira issue key: {arg}`. Capture `project_key` as the prefix.
+
+Fetch: `mcp__atlassian__jira_get_issue(issue_key={issue_key}, expand="comments,renderedFields")`. Failures: `issue not found` → `Jira issue {issue_key} not found.`; any other MCP error verbatim.
+
+Normalize into an `issue` dict: `project_key` (must equal `issue_key` prefix — guard catches fetcher bugs, not user input), `issue_key`, `issue_type` (Story | Bug | Task | Epic | Sub-task | …), `title`, `status`, `priority` (nullable), `reporter`, `assignee` (nullable), `created_at` / `updated_at` (ISO 8601), `resolved_at` (ISO 8601 on terminal status, else null), `sprint` (nullable), `fix_versions` / `components` / `labels` (lists), `description` **as authored**, `description_format` (`adf` | `wiki` | `markdown`; default `adf`), `resolution` (short string on terminal status), `linked_issues` (ordered `{key, type}` pairs), `comments` (ordered `{author, created_at, body, body_format}` oldest-first; body **as authored**), `tenant_base_url` (reconstruct from MCP context when not surfaced).
+
+If `issue.project_key` doesn't match the `issue_key` prefix, fail with `Atlassian MCP returned project_key {issue.project_key} that does not match issue_key prefix.`
+
+Compose `canonical_url = "{issue.tenant_base_url}/browse/{issue.issue_key}"` (fall back to `https://{inferred-tenant}.atlassian.net/browse/{issue.issue_key}`).
+
+### Step 3 — Dedup check
+
+Always upsert; the check tells Step 5 whether to create or replace. `akb_search(vault={vault_name}, collection=atlassian-issues, type=reference, tags=["issue-key:{issue_key}"], limit=5)`. Single-tag filter narrows to exact-membership (AKB's `tags` filter has OR semantics, so multi-tag would broaden); Jira issue keys are tenant-unique, so `issue-key:{issue_key}` + collection is sufficient. On hit, capture `existing_doc_id`.
+
+No version field maps cleanly to a monotonic counter (`updated_at` can replay); compiled-truth is rewritten every invocation, and the timeline records each re-ingest — same pattern as `ingest-pr`.
+
+### Step 4 — Convert structured content
+
+Apply the conversion guide to (1) `description` using `description_format`, (2) each `comment.body` using `body_format` (default `adf`), (3) `resolution` as `markdown` when `*_format` is unspecified.
+
+Conversion guide every Atlassian ingest subagent applies when transforming Confluence storage format (HTML + macros) or Atlassian Document Format (ADF) into clean markdown for the document body. Both ingest skills share these rules so a page rendered by `ingest-confluence` and the description of an issue rendered by `ingest-jira` look consistent in the vault.
+
+The conversion is **structural fidelity over visual fidelity** — preserve information that has retrieval value, drop visual artifacts that do not.
+
+## Headings
+
+- Confluence `<h1>`–`<h6>` → markdown `#`–`######`. Preserve the level relative to the page; do not collapse hierarchy.
+- ADF `heading` nodes (`level: 1..6`) follow the same mapping.
+
+## Paragraphs and inline formatting
+
+- `<p>`, ADF `paragraph` → blank-line-separated paragraphs.
+- `<strong>`/`<b>` → `**bold**`. `<em>`/`<i>` → `*italic*`. `<code>` → `` `inline code` ``. ADF `marks` (`strong`, `em`, `code`, `link`, `underline`, `strike`) map to the corresponding markdown.
+- Hyperlinks (`<a href>`, ADF `link` mark) → `[label](url)`. Preserve the original URL verbatim, including query string. Do not re-encode.
+
+## Lists
+
+- `<ul>`/`<ol>` and ADF `bulletList`/`orderedList` → markdown `-` or `1.` lists. Preserve nesting depth via 2-space indentation.
+- Task lists (Confluence `<ac:task-list>`, ADF `taskList`) → `- [ ]` / `- [x]` per item state.
+
+## Tables
+
+- `<table>` and ADF `table` → GitHub-Flavored Markdown table. The first row becomes the header. If the source has no header row, synthesize one with column labels `Col 1`, `Col 2`, … so downstream tooling can parse it.
+- Tables exceeding 8 columns or with merged cells that cannot be flattened: render the first row as a markdown header line, then keep the remaining rows as-is (each row a single line of pipe-separated cells), and append a note `<!-- Source table had merged cells; flattened. -->`.
+
+## Code blocks
+
+- Confluence `<ac:structured-macro ac:name="code">` (with optional `ac:parameter ac:name="language">`) → fenced code block ` ```<language>\n…\n``` `. If no language parameter, use ` ``` ` without one.
+- ADF `codeBlock` (`attrs.language`) → same fenced block.
+- Inline `<code>` already covered above.
+
+## Confluence macros
+
+| Macro | Markdown form |
+|---|---|
+| `info` / `note` | Block quote prefixed with `> **Note:** ` (or `**Info:**`, `**Tip:**`, `**Warning:**` per macro) |
+| `panel` (with `title`) | `> **{title}**\n>\n> {body, recursively converted}` |
+| `expand` (collapsible) | `<details><summary>{title}</summary>\n\n{body}\n\n</details>` |
+| `toc` | Drop entirely. Do not emit a placeholder. |
+| `excerpt` / `excerpt-include` | Inline the excerpt body. Drop the macro wrapper. |
+| `jira` (single-issue inline) | `[{issue_key}]({issue_url})`. Issue keys also collected into the page's `linked_issues` axis (handled by ingest skill, not by this conversion). |
+| Other unknown macros | Render the macro's textual body if available; if not, emit `<!-- macro: {macro_name} (rendered text unavailable) -->` so the user can re-ingest with the rendered form. |
+
+## ADF panel and decision nodes
+
+| ADF node | Markdown form |
+|---|---|
+| `panel` (`type: info|note|warning|success|error`) | `> **{Type}:** {body}` |
+| `decision` | `> **Decision:** {body}` |
+| `mediaSingle` / `mediaGroup` | Image reference only — see below. |
+
+## Images and attachments
+
+- `<ac:image>` and ADF `media` nodes → `![{alt or filename}]({attachment_url})`. The attachment file itself is **not** downloaded into AKB at this version; the URL is left as a reference. A future raw-layer integration may download attachment bytes via `akb_put_file`.
+- If the attachment URL is relative (Confluence-internal), prefix it with the tenant base URL captured at fetch time so the link is followable from outside the wiki.
+
+## Mentions and metadata noise
+
+- `@mentions` (Confluence `<ac:link>` to users, ADF `mention`) → `@{display_name}`. Drop the user-id payload.
+- Date / status / emoji inline pills → plain text equivalent (`📅 2026-04-20`, `🟢 In progress`, `:thumbs_up:`).
+- Drop any "last edited / version" footers Confluence injects into the body — frontmatter already carries those axes.
+
+## Whitespace cleanup
+
+- Collapse runs of 3+ blank lines to a single blank line.
+- Strip trailing whitespace from every line.
+- Ensure a single trailing newline at the end of the converted body.
+
+## What this conversion is **not**
+
+- No agent rewriting. The conversion is structural (HTML/ADF → markdown). Do not summarize, paraphrase, or "clean up" prose. Compiled-truth synthesis (TL;DR / Key Points) happens in the calling skill's separate compose step on top of this converted body.
+- No external link verification. Do not fetch any URL referenced inside the body.
+- No attachment download. URLs are preserved as-is.
+
+If a fragment cannot be converted faithfully, prefer leaving the source HTML/ADF inline (verbatim, in a code block) over guessing a markdown equivalent. The vault would rather hold an awkward but lossless record than a polished but misleading one.
+
+Comment safety-net: if a converted comment exceeds `4000` chars, truncate at the nearest paragraph boundary and append `(truncated, see Jira for full text)`; mark `truncated: true` for Step 5 reporting. Description and resolution are **not truncated** — they're high-value compiled-truth; let the external maintenance layer flag oversize cases.
+
+### Step 5 — Assemble the body
+
+Strict templating from the `issue` dict + converted content. Sections with no data are **omitted entirely** (do not print empty section headers).
+
+```markdown
+# {issue_key}: {title}
+
+## Description
+
+{converted_description}
+
+(If description is empty/null: emit `(no description)` as the section body.)
+
+## Resolution
+
+{converted_resolution}
+
+(Omit this entire section when status is non-terminal OR resolution is null/empty.)
+
+## Comments ({len(comments)})
+
+### {N}. {comment.author} — {comment.created_at}
+
+{converted_comment_body}
+
+(Repeat per comment in chronological order, with N starting at 1. Omit the entire `## Comments` section when comments is empty.)
+
+## Linked
+
+- {link.type}: [{link.key}]({tenant_base_url}/browse/{link.key})
+
+(Repeat per linked issue. Omit the entire section when linked_issues is empty.)
+
+## Source
+
+- Location: {canonical_url}
+- Project: {project_key}
+- Issue-Key: {issue_key}
+- Type: {issue_type}
+- Status: {status}
+- Priority: {priority | "—"}
+- Reporter: {reporter}
+- Assignee: {assignee | "—"}
+- Sprint: {sprint | "—"}
+- Fix Versions: {fix_versions joined or "—"}
+- Components: {components joined or "—"}
+- Created: {created_at}
+- Updated: {updated_at}
+- Resolved: {resolved_at | "—"}
+- Ingested: {today}
+
+---
+
+## Timeline
+
+- **{today}** | Ingested at status `{status}`, {len(comments)} comments{", N comment(s) truncated" if any truncated}. [Source: ingest-jira, {today}]
+```
+
+The Source block carries every Jira-specific axis the document needs to be searchable and consolidatable. It deliberately keeps `Location:` / `Ingested:` line shapes consistent with `/akb-ingest` and `/ingest-confluence`; only the middle axes differ.
+
+#### Frontmatter
+
+```yaml
+type: reference
+status: active
+title: "{issue_key}: {issue.title}"
+summary: "{issue.title}"
+
+project: "{project_arg | null}"           # project-rollup namespace; only set when --project was supplied
+sprint: "{issue.sprint | null}"
+fix_versions: [{version}, ...]
+linked_issues: [{key_1}, {key_2}, ...]   # raw issue keys, ordered as Jira returns them; not yet resolved to AKB doc_ids
+
+tags: [
+  "atlassian",
+  "kind:atlassian-issue",
+  "jira-project:{project_key | lower}",
+  "issue-key:{issue_key}",
+  "project:{project_arg | lower}",
+  "type:{issue_type | lower}",
+  "status:{status | lower}",
+  "component:{component_1 | lower}", "component:{component_2 | lower}",
+  "label:{label_1}", "label:{label_2}"
+]
+
+related_to: []
+```
+
+Important distinctions:
+
+- `status: active` is the AKB doc status; Jira workflow status lives in the `status:{state}` tag — never collapse them.
+- `tags` carries: `atlassian` (provenance), `kind:atlassian-issue` (cross-plugin discriminator), `jira-project:{project_key | lower}` (Step 3 dedup + external maintenance layer cell axis), `issue-key:{issue_key}` (deterministic dedup, keep verbatim case), `project:{project_arg | lower}` (only with `--project`; rollup takes precedence for downstream cross-source rollup), `type:{issue_type | lower}` / `status:{status | lower}` (display + filter; the `type:*` namespace collides with `/ingest-commit`'s `type:{conv_type}` deliberately — `kind:*` disambiguates), `component:{name | lower}` (one per Jira component; the external maintenance layer reads off tags directly), `label:{name}`. All lowercased except `issue-key:`. Duplicates dropped.
+- `priority` / `reporter` / `assignee` / `created_at` / `updated_at` / `resolved_at` live in the `## Source` block; not frontmatter fields.
+- `linked_issues` stays as raw external keys; the external maintenance layer does not resolve them to AKB edges.
+
+### Step 6 — Write
+
+Branch by Step 3 result.
+
+**Create** (no existing doc) — `akb_put(vault={vault_name}, collection=atlassian-issues, title="{issue_key}: {issue.title}", type=reference, tags={tags}, content={assembled_body}, summary={issue.title})`. Capture `doc_id`.
+
+**Update** (`existing_doc_id` from Step 3):
+
+1. `akb_get(vault={vault_name}, doc_id={existing_doc_id}) → existing_content`.
+2. Compose `draft_body` = full new body (compiled-truth + Source + `---` + `## Timeline` + the single new entry).
+3. Apply **timeline merge — Mode A (full-body merge)** against `existing_content`.
+4. `akb_update(vault={vault_name}, doc_id={existing_doc_id}, title="{issue_key}: {issue.title}", tags={tags}, content={merged_body}, summary={issue.title}, message="Re-ingested at status {status}, {N} comments")`.
+
+Mode A is correct: the compiled-truth zone (Description, Resolution, Comments, Linked, Source) is rewritten from the new fetch — not appended to. Timeline preserves history; the rest mirrors current Jira state.
+
+### Step 7 — Report
+
+Successful create:
+
+```markdown
+## ingest-jira: created
+- issue: {issue_key}
+- title: {issue.title}
+- doc_id: {doc_id}
+- vault: {vault_name}
+- collection: atlassian-issues
+- status: {issue.status}
+- comments: {len(comments)} ({truncated_count} truncated)
+```
+
+Successful update:
+
+```markdown
+## ingest-jira: updated
+- issue: {issue_key}
+- doc_id: {existing_doc_id}
+- vault: {vault_name}
+- status: {issue.status}
+- comments: {len(comments)} ({truncated_count} truncated)
+- timeline entries: {N (after append)}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<issue-key>` missing | `Missing required argument: <issue-key>.` |
+| Invalid issue-key shape | `Invalid Jira issue key: {arg}` |
+| Atlassian MCP not connected | `Atlassian MCP server not connected. Check your MCP configuration — this plugin requires the Atlassian MCP server.` |
+| Issue not found by MCP | `Jira issue {issue_key} not found.` |
+| MCP-returned `project_key` does not match `issue_key` prefix | `Atlassian MCP returned project_key {project_key} that does not match issue_key prefix.` |
+| ADF / Wiki conversion fails on a fragment | Inline the raw fragment inside a `<details>` block as documented in the conversion guide. Not a hard failure. |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| AKB MCP unreachable | `AKB MCP server not accessible. Check your MCP configuration.` |
+
+## Appendix: Timeline Merge Procedure
+
+Shared procedure for every skill that writes back to an existing note. Two modes — every caller picks **one** explicitly.
+
+**Shared helper.** `split_body(content)` — locate the first standalone `---` line that is followed (eventually) by a `## Timeline` heading. Return `(body_above, timeline_entries)`. If no `## Timeline` heading exists, return `(content, [])`.
+
+### Mode A: Full-body merge
+
+Used when the caller has produced a **rewritten compiled-truth body** (the new canonical state) plus exactly **one** new timeline entry. Callers: session-ingest Phase 4-2 (session update), session-ingest Phase 4-3 (sub-note append), and ingest-jira (issue upsert).
+
+Inputs: `draft_body` (full new body — includes `---` + `## Timeline` + one new bullet), `existing_content` (current doc).
+
+1. `(draft_above, draft_entries) = split_body(draft_body)`. `draft_entries` must contain exactly one bullet. If it contains zero, treat as drafter error → fall back to `akb_update` with `draft_body` unchanged and log a warning.
+2. `(_, existing_entries) = split_body(existing_content)`.
+3. Compose merged content:
+   ```
+   {draft_above}
+
+   ---
+
+   ## Timeline
+
+   {draft_entries[0]}
+   {existing_entries}
+   ```
+4. Newest entry first. Never edit or remove past entries.
+
+### Mode B: Entry-only append
+
+Used when the caller produced **only a new timeline bullet** and wants the existing compiled-truth zone preserved verbatim. Callers: session-ingest Phase 4-4 (task resolve) and the decision supersede path, ingest-doc re-ingest, and ingest-confluence re-ingest.
+
+Inputs: `new_entry` (a single bullet line, possibly with sub-bullets), `existing_content`.
+
+1. `(existing_above, existing_entries) = split_body(existing_content)`.
+2. If `existing_content` had no `## Timeline` section, append `"\n\n---\n\n## Timeline\n\n"` to `existing_above` before proceeding.
+3. Compose merged content:
+   ```
+   {existing_above}
+
+   ---
+
+   ## Timeline
+
+   {new_entry}
+   {existing_entries}
+   ```
+4. **Never rewrite the compiled-truth zone in this mode.** If the caller needs to change compiled truth, it must use Mode A instead.

--- a/plugins/codex/akb-wiki/support/agents/ingest-pr.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-pr.md
@@ -1,0 +1,236 @@
+---
+name: ingest-pr
+description: Record a single GitHub PR merge event as a git-pr document in an AKB vault — PR title/body quoted verbatim, commit summaries pulled from pre-ingested git-commit docs. Fetched live via gh pr view.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Git PR Ingest
+
+Record a **single PR merge event** as a `git-pr` document in the target AKB vault. Mechanical assembly — PR title/body quoted as author-authored compiled-truth; commit summaries pulled verbatim from `git-commit` documents already in the vault. No LLM synthesis. PR metadata is fetched live via `gh pr view`.
+
+Scope boundaries:
+
+- **One PR per invocation.** No loops, no cross-PR consolidation.
+- **GitHub-only via `gh` CLI.** GitLab / Bitbucket / self-hosted forges unsupported. The repo at `--repo` must have a GitHub remote `gh` can resolve.
+- **Commits must be pre-ingested** in `git-commits` as `git-commit` documents.
+- **No LLM synthesis.** PR title/body quoted as-is; agent work is pulling commit summaries into a table.
+- **No review/approval metadata.** Reviewers, labels, check statuses, comment threads are out of scope — `gh pr view` returns more fields than this schema uses; extras are ignored.
+- **Upsert.** Dedup by `(repo, pr_number)`; re-ingest silently overwrites (normal when post-merge edits land on the PR description).
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-pr <pr-number> --vault {vault_name} [--repo {path}]
+```
+
+- `<pr-number>` (required, positional) — GitHub PR number (integer). The PR must be merged.
+- `--vault` (required) — target AKB vault.
+- `--repo` (optional) — path to the local clone of the GitHub repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` and `gh` are available on PATH.
+- `gh auth status` succeeds — the `gh` CLI is signed in to a GitHub account with read access to the target repo.
+- The repo at `--repo` (or `pwd`) has a GitHub remote `gh` can resolve.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Validate `gh` is authenticated: `gh auth status` (non-zero → `gh CLI unavailable or not authenticated. Run gh auth login.`).
+
+Fetch: `(cd {repo_path} && gh pr view {pr_number} --json number,title,body,author,mergedAt,mergeCommit,baseRefName,headRefName,baseRefOid,headRefOid,closingIssuesReferences)`.
+
+Failure paths: "no GitHub remote" / "not a github repository" → `Repo at {repo_path} has no GitHub remote that gh can resolve.`; "no pull request found" / "could not resolve" → `PR not found in the configured GitHub remote: #{pr_number}.`; any other non-zero → surface `gh` stderr and fail with `gh pr view failed for #{pr_number}: {stderr}.`
+
+Parse JSON into `pr`. If `pr.mergedAt` is null, fail with `PR #{pr_number} is not merged; this skill records merge events only.`
+
+Set `merge_sha = pr.mergeCommit.oid`; validate via `git -C {repo_path} rev-parse --verify {merge_sha}^{commit}` (failure → `merge_sha not found in local repository: {merge_sha}. Fetch latest from the GitHub remote.`).
+
+### Step 2 — Enumerate the PR's commits
+
+Apply the strategies below in order; the first match wins.
+
+1. **Explicit boundary** — if `pr.baseRefOid` and `pr.headRefOid` are both present and resolve in the local repo:
+   ```bash
+   git -C {repo_path} log --reverse --format=%H {pr.baseRefOid}..{pr.headRefOid}
+   ```
+   Covers rebase-and-merge repos where the merge commit has only one parent but multiple PR commits landed on the base. If either oid does not resolve locally (e.g. the head branch was deleted and pruned), fall through to strategy 2.
+
+2. **Merge commit** — else, if `git -C {repo_path} rev-list --parents -n 1 {merge_sha}` reports **2 parents**:
+   ```bash
+   git -C {repo_path} log --reverse --format=%H {merge_sha}^1..{merge_sha}^2
+   ```
+
+3. **Squash / single-commit** — else (merge_sha has 1 parent): the commit set is `[merge_sha]` itself.
+
+Call the resulting ordered list `sha_list` (chronologically ascending). If `sha_list` is empty, fail with `No commits enumerated for PR #{pr_number}; the local repo may be missing branch refs — fetch latest from the GitHub remote.`
+
+### Step 3 — Dedup check
+
+`akb_search(query="PR #{pr_number} {repo_name}", vault={vault_name}, collection=git-prs, type=reference, tags=["git", "kind:pr", "project:{repo_name}"], limit=5)`. Among hits, find the one whose frontmatter has `repo == repo_name AND pr_number == pr_number`; on match capture `existing_doc_id` (update path), else create path.
+
+### Step 4 — Fetch commit documents
+
+Given a chronologically-ordered list `sha_list`, resolve each SHA to its commit document (`type=reference, kind:commit`) in the vault.
+
+**Concurrency is required.** Issue all searches in a single parallel tool-use block, then issue any required `akb_get` calls in a second parallel block. Sequential per-SHA loops are forbidden — a 30-commit input is two batched round trips, not 30 or 60.
+
+```text
+mcp__akb__akb_search(
+  query="{sha}",
+  vault="{vault_name}",
+  collection="git-commits",
+  type="reference",
+  tags=["git", "kind:commit"],
+  limit=3
+)
+```
+
+For each search, pick the hit whose title prefix matches `{short_sha}` — the per-commit summary doc's title is `{short_sha} {message_subject}`, and `akb_search` returns the title in its hit payload, so the search query (`query="{full_sha}"`) plus a title-prefix check uniquely identifies the matching commit. The downstream-needed fields below are all reachable from the `akb_search` hit (`path`, `title`, `summary`, `tags`); only fall back to `akb_get` if a specific consumer needs body content (e.g., for surfacing author detail in a human-readable table).
+
+For each `commit_records[i]`, populate the downstream-needed fields from the AKB primitives that durably persist them:
+
+- `doc_id`, `path`, `title`, `summary` — from the search hit (whitelist fields exposed by `akb_search`).
+- `short_sha` — first 7 chars of the full SHA (already known from the search query); also recoverable from the title prefix.
+- `author` — parse from the row's `tags` array as `tag[len("author:"):]` for the first `author:*` tag emitted by `/ingest-commit` Step 6. Single-author commits emit one such tag; merge commits emit either the merging committer or whichever name `.mailmap` resolved. `null` if no `author:*` tag is present (defensive — the commit ingest always emits one).
+- `conv_type` — parse from the row's `tags` array as `tag[len("type:"):]` for the first `type:*` tag. `null` when the commit subject did not match the conventional-commit pattern.
+- `scope` — parse `tag[len("scope:"):]` for the first `scope:*` tag. Drives PR-level `pr_scope` aggregation downstream without re-deriving from a `paths` list.
+
+Skip the secondary `akb_get` whenever the search hit already exposes everything in the list above — PR / release ingest only needs `path` / `summary` / `tags`, all reachable from `akb_search`. A 30-commit PR is one batched `akb_search` round trip, not 30+30.
+
+The full file list, per-commit stats, and diff scope are not aggregated across commits — the per-commit body's `### Paths` and `## Stats` sections are the audit surface, reachable via the PR's `depends_on` graph edge.
+
+If any SHA in `sha_list` has no matching hit, **fail** before proceeding:
+
+```text
+Missing commit(s) in vault: {missing_sha_list}.
+Run `/akb-ingest <sha>` for each before re-running.
+```
+
+Never re-fetch diffs or invoke git for individual commits here. The ingested `summary` and `Changes` block are authoritative — diff re-reading would defeat the reason ingest paid that cost.
+
+Collect the results into `commit_records`, aligned with `sha_list`.
+
+### Step 5 — Aggregate frontmatter axes
+
+Compute from `commit_records`:
+
+- `commit_uris` — ordered list of full URIs `akb://{vault_name}/doc/{commit_doc_path}` (chronological). Passed as `depends_on` in Step 7. Always-URI convention even for single-vault deployments.
+- `commit_shas` — ordered chronological SHAs, preserved for cheap lookup without graph traversal.
+- `pr_scope` — most-frequent non-null `scope` across records (parsed from each record's `scope:*` tag in `_fetch_commit_docs`; the per-commit summary derives it once at ingest as `conv_scope or top_level_paths[0]`). Ties → chronologically earliest contributor. `null` when all commits' scopes are null. Emitted as `scope:{pr_scope}` in Step 6.
+
+PR doc body renders from per-commit doc bodies via the `depends_on` edge — no per-commit aggregation here. PR-level author is `pr.author.login`; commit authors live on each commit doc's `## Source`.
+
+Build `links` from `pr.closingIssuesReferences`: each entry becomes `#{number}` (cross-repo: `{owner}/{repo}#{number}`). Order preserved from `gh`.
+
+### Step 6 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"
+project: "{repo_name}"             # mirrors repo; `repo` is the source-system identifier, `project` is the project-rollup namespace
+pr_number: {pr.number}
+title: "{pr.title}"
+
+merged_at: "{pr.mergedAt}"
+merge_sha: "{merge_sha}"
+base_ref: "{pr.baseRefName | null}"
+head_ref: "{pr.headRefName | null}"
+base_sha: "{pr.baseRefOid | null}"
+head_sha: "{pr.headRefOid | null}"
+
+commit_shas: [{sha}, ...]
+
+links: [{link}, ...]
+tags: ["git", "project:{repo_name}", "kind:pr", "scope:{pr_scope}"]
+summary: "{pr.title}"
+
+related_to: []
+```
+
+PR commit membership lives on the `depends_on` graph edge passed as a top-level arg in Step 7 — not frontmatter. Outgoing `depends_on` is queryable via `akb_relations`; the release skill consumes it through `akb_search` + `set(pr.depends_on)`.
+
+`scope:{pr_scope}` omitted when Step 5 produced null. `kind:pr` is the cross-plugin discriminator (read by the external maintenance layer and `/ingest-release` Step 7); `project:{repo_name}` is the rollup namespace and repo-identifier SSOT. Per-commit author / paths / stats / conv-type / diff-scope live on each commit doc's tags + `## Source`, not aggregated here.
+
+Body:
+
+```markdown
+# {pr.title}
+
+## Description
+> {pr.body, verbatim, preserving blank lines and formatting}
+
+## Linked
+- {link_1}
+- {link_2}
+...
+
+(If `links` is empty, omit this section entirely.)
+
+## Commits
+| # | SHA | Author | Summary |
+|---|-----|--------|---------|
+| 1 | `{short_sha}` | {author} | {summary from commit doc} |
+| 2 | ... | ... | ... |
+
+## Merge
+- merge_sha: `{merge_sha}`
+- base_ref → head_ref: `{pr.baseRefName}` → `{pr.headRefName}` (if provided)
+- merged_at: {pr.mergedAt}
+```
+
+Assembly rules: quote the PR body as a single block-quote (no paraphrase / truncate / reflow); render `> (no description)` when `pr.body` is empty rather than omitting; preserve fenced code blocks inside the quote; pull Commits table `summary` from each commit doc (never re-derive); append `(truncated)` to a row when the commit doc has `truncated: true`.
+
+### Step 7 — Write the PR document
+
+**Create** — `akb_put(vault={vault_name}, collection=git-prs, title="PR #{pr.number}: {pr.title}", type=reference, tags={tags}, content={assembled_body}, summary={pr.title}, depends_on={commit_uris})`.
+
+**Update** — `akb_update(doc_id={existing_doc_id}, vault={vault_name}, title="PR #{pr.number}: {pr.title}", tags={tags}, content={assembled_body}, summary={pr.title}, depends_on={commit_uris})`.
+
+`depends_on` passes as a top-level arg so AKB stores graph edges (queryable via `akb_relations`), not opaque frontmatter. PR-to-commits lives entirely on this edge — no commit-side backlink. Re-ingest rewrites the edge set idempotently. Capture `pr_doc_id` / `pr_doc_path`.
+
+### Step 8 — Return
+
+```markdown
+## ingest-pr: {created|updated}
+- repo: {repo_name}
+- pr_number: {pr.number}
+- doc_id: {pr_doc_id}
+- commits: {N}
+- vault: {vault_name}
+- collection: git-prs
+- merge strategy: {explicit | merge_commit | squash}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<pr-number>` missing | `Missing required argument: <pr-number>` |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| `gh` not on PATH or not authenticated | `gh CLI unavailable or not authenticated. Run gh auth login.` |
+| Repo has no GitHub remote | `Repo at {repo_path} has no GitHub remote that gh can resolve.` |
+| `gh pr view` reports PR not found | `PR not found in the configured GitHub remote: #{pr_number}.` |
+| `gh pr view` failed for any other reason | `gh pr view failed for #{pr_number}: {stderr}.` |
+| PR not yet merged (`mergedAt` is null) | `PR #{pr_number} is not merged; this skill records merge events only.` |
+| `merge_sha` from `gh` not in local repo | `merge_sha not found in local repository: {merge_sha}. Fetch latest from the GitHub remote.` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| Enumeration yielded 0 commits | `No commits enumerated for PR #{pr_number}; the local repo may be missing branch refs — fetch latest from the GitHub remote.` |
+| One or more commits missing in vault | `Missing commit(s) in vault: {sha_list}. Ingest the commit(s) via /akb-ingest first.` |
+| AKB write fails | Surface the error verbatim; do not retry. |
+| Dedup hit | Update existing PR doc silently. Not an error. |

--- a/plugins/codex/akb-wiki/support/agents/ingest-release.md
+++ b/plugins/codex/akb-wiki/support/agents/ingest-release.md
@@ -1,0 +1,333 @@
+---
+name: ingest-release
+description: Record a single release tag as a git-release document in an AKB vault — release notes from the matching GitHub Release (annotated tag message fallback), commits bucketed by conv_type. Requires range commits pre-ingested.
+model: gpt-5.4-mini
+reasoning_effort: medium
+---
+
+# AKB Git Release Ingest
+
+Record a **single release/tag event** as a `git-release` document in the target AKB vault. Mechanical assembly only — the release notes (from a GitHub Release fetched via `gh release view`, or the annotated tag message as fallback) are quoted as compiled-truth, and the commit/PR membership is derived from documents already in the vault. No LLM synthesis. This skill does not accept hand-supplied payloads — the canonical sources of release-notes text are GitHub itself (via `gh`) and `git` itself (annotated tag message).
+
+Scope boundaries:
+
+- **One tag per invocation.** No loops, no cross-release consolidation.
+- **GitHub-first, git-fallback for release notes.** A GitHub Release for the tag (fetched via `gh release view --json`) wins as compiled-truth body; if no GitHub Release exists, an annotated tag message is the fallback; otherwise the body is `(no release notes)`. Lightweight tags with no GitHub Release legitimately have no body.
+- **Commits must be pre-ingested.** Every commit in the tag window must already exist in `git-commits` as a `git-commit` document.
+- **No LLM synthesis.** Release notes are quoted verbatim; commits are bucketed by `conv_type` mechanically, not summarized by an agent.
+- **No release asset / binary handling.** Checksums, artifact URLs, draft/prerelease flags, and signing metadata are out of scope.
+- **No semver interpretation.** The `tag` string is treated opaquely — this skill does not parse version components or enforce ordering rules.
+- **Upsert.** Dedup by `(repo, tag)`. Re-ingesting the same tag silently overwrites — legitimate when release notes are edited after the fact on GitHub.
+
+## Inputs (provided by the /akb-ingest router)
+
+```text
+/ingest-release <tag> --vault {vault_name} [--prev-tag {tag}] [--repo {path}]
+```
+
+- `<tag>` (required, positional) — release tag name (e.g. `v3.0.0`). Must resolve inside the target repo.
+- `--vault` (required) — target AKB vault.
+- `--prev-tag` (optional) — the previous release tag; overrides auto-discovery. First releases (no prior tag) are valid and enumerate from root.
+- `--repo` (optional) — path to the local clone of the GitHub repository. Defaults to the current working directory.
+
+## Prerequisites
+
+- AKB MCP server is accessible.
+- `--vault {name}` provided.
+- `git` and `gh` are available on PATH.
+- `gh auth status` succeeds — required so the skill can attempt to fetch a GitHub Release for the tag. (If the repo has no GitHub remote or no Release exists for the tag, the skill falls back to the annotated tag message — `gh` itself is still required.)
+- `{tag}` resolves inside the target repo.
+- Every commit in the `prev_tag..tag` (or root..tag, for first release) range has a `git-commit` document in the vault.
+
+## Workflow
+
+### Step 1 — Resolve inputs
+
+Common resolution every git ingest subagent performs before its own skill-specific validation.
+
+- Resolve `repo_path` from `--repo` or `pwd`. If `git -C {repo_path} rev-parse --git-dir` fails, fail with `Not a git repository: {repo_path}`.
+- Resolve `vault_name` from `--vault`. Hard-fail if missing: `--vault {name} required.`
+- Resolve `repo_name` as the last path segment of `repo_path` (normalized). All git ingest subagents use this same rule so they agree on the `repo` axis.
+
+Then validate that `gh` is available and authenticated:
+
+```bash
+gh auth status
+```
+
+Fail with `gh CLI unavailable or not authenticated. Run gh auth login.` on non-zero exit.
+
+Then validate the tag: `git -C {repo_path} rev-parse --verify {tag}`. Fail with `Tag not found in repository: {tag}` on error. Also resolve `tagged_commit_sha = git -C {repo_path} rev-parse {tag}^{commit}`.
+
+### Step 2 — Extract tag metadata
+
+Determine the tag kind:
+
+```bash
+git -C {repo_path} cat-file -t {tag}
+```
+
+- If the output is `tag` → **annotated**. Parse the tag object:
+  ```bash
+  git -C {repo_path} cat-file tag {tag}
+  ```
+  Extract `tagger` (name + email), `tagged_at` (ISO 8601), and the tag message (everything after the blank line separator). Normalize the tagger name using the same rules as `ingest-commit` (`.mailmap` + `author_aliases`).
+- If the output is `commit` → **lightweight**. Use the tagged commit's committer as `tagger` and its `committed_at` as `tagged_at`. `tag_message` is `null`.
+
+Record `tag_kind` as `"annotated"` or `"lightweight"`.
+
+#### Fetch GitHub Release notes
+
+Attempt `(cd {repo_path} && gh release view {tag} --json tagName,name,body,publishedAt,author)`. Outcome handling:
+
+- Exit 0 → set `gh_release.body` and `gh_release.published_at` from the response. Step 9 prefers `body` over the tag message only when non-empty after trimming whitespace.
+- `gh` reports "release not found" / no GitHub remote → set `gh_release = null` and continue. Not a failure — many tags have no corresponding GitHub Release; non-GitHub remotes still ingest using only the annotated tag message.
+- Any other non-zero exit → fail with `gh release view failed for {tag}: {stderr}.`
+
+### Step 3 — Resolve `prev_tag`
+
+1. Use the `--prev-tag` CLI argument if provided.
+2. Otherwise auto-discover:
+   ```bash
+   git -C {repo_path} describe --tags --abbrev=0 {tag}^
+   ```
+   If this fails (no prior tag exists), treat as the first release. Emit an informational line in the final report (`first release — enumerating from root`) — not an error.
+
+If `--prev-tag` was given, validate with `git -C {repo_path} rev-parse --verify {prev_tag}`. Fail with `prev_tag not found in repository: {prev_tag}` if the override is invalid.
+
+### Step 4 — Enumerate commits
+
+If `prev_tag` is resolved:
+
+```bash
+git -C {repo_path} log --reverse --format=%H {prev_tag}..{tag}
+```
+
+If `prev_tag` is `null` (first release):
+
+```bash
+git -C {repo_path} log --reverse --format=%H {tag}
+```
+
+Call the resulting ordered list `sha_list` (chronologically ascending). If `sha_list` is empty:
+
+- For first-release case with empty history: fail with `No commits in tag {tag}.`
+- For `prev_tag..tag` yielding empty: fail with `No commits between {prev_tag} and {tag}; check the range.`
+
+### Step 5 — Dedup check
+
+```text
+mcp__akb__akb_search(
+  query="release {tag} {repo_name}",
+  vault="{vault_name}",
+  collection="git-releases",
+  type="reference",
+  tags=["git", "kind:release", "project:{repo_name}"],
+  limit=5
+)
+```
+
+Among the hits, find the one whose frontmatter has `repo == repo_name AND tag == tag`. If found, capture `existing_doc_id` for the update path; otherwise, proceed to create.
+
+### Step 6 — Fetch commit documents
+
+Given a chronologically-ordered list `sha_list`, resolve each SHA to its commit document (`type=reference, kind:commit`) in the vault.
+
+**Concurrency is required.** Issue all searches in a single parallel tool-use block, then issue any required `akb_get` calls in a second parallel block. Sequential per-SHA loops are forbidden — a 30-commit input is two batched round trips, not 30 or 60.
+
+```text
+mcp__akb__akb_search(
+  query="{sha}",
+  vault="{vault_name}",
+  collection="git-commits",
+  type="reference",
+  tags=["git", "kind:commit"],
+  limit=3
+)
+```
+
+For each search, pick the hit whose title prefix matches `{short_sha}` — the per-commit summary doc's title is `{short_sha} {message_subject}`, and `akb_search` returns the title in its hit payload, so the search query (`query="{full_sha}"`) plus a title-prefix check uniquely identifies the matching commit. The downstream-needed fields below are all reachable from the `akb_search` hit (`path`, `title`, `summary`, `tags`); only fall back to `akb_get` if a specific consumer needs body content (e.g., for surfacing author detail in a human-readable table).
+
+For each `commit_records[i]`, populate the downstream-needed fields from the AKB primitives that durably persist them:
+
+- `doc_id`, `path`, `title`, `summary` — from the search hit (whitelist fields exposed by `akb_search`).
+- `short_sha` — first 7 chars of the full SHA (already known from the search query); also recoverable from the title prefix.
+- `author` — parse from the row's `tags` array as `tag[len("author:"):]` for the first `author:*` tag emitted by `/ingest-commit` Step 6. Single-author commits emit one such tag; merge commits emit either the merging committer or whichever name `.mailmap` resolved. `null` if no `author:*` tag is present (defensive — the commit ingest always emits one).
+- `conv_type` — parse from the row's `tags` array as `tag[len("type:"):]` for the first `type:*` tag. `null` when the commit subject did not match the conventional-commit pattern.
+- `scope` — parse `tag[len("scope:"):]` for the first `scope:*` tag. Drives PR-level `pr_scope` aggregation downstream without re-deriving from a `paths` list.
+
+Skip the secondary `akb_get` whenever the search hit already exposes everything in the list above — PR / release ingest only needs `path` / `summary` / `tags`, all reachable from `akb_search`. A 30-commit PR is one batched `akb_search` round trip, not 30+30.
+
+The full file list, per-commit stats, and diff scope are not aggregated across commits — the per-commit body's `### Paths` and `## Stats` sections are the audit surface, reachable via the PR's `depends_on` graph edge.
+
+If any SHA in `sha_list` has no matching hit, **fail** before proceeding:
+
+```text
+Missing commit(s) in vault: {missing_sha_list}.
+Run `/akb-ingest <sha>` for each before re-running.
+```
+
+Never re-fetch diffs or invoke git for individual commits here. The ingested `summary` and `Changes` block are authoritative — diff re-reading would defeat the reason ingest paid that cost.
+
+Collect the results into `commit_records`, aligned with `sha_list`.
+
+### Step 7 — Derive the PR axis
+
+There is no commit-side backlink to read — PR-to-commit linkage lives on each PR document's outgoing `depends_on` graph edge (set by `ingest-pr` Step 7). Discover candidate PRs by searching the vault, then intersect each PR's `depends_on` with the release's commit set: `range_commit_uris = { "akb://{vault_name}/doc/{record.path}" for record in commit_records }`.
+
+Search for PRs: `akb_search(vault="{vault_name}", query="pr {repo_name}", collection="git-prs", type="reference", tags=["git", "kind:pr", "project:{repo_name}"], limit=500)`. Hits return summaries (`path`, `title`, `summary`, `tags`, fusion score) but no frontmatter or graph edges — hydrate separately:
+
+1. **Hydration block** (one parallel tool-use block) — `akb_get(vault="{vault_name}", doc_id={hit.path})` for every hit. Capture `path`, frontmatter `repo` / `pr_number` / `merged_at`, and `title`. Filter to rows whose `repo == repo_name`.
+2. **Outgoing-edge block** (second parallel tool-use block) — `akb_relations(vault="{vault_name}", resource_uri="akb://{vault_name}/doc/{pr.path}", direction="outgoing", type="depends_on")` for each surviving PR. Sequential per-PR fetches are forbidden.
+
+For each PR, set `pr.commit_uris` to the outgoing edges and compute `pr.commit_uris ∩ range_commit_uris`. Drop PRs with empty intersection (out of range) and PRs with empty `depends_on` (their commits surface as orphans in the body). Order survivors by `merged_at` ascending into `pr_records` with `doc_id` / `path` / `pr_number` / `title` / `merged_at` / `covered_commit_uris`.
+
+Compose:
+
+```
+pr_doc_refs         = [ "akb://{vault_name}/doc/{pr.path}" for pr in pr_records ]   # full URIs, chronological
+covered_commit_uris = ⋃ { pr.covered_commit_uris for pr in pr_records }
+orphan_commit_uris  = range_commit_uris − covered_commit_uris
+```
+
+`covered_commit_uris` and `orphan_commit_uris` partition `range_commit_uris`. Orphans render as individual commit rows in the body.
+
+### Step 8 — Compose the release's graph edge
+
+From `commit_records`, the only downstream-needed value is `commit_shas` — an ordered list of full SHAs (chronological), preserved in the release doc's frontmatter for cheap audit lookup without traversing the `depends_on` chain. No per-commit aggregation (stats / conv-types / diff-scope / authors / paths) is performed at the release level — those keys are silent-dropped by the `akb_put` whitelist anyway. The body's `## Changes` / `## All commits` / Range sections render directly from `commit_records` and `pr_records` for human readers; the external maintenance layer does not aggregate from release docs.
+
+Compose the release's `depends_on` set — the PR-or-orphan-commit edges this release covers (PR-covered commits are reachable transitively via the PR's own `depends_on`, so the release does not duplicate them):
+
+```
+release_depends_on = pr_doc_refs + sorted(orphan_commit_uris by chronological order in commit_records)
+```
+
+### Step 9 — Assemble the page
+
+Frontmatter:
+
+```yaml
+type: reference
+status: active
+
+repo: "{repo_name}"
+tag: "{tag}"
+prev_tag: "{prev_tag | null}"
+
+tagger: "{canonical_tagger_name}"
+tagger_email: "{raw_tagger_email}"
+tagged_at: "{tagged_at_iso}"
+tagged_commit_sha: "{tagged_commit_sha}"
+tag_kind: "{annotated | lightweight}"
+
+commit_shas: [{sha}, ...]
+
+tags: ["git", "project:{repo_name}", "kind:release"]
+summary: "{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)"
+```
+
+Commit and PR membership lives entirely on the `depends_on` graph edge passed to `akb_put` / `akb_update` in Step 10 (PR-covered commits transitively, orphans directly) — not in frontmatter. `akb_relations` traverses both layers.
+
+Body (bucket by `conv_type`):
+
+```markdown
+# {tag}
+
+## Release notes
+> {gh_release.body (if non-empty) OR tag_message OR "(no release notes)"}
+
+## Changes
+
+### New Features
+- PR #{pr_number}: {pr_title}
+- Commit `{short_sha}`: {commit_summary}
+
+### Fixes
+- ...
+
+### Other
+- ...
+
+## Range
+- prev_tag → tag: `{prev_tag | "—"}` → `{tag}`
+- tagged_commit: `{short_tagged_commit_sha}`
+- tagged_at: {tagged_at}
+- kind: {tag_kind}
+
+## All commits
+| # | SHA | PR | Author | Summary |
+|---|-----|-----|--------|---------|
+| 1 | `{short_sha}` | `#{pr_number}` or `—` | {author} | {commit_summary} |
+| 2 | ... | ... | ... | ... |
+```
+
+#### Bucketing rules for `## Changes`
+
+Render three subsections: **New Features**, **Fixes**, **Other**.
+
+1. Assign each PR in `pr_records` to a bucket by its dominant `conv_type`:
+   - At least one commit with `conv_type == feat` → **New Features**
+   - Else at least one with `conv_type == fix` → **Fixes**
+   - Else → **Other**
+   Render one row per PR: `- PR #{pr_number}: {pr_title}`.
+2. Assign each orphan commit (whose URI is in `orphan_commit_uris` from Step 7) by its own `conv_type`:
+   - `feat` → **New Features**
+   - `fix` → **Fixes**
+   - Anything else (including `null` conv_type) → **Other**
+   Render one row per orphan commit: ``- Commit `{short_sha}`: {commit_summary}``.
+3. Omit any bucket that is empty (do not print an empty section header).
+
+This bucketing is **rule-based**, not LLM-driven. Do not reword the PR titles or commit summaries — quote them as they already exist in the vault.
+
+#### `## All commits` table
+
+Lists **every** commit in `sha_list` (chronological), regardless of PR membership. Columns:
+
+- `#` — 1-based index.
+- `SHA` — `short_sha` in code formatting.
+- `PR` — `#{pr_number}` if the commit's URI appears in any `pr.covered_commit_uris` from `pr_records`, else `—`.
+- `Author` — from the commit doc.
+- `Summary` — the commit doc's `summary` (faithful 1-line). Append `(truncated)` if its `truncated` flag is true.
+
+### Step 10 — Write the release document
+
+**Create.** `akb_put(vault="{vault_name}", collection="git-releases", title="Release {tag}", type="reference", tags={tags}, content={assembled_body}, summary="{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)", depends_on={release_depends_on})`.
+
+**Update.** `akb_update(vault="{vault_name}", doc_id={existing_doc_id}, title="Release {tag}", tags={tags}, content={assembled_body}, summary="{tag} ({len(commit_records)} commits, {len(pr_records)} PRs)", depends_on={release_depends_on})`.
+
+`depends_on` is passed as a top-level argument so AKB stores it as graph edges. The release-to-PR-and-orphan-commit relationship lives entirely on this edge — no member-side `release` backlink is written. PR-covered commits are reachable transitively via the PR's own `depends_on`. Re-ingest of the same tag rewrites the edge set idempotently. Capture the resulting `release_doc_id` and `release_doc_path`.
+
+### Step 11 — Return
+
+```markdown
+## ingest-release: {created|updated}
+- repo: {repo_name}
+- tag: {tag}
+- prev_tag: {prev_tag | "— (first release)"}
+- doc_id: {release_doc_id}
+- commits: {len(commit_records)} ({len(orphan_commit_uris)} orphan, {len(commit_records) - len(orphan_commit_uris)} PR-covered)
+- prs: {len(pr_records)}{ ", {K} PR(s) skipped (empty depends_on)" if K > 0 }
+- vault: {vault_name}
+- collection: git-releases
+- tag_kind: {annotated | lightweight}
+```
+
+## Failure handling
+
+| Situation | Response |
+|---|---|
+| `<tag>` missing | `Missing required argument: <tag>` |
+| Tag not in repo | `Tag not found in repository: {tag}` |
+| `--prev-tag` override not in repo | `prev_tag not found in repository: {prev_tag}` |
+| prev_tag auto-discovery fails | Proceed as first release; report it in the final summary. |
+| `gh` not on PATH or not authenticated | `gh CLI unavailable or not authenticated. Run gh auth login.` |
+| `gh release view` failed for a non-"not found" reason | `gh release view failed for {tag}: {stderr}.` |
+| `gh release view` reports no release for the tag, or repo has no GitHub remote | Continue with `gh_release = null`; the annotated tag message becomes the release-notes body. Not an error. |
+| Repo path is not a git repo | `Not a git repository: {repo_path}` |
+| `--vault` not passed | `--vault {name} required.` |
+| Vault does not exist | `Vault "{vault_name}" not found. Create with mcp__akb__akb_create_vault first.` |
+| Empty commit range | `No commits between {prev_tag} and {tag}; check the range.` (or `No commits in tag {tag}.` for first release) |
+| One or more commits missing in vault | `Missing commit(s) in vault: {sha_list}. Ingest the commit(s) via /akb-ingest first.` |
+| A PR in the repo has empty `depends_on` | Drop silently from `pr_records`; affected commits surface as orphans. Reported in the return summary as informational, not an error. |
+| AKB write fails | Surface verbatim; do not retry. |
+| Dedup hit | Update existing release doc silently. |

--- a/plugins/skillpack-plugins.md
+++ b/plugins/skillpack-plugins.md
@@ -1,0 +1,50 @@
+# AKB agent plugins
+
+Plugins that turn [AKB](https://github.com/dnotitia/akb) into an agent-native
+knowledgebase you can drive from **Claude Code** and **Codex** — ingest sources
+into a vault and query across it without leaving your agent.
+
+## Plugins
+
+- **akb-wiki** — the foundational layer for any AKB vault. `/akb-ingest` takes
+  whatever you point it at — a local file, a web URL, a GitHub PR / release /
+  commit, a Confluence page, or a Jira issue — classifies it, and writes a
+  structured document into your vault. `/akb-query` answers questions from the
+  vault with grounded, cited synthesis (read-only). It carries the `akb` MCP
+  server the other plugins reuse, so **install it first**.
+- **akb-sessions** — capture a coding session as structured notes: a session
+  report plus parallel-drafted TIL / task / idea / decision sub-notes, written
+  straight into your vault.
+- **akb-claude-code** *(Claude Code only)* — a lifecycle bridge wired through
+  Claude Code hooks (no slash command): it anchors each session to your AKB
+  memory vault, injecting your preferences and recent learnings at session
+  start, snapshotting before context compaction, and writing a recap at the end.
+
+## Install
+
+Prepare your AKB credentials first (each plugin asks for these on install):
+
+- `AKB_MCP_URL` — your AKB MCP server URL (ends in `/mcp/`)
+- `AKB_PAT` — a personal access token from your AKB instance
+
+### Claude Code
+
+```
+/plugin marketplace add dnotitia/akb
+/plugin install akb-wiki@akb-skillpack
+/plugin install akb-sessions@akb-skillpack
+/plugin install akb-claude-code@akb-skillpack
+```
+
+### Codex
+
+```bash
+codex plugin marketplace add dnotitia/akb
+codex plugin install akb-wiki
+codex plugin install akb-sessions
+```
+
+Pin a revision with `codex plugin marketplace add … --ref <sha>`; refresh with
+`codex plugin marketplace upgrade akb-skillpack`.
+
+Every skill takes `--vault {name}` per invocation to choose the target vault.


### PR DESCRIPTION
## What

Vendor the rendered, installable **Claude Code + Codex** plugin payloads from the [akb-skillpack](https://github.com/younglo-kim_dnotitia/akb-skillpack) project into this repo, so AKB users can install them straight from `dnotitia/akb`:

```
/plugin marketplace add dnotitia/akb        # Claude Code
codex plugin marketplace add dnotitia/akb   # Codex
```

**OpenClaw is excluded** — the OpenClaw bundle is not vendored, and the session-ingest skill's `--delegate openclaw` path / Gateway tool grant are stripped from the Claude/Codex payloads.

## Layout

- `plugins/claude/{akb-wiki,akb-sessions,akb-claude-code}` and `plugins/codex/{akb-wiki,akb-sessions}` — payload trees under `plugins/` to keep the repo root uncluttered (`akb-claude-code` is Claude-only).
- `.claude-plugin/marketplace.json` + `.agents/plugins/marketplace.json` — marketplace catalogs at the repo root (where `plugin marketplace add <repo>` discovers them); their plugin `source` paths are re-rooted under `plugins/`.
- `plugins/skillpack-plugins.md` — user-facing intro + install guide.
- `README.md` — new **Plugins** section + a Project Structure entry.

## Plugins

- **akb-wiki** — unified ingest (file / URL / GitHub PR / release / commit / Confluence / Jira) + read-only, cited Q&A over the vault.
- **akb-sessions** — capture a coding session as structured notes (report + follow-up tasks, learnings, ideas, decisions).
- **akb-claude-code** — Claude Code lifecycle bridge (hooks → `/api/v1/agent-sessions`); anchors each session to the user's AKB memory vault.

## Provenance

These payloads are generated upstream in akb-skillpack and pushed here by its `sync_to_akb.py` (`--check` is a drift gate). Edit upstream, not these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)