### PR TITLE
fix(frontend): strip embedded frontmatter so its closing `---` isn't rendered as a heading

### DIFF
--- a/frontend/src/components/markdown-render.tsx
+++ b/frontend/src/components/markdown-render.tsx
@@ -45,7 +45,7 @@ import {
 } from "lucide-react";
 import "katex/dist/katex.min.css";
 import { cn, sanitizeLinkUrl } from "@/lib/utils";
-import { parseHeadings, slugify } from "@/lib/markdown";
+import { parseHeadings, slugify, stripFrontmatter } from "@/lib/markdown";
 
 /* ── LaTeX delimiter normalization ────────────────────────────────
    GPT-family models emit \[..\] / \(..\); remark-math only groks the
@@ -688,13 +688,18 @@ export interface MarkdownRenderProps {
  * (see src/index.css).
  */
 export function MarkdownRender({ markdown, className }: MarkdownRenderProps) {
+  // Drop any leading embedded frontmatter block before rendering so its
+  // closing `---` isn't parsed as a setext heading (see stripFrontmatter).
+  // Sharing the stripped body keeps the rendered headings and the slug
+  // queue built inside buildComponents in lock-step.
+  const body = useMemo(() => stripFrontmatter(markdown || ""), [markdown]);
   const normalized = useMemo(
-    () => normalizeLatexDelimiters(markdown || ""),
-    [markdown],
+    () => normalizeLatexDelimiters(body),
+    [body],
   );
   const components = useMemo(
-    () => buildComponents(markdown || ""),
-    [markdown],
+    () => buildComponents(body),
+    [body],
   );
 
   return (

--- a/frontend/src/lib/__tests__/markdown.test.ts
+++ b/frontend/src/lib/__tests__/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseHeadings, slugify } from "@/lib/markdown";
+import { parseHeadings, slugify, stripFrontmatter } from "@/lib/markdown";
 
 describe("slugify", () => {
   it("lowercases and hyphenates", () => {
@@ -56,5 +56,35 @@ describe("parseHeadings — setext", () => {
   it("doesn't treat --- after an empty line as setext", () => {
     const h = parseHeadings("\n---\n");
     expect(h).toEqual([]);
+  });
+});
+
+describe("stripFrontmatter", () => {
+  it("removes a leading frontmatter block", () => {
+    const md = '---\ntype: decision\ntags: ["a", "b"]\n---\n\n# Real Title\n';
+    expect(stripFrontmatter(md)).toBe("\n# Real Title\n");
+  });
+  it("tolerates an optional BOM before the fence", () => {
+    const md = '﻿---\ntype: note\n---\n# T\n';
+    expect(stripFrontmatter(md)).toBe("# T\n");
+  });
+  it("leaves bodies without leading frontmatter untouched", () => {
+    const md = "# Title\n\nSome --- text\n\n---\n";
+    expect(stripFrontmatter(md)).toBe(md);
+  });
+  it("ignores a fence that isn't at the very start", () => {
+    const md = "intro\n\n---\ntype: x\n---\n";
+    expect(stripFrontmatter(md)).toBe(md);
+  });
+});
+
+describe("parseHeadings — embedded frontmatter", () => {
+  it("doesn't surface a trailing `tags:` line as a heading", () => {
+    const md =
+      '---\ntype: decision\nstatus: active\ntags: ["sparse-embedding-server", "seahorsedb-writer"]\n---\n\n# OOM 대응 내역\n\n## 배경\n';
+    expect(parseHeadings(md).map((x) => x.text)).toEqual([
+      "OOM 대응 내역",
+      "배경",
+    ]);
   });
 });

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -21,6 +21,25 @@ export function slugify(text: string): string {
 }
 
 /**
+ * Strip a leading YAML frontmatter block (`---\n…\n---`) from a body.
+ *
+ * The server-managed frontmatter is removed before content reaches us, but
+ * some documents carry a *second*, author-embedded frontmatter block inside
+ * their body (e.g. distilled docs whose source already had one). That inner
+ * block survives stripping, and its closing `---` would otherwise be read as
+ * a setext underline — turning the last `tags: […]` / `key: value` line into
+ * a spurious heading in both the outline and the rendered body. Removing the
+ * block at the source keeps every consumer (outline, renderer, slug queue)
+ * consistent. Only a block at the very start counts as frontmatter; a `---`
+ * thematic break later in the body is untouched.
+ */
+export function stripFrontmatter(md: string): string {
+  if (!md) return md;
+  const m = /^\uFEFF?---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/.exec(md);
+  return m ? md.slice(m[0].length) : md;
+}
+
+/**
  * Extract ATX (`# Title`) and setext (`Title\n===`) headings from raw
  * markdown. Fenced code blocks are ignored so `# comment` inside a snippet
  * doesn't pollute the outline, and slugs are made unique by appending
@@ -31,7 +50,7 @@ export function slugify(text: string): string {
  */
 export function parseHeadings(md: string): Heading[] {
   if (!md) return [];
-  const lines = md.split("\n").map((l) => l.replace(/\r$/, ""));
+  const lines = stripFrontmatter(md).split("\n").map((l) => l.replace(/\r$/, ""));
   const seen = new Map<string, number>();
   const out: Heading[] = [];
   let inFence = false;


### PR DESCRIPTION
## Problem

In the document view, the **Outline** tab (and the rendered body) surfaced a stray `tags: ["...", ...]` line as a heading, above the real document title.

Root cause is a combination of data state + parser behavior:

- Some documents carry a **second, author-embedded YAML frontmatter block inside their body** — e.g. distilled docs whose source content already had one. The server-managed frontmatter is stripped before content reaches the client (so `metadata.status` differs from the body's `status:`), but this inner block survives.
- `parseHeadings` (outline) and `react-markdown` (body) then read the block's closing `---` as a **setext underline**, turning the last `tags: [...]` / `key: value` line into a spurious H2.

Repro doc: `storage-team/design/sparse-embedding-server OOM 및 seahorsedb-writer probe timeout 대응 내역` — its body begins with a full `---\n…\ntags: [...]\n---` block.

## Fix

- Add a shared `stripFrontmatter()` in `lib/markdown.ts` that removes a leading `---\n…\n---` block. Only a block at the **very start** counts as frontmatter; a `---` thematic break later in the body is untouched.
- Apply it in `parseHeadings` (covers the outline + the heading-count badge) and in `MarkdownRender` (body render + the slug queue built in `buildComponents`, kept in lock-step off the same stripped body).

Real headings (배경 / 대응 조치 / TODOs / …) are preserved; only the frontmatter remnant disappears.

## Tests

- New unit tests for `stripFrontmatter` (leading block, optional BOM, no-leading-block, mid-body fence left intact) and a `parseHeadings` regression that the trailing `tags:` line is no longer a heading.
- `bash scripts/check.sh` green (eslint / tsc / vitest 254 passed / detect-secrets).

Frontend-only; no backend changes. Already built + rolled out to the internal cluster for visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)