### PR TITLE
fix(ui): dashboard time unification + vault sidebar kind chips & grouping

### DIFF
--- a/frontend/src/components/ui/relative-time.tsx
+++ b/frontend/src/components/ui/relative-time.tsx
@@ -1,0 +1,49 @@
+import { cn, formatDate, isFresh, timeAgo } from "@/lib/utils";
+
+interface RelativeTimeProps {
+  /** ISO timestamp to render relatively (e.g. "3h ago", "8mo ago"). */
+  iso?: string | null;
+  /** Layout classes for the call site (width, alignment). Applied to both
+   *  the fresh and the muted variant so they align identically. */
+  className?: string;
+  /** Rendered when `iso` is missing. Defaults to timeAgo's "-". */
+  fallback?: string;
+}
+
+/**
+ * The single relative-time chip used everywhere a timestamp appears — the
+ * grammar the Home "Recent activity" card established: a just-touched item
+ * (<1h) gets the warm spark dot + spark-tinted time; everything older reads
+ * as a muted `coord` label. Extracted so the dashboard recent feed, the vault
+ * directory rows, the vault overview header, and the per-vault recent list all
+ * speak ONE time format instead of each re-rolling timeAgo() inline.
+ *
+ * Pass alignment/width via `className` (e.g. "justify-end text-right w-[56px]").
+ */
+export function RelativeTime({ iso, className, fallback }: RelativeTimeProps) {
+  if (!iso) {
+    return <span className={cn("coord tabular-nums", className)}>{fallback ?? "-"}</span>;
+  }
+  // Exact date on hover, everywhere — the relative grain is the glance, the
+  // tooltip is the precise answer.
+  const title = formatDate(iso);
+  if (isFresh(iso)) {
+    return (
+      <span
+        title={title}
+        className={cn(
+          "inline-flex items-center gap-1 text-[11px] font-medium tabular-nums text-spark",
+          className,
+        )}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-spark" aria-hidden />
+        {timeAgo(iso)}
+      </span>
+    );
+  }
+  return (
+    <span title={title} className={cn("coord tabular-nums", className)}>
+      {timeAgo(iso)}
+    </span>
+  );
+}

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -3,10 +3,10 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
-  File,
   FilePlus,
   FileText,
   FolderPlus,
+  Paperclip,
   Sparkles,
   Table,
   Trash2,
@@ -406,7 +406,7 @@ const TreeRow = memo(function TreeRow({
           data-sig={sig}
           onClick={() => onToggle(node.path)}
           style={indent}
-          className={`flex-1 min-w-0 flex items-center gap-1.5 pr-2 py-1 text-left transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none cursor-pointer ${
+          className={`flex-1 min-w-0 flex items-center gap-1.5 pr-2 py-1.5 min-h-9 text-left transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none cursor-pointer ${
             isActive ? "bg-surface-selected text-surface-selected-foreground" : ""
           }`}
         >
@@ -468,7 +468,7 @@ const TreeRow = memo(function TreeRow({
 
   const href = leafHref(vault, node);
   const isSkill = node.kind === "document" && node.raw?.doc_type === "skill";
-  const LeafIcon = isSkill ? Sparkles : node.kind === "document" ? FileText : node.kind === "table" ? Table : File;
+  const LeafIcon = isSkill ? Sparkles : node.kind === "document" ? FileText : node.kind === "table" ? Table : Paperclip;
   // Tint the leaf icon by resource kind from the categorical ramp (the same
   // doc=cat-1 / table=cat-3 / file=cat-4 mapping the Home + overview rows use),
   // so a doc vs a table vs a file is a colour at a glance — not just an icon
@@ -485,15 +485,34 @@ const TreeRow = memo(function TreeRow({
       aria-current={isActive ? "page" : undefined}
       aria-selected={isActive}
       style={indent}
-      className={`flex items-center gap-1.5 pr-2 py-1 group transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none ${
+      className={`flex items-center gap-1.5 pr-2 py-1.5 min-h-9 group transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none ${
         isActive ? "bg-surface-selected text-surface-selected-foreground border-l-2 border-primary -ml-[2px]" : ""
       }`}
     >
-      <LeafIcon
-        className="h-3 w-3 shrink-0"
-        style={{ color: leafTone }}
+      {/* Tinted icon chip — the same kind-swatch grammar Home + the vault
+          overview use, so a doc vs table vs file is pre-attentive here too
+          (was a bare 12px glyph, the one surface that dropped the chip). */}
+      <span
+        className="inline-flex h-4 w-4 items-center justify-center rounded-[var(--radius-sm)] shrink-0"
+        style={{
+          color: leafTone,
+          backgroundColor: `color-mix(in srgb, ${leafTone} 12%, transparent)`,
+        }}
         aria-hidden
-      />
+      >
+        <LeafIcon className="h-2.5 w-2.5" aria-hidden />
+      </span>
+      {/* The chip is aria-hidden, so name kind to assistive tech in words
+          (otherwise a SR user hears the bare title with no type). */}
+      <span className="sr-only">
+        {node.kind === "document"
+          ? isSkill
+            ? "Skill: "
+            : "Document: "
+          : node.kind === "table"
+            ? "Table: "
+            : "File: "}
+      </span>
       <span title={node.name} className="truncate min-w-0 text-[13px] group-hover:text-link">{node.name}</span>
       {isSkill && <SkillBadge defined className="ml-auto shrink-0" />}
     </Link>

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import { Alert } from "@/components/ui/alert";
 import { SkillBadge } from "@/components/ui/skill-badge";
-import { useVaultTree, useExpandedPaths, type TreeNode } from "@/hooks/use-vault-tree";
+import { useVaultTree, useExpandedPaths, type NodeKind, type TreeNode } from "@/hooks/use-vault-tree";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import {
   activePathFromRoute,
@@ -260,8 +260,9 @@ export function VaultExplorer({
 
         {!loading && !error &&
           visibleRows.map((r) => (
-            <TreeRow
-              key={r.sig}
+            <Fragment key={r.sig}>
+              {r.kindHeader && <KindGroupLabel kind={r.kindHeader} depth={r.depth} />}
+              <TreeRow
               node={r.node}
               depth={r.depth}
               sig={r.sig}
@@ -295,7 +296,8 @@ export function VaultExplorer({
                   subCollectionCount: countSubCollections(node),
                 })
               }
-            />
+              />
+            </Fragment>
           ))}
 
         {!loading && !error && !filter && !uncapped &&
@@ -518,6 +520,34 @@ const TreeRow = memo(function TreeRow({
     </Link>
   );
 });
+
+/* ── Kind-group label (Documents / Tables / Files) ────────────────────────── */
+
+const KIND_LABEL: Partial<Record<NodeKind, string>> = {
+  document: "Documents",
+  table: "Tables",
+  file: "Files",
+};
+
+/**
+ * A muted, non-interactive group heading rendered above the first row of each
+ * leaf-kind run when a collection mixes kinds (Sentence case per the design
+ * system). `role="presentation"` + no `data-sig` keeps it out of the tree's
+ * roving keyboard nav and the aria-tree row set — it's purely a visual divider.
+ */
+function KindGroupLabel({ kind, depth }: { kind: NodeKind; depth: number }) {
+  const label = KIND_LABEL[kind];
+  if (!label) return null;
+  return (
+    <div
+      role="presentation"
+      style={{ paddingLeft: `${depth * 12 + 12}px` }}
+      className="coord px-2 pt-2 pb-0.5 select-none"
+    >
+      {label}
+    </div>
+  );
+}
 
 /* ── Helpers ──────────────────────────────────────────────────────────────── */
 

--- a/frontend/src/components/vault-list.tsx
+++ b/frontend/src/components/vault-list.tsx
@@ -6,8 +6,8 @@ import { Panel } from "@/components/ui/panel";
 import { Badge } from "@/components/ui/badge";
 import { VaultChip } from "@/components/ui/vault-chip";
 import { RoleBadge } from "@/components/status-badge";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { recentTone } from "@/lib/recent";
-import { isFresh, timeAgo } from "@/lib/utils";
 
 export interface VaultRow {
   id: string;
@@ -103,18 +103,11 @@ export function VaultList({ vaults }: { vaults: VaultRow[] }) {
                 <div className="flex items-center gap-3 shrink-0">
                   <VaultStatsCell m={m} />
                   {m ? (
-                    lastActivity && isFresh(lastActivity) ? (
-                      // Fresh (<1h) → the same spark treatment the Home Recent
-                      // card uses, so the dashboard's two time columns match.
-                      <span className="inline-flex w-[56px] items-center justify-end gap-1 text-[11px] font-medium tabular-nums text-spark">
-                        <span className="h-1.5 w-1.5 rounded-full bg-spark" aria-hidden />
-                        {timeAgo(lastActivity)}
-                      </span>
-                    ) : (
-                      <span className="coord tabular-nums whitespace-nowrap w-[56px] text-right">
-                        {lastActivity ? timeAgo(lastActivity) : "—"}
-                      </span>
-                    )
+                    <RelativeTime
+                      iso={lastActivity}
+                      fallback="—"
+                      className="w-[56px] justify-end text-right whitespace-nowrap"
+                    />
                   ) : (
                     <span
                       className="h-3 w-[56px] rounded bg-surface-muted animate-pulse"

--- a/frontend/src/components/vault-list.tsx
+++ b/frontend/src/components/vault-list.tsx
@@ -6,7 +6,8 @@ import { Panel } from "@/components/ui/panel";
 import { Badge } from "@/components/ui/badge";
 import { VaultChip } from "@/components/ui/vault-chip";
 import { RoleBadge } from "@/components/status-badge";
-import { timeAgo } from "@/lib/utils";
+import { recentTone } from "@/lib/recent";
+import { isFresh, timeAgo } from "@/lib/utils";
 
 export interface VaultRow {
   id: string;
@@ -102,9 +103,18 @@ export function VaultList({ vaults }: { vaults: VaultRow[] }) {
                 <div className="flex items-center gap-3 shrink-0">
                   <VaultStatsCell m={m} />
                   {m ? (
-                    <span className="coord tabular-nums whitespace-nowrap w-[56px] text-right">
-                      {lastActivity ? timeAgo(lastActivity) : "—"}
-                    </span>
+                    lastActivity && isFresh(lastActivity) ? (
+                      // Fresh (<1h) → the same spark treatment the Home Recent
+                      // card uses, so the dashboard's two time columns match.
+                      <span className="inline-flex w-[56px] items-center justify-end gap-1 text-[11px] font-medium tabular-nums text-spark">
+                        <span className="h-1.5 w-1.5 rounded-full bg-spark" aria-hidden />
+                        {timeAgo(lastActivity)}
+                      </span>
+                    ) : (
+                      <span className="coord tabular-nums whitespace-nowrap w-[56px] text-right">
+                        {lastActivity ? timeAgo(lastActivity) : "—"}
+                      </span>
+                    )
                   ) : (
                     <span
                       className="h-3 w-[56px] rounded bg-surface-muted animate-pulse"
@@ -146,9 +156,9 @@ function CompositionBar({ d, t, f }: { d: number; t: number; f: number }) {
       className="inline-flex h-1 w-10 shrink-0 overflow-hidden rounded-full bg-surface-muted"
       aria-hidden
     >
-      {seg(d, "var(--color-cat-1)")}
-      {seg(t, "var(--color-cat-3)")}
-      {seg(f, "var(--color-cat-4)")}
+      {seg(d, recentTone("document"))}
+      {seg(t, recentTone("table"))}
+      {seg(f, recentTone("file"))}
     </span>
   );
 }
@@ -173,6 +183,8 @@ function VaultStatsCell({ m }: { m?: VaultMetrics }) {
     <span
       className="coord tabular-nums whitespace-nowrap inline-flex items-center gap-2"
       title={title}
+      role="img"
+      aria-label={title}
     >
       <CompositionBar d={d} t={t} f={f} />
       {d + t + f === 0 ? (
@@ -181,19 +193,19 @@ function VaultStatsCell({ m }: { m?: VaultMetrics }) {
         <>
           {d > 0 && (
             <span className="inline-flex items-center gap-1">
-              <FileText className="h-3 w-3" aria-hidden />
+              <FileText className="h-3 w-3" style={{ color: recentTone("document") }} aria-hidden />
               {d}
             </span>
           )}
           {t > 0 && (
             <span className="inline-flex items-center gap-1">
-              <TableIcon className="h-3 w-3" aria-hidden />
+              <TableIcon className="h-3 w-3" style={{ color: recentTone("table") }} aria-hidden />
               {t}
             </span>
           )}
           {f > 0 && (
             <span className="inline-flex items-center gap-1">
-              <FileIcon className="h-3 w-3" aria-hidden />
+              <FileIcon className="h-3 w-3" style={{ color: recentTone("file") }} aria-hidden />
               {f}
             </span>
           )}

--- a/frontend/src/lib/__tests__/time-ago.test.ts
+++ b/frontend/src/lib/__tests__/time-ago.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isFresh, timeAgo } from "@/lib/utils";
+
+// timeAgo / isFresh are time-relative, so pin "now" to a fixed instant and
+// build each input as an offset back from it. Locks the bucket boundaries
+// (incl. the dormant tail w/mo/y added so directories don't show "247d ago",
+// and the 360–364d window that must read "12mo", never "0y").
+
+const NOW = Date.UTC(2026, 5, 11, 12, 0, 0); // 2026-06-11T12:00:00Z
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("timeAgo", () => {
+  it("recent grammar holds for the first week (just now / m / h / d)", () => {
+    expect(timeAgo(ago(30 * 1000))).toBe("just now");
+    expect(timeAgo(ago(59 * MIN))).toBe("59m ago");
+    expect(timeAgo(ago(HOUR))).toBe("1h ago");
+    expect(timeAgo(ago(23 * HOUR))).toBe("23h ago");
+    expect(timeAgo(ago(DAY))).toBe("1d ago");
+    expect(timeAgo(ago(6 * DAY))).toBe("6d ago");
+  });
+
+  it("collapses the dormant tail into coarse buckets past a week", () => {
+    expect(timeAgo(ago(7 * DAY))).toBe("1w ago"); // 6d → 1w flip
+    expect(timeAgo(ago(28 * DAY))).toBe("4w ago");
+    expect(timeAgo(ago(30 * DAY))).toBe("1mo ago");
+    expect(timeAgo(ago(364 * DAY))).toBe("12mo ago");
+    expect(timeAgo(ago(365 * DAY))).toBe("1y ago");
+    expect(timeAgo(ago(730 * DAY))).toBe("2y ago");
+  });
+
+  it("has no 360–364d gap (must be 12mo, never 0y)", () => {
+    expect(timeAgo(ago(360 * DAY))).toBe("12mo ago");
+    expect(timeAgo(ago(364 * DAY))).toBe("12mo ago");
+  });
+
+  it("falls back to '-' for missing or non-ISO input (never 'NaNm ago')", () => {
+    expect(timeAgo(null)).toBe("-");
+    expect(timeAgo(undefined)).toBe("-");
+    expect(timeAgo("not-a-date")).toBe("-");
+  });
+});
+
+describe("isFresh", () => {
+  it("is true within the default 1h window, false outside", () => {
+    expect(isFresh(ago(30 * MIN))).toBe(true);
+    expect(isFresh(ago(2 * HOUR))).toBe(false);
+    expect(isFresh(null)).toBe(false);
+    expect(isFresh("not-a-date")).toBe(false);
+  });
+});

--- a/frontend/src/lib/__tests__/tree-route.test.ts
+++ b/frontend/src/lib/__tests__/tree-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { activePathFromRoute, filterTree, findDoc, leafHref } from "@/lib/tree-route";
+import { activePathFromRoute, filterTree, findDoc, flattenVisible, leafHref } from "@/lib/tree-route";
 import type { TreeNode } from "@/hooks/use-vault-tree";
 
 const t: TreeNode[] = [
@@ -64,5 +64,51 @@ describe("filterTree", () => {
   it("drops non-matching branches", () => {
     const out = filterTree(t, "xxx");
     expect(out).toEqual([]);
+  });
+});
+
+describe("flattenVisible — kind-group headers", () => {
+  it("labels each leaf-kind group only when a parent mixes ≥2 kinds", () => {
+    const tree: TreeNode[] = [
+      {
+        kind: "collection", name: "mixed", path: "mixed", children: [
+          { kind: "document", name: "a", path: "mixed/a.md" },
+          { kind: "document", name: "b", path: "mixed/b.md" },
+          { kind: "table", name: "t1", path: "t1" },
+          { kind: "file", name: "f1", path: "f1" },
+        ],
+      },
+      {
+        kind: "collection", name: "docsonly", path: "docsonly", children: [
+          { kind: "document", name: "c", path: "docsonly/c.md" },
+          { kind: "document", name: "d", path: "docsonly/d.md" },
+        ],
+      },
+    ];
+    const rows = flattenVisible(tree, new Set(["mixed", "docsonly"]), false);
+    expect(rows.map((r) => [r.node.name, r.kindHeader])).toEqual([
+      ["mixed", undefined],
+      ["a", "document"], // first doc of a mixed parent → header
+      ["b", undefined],
+      ["t1", "table"], // kind transition → header
+      ["f1", "file"],
+      ["docsonly", undefined],
+      ["c", undefined], // single-kind collection → no headers
+      ["d", undefined],
+    ]);
+  });
+
+  it("groups loose leaf kinds at the vault root too; collections never get a header", () => {
+    const tree: TreeNode[] = [
+      { kind: "collection", name: "col", path: "col", children: [] },
+      { kind: "document", name: "rdoc", path: "rdoc.md" },
+      { kind: "table", name: "rtab", path: "rtab" },
+    ];
+    const rows = flattenVisible(tree, new Set(), false);
+    expect(rows.map((r) => [r.node.name, r.kindHeader])).toEqual([
+      ["col", undefined],
+      ["rdoc", "document"],
+      ["rtab", "table"],
+    ]);
   });
 });

--- a/frontend/src/lib/tree-route.ts
+++ b/frontend/src/lib/tree-route.ts
@@ -1,5 +1,5 @@
 import { matchPath } from "react-router-dom";
-import type { TreeNode } from "@/hooks/use-vault-tree";
+import type { NodeKind, TreeNode } from "@/hooks/use-vault-tree";
 
 /**
  * Resolve which tree node (if any) the current URL refers to. Returns a
@@ -93,6 +93,11 @@ export interface FlatRow {
   sig: string;
   /** True iff this collection is currently expanded. `false` for leaves. */
   isOpen: boolean;
+  /** When set, render a kind-group label ("Documents"/"Tables"/"Files") just
+   *  above this row. Populated only on the first row of each leaf-kind group,
+   *  and only inside a parent that actually mixes ≥2 leaf kinds — a doc-only
+   *  collection stays unlabeled. Purely visual; not a focusable tree row. */
+  kindHeader?: NodeKind;
 }
 
 /**
@@ -111,9 +116,22 @@ export function flattenVisible(
 ): FlatRow[] {
   const out: FlatRow[] = [];
   const visit = (list: TreeNode[], depth: number) => {
+    // Label kind groups only when this sibling list mixes ≥2 leaf kinds
+    // (sub-collections don't count) — a doc-only collection stays unlabeled so
+    // the common case carries no extra chrome. The list is already sorted
+    // collection→document→table→file, so each kind arrives in one contiguous run.
+    const leafKinds = new Set<NodeKind>();
+    for (const n of list) if (n.kind !== "collection") leafKinds.add(n.kind);
+    const grouped = leafKinds.size >= 2;
+    let prevLeafKind: NodeKind | null = null;
     for (const n of list) {
       const isOpen = n.kind === "collection" && (forceOpen || expanded.has(n.path));
-      out.push({ node: n, depth, sig: signatureOf(n), isOpen });
+      let kindHeader: NodeKind | undefined;
+      if (grouped && n.kind !== "collection" && n.kind !== prevLeafKind) {
+        kindHeader = n.kind;
+      }
+      if (n.kind !== "collection") prevLeafKind = n.kind;
+      out.push({ node: n, depth, sig: signatureOf(n), isOpen, kindHeader });
       if (isOpen && n.children) visit(n.children, depth + 1);
     }
   };

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -54,7 +54,16 @@ export function timeAgo(iso: string | null | undefined): string {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
+  // Past a week, collapse the dormant tail to coarse buckets so a directory
+  // of old vaults reads "8mo ago", not a two/three-digit "247d ago" sitting
+  // next to a fresh feed's "3h ago". The recent grammar (just now / m / h / d)
+  // is preserved for the first week — the window that actually matters.
+  // Day-thresholds (not floor-then-compare) so there's no 360–364d gap that
+  // would fall through to "0y ago".
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
 }
 
 /**

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -28,6 +28,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { VaultList, type VaultRow } from "@/components/vault-list";
 import { VaultChip } from "@/components/ui/vault-chip";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { QuickstartDialog, QUICKSTART_DISMISS_KEY } from "@/components/quickstart-dialog";
 import {
   listVaults,
@@ -36,7 +37,7 @@ import {
   listPATs,
   revokePAT,
 } from "@/lib/api";
-import { isFresh, timeAgo } from "@/lib/utils";
+import { timeAgo } from "@/lib/utils";
 import { recentIcon, recentTone } from "@/lib/recent";
 import { mcpInstallSnippets, MCP_AGENT_FILES } from "@/lib/mcp-snippets";
 
@@ -288,7 +289,6 @@ export default function HomePage() {
                 {recent.map((c, i) => {
                   const Icon = recentIcon(c.type);
                   const tone = recentTone(c.type);
-                  const fresh = isFresh(c.changed_at);
                   return (
                   <li key={`${c.doc_id}:${c.changed_at ?? ""}:${i}`}>
                     <Link
@@ -315,16 +315,7 @@ export default function HomePage() {
                         <VaultChip name={c.vault} size="sm" />
                         <span className="truncate text-xs text-foreground-muted">{c.vault}</span>
                       </span>
-                      {fresh ? (
-                        <span className="inline-flex items-center justify-end gap-1 text-right text-[11px] font-medium tabular-nums text-spark">
-                          <span className="h-1.5 w-1.5 rounded-full bg-spark" aria-hidden />
-                          {timeAgo(c.changed_at)}
-                        </span>
-                      ) : (
-                        <span className="coord tabular-nums text-right">
-                          {timeAgo(c.changed_at)}
-                        </span>
-                      )}
+                      <RelativeTime iso={c.changed_at} className="justify-end text-right" />
                     </Link>
                   </li>
                   );

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { listPublications, deletePublication, getDocument, type Publication } from "@/lib/api";
 import { parseDocUri, parseFileUri } from "@/lib/uri";
-import { timeAgo } from "@/lib/utils";
+import { formatDate, timeAgo } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/empty-state";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -205,7 +205,7 @@ export default function PublicationsPage() {
                     </span>
                     <span className="coord tabular-nums hidden sm:inline">
                       {p.expires_at
-                        ? `Expires ${timeAgo(p.expires_at).replace("ago", "").trim()}`
+                        ? `Expires ${formatDate(p.expires_at)}`
                         : "Evergreen"}
                     </span>
                     <span className="coord tabular-nums">

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -14,7 +14,8 @@ import {
 } from "lucide-react";
 import { listPublications, deletePublication, getDocument, type Publication } from "@/lib/api";
 import { parseDocUri, parseFileUri } from "@/lib/uri";
-import { formatDate, timeAgo } from "@/lib/utils";
+import { formatDate } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/empty-state";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -208,9 +209,7 @@ export default function PublicationsPage() {
                         ? `Expires ${formatDate(p.expires_at)}`
                         : "Evergreen"}
                     </span>
-                    <span className="coord tabular-nums">
-                      {timeAgo(p.created_at)}
-                    </span>
+                    <RelativeTime iso={p.created_at} />
                     {/* Benign Copy/Open pair, then a separated destructive Unpub. */}
                     <div className="flex items-center gap-1">
                       <button

--- a/frontend/src/pages/vault-activity.tsx
+++ b/frontend/src/pages/vault-activity.tsx
@@ -6,7 +6,7 @@ import { Alert } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/empty-state";
 import { useDebounce } from "@/hooks/use-debounce";
-import { timeAgo } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/relative-time";
 
 const PAGE_SIZE = 50;
 
@@ -168,12 +168,10 @@ export default function VaultActivityPage() {
                       </div>
                     )}
                   </div>
-                  <span
-                    className="coord tabular-nums w-[64px] text-right shrink-0"
-                    title={e.timestamp}
-                  >
-                    {timeAgo(e.timestamp)}
-                  </span>
+                  <RelativeTime
+                    iso={e.timestamp}
+                    className="w-[64px] text-right shrink-0"
+                  />
                 </Link>
               </li>
             );

--- a/frontend/src/pages/vault.tsx
+++ b/frontend/src/pages/vault.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { getDocument, getRecent, getVaultActivity, getVaultInfo } from "@/lib/api";
-import { isFresh, timeAgo } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/relative-time";
 import { recentIcon, recentTone } from "@/lib/recent";
 import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -316,9 +316,10 @@ export default function VaultPage() {
               <span className="text-foreground">{info.owner_display_name}</span>
             </>,
           );
-        if (info.created_at) segs.push(<>Created {timeAgo(info.created_at)}</>);
+        if (info.created_at)
+          segs.push(<>Created <RelativeTime iso={info.created_at} /></>);
         if (info.last_activity)
-          segs.push(<>Last active {timeAgo(info.last_activity)}</>);
+          segs.push(<>Last active <RelativeTime iso={info.last_activity} /></>);
         if (!segs.length) return null;
         return (
           <div className="coord mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -514,7 +515,6 @@ export default function VaultPage() {
               {recent.map((c, i) => {
                 const Icon = recentIcon(c.type);
                 const tone = recentTone(c.type);
-                const fresh = isFresh(c.changed_at);
                 return (
                   <li key={`${c.doc_id}:${c.commit ?? ""}:${i}`}>
                     <Link
@@ -554,19 +554,10 @@ export default function VaultPage() {
                             {c.commit.slice(0, 7)}
                           </span>
                         )}
-                        {fresh ? (
-                          <span className="inline-flex w-[60px] items-center justify-end gap-1 text-[11px] font-medium tabular-nums text-spark">
-                            <span
-                              className="h-1.5 w-1.5 rounded-full bg-spark"
-                              aria-hidden
-                            />
-                            {timeAgo(c.changed_at)}
-                          </span>
-                        ) : (
-                          <span className="coord tabular-nums w-[60px] text-right">
-                            {timeAgo(c.changed_at)}
-                          </span>
-                        )}
+                        <RelativeTime
+                          iso={c.changed_at}
+                          className="w-[60px] justify-end text-right"
+                        />
                       </div>
                     </Link>
                   </li>
@@ -660,9 +651,7 @@ export default function VaultPage() {
                           )}
                         </span>
                         <span className="text-center">{changeMark(change)}</span>
-                        <span className="coord tabular-nums text-right">
-                          {timeAgo(c.timestamp)}
-                        </span>
+                        <RelativeTime iso={c.timestamp} className="text-right" />
                       </Link>
                     </li>
                   );


### PR DESCRIPTION
## Summary

Four small, frontend-only UX fixes on top of the design-system base, from a
ui-ux-pro-max review pass on the dashboard + vault sidebar.

- **Collection sidebar — kind affordance** (`613aea9`): promote the leaf glyph
  to the app's tinted icon chip (doc/table/file/skill), sr-only kind word for
  AT, File→Paperclip, ~36px row floor.
- **Dashboard time + composition bar** (`1ff4b02`): coarse w/mo/y buckets in
  timeAgo so a dormant vault reads "8mo ago" not "247d ago"; tint the vault-row
  count icons to match their composition-bar segments (so the 4px bar reads as
  doc/table/file, not a % meter) + role="img"/aria-label; fix the publications
  "Expires just now" future-timestamp bug.
- **Shared RelativeTime** (`1a5dd4e`): extract the Recent card's time chip
  (spark-when-fresh / muted otherwise + exact-date tooltip) into one reusable
  component, used across the dashboard recent feed, the vault directory rows,
  the vault overview header + recent/commit rows, activity, and publications —
  so every time reads identically (the dashboard recent-vs-vault mismatch).
- **Sidebar kind grouping** (`b17c30a`): muted "Documents / Tables / Files"
  sub-headers above each kind run, only when a collection mixes kinds;
  non-focusable (role=presentation), keyboard nav + aria-tree unchanged.

## Verification

`cd frontend && npm run design:check && npm run typecheck && npm run lint && npm run test`
→ all clean, **264 tests** (+7 over base: time-ago boundaries + tree grouping).
Verified in the browser against seeded mixed/fresh data: sidebar shows
Documents/Tables groups with tinted chips; recent + vault rows render the
identical spark chip (rgb 196,74,30) for a fresh item; composition-bar segment
color === count-icon color.

Frontend-only — no backend image change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
