### PR TITLE
fix(graph): draw the whole graph by default (kill the blank entry-point gate)

### DIFF
--- a/frontend/src/components/graph/GraphCanvas.tsx
+++ b/frontend/src/components/graph/GraphCanvas.tsx
@@ -37,7 +37,6 @@ interface Props {
   selected?: string;
   pinned: Set<string>;
   hidden: Set<string>;
-  degraded: boolean;
   onSelect: (uri: string | undefined) => void;
   onContextMenu: (
     node: GraphNode,
@@ -59,7 +58,24 @@ interface RenderEdge {
 }
 
 const NODE_SIZE = 16;
-const LABEL_ZOOM_THRESHOLD = 0.3;
+/** Above this zoom every node labels; below it only hovered/selected/pinned do,
+ *  so a 600-node graph reads as glyphed squares instead of a smear of names. */
+const LABEL_ALL_ZOOM = 1.2;
+
+/**
+ * Layout effort by node count. `warmup` ticks run SYNCHRONOUSLY off-screen
+ * before the first paint, so node positions ALWAYS exist even when the animated
+ * `cooldown` is short or zero — this is what prevents the old origin-stacking
+ * blank on large graphs. Bigger graphs warm up more (so they're laid out) but
+ * animate less (so the tab stays responsive); `collide` (the only O(n²) force)
+ * is dropped past ~1200 nodes.
+ */
+function layoutTier(n: number) {
+  if (n > 3000) return { warmup: 250, cooldownTicks: 0, collide: false };
+  if (n > 1200) return { warmup: 150, cooldownTicks: 60, collide: false };
+  if (n > 400) return { warmup: 60, cooldownTicks: 120, collide: true };
+  return { warmup: 0, cooldownTicks: 200, collide: true };
+}
 
 export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCanvas(
   {
@@ -68,7 +84,6 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     selected,
     pinned,
     hidden,
-    degraded,
     onSelect,
     onContextMenu,
   },
@@ -82,6 +97,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   // Snap (don't animate) the layout when the OS asks for reduced motion.
   const [frozen, setFrozen] = useState(() => prefersReducedMotion());
   const [clustered, setClustered] = useState(true);
+  const [hovered, setHovered] = useState<string>();
   const [size, setSize] = useState({ w: 0, h: 0 });
 
   // react-force-graph-2d defaults to window.innerWidth/Height with no resize
@@ -102,7 +118,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     (): GraphCanvasHandle => ({
       centerOnNode: (uri) => {
         const n = nodes.find((node) => node.uri === uri);
-        if (!n || n.x == null || n.y == null) return;
+        if (!n || n.x == null || n.y == null) {
+          fgRef.current?.zoomToFit(400, 60);
+          return;
+        }
         fgRef.current?.centerAt(n.x, n.y, 400);
         fgRef.current?.zoom(Math.max(fgRef.current?.zoom() || 1, 1.5), 400);
       },
@@ -117,24 +136,23 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   useEffect(() => {
     const fg = fgRef.current;
     if (!fg) return;
-    // Pause the sim while frozen/degraded. We intentionally leave the built-in
-    // 'center' force installed — pausing already stops all ticks, and nulling
-    // center permanently would let the layout drift off-centre on a later
-    // resume/reheat.
-    if (degraded || frozen) fg.pauseAnimation();
+    // Pause only for Freeze / reduced-motion — NEVER for node count. Suspending
+    // the sim on a large graph was the old blank bug. The built-in 'center'
+    // force stays installed; pausing already stops all ticks.
+    if (frozen) fg.pauseAnimation();
     else fg.resumeAnimation();
-  }, [degraded, frozen]);
+  }, [frozen]);
 
-  // Auto fit-to-view once when nodes first populate
-  useEffect(() => {
+  // Fit once the layout settles. onEngineStop fires after warmup+cooldown for
+  // every tier (incl. the snap tier, where the synchronous warmup already
+  // placed every node), so zoomToFit always has a real bounding box instead of
+  // racing a fixed timer. fittedRef resets via the page's key={structureKey}
+  // remount on a structural change.
+  const handleEngineStop = useCallback(() => {
     if (fittedRef.current) return;
-    if (nodes.length === 0) return;
-    const t = setTimeout(() => {
-      fgRef.current?.zoomToFit(400, 60);
-      fittedRef.current = true;
-    }, 500);
-    return () => clearTimeout(t);
-  }, [nodes.length]);
+    fgRef.current?.zoomToFit(400, 60);
+    fittedRef.current = true;
+  }, []);
 
   // node.group is assigned at data ingest (use-graph-data.ts), so it travels
   // with the node and this stays a pure filter.
@@ -142,6 +160,8 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
     () => nodes.filter((n) => !hidden.has(n.uri)),
     [nodes, hidden],
   );
+  // Layout effort scales with the rendered node count (see layoutTier).
+  const tier = useMemo(() => layoutTier(visibleNodes.length), [visibleNodes.length]);
   const visibleEdges = useMemo(
     () =>
       edges.filter(
@@ -168,19 +188,20 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
   useEffect(() => {
     const fg = fgRef.current;
     if (!fg) return;
-    const on = clustered && !degraded;
+    const on = clustered; // forceCluster (centroid pass, O(n)) — fine at every tier
+    const collideOn = clustered && tier.collide; // forceCollide (O(n²)) only ≤1200
     fg.d3Force("cluster", on ? (forceCluster(CLUSTER_STRENGTH) as never) : null);
-    fg.d3Force("collide", on ? (forceCollide(COLLIDE_RADIUS) as never) : null);
+    fg.d3Force("collide", collideOn ? (forceCollide(COLLIDE_RADIUS) as never) : null);
     const charge = fg.d3Force("charge") as { strength?: (v: number) => unknown } | undefined;
     charge?.strength?.(on ? CHARGE_STRENGTH : DEFAULT_CHARGE);
     // Don't reheat on a reduced-motion preference — the freeze effect owns
     // pause/resume; reheating from alpha=1 is the cost Freeze exists to avoid.
-    if (!degraded && !prefersReducedMotion()) fg.d3ReheatSimulation();
+    if (!prefersReducedMotion()) fg.d3ReheatSimulation();
     return () => {
       fgRef.current?.d3Force("cluster", null);
       fgRef.current?.d3Force("collide", null);
     };
-  }, [clustered, degraded]);
+  }, [clustered, tier.collide]);
 
   const paintNode = useCallback(
     (n: RenderNode, ctx: CanvasRenderingContext2D, scale: number) => {
@@ -251,7 +272,13 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         ctx.fillText(glyph, x, y);
       }
 
-      if (scale > LABEL_ZOOM_THRESHOLD) {
+      // Label every node only when zoomed in past LABEL_ALL_ZOOM; otherwise
+      // (e.g. the fit-to-view overview of a 600-node graph) only the hovered /
+      // selected / pinned node labels, so the canvas reads as glyphed squares
+      // instead of a smear of overlapping names.
+      const labelThis =
+        scale > LABEL_ALL_ZOOM || n.uri === selected || n.uri === hovered || pinned.has(n.uri);
+      if (labelThis) {
         // Render the title as-authored — never .toUpperCase() user copy (it
         // corrupts acronyms/camelCase/non-Latin titles).
         const raw = n.name || "";
@@ -263,7 +290,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         ctx.fillText(label, x, y + NODE_SIZE / 2 + 4);
       }
     },
-    [colors, selected, pinned, clustered],
+    [colors, selected, pinned, clustered, hovered],
   );
 
   const paintLink = useCallback(
@@ -380,7 +407,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, Props>(function GraphCa
         linkDirectionalArrowLength={5}
         linkDirectionalArrowRelPos={1}
         linkDirectionalArrowColor={colors.foregroundMuted}
-        cooldownTicks={degraded || frozen ? 0 : 200}
+        warmupTicks={tier.warmup}
+        cooldownTicks={frozen ? 0 : tier.cooldownTicks}
+        onEngineStop={handleEngineStop}
+        onNodeHover={(n) => setHovered((n as RenderNode | undefined)?.uri)}
         onNodeClick={handleNodeClick as never}
         onBackgroundClick={handleBackgroundClick}
         onNodeRightClick={handleNodeRightClick as never}

--- a/frontend/src/components/graph/GraphSidebar.tsx
+++ b/frontend/src/components/graph/GraphSidebar.tsx
@@ -136,18 +136,23 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
         </div>
       )}
 
-      <Section label="Entry point" className="px-2">
+      <Section label="Focus" className="px-2">
         <div className="relative">
           <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-foreground-muted pointer-events-none" />
           <input
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search documents"
-            aria-label="Search documents"
+            placeholder="Search to focus on a document"
+            aria-label="Search to focus on a document"
             className="w-full h-9 pl-6 pr-2 rounded-[var(--radius-md)] bg-background border border-border text-[11px] focus:outline-none focus:border-primary"
           />
         </div>
+        {!view.entry && hits.length === 0 && (
+          <p className="coord text-foreground-muted mt-1.5 leading-relaxed">
+            Showing the whole graph. Search to zoom into one document&rsquo;s neighborhood.
+          </p>
+        )}
         {hits.length > 0 && (
           <ul className="mt-1 flex flex-col gap-px">
             {hits.map((h) => (
@@ -164,14 +169,17 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
             ))}
           </ul>
         )}
-        {view.entry && hits.length === 0 && (
-          <div className="mt-1 flex items-center justify-between gap-2 px-2 h-7 text-[11px] bg-surface-muted">
-            <span title={`entry: ${view.entry}`} className="truncate">entry: {view.entry}</span>
+        {view.entry && (
+          <div className="mt-1 flex items-center justify-between gap-2 px-2 h-7 text-[11px] bg-surface-muted rounded-[var(--radius-sm)]">
+            <span title={`focused on ${view.entry}`} className="truncate">
+              Focused on <span className="coord">{view.entry}</span>
+            </span>
             <button
               type="button"
               onClick={() => onChange({ ...view, entry: undefined })}
-              aria-label="Clear entry"
-              className="text-foreground-muted hover:text-foreground"
+              aria-label="Show whole graph"
+              title="Show whole graph"
+              className="shrink-0 text-foreground-muted hover:text-foreground"
             >
               <X className="h-3 w-3" />
             </button>
@@ -179,40 +187,26 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
         )}
       </Section>
 
-      <Section label="Hops" className="px-2">
-        <div
-          className={cn(
-            "flex items-center gap-3 text-[11px]",
-            !view.entry && "opacity-50",
-          )}
-          aria-disabled={!view.entry}
-        >
-          {([1, 2, 3] as const).map((d) => (
-            <label
-              key={d}
-              className={cn(
-                "inline-flex items-center gap-1",
-                view.entry ? "cursor-pointer" : "cursor-not-allowed",
-              )}
-            >
-              <input
-                type="radio"
-                name="hops"
-                checked={view.hops === d}
-                disabled={!view.entry}
-                onChange={() => onChange({ ...view, hops: d })}
-                aria-label={`${d} hop${d === 1 ? "" : "s"}`}
-              />
-              {d}
-            </label>
-          ))}
-        </div>
-        {!view.entry && (
-          <p className="coord text-foreground-muted mt-2">
-            Set an entry point to enable
-          </p>
-        )}
-      </Section>
+      {/* Hops only matters inside a focus — hidden in the whole-graph view so
+          the rail isn't half-disabled on first open. */}
+      {view.entry && (
+        <Section label="Hops" className="px-2">
+          <div className="flex items-center gap-3 text-[11px]">
+            {([1, 2, 3] as const).map((d) => (
+              <label key={d} className="inline-flex items-center gap-1 cursor-pointer">
+                <input
+                  type="radio"
+                  name="hops"
+                  checked={view.hops === d}
+                  onChange={() => onChange({ ...view, hops: d })}
+                  aria-label={`${d} hop${d === 1 ? "" : "s"}`}
+                />
+                {d}
+              </label>
+            ))}
+          </div>
+        </Section>
+      )}
 
       <Section label="Types" className="px-2">
         <div className="flex flex-wrap gap-1">

--- a/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.cluster.test.tsx
@@ -38,7 +38,6 @@ const baseProps = {
   edges: [],
   pinned: new Set<string>(),
   hidden: new Set<string>(),
-  degraded: false,
   onSelect: () => {},
   onContextMenu: () => {},
 };

--- a/frontend/src/components/graph/__tests__/GraphCanvas.smoke.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphCanvas.smoke.test.tsx
@@ -21,7 +21,6 @@ describe("GraphCanvas smoke", () => {
           edges={[]}
           pinned={new Set()}
           hidden={new Set()}
-          degraded={false}
           onSelect={() => {}}
           onContextMenu={() => {}}
         />,

--- a/frontend/src/components/graph/__tests__/GraphSidebar.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphSidebar.test.tsx
@@ -45,10 +45,9 @@ describe("GraphSidebar · types", () => {
 });
 
 describe("GraphSidebar · hops", () => {
-  it("is disabled when no entry is set", () => {
+  it("is hidden until a focus is set", () => {
     setup();
-    const radio = screen.getByRole("radio", { name: /3 hops/i });
-    expect(radio).toBeDisabled();
+    expect(screen.queryByRole("radio", { name: /3 hops/i })).toBeNull();
   });
 
   it("emits hops change when entry is set", async () => {
@@ -110,7 +109,7 @@ describe("GraphSidebar · entry search", () => {
         onNavigate={() => {}}
       />,
     );
-    const input = screen.getByPlaceholderText(/search documents/i);
+    const input = screen.getByPlaceholderText(/search to focus/i);
     // Use fireEvent to set value directly and avoid userEvent fake-timer conflicts.
     fireEvent.change(input, { target: { value: "road" } });
     await vi.advanceTimersByTimeAsync(300);
@@ -143,7 +142,7 @@ describe("GraphSidebar · entry search", () => {
         onNavigate={() => {}}
       />,
     );
-    const input = screen.getByPlaceholderText(/search documents/i);
+    const input = screen.getByPlaceholderText(/search to focus/i);
     await u.type(input, "road");
     // Wait for debounce (300ms) + microtask flush.
     const hit = await screen.findByText("Roadmap", undefined, { timeout: 1500 });

--- a/frontend/src/components/graph/__tests__/use-graph-data.test.ts
+++ b/frontend/src/components/graph/__tests__/use-graph-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { mergeGraph, bfsExpand, applyFilters, isDegraded, docIdFromUri } from "../use-graph-data";
+import { mergeGraph, bfsExpand, applyFilters, docIdFromUri } from "../use-graph-data";
 import { docUri } from "@/lib/uri";
 import { DEFAULT_VIEW, type GraphNode, type GraphEdge } from "../graph-types";
 
@@ -90,13 +90,6 @@ describe("applyFilters", () => {
     const out = applyFilters({ nodes, edges }, DEFAULT_VIEW);
     expect(out.nodes.length).toBe(3);
     expect(out.edges.length).toBe(2);
-  });
-});
-
-describe("isDegraded", () => {
-  it("flips at > 500 raw nodes (unfiltered count)", () => {
-    expect(isDegraded(500)).toBe(false);
-    expect(isDegraded(501)).toBe(true);
   });
 });
 

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -89,12 +89,6 @@ export function applyFilters(p: GraphPayload, v: GraphView): GraphPayload {
   return { nodes, edges };
 }
 
-export const DEGRADED_NODE_THRESHOLD = 500;
-
-export function isDegraded(rawNodeCount: number): boolean {
-  return rawNodeCount > DEGRADED_NODE_THRESHOLD;
-}
-
 interface BfsExpandArgs {
   vault: string;
   entry: string; // doc path within the vault
@@ -245,10 +239,10 @@ export function useFullGraph(vault: string, enabled: boolean) {
     queryKey: ["graph", vault, "full"],
     enabled,
     queryFn: async (): Promise<GraphPayload> => {
-      // Full mode loads up to 200 nodes; `isDegraded` (>500) is unreachable
-      // today, so 200 is the practical upper bound on full-vault renders.
-      // Truncation is silent — surface "showing first N of M" if it becomes
-      // a real concern.
+      // Loads the whole vault graph. The 200 here is the backend BFS relation
+      // fan-out `limit` (per traversal), NOT a cap on |V| — large vaults return
+      // hundreds/thousands of nodes, which the canvas handles via its layout
+      // perf tiers (GraphCanvas.layoutTier), not a render gate.
       const resp = await getGraph(vault, undefined, 2, 200);
       const nodes: GraphNode[] = resp.nodes.map((n) => ({
         uri: n.uri,

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { PanelLeftOpen } from "lucide-react";
+import { PanelLeftOpen, X } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { Alert } from "@/components/ui/alert";
@@ -13,7 +13,6 @@ import {
   useNeighborhood,
   applyFilters,
   mergeGraph,
-  isDegraded,
   docIdFromUri,
 } from "@/components/graph/use-graph-data";
 import { viewToQuery, queryToView } from "@/components/graph/graph-state";
@@ -42,8 +41,6 @@ export default function GraphPage() {
   const base = view.entry ? neighborQuery.data : fullQuery.data;
   const loading = view.entry ? neighborQuery.isLoading : fullQuery.isLoading;
   const error = view.entry ? neighborQuery.error : fullQuery.error;
-  const rawNodeCount = base?.nodes.length || 0;
-  const degraded = isDegraded(rawNodeCount);
 
   // Click-expand merges into a session-scoped overlay so URL state stays clean.
   const [overlay, setOverlay] = useState<{ nodes: GraphNode[]; edges: GraphEdge[] }>({
@@ -86,6 +83,14 @@ export default function GraphPage() {
   const [pinned, setPinned] = useState<Set<string>>(new Set());
   const [hidden, setHidden] = useState<Set<string>>(new Set());
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  // One-time orientation hint (persisted dismissed).
+  const [hintOpen, setHintOpen] = useState(
+    () => localStorage.getItem("akb:graph:hint-dismissed") !== "1",
+  );
+  const dismissHint = useCallback(() => {
+    setHintOpen(false);
+    localStorage.setItem("akb:graph:hint-dismissed", "1");
+  }, []);
   const lastClickRef = useRef<{ uri: string; at: number } | null>(null);
 
   // Double-click emulation: two clicks on the same URI within DOUBLECLICK_MS
@@ -131,6 +136,25 @@ export default function GraphPage() {
     return { selectedNode: node, selectedDocId: docId };
   }, [merged, view.selected]);
   const detailOpen = !!selectedNode && !!selectedDocId;
+
+  // Friendly title for the focus-mode banner.
+  const entryTitle =
+    merged.nodes.find((n) => docIdFromUri(n.uri) === view.entry || n.doc_id === view.entry)?.name ??
+    view.entry;
+
+  // Degree-ranked top 50 for the sr-only list — 600 raw buttons is a
+  // screen-reader wall; surface the structurally important nodes first, with
+  // the sidebar search as the path to the long tail.
+  const topNodes = useMemo(() => {
+    const degree = new Map<string, number>();
+    for (const e of merged.edges) {
+      degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
+      degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
+    }
+    return [...merged.nodes]
+      .sort((a, b) => (degree.get(b.uri) ?? 0) - (degree.get(a.uri) ?? 0))
+      .slice(0, 50);
+  }, [merged]);
 
   // Clicking a relation in the detail panel selects that node in the graph.
   // If it isn't currently rendered (filtered out, or outside the loaded
@@ -198,9 +222,45 @@ export default function GraphPage() {
       )}
 
       <div className="relative bg-background overflow-hidden">
-        {degraded && (
+        {/* Focus mode: a clear "you're zoomed into one node — get out" banner.
+            The whole-graph view (no entry) shows the orientation hint instead. */}
+        {view.entry && (
           <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 w-max max-w-[90%]">
-            <Alert variant="warning">{rawNodeCount} nodes — pick an entry point to explore.</Alert>
+            <Alert variant="info">
+              <div className="flex items-center gap-3">
+                <span className="truncate max-w-[40ch]">Focused on {entryTitle}</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setView({ ...view, entry: undefined })}
+                >
+                  Show whole graph
+                </Button>
+              </div>
+            </Alert>
+          </div>
+        )}
+
+        {/* Non-blocking orientation hint (whole-graph view only), dismissible
+            + persisted. Replaces the old blocking "pick an entry point" gate. */}
+        {!view.entry && hintOpen && !loading && !error && merged.nodes.length > 0 && (
+          <div className="absolute bottom-3 left-3 z-10 w-max max-w-[90%]">
+            <Alert variant="info">
+              <div className="flex items-center gap-3">
+                <span>
+                  {merged.nodes.length} nodes · {merged.edges.length} links — drag to pan ·
+                  scroll to zoom · click a node to focus
+                </span>
+                <button
+                  type="button"
+                  onClick={dismissHint}
+                  aria-label="Dismiss hint"
+                  className="shrink-0 text-foreground-muted hover:text-foreground transition-colors cursor-pointer rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <X className="h-3 w-3" aria-hidden />
+                </button>
+              </div>
+            </Alert>
           </div>
         )}
 
@@ -235,7 +295,6 @@ export default function GraphPage() {
               selected={selectedNode?.uri}
               pinned={pinned}
               hidden={hidden}
-              degraded={degraded}
               onSelect={handleSelect}
               onContextMenu={handleContextMenu}
             />
@@ -245,7 +304,7 @@ export default function GraphPage() {
             <div className="sr-only">
               <h2>Graph nodes ({merged.nodes.length})</h2>
               <ul>
-                {merged.nodes.map((n) => (
+                {topNodes.map((n) => (
                   <li key={n.uri}>
                     <button type="button" onClick={() => handleSelect(n.uri)}>
                       {n.name} — {n.kind}
@@ -253,6 +312,12 @@ export default function GraphPage() {
                     </button>
                   </li>
                 ))}
+                {merged.nodes.length > topNodes.length && (
+                  <li>
+                    {merged.nodes.length - topNodes.length} more — use the sidebar search to
+                    reach them.
+                  </li>
+                )}
               </ul>
             </div>
           </>


### PR DESCRIPTION
## Summary

On a 600+ node vault the graph page showed `624 nodes — pick an entry point to explore` over a **blank canvas**. Root cause: the `degraded` (>500) path fed `cooldownTicks=0` + `pauseAnimation()` with no warmup, so the d3 sim ran zero ticks and every node stacked at the origin (0,0); the "gate" was an accidental blank. The backend `/graph` `limit=200` is a BFS fan-out cap, not a `|V|` cap, so degraded was reachable despite a stale "unreachable" comment.

Per the owner: just **draw everything** (entry-point is opaque/unfriendly).

- **GraphCanvas**: drop the `degraded` prop; derive a `layoutTier` from node count. Every tier runs synchronous `warmupTicks` before first paint → positions always exist (no origin-stack). `collide` (O(n²)) drops past ~1200; cluster tints + centroid force stay on. `pauseAnimation` follows only Freeze/reduced-motion. Fit on `onEngineStop`. Labels: all past zoom 1.2, else only hovered/selected/pinned. `centerOnNode` falls back to fit.
- **graph.tsx**: remove the blocking warning → dismissible bottom-left hint (whole-graph) + a "Focused on X · Show whole graph" banner (focus mode). sr-only node list degree-ranked + capped at 50.
- **GraphSidebar**: "Entry point" → "Focus" (optional) + helper copy; Hops hidden until a focus is set.
- **use-graph-data**: remove `isDegraded`/`DEGRADED_NODE_THRESHOLD`; fix the stale comment.

## Verification
`design:check` ✓ · `typecheck` ✓ · `lint` 0 errors · **263 tests** (graph tests updated). Browser-verified on a seeded 2-node graph (renders + fits + hint; sidebar Focus, Hops hidden). The 600+ path is deterministic via `warmupTicks` — verify on a large prod vault.

Frontend-only — no backend image change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)