### PR TITLE
fix(tables): create reserved/dup column → 422 (was 500) + viewer bare-name query; recency time ramp (backend 0.8.10)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2611
+        "line_number": 2619
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-10T02:21:33Z"
+  "generated_at": "2026-06-11T10:05:58Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,14 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.10 — 2026-06-11  *(patch — table create: reserved/duplicate column → clean 422, never 500)*
+
+`POST /api/v1/tables/{vault}` returned a bare **500** when a create payload included a reserved column name (`id`/`created_at`/`updated_at`/`created_by`) or two same-named columns — a client contract violation surfaced as an opaque internal error. Two paths produced it: `_validate_column_name` raised a bare `ValueError` (not an `AKBError`, so the global handler missed it → FastAPI 500), and a duplicate column reached the DDL as an uncaught `asyncpg.DuplicateColumnError`. The reserved-reject gap dates to 0.3.6; it only began firing when a caller (reef) started sending an `id` column.
+
+Now every reserved / duplicate / malformed / missing-`name` column on create (and the symmetric `alter_table` paths) returns a clean **422** with an actionable message, on both REST and MCP. Keystone: `ValidationError` now **IS-A** `ValueError`, so the existing `except ValueError` MCP handlers and `pytest.raises(ValueError)` guards keep classifying validation rejects correctly (`AKBError` stays first in the MRO → status stays 422). Adds `tests/concurrency/test_invariants_unit.py::test_p2_create_table_bad_columns_are_validation_errors` covering every create-422 vector plus the corrected-create-succeeds path. reef must drop the reserved `id` (it already has `reef_id`); AKB does not alias reserved columns by design.
+
+Companion **frontend** fix (separate image): the table viewer referenced a table with a double-quoted identifier (`SELECT * FROM "reef_issues"`), which the akb_sql rewriter intentionally skips, so it was never resolved to the physical `vt_<vault>__<table>` → "relation … does not exist" even though the table + rows existed. The viewer now sends the bare short name (table names are `^[a-z][a-z0-9_]*$`, so a bare reference is always well-formed and gets rewritten).
+
 ## 0.8.9 — 2026-06-10  *(patch — register migration 035 in the runtime applier + guard test)*
 
 Migrations run from an **explicit hardcoded list** in `_apply_migrations` (`app/db/postgres.py`), not by globbing the directory — a deliberate design so a steady-state boot runs zero DDL. 0.8.8 added `035_fix_wikilink_alias_edges.py` but **not** its entry in that list, so the migration shipped as a **no-op**: the file was in the image but never invoked, and the already-corrupted edges stayed corrupted on deploy.

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -33,6 +33,14 @@ class ForbiddenError(AKBError):
         super().__init__(message, status_code=403)
 
 
-class ValidationError(AKBError):
+class ValidationError(AKBError, ValueError):
+    """Client-input error → HTTP 422.
+
+    Also IS-A ``ValueError`` so the many ``except ValueError`` sites (MCP tool
+    handlers, the alter-table guard tests) keep catching validation rejects as
+    invalid-argument rather than letting a service-layer reject leak out as an
+    internal 500. AKBError comes first in the MRO, so ``status_code`` stays 422.
+    """
+
     def __init__(self, message: str):
         super().__init__(message, status_code=422)

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -65,22 +65,25 @@ _COLUMN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 def _validate_column_name(name) -> None:
-    """Reject reserved + malformed column names (raises ValueError).
+    """Reject reserved + malformed column names (raises ValidationError → 422).
 
     Shared by create_table and alter_table so the two paths stay
     consistent: reserved names collide with the auto-added bookkeeping
     columns (id/created_at/updated_at/created_by), and the shape check
     keeps the registry name identical to its `safe_ident` PG identity.
+
+    Raises ValidationError (which IS-A ValueError) so a bad column name is a
+    clean 422 on REST and invalid_argument on MCP — never an internal 500.
     """
     if not isinstance(name, str) or not name:
-        raise ValueError("Column name must be a non-empty string.")
+        raise ValidationError("Column name must be a non-empty string.")
     if name.lower() in _RESERVED:
-        raise ValueError(
+        raise ValidationError(
             f"Column name '{name}' is reserved (auto-added by AKB). "
             f"Reserved names: {sorted(_RESERVED)}. Choose a different name."
         )
     if not _COLUMN_NAME_RE.fullmatch(name):
-        raise ValueError(
+        raise ValidationError(
             f"Invalid column name {name!r}: must match {_COLUMN_NAME_RE.pattern} "
             f"(lowercase letter then letters/digits/underscores)."
         )
@@ -160,8 +163,22 @@ async def create_table(
             if existing:
                 raise ConflictError(f"Table already exists: {name}")
 
+            seen: set[str] = set()
             for col in columns:
-                _validate_column_name(col["name"])
+                if not isinstance(col, dict) or "name" not in col:
+                    raise ValidationError(
+                        f"Each column must be an object with a 'name' field; got {col!r}."
+                    )
+                cname = col["name"]
+                _validate_column_name(cname)
+                key = cname.lower()
+                if key in seen:
+                    raise ValidationError(
+                        f"Duplicate column name {cname!r}. Column names must be "
+                        f"unique (case-insensitive) and must not collide with "
+                        f"reserved names {sorted(_RESERVED)}."
+                    )
+                seen.add(key)
 
             collection_id = None
             if collection_path:
@@ -192,6 +209,15 @@ async def create_table(
                     created_by=actor_id, now=now,
                     collection_id=collection_id,
                 )
+            except asyncpg.DuplicateColumnError as e:
+                # Belt-and-suspenders: a duplicate/reserved column that reached
+                # DDL despite the input guard above. 42701 is always caller-
+                # fixable input, so surface a clean 422 (not a 500).
+                raise ValidationError(
+                    f"Duplicate or reserved column in table {name!r}: {e}. "
+                    f"Column names (including the reserved id/created_at/"
+                    f"updated_at/created_by) must each appear once."
+                ) from e
             except asyncpg.UniqueViolationError as e:
                 # Concurrent create past the find_by_name check races on
                 # UNIQUE(vault_tables) or pg_type. Surface as 409.
@@ -386,20 +412,24 @@ async def alter_table(
             # those are exactly the _RESERVED set — so a client can no
             # longer drop the PK or shadow a reserved name.
             for col in (add_columns or []):
+                if not isinstance(col, dict) or "name" not in col:
+                    raise ValidationError(
+                        f"Each added column must be an object with a 'name' field; got {col!r}."
+                    )
                 _validate_column_name(col["name"])
             for col_name in (drop_columns or []):
                 if not isinstance(col_name, str) or not col_name:
-                    raise ValueError("Drop column name must be a non-empty string.")
+                    raise ValidationError("Drop column name must be a non-empty string.")
                 if col_name.lower() in _RESERVED:
-                    raise ValueError(
+                    raise ValidationError(
                         f"Column '{col_name}' is a reserved bookkeeping column "
                         f"and cannot be dropped. Reserved: {sorted(_RESERVED)}."
                     )
             for old_name, new_name in (rename_columns or {}).items():
                 if not isinstance(old_name, str) or not old_name:
-                    raise ValueError("Rename source column must be a non-empty string.")
+                    raise ValidationError("Rename source column must be a non-empty string.")
                 if old_name.lower() in _RESERVED:
-                    raise ValueError(
+                    raise ValidationError(
                         f"Column '{old_name}' is a reserved bookkeeping column "
                         f"and cannot be renamed. Reserved: {sorted(_RESERVED)}."
                     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.9"
+version = "0.8.10"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 # Runtime deps are exact-pinned for the same reproducibility reason

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -533,6 +533,58 @@ async def test_p2_alter_table_reserved_guard(pool):
     assert has_id == 1, "PK column must still exist after rejected drop"
 
 
+# ── P2: create_table reserved/duplicate/malformed column → 422 ────
+
+
+@pytest.mark.asyncio
+async def test_p2_create_table_bad_columns_are_validation_errors(pool):
+    """Every reserved / duplicate / malformed / missing-name column on create
+    must surface as a clean ValidationError (HTTP 422 / MCP invalid_argument),
+    never a bare ValueError-as-500 or an uncaught asyncpg DuplicateColumnError.
+    Regression: reef's POST /tables with an `id` column returned a 500."""
+    from app.services import table_service
+    from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
+    from app.exceptions import ValidationError
+
+    set_role_sync(RoleSync(pool))
+    vault_repo = VaultRepository(pool)
+    name = f"_p2create_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(name=name, description="x", git_path=f"/tmp/{name}.git", owner_id=None)
+    await get_role_sync().on_vault_create(vid, None)
+
+    bad_payloads = [
+        [{"name": "id", "type": "text"}],                      # reserved (reef's case)
+        [{"name": "created_at", "type": "text"}],              # reserved
+        [{"name": "title"}, {"name": "title"}],                # duplicate → would be 42701
+        [{"name": "Title", "type": "text"}],                   # malformed (uppercase)
+        [{"type": "text"}],                                    # missing "name"
+    ]
+    for i, cols in enumerate(bad_payloads):
+        with pytest.raises(ValidationError):
+            await table_service.create_table(vid, f"t_{i}", cols, actor_id="t")
+        # IS-A ValueError too, so MCP `except ValueError` handlers still classify it.
+        try:
+            await table_service.create_table(vid, f"t_{i}b", cols, actor_id="t")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"payload {cols!r} should have raised")
+
+    # A clean payload still succeeds and is queryable by its bare name.
+    await table_service.create_table(
+        vid, "reef_issues",
+        [{"name": "reef_id", "type": "text"}, {"name": "title", "type": "text"}],
+        actor_id="t",
+    )
+    async with pool.acquire() as conn:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = $1",
+            table_service.table_data_repo.pg_table_name(name, "reef_issues"),
+        )
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+    assert exists == 1, "the corrected (no reserved id) create must succeed"
+
+
 # ── P2: archived vault is read-only via akb_sql ───────────────────
 
 

--- a/frontend/src/components/ui/relative-time.tsx
+++ b/frontend/src/components/ui/relative-time.tsx
@@ -1,4 +1,4 @@
-import { cn, formatDate, isFresh, timeAgo } from "@/lib/utils";
+import { cn, formatDate, isFresh, recencyTone, timeAgo } from "@/lib/utils";
 
 interface RelativeTimeProps {
   /** ISO timestamp to render relatively (e.g. "3h ago", "8mo ago"). */
@@ -24,25 +24,27 @@ export function RelativeTime({ iso, className, fallback }: RelativeTimeProps) {
   if (!iso) {
     return <span className={cn("coord tabular-nums", className)}>{fallback ?? "-"}</span>;
   }
-  // Exact date on hover, everywhere — the relative grain is the glance, the
-  // tooltip is the precise answer.
+  // Exact date on hover; the relative grain is the glance, the tooltip the
+  // precise answer.
   const title = formatDate(iso);
-  if (isFresh(iso)) {
-    return (
-      <span
-        title={title}
-        className={cn(
-          "inline-flex items-center gap-1 text-[11px] font-medium tabular-nums text-spark",
-          className,
-        )}
-      >
-        <span className="h-1.5 w-1.5 rounded-full bg-spark" aria-hidden />
-        {timeAgo(iso)}
-      </span>
-    );
-  }
+  // Every tier is tinted on the recency ramp (recencyTone): vivid warm when
+  // just-touched, cooling to muted gray as it ages — so "how recent" reads at a
+  // glance, not just from the number. Only the fresh (<1h) tier keeps the spark
+  // dot, an "active now" marker that's odd on an old timestamp.
+  const tone = recencyTone(iso);
+  const fresh = isFresh(iso);
   return (
-    <span title={title} className={cn("coord tabular-nums", className)}>
+    <span
+      title={title}
+      style={{ color: tone }}
+      className={cn(
+        "inline-flex items-center gap-1 text-[11px] font-medium tabular-nums",
+        className,
+      )}
+    >
+      {fresh && (
+        <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone }} aria-hidden />
+      )}
       {timeAgo(iso)}
     </span>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -92,6 +92,14 @@
   --color-cat-5: #c44a1e;
   --color-cat-6: #5e6068;
 
+  /* Recency ramp — the relative-time chip cools from vivid warm (just-touched,
+     == --color-spark) through a desaturating warm to the muted gray of old
+     timestamps. It DESATURATES (not lightens), so every tier keeps AA contrast
+     on paper; <1h uses --color-spark, ≥1mo falls back to --color-foreground-muted. */
+  --color-recency-h: #aa5031; /* < 1 day */
+  --color-recency-d: #915543; /* < 1 week */
+  --color-recency-w: #775a56; /* < 1 month */
+
   /* shadcn alias set (existing components inherit) — primary is teal now */
   --color-primary: #004059;
   --color-primary-foreground: #ffffff;
@@ -210,6 +218,10 @@
   --color-cat-4: #e3a13f;
   --color-cat-5: #f0744a;
   --color-cat-6: #9aa4af;
+  /* Recency ramp (dark): lighter warm → light gray, AA on the dark surface. */
+  --color-recency-h: #da8063;
+  --color-recency-d: #c58c7c;
+  --color-recency-w: #af9896;
 
   --color-primary: #0a6f86;
   --color-primary-foreground: #ffffff;

--- a/frontend/src/lib/__tests__/time-ago.test.ts
+++ b/frontend/src/lib/__tests__/time-ago.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isFresh, timeAgo } from "@/lib/utils";
+import { isFresh, recencyTone, timeAgo } from "@/lib/utils";
 
 // timeAgo / isFresh are time-relative, so pin "now" to a fixed instant and
 // build each input as an offset back from it. Locks the bucket boundaries
@@ -57,5 +57,19 @@ describe("isFresh", () => {
     expect(isFresh(ago(2 * HOUR))).toBe(false);
     expect(isFresh(null)).toBe(false);
     expect(isFresh("not-a-date")).toBe(false);
+  });
+});
+
+describe("recencyTone", () => {
+  it("cools from spark through the warm ramp to muted with age", () => {
+    expect(recencyTone(ago(30 * MIN))).toBe("var(--color-spark)"); // <1h
+    expect(recencyTone(ago(5 * HOUR))).toBe("var(--color-recency-h)"); // <1d
+    expect(recencyTone(ago(3 * DAY))).toBe("var(--color-recency-d)"); // <1w
+    expect(recencyTone(ago(20 * DAY))).toBe("var(--color-recency-w)"); // <1mo
+    expect(recencyTone(ago(90 * DAY))).toBe("var(--color-foreground-muted)"); // ≥1mo
+  });
+  it("falls back to muted for missing/invalid input", () => {
+    expect(recencyTone(null)).toBe("var(--color-foreground-muted)");
+    expect(recencyTone("not-a-date")).toBe("var(--color-foreground-muted)");
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -79,6 +79,27 @@ export function isFresh(iso: string | null | undefined, withinMs = 3_600_000): b
 }
 
 /**
+ * Color for a relative timestamp on the recency ramp — vivid warm when
+ * just-touched (== --color-spark), desaturating warm as it ages, muted gray
+ * once old. Buckets mirror timeAgo(): <1h spark / <1d / <1w / <1mo / ≥1mo. The
+ * time TEXT carries the meaning; this is a secondary "how recent" tint (the dot
+ * in <RelativeTime> shows only for the fresh tier). Returns a CSS var token.
+ */
+export function recencyTone(iso: string | null | undefined): string {
+  if (!iso) return "var(--color-foreground-muted)";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "var(--color-foreground-muted)";
+  const mins = (Date.now() - t) / 60000;
+  if (mins < 60) return "var(--color-spark)"; // < 1h (fresh)
+  const hrs = mins / 60;
+  if (hrs < 24) return "var(--color-recency-h)"; // < 1d
+  const days = hrs / 24;
+  if (days < 7) return "var(--color-recency-d)"; // < 1w
+  if (days < 30) return "var(--color-recency-w)"; // < 1mo
+  return "var(--color-foreground-muted)"; // ≥ 1mo
+}
+
+/**
  * Deterministic string → hue in [0,360) (FNV-1a). Same key always maps to the
  * same hue regardless of how many keys exist, so a vault keeps one identity
  * color across Recent activity, the directory, and the graph clusters (which

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -46,9 +46,14 @@ export default function TablePage() {
         if (found) setInfo(found);
       })
       .catch(() => {});
-    // Quote the identifier so reserved/upper/space-bearing names don't produce
-    // malformed SQL. (PG ACL still bounds visibility via SET LOCAL ROLE.)
-    const ident = `"${(table || "").replace(/"/g, '""')}"`;
+    // Reference the table by its BARE short name so the backend akb_sql
+    // rewriter resolves it to the physical `vt_<vault>__<table>` relation
+    // (PG ACL still bounds visibility via SET LOCAL ROLE). A double-quoted
+    // identifier is intentionally NOT rewritten — the rewriter skips quoted
+    // spans so it can't corrupt string literals — so quoting here silently
+    // bypassed the mapping → "relation <table> does not exist". Table names are
+    // constrained to ^[a-z][a-z0-9_]*$, so a bare reference is always well-formed.
+    const ident = table || "";
     fetch(`/api/v1/tables/${vault}/sql`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${t}` },


### PR DESCRIPTION
## Summary

Two table bugs reef surfaced, plus a small time-color follow-up. **Backend change → bumps backend to 0.8.10.**

### Bug 1 — `POST /tables` 500 ("id field duplicated/reserved")
reef sent a column named `id` (reserved). Root cause: `_validate_column_name` raised a bare `ValueError` (not an `AKBError` → FastAPI 500); a duplicate column hit DDL as an uncaught `asyncpg.DuplicateColumnError` → 500. **Fix:** `ValidationError` IS-A `ValueError` (keystone, keeps `except ValueError` MCP handlers + tests working), `_validate_column_name`→`ValidationError`, create-loop guards missing-`name`/dup, `DuplicateColumnError`→`ValidationError`, alter symmetry. Every bad column → clean **422**.

### Bug 2 — table viewer "relation \"reef_issues\" does not exist"
The table + 161 rows exist; the viewer quoted the name (`SELECT * FROM "reef_issues"`) and the akb_sql rewriter skips quoted spans → never resolved to `vt_<vault>__<table>`. **Fix:** the viewer sends the bare short name (names are `^[a-z][a-z0-9_]*$`, always well-formed; the rewriter resolves it).

### Recency time ramp (`5779d47`, frontend)
Every relative-time tier is tinted on a warm→muted recency ramp (was only the fresh tier); new `--color-recency-*` tokens (desaturating, AA-safe).

## Verification (local docker)
Every bad-column create → **422** (id/created_at/dup/missing-name/uppercase); corrected create → 200; the viewer **renders reef_issues rows** (no error); quoted query still fails (control), bare query 200. New backend invariant test covers all create-422 vectors. Frontend gate green (265 tests).

reef must drop the reserved `id` column for its create to succeed (it already has `reef_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)