### PR TITLE
chore: OSS hygiene sweep — kill stray prints, hardcoded path, license field

### DIFF
--- a/backend/app/db/migrations/001_relations_to_edges.py
+++ b/backend/app/db/migrations/001_relations_to_edges.py
@@ -9,12 +9,15 @@ Run:  python -m app.db.migrations.001_relations_to_edges
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from app.db.postgres import get_pool, init_db, close_pool
+
+logger = logging.getLogger("akb.migrations")
 
 
 async def migrate():
@@ -27,13 +30,13 @@ async def migrate():
             "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'edges')"
         )
         if not exists:
-            print("edges table does not exist. Run init.sql first.")
+            logger.warning("edges table does not exist. Run init.sql first.")
             return
 
         # Check if migration already ran
         edge_count = await conn.fetchval("SELECT COUNT(*) FROM edges")
         if edge_count > 0:
-            print(f"edges table already has {edge_count} rows — skipping migration.")
+            logger.info("edges table already has %d rows — skipping migration.", edge_count)
             return
 
         rows = await conn.fetch("""
@@ -58,7 +61,7 @@ async def migrate():
             """, r["vault_id"], source_uri, target_uri, r["relation_type"], r["created_at"])
             migrated += 1
 
-        print(f"Migrated {migrated} relations → edges")
+        logger.info("Migrated %d relations → edges", migrated)
 
     await close_pool()
 

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 import asyncpg
 from pathlib import Path
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
 
 _pool: asyncpg.Pool | None = None
 
@@ -63,7 +66,10 @@ async def init_db(max_retries: int = 10, delay: float = 2.0) -> None:
             return
         except (ConnectionRefusedError, asyncpg.CannotConnectNowError, OSError):
             if attempt < max_retries - 1:
-                print(f"DB not ready (attempt {attempt + 1}/{max_retries}), retrying in {delay}s...")
+                logger.warning(
+                    "DB not ready (attempt %d/%d), retrying in %.1fs...",
+                    attempt + 1, max_retries, delay,
+                )
                 await asyncio.sleep(delay)
             else:
                 raise

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,6 +3,7 @@ name = "akb"
 version = "0.8.10"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
+license = "BUSL-1.1"
 # Runtime deps are exact-pinned for the same reproducibility reason
 # the [dev] tools below are: a silent resolver upgrade should not be
 # able to swap our backend image's behavior on a re-deploy. Bumps are

--- a/eval/agentic-bench/scripts/run_v4_multiproc.sh
+++ b/eval/agentic-bench/scripts/run_v4_multiproc.sh
@@ -15,7 +15,10 @@ cd "$(dirname "$0")/.."
 : "${RUNS_DIR:=runs_v4}"
 
 ARMS=(A1_search_only A2_grep_only A3_tree A4_all)
-PY=/Users/byongjohn_han/git-repository/akb/backend/.venv/bin/python
+# Default to the repo-relative backend venv; override with PY=... if your
+# venv lives elsewhere or you're running outside the repo tree.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY="${PY:-${SCRIPT_DIR}/../../../backend/.venv/bin/python}"
 
 mkdir -p "$RUNS_DIR"
 

--- a/frontend/src/components/__tests__/user-menu.test.tsx
+++ b/frontend/src/components/__tests__/user-menu.test.tsx
@@ -6,9 +6,9 @@ import { UserMenu } from "../user-menu";
 
 vi.mock("@/lib/api", () => ({
   getMe: vi.fn().mockResolvedValue({
-    username: "gnu",
-    email: "kwoo24@dnotitia.com",
-    display_name: "gnu",
+    username: "alice",
+    email: "alice@example.com",
+    display_name: "alice",
     is_admin: false,
   }),
   setToken: vi.fn(),


### PR DESCRIPTION
## Summary

Surfaced by a quick OSS-readiness audit on a clean `main`. Five small, low-risk cleanups; no behavior change.

- `eval/agentic-bench/scripts/run_v4_multiproc.sh:18` — `PY=` was a personal absolute path (`/Users/byongjohn_han/...`). Derived from the script's own location now, with `PY=...` env override.
- `backend/app/db/postgres.py:66` — stray `print()` in the init_db retry loop → `logger.warning(...)`. Matches the rest of the project.
- `backend/app/db/migrations/001_relations_to_edges.py:30/36/61` — same shape: three `print()` calls → `logger.info`/`warning`. 001 was the only migration still using `print()`.
- `backend/pyproject.toml` — add `license = "BUSL-1.1"` so dep-scanning tools don't show `UNKNOWN`.
- `frontend/src/components/__tests__/user-menu.test.tsx:10` — swap a test fixture email (real employee handle) for `alice@example.com`.

## Test plan

- [x] `bash scripts/check.sh` green locally (ruff + mypy + bandit + eslint + tsc + vitest 265/265 + detect-secrets)
- [x] No DB/runtime contract change → no e2e re-run needed