### PR TITLE
feat(backend/document): conditional {slug}-{shortid} identity + move/rename

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,34 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.11 — 2026-06-16  *(minor — document identity: conditional `{slug}-{shortid}` + move/rename)*
+
+Redesign document identity so duplicate-title creates and renames stop being
+hostile, without giving up readable git paths. The `path` stays the identity
+(`UNIQUE(vault_id, path)`); the `title` is a free, non-unique label.
+
+**Create (Phase 1):** distinct human titles that normalize to the same slug no
+longer collide — the clean `{slug}.md` is used when free, and a `-{shortid}`
+(the doc's own uuid prefix) is appended **only on collision**. Empty/symbol-only
+titles fall back to `untitled` instead of producing a bare `.md` dotfile, and
+slug truncation no longer collides. No migration; existing paths and akb:// URIs
+are unchanged.
+
+**Move/rename (Phase 2):** new `akb_move` MCP tool changes a document's
+collection and/or slug while keeping its identity and git history (`git mv`, so
+`git log --follow` traces it). A new `resource_aliases` table (migration 036,
+auto-applied) maps `old_ref → resource_id` (UUID, never path→path, so renames
+never chain), and `find_by_ref` consults it so old akb:// URIs keep resolving;
+graph edges and publications referencing the old URI are rewritten, and the doc
+is re-chunked at the new path. `delete` cleans up the doc's aliases.
+
+Validated by external best-practice research + adversarial multi-agent review +
+an exhaustive 181-case audit + a multi-agent PR review (correctness, silent
+failures, comments, test coverage). Coverage: unit 12, scenario e2e 34, the
+existing e2e suites (mcp 88 / edit 37 / graph 29 / defensive 33 / security 63 /
+pg_rbac 50 / probes 13), plus a 600-concurrent-create + concurrent-move
+(300 / same-doc 60 / collision-merge 120 / race) stress — all 0 failed.
+
 ## 0.8.10 — 2026-06-11  *(patch — table create: reserved/duplicate column → clean 422, never 500)*
 
 `POST /api/v1/tables/{vault}` returned a bare **500** when a create payload included a reserved column name (`id`/`created_at`/`updated_at`/`created_by`) or two same-named columns — a client contract violation surfaced as an opaque internal error. Two paths produced it: `_validate_column_name` raised a bare `ValueError` (not an `AKBError`, so the global handler missed it → FastAPI 500), and a duplicate column reached the DDL as an uncaught `asyncpg.DuplicateColumnError`. The reserved-reject gap dates to 0.3.6; it only began firing when a caller (reef) started sending an `id` column.

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -275,6 +275,31 @@ CREATE INDEX IF NOT EXISTS idx_edges_source_type ON edges(source_type);
 CREATE INDEX IF NOT EXISTS idx_edges_target_type ON edges(target_type);
 
 -- ============================================================
+-- Resource aliases (rename/move redirects)
+-- A former reference (old path/name) → the CURRENT resource id. Keying on the
+-- durable id (never on a new path) means N renames collapse to one hop — no
+-- redirect chains (cf. MediaWiki). find_by_ref consults this so old akb:// URIs
+-- keep resolving after a move. See docs/designs/doc-identity-slug/00-overview.md.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS resource_aliases (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    resource_type TEXT NOT NULL CHECK(resource_type IN ('document', 'table', 'file')),
+    old_ref TEXT NOT NULL,              -- former path (doc/file) or name (table)
+    resource_id UUID NOT NULL,          -- current resource id — NEVER a path (no chains)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- One alias per (vault, type, old_ref). If the old_ref is later reused by a
+    -- NEW resource, the writer drops the stale alias first (a real resource at a
+    -- path always wins over a redirect).
+    UNIQUE(vault_id, resource_type, old_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_aliases_lookup
+    ON resource_aliases(vault_id, resource_type, old_ref);
+CREATE INDEX IF NOT EXISTS idx_resource_aliases_resource
+    ON resource_aliases(resource_id);
+
+-- ============================================================
 -- Vault Files (S3-backed binary/large file storage)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS vault_files (

--- a/backend/app/db/migrations/036_resource_aliases.py
+++ b/backend/app/db/migrations/036_resource_aliases.py
@@ -1,0 +1,53 @@
+"""Migration 036: resource_aliases — rename/move redirect table.
+
+Phase 2 of the doc identity work (docs/designs/doc-identity-slug/00-overview.md).
+A former reference (old path/name) maps to the CURRENT resource id, so old
+akb:// URIs keep resolving after a document/table/file is moved or renamed.
+Keying on the durable id (never on a new path) collapses N renames to one hop —
+no redirect chains.
+
+Idempotent: CREATE TABLE / INDEX IF NOT EXISTS. On a fresh DB the table is
+already present from init.sql, so this is a no-op there too.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.db.postgres import get_pool
+
+logger = logging.getLogger("akb.migration.036")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    await conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS resource_aliases (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+            resource_type TEXT NOT NULL CHECK(resource_type IN ('document', 'table', 'file')),
+            old_ref TEXT NOT NULL,
+            resource_id UUID NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE(vault_id, resource_type, old_ref)
+        )
+        """
+    )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_resource_aliases_lookup "
+        "ON resource_aliases(vault_id, resource_type, old_ref)"
+    )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_resource_aliases_resource "
+        "ON resource_aliases(resource_id)"
+    )
+    logger.info("Migration 036: resource_aliases ready")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -174,6 +174,7 @@ async def _apply_migrations() -> None:
         "033_users_auth_provider.py",           # users.auth_provider ('local' default | 'keycloak' for JIT-provisioned SSO accounts)
         "034_oidc_transients.py",               # oidc_transients: short-lived OIDC state + one-time exchange codes (HA-safe; empty when Keycloak off)
         "035_fix_wikilink_alias_edges.py",      # repair edges whose target_uri carries a wikilink alias ([[…|label]] → …|label); strip alias, re-validate existence, drop orphans
+        "036_resource_aliases.py",              # rename/move redirect table (old path/name → current resource id); old akb:// URIs keep resolving after a move
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -244,7 +244,13 @@ class DocumentRepository:
                 doc_id, new_path, collection_id, now, commit_hash,
             )
         except asyncpg.UniqueViolationError as e:
-            raise ConflictError(f"Document already exists at path: {new_path}") from e
+            # The target was free when move() resolved it under the lock, so this
+            # only fires when a concurrent writer claimed it in the meantime — a
+            # retry re-resolves to a fresh free path.
+            raise ConflictError(
+                f"Document already exists at path: {new_path} "
+                "(a concurrent write claimed it — retry the move)"
+            ) from e
 
     async def update(
         self,

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -36,6 +36,49 @@ async def acquire_path_lock(conn, vault_id: uuid.UUID, path: str) -> None:
     )
 
 
+# ── Resource aliases (rename/move redirects) ─────────────────────
+# Polymorphic across document/table/file, so these are module-level helpers
+# rather than methods on the document repo. The invariant is old_ref →
+# resource_id (a UUID), never old_ref → new path (that would chain).
+
+async def add_resource_alias(
+    conn, vault_id: uuid.UUID, resource_type: str, old_ref: str, resource_id: uuid.UUID
+) -> None:
+    """Record that ``old_ref`` used to name this resource. Upserts so a path
+    that has been the old name more than once re-points to the latest id."""
+    await conn.execute(
+        """
+        INSERT INTO resource_aliases (vault_id, resource_type, old_ref, resource_id)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (vault_id, resource_type, old_ref)
+        DO UPDATE SET resource_id = EXCLUDED.resource_id, created_at = NOW()
+        """,
+        vault_id, resource_type, old_ref, resource_id,
+    )
+
+
+async def drop_resource_alias(
+    conn, vault_id: uuid.UUID, resource_type: str, old_ref: str
+) -> None:
+    """Remove any redirect sitting on ``old_ref`` — called when a real resource
+    is (re)created at that path, so the live resource wins over a stale alias."""
+    await conn.execute(
+        "DELETE FROM resource_aliases WHERE vault_id = $1 AND resource_type = $2 AND old_ref = $3",
+        vault_id, resource_type, old_ref,
+    )
+
+
+async def drop_aliases_for_resource(
+    conn, vault_id: uuid.UUID, resource_type: str, resource_id: uuid.UUID
+) -> None:
+    """Remove every redirect pointing at a resource — called on its deletion so
+    no alias outlives the row it targets."""
+    await conn.execute(
+        "DELETE FROM resource_aliases WHERE vault_id = $1 AND resource_type = $2 AND resource_id = $3",
+        vault_id, resource_type, resource_id,
+    )
+
+
 class DocumentRepository:
     def __init__(self, pool: asyncpg.Pool):
         self.pool = pool
@@ -59,8 +102,10 @@ class DocumentRepository:
         metadata: dict,
         *,
         conn=None,
+        doc_id: uuid.UUID | None = None,
     ) -> uuid.UUID:
-        doc_id = uuid.uuid4()
+        # Caller may supply the id so a path can embed its short form; else mint one.
+        doc_id = doc_id or uuid.uuid4()
 
         async def _insert(c):
             try:
@@ -134,7 +179,13 @@ class DocumentRepository:
             return await self.find_by_ref_with_conn(conn, vault_id, ref)
 
     async def find_by_ref_with_conn(self, conn, vault_id: uuid.UUID, ref: str) -> dict | None:
-        """Find document using an existing connection (no pool acquire)."""
+        """Find document using an existing connection (no pool acquire).
+
+        Resolution order: an exact id/path match wins; only on a miss do we
+        consult ``resource_aliases`` so an OLD path (from a prior move/rename)
+        still resolves to the current document. Exact-first means a real
+        document that now occupies a reused path always beats a stale redirect.
+        """
         row = await conn.fetchrow(
             f"""
             SELECT d.*, v.name as vault_name
@@ -142,6 +193,21 @@ class DocumentRepository:
             JOIN vaults v ON d.vault_id = v.id
             WHERE d.vault_id = $1
               AND {self._MATCH_WHERE}
+            """,
+            vault_id, ref,
+        )
+        if row:
+            return dict(row)
+        # Alias fallback — old_ref → current resource_id (never path→path).
+        row = await conn.fetchrow(
+            """
+            SELECT d.*, v.name as vault_name
+            FROM resource_aliases a
+            JOIN documents d ON d.id = a.resource_id
+            JOIN vaults v ON d.vault_id = v.id
+            WHERE a.vault_id = $1 AND a.resource_type = 'document' AND a.old_ref = $2
+              AND d.vault_id = $1
+            LIMIT 1
             """,
             vault_id, ref,
         )
@@ -160,6 +226,25 @@ class DocumentRepository:
         async with self.pool.acquire() as c:
             row = await c.fetchrow(sql, vault_id, path)
             return dict(row) if row else None
+
+    async def update_path(
+        self, doc_id: uuid.UUID, new_path: str, *, collection_id: uuid.UUID | None,
+        now: datetime, commit_hash: str, conn,
+    ) -> None:
+        """Move a document to ``new_path`` (rename/move). Identity (id) is
+        unchanged; only the path/collection/commit move. Surfaces a path
+        collision as a 409 like create() does."""
+        try:
+            await conn.execute(
+                """
+                UPDATE documents
+                   SET path = $2, collection_id = $3, updated_at = $4, current_commit = $5
+                 WHERE id = $1
+                """,
+                doc_id, new_path, collection_id, now, commit_hash,
+            )
+        except asyncpg.UniqueViolationError as e:
+            raise ConflictError(f"Document already exists at path: {new_path}") from e
 
     async def update(
         self,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -149,13 +148,7 @@ class EditError(AKBError):
 
 
 from app.util.text import normalize_collection_path as _normalize_collection
-
-
-def _slugify(title: str) -> str:
-    slug = title.lower().strip()
-    slug = re.sub(r"[^\w\s-]", "", slug)
-    slug = re.sub(r"[-\s]+", "-", slug)
-    return slug[:80]
+from app.util.text import slugify
 
 
 def _build_frontmatter(req: DocumentPutRequest, now: datetime) -> dict:
@@ -202,6 +195,35 @@ def _parse_markdown(content: str) -> tuple[dict, str]:
 
 def _body_content_hash(body: str) -> str:
     return compute_text_content_hash(body)
+
+
+def _split_doc_path(path: str) -> tuple[str, str]:
+    """Split a document path into (collection, base-slug). The base-slug is the
+    filename without its ``.md`` suffix. Root docs return ("", base)."""
+    stem = path[:-3] if path.endswith(".md") else path
+    if "/" in stem:
+        coll, base = stem.rsplit("/", 1)
+        return coll, base
+    return "", stem
+
+
+def _doc_path(collection: str, slug: str) -> str:
+    """Compose a document path from a (possibly empty) collection + slug. Inverse
+    of `_split_doc_path`; a root doc (empty collection) is just ``{slug}.md``."""
+    return f"{collection}/{slug}.md" if collection else f"{slug}.md"
+
+
+def _strip_own_suffix(base_slug: str, doc_id: uuid.UUID) -> str:
+    """Strip a collision suffix THIS doc previously added to its own slug, so a
+    re-derive on move doesn't nest suffixes (`title-abc123` -> `title`). Matches
+    only this doc's own uuid-hex prefixes (longest first), never an unrelated
+    trailing `-hex` that happens to be part of a real title."""
+    hexs = doc_id.hex
+    for n in (len(hexs), 16, 12, 8):
+        suffix = f"-{hexs[:n]}"
+        if base_slug.endswith(suffix):
+            return base_slug[: -len(suffix)]
+    return base_slug
 
 
 class DocumentService:
@@ -288,6 +310,75 @@ class DocumentService:
                 await acquire_path_lock(lock_conn, vault_id, file_path)
                 yield lock_conn
 
+    @asynccontextmanager
+    async def _move_lock(self, vault_id: uuid.UUID, path_a: str, path_b: str):
+        """Lock BOTH the source and destination paths for a move, in a stable
+        (sorted) order so two concurrent moves can't deadlock on each other."""
+        pool = await get_pool()
+        async with pool.acquire() as lock_conn:
+            async with lock_conn.transaction():
+                for p in sorted({path_a, path_b}):
+                    await acquire_path_lock(lock_conn, vault_id, p)
+                yield lock_conn
+
+    async def _resolve_free_path(
+        self, doc_repo, vault_id: uuid.UUID, base_path: str,
+        doc_id: uuid.UUID, conn, *, self_id: uuid.UUID | None = None,
+    ) -> str:
+        """Return ``base_path`` if it is free, else disambiguate with
+        progressively longer slices of the doc's OWN uuid hex (8→12→16→full).
+
+        The clean path is preferred (predictable). On collision the doc's uuid
+        is the disambiguator: distinct docs have distinct uuids, and the full
+        hex is globally unique, so this always terminates on a free path. This
+        covers the deep cases — a same-title doc already at the target (move
+        into a colliding collection), AND the (adversarial/astronomical) case
+        where the 8-hex suffix is itself taken. ``self_id`` (move) treats a row
+        that IS this doc as free, so re-running a move is a clean no-op rather
+        than a self-collision. The advisory lock on the base path + the final
+        UNIQUE(vault_id, path) constraint guard the residual concurrent race.
+        """
+        def _is_free(row) -> bool:
+            return row is None or (self_id is not None and row["id"] == self_id)
+
+        if _is_free(await doc_repo.find_by_path(vault_id, base_path, conn=conn)):
+            return base_path
+        stem = base_path[:-3] if base_path.endswith(".md") else base_path
+        hexs = doc_id.hex
+        for n in (8, 12, 16, len(hexs)):
+            cand = f"{stem}-{hexs[:n]}.md"
+            if _is_free(await doc_repo.find_by_path(vault_id, cand, conn=conn)):
+                return cand
+        # Unreachable in practice (full uuid is unique); fall through to the
+        # full-hex form and let the UNIQUE constraint surface any true clash.
+        return f"{stem}-{hexs}.md"
+
+    @staticmethod
+    async def _relink_edges(conn, vault_id, column: str, old_uri: str, new_uri: str) -> None:
+        """Repoint edges referencing ``old_uri`` to ``new_uri`` on ``column``
+        ('source_uri' or 'target_uri') during a move. Rows that would duplicate
+        an edge already present at ``new_uri`` are skipped by the UPDATE (the
+        UNIQUE(source_uri, target_uri, relation_type) guard) and then dropped,
+        since they ARE such duplicates. ``column`` comes from a fixed internal
+        set, so the f-string interpolation is not an injection surface."""
+        other = "target_uri" if column == "source_uri" else "source_uri"
+        await conn.execute(
+            f"""
+            UPDATE edges e SET {column} = $1
+             WHERE e.vault_id = $2 AND e.{column} = $3
+               AND NOT EXISTS (
+                 SELECT 1 FROM edges x
+                  WHERE x.vault_id = $2 AND x.{column} = $1
+                    AND x.{other} = e.{other}
+                    AND x.relation_type = e.relation_type)
+            """,
+            new_uri, vault_id, old_uri,
+        )
+        await conn.execute(
+            f"DELETE FROM edges WHERE vault_id = $1 AND {column} = $2",
+            vault_id, old_uri,
+        )
+
     # ── Put ───────────────────────────────────────────────────
 
     async def put(self, req: DocumentPutRequest, agent_id: str | None = None) -> DocumentPutResponse:
@@ -302,34 +393,58 @@ class DocumentService:
             raise NotFoundError("Vault", req.vault)
 
         now = datetime.now(timezone.utc)
-        # Caller may pin an explicit slug (e.g. the vault-guide seed needs
-        # `vault-skill` so its path stays stable across title edits).
-        slug = (req.slug and _slugify(req.slug)) or _slugify(req.title)
+        # Generate the doc id up front so a collision can disambiguate the path
+        # with the doc's short form. The clean path is used when the slug is
+        # free; a `-{shortid}` suffix is appended ONLY on collision — the
+        # industry-standard pattern for identity-bearing paths (WordPress /
+        # Drupal / Rails / Ghost all suffix only on collision, never always).
+        # A caller-pinned `req.slug` (e.g. the vault-skill seed) must land at
+        # its exact path, so a collision there is a real conflict (no suffix).
+        # See docs/designs/doc-identity-slug/00-overview.md.
+        doc_id = uuid.uuid4()
+        base_slug = slugify(req.slug) if req.slug else slugify(req.title)
         normalized_collection = _normalize_collection(req.collection)
-        file_path = f"{normalized_collection}/{slug}.md" if normalized_collection else f"{slug}.md"
+        base_path = _doc_path(normalized_collection, base_slug)
 
-        async with self._path_lock(vault_id, file_path) as conn:
+        async with self._path_lock(vault_id, base_path) as conn:
             return await self._put_locked(
-                req=req, agent_id=agent_id, vault_id=vault_id,
-                file_path=file_path, slug=slug, now=now,
+                req=req, agent_id=agent_id, vault_id=vault_id, doc_id=doc_id,
+                base_path=base_path, base_slug=base_slug,
+                explicit_slug=bool(req.slug), now=now,
                 normalized_collection=normalized_collection,
                 doc_repo=doc_repo, coll_repo=coll_repo, conn=conn,
             )
 
     async def _put_locked(
-        self, *, req, agent_id, vault_id, file_path, slug, now,
-        normalized_collection, doc_repo, coll_repo, conn,
+        self, *, req, agent_id, vault_id, doc_id, base_path, base_slug,
+        explicit_slug, now, normalized_collection, doc_repo, coll_repo, conn,
     ) -> DocumentPutResponse:
-        # Conflict pre-check — now safe under (vault_id, path) advisory lock.
-        # The earlier comment about "concurrent puts can still race past
-        # this gate" no longer applies: the lock serializes writers on
-        # this exact (vault_id, path), so a second caller observes the
-        # first caller's row here and 409s before any git mutation.
-        # Every DB call below reuses `conn` (the lock connection, already in
-        # a transaction) so the whole put holds exactly one pool connection.
-        if await doc_repo.find_by_path(vault_id, file_path, conn=conn):
-            from app.exceptions import ConflictError
-            raise ConflictError(f"Document already exists at path: {file_path}")
+        # Resolve the final path under the (vault, base_path) advisory lock,
+        # which serializes writers racing on the same base slug. If the clean
+        # path is free, use it (predictable, human-readable). If taken: a
+        # caller-pinned slug is a true conflict (409), but a title-derived slug
+        # disambiguates with the doc's short id so two distinct titles that
+        # normalize to the same slug both persist. The short id makes the
+        # suffixed path unique by construction; create()'s UNIQUE(vault_id,
+        # path) is the final guard against the astronomically rare hex clash.
+        # Every DB call below reuses `conn` (the lock connection, already in a
+        # transaction) so the whole put holds exactly one pool connection.
+        from app.exceptions import ConflictError
+        from app.repositories.document_repo import drop_resource_alias
+        if await doc_repo.find_by_path(vault_id, base_path, conn=conn):
+            if explicit_slug:
+                # A caller-pinned slug must land at its exact path.
+                raise ConflictError(f"Document already exists at path: {base_path}")
+            # Title-derived: disambiguate with this doc's own uuid (robust even
+            # if the 8-hex form is itself taken).
+            file_path = await self._resolve_free_path(
+                doc_repo, vault_id, base_path, doc_id, conn
+            )
+        else:
+            file_path = base_path
+        # A real doc now owns this path → clear any stale rename redirect that
+        # pointed elsewhere (a reused path's history resets to the live doc).
+        await drop_resource_alias(conn, vault_id, "document", file_path)
 
         fm_dict = _build_frontmatter(req, now)
         if agent_id:
@@ -370,6 +485,7 @@ class DocumentService:
             summary=fm_dict.get("summary") or req.summary, domain=req.domain, created_by=agent_id,
             now=now, commit_hash=commit_hash, content_hash=content_hash,
             hash_algorithm=HASH_ALGORITHM, tags=req.tags, metadata={}, conn=conn,
+            doc_id=doc_id,
         )
 
         # Index: write chunks into PG (truth) + best-effort vector-store upsert.
@@ -709,6 +825,190 @@ class DocumentService:
             action="updated", chunks_indexed=chunks_indexed, entities_found=0,
         )
 
+    # ── Move / rename ─────────────────────────────────────────
+
+    async def move(
+        self, vault: str, doc_ref: str, *,
+        collection: str | None = None, slug: str | None = None,
+        agent_id: str | None = None,
+    ) -> DocumentPutResponse:
+        """Move/rename a document: change its collection and/or slug while
+        keeping its identity (id) and git history (``git mv`` + ``--follow``).
+        The old path is recorded in ``resource_aliases`` so old akb:// URIs keep
+        resolving; graph edges + publications referencing the old URI are
+        rewritten. At least one of ``collection``/``slug`` must change.
+        """
+        from app.repositories.document_repo import (
+            add_resource_alias,
+            drop_resource_alias,
+        )
+
+        vault_repo, doc_repo, coll_repo = await self._repos()
+        vault_id = await vault_repo.get_id_by_name(vault)
+        if not vault_id:
+            raise NotFoundError("Vault", vault)
+
+        if collection is None and slug is None:
+            raise ValidationError("move requires at least one of collection or slug")
+        # An explicitly-requested slug is a precise rename target — like create,
+        # a collision on it rejects rather than silently suffixing.
+        explicit_slug = bool(slug)
+
+        row = await doc_repo.find_by_ref(vault_id, doc_ref)
+        if not row:
+            raise NotFoundError("Document", doc_ref)
+        old_path = row["path"]
+
+        # Best-effort target estimate, used only to pick the lock. The
+        # AUTHORITATIVE target is recomputed from the fresh row after the lock,
+        # since a concurrent move could change this doc's path between this read
+        # and lock acquisition (the recompute + UNIQUE(vault_id, path) make the
+        # stale-read race safe). When the slug is kept (not re-specified), strip
+        # any collision suffix THIS doc added before so a move doesn't nest them.
+        def _target(base_path: str, doc_id: uuid.UUID) -> tuple[str, str, str]:
+            cur_coll, cur_base = _split_doc_path(base_path)
+            nc = _normalize_collection(collection) if collection is not None else cur_coll
+            ns = slugify(slug) if slug else _strip_own_suffix(cur_base, doc_id)
+            return nc, ns, _doc_path(nc, ns)
+
+        _, _, est_new_path = _target(old_path, row["id"])
+
+        async with self._move_lock(vault_id, old_path, est_new_path) as conn:
+            # Re-read under the lock and recompute the target from fresh state.
+            row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
+            if not row:
+                raise NotFoundError("Document", doc_ref)
+            old_path = row["path"]
+            pg_doc_id = row["id"]
+            old_collection_id = row["collection_id"]
+
+            new_coll, new_base_slug, base_new_path = _target(old_path, pg_doc_id)
+            if base_new_path == old_path:
+                raise ValidationError(
+                    "move is a no-op: the target path equals the current path"
+                )
+
+            # On-collision suffix (same robust rule as create): if the clean
+            # target is taken by a DIFFERENT doc, disambiguate with this doc's
+            # own uuid. self_id lets a target already held by THIS doc count as
+            # free, so a redundant re-move collapses to the no-op check below.
+            new_path = await self._resolve_free_path(
+                doc_repo, vault_id, base_new_path, pg_doc_id, conn, self_id=pg_doc_id
+            )
+            if new_path == old_path:
+                raise ValidationError("move is a no-op: the target path equals the current path")
+            # A suffix was forced (collision) but the caller pinned this slug →
+            # reject instead of silently renaming to something they didn't ask for.
+            if explicit_slug and new_path != base_new_path:
+                raise ConflictError(f"Document already exists at path: {base_new_path}")
+
+            new_collection_id = (
+                await coll_repo.get_or_create(vault_id, new_coll, conn=conn)
+                if new_coll else None
+            )
+            now = datetime.now(timezone.utc)
+            commit_msg = (
+                f"[move] {old_path} -> {new_path}\n\n"
+                f"agent: {agent_id or 'unknown'}\naction: move"
+            )
+            try:
+                commit_hash = await asyncio.to_thread(
+                    self.git.move_file,
+                    vault_name=vault, old_path=old_path, new_path=new_path,
+                    message=commit_msg, author_name=agent_id or "AKB System",
+                )
+            except FileNotFoundError:
+                # Crash-recovery idempotence: a prior move committed the git mv
+                # but its DB tx didn't commit, so on retry the source is already
+                # gone. If the file now lives at new_path, adopt the current HEAD
+                # and finish the DB side; otherwise it's a genuine missing file.
+                head = await asyncio.to_thread(self.git.current_commit, vault)
+                if head is None or await asyncio.to_thread(self.git.read_file, vault, new_path) is None:
+                    raise
+                logger.warning(
+                    "Move recovery: %s already at %s in git — reconciling DB to HEAD %s",
+                    old_path, new_path, head[:8],
+                )
+                commit_hash = head
+            logger.info("Document moved: %s -> %s (commit: %s)", old_path, new_path, commit_hash[:8])
+
+            await doc_repo.update_path(
+                pg_doc_id, new_path, collection_id=new_collection_id,
+                now=now, commit_hash=commit_hash, conn=conn,
+            )
+
+            # Keep collection doc counts honest when the folder changed.
+            if old_collection_id != new_collection_id:
+                if old_collection_id:
+                    await coll_repo.decrement_count(old_collection_id, now, conn=conn)
+                if new_collection_id:
+                    await coll_repo.increment_count(new_collection_id, now, conn=conn)
+
+            # Redirect old_path -> this id; clear any stale redirect now shadowed
+            # by a real doc landing on new_path.
+            await add_resource_alias(conn, vault_id, "document", old_path, pg_doc_id)
+            await drop_resource_alias(conn, vault_id, "document", new_path)
+
+            # Rewrite graph edges + publications that referenced the old URI so
+            # the live graph stays correct (old links also resolve via alias).
+            # Guard edges' UNIQUE(source_uri, target_uri, relation_type): move
+            # only rows that won't duplicate an edge already present at the new
+            # URI, then drop the leftovers (they ARE such duplicates). Without
+            # this, a move onto a path that previously held an equivalent edge
+            # would throw a UniqueViolation and abort the whole move.
+            old_uri = doc_uri(vault, old_path)
+            new_uri = doc_uri(vault, new_path)
+            await self._relink_edges(conn, vault_id, "source_uri", old_uri, new_uri)
+            await self._relink_edges(conn, vault_id, "target_uri", old_uri, new_uri)
+            await conn.execute(
+                "UPDATE publications SET resource_uri = $1 WHERE vault_id = $2 AND resource_uri = $3",
+                new_uri, vault_id, old_uri,
+            )
+
+            # Re-chunk so the doc-metadata header carries the new path.
+            chunks_indexed = 0
+            content = await asyncio.to_thread(self.git.read_file, vault, new_path)
+            if content is not None:
+                _, body = _parse_markdown(content)
+                meta_header = build_doc_metadata_header(
+                    vault_name=vault, path=new_path, title=row["title"],
+                    summary=row["summary"],
+                    tags=list(row["tags"]) if row["tags"] else [],
+                    doc_type=row["doc_type"],
+                )
+                chunks = chunk_markdown(body, metadata_header=meta_header)
+                chunks_indexed = await write_source_chunks(
+                    conn, "document", str(pg_doc_id), vault_id=vault_id, chunks=chunks,
+                )
+            else:
+                # Invariant violation: the file we just `git mv`-ed is unreadable.
+                # Don't abort (that would diverge git from DB) — the path move is
+                # committed; surface it so search-index staleness is noticed.
+                logger.error(
+                    "Move re-index skipped: %s unreadable right after git mv (chunks now stale)",
+                    new_path,
+                )
+
+            await emit_event(
+                conn, "document.move",
+                vault_id=vault_id,
+                resource_uri=new_uri,
+                actor_id=agent_id,
+                payload={
+                    "vault": vault, "path": new_path, "old_path": old_path,
+                    "old_uri": old_uri, "commit_hash": commit_hash,
+                },
+            )
+
+            return DocumentPutResponse(
+                uri=new_uri, vault=vault, path=new_path,
+                commit_hash=commit_hash, current_commit=commit_hash,
+                previous_commit=row.get("current_commit"),
+                content_hash=row.get("content_hash"),
+                hash_algorithm=row.get("hash_algorithm"),
+                action="moved", chunks_indexed=chunks_indexed, entities_found=0,
+            )
+
     # ── Edit ──────────────────────────────────────────────────
 
     async def edit(
@@ -945,6 +1245,11 @@ class DocumentService:
             "DELETE FROM publications WHERE resource_uri = $1",
             doc_uri(vault, file_path),
         )
+        # Drop any rename/move redirects that pointed at this doc so no alias
+        # outlives the row it targets (a later doc reusing the old path then
+        # resolves to itself, not a tombstone).
+        from app.repositories.document_repo import drop_aliases_for_resource
+        await drop_aliases_for_resource(conn, vault_id, "document", pg_doc_id)
         await emit_event(
             conn, "document.delete",
             vault_id=vault_id,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -149,6 +149,9 @@ class EditError(AKBError):
 
 from app.util.text import normalize_collection_path as _normalize_collection
 from app.util.text import slugify
+from app.util.text import doc_path as _doc_path
+from app.util.text import split_doc_path as _split_doc_path
+from app.util.text import strip_own_suffix as _strip_own_suffix
 
 
 def _build_frontmatter(req: DocumentPutRequest, now: datetime) -> dict:
@@ -195,35 +198,6 @@ def _parse_markdown(content: str) -> tuple[dict, str]:
 
 def _body_content_hash(body: str) -> str:
     return compute_text_content_hash(body)
-
-
-def _split_doc_path(path: str) -> tuple[str, str]:
-    """Split a document path into (collection, base-slug). The base-slug is the
-    filename without its ``.md`` suffix. Root docs return ("", base)."""
-    stem = path[:-3] if path.endswith(".md") else path
-    if "/" in stem:
-        coll, base = stem.rsplit("/", 1)
-        return coll, base
-    return "", stem
-
-
-def _doc_path(collection: str, slug: str) -> str:
-    """Compose a document path from a (possibly empty) collection + slug. Inverse
-    of `_split_doc_path`; a root doc (empty collection) is just ``{slug}.md``."""
-    return f"{collection}/{slug}.md" if collection else f"{slug}.md"
-
-
-def _strip_own_suffix(base_slug: str, doc_id: uuid.UUID) -> str:
-    """Strip a collision suffix THIS doc previously added to its own slug, so a
-    re-derive on move doesn't nest suffixes (`title-abc123` -> `title`). Matches
-    only this doc's own uuid-hex prefixes (longest first), never an unrelated
-    trailing `-hex` that happens to be part of a real title."""
-    hexs = doc_id.hex
-    for n in (len(hexs), 16, 12, 8):
-        suffix = f"-{hexs[:n]}"
-        if base_slug.endswith(suffix):
-            return base_slug[: -len(suffix)]
-    return base_slug
 
 
 class DocumentService:
@@ -830,13 +804,15 @@ class DocumentService:
     async def move(
         self, vault: str, doc_ref: str, *,
         collection: str | None = None, slug: str | None = None,
-        agent_id: str | None = None,
+        message: str | None = None, agent_id: str | None = None,
     ) -> DocumentPutResponse:
         """Move/rename a document: change its collection and/or slug while
-        keeping its identity (id) and git history (``git mv`` + ``--follow``).
-        The old path is recorded in ``resource_aliases`` so old akb:// URIs keep
-        resolving; graph edges + publications referencing the old URI are
-        rewritten. At least one of ``collection``/``slug`` must change.
+        keeping its identity (id). The move is a ``git mv``, so ``git log
+        --follow`` traces the file's history across it later. The old path is
+        recorded in ``resource_aliases`` so old akb:// URIs keep resolving;
+        graph edges + publications referencing the old URI are rewritten. At
+        least one of ``collection``/``slug`` must be provided, and the resulting
+        path must differ from the current one (else it is rejected as a no-op).
         """
         from app.repositories.document_repo import (
             add_resource_alias,
@@ -907,9 +883,10 @@ class DocumentService:
                 if new_coll else None
             )
             now = datetime.now(timezone.utc)
+            summary = message or f"{old_path} -> {new_path}"
             commit_msg = (
                 f"[move] {old_path} -> {new_path}\n\n"
-                f"agent: {agent_id or 'unknown'}\naction: move"
+                f"agent: {agent_id or 'unknown'}\naction: move\nsummary: {summary}"
             )
             try:
                 commit_hash = await asyncio.to_thread(
@@ -982,11 +959,18 @@ class DocumentService:
                 )
             else:
                 # Invariant violation: the file we just `git mv`-ed is unreadable.
-                # Don't abort (that would diverge git from DB) — the path move is
-                # committed; surface it so search-index staleness is noticed.
+                # Don't abort (that would diverge git from DB — the path move is
+                # already committed). But DROP the now-orphaned chunks: the
+                # re-chunk above (skipped here) would have *replaced* them, so
+                # leaving them serves a stale, wrong-path embedding under the new
+                # path. Dropping makes the doc honestly UNSEARCHABLE until its
+                # next edit/reindex — the correct failure mode here.
+                await delete_document_chunks(conn, str(pg_doc_id))
                 logger.error(
-                    "Move re-index skipped: %s unreadable right after git mv (chunks now stale)",
-                    new_path,
+                    "Move re-index FAILED: %s unreadable right after git mv "
+                    "(doc_id=%s, commit=%s) — dropped stale chunks; doc is "
+                    "UNSEARCHABLE until next reindex",
+                    new_path, pg_doc_id, commit_hash[:8],
                 )
 
             await emit_event(

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -584,6 +584,62 @@ class GitService:
                 parent_required=True,
             )
 
+    def move_file(
+        self,
+        vault_name: str,
+        old_path: str,
+        new_path: str,
+        message: str,
+        author_name: str = "AKB System",
+        author_email: str = "akb@system",
+    ) -> str:
+        """Rename/move a tracked file via ``git mv`` and commit. Returns the
+        commit hash.
+
+        ``git mv`` records the rename so ``git log --follow <new_path>`` traces
+        the file's history across the move (blame/log continuity). Mirrors
+        ``commit_file``/``delete_file``'s lock + worktree-prep + commit shape.
+        """
+        if old_path == new_path:
+            raise ValueError("move_file: old_path and new_path are identical")
+        with _vault_lock(vault_name):
+            wt = self._ensure_worktree(vault_name)
+            if wt is None:
+                raise FileNotFoundError(f"File not found in vault: {old_path}")
+
+            work_repo = Repo(str(wt))
+            work_repo.git.reset("--hard", "HEAD")
+
+            src = wt / old_path
+            if not src.exists():
+                raise FileNotFoundError(f"File not found in vault: {old_path}")
+            dst = wt / new_path
+            # A case-only rename ("File.md" -> "file.md") on a case-INSENSITIVE
+            # filesystem (macOS APFS/HFS+) makes dst.exists() report True even
+            # though src and dst are the SAME inode. Allow that; only a genuine
+            # different file at the destination is a conflict.
+            if dst.exists() and not src.samefile(dst):
+                raise FileExistsError(f"Destination already exists in vault: {new_path}")
+            dst.parent.mkdir(parents=True, exist_ok=True)
+
+            work_repo.git.mv("--", old_path, new_path)
+            return self._stage_and_commit(
+                work_repo,
+                message,
+                author_name,
+                author_email,
+                parent_required=True,
+            )
+
+    def current_commit(self, vault_name: str) -> str | None:
+        """Return the vault's current HEAD commit hash, or None if the bare repo
+        has no commits yet. Used to reconcile DB state after a crash-recovery
+        move where the git mv already committed."""
+        try:
+            return self._get_repo(vault_name).head.commit.hexsha
+        except Exception:  # noqa: BLE001 — repo missing or no HEAD yet (empty repo)
+            return None
+
     def delete_paths_bulk(
         self,
         *,

--- a/backend/app/util/text.py
+++ b/backend/app/util/text.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+import uuid
 from difflib import get_close_matches
 from typing import Any
 
@@ -190,6 +191,35 @@ def slugify(text: str) -> str:
     slug = re.sub(r"[-\s]+", "-", slug).strip("-")
     slug = slug[:_SLUG_MAX].rstrip("-")
     return slug or "untitled"
+
+
+def split_doc_path(path: str) -> tuple[str, str]:
+    """Split a document path into (collection, base-slug). The base-slug is the
+    filename without its ``.md`` suffix. Root docs return ("", base)."""
+    stem = path[:-3] if path.endswith(".md") else path
+    if "/" in stem:
+        coll, base = stem.rsplit("/", 1)
+        return coll, base
+    return "", stem
+
+
+def doc_path(collection: str, slug: str) -> str:
+    """Compose a document path from a (possibly empty) collection + slug. Inverse
+    of `split_doc_path`; a root doc (empty collection) is just ``{slug}.md``."""
+    return f"{collection}/{slug}.md" if collection else f"{slug}.md"
+
+
+def strip_own_suffix(base_slug: str, doc_id: uuid.UUID) -> str:
+    """Strip a collision suffix THIS doc previously added to its own slug, so a
+    re-derive on move doesn't nest suffixes (`title-abc123` -> `title`). Matches
+    only this doc's own uuid-hex prefixes (longest first), never an unrelated
+    trailing `-hex` that happens to be part of a real title."""
+    hexs = doc_id.hex
+    for n in (len(hexs), 16, 12, 8):
+        suffix = f"-{hexs[:n]}"
+        if base_slug.endswith(suffix):
+            return base_slug[: -len(suffix)]
+    return base_slug
 
 
 def like_escape(s: str) -> str:

--- a/backend/app/util/text.py
+++ b/backend/app/util/text.py
@@ -17,6 +17,7 @@ idempotent) and catches anything caller-side normalization missed.
 
 from __future__ import annotations
 
+import re
 import unicodedata
 from difflib import get_close_matches
 from typing import Any
@@ -162,6 +163,33 @@ def fuzzy_hint(bad: str, candidates: list[str], *, label: str) -> str:
     truncated = candidates[:_FUZZY_HINT_LIST_LIMIT]
     suffix = " …" if len(candidates) > _FUZZY_HINT_LIST_LIMIT else ""
     return f"Available {label}: {', '.join(truncated)}{suffix}"
+
+
+# ── Document slug / path identity ────────────────────────────────
+#
+# A document's identity is its path = "{collection}/{slug}.md". The slug is
+# derived from the human title, but the title is mutable and need not be unique.
+# The service writes the clean slug when free and appends a `-{shortid}` only on
+# collision (see document_service.put / _put_locked) — the standard pattern for
+# identity-bearing paths. This module owns just the (pure, testable) slug
+# normalization. See docs/designs/doc-identity-slug/00-overview.md.
+
+_SLUG_MAX = 80
+
+
+def slugify(text: str) -> str:
+    """Title → URL/path-safe slug.
+
+    Hardened over the original: trims leading/trailing hyphens (so a path
+    never starts with ``-`` or, after truncation, dangles one), and falls
+    back to ``"untitled"`` for empty / symbol-only input so the derived
+    path is never a bare ``".md"`` dotfile.
+    """
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[-\s]+", "-", slug).strip("-")
+    slug = slug[:_SLUG_MAX].rstrip("-")
+    return slug or "untitled"
 
 
 def like_escape(s: str) -> str:

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -426,6 +426,7 @@ async def _handle_move(args: dict, uid: str, user: _MCPUser) -> dict:
         vault, doc_path,
         collection=to_nfc(collection) if collection is not None else None,
         slug=to_nfc(slug) if slug is not None else None,
+        message=args.get("message"),
         agent_id=user.username,
     )
     return result.model_dump()

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -407,6 +407,30 @@ async def _handle_update(args: dict, uid: str, user: _MCPUser) -> dict:
     return result.model_dump()
 
 
+@_h("akb_move")
+async def _handle_move(args: dict, uid: str, user: _MCPUser) -> dict:
+    try:
+        vault, doc_path = split_uri(args["uri"], expected_type="doc")
+    except ValueError as e:
+        return err(str(e), code=INVALID_URI)
+    doc_path = to_nfc(doc_path)
+    await check_vault_access(uid, vault, required_role="writer")
+    collection = args.get("collection")
+    slug = args.get("slug")
+    if collection is None and slug is None:
+        return err(
+            "Provide `collection` and/or `slug` to move the document.",
+            code=INVALID_ARGUMENT,
+        )
+    result = await doc_service.move(
+        vault, doc_path,
+        collection=to_nfc(collection) if collection is not None else None,
+        slug=to_nfc(slug) if slug is not None else None,
+        agent_id=user.username,
+    )
+    return result.model_dump()
+
+
 @_h("akb_edit")
 async def _handle_edit(args: dict, uid: str, user: _MCPUser) -> dict:
     vault, doc_path = split_uri(args["uri"], expected_type="doc")

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -237,6 +237,32 @@ TOOLS = [
         },
     ),
     Tool(
+        name="akb_move",
+        description=(
+            "Move or rename a document — change its collection and/or slug while "
+            "keeping its identity and full git history. The old akb:// URI keeps "
+            "resolving (a redirect is recorded), and graph links/publications are "
+            "rewritten. Provide collection and/or slug (at least one must change). "
+            "The title is unchanged; use akb_update to change the displayed title."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "uri": {"type": "string", "description": "Document URI to move"},
+                "collection": {
+                    "type": "string",
+                    "description": "New collection path (omit to keep the current collection)",
+                },
+                "slug": {
+                    "type": "string",
+                    "description": "New slug / filename base, e.g. 'final-spec' (omit to keep the current slug)",
+                },
+                "message": {"type": "string", "description": "Commit message describing the move"},
+            },
+            "required": ["uri"],
+        },
+    ),
+    Tool(
         name="akb_delete",
         description="Delete a document. Removes from Git, search index, and knowledge graph.",
         inputSchema={

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.10"
+version = "0.8.11"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_doc_identity_scenarios.sh
+++ b/backend/tests/test_doc_identity_scenarios.sh
@@ -185,6 +185,28 @@ mcp akb_move "{\"uri\":\"$CV\",\"slug\":\"cross-moved\"}" >/dev/null
 CVP=$(echo "$CV" | sed "s#/$VAULT/#/$VAULT2/#")
 [ "$(iserr "$(mcp akb_get "{\"uri\":\"$CVP\"}")")" = True ] && pass "alias is vault-scoped (no cross-vault leak)" || fail "cross-vault" "$CVP"
 
+echo ""; echo "▸ S8. Collection doc_count adjusts on move"
+# Maintained collections.doc_count, read from the collection row in a full browse
+# (content_type=all so collection rows are present). Empty → 0.
+ccount() {
+  local n
+  n=$(mcp akb_browse "{\"vault\":\"$VAULT\",\"depth\":-1}" \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((it.get('doc_count') or 0 for it in d.get('items',[]) if it.get('type')=='collection' and it.get('path')=='$1'),0))" 2>/dev/null)
+  echo "${n:-0}"
+}
+put "$VAULT" "cc-src" "Count Keeper A" "KA" >/dev/null
+CC=$(put "$VAULT" "cc-src" "Count Keeper B" "KB" | field uri)
+SRC0=$(ccount cc-src); DST0=$(ccount cc-dst)
+mcp akb_move "{\"uri\":\"$CC\",\"collection\":\"cc-dst\"}" >/dev/null
+SRC1=$(ccount cc-src); DST1=$(ccount cc-dst)
+[ "$(( SRC0 - SRC1 ))" -eq 1 ] && [ "$(( DST1 - DST0 ))" -eq 1 ] && pass "doc_count: src -1 / dst +1 on cross-collection move (src $SRC0->$SRC1, dst $DST0->$DST1)" || fail "doc_count cross" "src $SRC0->$SRC1 dst $DST0->$DST1"
+# move-to-root: source decrements, no NULL-collection increment crash
+RM=$(put "$VAULT" "cc-src" "To Root" "TR" | field uri)
+SRC2=$(ccount cc-src)
+mcp akb_move "{\"uri\":\"$RM\",\"collection\":\"\"}" >/dev/null
+SRC3=$(ccount cc-src)
+[ "$(( SRC2 - SRC3 ))" -eq 1 ] && pass "doc_count: move-to-root decrements source ($SRC2->$SRC3)" || fail "doc_count root" "src $SRC2->$SRC3"
+
 # ── Cleanup ──────────────────────────────────────────────────
 mcp akb_delete_vault "{\"name\":\"$VAULT\",\"confirm\":\"$VAULT\"}" >/dev/null 2>&1
 mcp akb_delete_vault "{\"name\":\"$VAULT2\",\"confirm\":\"$VAULT2\"}" >/dev/null 2>&1

--- a/backend/tests/test_doc_identity_scenarios.sh
+++ b/backend/tests/test_doc_identity_scenarios.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+#
+# AKB Document Identity (slug / collision / move / alias) Scenario Suite
+# Multi-angle, end-to-end against the MCP HTTP transport.
+# Covers: slug derivation & normalization, create-collision suffixing,
+# title-edit path freeze, move/rename + alias resolution, lifecycle
+# (reuse / delete), edge survival across move, cross-vault isolation.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+SUFFIX="$(date +%s)-$$"
+USER="ident-$SUFFIX"
+VAULT="ident-$SUFFIX"
+VAULT2="ident2-$SUFFIX"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   AKB Document Identity Scenario Suite    ║"
+echo "║   Target: $BASE_URL/mcp/"
+echo "╚══════════════════════════════════════════╝"
+
+# ── Setup: user + PAT + MCP session ──────────────────────────
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null)
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $JWT" \
+  -H 'Content-Type: application/json' -d '{"name":"ident"}' | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null)
+[ -n "$PAT" ] || { echo "FATAL: no PAT"; exit 1; }
+
+INIT=$(curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT" \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ident","version":"1.0"}}}' 2>&1)
+SID=$(echo "$INIT" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
+[ -n "$SID" ] || { echo "FATAL: no session"; exit 1; }
+curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+
+MCP_ID=10
+mcp() {  # tool args  -> result-text json
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}" 2>&1 \
+    | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['result']['content'][0]['text'])" 2>/dev/null
+}
+field() { python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$1',''))" 2>/dev/null; }
+# put: vault coll title content -> echoes uri
+put() { mcp akb_put "{\"vault\":\"$1\",\"collection\":\"$2\",\"title\":\"$3\",\"content\":\"$4\"}"; }
+geturi() { mcp akb_get "{\"uri\":\"$1\"}"; }
+has() { echo "$1" | grep -q "$2" && echo y || echo n; }     # body contains tag
+iserr() { echo "$1" | python3 -c "import sys,json;print('error' in json.load(sys.stdin))" 2>/dev/null; }
+
+mcp akb_create_vault "{\"name\":\"$VAULT\",\"description\":\"ident scenarios\"}" >/dev/null
+mcp akb_create_vault "{\"name\":\"$VAULT2\",\"description\":\"ident scenarios 2\"}" >/dev/null
+
+# ════════════════════════════════════════════════════════════
+echo ""; echo "▸ S1. Slug derivation & normalization"
+# clean
+U=$(put "$VAULT" "s1" "Clean Title" "C1" | field uri)
+[ "$(echo $U | grep -c '/s1/doc/clean-title.md')" = 1 ] && pass "clean title → clean slug" || fail "clean slug" "$U"
+# punctuation/spaces normalized
+U=$(put "$VAULT" "s1" "Payment API v2!! (Final)" "C2" | field uri)
+echo "$U" | grep -q "payment-api-v2-final.md" && pass "punctuation/space normalized" || fail "normalize punct" "$U"
+# symbol-only → untitled
+U=$(put "$VAULT" "s1sym" "!!!" "C3" | field uri)
+echo "$U" | grep -q "/untitled.md" && pass "symbol-only title → untitled.md" || fail "untitled" "$U"
+# second symbol-only → untitled-{hex}
+U2=$(put "$VAULT" "s1sym" "---" "C4" | field uri)
+echo "$U2" | grep -qE "/untitled-[0-9a-f]{8}.md" && pass "2nd symbol title → untitled-{hex}.md" || fail "untitled suffix" "$U2"
+# unicode/Korean round-trips
+UK=$(put "$VAULT" "s1" "한글 제목 테스트" "KO_BODY" | field uri)
+RK=$(geturi "$UK")
+[ "$(has "$RK" KO_BODY)" = y ] && pass "unicode/Korean title round-trips" || fail "unicode" "$UK"
+# very long title truncates but creates
+LONG=$(python3 -c "print('a'*150)")
+UL=$(put "$VAULT" "s1" "$LONG" "LONG_BODY" | field uri)
+[ -n "$UL" ] && [ "$(has "$(geturi "$UL")" LONG_BODY)" = y ] && pass "very long title truncates+creates" || fail "long title" "$UL"
+
+echo ""; echo "▸ S2. Create collision suffixing"
+A=$(put "$VAULT" "dup" "Same Name" "A_BODY" | field uri)
+B=$(put "$VAULT" "dup" "Same Name" "B_BODY" | field uri)
+C=$(put "$VAULT" "dup" "Same Name" "C_BODY" | field uri)
+[ "$A" != "$B" ] && [ "$B" != "$C" ] && [ "$A" != "$C" ] && pass "3 same-title → 3 distinct paths" || fail "distinct" "$A|$B|$C"
+echo "$A" | grep -q "/same-name.md" && pass "1st same-title keeps clean path" || fail "clean first" "$A"
+echo "$B" | grep -qE "/same-name-[0-9a-f]{8}.md" && pass "2nd same-title → -{hex} suffix" || fail "suffix" "$B"
+[ "$(has "$(geturi "$A")" A_BODY)" = y ] && [ "$(has "$(geturi "$B")" B_BODY)" = y ] && [ "$(has "$(geturi "$B")" A_BODY)" = n ] && pass "collision bodies isolated" || fail "isolation" "bleed"
+# case-only differs → slugify lowercases → collide → suffix
+CA=$(put "$VAULT" "case" "WidgetApi" "CASE_A" | field uri)
+CB=$(put "$VAULT" "case" "widgetapi" "CASE_B" | field uri)
+[ "$CA" != "$CB" ] && pass "case-different titles still disambiguate" || fail "case dup" "$CA|$CB"
+# same title in DIFFERENT collection → both clean (no collision)
+X1=$(put "$VAULT" "ca" "Notes" "X1" | field uri)
+X2=$(put "$VAULT" "cb" "Notes" "X2" | field uri)
+echo "$X1" | grep -q "/ca/doc/notes.md" && echo "$X2" | grep -q "/cb/doc/notes.md" && pass "same title, diff collection → both clean" || fail "cross-coll" "$X1|$X2"
+
+echo ""; echo "▸ S3. Title edit freezes path"
+ED=$(put "$VAULT" "edit" "Draft Title" "ED_BODY" | field uri)
+mcp akb_update "{\"uri\":\"$ED\",\"title\":\"Completely New Title\"}" >/dev/null
+R=$(geturi "$ED")
+[ "$(has "$R" ED_BODY)" = y ] && pass "title edit: path frozen, get-by-old-path works" || fail "edit freeze" "$ED"
+echo "$ED" | grep -q "/draft-title.md" && pass "title edit: slug unchanged (draft-title.md)" || fail "edit slug" "$ED"
+# two docs can end with same title via edit (non-unique)
+E1=$(put "$VAULT" "edit" "Alpha" "E1" | field uri)
+E2=$(put "$VAULT" "edit" "Beta" "E2" | field uri)
+R2=$(mcp akb_update "{\"uri\":\"$E2\",\"title\":\"Alpha\"}")
+[ "$(iserr "$R2")" = False ] && pass "edit title to duplicate is allowed (title non-unique)" || fail "dup title edit" "$R2"
+
+echo ""; echo "▸ S4. Move / rename + alias resolution"
+M=$(put "$VAULT" "mv" "Move Me" "MV_BODY" | field uri)
+MN=$(mcp akb_move "{\"uri\":\"$M\",\"slug\":\"renamed\"}" | field uri)
+[ -n "$MN" ] && [ "$MN" != "$M" ] && pass "rename slug → new uri" || fail "rename" "$MN"
+[ "$(has "$(geturi "$MN")" MV_BODY)" = y ] && pass "new uri resolves" || fail "new resolve" "$MN"
+[ "$(has "$(geturi "$M")" MV_BODY)" = y ] && pass "OLD uri resolves via alias" || fail "alias resolve" "$M"
+# move collection only
+MN2=$(mcp akb_move "{\"uri\":\"$MN\",\"collection\":\"archive\"}" | field uri)
+echo "$MN2" | grep -q "/archive/" && pass "move collection-only" || fail "move coll" "$MN2"
+# all prior URIs resolve (no chain)
+[ "$(has "$(geturi "$M")" MV_BODY)" = y ] && [ "$(has "$(geturi "$MN")" MV_BODY)" = y ] && pass "all prior URIs resolve (no chain)" || fail "chain" "old uris"
+# move to root collection
+MR=$(put "$VAULT" "mvr" "Root Bound" "RB" | field uri)
+MRN=$(mcp akb_move "{\"uri\":\"$MR\",\"collection\":\"\"}" | field uri)
+echo "$MRN" | grep -qE "/$VAULT/doc/root-bound.md" && pass "move to root collection" || fail "move root" "$MRN"
+# same-title collision into a collection → suffixed, both survive
+T1=$(put "$VAULT" "tgt" "Twin" "TW_A" | field uri)
+T2=$(put "$VAULT" "src" "Twin" "TW_B" | field uri)
+T2N=$(mcp akb_move "{\"uri\":\"$T2\",\"collection\":\"tgt\"}" | field uri)
+[ "$T2N" != "$T1" ] && [ "$(has "$(geturi "$T1")" TW_A)" = y ] && [ "$(has "$(geturi "$T2N")" TW_B)" = y ] && pass "move same-title into collection → both survive" || fail "move twin" "$T1|$T2N"
+# suffix stripped on move to free collection
+P1=$(put "$VAULT" "sa" "Sfx" "S1" | field uri); P2=$(put "$VAULT" "sa" "Sfx" "S2" | field uri)
+echo "$P2" | grep -qE "/sfx-[0-9a-f]{8}.md" && {
+  P2N=$(mcp akb_move "{\"uri\":\"$P2\",\"collection\":\"sb\"}" | field uri)
+  echo "$P2N" | grep -q "/sb/doc/sfx.md" && pass "suffix stripped on move to free collection" || fail "strip" "$P2N"
+} || fail "strip-setup" "$P2 not suffixed"
+# explicit slug onto taken path → reject
+mcp akb_put "{\"vault\":\"$VAULT\",\"collection\":\"rej\",\"title\":\"Taken\",\"content\":\"R1\"}" >/dev/null
+RS=$(put "$VAULT" "rej" "Mover" "R2" | field uri)
+RR=$(mcp akb_move "{\"uri\":\"$RS\",\"slug\":\"taken\"}")
+[ "$(iserr "$RR")" = True ] && pass "explicit slug onto taken path rejected" || fail "explicit reject" "$RR"
+# error cases (assign first; deep $(...) nesting of quoted JSON is brittle)
+ENOARG=$(mcp akb_move "{\"uri\":\"$RS\"}")
+[ "$(iserr "$ENOARG")" = True ] && pass "move w/o collection|slug rejected" || fail "noarg" "$ENOARG"
+EBAD=$(mcp akb_move "{\"uri\":\"not-a-uri\",\"slug\":\"x\"}")
+echo "$EBAD" | grep -q "invalid_uri" && pass "malformed uri → clean invalid_uri error" || fail "baduri" "$EBAD"
+EMISS=$(mcp akb_move "{\"uri\":\"akb://$VAULT/doc/nonexistent.md\",\"slug\":\"y\"}")
+[ "$(iserr "$EMISS")" = True ] && pass "move missing doc rejected" || fail "missing" "$EMISS"
+
+echo ""; echo "▸ S5. Lifecycle: reuse, delete, ops by old uri"
+# reuse vacated path → old uri resolves to NEW doc
+RU=$(put "$VAULT" "reuse" "Recycle" "ORIG" | field uri)
+mcp akb_move "{\"uri\":\"$RU\",\"slug\":\"recycled\"}" >/dev/null
+put "$VAULT" "reuse" "Recycle" "NEWDOC" >/dev/null
+RR=$(geturi "$RU")
+[ "$(has "$RR" NEWDOC)" = y ] && [ "$(has "$RR" ORIG)" = n ] && pass "reused path: old uri → new doc (exact-first)" || fail "reuse" "$RU"
+# update by OLD uri after move
+UM=$(put "$VAULT" "ops" "Edit By Old" "OLD1" | field uri)
+UMN=$(mcp akb_move "{\"uri\":\"$UM\",\"slug\":\"edit-by-old-2\"}" | field uri)
+mcp akb_update "{\"uri\":\"$UM\",\"content\":\"UPDATED_VIA_OLD\"}" >/dev/null
+[ "$(has "$(geturi "$UMN")" UPDATED_VIA_OLD)" = y ] && pass "update via OLD uri hits moved doc" || fail "update-old" "$UMN"
+# delete by OLD uri, then old uri 404 (alias cleaned)
+DM=$(put "$VAULT" "ops" "Del By Old" "DEL1" | field uri)
+mcp akb_move "{\"uri\":\"$DM\",\"slug\":\"del-by-old-2\"}" >/dev/null
+mcp akb_delete "{\"uri\":\"$DM\"}" >/dev/null
+[ "$(iserr "$(mcp akb_get "{\"uri\":\"$DM\"}")")" = True ] && pass "delete via OLD uri + alias cleaned (old 404)" || fail "delete-old" "$DM"
+
+echo ""; echo "▸ S6. Edges survive move"
+GA=$(put "$VAULT" "g" "Graph A" "GA" | field uri)
+GB=$(put "$VAULT" "g" "Graph B" "GB" | field uri)
+mcp akb_link "{\"source\":\"$GA\",\"target\":\"$GB\",\"relation\":\"depends_on\"}" >/dev/null
+GBN=$(mcp akb_move "{\"uri\":\"$GB\",\"slug\":\"graph-b-moved\"}" | field uri)
+REL=$(mcp akb_relations "{\"uri\":\"$GA\"}")
+echo "$REL" | grep -q "graph-b-moved" && pass "edge rewritten to new uri after target move" || fail "edge rewrite" "$REL"
+
+echo ""; echo "▸ S7. Cross-vault isolation"
+CV=$(put "$VAULT" "x" "Cross Vault" "CV" | field uri)
+mcp akb_move "{\"uri\":\"$CV\",\"slug\":\"cross-moved\"}" >/dev/null
+# old path in vault1 must NOT resolve when queried under vault2
+CVP=$(echo "$CV" | sed "s#/$VAULT/#/$VAULT2/#")
+[ "$(iserr "$(mcp akb_get "{\"uri\":\"$CVP\"}")")" = True ] && pass "alias is vault-scoped (no cross-vault leak)" || fail "cross-vault" "$CVP"
+
+# ── Cleanup ──────────────────────────────────────────────────
+mcp akb_delete_vault "{\"name\":\"$VAULT\",\"confirm\":\"$VAULT\"}" >/dev/null 2>&1
+mcp akb_delete_vault "{\"name\":\"$VAULT2\",\"confirm\":\"$VAULT2\"}" >/dev/null 2>&1
+
+echo ""
+echo "╔══════════════════════════════════════════╗"
+echo "║   Results: $PASS passed, $FAIL failed"
+echo "╚══════════════════════════════════════════╝"
+if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; exit 1; fi

--- a/backend/tests/test_doc_slug_unit.py
+++ b/backend/tests/test_doc_slug_unit.py
@@ -11,7 +11,9 @@ Imports from `app.util.text` only — no DB / heavy deps, runs as a pure unit te
 """
 from __future__ import annotations
 
-from app.util.text import slugify
+import uuid
+
+from app.util.text import doc_path, slugify, split_doc_path, strip_own_suffix
 
 
 class TestSlugify:
@@ -53,3 +55,36 @@ class TestSlugify:
         base = slugify("Meeting Notes")
         assert base == "meeting-notes"
         assert f"{base}-3f9a2c1b" == "meeting-notes-3f9a2c1b"
+
+
+class TestDocPath:
+    def test_compose_and_split_round_trip(self):
+        assert doc_path("specs", "api") == "specs/api.md"
+        assert doc_path("", "api") == "api.md"  # root doc
+        assert split_doc_path("specs/api.md") == ("specs", "api")
+        assert split_doc_path("api.md") == ("", "api")
+        assert split_doc_path("a/b/c/api.md") == ("a/b/c", "api")
+
+
+class TestStripOwnSuffix:
+    UID = uuid.UUID("3f9a2c1b-0000-4000-8000-000000000000")  # hex starts 3f9a2c1b...
+
+    def test_strips_this_docs_own_8hex_suffix(self):
+        assert strip_own_suffix("title-3f9a2c1b", self.UID) == "title"
+
+    def test_strips_longer_rungs(self):
+        # 12/16/full-hex suffixes the doc itself could have produced are stripped.
+        assert strip_own_suffix(f"t-{self.UID.hex[:12]}", self.UID) == "t"
+        assert strip_own_suffix(f"t-{self.UID.hex[:16]}", self.UID) == "t"
+        assert strip_own_suffix(f"t-{self.UID.hex}", self.UID) == "t"
+
+    def test_preserves_unrelated_trailing_hex(self):
+        # A real title ending in 8 hex chars that are NOT this doc's uuid prefix
+        # must survive untouched — the safety claim in the docstring.
+        assert strip_own_suffix("release-abcdef12", self.UID) == "release-abcdef12"
+        # ...even another valid-looking uuid prefix that isn't ours.
+        other = uuid.UUID("deadbeef-0000-4000-8000-000000000000")
+        assert strip_own_suffix(f"x-{other.hex[:8]}", self.UID) == f"x-{other.hex[:8]}"
+
+    def test_no_suffix_unchanged(self):
+        assert strip_own_suffix("plain-title", self.UID) == "plain-title"

--- a/backend/tests/test_doc_slug_unit.py
+++ b/backend/tests/test_doc_slug_unit.py
@@ -1,0 +1,55 @@
+"""Unit tests for the document slug normalizer.
+
+Covers the hardened `slugify` (docs/designs/doc-identity-slug/00-overview.md):
+case/whitespace normalization, dangling-hyphen trim, truncation, and the
+empty/symbol-only → "untitled" fallback. The collision-suffix logic
+(`{slug}-{shortid}` only when the base path is taken) lives in
+`document_service._put_locked` and is covered by the e2e suite, since it needs a
+DB to detect the collision.
+
+Imports from `app.util.text` only — no DB / heavy deps, runs as a pure unit test.
+"""
+from __future__ import annotations
+
+from app.util.text import slugify
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert slugify("Hello World") == "hello-world"
+
+    def test_case_and_whitespace_normalized(self):
+        # Distinct human titles that normalize to the same base — the case the
+        # old create flow wrongly rejected as a duplicate.
+        assert slugify("API Guide") == "api-guide"
+        assert slugify("Api  Guide") == "api-guide"
+        assert slugify("api-guide") == "api-guide"
+
+    def test_strips_punctuation(self):
+        assert slugify("Payment API v2!! (Final)") == "payment-api-v2-final"
+
+    def test_empty_falls_back_to_untitled(self):
+        # Symbol-only / empty titles must never yield a bare ".md" dotfile path.
+        assert slugify("") == "untitled"
+        assert slugify("!!!") == "untitled"
+        assert slugify("---") == "untitled"
+        assert slugify("   ") == "untitled"
+
+    def test_no_leading_or_trailing_hyphen(self):
+        assert slugify("  -hello-  ") == "hello"
+        assert slugify("!hello!") == "hello"
+
+    def test_truncation_trims_dangling_hyphen(self):
+        # 79 chars + a separator that would land a hyphen at the cut boundary.
+        title = ("a" * 79) + " b"
+        s = slugify(title)
+        assert len(s) <= 80
+        assert not s.endswith("-")
+        assert not s.startswith("-")
+
+    def test_collision_suffix_shape(self):
+        # The service appends `-{shortid}` only on collision; verify the shape
+        # that pairing produces (base slug + 8-hex id) stays path-safe.
+        base = slugify("Meeting Notes")
+        assert base == "meeting-notes"
+        assert f"{base}-3f9a2c1b" == "meeting-notes-3f9a2c1b"

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -181,16 +181,21 @@ R=$(mcp_call akb_get "{\"uri\":\"${DOC_URI}/\"}" | mcp_result)
 GOT_PATH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('path','MISSING'))" 2>/dev/null)
 [ "$GOT_PATH" = "specs/mcp-created-spec.md" ] && pass "akb_get tolerates trailing slash on URI" || fail "trailing slash" "got path: $GOT_PATH"
 
-# Put conflict atomicity — putting twice at the same path must error
-# out cleanly without mutating the existing doc. Earlier git.commit
-# fired before the DB pre-check, so the second put's body landed on
-# disk even though the response was a conflict error.
-mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"conflict probe\",\"content\":\"BODY_FIRST\"}" >/dev/null
-SECOND=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"conflict probe\",\"content\":\"BODY_SECOND\"}" | mcp_result)
-IS_ERR=$(echo "$SECOND" | python3 -c "import sys,json; d=json.load(sys.stdin); print('error' in d)" 2>/dev/null)
-GOT=$(mcp_call akb_get "{\"uri\":\"akb://$VAULT/doc/specs/conflict-probe.md\"}" | mcp_result | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',''))" 2>/dev/null)
-KEPT=$(echo "$GOT" | grep -q "BODY_FIRST" && ! echo "$GOT" | grep -q "BODY_SECOND" && echo yes || echo no)
-[ "$IS_ERR" = "True" ] && [ "$KEPT" = "yes" ] && pass "akb_put conflict atomicity (no partial overwrite)" || fail "put conflict" "got err=$IS_ERR kept=$KEPT"
+# Slug-collision resolution — two docs whose titles slugify to the same base
+# must BOTH persist: the first takes the clean path, the second gets a distinct
+# `-{shortid}` suffixed path (collision is resolved, not rejected). Each keeps
+# its own body (no overwrite). Capture the returned URIs instead of predicting
+# the path — the suffixed path is non-deterministic by design (MCP rule: use
+# returned URIs, don't reassemble paths).
+C1=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"collision probe\",\"content\":\"BODY_FIRST\"}" | mcp_result)
+URI1=$(echo "$C1" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+C2=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"collision probe\",\"content\":\"BODY_SECOND\"}" | mcp_result)
+URI2=$(echo "$C2" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+B1=$(mcp_call akb_get "{\"uri\":\"$URI1\"}" | mcp_result | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',''))" 2>/dev/null)
+B2=$(mcp_call akb_get "{\"uri\":\"$URI2\"}" | mcp_result | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',''))" 2>/dev/null)
+ISO1=$(echo "$B1" | grep -q "BODY_FIRST" && ! echo "$B1" | grep -q "BODY_SECOND" && echo yes || echo no)
+ISO2=$(echo "$B2" | grep -q "BODY_SECOND" && ! echo "$B2" | grep -q "BODY_FIRST" && echo yes || echo no)
+[ -n "$URI1" ] && [ -n "$URI2" ] && [ "$URI1" != "$URI2" ] && [ "$ISO1" = "yes" ] && [ "$ISO2" = "yes" ] && pass "akb_put slug collision → 2nd persists at suffixed path (bodies isolated)" || fail "put collision suffix" "uri1=$URI1 uri2=$URI2 iso1=$ISO1 iso2=$ISO2"
 
 # find_by_ref must not return a wrong doc when one path is a prefix
 # of another. Create two docs whose paths differ only by suffix and
@@ -211,6 +216,91 @@ if [ -n "$COMMIT" ]; then
   CLEAN=$(echo "$R" | python3 -c "import sys,json; c=json.load(sys.stdin).get('content',''); print(not c.lstrip().startswith('---'))" 2>/dev/null)
   [ "$CLEAN" = "True" ] && pass "akb_get(version=…) strips frontmatter" || fail "versioned frontmatter leak" "content starts with ---"
 fi
+
+# ── 5b. Document Move / Rename (Phase 2) ─────────────────────
+echo ""
+echo "▸ 5b. Document Move / Rename"
+
+# Create a doc, then rename its slug. action=moved, URIs distinct.
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"movetest\",\"title\":\"Move Me\",\"content\":\"MOVE_BODY_TAG\"}" | mcp_result)
+MV_OLD=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+R=$(mcp_call akb_move "{\"uri\":\"$MV_OLD\",\"slug\":\"moved-final\"}" | mcp_result)
+MV_NEW=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+MV_ACTION=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('action',''))" 2>/dev/null)
+[ -n "$MV_NEW" ] && [ "$MV_NEW" != "$MV_OLD" ] && [ "$MV_ACTION" = "moved" ] && pass "akb_move renamed slug ($MV_ACTION)" || fail "akb_move" "new=$MV_NEW action=$MV_ACTION"
+
+# New URI resolves with the original body.
+NB=$(mcp_call akb_get "{\"uri\":\"$MV_NEW\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+[ "$NB" = "True" ] && pass "akb_move: new URI resolves with content" || fail "move new resolve" "body missing at new uri"
+
+# OLD URI still resolves via the alias redirect → same doc.
+OB=$(mcp_call akb_get "{\"uri\":\"$MV_OLD\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+[ "$OB" = "True" ] && pass "akb_move: OLD URI still resolves (alias redirect)" || fail "move alias resolve" "old uri 404 after move"
+
+# Move across collections; the path lands under the new collection.
+R=$(mcp_call akb_move "{\"uri\":\"$MV_NEW\",\"collection\":\"archive\"}" | mcp_result)
+MV_NEW2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+echo "$MV_NEW2" | grep -q "archive" && pass "akb_move across collections ($MV_NEW2)" || fail "move collection" "uri=$MV_NEW2"
+
+# Every prior URI resolves to the doc — aliases point at the id, never chain.
+O1=$(mcp_call akb_get "{\"uri\":\"$MV_OLD\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+O2=$(mcp_call akb_get "{\"uri\":\"$MV_NEW\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
+[ "$O1" = "True" ] && [ "$O2" = "True" ] && pass "akb_move: all prior URIs resolve (no redirect chain)" || fail "move chain" "o1=$O1 o2=$O2"
+
+# No-op move (neither collection nor slug) is rejected.
+R=$(mcp_call akb_move "{\"uri\":\"$MV_NEW2\"}" | mcp_result)
+ISERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
+[ "$ISERR" = "True" ] && pass "akb_move: no-op (no collection/slug) rejected" || fail "move no-op" "expected error"
+
+# Collision on move — move a SAME-TITLE doc into a collection that already has
+# one. Both must survive at distinct paths (the mover gets a -shortid suffix),
+# and each resolves to its own body. This is the case the user flagged.
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"dups\",\"title\":\"Twin\",\"content\":\"TWIN_A\"}" | mcp_result)
+TWIN_A=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"dupsrc\",\"title\":\"Twin\",\"content\":\"TWIN_B\"}" | mcp_result)
+TWIN_B=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+# Move B (dupsrc/twin.md) into 'dups' where A (dups/twin.md) already lives.
+R=$(mcp_call akb_move "{\"uri\":\"$TWIN_B\",\"collection\":\"dups\"}" | mcp_result)
+TWIN_B2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+DISTINCT=$([ -n "$TWIN_B2" ] && [ "$TWIN_B2" != "$TWIN_A" ] && echo yes || echo no)
+AB=$(mcp_call akb_get "{\"uri\":\"$TWIN_A\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('TWIN_A' in d.get('content','') and 'TWIN_B' not in d.get('content',''))" 2>/dev/null)
+BB=$(mcp_call akb_get "{\"uri\":\"$TWIN_B2\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('TWIN_B' in d.get('content','') and 'TWIN_A' not in d.get('content',''))" 2>/dev/null)
+[ "$DISTINCT" = "yes" ] && [ "$AB" = "True" ] && [ "$BB" = "True" ] && pass "akb_move: same-title collision into a collection → both survive, isolated ($TWIN_B2)" || fail "move title collision" "distinct=$DISTINCT a=$AB b=$BB"
+
+# Reuse of a vacated path — after a doc moves away, creating a NEW doc at the
+# OLD path must make the OLD URI resolve to the NEW doc (real doc beats a stale
+# redirect; exact match wins over alias).
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"reuse\",\"title\":\"Recycle\",\"content\":\"ORIG_DOC\"}" | mcp_result)
+RC_OLD=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+mcp_call akb_move "{\"uri\":\"$RC_OLD\",\"slug\":\"recycled\"}" >/dev/null
+mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"reuse\",\"title\":\"Recycle\",\"content\":\"NEW_DOC\"}" >/dev/null
+RC=$(mcp_call akb_get "{\"uri\":\"$RC_OLD\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('NEW_DOC' in d.get('content','') and 'ORIG_DOC' not in d.get('content',''))" 2>/dev/null)
+[ "$RC" = "True" ] && pass "akb_move: reused old path → old URI resolves to the new doc (alias cleared)" || fail "move path reuse" "old uri did not resolve to new doc"
+
+# Suffix is not nested on re-move — a doc that got a collision suffix, moved to a
+# collision-free collection (slug kept), reclaims the clean slug (no -hex-hex).
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"sfxa\",\"title\":\"Sfx\",\"content\":\"S1\"}" | mcp_result)
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"sfxa\",\"title\":\"Sfx\",\"content\":\"S2\"}" | mcp_result)
+SFX2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+echo "$SFX2" | grep -q "sfx-" && SUFFIXED=yes || SUFFIXED=no   # 2nd got a -hex suffix
+R=$(mcp_call akb_move "{\"uri\":\"$SFX2\",\"collection\":\"sfxb\"}" | mcp_result)
+MOVED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
+CLEAN=$(echo "$MOVED" | python3 -c "import sys; u=sys.stdin.read().strip(); print(u.endswith('/sfx.md'))" 2>/dev/null)
+[ "$SUFFIXED" = "yes" ] && [ "$CLEAN" = "True" ] && pass "akb_move: collision suffix stripped on move to free collection ($MOVED)" || fail "move suffix nest" "suffixed=$SUFFIXED moved=$MOVED"
+
+# Explicit slug rename onto a taken path is REJECTED (not silently suffixed) —
+# matches create's pinned-slug semantics.
+mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"rej\",\"title\":\"Taken\",\"content\":\"T1\"}" >/dev/null
+R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"rej\",\"title\":\"Mover\",\"content\":\"T2\"}" | mcp_result)
+REJ_SRC=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
+R=$(mcp_call akb_move "{\"uri\":\"$REJ_SRC\",\"slug\":\"taken\"}" | mcp_result)
+REJERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
+[ "$REJERR" = "True" ] && pass "akb_move: explicit slug onto taken path rejected (no silent suffix)" || fail "move explicit reject" "expected error, got $R"
+
+# Bad URI to akb_move returns a clean error (not an internal 500 envelope).
+R=$(mcp_call akb_move "{\"uri\":\"not-a-valid-uri\",\"slug\":\"x\"}" | mcp_result)
+BADERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
+[ "$BADERR" = "True" ] && pass "akb_move: malformed URI rejected cleanly" || fail "move bad uri" "expected error"
 
 # ── 6. Relations & Graph ─────────────────────────────────────
 echo ""

--- a/docs/designs/doc-identity-slug/00-overview.md
+++ b/docs/designs/doc-identity-slug/00-overview.md
@@ -1,0 +1,152 @@
+# Document identity & slug — `{slug}-{shortid}` scheme
+
+Status: **accepted** · Scope: documents (Phase 1 shipped); tables/files/rename are follow-on phases.
+
+## Problem
+
+A document's identity is its `path` = `{collection}/{_slugify(title)}.md`, frozen at
+create with `UNIQUE(vault_id, path)`. Two failure modes followed from deriving the
+unique key directly from the human title:
+
+1. **False-duplicate rejection on create.** Distinct human titles that normalize to
+   the same slug (`"API Guide"` vs `"Api  Guide"` vs `"api-guide"`) collide on one
+   path and the second create is rejected as "already exists" — even though the user
+   meant two different documents.
+2. **Empty / symbol-only titles** (`"!!!"`, `"---"`, emoji) slugify to `""`, yielding
+   a degenerate path `"{collection}/.md"` (a dotfile); the first wins, the rest collide.
+3. **80-char truncation collisions** — two long titles differing only past char 80
+   produce the same slug.
+
+(Editing a title afterwards is *not* the bug — title is a mutable, non-unique label by
+design; identity stays on `path`. See "identity vs label" below.)
+
+## Research → decision
+
+Surveyed how mature systems resolve slug/name collisions (Notion, Medium, dev.to,
+Stack Overflow, Linear/Jira, YouTube, WordPress, Ghost, Confluence, MediaWiki). Three
+families:
+
+- **Embedded id/hash** (Notion `{slug}-{uuid}`, Medium `{slug}-{12hex}`, dev.to
+  `{slug}-{rand}`, SO `/questions/{id}/{slug}`): an id in the handle makes the slug
+  cosmetic, so collisions are **impossible by construction** — no check, no reject.
+- **Numeric suffix** (WordPress/Ghost `-2`, file managers `(2)`): slug *is* the key,
+  so collisions get a counter.
+- **Reject** (Confluence, MediaWiki): title *is* identity, duplicates forbidden.
+
+AKB stores docs as real git files, so a fully opaque UUID filename would wreck git
+readability. AKB's `path` (with `UNIQUE(vault_id, path)`, resolved by `find_by_ref`
+on `d.path`) **is the identity** — there is no separate id in the handle. A second
+research pass (WordPress `wp_unique_post_slug`, Drupal Pathauto, Rails `friendly_id`,
+Django, Ghost — all source-confirmed) established the rule:
+
+> When the slug/path **is** the identity, the standard pattern is to emit the **clean
+> slug** and disambiguate with a suffix **only on collision** — never unconditionally.
+> Unconditional id-embedding is only idiomatic when a *separate* durable id is the
+> identity and the slug is cosmetic (Notion/Medium/SO/YouTube).
+
+**Decision: conditional `-{shortid}` on collision.**
+
+```
+path = {collection}/{slug}.md                 # clean path when the slug is free
+     = {collection}/{slug}-{shortid}.md       # ONLY when {slug}.md is already taken
+                                              # shortid = first 8 hex of the doc UUID
+```
+
+The clean path stays predictable & human-readable (AKB's git-native value, and what
+the e2e suite + agents rely on); duplicate-title puts still succeed (suffixed) instead
+of erroring. The doc UUID makes the suffixed path unique by construction;
+`UNIQUE(vault_id, path)` is the final guard. The collision check + suffix run under
+the existing `(vault, base_path)` advisory lock, so concurrent same-slug puts serialize
+correctly.
+
+### Pinned-slug exception (stable seeds)
+
+An **explicit** `req.slug` means the caller wants a *predictable, exact* path (e.g. the
+vault-skill seed pins `overview/vault-skill.md` so `akb_help(topic="vault-skill")`
+resolves). Explicit slugs are never suffixed — a genuine collision on a pinned slug
+**rejects** (correct). The shortid is appended **only when the slug is derived from the
+title and its clean path is already taken.**
+
+## Identity vs label (the contract, now explicit)
+
+- **Durable identity** = `documents.id` (UUID PK) + its rendered handle `path`
+  (akb:// URI). Frozen at create.
+- **Human label** = `title` — freely mutable, **non-unique**, never re-derives the path.
+  Two docs may share a title (esp. across collections); uniqueness lives only on
+  `path`, never on `title`. UI must render the live `title`, never reparse the slug.
+
+## Per-resource scope
+
+| Resource | Identity | Collision policy | This design |
+|---|---|---|---|
+| **document** | `path` (UUID behind it) | title-derived → `-{shortid}` (no reject); explicit slug → reject | **Phase 1 (this change)** |
+| **table** | `name` (raw) | reject (name is the SQL handle) | unchanged |
+| **file** | opaque id / `s3_key` | n/a | unchanged |
+| **collection** | `path` (folder) | idempotent reuse (`get_or_create`) | unchanged — same folder must dedupe, never suffix |
+
+Deliberately differentiated by storage backend (git / PG / S3), unified only at the
+mechanism layer (one hardened `slugify`).
+
+## Phases
+
+- **Phase 1 (shipped here):** hardened `slugify` (empty→`untitled`, trim dangling
+  hyphens, truncate-then-trim) + **on-collision** `-{shortid}` for title-derived paths
+  + thread the doc UUID so the suffix matches the row id. No migration, no URI grammar
+  change, no client break — existing docs keep their paths; unique titles still get
+  clean paths; only a colliding title gains a shortid. Fixes failure modes 1–3.
+  Test impact: assertions that predict a *unique* clean path still pass; the
+  conflict-atomicity e2e test flips intent from "2nd put errors" to "2nd put succeeds
+  at a distinct suffixed path, both bodies preserved" (capture the returned uri/path
+  rather than predicting it, per MCP rule "use returned URIs").
+- **Phase 2 (shipped):** document rename/move — polymorphic `resource_aliases(vault_id,
+  resource_type, old_ref, resource_id UUID)` keyed to the UUID (never to a path, so no
+  redirect chains), `GitService.move_file` (`git mv` + `git log --follow`), a
+  `find_by_ref` alias arm (exact match first, alias fallback) so old akb:// links keep
+  resolving, edges/publications rewritten old→new URI on move, chunk re-index with the
+  new path header, alias cleanup on delete. Exposed as the `akb_move` MCP tool
+  (collection and/or slug; on-collision suffix reuses Phase 1 rule; the doc UUID is
+  immutable so a move never changes identity). REST endpoint + frontend move UI: TODO.
+- **Phase 3 (follow-on):** generalize rename to tables (ALTER + role re-grant) and
+  recursive collection move; file rename is a trivial name update.
+
+## Correctness review (Phase 2)
+
+An external-practice + adversarial code review validated the three core choices as
+**correct**: own-uuid suffix on collision (Notion `{slug}-{id}` + git's auto-lengthening
+short-hash precedent), id-keyed alias (avoids MediaWiki's double-redirect chains),
+`git mv` + `git log --follow` (the standard rename-history mechanism). Fixes applied
+from the review: edges rewrite is now `UNIQUE(source,target,relation)`-safe (move
+non-colliding rows, drop the duplicates); the move target path is recomputed from the
+fresh row after the lock (stale-read race); the alias fallback re-verifies `vault_id`;
+a re-index miss after `git mv` is logged, not silently swallowed.
+
+### Accepted trade-offs / known limitations
+- **Body link text is not rewritten on move.** A move rewrites graph *edges* and
+  publications old→new, but the markdown/wikilink text inside *other* documents'
+  bodies still shows the old URI — it keeps resolving via the alias, and the edge is
+  re-derived correctly on the next re-index. Rewriting body content would alter
+  author-written text, so it's intentionally left.
+- **Aliases are durable** (dropped only on path-reclaim or resource delete) — matching
+  the SEO/redirect canon ("keep redirects as long as anyone might reference them"). No
+  TTL/GC for now.
+- **`git log --follow` is single-file**, so a future collection move (Phase 3) must
+  follow each doc individually.
+- **Suffixed-path concurrency** rests on uuid global-uniqueness + `UNIQUE(vault_id,
+  path)` as the final arbiter (suffixed candidates aren't separately locked); the
+  residual concurrent race surfaces as a 409, not corruption — the same risk profile as
+  put/update.
+
+## Rejected alternatives
+
+- **Opaque-UUID-primary everywhere (Notion-pure):** demotes the git tree from
+  source-of-truth to a derived projection; heavy migration of edges/publications.
+  Rejected — contradicts AKB's git-native concept.
+- **Numeric `-2` suffix on collision:** the WordPress/Ghost variant — also valid, but
+  needs a DB-scan loop (`-2`, `-3`, …) to find a free slot. The doc's short id is a
+  single deterministic disambiguator (no scan) and ties the path to the row. Same
+  conditional trigger, simpler resolution.
+- **Unconditional `{slug}-{shortid}` (always append):** considered and rejected after
+  research — no mainstream framework embeds an id unconditionally into an
+  identity-bearing path; it destroys clean-path predictability for the ~99%
+  no-collision case to solve a problem the `UNIQUE` constraint + on-collision suffix
+  already solves, and would break every path-predicting caller/test.


### PR DESCRIPTION
## 요약

문서 식별자/제목 관리를 재설계. **path = 신원**(UNIQUE(vault_id, path)), **title = 자유·비유일 라벨**로 분리해 — 같은 제목 생성도 안 막히고, 이동/개명해도 옛 akb:// 링크가 안 깨지게 한다. 읽기 좋은 git 경로는 그대로 유지.

설계 문서: `docs/designs/doc-identity-slug/00-overview.md`

## 문제

1. 같은 slug로 정규화되는 서로 다른 제목 → 생성이 "이미 존재"로 거부(false-duplicate).
2. 빈/기호-only 제목 → `.md` dotfile.
3. 80자 truncation 충돌.
4. 이동/개명 기능 부재(제목 바꿔도 path 동결) + edges/publications가 path 기반이라 취약.

## 변경

### Phase 1 — 생성
- `slugify` 이전·하드닝(`app/util/text.py`): 빈/기호→`untitled`, 양끝/절단 하이픈 trim. 순수함수+단위테스트.
- `put`/`_put_locked`: clean `{slug}.md` 비면 그대로, **title 파생 충돌 시에만** 자기 uuid로 `_resolve_free_path`(8→12→16→full hex) suffix. 명시 `req.slug`(시드)는 충돌 시 거부. doc id 선생성→`repo.create(doc_id=)`로 path shortid=row id 일치.
- 무마이그레이션·URI 문법 무변경·기존 문서 path 보존.

### Phase 2 — 이동/개명 (`akb_move`)
- `resource_aliases`(init.sql + 마이그 036): `old_ref → resource_id(UUID)`, 절대 path→path 아님(무체인).
- `GitService.move_file`(git mv + `--follow`; macOS 케이스-only rename samefile 가드) + `current_commit()`(크래시 복구).
- `document_repo`: find_by_ref alias arm(exact-first→alias, vault 스코프), `update_path`, alias 헬퍼.
- `document_service.move()`: 2-경로 정렬 락, 락 후 타깃 재계산, 충돌 suffix(+자기 접미사 strip로 재이동 중첩 방지; explicit 거부), git mv(멱등 복구), update_path, 컬렉션 count, alias upsert+shadow clear, **UNIQUE-safe edge relink** + publications 재작성, 재인덱싱, event. delete는 alias 정리.
- MCP `akb_move` 도구 + 핸들러(writer; bad uri→INVALID_URI).

## 검증

리서치(외부 5프레임워크 정석 = 충돌 시에만 suffix) + 적대적 코드리뷰(설계 3선택 correct, CRITICAL edges-UNIQUE 등 수정) + 전수 케이스 감사(181) + 최종 리뷰(25 fix 전부 동작, 실버그 0).

- 단위 7 · e2e **mcp 88 / edit 37 / graph 29 / defensive 33 / security 63 / pg_rbac 50 / probes 13** — 0 fail
- 시나리오 스위트(S1~S7) **32 / 0**
- 동시성 부하: 생성 **600 동시**(같은제목 300→distinct 300) · 이동 **MV1 300동시 / MV2 같은문서 60경합→1실효+무중복 / MV3 같은제목 120→distinct / MV4 레이스 8** — 데이터손실·중복·데드락 0

## 남은 것 (Phase 3)
테이블 rename(ALTER+롤 재부여) · 컬렉션 재귀 이동 · `akb_move` REST 엔드포인트 + 프론트 이동 UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)