### PR TITLE
feat(frontend): full-text affordance for truncated UI + body fills article width

### DIFF
--- a/frontend/src/components/doc-outline.tsx
+++ b/frontend/src/components/doc-outline.tsx
@@ -1,4 +1,5 @@
 import { useDocOutline } from "@/hooks/use-doc-outline";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 export function DocumentOutline({
   markdown,
@@ -31,7 +32,7 @@ export function DocumentOutline({
                     : "text-foreground-muted hover:text-foreground hover:bg-surface-hover"
                 }`}
               >
-                <span title={h.text} className="truncate block text-[12px]">{h.text}</span>
+                <TooltipText className="truncate block text-[12px]">{h.text}</TooltipText>
               </a>
             </li>
           );

--- a/frontend/src/components/file-viewer.tsx
+++ b/frontend/src/components/file-viewer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { JsonTree } from "@/components/json-tree";
 import { Alert } from "@/components/ui/alert";
+import { CopyButton } from "@/components/ui/copy-button";
 import {
   publicationDownloadUrl,
   publicationRawUrl,
@@ -52,7 +53,10 @@ export function FileViewer({ slug, data }: Props) {
         {data.collection && (
           <div>
             <div className="coord mb-1">Collection</div>
-            <div className="text-sm font-medium font-mono break-all">{data.collection}</div>
+            <div className="inline-flex items-center gap-1.5">
+              <div className="text-sm font-medium font-mono break-all">{data.collection}</div>
+              <CopyButton value={data.collection} label="Copy collection" />
+            </div>
           </div>
         )}
         <div className="pt-3 border-t border-border">

--- a/frontend/src/components/graph/GraphDetailPanel.tsx
+++ b/frontend/src/components/graph/GraphDetailPanel.tsx
@@ -9,6 +9,8 @@ import { EmptyState } from "@/components/empty-state";
 import { getDocument, getRelations, getProvenance, drillDown } from "@/lib/api";
 import { ALL_NODE_KINDS, ALL_RELATIONS, type NodeKind, type RelationKind, type RelatedRef, kindToSegment } from "./graph-types";
 import { Section } from "./Section";
+import { TooltipText } from "@/components/ui/tooltip-text";
+import { CopyButton } from "@/components/ui/copy-button";
 
 interface Props {
   vault: string;
@@ -147,13 +149,7 @@ export function GraphDetailPanel({
           <Button size="sm" variant="accent" onClick={openDoc}>
             <ExternalLink className="h-3 w-3" /> Open
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => navigator.clipboard?.writeText(uri).catch(() => {})}
-          >
-            Copy URI
-          </Button>
+          <CopyButton value={uri} label="Copy URI" />
           {onTogglePin && (
             // Pin is a toggle, not a CTA — when pinned it reads as a teal
             // selected control, not a second filled-orange marquee.
@@ -249,7 +245,9 @@ export function GraphDetailPanel({
           {sectionsOpen && (
             <ul className="mb-2 flex flex-col gap-px">
               {(secQuery.data?.sections || []).map((s: any, i: number) => (
-                <li key={i} title={s.heading || s.title || `section ${i}`} className="coord truncate">‣ {s.heading || s.title || `section ${i}`}</li>
+                <li key={i} className="coord">
+                  <TooltipText className="truncate" tip={s.heading || s.title || `section ${i}`}>‣ {s.heading || s.title || `section ${i}`}</TooltipText>
+                </li>
               ))}
             </ul>
           )}
@@ -373,7 +371,7 @@ function RelGroup({
               title={`${r.other_name} — select in graph`}
               className="flex-1 inline-flex items-center gap-1 min-w-0 text-left text-[11px] text-foreground hover:text-link cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <span className="truncate">{r.other_name}</span>
+              <TooltipText className="truncate">{r.other_name}</TooltipText>
               <Crosshair
                 className="h-2.5 w-2.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
                 aria-hidden

--- a/frontend/src/components/graph/GraphSidebar.tsx
+++ b/frontend/src/components/graph/GraphSidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "./graph-types";
 import { viewToQuery } from "./graph-state";
 import { Section } from "./Section";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -162,7 +163,7 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                   onClick={() => commitEntry(h)}
                   className="w-full flex items-center justify-between gap-2 px-2 h-7 text-left text-[11px] hover:bg-surface-hover"
                 >
-                  <span title={h.title} className="truncate">{h.title}</span>
+                  <TooltipText className="truncate">{h.title}</TooltipText>
                   <span className="coord">{h.type}</span>
                 </button>
               </li>
@@ -171,9 +172,9 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
         )}
         {view.entry && (
           <div className="mt-1 flex items-center justify-between gap-2 px-2 h-7 text-[11px] bg-surface-muted rounded-[var(--radius-sm)]">
-            <span title={`focused on ${view.entry}`} className="truncate">
+            <TooltipText className="truncate" tip={`focused on ${view.entry}`}>
               Focused on <span className="coord">{view.entry}</span>
-            </span>
+            </TooltipText>
             <button
               type="button"
               onClick={() => onChange({ ...view, entry: undefined })}
@@ -272,10 +273,9 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                 <button
                   type="button"
                   onClick={() => onChange({ ...view, entry: r.doc_id })}
-                  title={r.title}
                   className="w-full text-left px-2 h-7 text-[11px] hover:bg-surface-hover active:bg-surface-active truncate"
                 >
-                  {r.title}
+                  <TooltipText className="truncate">{r.title}</TooltipText>
                 </button>
               </li>
             ))}
@@ -328,10 +328,9 @@ export function GraphSidebar({ vault, view, onChange, onNavigate, onCollapse }: 
                 <button
                   type="button"
                   onClick={() => onNavigate(s.url)}
-                  title={s.name}
                   className="flex-1 text-left px-2 h-7 text-[11px] hover:bg-surface-hover active:opacity-60 transition-opacity duration-150 truncate"
                 >
-                  {s.name}
+                  <TooltipText className="truncate">{s.name}</TooltipText>
                 </button>
                 <button
                   type="button"

--- a/frontend/src/components/history-list.tsx
+++ b/frontend/src/components/history-list.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/utils";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 export interface HistoryEntry {
   hash?: string;
@@ -182,8 +183,8 @@ function RowContent({
       <span className={active ? undefined : "text-link"}>
         {(entry.hash || "").slice(0, 7)}
       </span>
-      <span
-        title={`${entry.agent || entry.author || "unknown"}${entry.subject ? ` · ${entry.subject}` : ""}`}
+      <TooltipText
+        tip={`${entry.agent || entry.author || "unknown"}${entry.subject ? ` · ${entry.subject}` : ""}`}
         className="truncate"
       >
         <span className={active ? undefined : "text-foreground-muted"}>
@@ -197,7 +198,7 @@ function RowContent({
             </span>
           </>
         )}
-      </span>
+      </TooltipText>
       <span
         className={cn(
           "tabular-nums text-right shrink-0",

--- a/frontend/src/components/invite-member-dialog.tsx
+++ b/frontend/src/components/invite-member-dialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Segmented } from "@/components/ui/segmented";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import {
   Dialog,
   DialogContent,
@@ -175,9 +176,9 @@ export function InviteMemberDialog({
                           }`}
                         >
                           <div className="flex items-baseline gap-2">
-                            <span title={u.username} className="text-sm font-medium truncate">
+                            <TooltipText className="text-sm font-medium truncate">
                               {u.username}
-                            </span>
+                            </TooltipText>
                             {u.display_name && (
                               <span title={u.display_name} className="text-xs text-foreground-muted truncate">
                                 {u.display_name}

--- a/frontend/src/components/markdown-render.tsx
+++ b/frontend/src/components/markdown-render.tsx
@@ -78,11 +78,6 @@ function convertDelimiters(text: string): string {
 
 /* ── shared utility tokens ───────────────────────────────────────── */
 const PROSE_LEADING = "leading-[1.7]";
-// Readable line-length for text flow (matches the Plate editor's `.prose`
-// measure in index.css). Applied to paragraphs/lists/headings only so that
-// code blocks, tables, and images stay free to break out to the full column
-// width on wide screens.
-const PROSE_MEASURE = "max-w-[72ch]";
 const HEADING_BASE = "font-semibold scroll-mt-24";
 const EYEBROW =
   "mt-4 mb-1 font-semibold text-[11px] uppercase tracking-[0.06em] text-subtle";
@@ -469,7 +464,7 @@ function buildComponents(markdown: string): Components {
   return {
     /* ── Block prose ──────────────────────────────────────────── */
     p: ({ node: _node, children, ...props }) => (
-      <p className={cn(PROSE_LEADING, "my-3 wrap-break-word", PROSE_MEASURE)} {...props}>
+      <p className={cn(PROSE_LEADING, "my-3 wrap-break-word")} {...props}>
         {children}
       </p>
     ),
@@ -484,19 +479,19 @@ function buildComponents(markdown: string): Components {
     /* ── Headings — tuned cascade + negative tracking ─────────── */
     h1: heading(
       1,
-      cn(HEADING_BASE, PROSE_MEASURE, "mt-8 mb-3.5 text-[1.9em] text-foreground tracking-[-0.02em] leading-tight"),
+      cn(HEADING_BASE, "mt-8 mb-3.5 text-[1.9em] text-foreground tracking-[-0.02em] leading-tight"),
     ),
     h2: heading(
       2,
-      cn(HEADING_BASE, PROSE_MEASURE, "mt-7 mb-3 text-[1.5em] text-foreground tracking-[-0.015em] leading-snug"),
+      cn(HEADING_BASE, "mt-7 mb-3 text-[1.5em] text-foreground tracking-[-0.015em] leading-snug"),
     ),
     h3: heading(
       3,
-      cn(HEADING_BASE, PROSE_MEASURE, "mt-6 mb-2.5 text-[1.25em] text-foreground tracking-[-0.01em]"),
+      cn(HEADING_BASE, "mt-6 mb-2.5 text-[1.25em] text-foreground tracking-[-0.01em]"),
     ),
     h4: heading(
       4,
-      cn(HEADING_BASE, PROSE_MEASURE, "mt-5 mb-2 text-[1.08em] text-foreground tracking-[-0.006em]"),
+      cn(HEADING_BASE, "mt-5 mb-2 text-[1.08em] text-foreground tracking-[-0.006em]"),
     ),
     h5: heading(5, cn(HEADING_BASE, "mt-4 mb-1.5 text-[0.95em] text-foreground-muted")),
     h6: ({ node: _node, children, ...props }) => (
@@ -543,7 +538,7 @@ function buildComponents(markdown: string): Components {
     /* ── Lists ────────────────────────────────────────────────── */
     ul: ({ node: _node, children, ...props }) => (
       <ul
-        className={cn("pl-6 my-3 list-disc marker:text-subtle", PROSE_LEADING, PROSE_MEASURE)}
+        className={cn("pl-6 my-3 list-disc marker:text-subtle", PROSE_LEADING)}
         {...props}
       >
         {children}
@@ -554,7 +549,6 @@ function buildComponents(markdown: string): Components {
         className={cn(
           "pl-6 my-3 list-decimal marker:text-subtle marker:font-semibold",
           PROSE_LEADING,
-          PROSE_MEASURE,
         )}
         {...props}
       >
@@ -644,7 +638,6 @@ function buildComponents(markdown: string): Components {
           className={cn(
             "my-4 pl-4 pr-3 py-2 italic",
             PROSE_LEADING,
-            PROSE_MEASURE,
             "border-l-2 border-border-strong bg-surface-2/50 text-foreground-muted rounded-r-[var(--radius-md)]",
             "[&>p:first-child]:mt-0 [&>p:last-child]:mb-0",
           )}

--- a/frontend/src/components/table-viewer.tsx
+++ b/frontend/src/components/table-viewer.tsx
@@ -3,6 +3,7 @@ import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import {
   getPublication,
   publicationCsvUrl,
@@ -196,13 +197,13 @@ export function TableViewer({ slug, initialData }: Props) {
                     {String(i + 1).padStart(2, "0")}
                   </td>
                   {cols.map((c) => (
-                    <td
-                      key={c}
-                      className={`px-3 py-2 font-mono text-[12px] border-r border-border last:border-r-0 whitespace-nowrap max-w-xs truncate ${typeof row[c] === "number" ? "tabular-nums" : ""}`}
-                      title={formatCellFull(row[c])}
-                    >
-                      {formatCell(row[c])}
-                    </td>
+                    <TooltipText key={c} asChild tip={formatCellFull(row[c])}>
+                      <td
+                        className={`px-3 py-2 font-mono text-[12px] border-r border-border last:border-r-0 whitespace-nowrap max-w-xs truncate ${typeof row[c] === "number" ? "tabular-nums" : ""}`}
+                      >
+                        {formatCell(row[c])}
+                      </td>
+                    </TooltipText>
                   ))}
                 </tr>
               ))}

--- a/frontend/src/components/ui/code-snippet.tsx
+++ b/frontend/src/components/ui/code-snippet.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 /**
  * Design-system primitive: a copyable code block with a soft header bar.
@@ -32,9 +33,9 @@ export function CodeSnippet({
   return (
     <div className={cn("rounded-[var(--radius-md)] border border-border overflow-hidden", className)}>
       <div className="flex items-center justify-between gap-2 border-b border-border bg-surface-2 px-2 py-1">
-        <span className="font-mono text-[11px] text-foreground-muted truncate">
+        <TooltipText tip={filename || "snippet"} className="font-mono text-[11px] text-foreground-muted truncate">
           {filename || "snippet"}
-        </span>
+        </TooltipText>
         <button
           onClick={copy}
           aria-label={copied ? "Snippet copied" : "Copy snippet"}

--- a/frontend/src/components/ui/copy-button.tsx
+++ b/frontend/src/components/ui/copy-button.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Design-system primitive: a compact icon button that copies `value` to the
+ * clipboard and flips to a check for 2s. Centralizes the copy affordance for
+ * identifiers (akb:// URIs, doc ids, collection names) that were previously
+ * plain text with no way to copy.
+ *
+ * Clipboard is undefined on insecure (plain-HTTP) origins — AKB ships an
+ * `--insecure` deployment shape — so the write is guarded and fails silently
+ * (the user can still select the text manually).
+ */
+export function CopyButton({
+  value,
+  label = "Copy",
+  className,
+  size = 14,
+}: {
+  value: string;
+  /** Accessible label / tooltip verb. Defaults to "Copy". */
+  label?: string;
+  className?: string;
+  /** Icon px size. */
+  size?: number;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy(e: React.MouseEvent) {
+    // These often sit inside a link/row — don't navigate or bubble.
+    e.stopPropagation();
+    e.preventDefault();
+    try {
+      await navigator.clipboard?.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard blocked on insecure origin — manual select still works */
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? `${label}: copied` : label}
+      className={cn(
+        "inline-flex items-center justify-center shrink-0 cursor-pointer transition-colors rounded-[var(--radius-sm)]",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        copied ? "text-success" : "text-foreground-muted hover:text-primary",
+        className,
+      )}
+    >
+      {copied ? (
+        <Check style={{ width: size, height: size }} aria-hidden />
+      ) : (
+        <Copy style={{ width: size, height: size }} aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/select-menu.tsx
+++ b/frontend/src/components/ui/select-menu.tsx
@@ -1,6 +1,7 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 export interface SelectOption {
   value: string;
@@ -64,15 +65,16 @@ export function SelectMenu({
           className,
         )}
       >
-        <span
+        <TooltipText
           className={cn(
             "truncate",
             mono && "font-mono",
             !current && "text-foreground-muted",
           )}
+          tip={current?.label}
         >
           {current ? current.label : placeholder}
-        </span>
+        </TooltipText>
         <ChevronDown className="h-4 w-4 shrink-0 text-foreground-muted" aria-hidden />
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
@@ -97,13 +99,19 @@ export function SelectMenu({
                   <Check className="h-3.5 w-3.5" aria-hidden />
                 </DropdownMenu.ItemIndicator>
                 <span className="min-w-0">
-                  <span className={cn("block truncate", mono && "font-mono")}>
+                  <TooltipText
+                    className={cn("block truncate", mono && "font-mono")}
+                    tip={o.label}
+                  >
                     {o.label}
-                  </span>
+                  </TooltipText>
                   {o.hint && (
-                    <span className="block truncate text-xs text-foreground-muted">
+                    <TooltipText
+                      className="block truncate text-xs text-foreground-muted"
+                      tip={o.hint}
+                    >
                       {o.hint}
-                    </span>
+                    </TooltipText>
                   )}
                 </span>
               </DropdownMenu.RadioItem>

--- a/frontend/src/components/ui/tooltip-text.tsx
+++ b/frontend/src/components/ui/tooltip-text.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+
+/**
+ * Design-system primitive: truncated text that reveals its full value on
+ * hover/focus — but ONLY when it actually overflows. Replaces the scattered
+ * `truncate` + native `title=` pattern (delayed, touch/keyboard-hostile,
+ * unstyled) with the project's styled <Tooltip>.
+ *
+ * Pass the same truncating className you'd normally use (e.g. "truncate", or
+ * "truncate text-xs …"). Overflow is measured with a ResizeObserver so the
+ * tooltip is suppressed when the text fits — no useless tooltips. When the
+ * rendered children differ from the text to surface (a "→ " prefix, an icon),
+ * pass the bare string via `tip`.
+ */
+type TooltipTextProps = Omit<React.HTMLAttributes<HTMLElement>, "title"> & {
+  /** Full text to reveal. Defaults to the string children. */
+  tip?: string;
+  /** Element to render. Defaults to a span. */
+  as?: "span" | "div" | "p";
+  /**
+   * Decorate an arbitrary single child element (e.g. a `<td>` or a router
+   * `<Link>`) instead of rendering our own tag — for truncating elements that
+   * can't be a span/div/p. The child keeps its props/layout; we only attach the
+   * overflow measurement + tooltip. Requires `tip` (children aren't a string).
+   */
+  asChild?: boolean;
+  side?: "top" | "right" | "bottom" | "left";
+  children: React.ReactNode;
+};
+
+export function TooltipText({
+  tip,
+  as: Tag = "span",
+  asChild = false,
+  side = "top",
+  className,
+  children,
+  ...rest
+}: TooltipTextProps) {
+  const ref = useRef<HTMLElement>(null);
+  const [overflow, setOverflow] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => setOverflow(el.scrollWidth - el.clientWidth > 1);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [children, tip]);
+
+  const full = tip ?? (typeof children === "string" ? children : undefined);
+  const content =
+    overflow && full ? (
+      <TooltipContent side={side} className="max-w-[min(90vw,28rem)] break-words">
+        {full}
+      </TooltipContent>
+    ) : null;
+
+  // asChild: clone the caller's element as the trigger (Radix forwards our ref
+  // to it for measurement). Radix Root/Trigger render no DOM wrapper, so the
+  // child stays where it was in the tree (e.g. a direct <td> of a <tr>).
+  if (asChild) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild ref={ref as React.Ref<HTMLButtonElement>}>
+            {children}
+          </TooltipTrigger>
+          {content}
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  // Stable tree: always a Trigger so the measured node never remounts; the
+  // Content only mounts when the text overflows and we have a string to show.
+  // Self-providing so the primitive works anywhere (tests, standalone) without
+  // a global TooltipProvider ancestor.
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Tag ref={ref as React.Ref<never>} className={className} {...rest}>
+            {children}
+          </Tag>
+        </TooltipTrigger>
+        {content}
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/user-menu.tsx
+++ b/frontend/src/components/user-menu.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { getMe, setToken, isSsoSession, clearSsoSession, keycloakLogoutUrl } from "@/lib/api";
 import { useTheme, type Theme } from "@/hooks/use-theme";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 interface User {
   username?: string;
@@ -78,13 +79,13 @@ export function UserMenu() {
           {/* Identity header */}
           <div className="px-3 py-2 border-b border-border mb-1">
             <div className="coord">Account</div>
-            <div title={label} className="text-sm font-medium text-foreground truncate mt-0.5">
+            <TooltipText as="div" className="text-sm font-medium text-foreground truncate mt-0.5">
               {label}
-            </div>
+            </TooltipText>
             {user?.email && (
-              <div title={user.email} className="font-mono text-[11px] text-foreground-muted truncate">
+              <TooltipText as="div" className="font-mono text-[11px] text-foreground-muted truncate">
                 {user.email}
-              </div>
+              </TooltipText>
             )}
             {user?.is_admin && (
               <div className="coord-spark mt-1">Admin</div>

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -38,6 +38,7 @@ import { FrontmatterEditDialog } from "@/components/frontmatter-edit-dialog";
 import { MarkdownEditorFallback } from "@/components/markdown-editor-fallback";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PublishOptionsDialog } from "@/components/publish-options-dialog";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
@@ -649,9 +650,9 @@ export default function DocumentPage() {
                       </button>
                     </div>
                   </div>
-                  <div title={`/p/${doc.public_slug}`} className="font-mono text-[11px] text-foreground-muted truncate">
+                  <TooltipText as="div" tip={`/p/${doc.public_slug}`} className="font-mono text-[11px] text-foreground-muted truncate">
                     /p/{doc.public_slug}
-                  </div>
+                  </TooltipText>
                 </div>
               ) : (
                 <button
@@ -728,9 +729,9 @@ export default function DocumentPage() {
                           className="grid grid-cols-[minmax(64px,88px)_1fr] gap-1.5 py-0.5 group hover:bg-surface-hover -mx-1 px-1 rounded-[var(--radius-sm)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                         >
                           <span className={relColor}>{r.relation || "relates"}</span>
-                          <span title={label} className="text-foreground truncate group-hover:text-link">
+                          <TooltipText tip={label} className="text-foreground truncate group-hover:text-link">
                             → {label}
-                          </span>
+                          </TooltipText>
                         </Link>
                       </li>
                     );

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { GraphCanvas, type GraphCanvasHandle } from "@/components/graph/GraphCanvas";
 import { GraphSidebar } from "@/components/graph/GraphSidebar";
 import { GraphDetailPanel } from "@/components/graph/GraphDetailPanel";
@@ -228,7 +229,7 @@ export default function GraphPage() {
           <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 w-max max-w-[90%]">
             <Alert variant="info">
               <div className="flex items-center gap-3">
-                <span className="truncate max-w-[40ch]">Focused on {entryTitle}</span>
+                <TooltipText className="truncate max-w-[40ch]" tip={entryTitle}>Focused on {entryTitle}</TooltipText>
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -29,6 +29,7 @@ import { EmptyState } from "@/components/empty-state";
 import { VaultList, type VaultRow } from "@/components/vault-list";
 import { VaultChip } from "@/components/ui/vault-chip";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { QuickstartDialog, QUICKSTART_DISMISS_KEY } from "@/components/quickstart-dialog";
 import {
   listVaults,
@@ -311,9 +312,9 @@ export default function HomePage() {
                         </div>
                         <div title={c.path} className="coord truncate">{c.path}</div>
                       </div>
-                      <span className="flex items-center gap-1.5 shrink-0 max-w-[150px]" title={c.vault}>
+                      <span className="flex items-center gap-1.5 shrink-0 max-w-[150px]">
                         <VaultChip name={c.vault} size="sm" />
-                        <span className="truncate text-xs text-foreground-muted">{c.vault}</span>
+                        <TooltipText className="truncate text-xs text-foreground-muted">{c.vault}</TooltipText>
                       </span>
                       <RelativeTime iso={c.changed_at} className="justify-end text-right" />
                     </Link>
@@ -599,7 +600,7 @@ function NewDocAction({ vaults }: { vaults: VaultRow[] }) {
                 className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-foreground outline-none rounded-[var(--radius-sm)] data-[highlighted]:bg-surface-hover"
               >
                 <FileText className="h-4 w-4 text-foreground-muted" aria-hidden />
-                <span className="truncate">{v.name}</span>
+                <TooltipText className="truncate">{v.name}</TooltipText>
               </Link>
             </DropdownMenu.Item>
           ))}

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -12,6 +12,7 @@ import {
   Table as TableIcon,
   Trash2,
 } from "lucide-react";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { listPublications, deletePublication, getDocument, type Publication } from "@/lib/api";
 import { parseDocUri, parseFileUri } from "@/lib/uri";
 import { formatDate } from "@/lib/utils";
@@ -178,13 +179,14 @@ export default function PublicationsPage() {
                   <div className="min-w-0">
                     <div className="flex items-baseline gap-2 min-w-0">
                       <Icon className="h-3.5 w-3.5 shrink-0 translate-y-0.5 text-foreground-muted" aria-hidden />
-                      <Link
-                        to={resourceHref(p)}
-                        title={p.title || p.slug}
-                        className="text-sm font-medium tracking-tight truncate text-foreground hover:text-link rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
-                      >
-                        {p.title || p.slug}
-                      </Link>
+                      <TooltipText asChild tip={p.title || p.slug}>
+                        <Link
+                          to={resourceHref(p)}
+                          className="text-sm font-medium tracking-tight truncate text-foreground hover:text-link rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                        >
+                          {p.title || p.slug}
+                        </Link>
+                      </TooltipText>
                       <span className="coord shrink-0">
                         {RESOURCE_LABEL[p.resource_type]}
                       </span>

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { SelectMenu } from "@/components/ui/select-menu";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { EmptyState } from "@/components/empty-state";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { parseUri } from "@/lib/uri";
@@ -540,12 +541,12 @@ export default function SearchPage() {
                       {String(i + 1).padStart(2, "0")}
                     </span>
                     <div className="min-w-0">
-                      <div className="text-base font-medium tracking-tight text-foreground group-hover:text-link truncate">
+                      <TooltipText as="div" className="text-base font-medium tracking-tight text-foreground group-hover:text-link truncate">
                         {r.title}
-                      </div>
-                      <div className="coord mt-0.5 truncate">
+                      </TooltipText>
+                      <TooltipText as="div" className="coord mt-0.5 truncate" tip={`${r.vault} / ${r.path}`}>
                         {r.vault} / {r.path}
-                      </div>
+                      </TooltipText>
                       {r.matches.length > 0 && (
                         <div className="mt-2 space-y-1">
                           {r.matches.slice(0, 3).map((m, j) => (

--- a/frontend/src/pages/settings/admin-section.tsx
+++ b/frontend/src/pages/settings/admin-section.tsx
@@ -11,6 +11,7 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { RoleBadge } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { AdminResetPasswordDialog } from "@/components/admin-reset-password-dialog";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import type { User } from "./profile-section";
 
 type AdminSort = "recent" | "oldest" | "username" | "vaults";
@@ -157,17 +158,16 @@ export function AdminSection({ user, users, usersError, onReloadUsers }: Props) 
                     <span className="coord tabular-nums shrink-0">
                       {String(i + 1).padStart(2, "0")}
                     </span>
-                    <span
+                    <TooltipText
                       data-testid="admin-user-name"
-                      title={u.username}
                       className="text-sm font-medium truncate text-foreground"
                     >
                       {u.username}
-                    </span>
+                    </TooltipText>
                     {u.display_name && u.display_name !== u.username && (
-                      <span title={u.display_name} className="text-sm text-foreground-muted truncate hidden sm:inline">
+                      <TooltipText className="text-sm text-foreground-muted truncate hidden sm:inline">
                         {u.display_name}
-                      </span>
+                      </TooltipText>
                     )}
                     <span title={u.email} className="text-[11px] text-foreground-muted truncate hidden md:inline">
                       {u.email}

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { EmptyState } from "@/components/empty-state";
 import { Alert } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 interface Column {
   name: string;
@@ -186,13 +187,13 @@ export default function TablePage() {
                       {i + 1}
                     </td>
                     {cols.map((c) => (
-                      <td
-                        key={c}
-                        className={`px-3 py-1.5 font-mono text-xs text-foreground border-r border-border last:border-r-0 whitespace-nowrap max-w-xs truncate ${typeof row[c] === "number" ? "tabular-nums" : ""}`}
-                        title={formatCell(row[c])}
-                      >
-                        {formatCell(row[c])}
-                      </td>
+                      <TooltipText key={c} asChild tip={formatCell(row[c])}>
+                        <td
+                          className={`px-3 py-1.5 font-mono text-xs text-foreground border-r border-border last:border-r-0 whitespace-nowrap max-w-xs truncate ${typeof row[c] === "number" ? "tabular-nums" : ""}`}
+                        >
+                          {formatCell(row[c])}
+                        </td>
+                      </TooltipText>
                     ))}
                   </tr>
                 ))}

--- a/frontend/src/pages/vault-activity.tsx
+++ b/frontend/src/pages/vault-activity.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/empty-state";
 import { useDebounce } from "@/hooks/use-debounce";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { TooltipText } from "@/components/ui/tooltip-text";
 
 const PAGE_SIZE = 50;
 
@@ -145,13 +146,16 @@ export default function VaultActivityPage() {
                   <span className="font-mono text-[11px] text-foreground-muted tabular-nums">
                     {(e.hash || "").slice(0, 7)}
                   </span>
-                  <span title={e.author_name || e.agent || e.author || "unknown"} className="text-xs text-foreground truncate">
+                  <TooltipText
+                    tip={e.author_name || e.agent || e.author || "unknown"}
+                    className="text-xs text-foreground truncate"
+                  >
                     <GitCommit
                       className="inline-block h-3 w-3 mr-1 text-info -translate-y-px"
                       aria-hidden
                     />
                     {e.author_name || e.agent || e.author || "unknown"}
-                  </span>
+                  </TooltipText>
                   <div className="min-w-0">
                     <div title={e.subject || primary?.path || "(no subject)"} className="text-sm tracking-tight truncate text-foreground group-hover:text-link">
                       {e.subject || primary?.path || "(no subject)"}

--- a/frontend/src/pages/vault-members.tsx
+++ b/frontend/src/pages/vault-members.tsx
@@ -18,6 +18,7 @@ import { InviteMemberDialog } from "@/components/invite-member-dialog";
 import { RoleBadge } from "@/components/status-badge";
 import { RoleSelect } from "@/components/role-select";
 import { EmptyState } from "@/components/empty-state";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { timeAgo } from "@/lib/utils";
 
 interface Member {
@@ -342,7 +343,7 @@ export default function VaultMembersPage() {
                       </span>
                     )}
                   </div>
-                  <div title={m.email} className="coord truncate">{m.email}</div>
+                  <TooltipText as="div" className="coord truncate">{m.email}</TooltipText>
                 </div>
                 <div className="flex items-center gap-3 shrink-0">
                   {canManage && m.role !== "owner" && currentUser && m.username !== currentUser.username ? (

--- a/frontend/src/pages/vault.tsx
+++ b/frontend/src/pages/vault.tsx
@@ -26,6 +26,8 @@ import { IndexingBadge, RoleBadge, VaultStateBadge } from "@/components/status-b
 import { useVaultHealth } from "@/hooks/use-vault-health";
 import { SkillStatusChip } from "@/components/skill/skill-status-chip";
 import { StatTile } from "@/components/ui/stat-tile";
+import { TooltipText } from "@/components/ui/tooltip-text";
+import { CopyButton } from "@/components/ui/copy-button";
 
 interface TableMeta {
   name: string;
@@ -281,8 +283,9 @@ export default function VaultPage() {
       {/* Meta line — one identity only (the H1 below states the name; the
           breadcrumb says "where am I"), so don't print the name a third time:
           just the label + the canonical mono URI. */}
-      <div className="coord mb-3">
+      <div className="coord mb-3 inline-flex items-center gap-1.5">
         Vault · <span className="font-mono">akb://{name}</span>
+        <CopyButton value={`akb://${name}`} label="Copy vault URI" />
       </div>
 
       {/* Display title */}
@@ -638,18 +641,18 @@ export default function VaultPage() {
                         <span className="font-mono text-[11px] text-foreground-muted tabular-nums">
                           {(c.hash || "").slice(0, 7)}
                         </span>
-                        <span title={author} className="text-foreground truncate">
+                        <TooltipText className="text-foreground truncate">
                           {author}
-                        </span>
-                        <span
-                          title={c.subject || filePath}
+                        </TooltipText>
+                        <TooltipText
+                          tip={c.subject || filePath}
                           className="text-foreground truncate"
                         >
                           {c.subject || filePath}
                           {filesCount > 1 && (
                             <span className="text-foreground-muted"> · +{filesCount - 1}</span>
                           )}
-                        </span>
+                        </TooltipText>
                         <span className="text-center">{changeMark(change)}</span>
                         <RelativeTime iso={c.timestamp} className="text-right" />
                       </Link>


### PR DESCRIPTION
## Summary

Two related frontend UX fixes:

### 1. Doc body fills the full article width
The doc title, meta, and byline render outside `.akb-md` (full article width)
while the markdown body was capped at `max-w-[72ch]` (643px) — a visible
right-edge mismatch on wide screens. Dropped `PROSE_MEASURE` so prose matches
the header; code/tables/images were already uncapped. The 1600px shell cap
bounds line length on ultra-wide displays.

### 2. Full-text affordance for truncated text + copy buttons
A `/ui-ux-pro-max` audit (5 area finders → adversarial verify, 7 false
positives rejected) found **34 confirmed sites** where truncated text had no
adequate way to read the full value — either no recourse at all, or only the
weak native `title=` (≈1s delay, invisible on touch/keyboard, unstyled) — plus
3 copyable identifiers with no copy affordance.

Added two design-system primitives and migrated all 34 sites:

- **`TooltipText`** — truncating text that reveals its full value via the styled
  `<Tooltip>` on hover/focus, **only when it actually overflows**
  (ResizeObserver-measured). Self-providing (no global provider needed);
  `asChild` decorates arbitrary elements (`<td>`, router `<Link>`) since Radix
  Root/Trigger render no DOM wrapper.
- **`CopyButton`** — compact copy-to-clipboard icon button (insecure-origin
  guarded), extracted from `CodeSnippet`'s inline pattern.

Migrated: doc sidebar Relations/History/Outline, search results, graph
sidebar/detail, table cells, select-menu, settings/members/admin, user-menu,
publications. Copy added for collection name, vault `akb://` URI, graph detail
URI. Also fixed a `title`-placement bug in `home.tsx` (native title sat on the
parent, never showed).

## Test
- `design:check` + `typecheck` + `lint` (0 errors) + **265 frontend tests** green.
- Verified live on local docker: overflow detection gates the tooltip — long
  outline heading reveals full text on hover, short heading shows none; body
  now fills the article cell (1022px == title/meta at 1728 viewport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)