### PR TITLE
fix(frontend): 4 small UX gaps (auto-refresh, collection refresh/summary, write-perm vault picker)

### DIFF
--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   FolderPlus,
   Paperclip,
+  RotateCw,
   Sparkles,
   Table,
   Trash2,
@@ -231,15 +232,24 @@ export function VaultExplorer({
       className="flex flex-col h-full overflow-hidden text-sm bg-background"
       aria-label={`${vault} collections`}
     >
-      <div className="border-b border-border px-2 py-1.5 shrink-0">
+      <div className="border-b border-border px-2 py-1.5 shrink-0 flex items-center gap-1.5">
         <input
           type="search"
           placeholder="Filter in vault…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="w-full h-9 px-2.5 rounded-[var(--radius-md)] bg-surface border border-border text-xs text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-primary focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+          className="flex-1 min-w-0 h-9 px-2.5 rounded-[var(--radius-md)] bg-surface border border-border text-xs text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-primary focus-visible:ring-2 focus-visible:ring-ring transition-colors"
           aria-label="Filter tree"
         />
+        <button
+          type="button"
+          onClick={() => refetch()}
+          aria-label="Refresh"
+          title="Refresh"
+          className="shrink-0 inline-flex h-9 w-9 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface text-foreground-muted hover:text-foreground hover:bg-surface-hover transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <RotateCw className="h-3.5 w-3.5" aria-hidden />
+        </button>
       </div>
 
       <div
@@ -416,7 +426,12 @@ const TreeRow = memo(function TreeRow({
             className="h-3 w-3 shrink-0 text-foreground-muted group-hover:text-link transition-colors"
             aria-hidden
           />
-          <span title={node.name} className="truncate font-medium tracking-tight text-[13px]">{node.name}</span>
+          <span
+            title={node.raw?.summary ? `${node.name} — ${node.raw.summary}` : node.name}
+            className="truncate font-medium tracking-tight text-[13px]"
+          >
+            {node.name}
+          </span>
           {count > 0 && <span className="coord ml-auto shrink-0 tabular-nums">{count}</span>}
         </button>
         {canWrite && onCreateDoc && (

--- a/frontend/src/pages/document-new.tsx
+++ b/frontend/src/pages/document-new.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ArrowRight, Check, ChevronRight, FolderPlus } from "lucide-r
 import { ApiError, putDocument } from "@/lib/api";
 import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
 import { useVaultTree, type TreeNode } from "@/hooks/use-vault-tree";
+import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import { MarkdownEditorFallback } from "@/components/markdown-editor-fallback";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -35,6 +36,9 @@ export default function DocumentNewPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { tree } = useVaultTree(name);
+  // Invalidate the shared vault tree/list after a create so the new doc shows
+  // up in the explorer + home recent without a manual refresh.
+  const { refetchTree, refetchVaults } = useVaultRefresh();
   // Existing collections power the one-tap picker chips; new names are still
   // accepted (the field stays a free-text input — created automatically when
   // the typed path doesn't exist yet).
@@ -159,6 +163,10 @@ export default function DocumentNewPage() {
         domain: domain.trim() || undefined,
         summary: summary.trim() || undefined,
       });
+      // Refresh the shared tree + vault list so the new doc appears without a
+      // manual reload (the explorer/home stay mounted across this navigation).
+      refetchTree();
+      refetchVaults();
       const path = result?.path;
       if (path) {
         navigate(`/vault/${name}/doc/${encodeURIComponent(path)}`);

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -208,7 +208,11 @@ export default function HomePage() {
           subtitle="Your knowledge base for AI agents — browse vaults, see recent changes, and manage agent connections."
           actions={
             <div className="flex items-center gap-2">
-              {vaults.length > 0 && <NewDocAction vaults={vaults} />}
+              {/* Only offer vaults the user can actually write to — a reader
+                  vault in the picker just leads to a 403 on create. */}
+              {vaults.some((v) => v.role !== "reader") && (
+                <NewDocAction vaults={vaults.filter((v) => v.role !== "reader")} />
+              )}
               <Button asChild variant={vaults.length > 0 ? "outline" : "accent"} size="md">
                 <Link to="/vault/new">
                   <Plus className="h-4 w-4" aria-hidden />


### PR DESCRIPTION
Quick wins triaged from a batch of small issues (the deeper #189 search work and #203/#204 are tracked separately).

| # | Fix |
|---|---|
| 1 | **Auto-refresh after doc create** — `document-new` now calls `useVaultRefresh().refetchTree/refetchVaults` before navigating, so a new doc shows in the explorer + home recent without a manual reload. |
| 2 | **Collection list refresh** — the explorer header gains a Refresh button next to the filter (forces a tree refetch); there was no manual refresh affordance. |
| 3 | **Collection summary surfaced** — `summary` was already stored (`createCollection` → REST → service) but never shown; the explorer collection row tooltip now displays `{name} — {summary}`, so the create-dialog input isn't write-only. |
| 6 | **Write-permission vault picker** — the Home "New document" picker is filtered to vaults the user can write to (`role !== "reader"`); a reader vault only led to a 403 on create. Backend already enforces writer — this is the UX half. |

Not in this PR: #4 (link-editing UI → issue #203), #7 (vault filter/search → issue #204), #5 (search limits → folds into #189, under analysis).

## Test
`design:check` + `typecheck` + `lint` (0 errors) + **265 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)