### PR TITLE
fix(search): server-side limit clamp + surface silent vector-store failures (#189 Phase 1)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -128,6 +128,13 @@ class Settings(BaseModel):
     # lets rerank-off searches dedup over a wider dense+BM25 candidate set.
     search_prefetch: int = Field(default=0, ge=0)
 
+    # Hard server-side ceiling on a search/grep `limit`. The MCP tool schema
+    # advertises max 50 but that is client-side only — a direct REST call or a
+    # non-validating client can pass an arbitrary limit that propagates into the
+    # vector-store prefetch (issue #189). Clamped at the service entry so every
+    # caller (MCP, REST, internal) is bounded uniformly.
+    search_limit_max: int = Field(default=50, ge=1)
+
     # S3-compatible object storage (for vault files)
     s3_endpoint_url: str = ""       # Internal endpoint (server → S3)
     s3_public_url: str = ""         # External endpoint for presigned URLs (client → S3). Falls back to s3_endpoint_url.

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -249,4 +249,10 @@ class SearchResponse(BaseModel):
     total_matches: int = 0
     truncated: bool = False
     hint: str | None = None
+    # `degraded` is true when the vector store raised (outage, or a filter-size
+    # overflow on the seahorse drivers) so the result set is incomplete/empty —
+    # distinct from a genuine zero-match. Previously such failures were swallowed
+    # into a silent `[]` (issue #189). `degradation_reason` is a short cause.
+    degraded: bool = False
+    degradation_reason: str | None = None
     results: list[SearchResult]

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -166,6 +166,12 @@ class SearchService:
             logger.warning("query embedding failed: %s", e)
             embeddings = []
         query_embedding = embeddings[0] if embeddings else None
+        # A None embedding here is intentionally NOT surfaced as `degraded`:
+        # sparse-only is a legitimate by-design mode (a deployment may leave
+        # `embed_base_url` unset), and we can't cheaply tell "configured but
+        # transiently down" from "intentionally absent" at this point. The
+        # symmetric sparse-leg failure IS flagged degraded in _run_vector_search
+        # because the BM25 vocab is always present when the feature is on.
 
         # Always pre-filter when user_id is provided so we never leak
         # documents from vaults the user can't read.
@@ -600,20 +606,32 @@ class SearchService:
         a derived view, so a failure never raises to the caller; PG truth is
         untouched. Previously every failure was swallowed into a silent ``[]``
         with no signal (issue #189)."""
+        sparse_failed = False
         try:
             sparse_idx, sparse_vals = await sparse_encoder.encode_query(query_text)
         except Exception as e:  # noqa: BLE001
             logger.warning("sparse encode_query failed (%s); dense-only path", e)
             sparse_idx, sparse_vals = [], []
+            sparse_failed = True
 
-        # Hybrid requires a sparse signal. If encode_query succeeded but
-        # returned no vocab terms (OOV / nonsense query) AND the embedding
-        # API succeeded (query_embedding not None), the right answer is [].
-        # Dense-only is a degraded mode for embedding-API outage, not for
-        # OOV — Qwen3-style embeddings sit at ~0.4-0.5 cosine for unrelated
-        # text and would return plausible-looking distractor neighbours.
-        if not sparse_idx and query_embedding is not None:
+        # OOV guard — fires ONLY when encode_query SUCCEEDED but produced no
+        # vocab terms (nonsense query) AND the embedding API succeeded: the
+        # right answer is []. Dense-only is a degraded mode for an outage, not
+        # for OOV — Qwen3-style embeddings sit at ~0.4-0.5 cosine for unrelated
+        # text and would return plausible-looking distractor neighbours. This
+        # must NOT fire on a sparse-encoder FAILURE (that's degraded, not OOV).
+        if not sparse_failed and not sparse_idx and query_embedding is not None:
             return [], None
+
+        # Sparse encoder DOWN with no dense leg either → we can't search at all.
+        # Surface it as degraded (issue #189) instead of a silent zero-match.
+        if sparse_failed and query_embedding is None:
+            return [], "sparse_encoder_failed"
+
+        # If the sparse leg failed but a dense leg is available, we proceed
+        # dense-only — but the result is degraded (one retrieval leg missing),
+        # so we flag it rather than passing it off as a complete result.
+        sparse_reason = "sparse_encoder_degraded" if sparse_failed else None
 
         # max(limit*3, 50): same heuristic the legacy native-fusion path used.
         # Driver-agnostic now, but the value transfers cleanly — RRF
@@ -630,7 +648,9 @@ class SearchService:
                 limit=limit,
                 prefetch_per_leg=prefetch_per_leg,
             )
-            return hits, None
+            # `sparse_reason` is None on the normal path; set when the sparse leg
+            # was down and we ran dense-only (degraded-but-has-results).
+            return hits, sparse_reason
         except VectorStoreUnavailable as e:
             # Transient/expected: store outage. Search degrades to empty but the
             # caller is told WHY instead of seeing a silent zero-match.

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -22,6 +22,7 @@ from app.models.document import SearchResponse, SearchResult
 from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.vector_store import VectorHit, get_vector_store
+from app.services.vector_store.base import VectorStoreUnavailable
 from app.services.rerank_service import RerankError, rerank
 from app.services.uri_service import parse_uri
 
@@ -85,6 +86,17 @@ def fuse_original_and_reranked_hits(
     return [hits[idx] for idx in ordered]
 
 
+def clamp_search_limit(limit: int) -> int:
+    """Clamp a user-supplied search/grep ``limit`` to ``[1, search_limit_max]``.
+
+    The MCP tool schema advertises ``maximum: 50`` but that is client-side only;
+    a direct REST call or a non-validating client can pass any value, which
+    propagates into the vector-store prefetch (issue #189). Applied at the
+    service entry so every caller (MCP, REST, internal) is bounded uniformly.
+    """
+    return max(1, min(limit, settings.search_limit_max))
+
+
 def resolve_first_stage_unique_limit(
     *,
     limit: int,
@@ -133,6 +145,13 @@ class SearchService:
         # this self-defends against any future caller that forgets.
         if vault is None and user_id is None:
             raise ValidationError("vault or user_id required")
+
+        # Server-side limit clamp (issue #189): the MCP schema caps `limit` at
+        # 50 but that is client-side only — a direct REST call or non-validating
+        # client could pass an arbitrary value that propagates into the vector
+        # store prefetch (target_unique * 3, prefetch_per_leg). Clamp here, the
+        # single entry point for every caller.
+        limit = clamp_search_limit(limit)
 
         pool = await get_pool()
 
@@ -296,7 +315,7 @@ class SearchService:
 
         # Hybrid (dense + BM25 sparse) via the configured driver. Returns [] on any vector-store
         # failure — PG is the source of truth, the index is rebuildable.
-        hits = await self._run_vector_search(
+        hits, degraded_reason = await self._run_vector_search(
             query_text=query,
             query_embedding=query_embedding,
             candidate_source_ids=candidate_source_ids,
@@ -304,7 +323,11 @@ class SearchService:
         )
 
         if not hits:
-            return SearchResponse(query=query, total=0, results=[])
+            return SearchResponse(
+                query=query, total=0, returned=0, total_matches=0, results=[],
+                degraded=degraded_reason is not None,
+                degradation_reason=degraded_reason,
+            )
 
         # Dedup at the source level — one hit per (source_type, source_id).
         # Previously dedup was by document_id only; generalizing keeps
@@ -352,6 +375,8 @@ class SearchService:
             total_matches=total_matches,
             truncated=prefetch_capped,
             hint=hint,
+            degraded=degraded_reason is not None,
+            degradation_reason=degraded_reason,
             results=results,
         )
 
@@ -565,10 +590,16 @@ class SearchService:
         query_embedding: list[float] | None,
         candidate_source_ids: list[str] | None,
         limit: int,
-    ):
-        """Hybrid search over the vector store. Returns [] on any failure —
-        the store is a derived view; outages surface as 'no results' while
-        PG truth is untouched."""
+    ) -> tuple[list, str | None]:
+        """Hybrid search over the vector store.
+
+        Returns ``(hits, degradation_reason)``. ``reason`` is None on success
+        OR on a genuine OOV-empty; a non-None reason means the store FAILED
+        (outage, or a filter-size overflow on the seahorse drivers) so the
+        empty/partial result is degraded — not a true zero-match. The store is
+        a derived view, so a failure never raises to the caller; PG truth is
+        untouched. Previously every failure was swallowed into a silent ``[]``
+        with no signal (issue #189)."""
         try:
             sparse_idx, sparse_vals = await sparse_encoder.encode_query(query_text)
         except Exception as e:  # noqa: BLE001
@@ -582,7 +613,7 @@ class SearchService:
         # OOV — Qwen3-style embeddings sit at ~0.4-0.5 cosine for unrelated
         # text and would return plausible-looking distractor neighbours.
         if not sparse_idx and query_embedding is not None:
-            return []
+            return [], None
 
         # max(limit*3, 50): same heuristic the legacy native-fusion path used.
         # Driver-agnostic now, but the value transfers cleanly — RRF
@@ -590,7 +621,7 @@ class SearchService:
         prefetch_per_leg = max(limit * 3, 50)
 
         try:
-            return await get_vector_store().hybrid_search(
+            hits = await get_vector_store().hybrid_search(
                 query_text=query_text,
                 query_dense=query_embedding,
                 query_sparse_indices=sparse_idx,
@@ -599,9 +630,17 @@ class SearchService:
                 limit=limit,
                 prefetch_per_leg=prefetch_per_leg,
             )
+            return hits, None
+        except VectorStoreUnavailable as e:
+            # Transient/expected: store outage. Search degrades to empty but the
+            # caller is told WHY instead of seeing a silent zero-match.
+            logger.warning("vector store unavailable (%s); degraded empty result", e)
+            return [], "vector_store_unavailable"
         except Exception as e:  # noqa: BLE001
-            logger.warning("vector hybrid_search failed (%s); returning empty", e)
-            return []
+            # Unexpected (e.g. seahorse filter-size overflow from a giant IN list
+            # — the #189 silent-failure mode). Log loudly + surface the signal.
+            logger.error("vector hybrid_search failed (%s); degraded empty result", e)
+            return [], "vector_store_error"
 
     async def grep(
         self,
@@ -664,6 +703,9 @@ class SearchService:
         # in that branch would silently produce a cross-vault scan.
         if vault is None and user_id is None:
             raise ValidationError("vault or user_id required")
+
+        # Server-side limit clamp (issue #189) — same ceiling as search().
+        limit = clamp_search_limit(limit)
 
         pool = await get_pool()
         async with pool.acquire() as conn:

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -363,7 +363,11 @@ TOOLS = [
             "deduped prefetch pool — NOT a corpus-wide hit count; vector ANN is top-K only). "
             "When `truncated=true` the prefetch pool was capped, meaning the corpus may hold "
             "more hits than reported — switch to akb_grep with count_only=true for an exact "
-            "literal-substring count, or refine the query."
+            "literal-substring count, or refine the query. "
+            "When `degraded=true` the retrieval index hit a transient failure (vector-store "
+            "outage or a degraded leg), so results may be incomplete or empty — this is NOT a "
+            "genuine zero-match; `degradation_reason` names the cause. Retry shortly, or fall "
+            "back to akb_grep for a literal search."
         ),
         inputSchema={
             "type": "object",

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -121,6 +121,73 @@ def test_search_response_degraded_defaults_false():
     assert r.degradation_reason is None
 
 
+@pytest.mark.asyncio
+async def test_run_vector_search_surfaces_store_and_sparse_failures(monkeypatch):
+    """_run_vector_search returns (hits, degradation_reason) and must classify
+    failures instead of swallowing them into a silent [] (issue #189):
+      - store raises VectorStoreUnavailable → 'vector_store_unavailable'
+      - store raises any other Exception     → 'vector_store_error'
+      - sparse encoder fails + no dense leg  → 'sparse_encoder_failed' (can't search)
+      - sparse encoder fails + dense leg ok  → dense-only hits, 'sparse_encoder_degraded'
+      - all healthy                          → hits, None
+    """
+    import app.services.search_service as ss
+
+    svc = ss.SearchService()
+
+    async def encode_ok(_q):
+        return [1, 2], [0.5, 0.5]
+
+    async def encode_fail(_q):
+        raise RuntimeError("sparse encoder down")
+
+    class _Store:
+        def __init__(self, behavior):
+            self.behavior = behavior
+
+        async def hybrid_search(self, **_kw):
+            if self.behavior == "unavailable":
+                raise ss.VectorStoreUnavailable("store down")
+            if self.behavior == "boom":
+                raise RuntimeError("filter-size overflow")
+            return [SimpleNamespace(source_type="document", source_id="d1", score=1.0)]
+
+    def use_store(behavior):
+        monkeypatch.setattr(ss, "get_vector_store", lambda: _Store(behavior))
+
+    async def run(*, embedding):
+        return await svc._run_vector_search(
+            query_text="q", query_embedding=embedding,
+            candidate_source_ids=["s1"], limit=10,
+        )
+
+    # store outage (transient) → vector_store_unavailable
+    monkeypatch.setattr(ss.sparse_encoder, "encode_query", encode_ok)
+    use_store("unavailable")
+    hits, reason = await run(embedding=[0.1, 0.2])
+    assert hits == [] and reason == "vector_store_unavailable"
+
+    # unexpected store error (e.g. seahorse IN overflow) → vector_store_error
+    use_store("boom")
+    hits, reason = await run(embedding=[0.1, 0.2])
+    assert hits == [] and reason == "vector_store_error"
+
+    # all healthy → hits, no degradation
+    use_store("ok")
+    hits, reason = await run(embedding=[0.1, 0.2])
+    assert len(hits) == 1 and reason is None
+
+    # sparse encoder down + a dense leg → dense-only, flagged degraded
+    monkeypatch.setattr(ss.sparse_encoder, "encode_query", encode_fail)
+    use_store("ok")
+    hits, reason = await run(embedding=[0.1, 0.2])
+    assert len(hits) == 1 and reason == "sparse_encoder_degraded"
+
+    # sparse encoder down + NO dense leg → can't search → degraded empty (not OOV)
+    hits, reason = await run(embedding=None)
+    assert hits == [] and reason == "sparse_encoder_failed"
+
+
 def test_search_response_carries_degraded_signal():
     """When the vector store fails (outage / seahorse filter-size overflow),
     the empty result is flagged degraded with a cause — no longer a silent []

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -6,6 +6,7 @@ from app.exceptions import ValidationError
 from app.models.document import SearchResponse
 from app.services.search_service import (
     SearchService,
+    clamp_search_limit,
     fuse_original_and_reranked_hits,
     resolve_first_stage_unique_limit,
 )
@@ -93,6 +94,48 @@ def test_search_response_carries_truncated_signal():
     )
     assert r.truncated is True
     assert r.hint and "Prefetch pool" in r.hint
+
+
+def test_clamp_search_limit(monkeypatch):
+    """Server-side limit clamp (issue #189): an over-large limit is capped to
+    search_limit_max, and a zero/negative limit floors at 1, so a direct REST
+    call or non-validating client can't blow up the vector-store prefetch."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "search_limit_max", 50, raising=False)
+    assert clamp_search_limit(1000) == 50  # over the ceiling → clamped
+    assert clamp_search_limit(50) == 50  # at the ceiling → unchanged
+    assert clamp_search_limit(10) == 10  # under → unchanged
+    assert clamp_search_limit(0) == 1  # zero → floored to 1
+    assert clamp_search_limit(-5) == 1  # negative → floored to 1
+    # Honors a per-deployment override.
+    monkeypatch.setattr(settings, "search_limit_max", 200, raising=False)
+    assert clamp_search_limit(1000) == 200
+
+
+def test_search_response_degraded_defaults_false():
+    """A response built without explicit degraded fields must default to
+    'not degraded' — a genuine zero-match, NOT a swallowed store failure."""
+    r = SearchResponse(query="x", total=0, returned=0, total_matches=0, results=[])
+    assert r.degraded is False
+    assert r.degradation_reason is None
+
+
+def test_search_response_carries_degraded_signal():
+    """When the vector store fails (outage / seahorse filter-size overflow),
+    the empty result is flagged degraded with a cause — no longer a silent []
+    (issue #189)."""
+    r = SearchResponse(
+        query="x",
+        total=0,
+        returned=0,
+        total_matches=0,
+        degraded=True,
+        degradation_reason="vector_store_error",
+        results=[],
+    )
+    assert r.degraded is True
+    assert r.degradation_reason == "vector_store_error"
 
 
 @pytest.mark.asyncio

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -66,6 +66,11 @@ rerank_timeout_seconds: 3.0
 # 0 keeps legacy behavior: only rerank-enabled searches use rerank_prefetch.
 # Set >limit to give rerank-off searches more dedup headroom.
 search_prefetch: 0
+# Hard server-side ceiling on a search/grep `limit`. The MCP tool schema
+# advertises max 50, but that is client-side only — a direct REST call or a
+# non-validating client could otherwise pass an arbitrary limit that propagates
+# into the vector-store prefetch (issue #189). Clamped at the service entry.
+search_limit_max: 50
 
 # === S3-compatible object storage (for vault file uploads) ===
 # Leave endpoints blank to disable file storage features.

--- a/docs/designs/search-acl-scale/00-overview.md
+++ b/docs/designs/search-acl-scale/00-overview.md
@@ -72,8 +72,22 @@ the limit and makes the seahorse overflow *visible*. The structural fix is Phase
 Push ACL down to **vault granularity** (the canonical multi-tenant pattern):
 
 1. Add `vault_id` to the vector-store point payload (pgvector column + index;
-   qdrant payload + idempotent index; seahorse_cloud/db column). Backfill via the
-   existing reindex pipeline (already knows `vault_id`).
+   qdrant payload + idempotent index; seahorse_cloud/db column).
+   **Backfill is metadata-only — NOT a re-embed** — because `vault_id` is
+   derivable from the already-stored `source_id` and the embeddings don't change:
+   - **pgvector** (the production driver): `ALTER TABLE vector_index.chunks ADD
+     COLUMN vault_id` → one `UPDATE … SET vault_id = src.vault_id FROM (source
+     JOIN) WHERE source_id = src.id` → `CREATE INDEX`. Seconds–minutes, zero
+     embedding-API calls.
+   - **qdrant**: batch `set_payload` from a `source_id → vault_id` map (vectors
+     untouched). No re-embed.
+   - **seahorse_cloud**: `ALTER` + `UPDATE` if the column can be added in place;
+     otherwise re-upsert.
+   - **seahorse_db / Coral** is the ONLY full-re-embed case (immutable schema →
+     drop + recreate → `scripts/reindex_all.py`). Production does not use it.
+   During the backfill window, gate the vault filter (fall back to the
+   `source_ids` path) until `vault_id` is fully populated, so no points are
+   missed.
 2. Extend `VectorStore.hybrid_search` with `vault_ids: list[str] | None`
    (keep `source_ids` for the doc-filter / `source_uris` path).
 3. Two codepaths in `SearchService.search`:

--- a/docs/designs/search-acl-scale/00-overview.md
+++ b/docs/designs/search-acl-scale/00-overview.md
@@ -1,0 +1,100 @@
+# Search ACL scale — bounded prefilter + limit clamp (issue #189)
+
+Status: **Phase 1 accepted/implemented** · Phase 2 (vault_id pushdown) proposed,
+needs migration + reindex approval.
+
+## Problem (issue #189)
+
+`SearchService.search` (behind both REST and MCP) has two spots that don't scale
+with document count:
+
+1. **Unbounded candidate prefilter.** Because the handlers always forward
+   `user_id`, `has_filters` is effectively always true, so every search
+   materializes *all* document/table/file ids the user can read (three SQL
+   queries with **no LIMIT**, `search_service.py:225/251/277`) into
+   `candidate_source_ids`, then passes that whole id list to the vector store as
+   the only filter primitive (`source_ids`). It's O(accessible-corpus) per query:
+   - pgvector → `= ANY($1::uuid[])` (planner cost grows with the array),
+   - qdrant → `MatchAny(any=[...all ids...])` (filter-eval cost blows up),
+   - seahorse_db / seahorse_cloud → a giant `source_id IN ('uuid', …)` **string
+     over HTTP** that, past the query-size limit, raises → caught and **silently
+     returns `[]`** (the user sees "no results" with no cause).
+2. **No server-side `limit` clamp.** The MCP schema says `maximum: 50` but that's
+   client-side only; a direct REST call or non-validating client can pass an
+   arbitrary `limit` that propagates into the prefetch
+   (`target_unique*3`, `prefetch_per_leg`).
+
+## Analysis (4-angle, validated)
+
+- **ACL is purely per-vault.** There is zero per-document/table/file ACL in AKB;
+  read access is entirely vault membership (owner / `vault_access` grant /
+  `public_access`). So a **vault-level** vector filter is ACL-equivalent to the
+  current per-doc id enumeration. Cardinality: a user accesses ~tens of vaults
+  vs thousands+ of docs.
+- **Vector points carry no `vault_id`.** The chunks payload (all four drivers)
+  stores only `source_id`/`source_type`/`section_path`/content/vectors — so the
+  only filter primitive today is an id list. `vault_id` *is* available at index
+  time (`embed_worker` / `reindex_all` already pass it).
+- **Industry pattern (unanimous):** isolate tenants by **one small field**, never
+  an id list — Qdrant payload index `is_tenant=true`, Pinecone namespaces,
+  Weaviate per-tenant shard, Milvus partition-key, pgvector indexed `tenant_id` +
+  `WHERE`. Passing thousands of ids in `MatchAny` / `IN (...)` is the documented
+  anti-pattern AKB reproduces.
+- **All four drivers can hold a `vault_id` payload + filter natively.** Effort:
+  pgvector lowest (column + index, zero-downtime), qdrant very low (idempotent
+  payload index), seahorse_cloud low (column + ALTER), seahorse_db/Coral moderate
+  (immutable schema → table recreate). A single contract change
+  (`hybrid_search(vault_ids=…)`) unifies all four. Backfill reuses the existing
+  reindex path.
+
+## Decision — phased
+
+### Phase 1 (implemented here, no migration, ship immediately)
+
+1. **Server-side limit clamp.** `clamp_search_limit(limit) = max(1, min(limit,
+   settings.search_limit_max))` (config, default 50), applied at the
+   `SearchService.search` and `.grep` entry points — the single chokepoint for
+   MCP + REST + internal. Blocks the client-bypass blowup.
+2. **Surface the silent failure.** `_run_vector_search` now returns
+   `(hits, degradation_reason)` and distinguishes `VectorStoreUnavailable`
+   (transient outage → warning, `"vector_store_unavailable"`) from any other
+   exception (e.g. seahorse filter-size overflow → `logger.error`,
+   `"vector_store_error"`). `SearchResponse` gains `degraded: bool` +
+   `degradation_reason: str | None`, so an incomplete/empty result from a store
+   failure is no longer indistinguishable from a genuine zero-match. Backward
+   compatible (fields default to `False`/`None`).
+
+Phase 1 does **not** remove the O(corpus) candidate materialization — it bounds
+the limit and makes the seahorse overflow *visible*. The structural fix is Phase 2.
+
+### Phase 2 (proposed — needs migration + reindex approval)
+
+Push ACL down to **vault granularity** (the canonical multi-tenant pattern):
+
+1. Add `vault_id` to the vector-store point payload (pgvector column + index;
+   qdrant payload + idempotent index; seahorse_cloud/db column). Backfill via the
+   existing reindex pipeline (already knows `vault_id`).
+2. Extend `VectorStore.hybrid_search` with `vault_ids: list[str] | None`
+   (keep `source_ids` for the doc-filter / `source_uris` path).
+3. Two codepaths in `SearchService.search`:
+   - **no doc-level filter** (collection/doc_type/tags/source_uris absent) →
+     resolve accessible `vault_ids` once (small), pass as the vector filter, skip
+     the doc enumeration → O(vaults).
+   - **doc-level filter present** → enumerate accessible `vault_ids`, then
+     `doc_ids` *within those vaults* (bounded by the vault set, tractable) →
+     pass `source_ids`.
+4. (Optional) apply the same vault-filter optimization to `grep`'s ACL scan.
+
+**Operational caveats:** a backfill window where un-reindexed points lack
+`vault_id` (filter would miss them) → reindex before cutover or gate on a flag;
+seahorse_db/Coral schema is immutable (drop+recreate). These are why Phase 2 is
+gated behind explicit approval.
+
+## Files (Phase 1)
+
+- `backend/app/config.py` — `search_limit_max` setting.
+- `backend/app/models/document.py` — `SearchResponse.degraded` + `.degradation_reason`.
+- `backend/app/services/search_service.py` — `clamp_search_limit`, clamp at
+  `search`/`grep` entry, `_run_vector_search` returns `(hits, reason)` with
+  error-class discrimination, degraded threaded into both responses.
+- `backend/tests/test_search_rerank_fusion.py` — clamp + degraded unit tests.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -308,6 +308,11 @@ export interface SearchResponse {
   total_matches: number;
   truncated?: boolean;
   hint?: string | null;
+  // Set when the retrieval index hit a transient failure (vector-store outage
+  // or a degraded leg): results may be incomplete/empty — NOT a genuine
+  // zero-match (backend issue #189). `degradation_reason` names the cause.
+  degraded?: boolean;
+  degradation_reason?: string | null;
   results: any[];
 }
 export const searchDocs = (query: string, vault?: string, limit = 10) => {

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -106,6 +106,7 @@ export default function SearchPage() {
   const [returnedMatches, setReturnedMatches] = useState(0);
   const [truncated, setTruncated] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
+  const [degraded, setDegraded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -161,6 +162,7 @@ export default function SearchPage() {
         setReturnedMatches(0);
         setTruncated(Boolean(d.truncated));
         setHint(d.hint ?? null);
+        setDegraded(Boolean(d.degraded));
       } else {
         const d = await grepDocs(s, v || undefined);
         if (id !== reqId.current) return;
@@ -174,6 +176,7 @@ export default function SearchPage() {
         setReturnedMatches(d.returned_matches ?? d.total_matches);
         setTruncated(Boolean(d.truncated));
         setHint(d.hint ?? null);
+        setDegraded(false); // literal/grep uses SQL, not the vector store
       }
     } catch (e) {
       if (id !== reqId.current) return;
@@ -188,6 +191,7 @@ export default function SearchPage() {
       setReturnedMatches(0);
       setTruncated(false);
       setHint(null);
+      setDegraded(false);
     } finally {
       if (id === reqId.current) setLoading(false);
     }
@@ -407,6 +411,21 @@ export default function SearchPage() {
             </button>
           )}
         </div>
+      )}
+
+      {degraded && (
+        <Alert variant="warning" className="mb-4">
+          Search is degraded — the retrieval index hit a transient issue, so these
+          results may be incomplete. This isn't a "no matches" result; try again
+          shortly, or switch to{" "}
+          <button
+            onClick={() => switchMode("literal")}
+            className="underline font-medium hover:text-link cursor-pointer rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Literal
+          </button>{" "}
+          search.
+        </Alert>
       )}
 
       {showLiteralHint && (


### PR DESCRIPTION
Addresses **#189** (unbounded search prefilter + no limit clamp). This is **Phase 1** — the safe, no-migration wins. Phase 2 (the structural `vault_id` ACL pushdown) is proposed in the design doc and gated behind a reindex/approval.

Backed by a 4-angle analysis (driver feasibility · ACL semantics · limit/error sites · industry pattern), captured in `docs/designs/search-acl-scale/00-overview.md`.

## Changes
1. **Server-side `limit` clamp** — `clamp_search_limit(limit) = max(1, min(limit, settings.search_limit_max))` (config, default 50), applied at the `search()` and `grep()` entry points. The MCP schema's `maximum: 50` is client-side only; a direct REST call or non-validating client could pass an arbitrary `limit` that propagated into the vector-store prefetch. One chokepoint now bounds MCP + REST + internal.
2. **Surface the silent failure** — `_run_vector_search` returns `(hits, degradation_reason)` and distinguishes `VectorStoreUnavailable` (transient → warning) from any other exception (e.g. the seahorse filter-size overflow from a giant `IN (...)` list → `logger.error`). `SearchResponse` gains `degraded: bool` + `degradation_reason: str | None`, so a store-failure empty is no longer indistinguishable from a genuine zero-match. Backward compatible (defaults `False`/`None`; flows through REST + MCP automatically).

## Not in this PR (Phase 2, needs reindex + approval)
The O(accessible-corpus) candidate materialization itself — fixed by adding `vault_id` to the vector-store payload across all four drivers and filtering by accessible `vault_ids` (~tens) instead of enumerating doc ids (thousands). ACL is purely per-vault, so this is correctness-equivalent. See the design doc.

## Test
New `clamp` + `degraded` unit tests; full search unit suite green (13). (E2E `test_hybrid_search_e2e.sh` exercises the live path; degraded signal is observable when the store is down.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)