### PR TITLE
feat(search): vault-granularity ACL filter (#189 Phase 2, pgvector)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -135,6 +135,17 @@ class Settings(BaseModel):
     # caller (MCP, REST, internal) is bounded uniformly.
     search_limit_max: int = Field(default=50, ge=1)
 
+    # Push the ACL filter down to VAULT granularity in the vector store (issue
+    # #189 Phase 2). When True AND the driver is pgvector AND a search has no
+    # doc-level filter (collection/doc_type/tags/source_uris), search filters by
+    # the user's accessible vault ids (a small set) instead of materializing
+    # every accessible source id (O(corpus)). OFF by default: flip to True only
+    # AFTER the vector index's `vault_id` column is fully backfilled
+    # (scripts/backfill_vault_id.py) — until then the column is partly NULL and
+    # the filter would miss un-backfilled points. While False the behavior is
+    # byte-identical to before (the source_ids path).
+    vault_filter_enabled: bool = False
+
     # S3-compatible object storage (for vault files)
     s3_endpoint_url: str = ""       # Internal endpoint (server → S3)
     s3_public_url: str = ""         # External endpoint for presigned URLs (client → S3). Falls back to s3_endpoint_url.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -179,11 +179,20 @@ async def health():
     reporting the same `chunks.vector_indexed_at IS NULL` count.
     """
     from app.services import sparse_encoder
-    vs_info: dict = {"reachable": await get_vector_store().health()}
+    store = get_vector_store()
+    vs_info: dict = {"reachable": await store.health()}
     try:
         vs_info["backfill"] = await embed_worker.pending_stats()
     except Exception as e:  # noqa: BLE001
         vs_info["backfill_error"] = str(e)
+    # vault_id backfill progress (issue #189 Phase 2): operators must see this
+    # reach 0 before flipping `vault_filter_enabled`. pgvector-only.
+    vault_backfill = getattr(store, "vault_backfill_pending", None)
+    if vault_backfill is not None:
+        try:
+            vs_info["vault_id_null_count"] = await vault_backfill()
+        except Exception as e:  # noqa: BLE001
+            vs_info["vault_id_null_count_error"] = str(e)
     try:
         vs_info["bm25"] = await sparse_encoder.stats_snapshot()
     except Exception as e:  # noqa: BLE001

--- a/backend/app/services/embed_worker.py
+++ b/backend/app/services/embed_worker.py
@@ -238,6 +238,7 @@ async def _process_once() -> int:
                         sparse_values=sparse_vals,
                         source_type=row["source_type"] or "document",
                         source_id=str(row["source_id"]),
+                        vault_id=str(row["vault_id"]),
                     )
                     await _mark_success(conn, row["id"])
         except VectorStoreUnavailable as e:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -86,6 +86,25 @@ def fuse_original_and_reranked_hits(
     return [hits[idx] for idx in ordered]
 
 
+def vault_path_eligible(
+    *,
+    collection: str | None,
+    doc_type: str | None,
+    tags: list[str] | None,
+    source_uris: list[str] | None,
+) -> bool:
+    """Whether a search should use the VAULT-granularity ACL path (issue #189
+    Phase 2) instead of enumerating source ids. Requires: the flag on, the
+    pgvector driver (only it stores vault_id), and NO doc-level narrowing filter
+    (those still need per-resource source_ids). When False, the existing
+    source_ids path runs unchanged."""
+    return (
+        settings.vault_filter_enabled
+        and settings.vector_store_driver == "pgvector"
+        and not (collection or doc_type or tags or source_uris)
+    )
+
+
 def clamp_search_limit(limit: int) -> int:
     """Clamp a user-supplied search/grep ``limit`` to ``[1, search_limit_max]``.
 
@@ -177,8 +196,36 @@ class SearchService:
         # documents from vaults the user can't read.
         has_filters = any([vault, collection, doc_type, tags, user_id, source_uris])
         candidate_source_ids: list[str] | None = None
+        candidate_vault_ids: list[str] | None = None
 
-        if has_filters:
+        # VAULT path (issue #189 Phase 2): when there's no doc-level narrowing
+        # filter, the flag is on, and the driver is pgvector, filter the vector
+        # search by the user's accessible VAULT ids (a small set) instead of
+        # enumerating every accessible source id (O(accessible corpus)). ACL in
+        # AKB is purely per-vault, so this is correctness-equivalent. Otherwise
+        # the existing SOURCE_IDS path runs UNCHANGED (flag off / other driver /
+        # any doc-level filter present).
+        use_vault_path = vault_path_eligible(
+            collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
+        )
+
+        if use_vault_path:
+            async with pool.acquire() as conn:
+                user_uuid = uuid.UUID(user_id) if user_id else None
+                is_admin = bool(await conn.fetchval(
+                    "SELECT is_admin FROM users WHERE id = $1", user_uuid,
+                )) if user_uuid is not None else False
+                candidate_vault_ids = await self._accessible_vault_ids(
+                    conn, user_uuid=user_uuid, is_admin=is_admin, vault=vault,
+                )
+            # None  → admin / anon-with-named-vault → unscoped (mirrors the
+            #         source path's no-ACL admin behavior; admin sees all).
+            # []    → the user can read no matching vault → no results.
+            if candidate_vault_ids is not None and not candidate_vault_ids:
+                return SearchResponse(
+                    query=query, total=0, returned=0, total_matches=0, results=[],
+                )
+        elif has_filters:
             async with pool.acquire() as conn:
                 # Resolve user access once — used in all three candidate
                 # queries below. Previously this repeated the lookup per
@@ -325,6 +372,7 @@ class SearchService:
             query_text=query,
             query_embedding=query_embedding,
             candidate_source_ids=candidate_source_ids,
+            candidate_vault_ids=candidate_vault_ids,
             limit=target_unique * 3,
         )
 
@@ -385,6 +433,40 @@ class SearchService:
             degradation_reason=degraded_reason,
             results=results,
         )
+
+    async def _accessible_vault_ids(
+        self, conn, *, user_uuid: uuid.UUID | None, is_admin: bool, vault: str | None,
+    ) -> list[str] | None:
+        """The vault ids the user may read — the VAULT-path ACL (issue #189
+        Phase 2). Mirrors the per-vault `_vault_acl` predicate exactly so the
+        flag is a pure performance change, never a security change.
+
+        Returns:
+          - ``None``  → no ACL filter needed (admin, or an anon caller scoped by
+            an explicit vault name) → an unscoped vector search, same as the
+            source path's no-ACL admin behavior.
+          - ``[]``    → the user can read no matching vault → caller returns [].
+          - ``[id…]`` → the accessible vault id(s) to filter on.
+        """
+        # admin / anon mirror `_vault_acl` returning (None, []): no predicate.
+        if user_uuid is None or is_admin:
+            if vault:
+                vid = await conn.fetchval("SELECT id FROM vaults WHERE name = $1", vault)
+                return [str(vid)] if vid is not None else []
+            return None  # admin, no named vault → unscoped
+        # Authenticated non-admin: owner / explicit grant / public.
+        acl = (
+            "v.id IN (SELECT vault_id FROM vault_access WHERE user_id = $1) "
+            "OR v.owner_id = $1 OR v.public_access IN ('reader', 'writer')"
+        )
+        if vault:
+            vid = await conn.fetchval(
+                f"SELECT v.id FROM vaults v WHERE v.name = $2 AND ({acl})",
+                user_uuid, vault,
+            )
+            return [str(vid)] if vid is not None else []
+        rows = await conn.fetch(f"SELECT v.id FROM vaults v WHERE {acl}", user_uuid)
+        return [str(r["id"]) for r in rows]
 
     async def _resolve_source_uris(
         self, conn, source_uris: list[str]
@@ -595,6 +677,7 @@ class SearchService:
         query_text: str,
         query_embedding: list[float] | None,
         candidate_source_ids: list[str] | None,
+        candidate_vault_ids: list[str] | None = None,
         limit: int,
     ) -> tuple[list, str | None]:
         """Hybrid search over the vector store.
@@ -645,6 +728,7 @@ class SearchService:
                 query_sparse_indices=sparse_idx,
                 query_sparse_values=sparse_vals,
                 source_ids=candidate_source_ids,
+                vault_ids=candidate_vault_ids,
                 limit=limit,
                 prefetch_per_leg=prefetch_per_leg,
             )

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -41,6 +41,10 @@ class ChunkUpsert:
     sparse_values: list[float]
     source_type: str
     source_id: str
+    # Owning vault, denormalized onto every point so a driver can filter by
+    # accessible vaults (small set) instead of an enumerated source_id list
+    # (issue #189 Phase 2). Always available at index time (main `chunks` row).
+    vault_id: str
 
 
 @dataclass
@@ -103,6 +107,7 @@ async def loop_upsert_batch(
             sparse_values=c.sparse_values,
             source_type=c.source_type,
             source_id=c.source_id,
+            vault_id=c.vault_id,
         )
 
 
@@ -186,6 +191,7 @@ class VectorStore(Protocol):
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         """Upsert one chunk into the driver. `dense` and `sparse_*` are
         pre-computed by the caller (`embed_worker` for indexing).
@@ -244,6 +250,7 @@ class VectorStore(Protocol):
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         """Dense + sparse search, RRF-fused.
 
@@ -252,9 +259,15 @@ class VectorStore(Protocol):
           falls back to sparse-only.
         - Empty `query_sparse_indices` means OOV query — driver falls
           back to dense-only.
-        - `source_ids` is the post-filter (resolved at the caller from
-          vault/collection/doc_type/tags/ACL); drivers translate to
+        - `source_ids` is the per-resource post-filter (resolved at the caller
+          from collection/doc_type/tags/source_uris); drivers translate to
           their own filter primitive.
+        - `vault_ids` is the per-VAULT ACL filter (issue #189 Phase 2): a small
+          set of accessible vault ids the caller passes INSTEAD of enumerating
+          every accessible source_id. Drivers that store `vault_id` on each
+          point (pgvector) filter on it natively; others ignore it for now and
+          keep filtering by `source_ids`. The caller sends one or the other,
+          never both at once.
         - `prefetch_per_leg` caps each leg's candidate pool before
           fusion. Caller decides — typically `max(limit * 3, 50)`.
         """

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -295,6 +295,7 @@ class PgvectorStore:
                     chunk_id        UUID PRIMARY KEY,
                     source_type     TEXT NOT NULL,
                     source_id       UUID NOT NULL,
+                    vault_id        UUID,
                     section_path    TEXT,
                     content         TEXT NOT NULL,
                     chunk_index     INTEGER NOT NULL,
@@ -312,6 +313,7 @@ class PgvectorStore:
                     chunk_id        UUID PRIMARY KEY,
                     source_type     TEXT NOT NULL,
                     source_id       UUID NOT NULL,
+                    vault_id        UUID,
                     section_path    TEXT,
                     content         TEXT NOT NULL,
                     chunk_index     INTEGER NOT NULL,
@@ -350,11 +352,27 @@ class PgvectorStore:
             f'ALTER TABLE "{self._schema}".chunks ALTER COLUMN dense DROP NOT NULL'
         )
 
+        # vault_id (issue #189 Phase 2): denormalized owning-vault on each point
+        # so the ACL filter can be by accessible vault (small set) instead of an
+        # enumerated source_id list. Idempotent ADD COLUMN for tables created
+        # before this column existed; nullable because the column is backfilled
+        # out-of-band (UPDATE from source) and the vault filter stays gated off
+        # (`vault_filter_enabled`) until the backfill completes.
+        await conn.execute(
+            f'ALTER TABLE "{self._schema}".chunks ADD COLUMN IF NOT EXISTS vault_id UUID'
+        )
+
         # Common indexes (both shapes).
         await conn.execute(
             f"""
             CREATE INDEX IF NOT EXISTS idx_vi_chunks_source_id
                 ON "{self._schema}".chunks (source_id)
+            """
+        )
+        await conn.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS idx_vi_chunks_vault_id
+                ON "{self._schema}".chunks (vault_id)
             """
         )
         # HNSW for dense KNN, partial on `WHERE dense IS NOT NULL` so
@@ -449,10 +467,12 @@ class PgvectorStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         await self.ensure_collection()
         cid = uuid.UUID(str(chunk_id))
         sid = uuid.UUID(str(source_id))
+        vid = uuid.UUID(str(vault_id))
         # `dense` goes through pgvector's binary codec — list[float]
         # straight into asyncpg's bind. No text literal, no `::vector`
         # cast needed. `None` (sparse-only fallback when the embed API
@@ -467,13 +487,14 @@ class PgvectorStore:
                     await c.execute(
                         f"""
                         INSERT INTO "{self._schema}".chunks
-                            (chunk_id, source_type, source_id, section_path,
+                            (chunk_id, source_type, source_id, vault_id, section_path,
                              content, chunk_index, dense,
                              sparse_terms, sparse_weights, indexed_at)
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
                         ON CONFLICT (chunk_id) DO UPDATE SET
                             source_type    = EXCLUDED.source_type,
                             source_id      = EXCLUDED.source_id,
+                            vault_id       = EXCLUDED.vault_id,
                             section_path   = EXCLUDED.section_path,
                             content        = EXCLUDED.content,
                             chunk_index    = EXCLUDED.chunk_index,
@@ -482,7 +503,7 @@ class PgvectorStore:
                             sparse_weights = EXCLUDED.sparse_weights,
                             indexed_at     = NOW()
                         """,
-                        cid, source_type, sid, section_path or "",
+                        cid, source_type, sid, vid, section_path or "",
                         content, int(chunk_index), dense_param,
                         list(sparse_indices), [float(v) for v in sparse_values],
                     )
@@ -490,19 +511,20 @@ class PgvectorStore:
                     await c.execute(
                         f"""
                         INSERT INTO "{self._schema}".chunks
-                            (chunk_id, source_type, source_id, section_path,
+                            (chunk_id, source_type, source_id, vault_id, section_path,
                              content, chunk_index, dense, indexed_at)
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
                         ON CONFLICT (chunk_id) DO UPDATE SET
                             source_type  = EXCLUDED.source_type,
                             source_id    = EXCLUDED.source_id,
+                            vault_id     = EXCLUDED.vault_id,
                             section_path = EXCLUDED.section_path,
                             content      = EXCLUDED.content,
                             chunk_index  = EXCLUDED.chunk_index,
                             dense        = EXCLUDED.dense,
                             indexed_at   = NOW()
                         """,
-                        cid, source_type, sid, section_path or "",
+                        cid, source_type, sid, vid, section_path or "",
                         content, int(chunk_index), dense_param,
                     )
                     # Replace posting rows for this chunk.
@@ -563,8 +585,13 @@ class PgvectorStore:
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         del query_text  # debug-only on this driver; keep signature parity
+        # vault_ids filtering is wired in Phase 2 increment B (vault-granularity
+        # ACL). Accepted now for contract parity; until then the caller still
+        # passes source_ids and this driver filters on that.
+        del vault_ids
         await self.ensure_collection()
 
         has_dense = query_dense is not None and len(query_dense) > 0

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -452,6 +452,17 @@ class PgvectorStore:
         except Exception:  # noqa: BLE001
             return False
 
+    async def vault_backfill_pending(self) -> int:
+        """How many points still have NULL `vault_id` (issue #189 Phase 2). The
+        vault filter (`vault_filter_enabled`) is only safe to enable once this is
+        0 — surfaced in /health so operators can tell when the backfill is done.
+        Cheap (indexed `vault_id` btree). Driver-specific (pgvector only)."""
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            return int(await conn.fetchval(
+                f'SELECT count(*) FROM "{self._schema}".chunks WHERE vault_id IS NULL'
+            ))
+
     # ── Upsert ────────────────────────────────────────────────────
 
     async def upsert_one(
@@ -588,10 +599,6 @@ class PgvectorStore:
         vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         del query_text  # debug-only on this driver; keep signature parity
-        # vault_ids filtering is wired in Phase 2 increment B (vault-granularity
-        # ACL). Accepted now for contract parity; until then the caller still
-        # passes source_ids and this driver filters on that.
-        del vault_ids
         await self.ensure_collection()
 
         has_dense = query_dense is not None and len(query_dense) > 0
@@ -599,8 +606,27 @@ class PgvectorStore:
         if not has_dense and not has_sparse:
             return []
 
-        src_uuids = [uuid.UUID(str(s)) for s in (source_ids or [])]
-        src_filter = src_uuids if src_uuids else None
+        # vault_ids (issue #189 Phase 2) vs source_ids: the caller sends EITHER
+        # the vault-granularity ACL filter OR the per-resource filter, never
+        # both. Both reduce to `<col> = ANY($N::uuid[])`, so we resolve a single
+        # (uuids, column) pair and pass the column name down — keeping each leg
+        # query single-branch (filter vs none) instead of duplicating it per
+        # column. `filter_col` is a fixed literal, never user input, so the
+        # f-string interpolation is as safe as the existing `self._schema` one.
+        # Defensive: the two filters are mutually exclusive by contract; if both
+        # ever arrive, vault_ids wins below — assert so a future caller bug is
+        # caught loudly instead of silently dropping the source filter.
+        assert not (vault_ids and source_ids), \
+            "hybrid_search got both vault_ids and source_ids; expected exactly one"
+        if vault_ids:
+            filter_uuids: list[uuid.UUID] | None = [uuid.UUID(str(s)) for s in vault_ids]
+            filter_col = "vault_id"
+        elif source_ids:
+            filter_uuids = [uuid.UUID(str(s)) for s in source_ids]
+            filter_col = "source_id"
+        else:
+            filter_uuids = None
+            filter_col = "source_id"  # unused when filter_uuids is None
         pool = await self._pool()
 
         async def _dense_leg() -> list[str]:
@@ -609,7 +635,8 @@ class PgvectorStore:
                 await self._ensure_codec(c)
                 return await self._search_dense(
                     c, query_dense=query_dense,
-                    src_uuids=src_filter, limit=prefetch_per_leg,
+                    filter_uuids=filter_uuids, filter_col=filter_col,
+                    limit=prefetch_per_leg,
                 )
 
         async def _sparse_leg() -> list[str]:
@@ -618,7 +645,8 @@ class PgvectorStore:
                 return await self._search_sparse(
                     c, terms=list(query_sparse_indices),
                     weights=list(query_sparse_values),
-                    src_uuids=src_filter, limit=prefetch_per_leg,
+                    filter_uuids=filter_uuids, filter_col=filter_col,
+                    limit=prefetch_per_leg,
                 )
 
         try:
@@ -666,23 +694,25 @@ class PgvectorStore:
         conn: asyncpg.Connection,
         *,
         query_dense: list[float],
-        src_uuids: list[uuid.UUID] | None,
+        filter_uuids: list[uuid.UUID] | None,
+        filter_col: str,
         limit: int,
     ) -> list[str]:
         # Binary codec → list[float] passes through directly.
         # `WHERE dense IS NOT NULL` mirrors the partial HNSW index above —
         # sparse-only points (embed API was down when they were indexed)
         # contribute only to the sparse leg, never to the dense KNN.
-        if src_uuids:
+        # `filter_col` is "source_id" or "vault_id" (literal — see hybrid_search).
+        if filter_uuids:
             rows = await conn.fetch(
                 f"""
                 SELECT chunk_id::text AS chunk_id
                 FROM "{self._schema}".chunks
-                WHERE source_id = ANY($2::uuid[]) AND dense IS NOT NULL
+                WHERE {filter_col} = ANY($2::uuid[]) AND dense IS NOT NULL
                 ORDER BY dense <=> $1
                 LIMIT $3
                 """,
-                list(query_dense), src_uuids, int(limit),
+                list(query_dense), filter_uuids, int(limit),
             )
         else:
             rows = await conn.fetch(
@@ -703,17 +733,19 @@ class PgvectorStore:
         *,
         terms: list[int],
         weights: list[float],
-        src_uuids: list[uuid.UUID] | None,
+        filter_uuids: list[uuid.UUID] | None,
+        filter_col: str,
         limit: int,
     ) -> list[str]:
         if not terms:
             return []
 
         if self._sparse_shape == "arrays":
-            # Two query branches (with/without source filter) keep the
-            # planner honest — a single SQL with `WHERE $3 IS NULL OR
-            # source_id = ANY($3)` confuses ANY-cardinality estimation.
-            if src_uuids:
+            # Two query branches (with/without filter) keep the planner honest —
+            # a single SQL with `WHERE $3 IS NULL OR <col> = ANY($3)` confuses
+            # ANY-cardinality estimation. `filter_col` is "source_id"/"vault_id"
+            # (literal — see hybrid_search), so the interpolation is safe.
+            if filter_uuids:
                 sql = f"""
                     WITH q AS (
                       SELECT unnest($1::bigint[]) AS tid,
@@ -722,7 +754,7 @@ class PgvectorStore:
                     cand AS (
                       SELECT chunk_id, sparse_terms, sparse_weights
                       FROM "{self._schema}".chunks
-                      WHERE source_id = ANY($3::uuid[])
+                      WHERE {filter_col} = ANY($3::uuid[])
                     )
                     SELECT c.chunk_id::text AS chunk_id,
                            SUM(q.w * t.weight) AS score
@@ -736,7 +768,7 @@ class PgvectorStore:
                 """
                 rows = await conn.fetch(
                     sql, list(terms), [float(w) for w in weights],
-                    src_uuids, int(limit),
+                    filter_uuids, int(limit),
                 )
             else:
                 sql = f"""
@@ -758,7 +790,7 @@ class PgvectorStore:
                     sql, list(terms), [float(w) for w in weights], int(limit),
                 )
         else:  # posting
-            if src_uuids:
+            if filter_uuids:
                 sql = f"""
                     WITH q AS (
                       SELECT unnest($1::bigint[]) AS tid,
@@ -769,14 +801,14 @@ class PgvectorStore:
                     FROM "{self._schema}".posting p
                     JOIN q ON q.tid = p.term_id
                     JOIN "{self._schema}".chunks c ON c.chunk_id = p.chunk_id
-                    WHERE c.source_id = ANY($3::uuid[])
+                    WHERE c.{filter_col} = ANY($3::uuid[])
                     GROUP BY p.chunk_id
                     ORDER BY score DESC
                     LIMIT $4
                 """
                 rows = await conn.fetch(
                     sql, list(terms), [float(w) for w in weights],
-                    src_uuids, int(limit),
+                    filter_uuids, int(limit),
                 )
             else:
                 sql = f"""

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -127,6 +127,7 @@ class QdrantStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         del conn  # external service; can't share PG transaction
         await self.ensure_collection()
@@ -192,6 +193,7 @@ class QdrantStore:
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         await self.ensure_collection()
         client = self._get_client()

--- a/backend/app/services/vector_store/seahorse_cloud.py
+++ b/backend/app/services/vector_store/seahorse_cloud.py
@@ -286,6 +286,7 @@ class SeahorseCloudStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         del conn
         await self.ensure_collection()
@@ -366,6 +367,7 @@ class SeahorseCloudStore:
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         # Seahorse runs its own RRF prefetch internally; the caller's
         # prefetch_per_leg hint isn't surfaced as an API knob.

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -216,6 +216,7 @@ class SeahorseDbStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         """Insert a single record into the AKB-shaped Coral table.
 
@@ -428,6 +429,7 @@ class SeahorseDbStore:
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         """Coral's hybrid search takes:
 

--- a/backend/app/services/vector_store/seahorse_db_grpc.py
+++ b/backend/app/services/vector_store/seahorse_db_grpc.py
@@ -278,6 +278,7 @@ class SeahorseDbGrpcStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> None:
         """Single-record insert. JSONL bytes carried over
         ``IngestService.InsertJsonl`` — identical to the REST
@@ -361,6 +362,7 @@ class SeahorseDbGrpcStore:
         source_ids: list[str] | None,
         limit: int,
         prefetch_per_leg: int,
+        vault_ids: list[str] | None = None,
     ) -> list[VectorHit]:
         """Server-streaming search. Each ``ResultStreamEvent`` carries
         one of ``header`` / ``chunk`` / ``result_set_boundary`` /

--- a/backend/scripts/backfill_vault_id.py
+++ b/backend/scripts/backfill_vault_id.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Backfill `vault_id` onto existing pgvector points (issue #189 Phase 2).
+
+Increment A added a `vault_id` column to the vector index (`vector_index.chunks`)
+and made the indexing path write it for NEW points. Points indexed BEFORE that
+have `vault_id = NULL`. This script populates them — a metadata-only update
+(NOT a re-embed): `vault_id` is derived from the already-stored `source_id`
+(documents / vault_tables / vault_files all carry vault_id), and the embeddings
+are untouched.
+
+Run this ONCE after deploying increment A and BEFORE flipping
+`vault_filter_enabled` to True. While any point is still NULL the vault filter
+would silently drop it (NULL never matches `= ANY(...)`), which is exactly why
+the flag must stay off until `--check` reports 0.
+
+Idempotent: only rows with `vault_id IS NULL` are touched, so re-running (or
+resuming after an interrupted run) is safe.
+
+Two deployment shapes:
+  - same-instance (`vector_store_dsn` blank): the vector index lives in the main
+    DB, so the backfill is a single SERVER-SIDE `UPDATE ... FROM (join)` — zero
+    client memory, one transaction.
+  - separate-instance: the source→vault map is STREAMED from MAIN via a
+    server-side cursor and applied to the VECTOR pool in transactional batches,
+    so neither side loads the whole corpus into memory.
+
+Usage:
+    python -m scripts.backfill_vault_id            # backfill
+    python -m scripts.backfill_vault_id --check    # report NULL count only
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.config import settings
+from app.db.postgres import get_pool, init_db, close_pool
+from app.services.vector_store import get_vector_store
+from app.services.vector_store.pgvector import PgvectorStore
+
+_BATCH = 5000
+
+# Pulled once; small + static SQL, interpolated only with the configured schema.
+_SOURCE_MAP_SQL = """
+    SELECT id::text AS sid, vault_id::text AS vid FROM documents
+    UNION ALL SELECT id::text, vault_id::text FROM vault_tables
+    UNION ALL SELECT id::text, vault_id::text FROM vault_files
+"""
+
+
+async def _vector_pool():
+    store = get_vector_store()
+    if not isinstance(store, PgvectorStore):
+        raise SystemExit(
+            f"driver '{settings.vector_store_driver}' has no SQL vault_id column; "
+            "this backfill is pgvector-only."
+        )
+    return await store._pool()
+
+
+async def _null_count(schema: str) -> int:
+    vpool = await _vector_pool()
+    async with vpool.acquire() as c:
+        return int(await c.fetchval(
+            f'SELECT count(*) FROM "{schema}".chunks WHERE vault_id IS NULL'
+        ))
+
+
+async def _apply_batch(vpool, schema: str, batch: list[tuple[str, str]]) -> int:
+    sids = [uuid.UUID(s) for s, _ in batch]
+    vids = [uuid.UUID(v) for _, v in batch]
+    async with vpool.acquire() as vc:
+        async with vc.transaction():
+            res = await vc.execute(
+                f"""
+                UPDATE "{schema}".chunks vi
+                SET vault_id = m.vid
+                FROM (SELECT unnest($1::uuid[]) AS sid,
+                             unnest($2::uuid[]) AS vid) m
+                WHERE vi.source_id = m.sid AND vi.vault_id IS NULL
+                """,
+                sids, vids,
+            )
+    return int(res.split()[-1]) if res.startswith("UPDATE") else 0
+
+
+async def _backfill_same_instance(schema: str) -> int:
+    """Server-side join UPDATE — the vector index is in the main DB, so no rows
+    cross into Python. Single transaction; idempotent on `vault_id IS NULL`."""
+    pool = await get_pool()
+    async with pool.acquire() as c:
+        async with c.transaction():
+            res = await c.execute(
+                f"""
+                UPDATE "{schema}".chunks vi
+                SET vault_id = src.vault_id
+                FROM (
+                  SELECT id, vault_id FROM documents
+                  UNION ALL SELECT id, vault_id FROM vault_tables
+                  UNION ALL SELECT id, vault_id FROM vault_files
+                ) src
+                WHERE vi.source_id = src.id AND vi.vault_id IS NULL
+                """
+            )
+    return int(res.split()[-1]) if res.startswith("UPDATE") else 0
+
+
+async def _backfill_separate(schema: str) -> int:
+    """Separate vector instance: stream the source→vault map from MAIN via a
+    server-side cursor and apply it to the vector pool in transactional batches.
+    Bounded memory on both sides."""
+    main = await get_pool()
+    vpool = await _vector_pool()
+    updated = 0
+    async with main.acquire() as mc:
+        async with mc.transaction():  # asyncpg cursors require a transaction
+            batch: list[tuple[str, str]] = []
+            async for r in mc.cursor(_SOURCE_MAP_SQL, prefetch=_BATCH):
+                batch.append((r["sid"], r["vid"]))
+                if len(batch) >= _BATCH:
+                    updated += await _apply_batch(vpool, schema, batch)
+                    batch = []
+            if batch:
+                updated += await _apply_batch(vpool, schema, batch)
+    return updated
+
+
+async def _log_orphans(schema: str) -> None:
+    """When points remain NULL, surface a sample of the offending source_ids so
+    an operator can investigate (stale vector rows whose source row was deleted),
+    rather than only a count."""
+    vpool = await _vector_pool()
+    async with vpool.acquire() as c:
+        rows = await c.fetch(
+            f"""
+            SELECT DISTINCT source_id::text AS sid
+            FROM "{schema}".chunks WHERE vault_id IS NULL LIMIT 20
+            """
+        )
+    if rows:
+        print("  orphan source_id sample (up to 20): "
+              + ", ".join(r["sid"] for r in rows))
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description="Backfill vault_id on pgvector points (#189 Phase 2).")
+    ap.add_argument("--check", action="store_true",
+                    help="report how many points still have NULL vault_id, then exit")
+    args = ap.parse_args()
+
+    await init_db()
+    schema = settings.vector_store_schema
+    try:
+        if args.check:
+            n = await _null_count(schema)
+            print(f"{n} point(s) with vault_id IS NULL in {schema}.chunks")
+            return
+
+        same_instance = not settings.vector_store_dsn.strip()
+        if same_instance:
+            updated = await _backfill_same_instance(schema)
+        else:
+            updated = await _backfill_separate(schema)
+        remaining = await _null_count(schema)
+
+        if remaining == 0:
+            print(f"backfilled {updated} point(s); 0 still NULL "
+                  "(OK — safe to flip vault_filter_enabled).")
+        else:
+            print(f"backfilled {updated} point(s); {remaining} still NULL — "
+                  "these are orphans (source_id not in any resource table). "
+                  "Do NOT flip vault_filter_enabled until 0.")
+            await _log_orphans(schema)
+    finally:
+        await close_pool()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/migrate_pgvector_to_seahorsedb.py
+++ b/backend/scripts/migrate_pgvector_to_seahorsedb.py
@@ -128,6 +128,7 @@ async def _iter_chunks(
                c.chunk_index    AS chunk_index,
                c.source_type    AS source_type,
                c.source_id::text AS source_id,
+               c.vault_id::text  AS vault_id,
                vi.dense         AS dense
           FROM chunks c
           JOIN vaults v ON v.id = c.vault_id
@@ -297,6 +298,7 @@ async def migrate(
                 sparse_values=sparse_values,
                 source_type=row["source_type"] or "document",
                 source_id=row["source_id"],
+                vault_id=row["vault_id"],
             ))
 
         if not batch_payload:
@@ -351,6 +353,7 @@ async def migrate(
                         sparse_values=c.sparse_values,
                         source_type=c.source_type,
                         source_id=c.source_id,
+                        vault_id=c.vault_id,
                     )
                     per_row_ok += 1
                 except Exception as ee:  # noqa: BLE001

--- a/backend/tests/test_pgvector_driver_e2e.sh
+++ b/backend/tests/test_pgvector_driver_e2e.sh
@@ -131,7 +131,7 @@ R=$(run_test "    cid = uuid.uuid4()
         chunk_id=str(cid), content='hello world', section_path='',
         chunk_index=0, dense=[0.1]*8,
         sparse_indices=[10, 20, 30], sparse_values=[1.0, 0.5, 0.25],
-        source_type='document', source_id=str(sid),
+        source_type='document', source_id=str(sid), vault_id=str(sid),
     )
     pool = await s._pool()
     async with pool.acquire() as c:
@@ -154,14 +154,14 @@ R=$(run_test "    sid = uuid.uuid4()
             chunk_id=str(c), content=f'doc {i}', section_path='', chunk_index=i,
             dense=[1.0 - i*0.1] * 8,
             sparse_indices=[100 + i], sparse_values=[float(i+1)],
-            source_type='document', source_id=str(sid),
+            source_type='document', source_id=str(sid), vault_id=str(sid),
         )
     # Distractor in another source.
     distractor = uuid.uuid4()
     await s.upsert_one(
         chunk_id=str(distractor), content='wrong vault', section_path='', chunk_index=0,
         dense=[0.9]*8, sparse_indices=[100], sparse_values=[5.0],
-        source_type='document', source_id=str(sid_other),
+        source_type='document', source_id=str(sid_other), vault_id=str(sid_other),
     )
     # Dense-only
     dense_hits = await s.hybrid_search(
@@ -206,7 +206,7 @@ R=$(run_test "    cid = uuid.uuid4()
     await s.upsert_one(
         chunk_id=str(cid), content='to-delete', section_path='', chunk_index=0,
         dense=[0.1]*8, sparse_indices=[1, 2], sparse_values=[0.5, 0.5],
-        source_type='document', source_id=str(sid),
+        source_type='document', source_id=str(sid), vault_id=str(sid),
     )
     await s.delete_point(str(cid))
     pool = await s._pool()
@@ -227,7 +227,7 @@ R=$(run_test "    cid = uuid.uuid4()
     await s.upsert_one(
         chunk_id=str(cid), content='codec', section_path='', chunk_index=0,
         dense=src_dense, sparse_indices=[], sparse_values=[],
-        source_type='document', source_id=str(sid),
+        source_type='document', source_id=str(sid), vault_id=str(sid),
     )
     pool = await s._pool()
     async with pool.acquire() as c:

--- a/backend/tests/test_seahorse_db_grpc_unit.py
+++ b/backend/tests/test_seahorse_db_grpc_unit.py
@@ -414,6 +414,7 @@ async def test_upsert_one_jsonl_record_shape(
         sparse_values=[1.0, 0.5, 0.25],
         source_type="document",
         source_id="11111111-2222-3333-4444-555555555555",
+        vault_id="99999999-8888-7777-6666-555555555555",
     )
 
     args = stub.InsertJsonl.await_args.args[0]

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -9,6 +9,7 @@ from app.services.search_service import (
     clamp_search_limit,
     fuse_original_and_reranked_hits,
     resolve_first_stage_unique_limit,
+    vault_path_eligible,
 )
 
 FUSION_K = 60
@@ -119,6 +120,65 @@ def test_search_response_degraded_defaults_false():
     r = SearchResponse(query="x", total=0, returned=0, total_matches=0, results=[])
     assert r.degraded is False
     assert r.degradation_reason is None
+
+
+def test_vault_path_eligible(monkeypatch):
+    """The VAULT path (issue #189 Phase 2) is taken ONLY with the flag on, the
+    pgvector driver, and NO doc-level filter; otherwise the source_ids path
+    (flag-off parity = byte-identical to before)."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "vector_store_driver", "pgvector", raising=False)
+
+    def call(**kw):
+        base = {"collection": None, "doc_type": None, "tags": None, "source_uris": None}
+        base.update(kw)
+        return vault_path_eligible(**base)
+
+    assert call() is True  # flag + pgvector + no filters → vault path
+    assert call(collection="specs") is False  # any doc-level filter → source path
+    assert call(doc_type="note") is False
+    assert call(tags=["x"]) is False
+    assert call(source_uris=["akb://v/doc/x"]) is False
+
+    # flag off → never (parity with pre-Phase-2 behavior)
+    monkeypatch.setattr(settings, "vault_filter_enabled", False, raising=False)
+    assert call() is False
+
+    # other driver → never (only pgvector stores vault_id)
+    monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "vector_store_driver", "qdrant", raising=False)
+    assert call() is False
+
+
+@pytest.mark.asyncio
+async def test_run_vector_search_forwards_vault_ids_to_driver(monkeypatch):
+    """The VAULT path threads candidate_vault_ids into the driver's hybrid_search
+    (and leaves source_ids None), so pgvector can filter by vault instead of an
+    enumerated source-id list."""
+    import app.services.search_service as ss
+
+    svc = ss.SearchService()
+    captured = {}
+
+    async def encode_ok(_q):
+        return [1], [1.0]
+
+    class _Store:
+        async def hybrid_search(self, **kw):
+            captured.update(kw)
+            return []
+
+    monkeypatch.setattr(ss.sparse_encoder, "encode_query", encode_ok)
+    monkeypatch.setattr(ss, "get_vector_store", lambda: _Store())
+
+    await svc._run_vector_search(
+        query_text="q", query_embedding=[0.1, 0.2],
+        candidate_source_ids=None, candidate_vault_ids=["v1", "v2"], limit=10,
+    )
+    assert captured["vault_ids"] == ["v1", "v2"]
+    assert captured["source_ids"] is None
 
 
 @pytest.mark.asyncio

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -71,6 +71,15 @@ search_prefetch: 0
 # non-validating client could otherwise pass an arbitrary limit that propagates
 # into the vector-store prefetch (issue #189). Clamped at the service entry.
 search_limit_max: 50
+# Push the ACL filter down to VAULT granularity in the vector store (issue #189
+# Phase 2). When true AND the driver is pgvector AND a search has no doc-level
+# filter, search filters by the user's accessible vault ids (small set) instead
+# of every accessible source id (O(corpus)). KEEP false until the vector index's
+# vault_id column is fully backfilled — run, to completion:
+#     python -m scripts.backfill_vault_id            # then --check reports 0
+# Until then the column is partly NULL and the filter would silently drop those
+# points. While false the behavior is identical to before.
+vault_filter_enabled: false
 
 # === S3-compatible object storage (for vault file uploads) ===
 # Leave endpoints blank to disable file storage features.


### PR DESCRIPTION
Stacked on #206 (Phase 1). Implements **#189 Phase 2** for the **pgvector** driver: push the ACL filter down to **vault granularity** so search filters by the user's accessible vault ids (a small set) instead of enumerating every accessible `source_id` (**O(corpus)**). ACL in AKB is purely per-vault, so this is correctness-equivalent. Backed by the 5-slice mapping + 4-dimension adversarial review workflows.

## Two increments
**A — store side (behavior-preserving):** `vault_id` on every vector point. Contract (`ChunkUpsert.vault_id`, `hybrid_search(vault_ids=…)`), pgvector column + idempotent `ALTER` + index + upsert, `embed_worker` passes it, other drivers accept+ignore. Search unchanged.

**B — activation (gated):**
- pgvector `hybrid_search` filters by `vault_id` when `vault_ids` is set (a single `filter_col` literal keeps `_search_dense`/`_search_sparse` single-branch); defensive assert the two filters are mutually exclusive.
- `search_service`: `vault_path_eligible()` (flag + pgvector + no doc-level filter) picks the VAULT path; `_accessible_vault_ids()` uses the **same** owner/grant/public predicate as `_vault_acl` (pure perf change). Source path untouched otherwise.
- `vault_filter_enabled` config flag (default **False**, documented). Safe rollout: deploy A → backfill → flip.
- `scripts/backfill_vault_id.py`: metadata-only (NOT a re-embed). Same-instance = one server-side `UPDATE…FROM(join)`; separate-instance = cursor-streamed transactional batches; orphans logged; idempotent.
- `/health` exposes `vault_id_null_count` → 0 means safe to flip.

## Verified (local docker)
- **driver**: `vault=[A]`→only A, `source=[B]`→only B, no-filter→both.
- **service**: flag ON `vault=vfa`→only vfa, no-vault→vfa+vfb, **ON == OFF parity**.
- **backfill**: 1498 existing points → 0 NULL, 0 mismatch vs source, idempotent re-run.
- **schema**: idempotent `ALTER`+index; new docs auto-populate `vault_id`.
- `/health vault_id_null_count: 0`.

## Review
Adversarial 4-dim review: **core ACL / SQL / two-path = 0 real bugs** (validates the deterministic tests); 9 backfill/ops findings **all addressed** (per-batch tx, `isinstance`, cursor streaming, orphan logging, example-config docs, `/health` signal, defensive assert). Backend unit suite green (182 passed); new unit tests for `vault_path_eligible` + vault_ids forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)