### PR TITLE
feat(search): zero-touch vault_id auto-backfill (#189 Phase 2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2619
+        "line_number": 2697
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-11T10:05:58Z"
+  "generated_at": "2026-06-16T09:48:46Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,32 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.13 — 2026-06-16  *(patch — search: zero-touch Phase 2 + retrieval fixes)*
+
+Follow-ups that make the 0.8.12 search work correct and operator-free at scale.
+
+**Zero-touch vault filter (#189 Phase 2 follow-up, #214):** the
+`vault_filter_enabled` optimization no longer needs a manual
+`scripts/backfill_vault_id.py` run or a hand-flipped flag. A `vault_backfill`
+worker started in `lifespan` backfills `vault_id` onto pre-upgrade pgvector
+points on startup (idempotent batches; same-instance via a server-side join),
+and search self-activates the vault path only once it reports ready — until then
+it transparently uses the source-id path (no under-fetch). The flag now defaults
+**on**; the readiness gate makes that safe, and an explicit `false` still opts
+out. Separate-instance pgvector gates readiness on the driver's NULL count
+(== the script's "0 before flip" contract) instead of auto-filling. `/health`
+gains `vector_store.vault_backfill {ready, applicable, null_remaining}`.
+
+**HNSW under-fetch fix (#212):** filtered dense search now sets
+`hnsw.iterative_scan = relaxed_order` + a larger `ef_search` inside the query
+transaction, so a selective vault/source filter no longer post-filters a fixed
+global top-`ef_search` down to a handful of rows (a selective query that
+returned 1 hit now returns the full set).
+
+**Web search UX (#213):** the results page requests a higher limit (25) and
+replaces the alarming "Truncated" warning with a calm informational note —
+semantic search returns the top matches, not an exhaustive count.
+
 ## 0.8.12 — 2026-06-16  *(minor — search: scale + safety (issue #189))*
 
 Make `akb_search` scale and fail honestly at corpus scale.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -139,12 +139,15 @@ class Settings(BaseModel):
     # #189 Phase 2). When True AND the driver is pgvector AND a search has no
     # doc-level filter (collection/doc_type/tags/source_uris), search filters by
     # the user's accessible vault ids (a small set) instead of materializing
-    # every accessible source id (O(corpus)). OFF by default: flip to True only
-    # AFTER the vector index's `vault_id` column is fully backfilled
-    # (scripts/backfill_vault_id.py) — until then the column is partly NULL and
-    # the filter would miss un-backfilled points. While False the behavior is
-    # byte-identical to before (the source_ids path).
-    vault_filter_enabled: bool = False
+    # every accessible source id (O(corpus)). Correctness-equivalent to the
+    # source-id path (AKB's ACL is purely per-vault).
+    #
+    # Safe to leave ON: search self-gates on `vault_backfill.is_ready()`, so the
+    # vault path only activates once every pre-upgrade point has its `vault_id`
+    # (the auto-backfill worker fills them on startup). Until then search
+    # transparently uses the source-id path — no under-fetch. Set False to opt
+    # out of the optimization entirely (byte-identical legacy behavior).
+    vault_filter_enabled: bool = True
 
     # S3-compatible object storage (for vault files)
     s3_endpoint_url: str = ""       # Internal endpoint (server → S3)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -178,21 +178,21 @@ async def health():
     `vector_store.backfill` and `embed_backfill` is gone — they were
     reporting the same `chunks.vector_indexed_at IS NULL` count.
     """
-    from app.services import sparse_encoder
+    from app.services import sparse_encoder, vault_backfill
     store = get_vector_store()
     vs_info: dict = {"reachable": await store.health()}
     try:
         vs_info["backfill"] = await embed_worker.pending_stats()
     except Exception as e:  # noqa: BLE001
         vs_info["backfill_error"] = str(e)
-    # vault_id backfill progress (issue #189 Phase 2): operators must see this
-    # reach 0 before flipping `vault_filter_enabled`. pgvector-only.
-    vault_backfill = getattr(store, "vault_backfill_pending", None)
-    if vault_backfill is not None:
-        try:
-            vs_info["vault_id_null_count"] = await vault_backfill()
-        except Exception as e:  # noqa: BLE001
-            vs_info["vault_id_null_count_error"] = str(e)
+    # vault_id auto-backfill progress (issue #189 Phase 2). `ready` flips True
+    # once every live-source point has its vault_id, which is when search
+    # activates the vault-filter path; `null_remaining` includes orphans (which
+    # never block readiness). pgvector same-instance only — else applicable=False.
+    try:
+        vs_info["vault_backfill"] = await vault_backfill.pending_stats()
+    except Exception as e:  # noqa: BLE001
+        vs_info["vault_backfill_error"] = str(e)
     try:
         vs_info["bm25"] = await sparse_encoder.stats_snapshot()
     except Exception as e:  # noqa: BLE001

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -10,7 +10,7 @@ import logging
 
 from app.config import settings
 from app.db.postgres import close_pool, get_pool, init_db
-from app.services import audit_log, delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker, sparse_encoder
+from app.services import audit_log, delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker, sparse_encoder, vault_backfill
 from app.services.git_service import GitService
 from app.services.role_sync import RoleSync, get_role_sync, set_role_sync
 from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
@@ -104,13 +104,18 @@ def start_workers() -> None:
     embed_worker.start()
     delete_worker.start()
     external_git_poller.start()
+    # Auto-backfill vault_id onto pre-upgrade pgvector points (issue #189
+    # Phase 2). Non-blocking; search self-activates the vault path once it
+    # reports ready (until then the source-id path runs unchanged). No-op for
+    # other drivers / separate-instance / fully-backfilled corpora.
+    vault_backfill.start()
     # BM25 corpus stats (total_docs, avgdl, per-term df) only become
     # non-degenerate after `recompute_stats()` runs. The refresher fires
     # once at startup and then on a configurable cadence so the sparse
     # leg of hybrid search isn't silently degraded on fresh installs or
     # after long periods without manual init.
     sparse_encoder.start_stats_refresher(settings.bm25_recompute_interval_secs)
-    started = ["embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher"]
+    started = ["embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher", "vault_backfill"]
     # s3_delete_worker drains s3_delete_outbox into S3 deletes. Only
     # makes sense when S3 is configured; otherwise file uploads are
     # disabled altogether and the outbox stays empty forever.
@@ -169,6 +174,7 @@ async def stop_workers() -> None:
     await s3_delete_worker.stop()
     await delete_worker.stop()
     await embed_worker.stop()
+    await vault_backfill.stop()
     await sparse_encoder.stop_stats_refresher()
 
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -205,9 +205,13 @@ class SearchService:
         # AKB is purely per-vault, so this is correctness-equivalent. Otherwise
         # the existing SOURCE_IDS path runs UNCHANGED (flag off / other driver /
         # any doc-level filter present).
+        # `is_ready()` additionally gates on the auto-backfill: until every
+        # pre-upgrade pgvector point carries its vault_id, fall back to the
+        # source-id path so a user can't miss their own un-backfilled docs.
+        from app.services import vault_backfill
         use_vault_path = vault_path_eligible(
             collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
-        )
+        ) and vault_backfill.is_ready()
 
         if use_vault_path:
             async with pool.acquire() as conn:

--- a/backend/app/services/vault_backfill.py
+++ b/backend/app/services/vault_backfill.py
@@ -1,0 +1,154 @@
+"""Automatic `vault_id` backfill (issue #189 Phase 2).
+
+Increment A added a `vault_id` column to the pgvector index and writes it for
+NEW points; points indexed before the upgrade have `vault_id = NULL`. The vault
+filter (`vault_filter_enabled`) is only correct once every LIVE-source point has
+its `vault_id`, otherwise a user could miss their own un-backfilled docs.
+
+Rather than make every operator run `scripts/backfill_vault_id.py` and flip a
+flag by hand, this background worker backfills the column automatically on
+startup (non-blocking, in bounded batches), and search self-activates the vault
+path only once it reports ready — until then it transparently uses the existing
+source-id path (no behavior change, no under-fetch). Zero-touch upgrade.
+
+Scope: pgvector in same-instance mode (the vector index lives in the main DB, so
+the backfill is a server-side join). For a SEPARATE vector instance or any other
+driver this worker is a no-op — those run `scripts/backfill_vault_id.py` by hand
+(rare; only pgvector implements the vault filter today).
+
+Readiness = "no LIVE-source point is missing vault_id". Orphan points (whose
+source row was deleted) keep `vault_id` NULL forever but are excluded by BOTH the
+vault and source paths, so they do NOT block readiness.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.services._backfill import BackfillRunner
+from app.services.vector_store import get_vector_store
+
+logger = logging.getLogger("akb.vault_backfill")
+
+_BATCH = 5000
+# Set once all live-source points carry vault_id. Increment A guarantees no NEW
+# nulls appear, so once True it stays True for the life of the process.
+_ready = False
+
+
+def is_ready() -> bool:
+    """True when the vault filter is safe to use (all live-source points have
+    vault_id). Read on the search hot path — must stay a cheap memory read."""
+    return _ready
+
+
+def _is_pgvector() -> bool:
+    return settings.vector_store_driver == "pgvector"
+
+
+def _same_instance() -> bool:
+    # The auto-join backfill needs the index to share the main DB
+    # (same-instance: vector_store_dsn blank).
+    return not settings.vector_store_dsn.strip()
+
+
+def _applicable() -> bool:
+    # True only where this worker can AUTO-backfill (same-instance pgvector). A
+    # separate vector instance is still gated for readiness below — it just isn't
+    # auto-filled here (the operator runs scripts/backfill_vault_id.py).
+    return _is_pgvector() and _same_instance()
+
+
+async def _process_once() -> int:
+    """One backfill step for the BackfillRunner. Returns rows updated; 0 makes
+    the runner idle. Flips `_ready` when the vault path is safe to use."""
+    global _ready
+    if _ready:
+        return 0
+
+    # Non-pgvector drivers have no vault_id column and `vault_path_eligible` is
+    # already False for them — the vault path is never taken, so readiness is
+    # moot. Latch ready so the worker stops looping instead of spinning forever.
+    if not _is_pgvector():
+        _ready = True
+        return 0
+
+    # Separate pgvector instance: we can't run the server-side join (the index
+    # lives in another DB), so we DON'T auto-backfill — the operator runs
+    # scripts/backfill_vault_id.py. But we still gate: readiness = the vector
+    # instance reports 0 NULL vault_id (exactly the manual script's
+    # "0 before flip" contract, orphans included). Until then the source-id path
+    # runs. This preserves the pre-auto-backfill escape hatch without the old
+    # under-fetch foot-gun (activating the flag before the backfill finished).
+    if not _same_instance():
+        fn = getattr(get_vector_store(), "vault_backfill_pending", None)
+        if fn is not None and await fn() == 0:
+            _ready = True
+            logger.info("vault_id backfill complete (separate instance) — vault filter path is now active")
+        return 0
+
+    schema = settings.vector_store_schema
+    pool = await get_pool()
+    async with pool.acquire() as c:
+        # Cheap EXISTS (stops at the first hit): is any LIVE-source point still
+        # missing vault_id? Orphans (no live source) are ignored — they never
+        # match and are excluded by both search paths anyway.
+        more = await c.fetchval(
+            f"""
+            SELECT EXISTS(
+              SELECT 1 FROM "{schema}".chunks vi
+              WHERE vi.vault_id IS NULL AND (
+                EXISTS(SELECT 1 FROM documents d   WHERE d.id = vi.source_id)
+                OR EXISTS(SELECT 1 FROM vault_tables t WHERE t.id = vi.source_id)
+                OR EXISTS(SELECT 1 FROM vault_files  f WHERE f.id = vi.source_id)))
+            """
+        )
+        if not more:
+            _ready = True
+            logger.info("vault_id backfill complete — vault filter path is now active")
+            return 0
+
+        async with c.transaction():
+            res = await c.execute(
+                f"""
+                WITH batch AS (
+                  SELECT vi.chunk_id, src.vault_id AS vid
+                  FROM "{schema}".chunks vi
+                  JOIN (
+                    SELECT id, vault_id FROM documents
+                    UNION ALL SELECT id, vault_id FROM vault_tables
+                    UNION ALL SELECT id, vault_id FROM vault_files
+                  ) src ON src.id = vi.source_id
+                  WHERE vi.vault_id IS NULL
+                  LIMIT {_BATCH}
+                )
+                UPDATE "{schema}".chunks vi
+                SET vault_id = batch.vid
+                FROM batch
+                WHERE vi.chunk_id = batch.chunk_id
+                """
+            )
+    return int(res.split()[-1]) if res.startswith("UPDATE") else 0
+
+
+# Idle cadence is generous: during the one-time backfill `_process_once` returns
+# >0 and the runner loops immediately (drains fast); once ready it returns 0 and
+# the runner sleeps. concurrency=1 — the batch UPDATE is idempotent on NULL, so a
+# rolling-deploy overlap is harmless.
+_runner = BackfillRunner("vault_backfill", _process_once, idle_secs=60)
+start = _runner.start
+stop = _runner.stop
+
+
+async def pending_stats() -> dict:
+    """For /health: readiness + remaining NULL count (the safe-to-activate
+    signal). null_remaining includes orphans; readiness ignores them."""
+    out: dict = {"ready": is_ready(), "applicable": _applicable()}
+    fn = getattr(get_vector_store(), "vault_backfill_pending", None)
+    if fn is not None:
+        try:
+            out["null_remaining"] = await fn()
+        except Exception as e:  # noqa: BLE001
+            out["null_remaining_error"] = str(e)
+    return out

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.12"
+version = "0.8.13"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/bench/sparse_shape_bench.py
+++ b/backend/tests/bench/sparse_shape_bench.py
@@ -156,6 +156,7 @@ async def populate_store(store: PgvectorStore, corpus: list[dict]) -> None:
             sparse_values=row["sparse_values"],
             source_type=row["source_type"],
             source_id=row["source_id"],
+            vault_id=row.get("vault_id", row["source_id"]),
         )
     dt = time.perf_counter() - t0
     print(

--- a/backend/tests/test_pgvector_ext_bootstrap_e2e.py
+++ b/backend/tests/test_pgvector_ext_bootstrap_e2e.py
@@ -174,6 +174,7 @@ async def test_ensure_collection_bootstraps_extension_own_pool(fresh_db_dsn):
         sparse_values=[1.0, 0.5],
         source_type="document",
         source_id=source_id,
+        vault_id=str(uuid.uuid4()),
     )
     hits = await store.hybrid_search(
         query_text="cpu spike",

--- a/backend/tests/test_seahorse_db_grpc_unit.py
+++ b/backend/tests/test_seahorse_db_grpc_unit.py
@@ -455,6 +455,7 @@ async def test_upsert_one_dense_none_raises(
             sparse_indices=[], sparse_values=[],
             source_type="document",
             source_id="11111111-2222-3333-4444-555555555555",
+            vault_id="99999999-8888-7777-6666-555555555555",
         )
     stub.InsertJsonl.assert_not_called()
 

--- a/backend/tests/test_vault_backfill.py
+++ b/backend/tests/test_vault_backfill.py
@@ -1,0 +1,130 @@
+"""Unit coverage for the auto vault_id backfill worker (issue #189 Phase 2).
+
+The worker's job is to make the vault-filter path zero-touch: it backfills
+`vault_id` onto pre-upgrade pgvector points on startup, and search reads
+`is_ready()` to decide whether the vault path is safe yet. These tests lock the
+contract that gates that decision — the DB-backed `_process_once` join is
+exercised end-to-end in the e2e suite, not here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services import vault_backfill
+
+
+@pytest.fixture(autouse=True)
+def _reset_ready(monkeypatch):
+    # `_ready` is module state that latches True for the process; isolate each test.
+    monkeypatch.setattr(vault_backfill, "_ready", False, raising=False)
+
+
+def test_is_ready_defaults_false_and_reflects_module_state(monkeypatch):
+    assert vault_backfill.is_ready() is False
+    monkeypatch.setattr(vault_backfill, "_ready", True, raising=False)
+    assert vault_backfill.is_ready() is True
+
+
+def test_applicable_only_for_pgvector_same_instance(monkeypatch):
+    from app.config import settings
+
+    # pgvector + blank dsn (index shares the main DB) → the auto-join backfill runs.
+    monkeypatch.setattr(settings, "vector_store_driver", "pgvector", raising=False)
+    monkeypatch.setattr(settings, "vector_store_dsn", "", raising=False)
+    assert vault_backfill._applicable() is True
+
+    # separate vector instance → the server-side join can't reach it → no-op.
+    monkeypatch.setattr(settings, "vector_store_dsn", "postgres://other/db", raising=False)
+    assert vault_backfill._applicable() is False
+
+    # any non-pgvector driver has no vault_id column at all.
+    monkeypatch.setattr(settings, "vector_store_dsn", "", raising=False)
+    monkeypatch.setattr(settings, "vector_store_driver", "qdrant", raising=False)
+    assert vault_backfill._applicable() is False
+
+
+@pytest.mark.asyncio
+async def test_process_once_non_pgvector_latches_ready_without_db(monkeypatch):
+    """Other drivers have no vault_id column and the vault path is never eligible
+    for them, so readiness is moot — latch ready (stop looping), never touch DB."""
+    monkeypatch.setattr(vault_backfill, "_is_pgvector", lambda: False)
+
+    async def _boom():
+        raise AssertionError("get_pool called for a non-pgvector driver")
+
+    monkeypatch.setattr(vault_backfill, "get_pool", _boom)
+    assert await vault_backfill._process_once() == 0
+    assert vault_backfill.is_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_process_once_separate_instance_gates_on_driver_count(monkeypatch):
+    """Separate pgvector instance: never auto-backfills (no server-side join) and
+    never touches the main pool — readiness follows the driver's NULL count, so
+    the manual-script escape hatch still activates the vault path (and only once
+    the backfill is actually done)."""
+    monkeypatch.setattr(vault_backfill, "_is_pgvector", lambda: True)
+    monkeypatch.setattr(vault_backfill, "_same_instance", lambda: False)
+
+    async def _boom():
+        raise AssertionError("get_pool (main DB) called for a separate instance")
+
+    monkeypatch.setattr(vault_backfill, "get_pool", _boom)
+
+    pending = {"n": 5}
+
+    class _Store:
+        async def vault_backfill_pending(self):
+            return pending["n"]
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
+
+    # Backfill not yet run on the separate instance → stays gated.
+    assert await vault_backfill._process_once() == 0
+    assert vault_backfill.is_ready() is False
+
+    # Operator ran the manual script → count hits 0 → readiness latches.
+    pending["n"] = 0
+    assert await vault_backfill._process_once() == 0
+    assert vault_backfill.is_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_process_once_short_circuits_once_ready(monkeypatch):
+    """After readiness latches, the step is a pure memory check — no DB work."""
+    monkeypatch.setattr(vault_backfill, "_ready", True, raising=False)
+    monkeypatch.setattr(vault_backfill, "_applicable", lambda: True)
+
+    async def _boom():
+        raise AssertionError("get_pool called after ready")
+
+    monkeypatch.setattr(vault_backfill, "get_pool", _boom)
+    assert await vault_backfill._process_once() == 0
+
+
+@pytest.mark.asyncio
+async def test_pending_stats_shape(monkeypatch):
+    """/health consumes this: always carries ready + applicable; null_remaining
+    only when the driver exposes the counter."""
+    monkeypatch.setattr(vault_backfill, "_applicable", lambda: True)
+
+    class _Store:
+        async def vault_backfill_pending(self):
+            return 42
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
+    stats = await vault_backfill.pending_stats()
+    assert stats["ready"] is False
+    assert stats["applicable"] is True
+    assert stats["null_remaining"] == 42
+
+
+@pytest.mark.asyncio
+async def test_pending_stats_omits_count_for_drivers_without_counter(monkeypatch):
+    class _Store:  # no vault_backfill_pending attribute
+        pass
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
+    stats = await vault_backfill.pending_stats()
+    assert "null_remaining" not in stats
+    assert set(stats) == {"ready", "applicable"}


### PR DESCRIPTION
## What

Makes the issue #189 Phase 2 vault-filter path **zero-touch** on upgrade — no manual `scripts/backfill_vault_id.py` run, no hand-flipped flag.

- **`vault_backfill` worker** (started in lifecycle): on startup backfills `vault_id` onto pre-upgrade pgvector points in idempotent 5k batches, then latches a cheap process-local `is_ready()`.
  - same-instance pgvector → auto-fills via a server-side join
  - separate-instance pgvector → does **not** auto-fill (operator runs the script), but gates readiness on the driver's NULL count == 0 (the script's "0 before flip" contract) so the escape hatch still works without the old under-fetch foot-gun
  - non-pgvector → latches ready immediately (vault path never eligible anyway)
- **Search gate**: `use_vault_path = vault_path_eligible(...) AND vault_backfill.is_ready()`. Until every pre-upgrade point carries `vault_id`, search transparently falls back to the source-id path — **no under-fetch**.
- **`vault_filter_enabled` now defaults `True`** (was `False`). The `is_ready()` gate makes this safe and zero-touch; an explicit `false` still fully opts out (byte-identical legacy behavior).
- **/health** reports `vector_store.vault_backfill {ready, applicable, null_remaining}`.

## New-user / mid-stream-user safety

- **New users / fresh corpus**: worker sees 0 live-NULL → ready immediately; every new ingest writes `vault_id` (required on the single write path). Zero-accessible-vault user → search returns empty *before any driver call* (never passes `[]` down → no global-search leak).
- **Mid-stream (upgrade w/ pre-Phase-2 corpus)**: column ADD is instant (nullable); search uses the source path while `is_ready()` is False; worker drains NULLs then activates the vault path. Backfill completion is guaranteed — only `document`/`table`/`file` source types exist (CHECK-constrained) and all are covered by the readiness check. Multi-replica safe (global EXISTS; idempotent batches; runner survives transient deadlocks).

## Verification

- Behavioral (local docker, same-instance): NULLed 200 then 150 points → worker drained to 0 and flipped `ready` on restart; backfilled `vault_id`s **match source** (0 mismatch), 0 live-source NULL.
- 7 worker unit tests (gate / applicable / per-driver-shape branches / stats) + 14 search unit tests + 17 search/lifecycle/health tests — all green.
- ACL parity: `_accessible_vault_ids` mirrors `_vault_acl` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)