### PR TITLE
feat(frontend): vault-picker filters (#204) + in-UI relation editing (#203)

### DIFF
--- a/frontend/src/components/relations/__tests__/relation-row-utils.test.ts
+++ b/frontend/src/components/relations/__tests__/relation-row-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { edgeFor, hrefFor } from "@/components/relations/relation-row-utils";
+import type { RelationRow } from "@/lib/api";
+
+const SRC = "akb://v1/coll/notes/doc/alpha.md";
+
+function row(partial: Partial<RelationRow> & { uri: string }): RelationRow {
+  return { direction: "outgoing", relation: "references", ...partial };
+}
+
+describe("edgeFor", () => {
+  const other = "akb://v1/coll/notes/doc/beta.md";
+
+  it("outgoing: this document is the source", () => {
+    expect(edgeFor(row({ direction: "outgoing", uri: other }), SRC)).toEqual({
+      source: SRC,
+      target: other,
+    });
+  });
+
+  it("incoming: this document is the target (source/target swapped)", () => {
+    expect(edgeFor(row({ direction: "incoming", uri: other }), SRC)).toEqual({
+      source: other,
+      target: SRC,
+    });
+  });
+
+  it("treats any non-incoming direction as outgoing", () => {
+    // Defensive: the type is required, but a stray value must not invert the edge.
+    const r = { direction: "both", relation: "references", uri: other } as unknown as RelationRow;
+    expect(edgeFor(r, SRC)).toEqual({ source: SRC, target: other });
+  });
+});
+
+describe("hrefFor", () => {
+  it("routes a collection doc to /doc with the FULL vault-relative ref (the historical blank-screen bug)", () => {
+    expect(hrefFor(row({ uri: "akb://v1/coll/notes/doc/beta.md" }), "v1")).toBe(
+      `/vault/v1/doc/${encodeURIComponent("notes/beta.md")}`,
+    );
+  });
+
+  it("routes a root-level doc to /doc", () => {
+    expect(hrefFor(row({ uri: "akb://v1/doc/readme.md" }), "v1")).toBe("/vault/v1/doc/readme.md");
+  });
+
+  it("routes a table URI to /table (basename id)", () => {
+    expect(hrefFor(row({ uri: "akb://v1/coll/data/table/sales" }), "v1")).toBe("/vault/v1/table/sales");
+  });
+
+  it("routes a file URI to /file", () => {
+    expect(hrefFor(row({ uri: "akb://v1/coll/x/file/uuid-123" }), "v1")).toBe("/vault/v1/file/uuid-123");
+  });
+
+  it("uses the URI's own vault, not the fallback", () => {
+    expect(hrefFor(row({ uri: "akb://other/coll/n/doc/z.md" }), "v1")).toBe(
+      `/vault/other/doc/${encodeURIComponent("n/z.md")}`,
+    );
+  });
+
+  it("returns '#' for a ref-less URI (vault root) rather than a broken half-path", () => {
+    expect(hrefFor(row({ uri: "akb://v1" }), "v1")).toBe("#");
+  });
+
+  it("returns '#' for an unparseable URI", () => {
+    expect(hrefFor(row({ uri: "not-a-uri" }), "v1")).toBe("#");
+  });
+});

--- a/frontend/src/components/relations/relation-row-utils.ts
+++ b/frontend/src/components/relations/relation-row-utils.ts
@@ -1,0 +1,37 @@
+import type { RelationRow } from "@/lib/api";
+import { parseUri } from "@/lib/uri";
+
+// Pure helpers for the Relations panel, lifted out of the component so the
+// branchy bits (edge direction, URI routing) are unit-testable. A relation row
+// from GET /relations carries only the "other side" (`uri`) plus a `direction`.
+
+/**
+ * Rebuild the (source, target) pair the unlink endpoint wants, from this
+ * document's vantage point. An outgoing edge has this doc as the source; an
+ * incoming edge has it as the target.
+ */
+export function edgeFor(
+  row: RelationRow,
+  sourceUri: string,
+): { source: string; target: string } {
+  return row.direction === "incoming"
+    ? { source: row.uri, target: sourceUri }
+    : { source: sourceUri, target: row.uri };
+}
+
+/**
+ * Route a relation's other-side URI to its in-app path. Returns "#" when the URI
+ * has no resolvable ref (e.g. a vault/coll URI) rather than a broken half-path —
+ * a flat regex here once produced `/vault/x/doc/` blank screens for collection
+ * docs, so this delegates to the canonical `parseUri`.
+ */
+export function hrefFor(row: RelationRow, vault: string): string {
+  const p = parseUri(row.uri);
+  const v = p?.vault ?? vault;
+  const ref = p?.id ?? "";
+  const kind = p?.kind ?? row.resource_type;
+  if (!ref) return "#";
+  if (kind === "table") return `/vault/${v}/table/${encodeURIComponent(ref)}`;
+  if (kind === "file") return `/vault/${v}/file/${encodeURIComponent(ref)}`;
+  return `/vault/${v}/doc/${encodeURIComponent(ref)}`;
+}

--- a/frontend/src/components/relations/relations-panel.tsx
+++ b/frontend/src/components/relations/relations-panel.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { GitGraph, Link2, Loader2, Plus, Unlink } from "lucide-react";
+import {
+  RELATION_TYPES,
+  type RelationType,
+  createRelation,
+  deleteRelation,
+} from "@/lib/api";
+import { parseUri } from "@/lib/uri";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { SelectMenu } from "@/components/ui/select-menu";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { TooltipText } from "@/components/ui/tooltip-text";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ResourcePicker, type PickedResource } from "@/components/relations/resource-picker";
+
+const RELATION_COLOR: Record<string, string> = {
+  implements: "text-success",
+  depends_on: "text-info",
+  references: "text-info",
+  related_to: "text-foreground-muted",
+  attached_to: "text-success",
+  derived_from: "text-warning",
+};
+
+const RELATION_LABEL: Record<RelationType, string> = {
+  references: "References",
+  related_to: "Related to",
+  depends_on: "Depends on",
+  implements: "Implements",
+  derived_from: "Derived from",
+  attached_to: "Attached to",
+};
+
+interface RelationRow {
+  direction?: "outgoing" | "incoming";
+  relation: string;
+  uri: string;
+  resource_type?: string;
+  name?: string;
+}
+
+interface RelationsPanelProps {
+  vault: string;
+  /** The current document's canonical akb:// URI (the link source). */
+  sourceUri: string;
+  relations: RelationRow[];
+  relationsError: boolean;
+  graphHref: string;
+  onReload: () => void;
+}
+
+export function RelationsPanel({
+  vault,
+  sourceUri,
+  relations,
+  relationsError,
+  graphHref,
+  onReload,
+}: RelationsPanelProps) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<RelationRow | null>(null);
+
+  // A relation row stores only the "other side" + a direction; rebuild the
+  // (source, target) pair the unlink endpoint wants from this doc's vantage.
+  function edgeFor(r: RelationRow): { source: string; target: string } {
+    return r.direction === "incoming"
+      ? { source: r.uri, target: sourceUri }
+      : { source: sourceUri, target: r.uri };
+  }
+
+  function hrefFor(r: RelationRow): string {
+    const p = parseUri(r.uri);
+    const v = p?.vault ?? vault;
+    const ref = p?.id ?? "";
+    const kind = p?.kind ?? r.resource_type;
+    if (!ref) return "#";
+    if (kind === "table") return `/vault/${v}/table/${encodeURIComponent(ref)}`;
+    if (kind === "file") return `/vault/${v}/file/${encodeURIComponent(ref)}`;
+    return `/vault/${v}/doc/${encodeURIComponent(ref)}`;
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="coord">{relations.length} relation{relations.length === 1 ? "" : "s"}</span>
+        <Button variant="ghost" size="sm" onClick={() => setAddOpen(true)}>
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          Add
+        </Button>
+      </div>
+
+      {relationsError ? (
+        <Alert variant="destructive">Failed to load relations.</Alert>
+      ) : relations.length === 0 ? (
+        <div className="coord">No relations yet.</div>
+      ) : (
+        <ol className="space-y-0.5 font-mono text-[11px] leading-[1.9]">
+          {relations.map((r) => {
+            const label = r.name || parseUri(r.uri)?.id || r.uri;
+            const relColor = RELATION_COLOR[r.relation] || "text-foreground-muted";
+            // `links_to` is auto-derived from markdown — re-created on save, so
+            // unlinking it is meaningless. Hide its delete affordance.
+            const deletable = r.relation !== "links_to";
+            return (
+              <li key={`${r.direction ?? "out"}:${r.relation}:${r.uri}`} className="group flex items-center gap-1">
+                <Link
+                  to={hrefFor(r)}
+                  className="grid min-w-0 flex-1 grid-cols-[minmax(64px,88px)_1fr] gap-1.5 rounded-[var(--radius-sm)] px-1 py-0.5 transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  <span className={relColor}>{r.relation || "relates"}</span>
+                  <TooltipText tip={label} className="truncate text-foreground group-hover:text-link">
+                    {r.direction === "incoming" ? "← " : "→ "}
+                    {label}
+                  </TooltipText>
+                </Link>
+                {deletable && (
+                  <button
+                    type="button"
+                    onClick={() => setPendingDelete(r)}
+                    aria-label={`Remove relation to ${label}`}
+                    className="shrink-0 rounded-[var(--radius-sm)] p-1 text-foreground-muted opacity-0 transition-colors hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <Unlink className="h-3 w-3" aria-hidden />
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      <Link
+        to={graphHref}
+        className="mt-3 inline-flex items-center gap-1 rounded-[var(--radius-sm)] text-xs text-link transition-colors hover:text-link-hover hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <GitGraph className="h-3 w-3" aria-hidden /> Open in graph →
+      </Link>
+
+      <AddRelationDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        vault={vault}
+        sourceUri={sourceUri}
+        onCreated={onReload}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(o) => !o && setPendingDelete(null)}
+        title="Remove relation?"
+        description={
+          pendingDelete
+            ? `This removes the "${pendingDelete.relation}" link to ${
+                pendingDelete.name || parseUri(pendingDelete.uri)?.id || pendingDelete.uri
+              }. The documents themselves are not affected.`
+            : ""
+        }
+        confirmLabel="Remove"
+        variant="destructive"
+        onConfirm={async () => {
+          if (!pendingDelete) return;
+          const { source, target } = edgeFor(pendingDelete);
+          await deleteRelation(source, target, pendingDelete.relation);
+          setPendingDelete(null);
+          onReload();
+        }}
+      />
+    </div>
+  );
+}
+
+interface AddRelationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vault: string;
+  sourceUri: string;
+  onCreated: () => void;
+}
+
+function AddRelationDialog({ open, onOpenChange, vault, sourceUri, onCreated }: AddRelationDialogProps) {
+  const [relation, setRelation] = useState<RelationType>("references");
+  const [target, setTarget] = useState<PickedResource | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setRelation("references");
+    setTarget(null);
+    setError(null);
+    setBusy(false);
+  }
+
+  async function submit() {
+    if (!target) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createRelation(sourceUri, target.uri, relation);
+      reset();
+      onOpenChange(false);
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create relation.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Link2 className="h-4 w-4 text-foreground-muted" aria-hidden />
+            Add relation
+          </DialogTitle>
+          <DialogDescription>
+            Link this document to another in the same vault with a typed relation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <span className="coord">Relation</span>
+            <SelectMenu
+              value={relation}
+              onValueChange={(v) => setRelation(v as RelationType)}
+              aria-label="Relation type"
+              options={RELATION_TYPES.map((t) => ({ value: t, label: RELATION_LABEL[t] }))}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <span className="coord">Target document</span>
+            <ResourcePicker
+              vault={vault}
+              excludeUri={sourceUri}
+              value={target}
+              onChange={setTarget}
+            />
+          </div>
+          {error && <Alert variant="destructive">{error}</Alert>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="accent" onClick={submit} disabled={!target || busy}>
+            {busy && <Loader2 className="h-4 w-4 animate-spin" aria-hidden />}
+            Add relation
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/relations/relations-panel.tsx
+++ b/frontend/src/components/relations/relations-panel.tsx
@@ -4,10 +4,12 @@ import { GitGraph, Link2, Loader2, Plus, Unlink } from "lucide-react";
 import {
   RELATION_TYPES,
   type RelationType,
+  type RelationRow,
   createRelation,
   deleteRelation,
 } from "@/lib/api";
 import { parseUri } from "@/lib/uri";
+import { edgeFor, hrefFor } from "@/components/relations/relation-row-utils";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { SelectMenu } from "@/components/ui/select-menu";
@@ -41,14 +43,6 @@ const RELATION_LABEL: Record<RelationType, string> = {
   attached_to: "Attached to",
 };
 
-interface RelationRow {
-  direction?: "outgoing" | "incoming";
-  relation: string;
-  uri: string;
-  resource_type?: string;
-  name?: string;
-}
-
 interface RelationsPanelProps {
   vault: string;
   /** The current document's canonical akb:// URI (the link source). */
@@ -69,25 +63,6 @@ export function RelationsPanel({
 }: RelationsPanelProps) {
   const [addOpen, setAddOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<RelationRow | null>(null);
-
-  // A relation row stores only the "other side" + a direction; rebuild the
-  // (source, target) pair the unlink endpoint wants from this doc's vantage.
-  function edgeFor(r: RelationRow): { source: string; target: string } {
-    return r.direction === "incoming"
-      ? { source: r.uri, target: sourceUri }
-      : { source: sourceUri, target: r.uri };
-  }
-
-  function hrefFor(r: RelationRow): string {
-    const p = parseUri(r.uri);
-    const v = p?.vault ?? vault;
-    const ref = p?.id ?? "";
-    const kind = p?.kind ?? r.resource_type;
-    if (!ref) return "#";
-    if (kind === "table") return `/vault/${v}/table/${encodeURIComponent(ref)}`;
-    if (kind === "file") return `/vault/${v}/file/${encodeURIComponent(ref)}`;
-    return `/vault/${v}/doc/${encodeURIComponent(ref)}`;
-  }
 
   return (
     <div className="flex h-full flex-col">
@@ -112,9 +87,9 @@ export function RelationsPanel({
             // unlinking it is meaningless. Hide its delete affordance.
             const deletable = r.relation !== "links_to";
             return (
-              <li key={`${r.direction ?? "out"}:${r.relation}:${r.uri}`} className="group flex items-center gap-1">
+              <li key={`${r.direction}:${r.relation}:${r.uri}`} className="group flex items-center gap-1">
                 <Link
-                  to={hrefFor(r)}
+                  to={hrefFor(r, vault)}
                   className="grid min-w-0 flex-1 grid-cols-[minmax(64px,88px)_1fr] gap-1.5 rounded-[var(--radius-sm)] px-1 py-0.5 transition-colors hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                   <span className={relColor}>{r.relation || "relates"}</span>
@@ -169,7 +144,7 @@ export function RelationsPanel({
         variant="destructive"
         onConfirm={async () => {
           if (!pendingDelete) return;
-          const { source, target } = edgeFor(pendingDelete);
+          const { source, target } = edgeFor(pendingDelete, sourceUri);
           await deleteRelation(source, target, pendingDelete.relation);
           setPendingDelete(null);
           onReload();

--- a/frontend/src/components/relations/resource-picker.tsx
+++ b/frontend/src/components/relations/resource-picker.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { Loader2, Search as SearchIcon, X } from "lucide-react";
+import { searchDocs } from "@/lib/api";
+import { parseUri } from "@/lib/uri";
+import { TooltipText } from "@/components/ui/tooltip-text";
+
+export interface PickedResource {
+  uri: string;
+  title: string;
+  path: string;
+}
+
+interface ResourcePickerProps {
+  /** Search is scoped to this vault — links must stay intra-vault. */
+  vault: string;
+  /** The source doc's own URI, filtered out so you can't self-link. */
+  excludeUri: string;
+  value: PickedResource | null;
+  onChange: (value: PickedResource | null) => void;
+}
+
+/**
+ * A lightweight search-as-you-type picker for choosing a target document within
+ * one vault. There is no shared combobox primitive yet, so this wraps an input +
+ * a results popdown over `searchDocs`, debounced. Selecting collapses to a chip.
+ */
+export function ResourcePicker({ vault, excludeUri, value, onChange }: ResourcePickerProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<PickedResource[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // Debounced search. A blank query clears results rather than listing the corpus.
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const t = setTimeout(() => {
+      let cancelled = false;
+      searchDocs(q, vault, 8)
+        .then((r) => {
+          if (cancelled) return;
+          const rows: PickedResource[] = (r.results || [])
+            .map((d: any) => ({
+              uri: d.uri as string,
+              title: (d.title as string) || (d.path as string) || d.uri,
+              path: (d.path as string) || parseUri(d.uri)?.id || "",
+            }))
+            .filter((d: PickedResource) => d.uri && d.uri !== excludeUri);
+          setResults(rows);
+        })
+        .catch(() => !cancelled && setResults([]))
+        .finally(() => !cancelled && setLoading(false));
+      return () => {
+        cancelled = true;
+      };
+    }, 250);
+    return () => clearTimeout(t);
+  }, [query, vault, excludeUri]);
+
+  // Dismiss the popdown on an outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  if (value) {
+    return (
+      <div className="flex items-center justify-between gap-2 rounded-[var(--radius-md)] border border-border bg-surface px-3 py-2">
+        <TooltipText className="truncate text-sm text-foreground" tip={value.path}>
+          {value.title}
+        </TooltipText>
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          aria-label="Clear selected target"
+          className="shrink-0 rounded-[var(--radius-sm)] text-foreground-muted transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={boxRef} className="relative">
+      <div className="relative">
+        <SearchIcon
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-muted"
+          aria-hidden
+        />
+        {loading && (
+          <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-foreground-muted" aria-hidden />
+        )}
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          placeholder="Search a document to link…"
+          aria-label="Search a target document"
+          className="h-10 w-full rounded-[var(--radius-md)] border border-border bg-surface pl-9 pr-9 text-sm text-foreground placeholder:text-foreground-muted transition-colors focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+      {open && query.trim() && (
+        <div className="absolute z-[var(--z-popover)] mt-1 max-h-60 w-full overflow-y-auto rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md">
+          {results.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-foreground-muted">
+              {loading ? "Searching…" : "No matching documents"}
+            </div>
+          ) : (
+            results.map((r) => (
+              <button
+                key={r.uri}
+                type="button"
+                onClick={() => {
+                  onChange(r);
+                  setOpen(false);
+                  setQuery("");
+                }}
+                className="flex w-full flex-col items-start gap-0.5 rounded-[var(--radius-sm)] px-3 py-2 text-left outline-none transition-colors hover:bg-surface-hover focus-visible:bg-surface-hover"
+              >
+                <TooltipText className="w-full truncate text-sm text-foreground" tip={r.title}>
+                  {r.title}
+                </TooltipText>
+                <TooltipText className="w-full truncate text-xs text-foreground-muted" tip={r.path}>
+                  {r.path}
+                </TooltipText>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/relations/resource-picker.tsx
+++ b/frontend/src/components/relations/resource-picker.tsx
@@ -28,39 +28,54 @@ export function ResourcePicker({ vault, excludeUri, value, onChange }: ResourceP
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<PickedResource[]>([]);
   const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState(false);
   const [open, setOpen] = useState(false);
   const boxRef = useRef<HTMLDivElement>(null);
 
   // Debounced search. A blank query clears results rather than listing the corpus.
+  // `cancelled` lives at effect scope (not inside setTimeout) so the cleanup
+  // actually flips it — an in-flight request that resolves after the user types
+  // again, clears the box, or unmounts must not clobber newer state.
   useEffect(() => {
     const q = query.trim();
     if (!q) {
       setResults([]);
       setLoading(false);
+      setSearchError(false);
       return;
     }
+    let cancelled = false;
     setLoading(true);
     const t = setTimeout(() => {
-      let cancelled = false;
       searchDocs(q, vault, 8)
         .then((r) => {
           if (cancelled) return;
+          setSearchError(false);
           const rows: PickedResource[] = (r.results || [])
-            .map((d: any) => ({
-              uri: d.uri as string,
-              title: (d.title as string) || (d.path as string) || d.uri,
-              path: (d.path as string) || parseUri(d.uri)?.id || "",
+            .map((d: { uri?: string; title?: string; path?: string }) => ({
+              uri: d.uri ?? "",
+              title: d.title || d.path || d.uri || "",
+              path: d.path || parseUri(d.uri)?.id || "",
             }))
-            .filter((d: PickedResource) => d.uri && d.uri !== excludeUri);
+            .filter((d) => d.uri && d.uri !== excludeUri);
           setResults(rows);
         })
-        .catch(() => !cancelled && setResults([]))
-        .finally(() => !cancelled && setLoading(false));
-      return () => {
-        cancelled = true;
-      };
+        .catch((e) => {
+          if (cancelled) return;
+          // Surface as a distinct state — a backend/network failure must not
+          // masquerade as a genuine "no matching documents" empty result.
+          console.error("ResourcePicker: target search failed", e);
+          setSearchError(true);
+          setResults([]);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
     }, 250);
-    return () => clearTimeout(t);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
   }, [query, vault, excludeUri]);
 
   // Dismiss the popdown on an outside click.
@@ -118,7 +133,11 @@ export function ResourcePicker({ vault, excludeUri, value, onChange }: ResourceP
         <div className="absolute z-[var(--z-popover)] mt-1 max-h-60 w-full overflow-y-auto rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md">
           {results.length === 0 ? (
             <div className="px-3 py-2 text-xs text-foreground-muted">
-              {loading ? "Searching…" : "No matching documents"}
+              {loading
+                ? "Searching…"
+                : searchError
+                  ? "Search is unavailable — try again."
+                  : "No matching documents"}
             </div>
           ) : (
             results.map((r) => (

--- a/frontend/src/components/ui/__tests__/menu-filter-util.test.ts
+++ b/frontend/src/components/ui/__tests__/menu-filter-util.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { filterByText, MENU_FILTER_THRESHOLD } from "@/components/ui/menu-filter-utils";
+
+const items = [
+  { name: "akb-platform" },
+  { name: "gnu-weekly" },
+  { name: "Design-System" },
+];
+
+describe("filterByText", () => {
+  it("returns all items for an empty query", () => {
+    expect(filterByText(items, "", (i) => i.name)).toHaveLength(3);
+  });
+
+  it("returns all items for a whitespace-only query", () => {
+    expect(filterByText(items, "   ", (i) => i.name)).toHaveLength(3);
+  });
+
+  it("filters case-insensitively via the accessor", () => {
+    expect(filterByText(items, "DESIGN", (i) => i.name)).toEqual([{ name: "Design-System" }]);
+  });
+
+  it("matches a substring anywhere in the text", () => {
+    expect(filterByText(items, "weekly", (i) => i.name)).toEqual([{ name: "gnu-weekly" }]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterByText(items, "zzz", (i) => i.name)).toEqual([]);
+  });
+});
+
+describe("MENU_FILTER_THRESHOLD", () => {
+  it("is a positive integer shared across pickers", () => {
+    expect(Number.isInteger(MENU_FILTER_THRESHOLD)).toBe(true);
+    expect(MENU_FILTER_THRESHOLD).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/ui/menu-filter-utils.ts
+++ b/frontend/src/components/ui/menu-filter-utils.ts
@@ -1,0 +1,17 @@
+// Shared filtering helpers for menu/picker surfaces. Kept in a non-component
+// module so the `MenuFilter` component file stays Fast-Refresh clean (a file
+// that exports a component must not also export constants/functions).
+
+/**
+ * Show a filter box atop a menu/picker once the list grows past this many items
+ * — a filter only earns its keep when the list is long enough to scan. Shared so
+ * every vault/option picker triggers at the same length.
+ */
+export const MENU_FILTER_THRESHOLD = 7;
+
+/** Case-insensitive substring filter over an arbitrary list by a text accessor. */
+export function filterByText<T>(items: T[], query: string, getText: (item: T) => string): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+  return items.filter((it) => getText(it).toLowerCase().includes(q));
+}

--- a/frontend/src/components/ui/menu-filter.tsx
+++ b/frontend/src/components/ui/menu-filter.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+import { Search as SearchIcon } from "lucide-react";
+
+interface MenuFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * A compact filter input designed to live at the top of a Radix DropdownMenu
+ * `Content` (SelectMenu, vault pickers). Radix menus run a typeahead handler at
+ * the content level that would otherwise swallow keystrokes, so we stop
+ * propagation for everything except Escape (which still closes the menu). Radix
+ * focuses the first menu item on open (it exposes no `onOpenAutoFocus` to stop
+ * that), so we steal focus back to this input on the next frame — best-effort:
+ * if Radix wins the race the user can still click the box.
+ */
+export function MenuFilter({
+  value,
+  onChange,
+  placeholder = "Filter…",
+  "aria-label": ariaLabel,
+}: MenuFilterProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => ref.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, []);
+  return (
+    <div className="px-1 pb-1 pt-0.5">
+      <div className="relative">
+        <SearchIcon
+          className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-foreground-muted"
+          aria-hidden
+        />
+        <input
+          ref={ref}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            // Let Escape bubble so Radix closes the menu; keep every other key
+            // (incl. the menu's typeahead + arrow nav) from hijacking input.
+            if (e.key !== "Escape") e.stopPropagation();
+          }}
+          placeholder={placeholder}
+          aria-label={ariaLabel ?? placeholder}
+          className="h-8 w-full rounded-[var(--radius-md)] border border-border bg-background pl-6 pr-2 text-xs text-foreground placeholder:text-foreground-muted transition-colors focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/select-menu.tsx
+++ b/frontend/src/components/ui/select-menu.tsx
@@ -1,7 +1,9 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronDown } from "lucide-react";
+import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { TooltipText } from "@/components/ui/tooltip-text";
+import { MenuFilter } from "@/components/ui/menu-filter";
 
 export interface SelectOption {
   value: string;
@@ -24,6 +26,13 @@ interface SelectMenuProps {
   "aria-describedby"?: string;
   /** Mono-format the trigger value (for identifier-shaped values). */
   mono?: boolean;
+  /**
+   * Show a live filter box atop the open list once the option count crosses
+   * `searchThreshold` (default 8). Filters options by their label.
+   */
+  searchable?: boolean;
+  searchThreshold?: number;
+  searchPlaceholder?: string;
 }
 
 /**
@@ -42,11 +51,21 @@ export function SelectMenu({
   className,
   disabled,
   mono,
+  searchable = false,
+  searchThreshold = 8,
+  searchPlaceholder = "Filter…",
   "aria-label": ariaLabel,
   "aria-invalid": ariaInvalid,
   "aria-describedby": ariaDescribedby,
 }: SelectMenuProps) {
   const current = options.find((o) => o.value === value);
+  const [filter, setFilter] = useState("");
+  const showFilter = searchable && options.length > searchThreshold;
+  const q = filter.trim().toLowerCase();
+  const filtered = useMemo(
+    () => (showFilter && q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options),
+    [options, q, showFilter],
+  );
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger
@@ -81,10 +100,23 @@ export function SelectMenu({
         <DropdownMenu.Content
           align="start"
           sideOffset={6}
+          onCloseAutoFocus={showFilter ? () => setFilter("") : undefined}
           className="z-[var(--z-popover)] max-h-[min(60vh,18rem)] min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
         >
+          {showFilter && (
+            <div className="sticky -top-1 z-10 -mx-1 -mt-1 mb-0.5 border-b border-border bg-surface px-1 pt-1">
+              <MenuFilter
+                value={filter}
+                onChange={setFilter}
+                placeholder={searchPlaceholder}
+              />
+            </div>
+          )}
+          {showFilter && filtered.length === 0 && (
+            <div className="px-3 py-2 text-xs text-foreground-muted">No matches</div>
+          )}
           <DropdownMenu.RadioGroup value={value} onValueChange={onValueChange}>
-            {options.map((o) => (
+            {filtered.map((o) => (
               <DropdownMenu.RadioItem
                 key={o.value}
                 value={o.value}

--- a/frontend/src/components/ui/select-menu.tsx
+++ b/frontend/src/components/ui/select-menu.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { MenuFilter } from "@/components/ui/menu-filter";
+import { MENU_FILTER_THRESHOLD, filterByText } from "@/components/ui/menu-filter-utils";
 
 export interface SelectOption {
   value: string;
@@ -52,7 +53,7 @@ export function SelectMenu({
   disabled,
   mono,
   searchable = false,
-  searchThreshold = 8,
+  searchThreshold = MENU_FILTER_THRESHOLD,
   searchPlaceholder = "Filter…",
   "aria-label": ariaLabel,
   "aria-invalid": ariaInvalid,
@@ -61,10 +62,9 @@ export function SelectMenu({
   const current = options.find((o) => o.value === value);
   const [filter, setFilter] = useState("");
   const showFilter = searchable && options.length > searchThreshold;
-  const q = filter.trim().toLowerCase();
   const filtered = useMemo(
-    () => (showFilter && q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options),
-    [options, q, showFilter],
+    () => (showFilter ? filterByText(options, filter, (o) => o.label) : options),
+    [options, filter, showFilter],
   );
   return (
     <DropdownMenu.Root>

--- a/frontend/src/lib/__tests__/api-relations.test.ts
+++ b/frontend/src/lib/__tests__/api-relations.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRelation, deleteRelation } from "@/lib/api";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
+    ...init,
+  });
+}
+
+const SRC = "akb://v1/coll/notes/doc/alpha.md";
+const TGT = "akb://v1/coll/notes/doc/beta.md";
+
+describe("createRelation", () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("POSTs to /relations with the full source/target/relation body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ linked: true, source: SRC, target: TGT, relation: "references" }),
+    );
+
+    const result = await createRelation(SRC, TGT, "references");
+
+    expect(result.linked).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/relations");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ source: SRC, target: TGT, relation: "references" });
+  });
+
+  it("includes metadata when provided", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ linked: true }));
+    await createRelation(SRC, TGT, "depends_on", { note: "x" });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.metadata).toEqual({ note: "x" });
+  });
+});
+
+describe("deleteRelation", () => {
+  const fetchMock = vi.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("DELETEs with source+target+relation in the query string", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ unlinked: 1, source: SRC, target: TGT }));
+
+    const result = await deleteRelation(SRC, TGT, "references");
+
+    expect(result.unlinked).toBe(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("DELETE");
+    const parsed = new URL(url, "http://x");
+    expect(parsed.pathname).toBe("/api/v1/relations");
+    expect(parsed.searchParams.get("source")).toBe(SRC);
+    expect(parsed.searchParams.get("target")).toBe(TGT);
+    expect(parsed.searchParams.get("relation")).toBe("references");
+  });
+
+  it("omits `relation` from the query when not given (drop-all-edges path)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ unlinked: 2, source: SRC, target: TGT }));
+
+    await deleteRelation(SRC, TGT);
+
+    const url = fetchMock.mock.calls[0][0];
+    const parsed = new URL(url, "http://x");
+    expect(parsed.searchParams.has("relation")).toBe(false);
+    expect(parsed.searchParams.get("source")).toBe(SRC);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -428,8 +428,11 @@ export const createRelation = (
     body: JSON.stringify({ source, target, relation, metadata }),
   });
 
-// Remove a relation edge. Omit `relation` to drop all edges between the two.
-// Backend bridges a 0-count unlink to an error, so success means ≥1 removed.
+// Remove a relation edge. `relation` is widened to `string` (vs createRelation's
+// `RelationType`) on purpose: unlink must also be able to name the read-only
+// `links_to` edge, and omitting it drops ALL edges between the two. Returns
+// `{ unlinked: <count> }`; a 0 count (nothing matched) is still a 200 success,
+// not an error — the UI only deletes edges it already shows, so count ≥ 1.
 export const deleteRelation = (source: string, target: string, relation?: string) => {
   const p = new URLSearchParams({ source, target });
   if (relation) p.set("relation", relation);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -403,6 +403,41 @@ export const getRelations = (vault: string, docPath: string) => {
   return api<{ uri: string; relations: RelationRow[] }>(`/relations?${p}`);
 };
 
+// User-settable link vocabulary (mirrors backend LinkRelationType). `links_to`
+// is auto-extracted from markdown and is NOT settable here.
+export const RELATION_TYPES = [
+  "references",
+  "related_to",
+  "depends_on",
+  "implements",
+  "derived_from",
+  "attached_to",
+] as const;
+export type RelationType = (typeof RELATION_TYPES)[number];
+
+// Create a typed relation edge. `source`/`target` are full akb:// URIs and must
+// live in the same vault (backend rejects cross-vault links). Needs writer role.
+export const createRelation = (
+  source: string,
+  target: string,
+  relation: RelationType,
+  metadata?: Record<string, unknown>,
+) =>
+  api<{ linked: boolean; source: string; target: string; relation: string }>(`/relations`, {
+    method: "POST",
+    body: JSON.stringify({ source, target, relation, metadata }),
+  });
+
+// Remove a relation edge. Omit `relation` to drop all edges between the two.
+// Backend bridges a 0-count unlink to an error, so success means ≥1 removed.
+export const deleteRelation = (source: string, target: string, relation?: string) => {
+  const p = new URLSearchParams({ source, target });
+  if (relation) p.set("relation", relation);
+  return api<{ unlinked: number; source: string; target: string }>(`/relations?${p}`, {
+    method: "DELETE",
+  });
+};
+
 // ── Recent ──
 export const getRecent = (vault?: string, limit = 20) => {
   const p = new URLSearchParams({ limit: String(limit) });

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -18,6 +18,7 @@ import {
   getDocument,
   getRelations,
   getVaultInfo,
+  type RelationRow,
   unpublishDoc,
   updateDocument,
 } from "@/lib/api";
@@ -62,7 +63,7 @@ export default function DocumentPage() {
         : rawView === "agent"
           ? "agent"
           : "rendered";
-  const [relations, setRelations] = useState<any[]>([]);
+  const [relations, setRelations] = useState<RelationRow[]>([]);
   const [relationsError, setRelationsError] = useState(false);
   const [provenance, setProvenance] = useState<any[]>([]);
   const [historyError, setHistoryError] = useState(false);

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -6,7 +6,6 @@ import {
   ArrowLeft,
   CheckCircle2,
   ExternalLink,
-  GitGraph,
   Loader2,
   Lock,
   Pencil,
@@ -23,7 +22,7 @@ import {
   updateDocument,
 } from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
-import { docUri, parseUri } from "@/lib/uri";
+import { docUri } from "@/lib/uri";
 import { parseHeadings } from "@/lib/markdown";
 import { DocumentOutline } from "@/components/doc-outline";
 import { DocumentView } from "@/components/document-view";
@@ -40,19 +39,11 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PublishOptionsDialog } from "@/components/publish-options-dialog";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
+import { RelationsPanel } from "@/components/relations/relations-panel";
 
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
 // (Rendered / Raw / Agent) stays cheap.
 const MarkdownEditor = lazy(() => import("@/components/markdown-editor"));
-
-const RELATION_COLOR: Record<string, string> = {
-  implements: "text-success",
-  depends_on: "text-info",
-  references: "text-info",
-  related_to: "text-foreground-muted",
-  attached_to: "text-success",
-  derived_from: "text-warning",
-};
 
 type DocView = "rendered" | "raw" | "agent" | "edit";
 
@@ -138,6 +129,16 @@ export default function DocumentPage() {
   // Parse headings once for the outline-tab count (the outline + renderer each
   // re-scan internally; this removes the third pass that ran on every render).
   const headingSlugs = useMemo(() => parseHeadings(doc?.content || ""), [doc?.content]);
+
+  // Re-pull relations after an add/remove from the Relations panel. Keyed off
+  // the doc *path* (the GET response has no internal id — see the load effect).
+  const reloadRelations = () => {
+    const p = doc?.path;
+    if (!p) return;
+    getRelations(name!, p)
+      .then((r) => setRelations(r.relations || []))
+      .catch(() => setRelationsError(true));
+  };
 
   useEffect(() => {
     const d = docQuery.data;
@@ -699,54 +700,14 @@ export default function DocumentPage() {
             value="relations"
             className="flex-1 min-h-0 overflow-y-auto rail-scroll pr-1 pt-3"
           >
-            {relationsError ? (
-              <Alert variant="destructive">Failed to load relations.</Alert>
-            ) : relations.length > 0 ? (
-              <>
-                <ol className="font-mono text-[11px] leading-[1.9] space-y-0.5">
-                  {relations.map((r) => {
-                    // Use the canonical URI parser (handles the `/coll/.../doc/`
-                    // form) — a flat regex missed collection docs and produced
-                    // an empty ref → `/vault/x/doc/` → blank screen.
-                    const p = parseUri(r.uri);
-                    const targetVault = p?.vault ?? name;
-                    const targetType = p?.kind ?? r.resource_type;
-                    const targetRef = p?.id ?? "";
-                    let href = "#";
-                    if (targetRef && targetType === "doc") {
-                      href = `/vault/${targetVault}/doc/${encodeURIComponent(targetRef)}`;
-                    } else if (targetRef && targetType === "table") {
-                      href = `/vault/${targetVault}/table/${encodeURIComponent(targetRef)}`;
-                    } else if (targetRef && targetType === "file") {
-                      href = `/vault/${targetVault}/file/${encodeURIComponent(targetRef)}`;
-                    }
-                    const label = r.name || targetRef || r.uri;
-                    const relColor = RELATION_COLOR[r.relation] || "text-foreground-muted";
-                    return (
-                      <li key={`${r.relation}:${r.uri}`}>
-                        <Link
-                          to={href}
-                          className="grid grid-cols-[minmax(64px,88px)_1fr] gap-1.5 py-0.5 group hover:bg-surface-hover -mx-1 px-1 rounded-[var(--radius-sm)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                        >
-                          <span className={relColor}>{r.relation || "relates"}</span>
-                          <TooltipText tip={label} className="text-foreground truncate group-hover:text-link">
-                            → {label}
-                          </TooltipText>
-                        </Link>
-                      </li>
-                    );
-                  })}
-                </ol>
-                <Link
-                  to={`/vault/${name}/graph?focus=${encodeURIComponent(doc.path ? docUri(name!, doc.path) : "")}`}
-                  className="mt-3 inline-flex items-center gap-1 text-xs text-link hover:text-link-hover hover:underline rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                >
-                  <GitGraph className="h-3 w-3" aria-hidden /> Open in graph →
-                </Link>
-              </>
-            ) : (
-              <div className="coord">No relations yet.</div>
-            )}
+            <RelationsPanel
+              vault={name!}
+              sourceUri={doc.path ? docUri(name!, doc.path) : ""}
+              relations={relations}
+              relationsError={relationsError}
+              graphHref={`/vault/${name}/graph?focus=${encodeURIComponent(doc.path ? docUri(name!, doc.path) : "")}`}
+              onReload={reloadRelations}
+            />
           </TabsContent>
 
           <TabsContent

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -31,6 +31,7 @@ import { VaultChip } from "@/components/ui/vault-chip";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { MenuFilter } from "@/components/ui/menu-filter";
+import { MENU_FILTER_THRESHOLD, filterByText } from "@/components/ui/menu-filter-utils";
 import { QuickstartDialog, QUICKSTART_DISMISS_KEY } from "@/components/quickstart-dialog";
 import {
   listVaults,
@@ -583,10 +584,8 @@ function NewDocAction({ vaults }: { vaults: VaultRow[] }) {
       </Button>
     );
   }
-  // A filter only earns its keep once the list is long enough to scan.
-  const showFilter = vaults.length > 7;
-  const q = filter.trim().toLowerCase();
-  const filtered = q ? vaults.filter((v) => v.name.toLowerCase().includes(q)) : vaults;
+  const showFilter = vaults.length > MENU_FILTER_THRESHOLD;
+  const filtered = filterByText(vaults, filter, (v) => v.name);
   return (
     <DropdownMenu.Root onOpenChange={(open) => !open && setFilter("")}>
       <DropdownMenu.Trigger asChild>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -30,6 +30,7 @@ import { VaultList, type VaultRow } from "@/components/vault-list";
 import { VaultChip } from "@/components/ui/vault-chip";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { TooltipText } from "@/components/ui/tooltip-text";
+import { MenuFilter } from "@/components/ui/menu-filter";
 import { QuickstartDialog, QUICKSTART_DISMISS_KEY } from "@/components/quickstart-dialog";
 import {
   listVaults,
@@ -571,6 +572,7 @@ export default function HomePage() {
  * One vault → straight to its new-doc form; several → a small vault picker.
  */
 function NewDocAction({ vaults }: { vaults: VaultRow[] }) {
+  const [filter, setFilter] = useState("");
   if (vaults.length === 1) {
     return (
       <Button asChild variant="accent" size="md">
@@ -581,8 +583,12 @@ function NewDocAction({ vaults }: { vaults: VaultRow[] }) {
       </Button>
     );
   }
+  // A filter only earns its keep once the list is long enough to scan.
+  const showFilter = vaults.length > 7;
+  const q = filter.trim().toLowerCase();
+  const filtered = q ? vaults.filter((v) => v.name.toLowerCase().includes(q)) : vaults;
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root onOpenChange={(open) => !open && setFilter("")}>
       <DropdownMenu.Trigger asChild>
         <Button variant="accent" size="md">
           <FilePlus className="h-4 w-4" aria-hidden />
@@ -596,18 +602,28 @@ function NewDocAction({ vaults }: { vaults: VaultRow[] }) {
           sideOffset={6}
           className="z-[var(--z-popover)] max-h-[60vh] overflow-y-auto min-w-[220px] rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
         >
-          <div className="px-3 py-1.5 coord">Choose a vault</div>
-          {vaults.map((v) => (
-            <DropdownMenu.Item key={v.id} asChild>
-              <Link
-                to={`/vault/${v.name}/doc/new`}
-                className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-foreground outline-none rounded-[var(--radius-sm)] data-[highlighted]:bg-surface-hover"
-              >
-                <FileText className="h-4 w-4 text-foreground-muted" aria-hidden />
-                <TooltipText className="truncate">{v.name}</TooltipText>
-              </Link>
-            </DropdownMenu.Item>
-          ))}
+          {showFilter ? (
+            <div className="sticky -top-1 z-10 -mx-1 -mt-1 mb-0.5 border-b border-border bg-surface px-1 pt-1">
+              <MenuFilter value={filter} onChange={setFilter} placeholder="Filter vaults" />
+            </div>
+          ) : (
+            <div className="px-3 py-1.5 coord">Choose a vault</div>
+          )}
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-foreground-muted">No matches</div>
+          ) : (
+            filtered.map((v) => (
+              <DropdownMenu.Item key={v.id} asChild>
+                <Link
+                  to={`/vault/${v.name}/doc/new`}
+                  className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-foreground outline-none rounded-[var(--radius-sm)] data-[highlighted]:bg-surface-hover"
+                >
+                  <FileText className="h-4 w-4 text-foreground-muted" aria-hidden />
+                  <TooltipText className="truncate">{v.name}</TooltipText>
+                </Link>
+              </DropdownMenu.Item>
+            ))
+          )}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -395,6 +395,8 @@ export default function SearchPage() {
             onValueChange={switchVault}
             aria-label="Search scope — limit to a vault"
             className="h-9 w-auto min-w-[220px] max-w-sm"
+            searchable
+            searchPlaceholder="Filter vaults"
             options={[
               { value: "", label: `All vaults (${vaults.length})` },
               ...vaults.map((v) => ({ value: v.name, label: v.name })),


### PR DESCRIPTION
Closes #204, closes #203.

Two small, self-contained frontend features.

## #204 — vault-picker filters
The vault **rail** already had a live filter; this extends the same affordance to the two remaining surfaces where vaults are listed for selection:
- **`SelectMenu`** gains an opt-in `searchable` prop — renders a filter box atop the open list once options exceed a threshold (default 8). Wired into the **search-scope selector**.
- **Home "New document" dropdown** gets the same filter when there are >7 vaults.
- New shared **`MenuFilter`** input — styled to live inside a Radix `DropdownMenu.Content`: stops typeahead propagation (keeps Escape), and steals focus back from the auto-focused first item via rAF.

## #203 — author relations from the UI
The Relations panel was view-only; the backend `POST`/`DELETE /relations` already existed. Now:
- `createRelation` / `deleteRelation` API clients + a `RELATION_TYPES` vocabulary mirror (`links_to` excluded — markdown-derived).
- **`RelationsPanel`**: per-row unlink (with confirm) + an **Add relation** dialog combining a typed-relation `SelectMenu` and a **`ResourcePicker`** (search-as-you-type, intra-vault, self excluded). `links_to` rows are non-deletable.
- `document.tsx` Relations tab renders `RelationsPanel` and reloads relations after add/remove.

## Verification
Browser-driven end-to-end against the local stack (ephemeral user/vaults/docs, cleaned up):
- Relation **create** (select type → search target → add) and **delete** (confirm) round-trip; tab badge + count update live.
- Both vault filters render past the threshold, **auto-focus** on open, and narrow the list live (`9→1`, `10→1`).

Gate green: `design:check` / `typecheck` / `lint` (0 errors) / `test` (265 passed) / `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)