### PR TITLE
feat(search): extend #189 Phase-2 vault filter to qdrant + seahorse drivers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2697
+        "line_number": 2735
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-16T09:48:46Z"
+  "generated_at": "2026-06-17T07:43:24Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,42 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.14 — 2026-06-17  *(feature — vault filter extended to qdrant + seahorse)*
+
+**#189 Phase 2 vault filter, now driver-agnostic.** The per-vault ACL search
+path (filter the vector search by the user's accessible vault ids instead of
+enumerating every accessible source id) previously only ran on pgvector. It now
+works on **qdrant** and the three **seahorse** drivers too.
+
+- **Capability flag, not a driver-name check.** `VectorStore.vault_filter_supported`
+  (default False; each capable driver sets it True on its own class) replaces the
+  hardcoded `driver == "pgvector"` in `search_service.vault_path_eligible`, the
+  `vault_backfill` worker, and `/health`. Read via `getattr(..., False)` so an
+  unknown driver is fail-safe (source-id path, never a wrong vault path).
+- **qdrant:** writes `vault_id` on each point's payload, indexes it (KEYWORD),
+  filters on it in `hybrid_search` under the exactly-one(vault_ids, source_ids)
+  contract, and counts un-backfilled points via `count(IsNullCondition, exact=True)`.
+- **seahorse (Coral REST / gRPC / Cloud):** `vault_id` column on the table schema
+  + written on every upsert; filtered via a shared `vault_filter_sql` helper
+  (`vault_id IN (…)`). The REST driver gates readiness on a `/data/scan` null
+  count (fail-closed); gRPC/Cloud store + filter but stay gated (no count
+  primitive) until a count is wired.
+- **Backfill-worker fix:** a capable non-pgvector driver now gates `is_ready()`
+  on its `vault_backfill_pending()==0` instead of latching ready immediately (the
+  prior latch would have activated the vault path before existing points carried
+  `vault_id`, under-fetching). pgvector same-instance keeps its server-side
+  auto-join backfill.
+- **Upgrade path for existing non-pgvector deployments:** reindex
+  (`UPDATE chunks SET vector_indexed_at = NULL`) so the worker re-upserts every
+  point *with* `vault_id`; until the null count hits 0 search stays on the safe
+  source-id path (correct, just not the O(vaults) speedup). Production runs
+  pgvector and is unaffected.
+- Tests: new qdrant + seahorse(REST/Cloud) vault-filter unit suites; gRPC unit
+  test extended (CI-only). NOTE: the seahorse drivers are unit-tested but not
+  live-verified against Coral here — the `/data/scan` count shape and qdrant's
+  `IsNullCondition` absent-key semantics should be confirmed against a live
+  server before relying on auto-activation.
+
 ## 0.8.13 — 2026-06-16  *(patch — search: zero-touch Phase 2 + retrieval fixes)*
 
 Follow-ups that make the 0.8.12 search work correct and operator-free at scale.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -19,7 +19,9 @@ works on **qdrant** and the three **seahorse** drivers too.
   unknown driver is fail-safe (source-id path, never a wrong vault path).
 - **qdrant:** writes `vault_id` on each point's payload, indexes it (KEYWORD),
   filters on it in `hybrid_search` under the exactly-one(vault_ids, source_ids)
-  contract, and counts un-backfilled points via `count(IsNullCondition, exact=True)`.
+  contract, and counts un-backfilled points via `count(IsEmptyCondition, exact=True)`
+  — IsEmpty matches missing-OR-null; IsNull would miss pre-upgrade points that
+  never carried the key (under-count → gate flips ready early).
 - **seahorse (Coral REST / gRPC / Cloud):** `vault_id` column on the table schema
   + written on every upsert; filtered via a shared `vault_filter_sql` helper
   (`vault_id IN (…)`). The REST driver gates readiness on a `/data/scan` null
@@ -37,9 +39,9 @@ works on **qdrant** and the three **seahorse** drivers too.
   pgvector and is unaffected.
 - Tests: new qdrant + seahorse(REST/Cloud) vault-filter unit suites; gRPC unit
   test extended (CI-only). NOTE: the seahorse drivers are unit-tested but not
-  live-verified against Coral here — the `/data/scan` count shape and qdrant's
-  `IsNullCondition` absent-key semantics should be confirmed against a live
-  server before relying on auto-activation.
+  live-verified against Coral here — the `/data/scan` count shape should be
+  confirmed against a live server before relying on seahorse auto-activation.
+  (qdrant's `IsEmptyCondition` absent-key count IS live-verified against 1.18.2.)
 
 ## 0.8.13 — 2026-06-16  *(patch — search: zero-touch Phase 2 + retrieval fixes)*
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -22,7 +22,7 @@ from app.models.document import SearchResponse, SearchResult
 from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.vector_store import VectorHit, get_vector_store
-from app.services.vector_store.base import VectorStoreUnavailable
+from app.services.vector_store.base import VectorStoreUnavailable, supports_vault_filter
 from app.services.rerank_service import RerankError, rerank
 from app.services.uri_service import parse_uri
 
@@ -100,7 +100,7 @@ def vault_path_eligible(
     When False, the existing source_ids path runs unchanged."""
     return (
         settings.vault_filter_enabled
-        and getattr(get_vector_store(), "vault_filter_supported", False)
+        and supports_vault_filter(get_vector_store())
         and not (collection or doc_type or tags or source_uris)
     )
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -94,13 +94,13 @@ def vault_path_eligible(
     source_uris: list[str] | None,
 ) -> bool:
     """Whether a search should use the VAULT-granularity ACL path (issue #189
-    Phase 2) instead of enumerating source ids. Requires: the flag on, the
-    pgvector driver (only it stores vault_id), and NO doc-level narrowing filter
-    (those still need per-resource source_ids). When False, the existing
-    source_ids path runs unchanged."""
+    Phase 2) instead of enumerating source ids. Requires: the flag on, a driver
+    whose `vault_filter_supported` is True (it stores vault_id and filters on it),
+    and NO doc-level narrowing filter (those still need per-resource source_ids).
+    When False, the existing source_ids path runs unchanged."""
     return (
         settings.vault_filter_enabled
-        and settings.vector_store_driver == "pgvector"
+        and getattr(get_vector_store(), "vault_filter_supported", False)
         and not (collection or doc_type or tags or source_uris)
     )
 

--- a/backend/app/services/vault_backfill.py
+++ b/backend/app/services/vault_backfill.py
@@ -11,10 +11,14 @@ startup (non-blocking, in bounded batches), and search self-activates the vault
 path only once it reports ready — until then it transparently uses the existing
 source-id path (no behavior change, no under-fetch). Zero-touch upgrade.
 
-Scope: pgvector in same-instance mode (the vector index lives in the main DB, so
-the backfill is a server-side join). For a SEPARATE vector instance or any other
-driver this worker is a no-op — those run `scripts/backfill_vault_id.py` by hand
-(rare; only pgvector implements the vault filter today).
+Auto-fill scope: pgvector in same-instance mode (the vector index lives in the
+main DB, so the backfill is a server-side join). Every OTHER vault-filter-capable
+driver (qdrant, seahorse, separate-instance pgvector) can't be reached by that
+join, so this worker doesn't auto-fill them — it only GATES readiness on the
+driver's own `vault_backfill_pending()` reaching 0 (the operator backfills:
+qdrant via `scripts/backfill_vault_id.py`, seahorse via recreate + reindex). A
+driver whose `vault_filter_supported` is False never takes the vault path, so the
+worker latches ready immediately for it.
 
 Readiness = "no LIVE-source point is missing vault_id". Orphan points (whose
 source row was deleted) keep `vault_id` NULL forever but are excluded by BOTH the
@@ -67,25 +71,33 @@ async def _process_once() -> int:
     if _ready:
         return 0
 
-    # Non-pgvector drivers have no vault_id column and `vault_path_eligible` is
-    # already False for them — the vault path is never taken, so readiness is
-    # moot. Latch ready so the worker stops looping instead of spinning forever.
-    if not _is_pgvector():
+    store = get_vector_store()
+
+    # A driver without the vault filter never takes the vault path
+    # (`vault_path_eligible` is False for it), so readiness is moot. Latch ready
+    # so the worker stops looping instead of spinning forever.
+    if not getattr(store, "vault_filter_supported", False):
         _ready = True
         return 0
 
-    # Separate pgvector instance: we can't run the server-side join (the index
-    # lives in another DB), so we DON'T auto-backfill — the operator runs
-    # scripts/backfill_vault_id.py. But we still gate: readiness = the vector
-    # instance reports 0 NULL vault_id (exactly the manual script's
-    # "0 before flip" contract, orphans included). Until then the source-id path
-    # runs. This preserves the pre-auto-backfill escape hatch without the old
-    # under-fetch foot-gun (activating the flag before the backfill finished).
-    if not _same_instance():
-        fn = getattr(get_vector_store(), "vault_backfill_pending", None)
-        if fn is not None and await fn() == 0:
+    # Capable driver this worker CANNOT auto-backfill — qdrant, seahorse, or a
+    # SEPARATE-instance pgvector: none is reachable by the same-DB server-side
+    # join below. We DON'T auto-fill; the operator backfills (qdrant: the script;
+    # seahorse: recreate + reindex; separate pgvector: scripts/backfill_vault_id).
+    # We still gate: readiness = the driver reports 0 NULL vault_id (the manual
+    # script's "0 before flip" contract). Until then search keeps the source-id
+    # path — no under-fetch. A capable driver MUST expose vault_backfill_pending();
+    # if one somehow doesn't, stay gated forever rather than activate blind.
+    if not _applicable():
+        fn = getattr(store, "vault_backfill_pending", None)
+        if fn is None:
+            return 0
+        if await fn() == 0:
             _ready = True
-            logger.info("vault_id backfill complete (separate instance) — vault filter path is now active")
+            logger.info(
+                "vault_id backfill complete (%s) — vault filter path is now active",
+                settings.vector_store_driver,
+            )
         return 0
 
     schema = settings.vector_store_schema
@@ -143,9 +155,17 @@ stop = _runner.stop
 
 async def pending_stats() -> dict:
     """For /health: readiness + remaining NULL count (the safe-to-activate
-    signal). null_remaining includes orphans; readiness ignores them."""
-    out: dict = {"ready": is_ready(), "applicable": _applicable()}
-    fn = getattr(get_vector_store(), "vault_backfill_pending", None)
+    signal). null_remaining includes orphans; readiness ignores them.
+    `applicable` = this worker auto-fills here (pgvector same-instance);
+    `vault_filter_supported` = the driver is capable at all (so an operator on
+    qdrant/seahorse, where applicable=False, still sees the gate is live)."""
+    store = get_vector_store()
+    out: dict = {
+        "ready": is_ready(),
+        "applicable": _applicable(),
+        "vault_filter_supported": getattr(store, "vault_filter_supported", False),
+    }
+    fn = getattr(store, "vault_backfill_pending", None)
     if fn is not None:
         try:
             out["null_remaining"] = await fn()

--- a/backend/app/services/vault_backfill.py
+++ b/backend/app/services/vault_backfill.py
@@ -32,6 +32,7 @@ from app.config import settings
 from app.db.postgres import get_pool
 from app.services._backfill import BackfillRunner
 from app.services.vector_store import get_vector_store
+from app.services.vector_store.base import supports_vault_filter
 
 logger = logging.getLogger("akb.vault_backfill")
 
@@ -58,9 +59,13 @@ def _same_instance() -> bool:
 
 
 def _applicable() -> bool:
-    # True only where this worker can AUTO-backfill (same-instance pgvector). A
-    # separate vector instance is still gated for readiness below — it just isn't
-    # auto-filled here (the operator runs scripts/backfill_vault_id.py).
+    # True only where this worker can AUTO-backfill via the server-side
+    # `UPDATE … JOIN documents/vault_tables/vault_files` (see _process_once).
+    # That needs BOTH: the index shares the main DB (_same_instance) AND the
+    # driver's points are joinable to the main catalog by source_id — which
+    # `_is_pgvector` stands in for (it's the only such driver; qdrant/seahorse
+    # store points out-of-band). A capable driver that isn't applicable is still
+    # gated for readiness below, just not auto-filled (operator backfills).
     return _is_pgvector() and _same_instance()
 
 
@@ -76,7 +81,7 @@ async def _process_once() -> int:
     # A driver without the vault filter never takes the vault path
     # (`vault_path_eligible` is False for it), so readiness is moot. Latch ready
     # so the worker stops looping instead of spinning forever.
-    if not getattr(store, "vault_filter_supported", False):
+    if not supports_vault_filter(store):
         _ready = True
         return 0
 
@@ -163,7 +168,7 @@ async def pending_stats() -> dict:
     out: dict = {
         "ready": is_ready(),
         "applicable": _applicable(),
-        "vault_filter_supported": getattr(store, "vault_filter_supported", False),
+        "vault_filter_supported": supports_vault_filter(store),
     }
     fn = getattr(store, "vault_backfill_pending", None)
     if fn is not None:

--- a/backend/app/services/vector_store/_seahorse_common.py
+++ b/backend/app/services/vector_store/_seahorse_common.py
@@ -67,3 +67,27 @@ def validate_uuid_for_sql(s: str) -> str:
     defense in depth against any caller mistake."""
     uuid.UUID(s)
     return s
+
+
+def vault_filter_sql(
+    vault_ids: list[str] | None,
+    source_ids: list[str] | None,
+    *,
+    vault_col: str = "vault_id",
+    source_col: str = "source_id",
+) -> str | None:
+    """The ACL pre-filter as a Coral SQL WHERE clause (issue #189 Phase 2):
+    vault_ids (per-VAULT) wins when present, else source_ids (per-resource),
+    else None (no filter). Mirrors the pgvector/qdrant exactly-one contract — the
+    caller sends one or the other, never both. Both id kinds are UUIDs, validated
+    before interpolation (defense in depth; the IN list is otherwise trusted)."""
+    assert not (vault_ids and source_ids), \
+        "vault_filter_sql got both vault_ids and source_ids; expected exactly one"
+    if vault_ids:
+        col, ids = vault_col, vault_ids
+    elif source_ids:
+        col, ids = source_col, source_ids
+    else:
+        return None
+    quoted = ", ".join(f"'{validate_uuid_for_sql(str(s))}'" for s in ids)
+    return f"{col} IN ({quoted})"

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -126,6 +126,16 @@ class VectorStore(Protocol):
     (idempotent by chunk_id).
     """
 
+    # Capability flag (issue #189 Phase 2). True only on drivers that (1) write
+    # `vault_id` on every point in upsert_one, (2) filter on it in hybrid_search
+    # under the exactly-one(vault_ids, source_ids) contract, AND (3) expose
+    # `vault_backfill_pending()`. The three ship together — this flag IS that
+    # contract. Drivers DUCK-TYPE this Protocol (they don't inherit), so this
+    # default does NOT propagate; every capable driver sets it on its own class,
+    # and every reader uses `getattr(store, "vault_filter_supported", False)` so
+    # an unknown driver is fail-safe (source-id path, never a wrong vault path).
+    vault_filter_supported: bool = False
+
     async def ensure_collection(self, *, conn=None) -> None:
         """Idempotent: create the underlying storage (Qdrant collection,
         PG schema/tables, etc.) if it doesn't exist. May reuse `conn`
@@ -264,10 +274,12 @@ class VectorStore(Protocol):
           their own filter primitive.
         - `vault_ids` is the per-VAULT ACL filter (issue #189 Phase 2): a small
           set of accessible vault ids the caller passes INSTEAD of enumerating
-          every accessible source_id. Drivers that store `vault_id` on each
-          point (pgvector) filter on it natively; others ignore it for now and
-          keep filtering by `source_ids`. The caller sends one or the other,
-          never both at once.
+          every accessible source_id. Drivers with `vault_filter_supported=True`
+          store `vault_id` on each point and filter on it natively (pgvector,
+          qdrant, seahorse); drivers without it never receive `vault_ids` (the
+          caller's `vault_path_eligible` gate is False for them) and keep
+          filtering by `source_ids`. The caller sends EXACTLY ONE of the two,
+          never both — capable drivers assert this.
         - `prefetch_per_leg` caps each leg's candidate pool before
           fusion. Caller decides — typically `max(limit * 3, 50)`.
         """

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -126,11 +126,14 @@ class VectorStore(Protocol):
     (idempotent by chunk_id).
     """
 
-    # Capability flag (issue #189 Phase 2). True only on drivers that (1) write
-    # `vault_id` on every point in upsert_one, (2) filter on it in hybrid_search
-    # under the exactly-one(vault_ids, source_ids) contract, AND (3) expose
-    # `vault_backfill_pending()`. The three ship together — this flag IS that
-    # contract. Drivers DUCK-TYPE this Protocol (they don't inherit), so this
+    # Capability flag (issue #189 Phase 2). True on drivers that (1) write
+    # `vault_id` on every point in upsert_one and (2) filter on it in
+    # hybrid_search under the exactly-one(vault_ids, source_ids) contract. A
+    # capable driver SHOULD also (3) expose `vault_backfill_pending()` so the
+    # readiness worker can auto-activate it; one that doesn't (seahorse gRPC /
+    # Cloud — no count primitive yet) stays permanently gated on the safe
+    # source-id path (correct, just not the O(vaults) speedup) until a count is
+    # wired. Drivers DUCK-TYPE this Protocol (they don't inherit), so this
     # default does NOT propagate; every capable driver sets it on its own class,
     # and every reader uses `getattr(store, "vault_filter_supported", False)` so
     # an unknown driver is fail-safe (source-id path, never a wrong vault path).

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -85,6 +85,17 @@ def has_dense(dense: list[float] | None) -> TypeGuard[list[float]]:
     return dense is not None and len(dense) > 0
 
 
+def supports_vault_filter(store) -> bool:
+    """Single source of truth for "this driver implements the vault filter"
+    (issue #189 Phase 2). Reads the `vault_filter_supported` capability via
+    `getattr(..., False)` because drivers DUCK-TYPE the Protocol (they don't
+    inherit, so the Protocol default doesn't propagate) — an unknown/future
+    driver therefore reads False and is fail-safe to the source-id path. Used by
+    `search_service.vault_path_eligible` and the `vault_backfill` worker so the
+    capability-read semantics live in one place, not three `getattr` literals."""
+    return getattr(store, "vault_filter_supported", False)
+
+
 async def loop_upsert_batch(
     store: "VectorStore",
     chunks: list[ChunkUpsert],

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -96,6 +96,10 @@ class PgvectorStore:
     pending (recoverable, but visible as a counter mismatch).
     """
 
+    # Stores vault_id, filters on it in hybrid_search, exposes
+    # vault_backfill_pending() — the reference vault-filter driver (issue #189).
+    vault_filter_supported = True
+
     def __init__(
         self,
         *,

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -33,10 +33,15 @@ PAYLOAD_SECTION_PATH = "section_path"
 PAYLOAD_CONTENT = "content"
 PAYLOAD_SOURCE_TYPE = "source_type"
 PAYLOAD_SOURCE_ID = "source_id"
+PAYLOAD_VAULT_ID = "vault_id"
 
 
 class QdrantStore:
     """VectorStore impl over Qdrant. Uses native RRF fusion."""
+
+    # Stores vault_id on each point's payload, filters on it in hybrid_search,
+    # exposes vault_backfill_pending() — vault filter capable (issue #189 P2).
+    vault_filter_supported = True
 
     def __init__(
         self,
@@ -102,6 +107,18 @@ class QdrantStore:
                 field_name=PAYLOAD_SOURCE_ID,
                 field_schema=qm.PayloadSchemaType.KEYWORD,
             )
+        # vault_id is the per-vault ACL filter key (issue #189 Phase 2). Indexed
+        # for the same reason as source_id. Created OUTSIDE the `if not exists`
+        # block (idempotent server-side) so an ALREADY-deployed collection
+        # — created before vault_id existed — also gets the index on first ensure.
+        try:
+            await client.create_payload_index(
+                collection_name=self._collection,
+                field_name=PAYLOAD_VAULT_ID,
+                field_schema=qm.PayloadSchemaType.KEYWORD,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("vault_id payload index ensure failed (non-fatal): %s", e)
         self._ensured_collection = True
 
     async def health(self) -> bool:
@@ -111,6 +128,33 @@ class QdrantStore:
             return True
         except Exception:  # noqa: BLE001
             return False
+
+    async def vault_backfill_pending(self) -> int:
+        """Points whose `vault_id` payload is missing/null (issue #189 Phase 2) —
+        the backfill-readiness signal the worker gates on (qdrant has no server-
+        side join to the main DB, so the operator backfills by reindexing). The
+        qdrant analogue of pgvector's `WHERE vault_id IS NULL`.
+
+        Uses `IsEmptyCondition`, NOT `IsNullCondition`: verified against qdrant
+        1.18.2, IsNull matches only an EXPLICIT null and MISSES a point that
+        never had the key — which is exactly the pre-upgrade point set we must
+        count. IsEmpty matches missing OR null. (A wrong choice here under-counts
+        → the gate flips ready early → users miss their un-backfilled docs.)
+        `exact=True` is mandatory: the default approximate count could read 0
+        prematurely for the same reason."""
+        await self.ensure_collection()
+        client = self._get_client()
+        try:
+            res = await client.count(
+                collection_name=self._collection,
+                count_filter=qm.Filter(
+                    must=[qm.IsEmptyCondition(is_empty=qm.PayloadField(key=PAYLOAD_VAULT_ID))],
+                ),
+                exact=True,
+            )
+            return int(res.count)
+        except Exception as e:  # noqa: BLE001
+            raise VectorStoreUnavailable(f"vault_backfill_pending failed: {e}") from e
 
     # ── Upsert ───────────────────────────────────────────────────
 
@@ -154,6 +198,7 @@ class QdrantStore:
                 PAYLOAD_CONTENT: content,
                 PAYLOAD_SOURCE_TYPE: source_type,
                 PAYLOAD_SOURCE_ID: str(source_id),
+                PAYLOAD_VAULT_ID: str(vault_id),
             },
         )
         await client.upsert(collection_name=self._collection, points=[point])
@@ -198,12 +243,17 @@ class QdrantStore:
         await self.ensure_collection()
         client = self._get_client()
 
+        # Exactly one ACL filter (issue #189 Phase 2): the caller sends vault_ids
+        # (vault path) OR source_ids (resource path), never both. Mirrors pgvector.
+        assert not (vault_ids and source_ids), \
+            "hybrid_search got both vault_ids and source_ids; expected exactly one"
+
         has_dense = query_dense is not None and len(query_dense) > 0
         has_sparse = len(query_sparse_indices) > 0
         if not has_dense and not has_sparse:
             return []
 
-        flt = _source_filter(source_ids)
+        flt = _acl_filter(vault_ids=vault_ids, source_ids=source_ids)
 
         if has_dense and has_sparse:
             prefetch = [
@@ -260,16 +310,19 @@ class QdrantStore:
         return [_to_hit(p) for p in result.points]
 
 
-def _source_filter(source_ids: list[str] | None):
-    if not source_ids:
+def _acl_filter(*, vault_ids: list[str] | None, source_ids: list[str] | None):
+    """The ACL pre-filter: vault_ids (per-vault, issue #189 Phase 2) wins when
+    present, else source_ids (per-resource), else no filter. The qdrant analogue
+    of pgvector's `WHERE {vault_id|source_id} = ANY(...)`. vault_id is stored as
+    UUID text (like source_id), so MatchAny over the keyword index is exact."""
+    if vault_ids:
+        key, vals = PAYLOAD_VAULT_ID, vault_ids
+    elif source_ids:
+        key, vals = PAYLOAD_SOURCE_ID, source_ids
+    else:
         return None
     return qm.Filter(
-        must=[
-            qm.FieldCondition(
-                key=PAYLOAD_SOURCE_ID,
-                match=qm.MatchAny(any=[str(d) for d in source_ids]),
-            ),
-        ],
+        must=[qm.FieldCondition(key=key, match=qm.MatchAny(any=[str(v) for v in vals]))],
     )
 
 

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -135,13 +135,13 @@ class QdrantStore:
         side join to the main DB, so the operator backfills by reindexing). The
         qdrant analogue of pgvector's `WHERE vault_id IS NULL`.
 
-        Uses `IsEmptyCondition`, NOT `IsNullCondition`: verified against qdrant
-        1.18.2, IsNull matches only an EXPLICIT null and MISSES a point that
-        never had the key — which is exactly the pre-upgrade point set we must
+        Uses `IsEmptyCondition`, NOT `IsNullCondition`: verified against a live
+        qdrant 1.18.x server, IsNull matches only an EXPLICIT null and MISSES a
+        point that never had the key — exactly the pre-upgrade point set we must
         count. IsEmpty matches missing OR null. (A wrong choice here under-counts
         → the gate flips ready early → users miss their un-backfilled docs.)
-        `exact=True` is mandatory: the default approximate count could read 0
-        prematurely for the same reason."""
+        We pin `exact=True` because an APPROXIMATE count (`exact=False`) could
+        read 0 prematurely for the same reason — don't rely on the client default."""
         await self.ensure_collection()
         client = self._get_client()
         try:

--- a/backend/app/services/vector_store/seahorse_cloud.py
+++ b/backend/app/services/vector_store/seahorse_cloud.py
@@ -30,6 +30,7 @@ from typing import Any
 import httpx
 
 from .base import ChunkUpsert, VectorHit, VectorStoreUnavailable, has_dense
+from ._seahorse_common import vault_filter_sql as _vault_filter_sql
 
 logger = logging.getLogger("akb.vector_store.seahorse")
 
@@ -52,6 +53,7 @@ COL_ID = "id"                       # PK == AKB chunk UUID
 COL_EXTERNAL_CHUNK_ID = "external_chunk_id"
 COL_SOURCE_TYPE = "source_type"
 COL_SOURCE_ID = "source_id"
+COL_VAULT_ID = "vault_id"           # per-vault ACL filter key (issue #189 P2)
 COL_SECTION_PATH = "section_path"
 COL_CONTENT = "content"
 COL_CHUNK_INDEX = "chunk_index"
@@ -86,6 +88,14 @@ def _sparse_to_str(indices: list[int], values: list[float]) -> str:
 
 class SeahorseCloudStore:
     """VectorStore impl over Seahorse Cloud's TABLE_V2 + BFF API."""
+
+    # Stores vault_id and filters on it in hybrid_search (issue #189 Phase 2).
+    # Like the gRPC driver, exposes no vault_backfill_pending(): the managed BFF
+    # host API has no documented count/scan primitive here, so the readiness
+    # worker keeps this driver on the safe source-id path until a count is wired
+    # (recreate+reindex, then it auto-activates). Storage + filtering are correct
+    # meanwhile.
+    vault_filter_supported = True
 
     def __init__(
         self,
@@ -207,6 +217,9 @@ class SeahorseCloudStore:
                 {"name": COL_EXTERNAL_CHUNK_ID, "nullable": False, "type": "STRING"},
                 {"name": COL_SOURCE_TYPE, "nullable": False, "type": "STRING"},
                 {"name": COL_SOURCE_ID, "nullable": False, "type": "STRING"},
+                # vault_id (issue #189 Phase 2). nullable=True so a recreate-and-
+                # reindex upgrade lands the column before rows carry their value.
+                {"name": COL_VAULT_ID, "nullable": True, "type": "STRING"},
                 {"name": COL_SECTION_PATH, "nullable": True, "type": "STRING"},
                 {"name": COL_CONTENT, "nullable": False, "type": "STRING"},
                 {"name": COL_CHUNK_INDEX, "nullable": False, "type": "INT64"},
@@ -295,6 +308,7 @@ class SeahorseCloudStore:
             COL_EXTERNAL_CHUNK_ID: str(chunk_id),
             COL_SOURCE_TYPE: source_type,
             COL_SOURCE_ID: str(source_id),
+            COL_VAULT_ID: str(vault_id),
             COL_SECTION_PATH: section_path or "",
             COL_CONTENT: content,
             COL_CHUNK_INDEX: int(chunk_index),
@@ -417,9 +431,13 @@ class SeahorseCloudStore:
             }
         if has_dense and has_sparse:
             body["fusion"] = {"type": "rrf", "parameters": {"k": RRF_K}}
-        if source_ids:
-            quoted = ",".join(f"'{_sql_quote(str(s))}'" for s in source_ids)
-            body["filter"] = f"{COL_SOURCE_ID} IN ({quoted})"
+        # ACL pre-filter (issue #189 Phase 2): exactly one of vault_ids /
+        # source_ids; vault_filter_sql asserts that + UUID-validates each id.
+        acl = _vault_filter_sql(
+            vault_ids, source_ids, vault_col=COL_VAULT_ID, source_col=COL_SOURCE_ID,
+        )
+        if acl is not None:
+            body["filter"] = acl
 
         try:
             client = await self._http()

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -80,7 +80,7 @@ logger = logging.getLogger("akb.vector_store.seahorse_db")
 from ._seahorse_common import (
     chunk_id_to_label as _chunk_id_to_label,
     encode_sparse_string as _encode_sparse_string,
-    validate_uuid_for_sql as _validate_uuid_for_sql,
+    vault_filter_sql as _vault_filter_sql,
 )
 
 
@@ -92,6 +92,10 @@ class SeahorseDbStore:
     ``ensure_collection`` does the catalog setup on first use (and
     is called from lifespan startup so the cost lands at boot, not
     on the first search request)."""
+
+    # Stores vault_id, filters on it in hybrid_search, exposes
+    # vault_backfill_pending() — vault filter capable (issue #189 Phase 2).
+    vault_filter_supported = True
 
     def __init__(
         self,
@@ -203,6 +207,51 @@ class SeahorseDbStore:
         except Exception:  # noqa: BLE001
             return False
 
+    async def vault_backfill_pending(self) -> int:
+        """Rows whose `vault_id` is NULL (issue #189 Phase 2) — the backfill-
+        readiness signal the worker gates on. Coral has no in-place UPDATE, so
+        the supported seahorse upgrade is recreate + reindex: a fresh table has
+        the column and every re-upserted row carries vault_id (this returns 0 and
+        the vault path activates); a pre-upgrade table lacks the column entirely
+        and this scan errors (kept gated → operator must recreate).
+
+        FAIL-CLOSED: returns 0 ONLY on a clear empty scan; ANY error or
+        unexpected shape raises VectorStoreUnavailable so the worker stays gated
+        and search keeps the safe source-id path — never activating the vault
+        path on an uncertain count. NOTE: the `/data/scan` request/response shape
+        is modeled on Coral's REST conventions but is NOT exercised by the e2e
+        suite — confirm against a live Coral before trusting the gate to flip."""
+        http = await self._http()
+        try:
+            resp = await http.post(
+                f"/v2/tables/{self._table}/data/scan",
+                json={"filter": "vault_id IS NULL", "limit": 1},
+            )
+        except httpx.HTTPError as e:
+            raise VectorStoreUnavailable(
+                f"Coral POST /v2/tables/{self._table}/data/scan: {e}"
+            ) from e
+        if resp.status_code != 200:
+            raise VectorStoreUnavailable(
+                f"Coral scan for null vault_id → {resp.status_code}: {resp.text[:200]}"
+            )
+        try:
+            body = resp.json()
+        except Exception as e:  # noqa: BLE001
+            raise VectorStoreUnavailable(f"Coral scan returned non-JSON: {e}") from e
+        # Coral scan returns the matching rows under `data`/`rows` (shape varies
+        # by version). Check key PRESENCE, not truthiness — an empty list (`[]`,
+        # the 0-null-rows / ready case) must not fall through to the error branch.
+        if "data" in body:
+            rows = body["data"]
+        elif "rows" in body:
+            rows = body["rows"]
+        else:
+            raise VectorStoreUnavailable(
+                f"Coral scan response missing data/rows: {str(body)[:200]}"
+            )
+        return len(rows)
+
     async def upsert_one(
         self,
         *,
@@ -242,6 +291,7 @@ class SeahorseDbStore:
             "chunk_index": chunk_index,
             "source_type": source_type,
             "source_id": source_id,
+            "vault_id": vault_id,
             "sparse": _encode_sparse_string(sparse_indices, sparse_values),
         }
         if has_dense(dense):
@@ -299,6 +349,7 @@ class SeahorseDbStore:
         sparse_values: list[float],
         source_type: str,
         source_id: str,
+        vault_id: str,
     ) -> dict[str, Any]:
         """Build the canonical Coral record dict for a single chunk.
         Shared by ``upsert_one`` and ``upsert_batch`` so the two paths
@@ -317,6 +368,7 @@ class SeahorseDbStore:
             "chunk_index": chunk_index,
             "source_type": source_type,
             "source_id": source_id,
+            "vault_id": vault_id,
             "sparse": _encode_sparse_string(sparse_indices, sparse_values),
             "embedding": dense,
         }
@@ -354,6 +406,7 @@ class SeahorseDbStore:
                 sparse_values=c.sparse_values,
                 source_type=c.source_type,
                 source_id=c.source_id,
+                vault_id=c.vault_id,
             )
             for c in chunks
         ]
@@ -529,12 +582,12 @@ class SeahorseDbStore:
         }
         if sparse_metadata is not None:
             payload["sparse"]["metadata"] = sparse_metadata
-        if source_ids:
-            # SQL WHERE clause — Coral parses this directly. Each
-            # `source_id` is a UUID, so the IN list is safe to
-            # build by interpolation. Defensive check + quote.
-            quoted = ", ".join(f"'{_validate_uuid_for_sql(s)}'" for s in source_ids)
-            payload["filter"] = f"source_id IN ({quoted})"
+        # ACL pre-filter as a Coral SQL WHERE clause (issue #189 Phase 2): the
+        # caller sends EXACTLY ONE of vault_ids (per-vault) / source_ids (per-
+        # resource). vault_filter_sql asserts that and UUID-validates each id.
+        acl = _vault_filter_sql(vault_ids, source_ids)
+        if acl is not None:
+            payload["filter"] = acl
 
         http = await self._http()
         try:
@@ -630,6 +683,10 @@ class SeahorseDbStore:
                 {"name": "chunk_index", "type": "INT64", "nullable": True},
                 {"name": "source_type", "type": "STRING", "nullable": False},
                 {"name": "source_id", "type": "STRING", "nullable": False},
+                # vault_id (issue #189 Phase 2): the per-vault ACL filter key.
+                # nullable=True so a recreate-and-reindex upgrade can land the
+                # column before every row is re-upserted with its value.
+                {"name": "vault_id", "type": "STRING", "nullable": True},
             ],
             "segmentation": {
                 "strategy": "hash",

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -240,13 +240,13 @@ class SeahorseDbStore:
         except Exception as e:  # noqa: BLE001
             raise VectorStoreUnavailable(f"Coral scan returned non-JSON: {e}") from e
         # Coral scan returns the matching rows under `data`/`rows` (shape varies
-        # by version). Check key PRESENCE, not truthiness — an empty list (`[]`,
-        # the 0-null-rows / ready case) must not fall through to the error branch.
-        if "data" in body:
-            rows = body["data"]
-        elif "rows" in body:
-            rows = body["rows"]
-        else:
+        # by version). Test with `is None`, not truthiness — an empty list (`[]`,
+        # the 0-null-rows / ready case) is not None, so it returns 0 rather than
+        # falling into the error branch; only a genuinely-missing key raises.
+        rows = body.get("data")
+        if rows is None:
+            rows = body.get("rows")
+        if rows is None:
             raise VectorStoreUnavailable(
                 f"Coral scan response missing data/rows: {str(body)[:200]}"
             )

--- a/backend/app/services/vector_store/seahorse_db_grpc.py
+++ b/backend/app/services/vector_store/seahorse_db_grpc.py
@@ -97,7 +97,7 @@ finally:
 from ._seahorse_common import (
     chunk_id_to_label as _chunk_id_to_label,
     encode_sparse_string as _encode_sparse_string,
-    validate_uuid_for_sql as _validate_uuid_for_sql,
+    vault_filter_sql as _vault_filter_sql,
 )
 from .base import ChunkUpsert, VectorHit, VectorStoreUnavailable, has_dense
 
@@ -159,6 +159,14 @@ class SeahorseDbGrpcStore:
     GetTable + CreateTable round-trip on first use; subsequent calls
     cheap-cache.
     """
+
+    # Stores vault_id and filters on it in hybrid_search (issue #189 Phase 2).
+    # Capable, but does NOT expose vault_backfill_pending(): the generated gRPC
+    # stubs here have no SqlService (no count primitive) and Coral has no scan
+    # RPC, so the readiness worker keeps this driver gated on the safe source-id
+    # path until a count is wired (recreate+reindex + a SQL/scan count, then it
+    # auto-activates). vault_id storage + filtering are still correct meanwhile.
+    vault_filter_supported = True
 
     def __init__(
         self,
@@ -302,6 +310,7 @@ class SeahorseDbGrpcStore:
             "chunk_index": chunk_index,
             "source_type": source_type,
             "source_id": source_id,
+            "vault_id": vault_id,
         }
         jsonl = (
             json.dumps(record, separators=(",", ":")) + "\n"
@@ -437,11 +446,11 @@ class SeahorseDbGrpcStore:
                 "chunk_id, source_type, source_id, section_path, content"
             ),
         )
-        if source_ids:
-            quoted = ", ".join(
-                f"'{_validate_uuid_for_sql(s)}'" for s in source_ids
-            )
-            request.filter = f"source_id IN ({quoted})"
+        # ACL pre-filter (issue #189 Phase 2): exactly one of vault_ids /
+        # source_ids; vault_filter_sql asserts that + UUID-validates each id.
+        acl = _vault_filter_sql(vault_ids, source_ids)
+        if acl is not None:
+            request.filter = acl
 
         ch = await self._ch()
         stub = query_pb2_grpc.QueryServiceStub(ch)
@@ -481,6 +490,8 @@ class SeahorseDbGrpcStore:
                 _column_scalar("chunk_index", "INT64", nullable=True),
                 _column_scalar("source_type", "STRING", nullable=False),
                 _column_scalar("source_id", "STRING", nullable=False),
+                # vault_id (issue #189 Phase 2): per-vault ACL filter key.
+                _column_scalar("vault_id", "STRING", nullable=True),
             ],
             segmentation=catalog_pb2.ExternalSegmentation(
                 strategy=catalog_pb2.SegmentationStrategy.Value(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.13"
+version = "0.8.14"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -99,6 +99,24 @@ async def test_hybrid_search_filters_by_vault_then_source_and_rejects_both():
 
 
 @pytest.mark.asyncio
+async def test_hybrid_search_dual_prefetch_filters_both_legs():
+    """The production-common path (dense AND sparse present) builds two Prefetch
+    legs and must attach the vault filter to BOTH — a leg missing the filter
+    would retrieve cross-vault candidates before RRF fusion."""
+    fake = _FakeClient()
+    store = _store_with(fake)
+    await store.hybrid_search(
+        query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
+        query_sparse_indices=[1, 2], query_sparse_values=[0.5, 0.5],
+        source_ids=None, vault_ids=["v1"], limit=10, prefetch_per_leg=50,
+    )
+    prefetch = store._client.last_query["prefetch"]
+    assert len(prefetch) == 2
+    for leg in prefetch:
+        assert leg.filter.must[0].key == PAYLOAD_VAULT_ID
+
+
+@pytest.mark.asyncio
 async def test_vault_backfill_pending_counts_null_exactly():
     fake = _FakeClient()
     store = _store_with(fake)

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -1,0 +1,122 @@
+"""Unit coverage for the qdrant driver's #189 Phase-2 vault filter — storage,
+the security-load-bearing hybrid_search filter branch, the readiness count, and
+the payload index. Pure-mocked (no live qdrant); the qdrant_client `models` (qm)
+are the real library so the asserted Filter/Condition objects are real."""
+from __future__ import annotations
+
+import pytest
+from qdrant_client import models as qm
+
+from app.services.vector_store.qdrant import (
+    QdrantStore,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_VAULT_ID,
+    _acl_filter,
+)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.upserts: list = []
+        self.indexes: list[str] = []
+        self.count_filter = None
+        self.count_exact = None
+
+    async def collection_exists(self, name):  # ensure_collection: skip create
+        return True
+
+    async def create_payload_index(self, *, collection_name, field_name, field_schema):
+        self.indexes.append(field_name)
+
+    async def upsert(self, *, collection_name, points):
+        self.upserts.extend(points)
+
+    async def count(self, *, collection_name, count_filter, exact):
+        self.count_filter = count_filter
+        self.count_exact = exact
+        return type("R", (), {"count": 7})()
+
+    async def query_points(self, **kw):
+        self.last_query = kw
+        return type("R", (), {"points": []})()
+
+
+def _store_with(fake: _FakeClient) -> QdrantStore:
+    s = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    s._client = fake
+    s._ensured_collection = True  # skip the create path; index asserted separately
+    return s
+
+
+def test_capability_flag():
+    assert QdrantStore.vault_filter_supported is True
+
+
+def test_acl_filter_branches():
+    fv = _acl_filter(vault_ids=["v1", "v2"], source_ids=None)
+    assert fv.must[0].key == PAYLOAD_VAULT_ID
+    assert fv.must[0].match.any == ["v1", "v2"]
+    fs = _acl_filter(vault_ids=None, source_ids=["s1"])
+    assert fs.must[0].key == PAYLOAD_SOURCE_ID
+    assert _acl_filter(vault_ids=None, source_ids=None) is None
+    # vault_ids wins if both somehow present (defensive, matches pgvector)
+    fb = _acl_filter(vault_ids=["v1"], source_ids=["s1"])
+    assert fb.must[0].key == PAYLOAD_VAULT_ID
+
+
+@pytest.mark.asyncio
+async def test_upsert_one_writes_vault_id_payload():
+    fake = _FakeClient()
+    store = _store_with(fake)
+    await store.upsert_one(
+        chunk_id="c1", content="hi", section_path=None, chunk_index=0,
+        dense=[0.1, 0.2, 0.3, 0.4], sparse_indices=[1], sparse_values=[0.5],
+        source_type="document", source_id="s1", vault_id="vault-9",
+    )
+    assert len(fake.upserts) == 1
+    assert fake.upserts[0].payload[PAYLOAD_VAULT_ID] == "vault-9"
+    assert fake.upserts[0].payload[PAYLOAD_SOURCE_ID] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_filters_by_vault_then_source_and_rejects_both():
+    fake = _FakeClient()
+    store = _store_with(fake)
+    common = dict(
+        query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
+        query_sparse_indices=[], query_sparse_values=[],
+        limit=10, prefetch_per_leg=50,
+    )
+    # vault path → filter on vault_id
+    await store.hybrid_search(source_ids=None, vault_ids=["v1"], **common)
+    assert store._client.last_query["query_filter"].must[0].key == PAYLOAD_VAULT_ID
+    # source path → filter on source_id
+    await store.hybrid_search(source_ids=["s1"], vault_ids=None, **common)
+    assert store._client.last_query["query_filter"].must[0].key == PAYLOAD_SOURCE_ID
+    # both at once → caller bug → AssertionError (security: exactly one)
+    with pytest.raises(AssertionError):
+        await store.hybrid_search(source_ids=["s1"], vault_ids=["v1"], **common)
+
+
+@pytest.mark.asyncio
+async def test_vault_backfill_pending_counts_null_exactly():
+    fake = _FakeClient()
+    store = _store_with(fake)
+    n = await store.vault_backfill_pending()
+    assert n == 7
+    assert fake.count_exact is True  # approximate count could flip the gate early
+    cond = fake.count_filter.must[0]
+    # IsEmpty (missing OR null), NOT IsNull (explicit-null only) — verified
+    # against qdrant 1.18.2: IsNull misses pre-upgrade points that never had the
+    # key, which under-counts and flips the readiness gate early.
+    assert isinstance(cond, qm.IsEmptyCondition)
+    assert cond.is_empty.key == PAYLOAD_VAULT_ID
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_indexes_vault_id():
+    fake = _FakeClient()
+    store = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    store._client = fake
+    await store.ensure_collection()
+    assert PAYLOAD_VAULT_ID in fake.indexes

--- a/backend/tests/test_seahorse_db_grpc_unit.py
+++ b/backend/tests/test_seahorse_db_grpc_unit.py
@@ -110,6 +110,12 @@ def test_endpoint_url_parsing(url: str, expected: str) -> None:
 # ── CreateTable schema parity with REST driver ─────────────────
 
 
+def test_vault_filter_capability_flag() -> None:
+    # Stores vault_id + filters on it (issue #189 Phase 2); no count primitive
+    # here (no SqlService stub), so the readiness worker keeps it gated.
+    assert sdgrpc.SeahorseDbGrpcStore.vault_filter_supported is True
+
+
 def test_create_table_request_shape() -> None:
     s = sdgrpc.SeahorseDbGrpcStore(
         coordinator_url="localhost:53286",
@@ -127,7 +133,7 @@ def test_create_table_request_shape() -> None:
     assert set(cols) == {
         "id", "chunk_id", "embedding", "sparse",
         "content", "section_path", "chunk_index",
-        "source_type", "source_id",
+        "source_type", "source_id", "vault_id",
     }
     # Nullability matches the REST driver's payload.
     assert cols["id"].nullable is False
@@ -139,6 +145,8 @@ def test_create_table_request_shape() -> None:
     assert cols["chunk_index"].nullable is True
     assert cols["source_type"].nullable is False
     assert cols["source_id"].nullable is False
+    # vault_id (issue #189 Phase 2): nullable so recreate+reindex can land it.
+    assert cols["vault_id"].nullable is True
     # Dense vector dim flows through from constructor.
     assert cols["embedding"].column_type.dense_vector.dim == 1024
 
@@ -427,6 +435,8 @@ async def test_upsert_one_jsonl_record_shape(
     assert record["content"] == "hello world"
     assert record["section_path"] == "intro"
     assert record["chunk_index"] == 3
+    # vault_id (issue #189 Phase 2) is stored on every row for the vault filter.
+    assert record["vault_id"] == "99999999-8888-7777-6666-555555555555"
     assert record["embedding"] == [0.1, 0.2, 0.3, 0.4]
     # Sparse is the "term_id:weight ..." compact form.
     assert record["sparse"] == "5:1 7:0.5 9:0.25"

--- a/backend/tests/test_seahorse_db_grpc_unit.py
+++ b/backend/tests/test_seahorse_db_grpc_unit.py
@@ -21,17 +21,24 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
-import grpc
-import pyarrow as pa
 import pytest
 
+# Skip cleanly (not a collection ERROR) where the gRPC stack is unavailable:
+# grpc/pyarrow missing, OR the generated protobuf stubs reject the installed
+# protobuf runtime (the local `runtime_version` ImportError — see
+# [[feedback_local_skip_ci_driver_tests]]). CI installs the pinned deps and runs
+# this in full.
+grpc = pytest.importorskip("grpc")
+pa = pytest.importorskip("pyarrow")
 
-# Stub-loading side-effect: importing the driver inserts the proto root
-# onto sys.path inside a try/finally. We exercise that side-effect once
-# at module import — every test below relies on the stubs being
-# importable, so a regression there would surface as a collection
-# error and we'd hear about it immediately.
-from app.services.vector_store import seahorse_db_grpc as sdgrpc
+# Stub-loading side-effect: importing the driver inserts the proto root onto
+# sys.path inside a try/finally. Guard it so a protobuf-version mismatch skips
+# the module instead of erroring at collection.
+try:
+    from app.services.vector_store import seahorse_db_grpc as sdgrpc
+except ImportError as _e:  # pragma: no cover - env-dependent
+    pytest.skip(f"coral gRPC stubs unimportable: {_e}", allow_module_level=True)
+
 from app.services.vector_store.base import VectorHit
 
 
@@ -649,6 +656,73 @@ async def test_hybrid_search_source_ids_filter(
         "'aaaaaaaa-bbbb-cccc-dddd-000000000010')"
     )
     assert req.filter == expected_filter
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_vault_ids_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    store: sdgrpc.SeahorseDbGrpcStore,
+    mock_channel: MagicMock,
+) -> None:
+    """The vault path (issue #189 Phase 2): vault_ids must filter on the
+    `vault_id` column, NOT source_id — a column mix-up here is a cross-vault
+    leak. Symmetric to test_hybrid_search_source_ids_filter."""
+    async def fake_stream(_request: query_pb2.HybridSearchRequest,
+                          timeout: float) -> object:
+        fake_stream.captured = _request  # type: ignore[attr-defined]
+        yield query_pb2.ResultStreamEvent(
+            header=query_pb2.ResultStreamHeader(num_result_sets=1),
+        )
+        yield query_pb2.ResultStreamEvent(footer=query_pb2.ResultStreamFooter())
+
+    stub = MagicMock()
+    stub.HybridSearch = fake_stream
+    monkeypatch.setattr(sdgrpc.query_pb2_grpc, "QueryServiceStub",
+                        lambda _ch: stub)
+    monkeypatch.setattr(
+        "app.services.sparse_encoder.load_stats",
+        AsyncMock(return_value={"total_docs": 10, "avgdl": 5.0, "k1": 1.5, "b": 0.75}),
+    )
+    monkeypatch.setattr(
+        "app.services.sparse_encoder.load_df_for_terms",
+        AsyncMock(return_value={5: 1}),
+    )
+
+    await store.hybrid_search(
+        query_text="x",
+        query_dense=[0.0, 0.0, 0.0, 0.1],
+        query_sparse_indices=[5], query_sparse_values=[0.1],
+        source_ids=None,
+        vault_ids=["11111111-2222-3333-4444-555555555555"],
+        limit=2, prefetch_per_leg=8,
+    )
+    req = fake_stream.captured  # type: ignore[attr-defined]
+    assert req.filter == "vault_id IN ('11111111-2222-3333-4444-555555555555')"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_rejects_both_vault_and_source(
+    monkeypatch: pytest.MonkeyPatch,
+    store: sdgrpc.SeahorseDbGrpcStore,
+    mock_channel: MagicMock,
+) -> None:
+    """Both filters at once is a caller bug → AssertionError (exactly-one)."""
+    monkeypatch.setattr(
+        "app.services.sparse_encoder.load_stats",
+        AsyncMock(return_value={"total_docs": 10, "avgdl": 5.0, "k1": 1.5, "b": 0.75}),
+    )
+    monkeypatch.setattr(
+        "app.services.sparse_encoder.load_df_for_terms",
+        AsyncMock(return_value={5: 1}),
+    )
+    with pytest.raises(AssertionError):
+        await store.hybrid_search(
+            query_text="x", query_dense=[0.0, 0.0, 0.0, 0.1],
+            query_sparse_indices=[5], query_sparse_values=[0.1],
+            source_ids=["11111111-2222-3333-4444-555555555555"],
+            vault_ids=["22222222-3333-4444-5555-666666666666"],
+            limit=2, prefetch_per_leg=8,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seahorse_vault_filter_unit.py
+++ b/backend/tests/test_seahorse_vault_filter_unit.py
@@ -97,6 +97,32 @@ async def test_db_upsert_one_inline_record_carries_vault_id():
 
 
 @pytest.mark.asyncio
+async def test_db_hybrid_search_filter_wires_vault_then_source(monkeypatch):
+    """The per-driver seam: vault_ids must reach the request `filter` as
+    `vault_id IN (…)`, source_ids as `source_id IN (…)`. A column mix-up here is
+    a cross-vault leak. (hybrid_search calls sparse_encoder.load_stats
+    unconditionally — mock it so no real PG/coordinator connection is made.)"""
+    from unittest.mock import AsyncMock
+    monkeypatch.setattr("app.services.sparse_encoder.load_stats", AsyncMock(return_value={}))
+
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    s._ensured_collection = True
+    s._client = _FakeHttp(_Resp(200, {"data": {"data": [[]]}}))
+    await s.hybrid_search(
+        query_text="q", query_dense=_DENSE, query_sparse_indices=[], query_sparse_values=[],
+        source_ids=None, vault_ids=[_UUID], limit=5, prefetch_per_leg=10,
+    )
+    assert s._client.calls[-1]["json"]["filter"] == f"vault_id IN ('{_UUID}')"
+
+    s._client = _FakeHttp(_Resp(200, {"data": {"data": [[]]}}))
+    await s.hybrid_search(
+        query_text="q", query_dense=_DENSE, query_sparse_indices=[], query_sparse_values=[],
+        source_ids=[_UUID], vault_ids=None, limit=5, prefetch_per_leg=10,
+    )
+    assert s._client.calls[-1]["json"]["filter"] == f"source_id IN ('{_UUID}')"
+
+
+@pytest.mark.asyncio
 async def test_db_vault_backfill_pending_counts_and_fails_closed():
     s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
     # empty scan → 0 pending (fresh/recreated table → vault path can activate)
@@ -138,3 +164,22 @@ async def test_cloud_upsert_one_row_carries_vault_id():
     )
     sent = json.loads(fake.calls[-1]["content"].decode("utf-8"))
     assert sent[COL_VAULT_ID] == "vault-9"
+
+
+@pytest.mark.asyncio
+async def test_cloud_hybrid_search_filter_uses_vault_col_override():
+    """seahorse_cloud is the ONLY driver passing non-default vault_col/source_col
+    to vault_filter_sql — a typo there filters the wrong column (cross-vault
+    leak), and it was otherwise untested. Assert vault_ids → `vault_id IN (…)`."""
+    s = SeahorseCloudStore(
+        management_url="http://x", token="t", tenant_uuid="ten", table_name="chunks",
+        dense_dim=4,
+    )
+    s._ensured = True
+    s._table_host = "http://host"
+    s._client = _FakeHttp(_Resp(200, {"data": {"data": [[]]}}))
+    await s.hybrid_search(
+        query_text="q", query_dense=_DENSE, query_sparse_indices=[], query_sparse_values=[],
+        source_ids=None, vault_ids=[_UUID], limit=5, prefetch_per_leg=10,
+    )
+    assert s._client.calls[-1]["json"]["filter"] == f"{COL_VAULT_ID} IN ('{_UUID}')"

--- a/backend/tests/test_seahorse_vault_filter_unit.py
+++ b/backend/tests/test_seahorse_vault_filter_unit.py
@@ -1,0 +1,140 @@
+"""Unit coverage for the #189 Phase-2 vault filter on the locally-importable
+Seahorse drivers (Coral REST + Seahorse Cloud). The security-load-bearing FILTER
+logic is the shared `vault_filter_sql` helper (exhaustively tested in
+test_seahorse_common_unit-style assertions below); these tests lock the STORAGE
+side per driver — the create-table column and that every upsert record/row
+carries vault_id (incl. the REST driver's inline-vs-_record_dict two-copy path,
+the documented drift risk). Pure-mocked; no live Coral.
+
+The gRPC driver's equivalents live in test_seahorse_db_grpc_unit.py (it imports
+grpc/pyarrow at module top → runs in CI, collection-skips locally)."""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from app.services.vector_store._seahorse_common import vault_filter_sql
+from app.services.vector_store.seahorse_cloud import SeahorseCloudStore, COL_VAULT_ID
+from app.services.vector_store.seahorse_db import SeahorseDbStore
+
+_UUID = str(uuid.uuid4())
+_DENSE = [0.1, 0.2, 0.3, 0.4]
+
+
+# ── shared filter helper (the security-critical exactly-one contract) ──
+
+def test_vault_filter_sql_contract():
+    assert vault_filter_sql([_UUID], None).startswith("vault_id IN (")
+    assert vault_filter_sql(None, [_UUID]).startswith("source_id IN (")
+    assert vault_filter_sql(None, None) is None
+    with pytest.raises(AssertionError):
+        vault_filter_sql([_UUID], [_UUID])  # both → caller bug
+
+
+# ── Coral REST driver ────────────────────────────────────────────
+
+class _Resp:
+    def __init__(self, status=200, body=None):
+        self.status_code = status
+        self._body = body if body is not None else {}
+        self.headers = {"content-type": "application/json"}
+        self.text = json.dumps(self._body)
+
+    def json(self):
+        return self._body
+
+
+class _FakeHttp:
+    def __init__(self, response=None):
+        self.calls: list[dict] = []
+        self._response = response or _Resp(200)
+
+    async def post(self, url, *, json=None, content=None, headers=None):
+        self.calls.append({"url": url, "json": json, "content": content})
+        return self._response
+
+    async def get(self, url, **kw):
+        return _Resp(200)
+
+
+def test_db_capability_flag():
+    assert SeahorseDbStore.vault_filter_supported is True
+
+
+def test_db_create_table_has_vault_id_column():
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    cols = {c["name"] for c in s._build_create_table_payload()["columns"]}
+    assert "vault_id" in cols
+
+
+def test_db_record_dict_carries_vault_id():
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    rec = s._record_dict(
+        chunk_id=_UUID, content="x", section_path=None, chunk_index=0,
+        dense=_DENSE, sparse_indices=[1], sparse_values=[0.5],
+        source_type="document", source_id=_UUID, vault_id="vault-9",
+    )
+    assert rec["vault_id"] == "vault-9"
+
+
+@pytest.mark.asyncio
+async def test_db_upsert_one_inline_record_carries_vault_id():
+    """upsert_one builds its OWN inline record (not via _record_dict) — capture
+    the ndjson body to catch the two-copy drift the audit flagged."""
+    fake = _FakeHttp(_Resp(200))
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    s._client = fake
+    s._ensured_collection = True
+    await s.upsert_one(
+        chunk_id=_UUID, content="x", section_path=None, chunk_index=0,
+        dense=_DENSE, sparse_indices=[1], sparse_values=[0.5],
+        source_type="document", source_id=_UUID, vault_id="vault-9",
+    )
+    sent = json.loads(fake.calls[-1]["content"].decode("utf-8"))
+    assert sent["vault_id"] == "vault-9"
+
+
+@pytest.mark.asyncio
+async def test_db_vault_backfill_pending_counts_and_fails_closed():
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    # empty scan → 0 pending (fresh/recreated table → vault path can activate)
+    s._client = _FakeHttp(_Resp(200, {"data": []}))
+    assert await s.vault_backfill_pending() == 0
+    # one null row → still pending
+    s._client = _FakeHttp(_Resp(200, {"data": [{"chunk_id": "x"}]}))
+    assert await s.vault_backfill_pending() == 1
+    # error / unexpected shape → FAIL-CLOSED (raise → worker stays gated)
+    from app.services.vector_store.base import VectorStoreUnavailable
+    s._client = _FakeHttp(_Resp(500, {"err": "boom"}))
+    with pytest.raises(VectorStoreUnavailable):
+        await s.vault_backfill_pending()
+    s._client = _FakeHttp(_Resp(200, {"unexpected": 1}))  # no data/rows key
+    with pytest.raises(VectorStoreUnavailable):
+        await s.vault_backfill_pending()
+
+
+# ── Seahorse Cloud driver ────────────────────────────────────────
+
+def test_cloud_capability_flag():
+    assert SeahorseCloudStore.vault_filter_supported is True
+
+
+@pytest.mark.asyncio
+async def test_cloud_upsert_one_row_carries_vault_id():
+    fake = _FakeHttp(_Resp(200))
+    s = SeahorseCloudStore(
+        management_url="http://x", token="t", tenant_uuid="ten", table_name="chunks",
+        dense_dim=4,
+    )
+    s._client = fake
+    s._ensured = True
+    s._table_host = "http://host"
+    await s.upsert_one(
+        chunk_id=_UUID, content="x", section_path=None, chunk_index=0,
+        dense=_DENSE, sparse_indices=[1], sparse_values=[0.5],
+        source_type="document", source_id=_UUID, vault_id="vault-9",
+    )
+    sent = json.loads(fake.calls[-1]["content"].decode("utf-8"))
+    assert sent[COL_VAULT_ID] == "vault-9"

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -123,20 +123,27 @@ def test_search_response_degraded_defaults_false():
 
 
 def test_vault_path_eligible(monkeypatch):
-    """The VAULT path (issue #189 Phase 2) is taken ONLY with the flag on, the
-    pgvector driver, and NO doc-level filter; otherwise the source_ids path
-    (flag-off parity = byte-identical to before)."""
+    """The VAULT path (issue #189 Phase 2) is taken ONLY with the flag on, a
+    vault-filter-CAPABLE driver (vault_filter_supported True), and NO doc-level
+    filter; otherwise the source_ids path (flag-off parity = byte-identical)."""
     from app.config import settings
+    from app.services import search_service
+
+    class _Capable:
+        vault_filter_supported = True
+
+    class _Plain:
+        vault_filter_supported = False
 
     monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
-    monkeypatch.setattr(settings, "vector_store_driver", "pgvector", raising=False)
+    monkeypatch.setattr(search_service, "get_vector_store", lambda: _Capable())
 
     def call(**kw):
         base = {"collection": None, "doc_type": None, "tags": None, "source_uris": None}
         base.update(kw)
         return vault_path_eligible(**base)
 
-    assert call() is True  # flag + pgvector + no filters → vault path
+    assert call() is True  # flag + capable driver + no filters → vault path
     assert call(collection="specs") is False  # any doc-level filter → source path
     assert call(doc_type="note") is False
     assert call(tags=["x"]) is False
@@ -146,9 +153,9 @@ def test_vault_path_eligible(monkeypatch):
     monkeypatch.setattr(settings, "vault_filter_enabled", False, raising=False)
     assert call() is False
 
-    # other driver → never (only pgvector stores vault_id)
+    # non-capable driver → never (fail-safe: unknown driver → source-id path)
     monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
-    monkeypatch.setattr(settings, "vector_store_driver", "qdrant", raising=False)
+    monkeypatch.setattr(search_service, "get_vector_store", lambda: _Plain())
     assert call() is False
 
 

--- a/backend/tests/test_vault_backfill.py
+++ b/backend/tests/test_vault_backfill.py
@@ -44,13 +44,17 @@ def test_applicable_only_for_pgvector_same_instance(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_once_non_pgvector_latches_ready_without_db(monkeypatch):
-    """Other drivers have no vault_id column and the vault path is never eligible
-    for them, so readiness is moot — latch ready (stop looping), never touch DB."""
-    monkeypatch.setattr(vault_backfill, "_is_pgvector", lambda: False)
+async def test_process_once_non_capable_latches_ready_without_db(monkeypatch):
+    """A driver without the vault filter (vault_filter_supported absent/False)
+    never takes the vault path, so readiness is moot — latch ready (stop looping),
+    never touch DB."""
+    class _Plain:  # no vault_filter_supported attribute
+        pass
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Plain())
 
     async def _boom():
-        raise AssertionError("get_pool called for a non-pgvector driver")
+        raise AssertionError("get_pool called for a non-capable driver")
 
     monkeypatch.setattr(vault_backfill, "get_pool", _boom)
     assert await vault_backfill._process_once() == 0
@@ -58,35 +62,53 @@ async def test_process_once_non_pgvector_latches_ready_without_db(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_once_separate_instance_gates_on_driver_count(monkeypatch):
-    """Separate pgvector instance: never auto-backfills (no server-side join) and
-    never touches the main pool — readiness follows the driver's NULL count, so
-    the manual-script escape hatch still activates the vault path (and only once
-    the backfill is actually done)."""
+async def test_process_once_capable_non_autofill_gates_on_count(monkeypatch):
+    """A capable driver this worker can't auto-fill (qdrant, seahorse, or a
+    separate pgvector instance): never touches the main pool — readiness follows
+    the driver's NULL count, so the manual-backfill escape hatch still activates
+    the vault path (and only once the backfill is actually done)."""
+    # Not same-instance pgvector → _applicable() is False → the count-gate branch.
     monkeypatch.setattr(vault_backfill, "_is_pgvector", lambda: True)
     monkeypatch.setattr(vault_backfill, "_same_instance", lambda: False)
 
     async def _boom():
-        raise AssertionError("get_pool (main DB) called for a separate instance")
+        raise AssertionError("get_pool (auto-join) called for a gate-only driver")
 
     monkeypatch.setattr(vault_backfill, "get_pool", _boom)
 
     pending = {"n": 5}
 
     class _Store:
+        vault_filter_supported = True
+
         async def vault_backfill_pending(self):
             return pending["n"]
 
     monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
 
-    # Backfill not yet run on the separate instance → stays gated.
+    # Backfill not yet run → stays gated.
     assert await vault_backfill._process_once() == 0
     assert vault_backfill.is_ready() is False
 
-    # Operator ran the manual script → count hits 0 → readiness latches.
+    # Operator ran the manual backfill → count hits 0 → readiness latches.
     pending["n"] = 0
     assert await vault_backfill._process_once() == 0
     assert vault_backfill.is_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_process_once_capable_without_counter_stays_gated(monkeypatch):
+    """A capable driver (e.g. seahorse gRPC/cloud) that exposes no
+    vault_backfill_pending() can't prove its existing points carry vault_id, so
+    the worker keeps it gated forever — never activate the vault path blind."""
+    monkeypatch.setattr(vault_backfill, "_is_pgvector", lambda: False)
+
+    class _Store:
+        vault_filter_supported = True  # capable, but NO vault_backfill_pending
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
+    assert await vault_backfill._process_once() == 0
+    assert vault_backfill.is_ready() is False
 
 
 @pytest.mark.asyncio
@@ -127,4 +149,4 @@ async def test_pending_stats_omits_count_for_drivers_without_counter(monkeypatch
     monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Store())
     stats = await vault_backfill.pending_stats()
     assert "null_remaining" not in stats
-    assert set(stats) == {"ready", "applicable"}
+    assert set(stats) == {"ready", "applicable", "vault_filter_supported"}


### PR DESCRIPTION
Completes the #189 Phase-2 vault filter across the remaining drivers. The per-vault ACL search path (filter the vector search by the user's accessible **vault ids** — O(vaults) — instead of enumerating every accessible **source id** — O(corpus)) was **pgvector-only**; qdrant and the three seahorse drivers accepted `vault_ids` but ignored it. Now they all implement it, behind a capability flag.

## Design
- **Capability flag, not a driver-name check.** `VectorStore.vault_filter_supported` (default `False`; each capable driver sets it `True` on its own class — drivers duck-type the `Protocol`, so reads use `getattr(store, "vault_filter_supported", False)` → an unknown driver is **fail-safe** to the source-id path, never a wrong vault path). Drives `search_service.vault_path_eligible`, the `vault_backfill` worker, and `/health`.
- **Backfill-worker latch-bug fix (the important one).** A capable non-pgvector driver now gates `is_ready()` on its `vault_backfill_pending()==0` instead of latching ready immediately. The prior latch would have activated the vault path *before* existing points carried `vault_id` → under-fetch. pgvector same-instance keeps its server-side auto-join backfill; a capable driver with no counter stays gated (fail-closed).

## Per driver
- **qdrant:** `vault_id` payload + KEYWORD index, exactly-one(`vault_ids`|`source_ids`) filter branch, `vault_backfill_pending` via `count(IsEmptyCondition, exact=True)`.
- **seahorse (Coral REST / gRPC / Cloud):** `vault_id` table column + written on every upsert; shared `vault_filter_sql` helper (`vault_id IN (…)`). REST gates on a `/data/scan` null count (fail-closed); gRPC/Cloud store + filter but stay **gated** (no count primitive) until one is wired.

## Live verification caught a real bug 🐛
Ran the actual `QdrantStore` against **qdrant 1.18.2**: the vault filter is correct (a `vault_ids=[V1]` search never returns a V2 point), but `vault_backfill_pending()` returned **0 when a pre-upgrade point (no `vault_id` key) existed** — `IsNullCondition` matches only an *explicit* null and **misses absent-key** points, which under-counts and flips the readiness gate early. **Fixed:** switched to `IsEmptyCondition` (missing OR null); re-verified the gate now stays gated while any un-backfilled point exists.

## Upgrade path (non-pgvector, existing deployments)
Reindex (`UPDATE chunks SET vector_indexed_at = NULL`) so the worker re-upserts every point *with* `vault_id`; until the null count hits 0 search stays on the safe source-id path (correct, just not the O(vaults) speedup). **Production runs pgvector and is unaffected.**

## Tests
New qdrant + seahorse(REST/Cloud) vault-filter unit suites; gRPC unit test extended (CI-only); contract tests migrated to the capability flag. Full local unit suite green (**204 passed**). Backend **0.8.14** + CHANGELOG.

⚠️ **Caveat:** the seahorse drivers are unit-tested but **not live-verified against Coral** — the `/data/scan` count shape needs confirmation on a live server before relying on seahorse auto-activation. qdrant is live-verified; pgvector unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)