### PR TITLE
fix(qdrant): convert client errors to VectorStoreUnavailable (#207)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2735
+        "line_number": 2750
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T07:43:24Z"
+  "generated_at": "2026-06-17T08:30:37Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,21 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.15 — 2026-06-17  *(fix — qdrant driver converts client errors to VectorStoreUnavailable, #207)*
+
+The qdrant driver now wraps its client calls so a transient failure (network
+drop, 5xx, `UnexpectedResponse`, gRPC error) surfaces as `VectorStoreUnavailable`
+— matching pgvector/seahorse, so `SearchService._run_vector_search` labels a
+qdrant outage `vector_store_unavailable` rather than a generic
+`vector_store_error`, and the write path no longer leaks raw client exceptions to
+the indexing worker. Applied to `ensure_collection`, `upsert_one`, `delete_point`,
+and all three `hybrid_search` legs via a shared `_qdrant_errors` async context
+manager. A `TypeError`/`ValueError` (a programming bug — e.g. a bad `qm.*`
+argument) is re-raised unmasked rather than mislabelled as an outage; the
+previously over-broad `ensure_collection` catch is narrowed the same way.
+qdrant-only and pre-existing (production runs pgvector). New driver unit tests +
+a live connection-failure check confirm the conversion.
+
 ## 0.8.14 — 2026-06-17  *(feature — vault filter extended to qdrant + seahorse)*
 
 **#189 Phase 2 vault filter, now driver-agnostic.** The per-vault ACL search

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -120,7 +120,13 @@ class QdrantStore:
         except (TypeError, ValueError):
             raise
         except Exception as e:  # noqa: BLE001
-            logger.warning("vault_id payload index ensure failed (non-fatal): %s", e)
+            # Non-fatal: a missing index doesn't break correctness (the readiness
+            # gate keys off the NULL-vault_id count, not the index), but every
+            # vault-filtered search then does a full payload scan. Log at ERROR,
+            # not WARNING, so a PERSISTENT failure (e.g. a managed cluster
+            # rejecting the schema) leaves a standing, greppable signal — this
+            # fires once per process since `_ensured_collection` latches below.
+            logger.error("qdrant vault_id payload index ensure failed (non-fatal, search falls back to full scan): %s", e)
         self._ensured_collection = True
 
     async def health(self) -> bool:

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -12,6 +12,7 @@ the legacy `vector_store.py`.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import Any
 
@@ -77,46 +78,47 @@ class QdrantStore:
         if self._ensured_collection:
             return
         client = self._get_client()
-        try:
+        async with _qdrant_errors("ensure_collection"):
             exists = await client.collection_exists(self._collection)
-        except Exception as e:  # noqa: BLE001
-            raise VectorStoreUnavailable(f"ping failed: {e}") from e
-
-        if not exists:
-            await client.create_collection(
-                collection_name=self._collection,
-                vectors_config={
-                    DENSE_VECTOR_NAME: qm.VectorParams(
-                        size=self._dense_dim,
-                        distance=qm.Distance.COSINE,
-                    ),
-                },
-                sparse_vectors_config={
-                    SPARSE_VECTOR_NAME: qm.SparseVectorParams(),
-                },
-            )
-            logger.info(
-                "Vector collection %r created (dense_dim=%d)",
-                self._collection, self._dense_dim,
-            )
-            # source_id is the primary filter key on every search.
-            # Without this payload index the store falls back to a
-            # full scan per query — measurable latency regression.
-            await client.create_payload_index(
-                collection_name=self._collection,
-                field_name=PAYLOAD_SOURCE_ID,
-                field_schema=qm.PayloadSchemaType.KEYWORD,
-            )
+            if not exists:
+                await client.create_collection(
+                    collection_name=self._collection,
+                    vectors_config={
+                        DENSE_VECTOR_NAME: qm.VectorParams(
+                            size=self._dense_dim,
+                            distance=qm.Distance.COSINE,
+                        ),
+                    },
+                    sparse_vectors_config={
+                        SPARSE_VECTOR_NAME: qm.SparseVectorParams(),
+                    },
+                )
+                logger.info(
+                    "Vector collection %r created (dense_dim=%d)",
+                    self._collection, self._dense_dim,
+                )
+                # source_id is the primary filter key on every search.
+                # Without this payload index the store falls back to a
+                # full scan per query — measurable latency regression.
+                await client.create_payload_index(
+                    collection_name=self._collection,
+                    field_name=PAYLOAD_SOURCE_ID,
+                    field_schema=qm.PayloadSchemaType.KEYWORD,
+                )
         # vault_id is the per-vault ACL filter key (issue #189 Phase 2). Indexed
         # for the same reason as source_id. Created OUTSIDE the `if not exists`
         # block (idempotent server-side) so an ALREADY-deployed collection
         # — created before vault_id existed — also gets the index on first ensure.
+        # Best-effort (non-fatal) — but a TypeError/ValueError is a programming
+        # bug, not a transient index hiccup, so let it surface.
         try:
             await client.create_payload_index(
                 collection_name=self._collection,
                 field_name=PAYLOAD_VAULT_ID,
                 field_schema=qm.PayloadSchemaType.KEYWORD,
             )
+        except (TypeError, ValueError):
+            raise
         except Exception as e:  # noqa: BLE001
             logger.warning("vault_id payload index ensure failed (non-fatal): %s", e)
         self._ensured_collection = True
@@ -201,7 +203,8 @@ class QdrantStore:
                 PAYLOAD_VAULT_ID: str(vault_id),
             },
         )
-        await client.upsert(collection_name=self._collection, points=[point])
+        async with _qdrant_errors("upsert"):
+            await client.upsert(collection_name=self._collection, points=[point])
 
     # ── Delete ───────────────────────────────────────────────────
 
@@ -221,10 +224,11 @@ class QdrantStore:
         del conn  # external service; can't share PG transaction
         await self.ensure_collection()
         client = self._get_client()
-        await client.delete(
-            collection_name=self._collection,
-            points_selector=[str(chunk_id)],
-        )
+        async with _qdrant_errors("delete"):
+            await client.delete(
+                collection_name=self._collection,
+                points_selector=[str(chunk_id)],
+            )
 
     # ── Search ───────────────────────────────────────────────────
 
@@ -273,41 +277,60 @@ class QdrantStore:
                     filter=flt,
                 ),
             ]
-            result = await client.query_points(
-                collection_name=self._collection,
-                prefetch=prefetch,
-                query=qm.FusionQuery(fusion=qm.Fusion.RRF),
-                limit=limit,
-                with_payload=True,
-            )
+            async with _qdrant_errors("hybrid_search"):
+                result = await client.query_points(
+                    collection_name=self._collection,
+                    prefetch=prefetch,
+                    query=qm.FusionQuery(fusion=qm.Fusion.RRF),
+                    limit=limit,
+                    with_payload=True,
+                )
             return [_to_hit(p) for p in result.points]
 
         if has_dense:
             # Dense-only: query has no known vocab term. Cross-encoder
             # rerank downstream filters semantically-weak matches.
+            async with _qdrant_errors("hybrid_search"):
+                result = await client.query_points(
+                    collection_name=self._collection,
+                    query=query_dense,
+                    using=DENSE_VECTOR_NAME,
+                    limit=limit,
+                    query_filter=flt,
+                    with_payload=True,
+                )
+            return [_to_hit(p) for p in result.points]
+
+        # Sparse-only: embedding API unavailable.
+        async with _qdrant_errors("hybrid_search"):
             result = await client.query_points(
                 collection_name=self._collection,
-                query=query_dense,
-                using=DENSE_VECTOR_NAME,
+                query=qm.SparseVector(
+                    indices=query_sparse_indices,
+                    values=query_sparse_values,
+                ),
+                using=SPARSE_VECTOR_NAME,
                 limit=limit,
                 query_filter=flt,
                 with_payload=True,
             )
-            return [_to_hit(p) for p in result.points]
-
-        # Sparse-only: embedding API unavailable.
-        result = await client.query_points(
-            collection_name=self._collection,
-            query=qm.SparseVector(
-                indices=query_sparse_indices,
-                values=query_sparse_values,
-            ),
-            using=SPARSE_VECTOR_NAME,
-            limit=limit,
-            query_filter=flt,
-            with_payload=True,
-        )
         return [_to_hit(p) for p in result.points]
+
+
+@contextlib.asynccontextmanager
+async def _qdrant_errors(op: str):
+    """Convert a qdrant-client call's transient failures (network drop, 5xx,
+    UnexpectedResponse, gRPC errors) into ``VectorStoreUnavailable`` so the
+    search/index paths label a qdrant outage `vector_store_unavailable` (not a
+    generic `vector_store_error`) — matching the pgvector/seahorse drivers
+    (#207). A ``TypeError``/``ValueError`` is a programming bug (e.g. a bad
+    ``qm.*`` argument), NOT an outage, so it propagates unmasked."""
+    try:
+        yield
+    except (TypeError, ValueError):
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise VectorStoreUnavailable(f"qdrant {op}: {e}") from e
 
 
 def _acl_filter(*, vault_ids: list[str] | None, source_ids: list[str] | None):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.14"
+version = "0.8.15"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -138,3 +138,83 @@ async def test_ensure_collection_indexes_vault_id():
     store._client = fake
     await store.ensure_collection()
     assert PAYLOAD_VAULT_ID in fake.indexes
+
+
+# ── #207: client errors → VectorStoreUnavailable (write + search paths) ──
+
+from app.services.vector_store.base import VectorStoreUnavailable
+
+
+class _BoomClient(_FakeClient):
+    """A client whose network calls raise a chosen exception."""
+
+    def __init__(self, exc: BaseException):
+        super().__init__()
+        self._exc = exc
+
+    async def collection_exists(self, name):
+        raise self._exc
+
+    async def create_payload_index(self, **kw):
+        raise self._exc
+
+    async def upsert(self, *, collection_name, points):
+        raise self._exc
+
+    async def delete(self, *, collection_name, points_selector):
+        raise self._exc
+
+    async def query_points(self, **kw):
+        raise self._exc
+
+
+async def _do_upsert(store):
+    await store.upsert_one(
+        chunk_id="c1", content="x", section_path=None, chunk_index=0,
+        dense=[0.1, 0.2, 0.3, 0.4], sparse_indices=[1], sparse_values=[0.5],
+        source_type="document", source_id="s1", vault_id="v1",
+    )
+
+
+async def _do_search(store):
+    await store.hybrid_search(
+        query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
+        query_sparse_indices=[], query_sparse_values=[],
+        source_ids=None, vault_ids=["v1"], limit=10, prefetch_per_leg=50,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", [_do_upsert, _do_search])
+async def test_transient_client_error_becomes_unavailable(action):
+    """A transient qdrant-client failure on the write/search path surfaces as
+    VectorStoreUnavailable (so _run_vector_search labels it correctly), not a
+    raw client exception."""
+    store = _store_with(_BoomClient(RuntimeError("connection refused")))
+    with pytest.raises(VectorStoreUnavailable):
+        await action(store)
+
+
+@pytest.mark.asyncio
+async def test_delete_point_error_becomes_unavailable():
+    store = _store_with(_BoomClient(RuntimeError("5xx")))
+    with pytest.raises(VectorStoreUnavailable):
+        await store.delete_point("c1")
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_error_becomes_unavailable():
+    store = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    store._client = _BoomClient(RuntimeError("ping failed"))
+    with pytest.raises(VectorStoreUnavailable):
+        await store.ensure_collection()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", [_do_upsert, _do_search])
+async def test_programming_error_is_not_masked(action):
+    """A TypeError/ValueError is a programming bug (bad qm.* arg), NOT an outage —
+    it must propagate unmasked rather than become VectorStoreUnavailable."""
+    store = _store_with(_BoomClient(TypeError("bad arg")))
+    with pytest.raises(TypeError):
+        await action(store)

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -176,7 +176,18 @@ async def _do_upsert(store):
     )
 
 
-async def _do_search(store):
+# hybrid_search has three independent legs, each with its own `async with
+# _qdrant_errors` — cover ALL three (dual-prefetch is the production-common path)
+# so a refactor dropping the wrap from one leg can't pass silently.
+async def _do_search_hybrid(store):  # dense + sparse → dual-prefetch leg
+    await store.hybrid_search(
+        query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
+        query_sparse_indices=[1, 2], query_sparse_values=[0.5, 0.5],
+        source_ids=None, vault_ids=["v1"], limit=10, prefetch_per_leg=50,
+    )
+
+
+async def _do_search_dense(store):  # dense only
     await store.hybrid_search(
         query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
         query_sparse_indices=[], query_sparse_values=[],
@@ -184,12 +195,23 @@ async def _do_search(store):
     )
 
 
+async def _do_search_sparse(store):  # sparse only (embed API down)
+    await store.hybrid_search(
+        query_text="q", query_dense=None,
+        query_sparse_indices=[1, 2], query_sparse_values=[0.5, 0.5],
+        source_ids=None, vault_ids=["v1"], limit=10, prefetch_per_leg=50,
+    )
+
+
+_ALL_ACTIONS = [_do_upsert, _do_search_hybrid, _do_search_dense, _do_search_sparse]
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize("action", [_do_upsert, _do_search])
+@pytest.mark.parametrize("action", _ALL_ACTIONS)
 async def test_transient_client_error_becomes_unavailable(action):
     """A transient qdrant-client failure on the write/search path surfaces as
     VectorStoreUnavailable (so _run_vector_search labels it correctly), not a
-    raw client exception."""
+    raw client exception. Covers all three hybrid_search legs."""
     store = _store_with(_BoomClient(RuntimeError("connection refused")))
     with pytest.raises(VectorStoreUnavailable):
         await action(store)
@@ -211,10 +233,46 @@ async def test_ensure_collection_error_becomes_unavailable():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("action", [_do_upsert, _do_search])
-async def test_programming_error_is_not_masked(action):
-    """A TypeError/ValueError is a programming bug (bad qm.* arg), NOT an outage —
-    it must propagate unmasked rather than become VectorStoreUnavailable."""
-    store = _store_with(_BoomClient(TypeError("bad arg")))
-    with pytest.raises(TypeError):
+@pytest.mark.parametrize("action", _ALL_ACTIONS)
+@pytest.mark.parametrize("exc", [TypeError("bad arg"), ValueError("bad value")])
+async def test_programming_error_is_not_masked(action, exc):
+    """TypeError AND ValueError are programming bugs (bad qm.* arg), NOT outages —
+    both must propagate unmasked rather than become VectorStoreUnavailable. Both
+    are named in the catch tuples, so both are guarded against a future trim."""
+    store = _store_with(_BoomClient(exc))
+    with pytest.raises(type(exc)):
         await action(store)
+
+
+# The vault_id payload index is best-effort (issue #189 P2) but its catch still
+# re-raises programming errors — assert both halves: a transient failure is
+# swallowed (ensure completes) while a TypeError/ValueError surfaces.
+class _VaultIndexBoom(_FakeClient):
+    """collection_exists → True (skip create); create_payload_index raises."""
+
+    def __init__(self, exc: BaseException):
+        super().__init__()
+        self._exc = exc
+
+    async def collection_exists(self, name):
+        return True
+
+    async def create_payload_index(self, **kw):
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_vault_index_transient_is_non_fatal():
+    store = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    store._client = _VaultIndexBoom(RuntimeError("index 5xx"))
+    await store.ensure_collection()  # best-effort: must NOT raise
+    assert store._ensured_collection is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [TypeError("bad"), ValueError("bad")])
+async def test_ensure_collection_vault_index_programming_error_propagates(exc):
+    store = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    store._client = _VaultIndexBoom(exc)
+    with pytest.raises(type(exc)):
+        await store.ensure_collection()


### PR DESCRIPTION
Closes #207.

The qdrant driver didn't wrap its client calls, unlike pgvector/seahorse — so a transient qdrant failure propagated as a raw exception. On the **search** path it's caught generically by `SearchService._run_vector_search` but **mislabelled** `vector_store_error` instead of `vector_store_unavailable`; on the **write** path raw exceptions reached the indexing worker.

## Change
- Shared `_qdrant_errors(op)` async context manager: wraps a qdrant-client call and `raise VectorStoreUnavailable(...) from e` on failure — **except** `TypeError`/`ValueError`, which are programming bugs (e.g. a bad `qm.*` argument), not outages, and so propagate **unmasked**.
- Applied to `ensure_collection` (create + ping), `upsert_one`, `delete_point`, and all three `hybrid_search` legs. The previously over-broad `ensure_collection` catch and the best-effort `vault_id`-index catch are narrowed the same way.

## Tests
- New driver unit tests: a simulated transient client error → `VectorStoreUnavailable` on upsert / delete / search / ensure_collection; a `TypeError` is **not** masked.
- **Live-verified**: a real connection failure (dead port) surfaces as `VectorStoreUnavailable: qdrant ensure_collection: All connection attempts failed`.

qdrant-only and pre-existing — **production runs pgvector**, so no production behavior change. backend **0.8.15** + CHANGELOG. Full local suite 247 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)