### PR TITLE
feat(tables): declarative unique_keys + indexes on table DDL tools (#215)

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -89,4 +89,14 @@ jobs:
         env:
           # Matches the fixture default + the dev compose override.
           AKB_TEST_DSN: postgresql://akb:akb@localhost:15432/akb  # pragma: allowlist secret
-        run: pytest tests/test_pgvector_ext_bootstrap_e2e.py -v --tb=short
+        # #215 declarative-DDL integration tests need a live PG too (index
+        # ASC/DESC physical order, migration 037 upgrade path, add-unique-key
+        # concurrency race). They skip in the DB-free unit job above, so gate
+        # them here where AKB_TEST_DSN is reachable.
+        run: >
+          pytest
+          tests/test_pgvector_ext_bootstrap_e2e.py
+          tests/test_migration_037_upgrade_unit.py
+          tests/test_index_order_unit.py
+          tests/concurrency/test_alter_unique_race_unit.py
+          -v --tb=short

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -157,6 +157,7 @@ jobs:
             test_pg_rbac_e2e.sh
             test_graph_replace_e2e.sh
             test_jwt_revocation_e2e.sh
+            test_table_constraints_e2e.sh
           )
           TOTAL_PASS=0
           TOTAL_FAIL=0

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1096,
+        "line_number": 1111,
         "is_secret": false
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2750
+        "line_number": 2782
       }
     ],
     "backend/mcp_server/help.py": [

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -29,8 +29,8 @@ specifically; the proxy has its own log in
 - A duplicate `INSERT` via `akb_sql` now returns a stable `unique_violation` code
   plus `pg_sqlstate=23505` (was the generic `sql_error` catch-all).
 - Declared metadata is persisted on `vault_tables` (migration `037`, idempotent)
-  and exposed via `list_tables`, the `akb_vault_info` introspection surface, and
-  the create/alter return dicts. REST `CreateTableRequest` threads
+  and exposed via `list_tables`, `akb_vault_info`, the create/alter return dicts,
+  and the hybrid-search metadata chunk. REST `CreateTableRequest` threads
   `unique_keys`/`indexes` (previously silently dropped).
 - Tests: a DB-free unit suite (`test_table_constraints_unit.py`) plus a live e2e
   suite (`test_table_constraints_e2e.sh`, now in the CI shell-e2e gate) covering

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,38 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.8.16 — 2026-06-17  *(feat — declarative unique keys + indexes on the table DDL tools, #215)*
+
+`akb_create_table` accepts optional declarative `unique_keys` and `indexes`;
+`akb_alter_table` gains `add_unique_keys` / `drop_unique_keys` / `add_indexes` /
+`drop_indexes`. Declarative JSON only — `akb_sql` stays DML-only.
+`check_constraints` (the rest of #215) ship in a follow-up PR.
+
+- DDL primitives + a deterministic, schema-global-namespaced, `sha1`-disambiguated
+  name generator (distinct column lists can never alias, e.g. `["a","b"]` vs
+  `["a_b"]`); every identifier flows through `safe_ident` and index order is a
+  closed `asc`/`desc` enum, so no raw caller input reaches a DDL string.
+- Adding a unique key preflights existing rows for duplicates BEFORE the
+  `ADD CONSTRAINT`; preflight + DDL + registry write share one transaction, so a
+  violation rolls back **both** physical schema and registry. The preflight mirrors
+  PostgreSQL `NULLS DISTINCT` (a row with any NULL key value never conflicts) so it
+  is not stricter than the constraint it guards. Post-preflight races and
+  schema-global name clashes surface as `invalid_argument` (422), not 500s.
+- A duplicate column within one key/index, or a mixed-case column reference, are
+  clean `invalid_argument` rejects rather than DDL 500s; referenced columns are
+  stored under their canonical declared name, and a column rename/drop keeps the
+  unique_key/index registry metadata consistent with the physical schema.
+- A duplicate `INSERT` via `akb_sql` now returns a stable `unique_violation` code
+  plus `pg_sqlstate=23505` (was the generic `sql_error` catch-all).
+- Declared metadata is persisted on `vault_tables` (migration `037`, idempotent)
+  and exposed via `list_tables`, the `akb_vault_info` introspection surface, and
+  the create/alter return dicts. REST `CreateTableRequest` threads
+  `unique_keys`/`indexes` (previously silently dropped).
+- Tests: a DB-free unit suite (`test_table_constraints_unit.py`) plus a live e2e
+  suite (`test_table_constraints_e2e.sh`, now in the CI shell-e2e gate) covering
+  AC #1–#6/#10/#11, the `akb_sql` DDL boundary, NULLS-DISTINCT, single-TX
+  atomicity, and the admin permission gate.
+
 ## 0.8.15 — 2026-06-17  *(fix — qdrant driver converts client errors to VectorStoreUnavailable, #207)*
 
 The qdrant driver now wraps its client calls so a transient failure (network

--- a/backend/app/api/routes/tables.py
+++ b/backend/app/api/routes/tables.py
@@ -16,6 +16,12 @@ class CreateTableRequest(NFCModel):
     description: str = ""
     columns: list[dict]
     collection: str | None = None
+    # Declarative unique keys / indexes (#215). Optional; mirror the MCP
+    # akb_create_table surface so REST/web clients can WRITE them, not
+    # just READ them back via list_tables. ValidationError/ConflictError
+    # from the service map to 422/409 via the global AKBError handler.
+    unique_keys: list[dict] | None = None
+    indexes: list[dict] | None = None
 
 
 class SqlRequest(NFCModel):
@@ -30,6 +36,7 @@ async def create_table(vault: str, req: CreateTableRequest, user: AuthenticatedU
         access["vault_id"], req.name, req.columns,
         actor_id=user.username, description=req.description,
         collection=req.collection,
+        unique_keys=req.unique_keys, indexes=req.indexes,
     )
 
 

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -220,6 +220,8 @@ CREATE TABLE IF NOT EXISTS vault_tables (
     name TEXT NOT NULL,
     description TEXT,
     columns JSONB NOT NULL DEFAULT '[]',
+    unique_keys JSONB NOT NULL DEFAULT '[]',
+    indexes JSONB NOT NULL DEFAULT '[]',
     created_by TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/backend/app/db/migrations/037_table_unique_keys_indexes.py
+++ b/backend/app/db/migrations/037_table_unique_keys_indexes.py
@@ -1,0 +1,79 @@
+"""Migration 037: add `vault_tables.unique_keys` + `vault_tables.indexes`.
+
+AKB #215 extends the table DDL tools with declarative UNIQUE keys and
+secondary indexes. The resolved metadata (the generated/validated names
++ columns) is persisted on the registry row so introspection
+(`list_tables`, browse) can surface it and drop-by-name works.
+
+Both columns are JSONB lists defaulting to `'[]'`, so every pre-existing
+table row keeps its current (empty) metadata and behaviour is unchanged.
+
+`check_constraints` is intentionally NOT added here — it ships with the
+follow-up PR's own migration so each PR's schema change stays
+self-contained.
+
+Idempotent: `ADD COLUMN IF NOT EXISTS` so re-running is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.037")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    existing = await conn.fetchval(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_name = 'vault_tables'
+           AND column_name = 'unique_keys'
+        """
+    )
+    if existing:
+        logger.info(
+            "Migration 037: vault_tables.unique_keys already exists; skipping"
+        )
+        return
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE vault_tables
+              ADD COLUMN IF NOT EXISTS unique_keys JSONB NOT NULL DEFAULT '[]',
+              ADD COLUMN IF NOT EXISTS indexes JSONB NOT NULL DEFAULT '[]'
+            """
+        )
+
+    logger.info(
+        "Migration 037 added vault_tables.unique_keys + .indexes "
+        "(default '[]' — existing tables unaffected)"
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/migrations/037_table_unique_keys_indexes.py
+++ b/backend/app/db/migrations/037_table_unique_keys_indexes.py
@@ -39,20 +39,13 @@ async def migrate(conn=None):
 
 
 async def _run(conn):
-    existing = await conn.fetchval(
-        """
-        SELECT 1
-          FROM information_schema.columns
-         WHERE table_name = 'vault_tables'
-           AND column_name = 'unique_keys'
-        """
-    )
-    if existing:
-        logger.info(
-            "Migration 037: vault_tables.unique_keys already exists; skipping"
-        )
-        return
-
+    # No early-return skip-guard: the `ADD COLUMN IF NOT EXISTS` pair below is
+    # already fully idempotent and — unlike a guard keyed on a SINGLE column —
+    # it self-heals a partial state where only ONE of the two columns is
+    # present (e.g. `indexes` dropped/missing while `unique_keys` exists). A
+    # guard checking only `unique_keys` would short-circuit and never re-add
+    # `indexes`, after which every read of vault_tables (which SELECTs both)
+    # would 500.
     async with conn.transaction():
         await conn.execute(
             """

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -175,6 +175,7 @@ async def _apply_migrations() -> None:
         "034_oidc_transients.py",               # oidc_transients: short-lived OIDC state + one-time exchange codes (HA-safe; empty when Keycloak off)
         "035_fix_wikilink_alias_edges.py",      # repair edges whose target_uri carries a wikilink alias ([[…|label]] → …|label); strip alias, re-validate existence, drop orphans
         "036_resource_aliases.py",              # rename/move redirect table (old path/name → current resource id); old akb:// URIs keep resolving after a move
+        "037_table_unique_keys_indexes.py",     # vault_tables.unique_keys + .indexes JSONB (declarative DDL metadata; AKB #215)
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -17,7 +17,10 @@ row-CRUD API is added later it will live in this module.
 
 from __future__ import annotations
 
+import hashlib
 import re
+
+from app.exceptions import ValidationError
 
 
 TYPE_MAP = {
@@ -127,6 +130,126 @@ async def rename_column(conn, pg_name: str, old_name: str, new_name: str) -> Non
     await conn.execute(
         f"ALTER TABLE {pg_name} RENAME COLUMN {old_name} TO {new_name}"
     )
+
+
+# ── Constraint / index DDL (AKB #215) ────────────────────────────
+
+
+# Closed enum for index column ordering. Never interpolate a raw user
+# value into DDL — map through this dict so only ASC/DESC can ever
+# reach the SQL string.
+_ORDER_SQL = {"asc": "ASC", "desc": "DESC"}
+
+
+def generate_constraint_name(pg_name: str, columns: list[str], *, kind: str) -> str:
+    """Deterministic, schema-global-safe name for a generated UNIQUE
+    constraint (``kind='uk'``) or index (``kind='idx'``).
+
+    Index names — and a UNIQUE constraint's implicit index name — are
+    SCHEMA-GLOBAL in PostgreSQL, so the generated name is namespaced by
+    the physical table (``pg_name``) to avoid cross-table collisions.
+
+    Shape: ``{pg_name}__{cols joined by _}_{digest}__{kind}``. ``digest``
+    is the first 8 hex chars of a ``hashlib.sha1`` over the NUL-joined
+    ``(pg_name, kind, *columns)`` tuple — pure ``hashlib`` (no randomness,
+    stable across calls/processes). It is ALWAYS present, for two reasons:
+    (1) it disambiguates column lists whose underscore-flattened forms
+    collide (``["a","b"]`` and ``["a_b"]`` both flatten to ``a_b``) — NUL
+    can never occur in a column name, so distinct lists always hash
+    differently; (2) when the readable part would exceed
+    ``PG_IDENT_MAX_LEN`` bytes it is truncated and the digest tail keeps
+    the result collision-safe.
+    """
+    suffix = f"__{kind}"
+    cols_part = "_".join(safe_ident(c) for c in columns)
+    # usedforsecurity=False: this digest is a collision-avoidance tag for a
+    # PG identifier, not a security primitive — SHA-1 is fine and the flag
+    # keeps static analysis (bandit B324) from flagging it as weak crypto.
+    digest = hashlib.sha1(
+        "\x00".join([pg_name, kind, *columns]).encode(), usedforsecurity=False
+    ).hexdigest()[:8]
+    logical = f"{pg_name}__{cols_part}_{digest}{suffix}"
+    if len(logical.encode()) <= PG_IDENT_MAX_LEN:
+        return logical
+    tail = f"_{digest}{suffix}"
+    # Keep the leading readable bytes; reserve room for the digest tail.
+    budget = PG_IDENT_MAX_LEN - len(tail.encode())
+    readable = f"{pg_name}__{cols_part}".encode()[:budget].decode(errors="ignore")
+    return f"{readable}{tail}"
+
+
+async def create_unique_constraint(
+    conn, pg_name: str, name: str, columns: list[str],
+) -> None:
+    """``ALTER TABLE {pg} ADD CONSTRAINT {name} UNIQUE ({cols})``.
+
+    Every identifier flows through ``safe_ident``; caller is expected to
+    have validated/resolved ``name`` already (see service layer)."""
+    safe_name = safe_ident(name)
+    cols = ", ".join(safe_ident(c) for c in columns)
+    await conn.execute(
+        f"ALTER TABLE {pg_name} ADD CONSTRAINT {safe_name} UNIQUE ({cols})"
+    )
+
+
+async def drop_constraint(conn, pg_name: str, name: str) -> None:
+    safe_name = safe_ident(name)
+    await conn.execute(
+        f"ALTER TABLE {pg_name} DROP CONSTRAINT IF EXISTS {safe_name}"
+    )
+
+
+async def create_index(
+    conn, pg_name: str, name: str, cols_with_order: list[tuple[str, str]],
+) -> None:
+    """``CREATE INDEX {name} ON {pg} ({col [ASC|DESC], ...})``.
+
+    ``cols_with_order`` is a list of ``(column, order)`` where order is
+    ``'asc'`` / ``'desc'`` (the closed enum). Identifiers via
+    ``safe_ident``; order via the ``_ORDER_SQL`` map — an unknown order
+    raises ``ValidationError`` rather than reaching the DDL string."""
+    safe_name = safe_ident(name)
+    parts = []
+    for col, order in cols_with_order:
+        order_sql = _ORDER_SQL.get((order or "asc").lower())
+        if order_sql is None:
+            raise ValidationError(
+                f"Invalid index order {order!r}: must be 'asc' or 'desc'."
+            )
+        parts.append(f"{safe_ident(col)} {order_sql}")
+    await conn.execute(
+        f"CREATE INDEX {safe_name} ON {pg_name} ({', '.join(parts)})"
+    )
+
+
+async def drop_index(conn, name: str) -> None:
+    safe_name = safe_ident(name)
+    await conn.execute(f"DROP INDEX IF EXISTS {safe_name}")
+
+
+async def unique_key_duplicates(
+    conn, pg_name: str, columns: list[str], limit: int = 5,
+) -> list[dict]:
+    """Preflight a candidate UNIQUE key against EXISTING data.
+
+    Returns up to ``limit`` groups of the *key columns only* (no other
+    columns leaked) that already have COUNT(*) > 1 — i.e. rows that
+    would violate the constraint. An empty list means the key can be
+    added safely.
+
+    ``SELECT {cols}, COUNT(*) FROM {pg} GROUP BY {cols} HAVING COUNT(*) > 1 LIMIT {n}``
+    — identifiers via ``safe_ident``; ``limit`` is coerced to ``int``."""
+    safe_cols = [safe_ident(c) for c in columns]
+    col_list = ", ".join(safe_cols)
+    lim = int(limit)
+    rows = await conn.fetch(
+        f"SELECT {col_list}, COUNT(*) AS dup_count "
+        f"FROM {pg_name} "
+        f"GROUP BY {col_list} "
+        f"HAVING COUNT(*) > 1 "
+        f"LIMIT {lim}"
+    )
+    return [dict(r) for r in rows]
 
 
 # ── SQL rewriting (for execute_sql + table_query share path) ─────

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -237,14 +237,23 @@ async def unique_key_duplicates(
     would violate the constraint. An empty list means the key can be
     added safely.
 
-    ``SELECT {cols}, COUNT(*) FROM {pg} GROUP BY {cols} HAVING COUNT(*) > 1 LIMIT {n}``
-    — identifiers via ``safe_ident``; ``limit`` is coerced to ``int``."""
+    PostgreSQL ``UNIQUE`` defaults to ``NULLS DISTINCT`` — a row whose key has
+    ANY NULL value never conflicts. The preflight mirrors that (``WHERE <each
+    col> IS NOT NULL``) so it is not STRICTER than the constraint it guards:
+    otherwise multiple legitimately-NULL rows would group together and falsely
+    block a valid ``ADD CONSTRAINT``.
+
+    ``SELECT {cols}, COUNT(*) FROM {pg} WHERE {cols all NOT NULL}
+    GROUP BY {cols} HAVING COUNT(*) > 1 LIMIT {n}`` — identifiers via
+    ``safe_ident``; ``limit`` is coerced to ``int``."""
     safe_cols = [safe_ident(c) for c in columns]
     col_list = ", ".join(safe_cols)
+    not_null = " AND ".join(f"{c} IS NOT NULL" for c in safe_cols)
     lim = int(limit)
     rows = await conn.fetch(
         f"SELECT {col_list}, COUNT(*) AS dup_count "
         f"FROM {pg_name} "
+        f"WHERE {not_null} "
         f"GROUP BY {col_list} "
         f"HAVING COUNT(*) > 1 "
         f"LIMIT {lim}"

--- a/backend/app/repositories/table_registry_repo.py
+++ b/backend/app/repositories/table_registry_repo.py
@@ -32,7 +32,8 @@ async def find_by_name(conn, vault_id: uuid.UUID, name: str) -> dict | None:
     row = await conn.fetchrow(
         """
         SELECT vt.id, vt.vault_id, vt.collection_id, c.path AS collection,
-               vt.name, vt.description, vt.columns, vt.created_by,
+               vt.name, vt.description, vt.columns,
+               vt.unique_keys, vt.indexes, vt.created_by,
                vt.created_at, vt.updated_at
           FROM vault_tables vt
           LEFT JOIN collections c ON c.id = vt.collection_id
@@ -76,7 +77,8 @@ async def list_for_vault(
             rows = await conn.fetch(
                 """
                 SELECT vt.id, vt.collection_id, c.path AS collection,
-                       vt.name, vt.description, vt.columns, vt.created_at
+                       vt.name, vt.description, vt.columns,
+                       vt.unique_keys, vt.indexes, vt.created_at
                   FROM vault_tables vt
                   LEFT JOIN collections c ON c.id = vt.collection_id
                  WHERE vt.vault_id = $1 AND vt.collection_id IS NULL
@@ -88,7 +90,8 @@ async def list_for_vault(
             rows = await conn.fetch(
                 """
                 SELECT vt.id, vt.collection_id, c.path AS collection,
-                       vt.name, vt.description, vt.columns, vt.created_at
+                       vt.name, vt.description, vt.columns,
+                       vt.unique_keys, vt.indexes, vt.created_at
                   FROM vault_tables vt
                   LEFT JOIN collections c ON c.id = vt.collection_id
                  WHERE vt.vault_id = $1 AND vt.collection_id = $2
@@ -131,7 +134,8 @@ async def list_for_vault(
         # the desired scoping behaviour.
         sql = (
             "SELECT vt.id, vt.collection_id, c.path AS collection, "
-            "       vt.name, vt.description, vt.columns, vt.created_at "
+            "       vt.name, vt.description, vt.columns, "
+            "       vt.unique_keys, vt.indexes, vt.created_at "
             "  FROM vault_tables vt "
             "  LEFT JOIN collections c ON c.id = vt.collection_id "
             " WHERE vt.vault_id = $1"
@@ -144,7 +148,8 @@ async def list_for_vault(
         rows = await conn.fetch(
             """
             SELECT vt.id, vt.collection_id, c.path AS collection,
-                   vt.name, vt.description, vt.columns, vt.created_at
+                   vt.name, vt.description, vt.columns,
+                   vt.unique_keys, vt.indexes, vt.created_at
               FROM vault_tables vt
               LEFT JOIN collections c ON c.id = vt.collection_id
              WHERE vt.vault_id = $1
@@ -166,16 +171,21 @@ async def insert(
     created_by: str | None,
     now: datetime,
     collection_id: uuid.UUID | None = None,
+    unique_keys: list[dict] | None = None,
+    indexes: list[dict] | None = None,
 ) -> None:
     await conn.execute(
         """
         INSERT INTO vault_tables
             (id, vault_id, collection_id, name, description, columns,
+             unique_keys, indexes,
              created_by, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
         """,
         table_id, vault_id, collection_id, name, description,
-        json.dumps(columns), created_by, now,
+        json.dumps(columns),
+        json.dumps(unique_keys or []), json.dumps(indexes or []),
+        created_by, now,
     )
 
 
@@ -190,10 +200,39 @@ async def update_columns(conn, table_id: uuid.UUID, columns: list[dict]) -> None
     )
 
 
+async def update_schema_meta(
+    conn,
+    table_id: uuid.UUID,
+    *,
+    unique_keys: list[dict],
+    indexes: list[dict],
+) -> None:
+    """Persist the resolved ``unique_keys`` / ``indexes`` metadata.
+
+    Called inside the same TX as the physical DDL so the registry can
+    never drift from the live schema (AKB #215 AC #10)."""
+    await conn.execute(
+        "UPDATE vault_tables "
+        "   SET unique_keys = $1, indexes = $2, updated_at = NOW() "
+        " WHERE id = $3",
+        json.dumps(unique_keys), json.dumps(indexes), table_id,
+    )
+
+
 def parse_columns(raw: Any) -> list[dict]:
     """Normalise the `columns` jsonb to list[dict]. asyncpg returns it as
     a pre-parsed list normally, but legacy rows inserted as JSON string
     literals come back as `str` — handle both."""
+    if isinstance(raw, str):
+        return ensure_list(raw)
+    return list(raw) if raw else []
+
+
+def parse_json_list(raw: Any) -> list[dict]:
+    """Normalise a JSONB list column (``unique_keys`` / ``indexes``) to
+    ``list[dict]``. Mirrors :func:`parse_columns`: asyncpg usually
+    returns a pre-parsed list, but legacy rows inserted as JSON string
+    literals come back as ``str`` — handle both, and ``None`` → ``[]``."""
     if isinstance(raw, str):
         return ensure_list(raw)
     return list(raw) if raw else []

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -451,7 +451,8 @@ async def _list_tables_with_schema(vault_name: str, vault_id) -> list[dict]:
     pool = await get_pool()
     async with pool.acquire() as conn:
         registry = await conn.fetch(
-            "SELECT id, name FROM vault_tables WHERE vault_id = $1 ORDER BY name",
+            "SELECT id, name, unique_keys, indexes FROM vault_tables "
+            "WHERE vault_id = $1 ORDER BY name",
             vault_id,
         )
         if not registry:
@@ -461,6 +462,7 @@ async def _list_tables_with_schema(vault_name: str, vault_id) -> list[dict]:
         # canonical sanitizer so hyphenated vault names map to the actual
         # `vt_<sanitised>__<sanitised>` PG identifiers.
         from app.repositories.table_data_repo import pg_table_name
+        from app.repositories import table_registry_repo
         pg_names = [pg_table_name(vault_name, r["name"]) for r in registry]
         col_rows = await conn.fetch(
             """
@@ -502,6 +504,11 @@ async def _list_tables_with_schema(vault_name: str, vault_id) -> list[dict]:
                 "name": r["name"],
                 "row_count": row_count,
                 "columns": columns,
+                # Declared guarantees (AKB #215) so an agent inspecting a
+                # vault sees uniqueness/index metadata without a mid-flow
+                # information_schema lookup — the point of this surface.
+                "unique_keys": table_registry_repo.parse_json_list(r["unique_keys"]),
+                "indexes": table_registry_repo.parse_json_list(r["indexes"]),
             })
         return out
 

--- a/backend/app/services/index_service.py
+++ b/backend/app/services/index_service.py
@@ -65,6 +65,8 @@ CHUNK_HEADER_KEYS: tuple[str, ...] = (
     "MIME",
     "SIZE",
     "DESCRIPTION",
+    "UNIQUE_KEYS",
+    "INDEXES",
 )
 
 
@@ -99,10 +101,17 @@ def build_table_chunk(
     name: str,
     description: str | None,
     columns: list[dict],
+    unique_keys: list[dict] | None = None,
+    indexes: list[dict] | None = None,
 ) -> "Chunk":
     """Single chunk representing a table's metadata + column schema.
     Tables are not markdown; we emit one metadata chunk so hybrid search
-    can find them alongside documents."""
+    can find them alongside documents.
+
+    Declared `unique_keys` / `indexes` (AKB #215) are surfaced too so the
+    table's guarantees are discoverable via hybrid search — otherwise an
+    agent searching for a uniqueness/index guarantee by name finds nothing
+    (AC #11 discovery surface)."""
     col_lines = []
     for col in columns or []:
         line = f"  - {col.get('name')}: {col.get('type', 'text')}"
@@ -119,6 +128,24 @@ def build_table_chunk(
     if col_lines:
         parts.append("COLUMNS:")
         parts.extend(col_lines)
+    if unique_keys:
+        parts.append("UNIQUE_KEYS:")
+        for uk in unique_keys:
+            cols = ", ".join(uk.get("columns", []))
+            parts.append(f"  - {uk.get('name')} ({cols})")
+    if indexes:
+        parts.append("INDEXES:")
+        for idx in indexes:
+            cparts = []
+            for c in idx.get("columns", []):
+                # index columns are normally {name, order} dicts, but tolerate a
+                # bare-string column (the resolver's own input shape) so a
+                # legacy/hand-edited row can never raise here.
+                if isinstance(c, dict):
+                    cparts.append(f"{c.get('name')} {c.get('order', 'asc')}")
+                else:
+                    cparts.append(f"{c} asc")
+            parts.append(f"  - {idx.get('name')} ({', '.join(cparts)})")
     content = "\n".join(parts)
     return Chunk(
         section_path="",

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -281,13 +281,17 @@ async def index_table_metadata(
     name: str,
     description: str | None,
     columns: list[dict],
+    unique_keys: list[dict] | None = None,
+    indexes: list[dict] | None = None,
 ) -> None:
     """Build + upsert the metadata chunk for a table so hybrid search can
     surface it. Safe to call repeatedly — write_source_chunks replaces
-    all prior chunks for this table first."""
+    all prior chunks for this table first. Declared unique_keys/indexes
+    are forwarded so the table's guarantees are searchable (AC #11)."""
     chunk = build_table_chunk(
         vault_name=vault_name, name=name,
         description=description, columns=columns,
+        unique_keys=unique_keys, indexes=indexes,
     )
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -462,6 +466,8 @@ async def create_table(
             name=name,
             description=description,
             columns=columns,
+            unique_keys=resolved_uks,
+            indexes=resolved_idxs,
         )
     except Exception as e:  # noqa: BLE001
         logger.warning("table metadata indexing failed for %s: %s", name, e)
@@ -875,6 +881,8 @@ async def alter_table(
             name=table_name,
             description=table["description"] or "",
             columns=columns,
+            unique_keys=existing_uks,
+            indexes=existing_idxs,
         )
     except Exception as e:  # noqa: BLE001
         logger.warning("alter_table chunk reindex failed for %s: %s", table_name, e)

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -31,7 +31,11 @@ from app.services.index_service import (
 )
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import table_uri
-from app.services.user_sql_executor import PermissionDeniedError, get_user_sql_executor
+from app.services.user_sql_executor import (
+    PermissionDeniedError,
+    UniqueViolationError,
+    get_user_sql_executor,
+)
 from app.util.errors import (
     err,
     METHOD_NOT_ALLOWED,
@@ -40,6 +44,7 @@ from app.util.errors import (
     SQL_ERROR,
     UNDEFINED_COLUMN,
     UNDEFINED_TABLE,
+    UNIQUE_VIOLATION,
     VAULT_ARCHIVED,
 )
 from app.util.text import fuzzy_hint
@@ -89,6 +94,159 @@ def _validate_column_name(name) -> None:
         )
 
 
+# ── Declarative unique-key / index resolution (AKB #215) ─────────
+
+# Order values accepted on an index column. Closed set — anything else
+# is caller-fixable input → ValidationError (422), never a 500.
+_INDEX_ORDERS = {"asc", "desc"}
+
+
+def _declared_column_lookup(columns: list[dict]) -> dict[str, str]:
+    """Map lower(name) → declared name, for case-insensitive existence
+    checks against a table's declared columns."""
+    return {c["name"].lower(): c["name"] for c in columns if isinstance(c, dict) and "name" in c}
+
+
+def _check_key_column(col, lookup: dict[str, str], *, ctx: str) -> None:
+    """Validate one referenced column: non-empty string, not reserved,
+    and present in the table's declared columns (case-insensitive)."""
+    if not isinstance(col, str) or not col:
+        raise ValidationError(f"{ctx}: each column must be a non-empty string; got {col!r}.")
+    if col.lower() in _RESERVED:
+        raise ValidationError(
+            f"{ctx}: column {col!r} is a reserved bookkeeping column "
+            f"(auto-added by AKB) and cannot be used. Reserved: {sorted(_RESERVED)}."
+        )
+    if col.lower() not in lookup:
+        raise ValidationError(
+            f"{ctx}: column {col!r} does not exist on this table. "
+            f"Declared columns: {sorted(lookup.values())}."
+        )
+
+
+def _resolve_unique_keys(
+    items, columns: list[dict], pg_name: str,
+) -> list[dict]:
+    """Validate + normalise declarative ``unique_keys`` items into
+    ``[{name, columns}]`` with a resolved (generated or caller-supplied)
+    name. Pure function — no DB. Raises ValidationError on bad input.
+
+    - ``columns`` must be a non-empty list of existing, non-reserved
+      column names (case-insensitive vs the table's declared columns).
+    - ``name`` is optional; when omitted a deterministic, schema-global
+      namespaced name is generated (see ``generate_constraint_name``).
+    - Names (generated or supplied) must be unique within the set.
+    """
+    if items is None:
+        return []
+    if not isinstance(items, list):
+        raise ValidationError("`unique_keys` must be a list of {name?, columns} objects.")
+    lookup = _declared_column_lookup(columns)
+    resolved: list[dict] = []
+    seen_names: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict) or "columns" not in item:
+            raise ValidationError(
+                f"Each unique key must be an object with a 'columns' field; got {item!r}."
+            )
+        cols = item["columns"]
+        if not isinstance(cols, list) or not cols:
+            raise ValidationError(
+                f"unique_keys.columns must be a non-empty list; got {cols!r}."
+            )
+        for col in cols:
+            _check_key_column(col, lookup, ctx="unique_keys")
+        name = item.get("name")
+        if name is not None:
+            if not isinstance(name, str) or not name:
+                raise ValidationError("unique_keys.name must be a non-empty string when given.")
+            name = table_data_repo.safe_ident(name)
+            if len(name.encode()) > table_data_repo.PG_IDENT_MAX_LEN:
+                raise ValidationError(
+                    f"unique_keys.name {name!r} exceeds the "
+                    f"{table_data_repo.PG_IDENT_MAX_LEN}-char PostgreSQL identifier limit."
+                )
+        else:
+            name = table_data_repo.generate_constraint_name(pg_name, cols, kind="uk")
+        if name in seen_names:
+            raise ValidationError(
+                f"Duplicate unique-key name {name!r}. Names (generated or supplied) "
+                f"must be unique within a table."
+            )
+        seen_names.add(name)
+        resolved.append({"name": name, "columns": list(cols)})
+    return resolved
+
+
+def _resolve_indexes(
+    items, columns: list[dict], pg_name: str,
+) -> list[dict]:
+    """Validate + normalise declarative ``indexes`` items into
+    ``[{name, columns:[{name, order}]}]`` with a resolved name. Pure.
+
+    Index columns accept a bare string (defaults to ``order='asc'``) or
+    an object ``{name, order?}`` where order ∈ {asc, desc}. Unique
+    indexes are expressed via ``unique_keys``, not here.
+    """
+    if items is None:
+        return []
+    if not isinstance(items, list):
+        raise ValidationError("`indexes` must be a list of {name?, columns} objects.")
+    lookup = _declared_column_lookup(columns)
+    resolved: list[dict] = []
+    seen_names: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict) or "columns" not in item:
+            raise ValidationError(
+                f"Each index must be an object with a 'columns' field; got {item!r}."
+            )
+        cols = item["columns"]
+        if not isinstance(cols, list) or not cols:
+            raise ValidationError(
+                f"indexes.columns must be a non-empty list; got {cols!r}."
+            )
+        norm_cols: list[dict] = []
+        col_names: list[str] = []
+        for col in cols:
+            if isinstance(col, str):
+                col_name, order = col, "asc"
+            elif isinstance(col, dict) and "name" in col:
+                col_name = col["name"]
+                order = (col.get("order") or "asc")
+                if not isinstance(order, str) or order.lower() not in _INDEX_ORDERS:
+                    raise ValidationError(
+                        f"indexes: column order {order!r} must be one of {sorted(_INDEX_ORDERS)}."
+                    )
+                order = order.lower()
+            else:
+                raise ValidationError(
+                    f"indexes: each column must be a string or {{name, order?}}; got {col!r}."
+                )
+            _check_key_column(col_name, lookup, ctx="indexes")
+            norm_cols.append({"name": col_name, "order": order})
+            col_names.append(col_name)
+        name = item.get("name")
+        if name is not None:
+            if not isinstance(name, str) or not name:
+                raise ValidationError("indexes.name must be a non-empty string when given.")
+            name = table_data_repo.safe_ident(name)
+            if len(name.encode()) > table_data_repo.PG_IDENT_MAX_LEN:
+                raise ValidationError(
+                    f"indexes.name {name!r} exceeds the "
+                    f"{table_data_repo.PG_IDENT_MAX_LEN}-char PostgreSQL identifier limit."
+                )
+        else:
+            name = table_data_repo.generate_constraint_name(pg_name, col_names, kind="idx")
+        if name in seen_names:
+            raise ValidationError(
+                f"Duplicate index name {name!r}. Names (generated or supplied) "
+                f"must be unique within a table."
+            )
+        seen_names.add(name)
+        resolved.append({"name": name, "columns": norm_cols})
+    return resolved
+
+
 # ── Indexing helpers ─────────────────────────────────────────────
 
 
@@ -134,6 +292,8 @@ async def create_table(
     actor_id: str,
     description: str = "",
     collection: str | None = None,
+    unique_keys: list[dict] | None = None,
+    indexes: list[dict] | None = None,
 ) -> dict:
     """Create a vault-scoped table inside an optional collection.
 
@@ -200,14 +360,32 @@ async def create_table(
                     f"the vault name ({vault['name']!r}) or table name "
                     f"({name!r})."
                 )
+
+            # Resolve + validate declarative constraints/indexes BEFORE any
+            # DDL so a bad spec rolls back with zero schema change. On a
+            # freshly-created (empty) table there is no duplicate-preflight
+            # to run — a later duplicate INSERT surfaces PG 23505 via akb_sql.
+            resolved_uks = _resolve_unique_keys(unique_keys, columns, pg_name)
+            resolved_idxs = _resolve_indexes(indexes, columns, pg_name)
+
             try:
                 await table_data_repo.create_dynamic_table(conn, pg_name, columns)
+                for uk in resolved_uks:
+                    await table_data_repo.create_unique_constraint(
+                        conn, pg_name, uk["name"], uk["columns"],
+                    )
+                for idx in resolved_idxs:
+                    await table_data_repo.create_index(
+                        conn, pg_name, idx["name"],
+                        [(c["name"], c["order"]) for c in idx["columns"]],
+                    )
                 await table_registry_repo.insert(
                     conn,
                     table_id=tid, vault_id=vault_id, name=name,
                     description=description, columns=columns,
                     created_by=actor_id, now=now,
                     collection_id=collection_id,
+                    unique_keys=resolved_uks, indexes=resolved_idxs,
                 )
             except asyncpg.DuplicateColumnError as e:
                 # Belt-and-suspenders: a duplicate/reserved column that reached
@@ -217,6 +395,17 @@ async def create_table(
                     f"Duplicate or reserved column in table {name!r}: {e}. "
                     f"Column names (including the reserved id/created_at/"
                     f"updated_at/created_by) must each appear once."
+                ) from e
+            except (asyncpg.DuplicateObjectError, asyncpg.DuplicateTableError) as e:
+                # A caller-supplied unique-key / index NAME collided with an
+                # existing constraint or index. These names share PostgreSQL's
+                # schema-global index namespace, so a clash with another table's
+                # index is possible and is caller-fixable input → clean 422.
+                raise ValidationError(
+                    f"A unique-key or index name in table {name!r} already "
+                    f"exists in the database: {e}. Constraint/index names are "
+                    f"shared schema-wide — choose a different name (or omit it "
+                    f"to let AKB generate a collision-safe one)."
                 ) from e
             except asyncpg.UniqueViolationError as e:
                 # Concurrent create past the find_by_name check races on
@@ -261,6 +450,8 @@ async def create_table(
         "collection": collection_path or None,
         "name": name,
         "columns": columns,
+        "unique_keys": resolved_uks,
+        "indexes": resolved_idxs,
     }
 
 
@@ -297,6 +488,8 @@ async def list_tables(vault_id: uuid.UUID) -> list[dict]:
                 "sql_name": table_data_repo.pg_short_name(r["name"]),
                 "description": r["description"],
                 "columns": table_registry_repo.parse_columns(r["columns"]),
+                "unique_keys": table_registry_repo.parse_json_list(r.get("unique_keys")),
+                "indexes": table_registry_repo.parse_json_list(r.get("indexes")),
                 "row_count": count,
                 "created_at": r["created_at"].isoformat(),
             })
@@ -372,14 +565,24 @@ async def alter_table(
     add_columns: list[dict] | None = None,
     drop_columns: list[str] | None = None,
     rename_columns: dict[str, str] | None = None,
+    add_unique_keys: list[dict] | None = None,
+    drop_unique_keys: list[str] | None = None,
+    add_indexes: list[dict] | None = None,
+    drop_indexes: list[str] | None = None,
 ) -> dict:
     """Apply schema changes to a vault table:
        - add_columns: [{name, type}, ...]
        - drop_columns: ["name", ...]
        - rename_columns: {"old": "new", ...}
+       - add_unique_keys: [{name?, columns}, ...]
+       - drop_unique_keys: ["name", ...]
+       - add_indexes: [{name?, columns}, ...]
+       - drop_indexes: ["name", ...]
 
-    All three are optional and combine in one TX. Emits `table.alter`
-    after the writes commit.
+    All are optional and combine in one TX. Adding a unique key
+    PREFLIGHTS existing rows for duplicates BEFORE any DDL — on a
+    violation the whole alter rolls back (physical schema + registry
+    unchanged). Emits `table.alter` after the writes commit.
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -466,7 +669,129 @@ async def alter_table(
                             c["name"] = new_name
                     renamed[old_name] = new_name
 
+            # ── Declarative unique keys / indexes (AKB #215) ─────────
+            # Existing metadata from the registry row; the merged result
+            # is persisted via update_schema_meta in the SAME TX.
+            existing_uks = table_registry_repo.parse_json_list(table.get("unique_keys"))
+            existing_idxs = table_registry_repo.parse_json_list(table.get("indexes"))
+            uk_changed = False
+            idx_changed = False
+
+            # Drops first so a drop+re-add of the same name in one alter
+            # works, and so adds validate against the post-drop set.
+            drop_uk_names = set(drop_unique_keys or [])
+            if drop_uk_names:
+                remaining_uks = []
+                for uk in existing_uks:
+                    if uk.get("name") in drop_uk_names:
+                        await table_data_repo.drop_constraint(conn, pg_name, uk["name"])
+                        uk_changed = True
+                    else:
+                        remaining_uks.append(uk)
+                existing_uks = remaining_uks
+
+            drop_idx_names = set(drop_indexes or [])
+            if drop_idx_names:
+                remaining_idxs = []
+                for idx in existing_idxs:
+                    if idx.get("name") in drop_idx_names:
+                        await table_data_repo.drop_index(conn, idx["name"])
+                        idx_changed = True
+                    else:
+                        remaining_idxs.append(idx)
+                existing_idxs = remaining_idxs
+
+            if add_unique_keys:
+                resolved_uks = _resolve_unique_keys(add_unique_keys, columns, pg_name)
+                taken = {uk["name"] for uk in existing_uks}
+                for uk in resolved_uks:
+                    if uk["name"] in taken:
+                        raise ValidationError(
+                            f"Unique-key name {uk['name']!r} already exists on this table."
+                        )
+                    # PREFLIGHT existing data BEFORE the ADD CONSTRAINT so a
+                    # duplicate fails pre-DDL — the TX rolls back leaving
+                    # schema + registry untouched (AC #4, #10).
+                    dups = await table_data_repo.unique_key_duplicates(
+                        conn, pg_name, uk["columns"], limit=5,
+                    )
+                    if dups:
+                        sample = [
+                            {c: row[table_data_repo.safe_ident(c)] for c in uk["columns"]}
+                            for row in dups
+                        ]
+                        raise ValidationError(
+                            f"Cannot add unique key {uk['name']!r} on columns "
+                            f"{uk['columns']}: existing rows already contain "
+                            f"duplicate values. Found {len(dups)} duplicate "
+                            f"group(s) (sample, key columns only): {sample}. "
+                            f"De-duplicate the data first, then retry."
+                        )
+                    try:
+                        await table_data_repo.create_unique_constraint(
+                            conn, pg_name, uk["name"], uk["columns"],
+                        )
+                    except asyncpg.UniqueViolationError as e:
+                        # The preflight above is best-effort: FOR UPDATE locks
+                        # only the registry row, not the data table, so a
+                        # concurrent INSERT can introduce a duplicate between
+                        # the preflight SELECT and here. ADD CONSTRAINT is the
+                        # real enforcement — surface its rejection as a clean
+                        # 422 (the TX still rolls back, leaving schema+registry
+                        # unchanged).
+                        raise ValidationError(
+                            f"Cannot add unique key {uk['name']!r} on columns "
+                            f"{uk['columns']}: existing rows violate uniqueness "
+                            f"(a concurrent write may have introduced a "
+                            f"duplicate after preflight). De-duplicate and retry."
+                        ) from e
+                    except (asyncpg.DuplicateObjectError, asyncpg.DuplicateTableError) as e:
+                        # Name collides with an existing constraint/index in the
+                        # schema-global namespace (possibly on another table).
+                        raise ValidationError(
+                            f"Unique-key name {uk['name']!r} already exists in "
+                            f"the database: {e}. Names are shared schema-wide — "
+                            f"choose a different one (or omit it for an "
+                            f"auto-generated collision-safe name)."
+                        ) from e
+                    taken.add(uk["name"])
+                    existing_uks.append(uk)
+                    uk_changed = True
+
+            if add_indexes:
+                resolved_idxs = _resolve_indexes(add_indexes, columns, pg_name)
+                taken_i = {idx["name"] for idx in existing_idxs}
+                for idx in resolved_idxs:
+                    if idx["name"] in taken_i:
+                        raise ValidationError(
+                            f"Index name {idx['name']!r} already exists on this table."
+                        )
+                    try:
+                        await table_data_repo.create_index(
+                            conn, pg_name, idx["name"],
+                            [(c["name"], c["order"]) for c in idx["columns"]],
+                        )
+                    except (asyncpg.DuplicateObjectError, asyncpg.DuplicateTableError) as e:
+                        # Index names share PostgreSQL's schema-global namespace
+                        # (incl. UNIQUE constraints' implicit indexes), so a
+                        # caller-supplied name can collide with an object on
+                        # another table → clean 422, not an uncaught 500.
+                        raise ValidationError(
+                            f"Index name {idx['name']!r} already exists in the "
+                            f"database: {e}. Names are shared schema-wide — "
+                            f"choose a different one (or omit it for an "
+                            f"auto-generated collision-safe name)."
+                        ) from e
+                    taken_i.add(idx["name"])
+                    existing_idxs.append(idx)
+                    idx_changed = True
+
             await table_registry_repo.update_columns(conn, table["id"], columns)
+            if uk_changed or idx_changed:
+                await table_registry_repo.update_schema_meta(
+                    conn, table["id"],
+                    unique_keys=existing_uks, indexes=existing_idxs,
+                )
 
             t_uri = table_uri(vault["name"], table_name, collection=table.get("collection"))
             await emit_event(
@@ -480,6 +805,8 @@ async def alter_table(
                     "added": added,
                     "dropped": dropped,
                     "renamed": renamed,
+                    "unique_keys_changed": uk_changed,
+                    "indexes_changed": idx_changed,
                 },
             )
 
@@ -503,6 +830,8 @@ async def alter_table(
         "vault": vault["name"],
         "name": table_name,
         "columns": columns,
+        "unique_keys": existing_uks,
+        "indexes": existing_idxs,
     }
 
 
@@ -598,6 +927,17 @@ async def execute_sql(
         return err(
             str(e),
             code=PERMISSION_DENIED,
+            pg_sqlstate=e.pg_sqlstate,
+        )
+    except UniqueViolationError as e:
+        # PG 23505 — an INSERT/UPDATE broke a declared unique key (#215,
+        # AC#2). Surface a *stable* envelope: a dedicated code with
+        # pg_sqlstate attached (mirroring PERMISSION_DENIED), so callers
+        # can branch on the conflict deterministically rather than
+        # string-matching the generic SQL_ERROR message.
+        return err(
+            str(e),
+            code=UNIQUE_VIOLATION,
             pg_sqlstate=e.pg_sqlstate,
         )
     except Exception as e:  # noqa: BLE001 — fall through to enrichment

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -107,9 +107,16 @@ def _declared_column_lookup(columns: list[dict]) -> dict[str, str]:
     return {c["name"].lower(): c["name"] for c in columns if isinstance(c, dict) and "name" in c}
 
 
-def _check_key_column(col, lookup: dict[str, str], *, ctx: str) -> None:
-    """Validate one referenced column: non-empty string, not reserved,
-    and present in the table's declared columns (case-insensitive)."""
+def _check_key_column(col, lookup: dict[str, str], *, ctx: str) -> str:
+    """Validate one referenced column and return its CANONICAL declared name.
+
+    Non-empty string, not reserved, and present in the table's declared
+    columns (case-insensitive). Returning the canonical name means a
+    mixed-case reference (e.g. ``"ACTOR"`` for declared ``"actor"``) is stored
+    as the real PG identifier — so the duplicate-preflight sample
+    (``row[safe_ident(name)]``) can't KeyError on a casing mismatch, and the
+    registry never records a divergent casing.
+    """
     if not isinstance(col, str) or not col:
         raise ValidationError(f"{ctx}: each column must be a non-empty string; got {col!r}.")
     if col.lower() in _RESERVED:
@@ -122,6 +129,7 @@ def _check_key_column(col, lookup: dict[str, str], *, ctx: str) -> None:
             f"{ctx}: column {col!r} does not exist on this table. "
             f"Declared columns: {sorted(lookup.values())}."
         )
+    return lookup[col.lower()]
 
 
 def _resolve_unique_keys(
@@ -154,8 +162,17 @@ def _resolve_unique_keys(
             raise ValidationError(
                 f"unique_keys.columns must be a non-empty list; got {cols!r}."
             )
+        canon_cols: list[str] = []
+        seen_cols: set[str] = set()
         for col in cols:
-            _check_key_column(col, lookup, ctx="unique_keys")
+            cname = _check_key_column(col, lookup, ctx="unique_keys")
+            if cname.lower() in seen_cols:
+                raise ValidationError(
+                    f"unique_keys: column {col!r} appears more than once in a single "
+                    f"key; a unique key's columns must be distinct."
+                )
+            seen_cols.add(cname.lower())
+            canon_cols.append(cname)
         name = item.get("name")
         if name is not None:
             if not isinstance(name, str) or not name:
@@ -167,14 +184,14 @@ def _resolve_unique_keys(
                     f"{table_data_repo.PG_IDENT_MAX_LEN}-char PostgreSQL identifier limit."
                 )
         else:
-            name = table_data_repo.generate_constraint_name(pg_name, cols, kind="uk")
+            name = table_data_repo.generate_constraint_name(pg_name, canon_cols, kind="uk")
         if name in seen_names:
             raise ValidationError(
                 f"Duplicate unique-key name {name!r}. Names (generated or supplied) "
                 f"must be unique within a table."
             )
         seen_names.add(name)
-        resolved.append({"name": name, "columns": list(cols)})
+        resolved.append({"name": name, "columns": canon_cols})
     return resolved
 
 
@@ -207,6 +224,7 @@ def _resolve_indexes(
             )
         norm_cols: list[dict] = []
         col_names: list[str] = []
+        seen_cols: set[str] = set()
         for col in cols:
             if isinstance(col, str):
                 col_name, order = col, "asc"
@@ -222,9 +240,15 @@ def _resolve_indexes(
                 raise ValidationError(
                     f"indexes: each column must be a string or {{name, order?}}; got {col!r}."
                 )
-            _check_key_column(col_name, lookup, ctx="indexes")
-            norm_cols.append({"name": col_name, "order": order})
-            col_names.append(col_name)
+            cname = _check_key_column(col_name, lookup, ctx="indexes")
+            if cname.lower() in seen_cols:
+                raise ValidationError(
+                    f"indexes: column {col_name!r} appears more than once in a single "
+                    f"index; an index's columns must be distinct."
+                )
+            seen_cols.add(cname.lower())
+            norm_cols.append({"name": cname, "order": order})
+            col_names.append(cname)
         name = item.get("name")
         if name is not None:
             if not isinstance(name, str) or not name:
@@ -676,6 +700,37 @@ async def alter_table(
             existing_idxs = table_registry_repo.parse_json_list(table.get("indexes"))
             uk_changed = False
             idx_changed = False
+
+            # Keep declarative metadata consistent with column rename/drop done
+            # in THIS alter, else the registry drifts from the physical schema:
+            # a PG column rename leaves the constraint/index under the old
+            # column name, and DROP COLUMN auto-drops any constraint/index the
+            # column was part of. Mirror both in the registry. (#220 review.)
+            if renamed:
+                ren = {old.lower(): new for old, new in renamed.items()}
+                for uk in existing_uks:
+                    new_cols = [ren.get(str(c).lower(), c) for c in uk.get("columns", [])]
+                    if new_cols != uk.get("columns"):
+                        uk["columns"] = new_cols
+                        uk_changed = True
+                for idx in existing_idxs:
+                    for c in idx.get("columns", []):
+                        if isinstance(c, dict) and str(c.get("name", "")).lower() in ren:
+                            c["name"] = ren[str(c["name"]).lower()]
+                            idx_changed = True
+            if dropped:
+                dset = {d.lower() for d in dropped}
+                kept_uks = [uk for uk in existing_uks
+                            if not any(str(c).lower() in dset for c in uk.get("columns", []))]
+                if len(kept_uks) != len(existing_uks):
+                    existing_uks = kept_uks
+                    uk_changed = True
+                kept_idxs = [idx for idx in existing_idxs
+                             if not any(isinstance(c, dict) and str(c.get("name", "")).lower() in dset
+                                        for c in idx.get("columns", []))]
+                if len(kept_idxs) != len(existing_idxs):
+                    existing_idxs = kept_idxs
+                    idx_changed = True
 
             # Drops first so a drop+re-add of the same name in one alter
             # works, and so adds validate against the post-drop set.

--- a/backend/app/services/user_sql_executor.py
+++ b/backend/app/services/user_sql_executor.py
@@ -65,6 +65,22 @@ class PermissionDeniedError(Exception):
         self.pg_sqlstate = pg_sqlstate
 
 
+class UniqueViolationError(Exception):
+    """Raised when PG returns SQLSTATE 23505 for the user-supplied SQL.
+
+    An INSERT/UPDATE that breaks a declared unique key (#215) surfaces
+    here. Like `PermissionDeniedError`, we hold the PG message and
+    sqlstate so the caller can pin a *stable* envelope (a dedicated
+    code + `pg_sqlstate='23505'`) rather than letting 23505 fall
+    through the generic SQL_ERROR catch-all. The generated/declared
+    constraint name is embedded in the PG message verbatim.
+    """
+
+    def __init__(self, message: str, pg_sqlstate: str = "23505") -> None:
+        super().__init__(message)
+        self.pg_sqlstate = pg_sqlstate
+
+
 # ── Executor ──────────────────────────────────────────────────
 
 
@@ -137,6 +153,17 @@ class UserSqlExecutor:
                 "PG denied user_sql for user=%s: %s", user_id, e,
             )
             raise PermissionDeniedError(str(e), pg_sqlstate="42501") from e
+        except asyncpg.exceptions.UniqueViolationError as e:
+            # SQLSTATE 23505 — an INSERT/UPDATE broke a declared unique
+            # key (#215). This is the *contracted* conflict path: surface
+            # it under a dedicated stable code with pg_sqlstate attached
+            # so callers can key off 23505 (and the constraint name in
+            # the verbatim PG message), instead of the generic SQL_ERROR
+            # catch-all that drops pg_sqlstate.
+            logger.info(
+                "PG unique violation in user_sql for user=%s: %s", user_id, e,
+            )
+            raise UniqueViolationError(str(e), pg_sqlstate="23505") from e
         except asyncpg.exceptions.UndefinedTableError:
             # 42P01 — table doesn't exist OR exists but role can't see it.
             # PG reports the same code for both ("relation X does not

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -52,6 +52,7 @@ INVALID_PATH = "invalid_path"              # collection / file path failure
 UNKNOWN_ARGUMENT = "unknown_argument"      # arg key not in tool schema (0.5.4)
 UNKNOWN_TOOL = "unknown_tool"
 CONFLICT = "conflict"                      # version / expected-state mismatch
+UNIQUE_VIOLATION = "unique_violation"      # PG 23505 — INSERT/UPDATE breaks a unique key
 NO_OP = "no_op"                            # nothing to update / already in state
 EDIT_FAILED = "edit_failed"                # akb_edit: old_string match / uniqueness failure
 

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -930,9 +930,22 @@ akb_drill_down(uri="akb://eng/doc/specs/api.md", section="API")     # Sections c
 | name | ✓ | Table name |
 | description | | What this table is for |
 | columns | ✓ | Column definitions |
+| unique_keys | | Declarative UNIQUE keys: `[{name?, columns}]` |
+| indexes | | Declarative lookup indexes: `[{name?, columns}]` |
 
 ## Column Types
 `text`, `number`, `boolean`, `date`, `json`
+
+## Unique keys & indexes
+- `unique_keys` — single or composite UNIQUE constraints. Each item is
+  `{name?, columns}`; `columns` is a list of existing column names.
+  Omit `name` and AKB generates a deterministic, stable name. Use this
+  (NOT `indexes`) when you want uniqueness enforced.
+- `indexes` — plain lookup (btree) indexes. Each item is `{name?, columns}`;
+  a column is a bare string or `{name, order}` with order `asc` (default)
+  or `desc`.
+- Declarative only — no raw SQL. Reserved bookkeeping columns
+  (id/created_at/updated_at/created_by) cannot be referenced.
 
 ## Example
 ```
@@ -944,7 +957,9 @@ akb_create_table(vault="finance", name="invoices",
     {"name": "status", "type": "text"},
     {"name": "due_date", "type": "date"},
     {"name": "metadata", "type": "json"}
-  ])
+  ],
+  unique_keys=[{"columns": ["client", "due_date"]}],
+  indexes=[{"columns": ["status", {"name": "due_date", "order": "desc"}]}])
 ```""",
 
     "akb_list_vaults": """# akb_list_vaults — List Accessible Vaults
@@ -1331,13 +1346,29 @@ The `confirm` parameter must match the vault name. Owner only.""",
 | add_columns | | Columns to add: [{"name": "col", "type": "text"}] |
 | drop_columns | | Column names to remove: ["old_col"] |
 | rename_columns | | Rename map: {"old_name": "new_name"} |
+| add_unique_keys | | UNIQUE keys to add: [{name?, columns}] |
+| drop_unique_keys | | UNIQUE-key names to drop: ["uk_name"] |
+| add_indexes | | Lookup indexes to add: [{name?, columns}] |
+| drop_indexes | | Index names to drop: ["idx_name"] |
+
+## Unique keys & indexes
+- `add_unique_keys` / `add_indexes` mirror the `akb_create_table` shape.
+- Adding a UNIQUE key on a table that already has data PREFLIGHTS for
+  duplicate rows; if any are found the whole alter fails BEFORE any DDL
+  (schema + metadata unchanged) and the error names the duplicate key
+  columns.
+- Drop by the resolved name shown in the table's `unique_keys` /
+  `indexes` metadata.
 
 ## Example
 ```
 akb_alter_table(uri="akb://eng/table/tasks",
   add_columns=[{"name": "priority", "type": "number"}],
   drop_columns=["old_field"],
-  rename_columns={"desc": "description"})
+  rename_columns={"desc": "description"},
+  add_unique_keys=[{"name": "uq_slug", "columns": ["slug"]}],
+  add_indexes=[{"columns": [{"name": "priority", "order": "desc"}]}],
+  drop_indexes=["vt_eng__tasks__old_field__idx"])
 ```
 
 Requires admin role.""",

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -853,6 +853,8 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
             actor_id=user.username,
             description=args.get("description", ""),
             collection=collection or None,
+            unique_keys=args.get("unique_keys"),
+            indexes=args.get("indexes"),
         )
     except (ValidationError, ValueError) as e:
         # ValidationError: bad table name / over-long PG identifier (422).
@@ -911,6 +913,10 @@ async def _handle_alter_table(args: dict, uid: str, user: _MCPUser) -> dict:
             add_columns=args.get("add_columns"),
             drop_columns=args.get("drop_columns"),
             rename_columns=args.get("rename_columns"),
+            add_unique_keys=args.get("add_unique_keys"),
+            drop_unique_keys=args.get("drop_unique_keys"),
+            add_indexes=args.get("add_indexes"),
+            drop_indexes=args.get("drop_indexes"),
         )
     except NotFoundError as e:
         return err(str(e), code=NOT_FOUND)

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -640,6 +640,61 @@ TOOLS = [
                         "required": ["name", "type"],
                     },
                 },
+                "unique_keys": {
+                    "type": "array",
+                    "description": (
+                        "Declarative UNIQUE keys. Each item is {name?, columns}. "
+                        "`columns` is a list of existing column names (single or "
+                        "composite). `name` is optional — when omitted AKB generates "
+                        "a deterministic, stable name. Use this (not `indexes`) for "
+                        "unique indexes."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "columns": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1,
+                            },
+                        },
+                        "required": ["columns"],
+                    },
+                },
+                "indexes": {
+                    "type": "array",
+                    "description": (
+                        "Declarative lookup (btree) indexes. Each item is "
+                        "{name?, columns}. A column is a bare string or "
+                        "{name, order} where order is 'asc' (default) or 'desc'. "
+                        "Unique indexes are expressed via `unique_keys`, not here."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "columns": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "order": {"type": "string", "enum": ["asc", "desc"]},
+                                            },
+                                            "required": ["name"],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        "required": ["columns"],
+                    },
+                },
             },
             "required": ["name", "columns"],
         },
@@ -705,6 +760,67 @@ TOOLS = [
                 "rename_columns": {
                     "type": "object",
                     "description": "Rename columns: {old_name: new_name}",
+                },
+                "add_unique_keys": {
+                    "type": "array",
+                    "description": (
+                        "UNIQUE keys to add: [{name?, columns}]. Adding a key on a "
+                        "table with existing data preflights for duplicate rows and "
+                        "fails before any DDL if any are found."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "columns": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1,
+                            },
+                        },
+                        "required": ["columns"],
+                    },
+                },
+                "drop_unique_keys": {
+                    "type": "array",
+                    "description": "UNIQUE-key names to drop (as shown in unique_keys metadata).",
+                    "items": {"type": "string"},
+                },
+                "add_indexes": {
+                    "type": "array",
+                    "description": (
+                        "Lookup indexes to add: [{name?, columns}]. A column is a "
+                        "bare string or {name, order} (order 'asc'|'desc')."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "columns": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "order": {"type": "string", "enum": ["asc", "desc"]},
+                                            },
+                                            "required": ["name"],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        "required": ["columns"],
+                    },
+                },
+                "drop_indexes": {
+                    "type": "array",
+                    "description": "Index names to drop (as shown in indexes metadata).",
+                    "items": {"type": "string"},
                 },
             },
             "required": ["uri"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.15"
+version = "0.8.16"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/concurrency/test_alter_unique_race_unit.py
+++ b/backend/tests/concurrency/test_alter_unique_race_unit.py
@@ -44,13 +44,21 @@ async def _can_connect(dsn: str) -> bool:
 async def seeded():
     if not await _can_connect(_DSN):
         pytest.skip(f"Postgres not reachable at {_DSN}")
+    from pathlib import Path
     from app.repositories.vault_repo import VaultRepository
     pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=6)
+    # Self-bootstrap the schema (idempotent) so this runs against a bare CI
+    # Postgres too — mirrors tests/concurrency/test_invariants_unit.py.
+    init_sql = (
+        Path(__file__).resolve().parents[2] / "app" / "db" / "init.sql"
+    ).read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(init_sql)
     vname = f"race_{uuid.uuid4().hex[:8]}"
     tname = "people"
     pg_name = table_data_repo.pg_table_name(vname, tname)
     cols = [{"name": "email", "type": "text"}]
-    # Real vaults/vault_tables schema (from init.sql, already present in the DB).
+    # Real vaults/vault_tables schema (from init.sql).
     vid = await VaultRepository(pool).create(
         name=vname, description="ephemeral race-test vault",
         git_path=f"/tmp/{vname}.git", owner_id=None,

--- a/backend/tests/concurrency/test_alter_unique_race_unit.py
+++ b/backend/tests/concurrency/test_alter_unique_race_unit.py
@@ -1,0 +1,117 @@
+"""Regression guard for the add-unique-key concurrency race (#220 review).
+
+`alter_table`'s FOR UPDATE locks only the `vault_tables` registry row, NOT the
+data table — so a concurrent INSERT can land a duplicate BETWEEN the
+duplicate-preflight SELECT and the `ADD CONSTRAINT`. The preflight is therefore
+best-effort; `ADD CONSTRAINT` is the real enforcement, and its
+`asyncpg.UniqueViolationError` must surface as a clean `ValidationError` (422),
+NOT an uncaught 500 — with the whole alter rolled back (no half-applied
+constraint).
+
+This reproduces the window DETERMINISTICALLY (no sleeps): a monkeypatched
+`unique_key_duplicates` runs the real preflight, then commits a duplicate on a
+SEPARATE connection, then returns the (clean) preflight result.
+
+Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.exceptions import ValidationError
+from app.repositories import table_data_repo
+from app.services import table_service
+
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:5433/akb")
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def seeded():
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    from app.repositories.vault_repo import VaultRepository
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=6)
+    vname = f"race_{uuid.uuid4().hex[:8]}"
+    tname = "people"
+    pg_name = table_data_repo.pg_table_name(vname, tname)
+    cols = [{"name": "email", "type": "text"}]
+    # Real vaults/vault_tables schema (from init.sql, already present in the DB).
+    vid = await VaultRepository(pool).create(
+        name=vname, description="ephemeral race-test vault",
+        git_path=f"/tmp/{vname}.git", owner_id=None,
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_tables (vault_id, name, columns) VALUES ($1, $2, $3::jsonb)",
+            vid, tname, '[{"name": "email", "type": "text"}]',
+        )
+        await table_data_repo.create_dynamic_table(conn, pg_name, cols)
+        # seed a single (non-duplicate) row so the preflight is genuinely clean
+        await conn.execute(f"INSERT INTO {pg_name} (email) VALUES ('seed@x')")
+    # wire the module-global pool that alter_table's get_pool() returns
+    from app.db import postgres as pg_mod
+    prev = pg_mod._pool
+    pg_mod._pool = pool
+    try:
+        yield {"vid": vid, "vname": vname, "tname": tname, "pg_name": pg_name, "pool": pool}
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {pg_name}")
+            await conn.execute("DELETE FROM vault_tables WHERE vault_id = $1", vid)
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+        pg_mod._pool = prev
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_insert_after_preflight_yields_clean_422(seeded, monkeypatch):
+    pg_name = seeded["pg_name"]
+    orig = table_data_repo.unique_key_duplicates
+
+    async def racing(conn, name, columns, limit=5):
+        res = await orig(conn, name, columns, limit=limit)  # real preflight → clean
+        # a concurrent committed writer introduces a duplicate in the window
+        w = await asyncpg.connect(_DSN)
+        try:
+            await w.execute(f"INSERT INTO {name} (email) VALUES ('seed@x')")
+        finally:
+            await w.close()
+        return res
+
+    monkeypatch.setattr(table_data_repo, "unique_key_duplicates", racing)
+
+    with pytest.raises(ValidationError) as ei:
+        await table_service.alter_table(
+            seeded["vid"], seeded["tname"], actor_id="tester",
+            add_unique_keys=[{"name": "people_email_key", "columns": ["email"]}],
+        )
+    # mapped to a clean 422, not a 500
+    assert ei.value.status_code == 422
+
+    # atomicity: no unique constraint was left half-applied, and the registry
+    # still advertises no unique key.
+    async with seeded["pool"].acquire() as conn:
+        ucount = await conn.fetchval(
+            "SELECT count(*) FROM pg_constraint WHERE conrelid = $1::regclass AND contype = 'u'",
+            pg_name,
+        )
+        assert ucount == 0
+        uk = await conn.fetchval(
+            "SELECT unique_keys FROM vault_tables WHERE vault_id = $1", seeded["vid"]
+        )
+        assert uk == "[]"

--- a/backend/tests/test_index_order_unit.py
+++ b/backend/tests/test_index_order_unit.py
@@ -1,0 +1,69 @@
+"""Index ASC/DESC order is PHYSICALLY applied, not just stored as metadata
+(#220 review). The e2e only checks index metadata via akb_vault_info; a
+regression that dropped the per-column order in create_index (e.g. ignoring
+the _ORDER_SQL map) would not be caught there. This asserts the real
+PostgreSQL index definition via pg_indexes.indexdef.
+
+Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable. Runs in
+a disposable database so it never touches a dev DB.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from app.repositories import table_data_repo
+
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:5433/akb")
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest.mark.asyncio
+async def test_create_index_emits_physical_asc_desc_order():
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    dbname = f"akb_idxord_{uuid.uuid4().hex[:8]}"
+    await admin.execute(f'CREATE DATABASE "{dbname}"')
+    try:
+        base, _ = _DSN.rsplit("/", 1)
+        conn = await asyncpg.connect(f"{base}/{dbname}")
+        try:
+            await conn.execute("CREATE TABLE t (a text, b text, c text)")
+            # asc (default, no keyword rendered), then desc — through the real
+            # create_index path so we test the production DDL builder.
+            await table_data_repo.create_index(
+                conn, "t", "myidx",
+                [("a", "asc"), ("b", "desc"), ("c", "asc")],
+            )
+            indexdef = await conn.fetchval(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'myidx'"
+            )
+            # PG normalises implicit-ASC to no keyword and renders only DESC.
+            assert "USING btree (a, b DESC, c)" in indexdef, indexdef
+            # discriminating: the non-default order is physically present
+            assert "b DESC" in indexdef
+
+            # A unique constraint's implicit index is a plain (all-ASC) btree.
+            await table_data_repo.create_unique_constraint(conn, "t", "t_a_key", ["a"])
+            ukdef = await conn.fetchval(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 't_a_key'"
+            )
+            assert "UNIQUE INDEX" in ukdef and "(a)" in ukdef, ukdef
+        finally:
+            await conn.close()
+    finally:
+        await admin.execute(f'DROP DATABASE "{dbname}" WITH (FORCE)')
+        await admin.close()

--- a/backend/tests/test_migration_037_upgrade_unit.py
+++ b/backend/tests/test_migration_037_upgrade_unit.py
@@ -1,0 +1,101 @@
+"""Upgrade-path test for migration 037 (#220 review).
+
+037 adds `vault_tables.unique_keys` + `vault_tables.indexes`. Its first cut
+short-circuited on a guard keyed only on `unique_keys`, so a PARTIAL state
+(unique_keys present, indexes missing) would never get `indexes` re-added —
+after which every read of vault_tables (which SELECTs both) 500s. The guard
+was removed in favour of the idempotent `ADD COLUMN IF NOT EXISTS` pair; this
+test pins that the upgrade self-heals a partial schema on EXISTING data.
+
+Talks to a real Postgres via `AKB_TEST_DSN` (default the audit stack's
+`localhost:5433`); skips when unreachable so the suite runs unattended.
+Runs in a disposable database so it never touches a dev DB's data.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:5433/akb")
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest.mark.asyncio
+async def test_migration_037_repairs_partial_state_on_existing_data():
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    dbname = f"akb_mig037_{uuid.uuid4().hex[:8]}"
+    await admin.execute(f'CREATE DATABASE "{dbname}"')
+    try:
+        base, _ = _DSN.rsplit("/", 1)
+        conn = await asyncpg.connect(f"{base}/{dbname}")
+        try:
+            await conn.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+            # Pre-037 PARTIAL state: unique_keys EXISTS but indexes does NOT —
+            # exactly what the old single-column guard mishandled.
+            await conn.execute(
+                """
+                CREATE TABLE vault_tables (
+                    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+                    vault_id uuid,
+                    name text,
+                    columns jsonb NOT NULL DEFAULT '[]',
+                    unique_keys jsonb NOT NULL DEFAULT '[]'
+                )
+                """
+            )
+            await conn.execute(
+                "INSERT INTO vault_tables (vault_id, name, columns, unique_keys) "
+                "VALUES (uuid_generate_v4(), 't', '[]', '[{\"name\": \"uk_x\"}]')"
+            )
+
+            # Load the migration straight from its source file (NOT
+            # importlib.import_module, which would honour a stale __pycache__
+            # .pyc and could mask a future source regression).
+            mig_path = (
+                Path(__file__).resolve().parents[1]
+                / "app" / "db" / "migrations" / "037_table_unique_keys_indexes.py"
+            )
+            spec = importlib.util.spec_from_file_location("mig_037_under_test", mig_path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            await mod.migrate(conn=conn)
+
+            names = {
+                r["column_name"]
+                for r in await conn.fetch(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'vault_tables'"
+                )
+            }
+            # BOTH columns present (old guard would have skipped → no `indexes`).
+            assert "unique_keys" in names and "indexes" in names
+
+            row = await conn.fetchrow(
+                "SELECT unique_keys, indexes FROM vault_tables WHERE name = 't'"
+            )
+            assert "uk_x" in row["unique_keys"]      # pre-existing data intact
+            assert row["indexes"] == "[]"            # new column defaulted
+
+            # Idempotent: a second run is a clean no-op.
+            await mod.migrate(conn=conn)
+        finally:
+            await conn.close()
+    finally:
+        await admin.execute(f'DROP DATABASE "{dbname}" WITH (FORCE)')
+        await admin.close()

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# AKB #215 E2E — declarative unique_keys + indexes on the table DDL tools.
+# Self-contained: registers a user, creates a vault, and exercises the
+# create/alter/sql paths over MCP Streamable HTTP. Covers acceptance
+# criteria #1-#6, #10, #11 (unique/index) and the akb_sql DML-only
+# boundary + non-admin alter permission gate (#13).
+#
+#   AKB_URL=http://localhost:18080 bash tests/test_table_constraints_e2e.sh
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+SUF="$(date +%s)-$$"
+VAULT="uk-e2e-$SUF"
+USER="uk-user-$SUF"
+USER2="uk-reader-$SUF"
+PASS=0
+FAIL=0
+ERRORS=()
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "▸ #215 unique_keys + indexes e2e → $BASE_URL"
+
+# ── helpers ──────────────────────────────────────────────────────
+register_pat() {  # $1=username → echoes PAT
+  local u=$1
+  curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$u\",\"email\":\"$u@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+  local jwt
+  jwt=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$u\",\"password\":\"test1234\"}" | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' -d '{"name":"e2e"}' \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null
+}
+
+mcp_session() {  # $1=PAT → echoes SID
+  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e","version":"1.0"}}}' 2>&1 \
+    | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}'
+}
+
+MCP_ID=10
+mcp() {  # $1=PAT $2=SID $3=tool $4=args-json → echoes result text (content[0].text)
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "mcp-session-id: $2" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$3\",\"arguments\":$4}}" 2>&1 \
+    | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null
+}
+field() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d$1)" 2>/dev/null; }
+
+# ── 0. setup ─────────────────────────────────────────────────────
+PAT=$(register_pat "$USER")
+[ -n "$PAT" ] && pass "PAT acquired" || { fail "setup" "no PAT"; exit 1; }
+SID=$(mcp_session "$PAT")
+[ -n "$SID" ] && pass "MCP session" || { fail "setup" "no session"; exit 1; }
+curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+R=$(mcp "$PAT" "$SID" akb_create_vault "{\"name\":\"$VAULT\",\"description\":\"#215 e2e\"}")
+echo "$R" | field "['name']" | grep -q "$VAULT" && pass "vault created" || fail "create_vault" "$R"
+
+# ── AC#1: create table with composite unique key + ordered multi-col index
+R=$(mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"events\",\"columns\":[{\"name\":\"principal_id\",\"type\":\"text\",\"required\":true},{\"name\":\"session_id\",\"type\":\"text\",\"required\":true},{\"name\":\"seq\",\"type\":\"number\",\"required\":true}],\"unique_keys\":[{\"columns\":[\"principal_id\",\"session_id\",\"seq\"]}],\"indexes\":[{\"columns\":[{\"name\":\"principal_id\"},{\"name\":\"session_id\"},{\"name\":\"seq\",\"order\":\"desc\"}]}]}")
+UK_NAME=$(echo "$R" | field "['unique_keys'][0]['name']")
+IDX_NAME=$(echo "$R" | field "['indexes'][0]['name']")
+[ -n "$UK_NAME" ] && pass "AC#1 create returns unique_keys ($UK_NAME)" || fail "AC#1 unique_keys" "$R"
+[ -n "$IDX_NAME" ] && pass "AC#1 create returns indexes ($IDX_NAME)" || fail "AC#1 indexes" "$R"
+
+# ── AC#11: vault_info introspection exposes declared guarantees
+R=$(mcp "$PAT" "$SID" akb_vault_info "{\"vault\":\"$VAULT\"}")
+VI_UK=$(echo "$R" | field "['tables'][0]['unique_keys'][0]['columns']")
+echo "$VI_UK" | grep -q "principal_id" && pass "AC#11 vault_info exposes unique_keys" || fail "AC#11 introspection" "$R"
+echo "$R" | field "['tables'][0]['indexes'][0]['name']" | grep -q "idx" && pass "AC#11 vault_info exposes indexes" || fail "AC#11 indexes" "$R"
+
+# ── AC#2: duplicate INSERT through akb_sql fails with a STABLE code
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO events (principal_id, session_id, seq) VALUES ('p1','s1',1)\"}")
+echo "$R" | field "['error']" | grep -qi "." && fail "AC#2 first insert" "unexpected error: $R" || pass "AC#2 first insert ok"
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO events (principal_id, session_id, seq) VALUES ('p1','s1',1)\"}")
+CODE=$(echo "$R" | field "['code']")
+SQLSTATE=$(echo "$R" | field "['details']['pg_sqlstate']")
+{ [ "$CODE" = "unique_violation" ] || [ "$SQLSTATE" = "23505" ]; } \
+  && pass "AC#2 duplicate insert → stable unique_violation (code=$CODE sqlstate=$SQLSTATE)" \
+  || fail "AC#2 duplicate stable error" "code=$CODE sqlstate=$SQLSTATE resp=$R"
+
+# ── AC#3: alter add/drop unique key
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"add_unique_keys\":[{\"name\":\"events_principal_key\",\"columns\":[\"principal_id\"]}]}")
+echo "$R" | field "['unique_keys']" | grep -q "events_principal_key" && pass "AC#3 alter add_unique_keys" || fail "AC#3 add_unique_keys" "$R"
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"drop_unique_keys\":[\"events_principal_key\"]}")
+echo "$R" | field "['unique_keys']" | grep -q "events_principal_key" && fail "AC#3 drop_unique_keys" "still present: $R" || pass "AC#3 alter drop_unique_keys"
+
+# ── AC#5/#6: alter add/drop index
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"add_indexes\":[{\"name\":\"events_seq_idx\",\"columns\":[\"seq\"]}]}")
+echo "$R" | field "['indexes']" | grep -q "events_seq_idx" && pass "AC#5/6 alter add_indexes" || fail "AC#5/6 add_indexes" "$R"
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"drop_indexes\":[\"events_seq_idx\"]}")
+echo "$R" | field "['indexes']" | grep -q "events_seq_idx" && fail "AC#5/6 drop_indexes" "still present: $R" || pass "AC#5/6 alter drop_indexes"
+
+# ── AC#4/#10: add unique key on duplicate data fails PRE-DDL, schema unchanged
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"dups\",\"columns\":[{\"name\":\"email\",\"type\":\"text\"}]}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO dups (email) VALUES ('a@x.dev')\"}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO dups (email) VALUES ('a@x.dev')\"}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/dups\",\"add_unique_keys\":[{\"name\":\"dups_email_key\",\"columns\":[\"email\"]}]}")
+CODE=$(echo "$R" | field "['code']")
+[ "$CODE" = "invalid_argument" ] && pass "AC#4 preflight blocks add on duplicate data (code=$CODE)" || fail "AC#4 preflight" "code=$CODE resp=$R"
+# schema+registry unchanged: vault_info shows dups has NO unique_keys
+R=$(mcp "$PAT" "$SID" akb_vault_info "{\"vault\":\"$VAULT\"}")
+DUPS_UK=$(echo "$R" | python3 -c "import sys,json;d=json.load(sys.stdin);t=[x for x in d['tables'] if x['name']=='dups'][0];print(len(x_uk) if (x_uk:=t.get('unique_keys')) else 0)" 2>/dev/null)
+[ "$DUPS_UK" = "0" ] && pass "AC#10 failed alter left registry unchanged (dups.unique_keys empty)" || fail "AC#10 registry unchanged" "dups unique_keys=$DUPS_UK"
+# constraint not physically created → a 3rd duplicate insert still succeeds (no UK enforced)
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO dups (email) VALUES ('a@x.dev')\"}")
+echo "$R" | field "['code']" | grep -qi "violation" && fail "AC#10 schema unchanged" "constraint leaked: $R" || pass "AC#10 failed alter left physical schema unchanged"
+
+# ── DML-only boundary: DDL via akb_sql is rejected
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"CREATE UNIQUE INDEX hack ON events (principal_id)\"}")
+CODE=$(echo "$R" | field "['code']")
+[ "$CODE" = "method_not_allowed" ] && pass "DDL via akb_sql rejected (code=$CODE)" || fail "akb_sql DDL boundary" "code=$CODE resp=$R"
+
+# ── permission: non-admin (reader) cannot alter_table
+PAT2=$(register_pat "$USER2")
+SID2=$(mcp_session "$PAT2")
+curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT2" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID2" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+mcp "$PAT" "$SID" akb_grant "{\"vault\":\"$VAULT\",\"user\":\"$USER2\",\"role\":\"reader\"}" >/dev/null
+R=$(mcp "$PAT2" "$SID2" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"add_indexes\":[{\"columns\":[\"principal_id\"]}]}")
+# admin gate fires BEFORE any DDL (check_vault_access). Assert the alter was
+# REJECTED (an error envelope, not a success table dict) and the message names
+# the role denial. NOTE: the dispatch currently surfaces ForbiddenError under
+# code=internal for every admin-gated tool (pre-existing, not #215) — we assert
+# the denial, not the specific code.
+CODE=$(echo "$R" | field "['code']")
+DENIED=$(echo "$R" | python3 -c "import sys,json;d=json.loads(sys.stdin.read());m=(str(d.get('error',''))+str(d.get('code',''))).lower();print(bool(d.get('code')) and any(w in m for w in ('forbid','permission','admin','role','denied','access')))" 2>/dev/null)
+[ "$DENIED" = "True" ] && pass "reader cannot alter_table (rejected; code=$CODE)" || fail "permission gate" "not rejected: $R"
+
+echo ""
+echo "── #215 e2e: $PASS passed, $FAIL failed ──"
+if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; exit 1; fi

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -53,6 +53,15 @@ mcp() {  # $1=PAT $2=SID $3=tool $4=args-json → echoes result text (content[0]
     | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null
 }
 field() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d$1)" 2>/dev/null; }
+# Strict success assertion: response must be valid JSON object with NO error/code
+# envelope (catches malformed/empty/error responses that "no code = success"
+# greps would silently pass). #220 review hardening.
+assert_ok() { # $1=response $2=label
+  echo "$1" | python3 -c "import sys,json
+d=json.loads(sys.stdin.read())
+assert isinstance(d, dict) and 'code' not in d and 'error' not in d, d" >/dev/null 2>&1 \
+    && pass "$2" || fail "$2" "not a clean success: $1"
+}
 
 # ── 0. setup ─────────────────────────────────────────────────────
 PAT=$(register_pat "$USER")
@@ -80,7 +89,7 @@ echo "$R" | field "['tables'][0]['indexes'][0]['name']" | grep -q "idx" && pass 
 
 # ── AC#2: duplicate INSERT through akb_sql fails with a STABLE code
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO events (principal_id, session_id, seq) VALUES ('p1','s1',1)\"}")
-echo "$R" | field "['error']" | grep -qi "." && fail "AC#2 first insert" "unexpected error: $R" || pass "AC#2 first insert ok"
+assert_ok "$R" "AC#2 first insert ok"
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO events (principal_id, session_id, seq) VALUES ('p1','s1',1)\"}")
 CODE=$(echo "$R" | field "['code']")
 SQLSTATE=$(echo "$R" | field "['details']['pg_sqlstate']")
@@ -113,7 +122,7 @@ DUPS_UK=$(echo "$R" | python3 -c "import sys,json;d=json.load(sys.stdin);t=[x fo
 [ "$DUPS_UK" = "0" ] && pass "AC#10 failed alter left registry unchanged (dups.unique_keys empty)" || fail "AC#10 registry unchanged" "dups unique_keys=$DUPS_UK"
 # constraint not physically created → a 3rd duplicate insert still succeeds (no UK enforced)
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO dups (email) VALUES ('a@x.dev')\"}")
-echo "$R" | field "['code']" | grep -qi "violation" && fail "AC#10 schema unchanged" "constraint leaked: $R" || pass "AC#10 failed alter left physical schema unchanged"
+assert_ok "$R" "AC#10 failed alter left physical schema unchanged (dup INSERT still succeeds)"
 
 # ── DML-only boundary: DDL via akb_sql is rejected
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"CREATE UNIQUE INDEX hack ON events (principal_id)\"}")
@@ -147,7 +156,7 @@ mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"nul\",\"col
 mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES (NULL)\"}" >/dev/null
 mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES (NULL)\"}" >/dev/null
 R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/nul\",\"add_unique_keys\":[{\"name\":\"nul_email_key\",\"columns\":[\"email\"]}]}")
-echo "$R" | field "['code']" | grep -q . && fail "F3 nullable UK blocked" "$R" || pass "F3 multiple-NULL rows don't block ADD UNIQUE (NULLS DISTINCT)"
+assert_ok "$R" "F3 multiple-NULL rows don't block ADD UNIQUE (NULLS DISTINCT)"
 mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}" >/dev/null
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}")
 [ "$(echo "$R" | field "['code']")" = "unique_violation" ] && pass "F3 non-null duplicate still enforced" || fail "F3 enforcement" "$R"
@@ -188,7 +197,15 @@ ATBOTH="$(tbl_meta atom indexes)$(tbl_meta atom unique_keys)"
 # strengthen drop AC: after drop_unique_keys, a previously-rejected dup INSERT now succeeds (physical-removal proof)
 mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/nul\",\"drop_unique_keys\":[\"nul_email_key\"]}" >/dev/null
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}")
-echo "$R" | field "['code']" | grep -qi "violation" && fail "drop UK physical proof" "still enforced: $R" || pass "AC#3 dropped UK physically gone (dup INSERT now succeeds)"
+assert_ok "$R" "AC#3 dropped UK physically gone (dup INSERT now succeeds)"
+
+# ── cleanup: drop the ephemeral vault + ALL its tables ────────────
+# Required for idempotent re-runs: several tests use caller-supplied
+# constraint/index names, and a UNIQUE constraint's implicit index name is
+# SCHEMA-GLOBAL in PostgreSQL — leaving them behind makes a second run collide
+# (and matches the AKB convention that tests clean up after themselves).
+R=$(mcp "$PAT" "$SID" akb_delete_vault "{\"vault\":\"$VAULT\"}")
+assert_ok "$R" "cleanup: ephemeral vault + tables deleted"
 
 echo ""
 echo "── #215 e2e: $PASS passed, $FAIL failed ──"

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -137,6 +137,59 @@ CODE=$(echo "$R" | field "['code']")
 DENIED=$(echo "$R" | python3 -c "import sys,json;d=json.loads(sys.stdin.read());m=(str(d.get('error',''))+str(d.get('code',''))).lower();print(bool(d.get('code')) and any(w in m for w in ('forbid','permission','admin','role','denied','access')))" 2>/dev/null)
 [ "$DENIED" = "True" ] && pass "reader cannot alter_table (rejected; code=$CODE)" || fail "permission gate" "not rejected: $R"
 
+# ── #220 review hardening ─────────────────────────────────────────
+tbl_meta() { # $1=table $2=field(unique_keys|indexes) → python expr over vault_info
+  mcp "$PAT" "$SID" akb_vault_info "{\"vault\":\"$VAULT\"}" | python3 -c "import sys,json;d=json.load(sys.stdin);t=[x for x in d['tables'] if x['name']=='$1'][0];print(json.dumps(t.get('$2',[])))" 2>/dev/null
+}
+
+# F3: PG UNIQUE is NULLS DISTINCT — multiple NULL rows must NOT block ADD CONSTRAINT
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"nul\",\"columns\":[{\"name\":\"email\",\"type\":\"text\"}]}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES (NULL)\"}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES (NULL)\"}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/nul\",\"add_unique_keys\":[{\"name\":\"nul_email_key\",\"columns\":[\"email\"]}]}")
+echo "$R" | field "['code']" | grep -q . && fail "F3 nullable UK blocked" "$R" || pass "F3 multiple-NULL rows don't block ADD UNIQUE (NULLS DISTINCT)"
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}")
+[ "$(echo "$R" | field "['code']")" = "unique_violation" ] && pass "F3 non-null duplicate still enforced" || fail "F3 enforcement" "$R"
+
+# F4: duplicate column within one key → clean 422 (not a DDL 500)
+R=$(mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"dupcol\",\"columns\":[{\"name\":\"a\",\"type\":\"text\"}],\"unique_keys\":[{\"columns\":[\"a\",\"a\"]}]}")
+[ "$(echo "$R" | field "['code']")" = "invalid_argument" ] && pass "F4 duplicate column in key → invalid_argument" || fail "F4 dup column" "$R"
+
+# F5: mixed-case column ref on an alter-add over duplicate data → clean 422 (was KeyError 500)
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"mc\",\"columns\":[{\"name\":\"principal\",\"type\":\"text\"}]}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO mc (principal) VALUES ('p')\"}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO mc (principal) VALUES ('p')\"}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/mc\",\"add_unique_keys\":[{\"name\":\"mc_principal_key\",\"columns\":[\"PRINCIPAL\"]}]}")
+[ "$(echo "$R" | field "['code']")" = "invalid_argument" ] && pass "F5 mixed-case preflight → invalid_argument (not 500)" || fail "F5 mixed-case" "$R"
+R=$(mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"mc2\",\"columns\":[{\"name\":\"principal\",\"type\":\"text\"}],\"unique_keys\":[{\"columns\":[\"PRINCIPAL\"]}]}")
+echo "$R" | field "['unique_keys'][0]['columns']" | grep -q "principal" && pass "F5b create stores canonical (lowercase) column name" || fail "F5b canonical" "$R"
+
+# F1: rename a column used by a unique_key → registry metadata follows the rename
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"rn\",\"columns\":[{\"name\":\"old_c\",\"type\":\"text\"}],\"unique_keys\":[{\"name\":\"rn_key\",\"columns\":[\"old_c\"]}]}" >/dev/null
+mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/rn\",\"rename_columns\":{\"old_c\":\"new_c\"}}" >/dev/null
+RNUK=$(tbl_meta rn unique_keys)
+{ echo "$RNUK" | grep -q "new_c" && ! echo "$RNUK" | grep -q "old_c"; } && pass "F1 rename updates UK metadata ($RNUK)" || fail "F1 rename drift" "uk=$RNUK"
+
+# F2: drop a column used by a unique_key → UK pruned from registry
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"dpc\",\"columns\":[{\"name\":\"keep\",\"type\":\"text\"},{\"name\":\"gone\",\"type\":\"text\"}],\"unique_keys\":[{\"name\":\"dpc_key\",\"columns\":[\"gone\"]}]}" >/dev/null
+mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/dpc\",\"drop_columns\":[\"gone\"]}" >/dev/null
+[ "$(tbl_meta dpc unique_keys)" = "[]" ] && pass "F2 drop-column prunes UK from registry" || fail "F2 drop drift" "uk=$(tbl_meta dpc unique_keys)"
+
+# critic: multi-op alter is all-or-nothing — valid add_indexes + dup add_unique_keys → BOTH rolled back
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"atom\",\"columns\":[{\"name\":\"x\",\"type\":\"text\"}]}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO atom (x) VALUES ('d')\"}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO atom (x) VALUES ('d')\"}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/atom\",\"add_indexes\":[{\"name\":\"atom_x_idx\",\"columns\":[\"x\"]}],\"add_unique_keys\":[{\"name\":\"atom_x_key\",\"columns\":[\"x\"]}]}")
+[ "$(echo "$R" | field "['code']")" = "invalid_argument" ] && pass "multi-op alter rejected on dup data" || fail "multi-op rejected" "$R"
+ATBOTH="$(tbl_meta atom indexes)$(tbl_meta atom unique_keys)"
+[ "$ATBOTH" = "[][]" ] && pass "multi-op rollback left NEITHER index nor UK (single-TX atomicity)" || fail "multi-op atomicity" "idx+uk=$ATBOTH"
+
+# strengthen drop AC: after drop_unique_keys, a previously-rejected dup INSERT now succeeds (physical-removal proof)
+mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/nul\",\"drop_unique_keys\":[\"nul_email_key\"]}" >/dev/null
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}")
+echo "$R" | field "['code']" | grep -qi "violation" && fail "drop UK physical proof" "still enforced: $R" || pass "AC#3 dropped UK physically gone (dup INSERT now succeeds)"
+
 echo ""
 echo "── #215 e2e: $PASS passed, $FAIL failed ──"
 if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; exit 1; fi

--- a/backend/tests/test_table_constraints_unit.py
+++ b/backend/tests/test_table_constraints_unit.py
@@ -1,0 +1,462 @@
+"""Unit tests for AKB #215 declarative `unique_keys` + `indexes`.
+
+DB-free. Covers the pure logic added for PR-1:
+
+* generated-name strategy — deterministic, schema-global-namespaced,
+  collision-safe, 63-byte truncation→sha1 hash (table_data_repo);
+* validation — column-existence (case-insensitive), reserved-column
+  rejection, index `order` enum, non-empty columns, duplicate names
+  (table_service._resolve_unique_keys / _resolve_indexes);
+* preflight duplicate-detection query SHAPE (table_data_repo.unique_key_duplicates);
+* registry JSON round-trip (table_registry_repo.parse_json_list).
+
+Style mirrors tests/test_table_identifier_unit.py — dependency-light,
+no pool, no live PG.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.repositories import table_data_repo
+from app.repositories.table_registry_repo import parse_json_list
+
+
+# ── generated-name strategy ───────────────────────────────────────
+
+
+def test_unique_key_name_is_deterministic_and_namespaced():
+    """A generated UNIQUE-key name namespaces by the pg table (index
+    names are schema-global) and is stable across repeated calls."""
+    pg = "vt_demo__events"
+    a = table_data_repo.generate_constraint_name(pg, ["actor", "ts"], kind="uk")
+    b = table_data_repo.generate_constraint_name(pg, ["actor", "ts"], kind="uk")
+    assert a == b, "name generation must be deterministic"
+    assert a.startswith("vt_demo__events"), a
+    assert a.endswith("__uk"), a
+    assert "actor" in a and "ts" in a
+
+
+def test_index_name_uses_idx_suffix():
+    pg = "vt_demo__events"
+    n = table_data_repo.generate_constraint_name(pg, ["ts"], kind="idx")
+    assert n.endswith("__idx"), n
+    assert n.startswith("vt_demo__events"), n
+
+
+def test_generated_names_differ_by_table_and_columns():
+    """Schema-global namespace: same columns on two different pg tables
+    must NOT collide; different columns on the same table differ too."""
+    n1 = table_data_repo.generate_constraint_name("vt_a__t", ["x"], kind="uk")
+    n2 = table_data_repo.generate_constraint_name("vt_b__t", ["x"], kind="uk")
+    n3 = table_data_repo.generate_constraint_name("vt_a__t", ["y"], kind="uk")
+    assert n1 != n2
+    assert n1 != n3
+
+
+def test_generated_names_disambiguate_underscore_flattened_columns():
+    """Distinct column lists whose `_`-joined forms collide (["a","b"] vs
+    ["a_b"]) must still get DISTINCT names — the structured sha1 digest is
+    always present so the underscore flattening can never alias them."""
+    pg = "vt_demo__t"
+    n_two = table_data_repo.generate_constraint_name(pg, ["a", "b"], kind="uk")
+    n_one = table_data_repo.generate_constraint_name(pg, ["a_b"], kind="uk")
+    assert n_two != n_one, (n_two, n_one)
+    # order is part of an index's identity → distinct names too
+    i_ab = table_data_repo.generate_constraint_name(pg, ["a", "b"], kind="idx")
+    i_ba = table_data_repo.generate_constraint_name(pg, ["b", "a"], kind="idx")
+    assert i_ab != i_ba, (i_ab, i_ba)
+
+
+def test_generated_name_fits_namedatalen_and_is_stable_for_long_inputs():
+    """When the readable name would exceed 63 bytes, it is truncated and a
+    deterministic sha1[:8] of the full logical name is appended. The
+    result must (a) fit, (b) be stable, (c) stay collision-safe across
+    distinct long inputs that share a truncated prefix."""
+    pg = "vt_" + "a" * 40 + "__" + "b" * 10
+    cols_1 = ["c" * 30, "d" * 30]
+    cols_2 = ["c" * 30, "e" * 30]  # shares the truncated prefix
+    n1 = table_data_repo.generate_constraint_name(pg, cols_1, kind="uk")
+    n1b = table_data_repo.generate_constraint_name(pg, cols_1, kind="uk")
+    n2 = table_data_repo.generate_constraint_name(pg, cols_2, kind="uk")
+    assert len(n1.encode()) <= table_data_repo.PG_IDENT_MAX_LEN
+    assert len(n2.encode()) <= table_data_repo.PG_IDENT_MAX_LEN
+    assert n1 == n1b, "hashed name must be stable"
+    assert n1 != n2, "distinct inputs sharing a prefix must not collide"
+
+
+def test_generated_name_hash_is_pure_hashlib():
+    """No randomness: recomputing the sha1 of the logical name yields the
+    suffix actually appended (proves stability across processes)."""
+    pg = "vt_" + "a" * 40 + "__tbl"
+    cols = ["x" * 40]
+    name = table_data_repo.generate_constraint_name(pg, cols, kind="uk")
+    # digest is sha1 over the NUL-joined (pg, kind, *columns) tuple — recompute
+    # it the same way to prove there is no randomness (stable across processes).
+    expected = hashlib.sha1("\x00".join([pg, "uk", *cols]).encode()).hexdigest()[:8]
+    # hash is embedded before the kind suffix: ..._{sha1[:8]}__uk
+    assert expected in name, (name, expected)
+    assert name.endswith("__uk")
+
+
+# ── preflight duplicate-detection query shape ─────────────────────
+
+
+class _RecordingConn:
+    """Captures the SQL + params a repo primitive would send to PG."""
+
+    def __init__(self, rows=None):
+        self.sql = None
+        self.params = None
+        self._rows = rows or []
+
+    async def fetch(self, sql, *params):
+        self.sql = sql
+        self.params = params
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_unique_key_duplicates_query_shape():
+    conn = _RecordingConn(rows=[])
+    await table_data_repo.unique_key_duplicates(
+        conn, "vt_demo__events", ["actor", "ts"], limit=5,
+    )
+    sql = conn.sql.upper()
+    assert "FROM VT_DEMO__EVENTS" in sql
+    assert "GROUP BY" in sql
+    assert "HAVING COUNT(*) > 1" in sql
+    # only the key columns (+ the COUNT) appear — no SELECT * that could
+    # leak other columns of the table into the duplicate sample.
+    select_clause = conn.sql.split("FROM")[0]
+    assert "actor" in select_clause and "ts" in select_clause
+    assert "COUNT(*)" in select_clause.upper()
+    assert "ACTOR" in sql and "TS" in sql
+    assert "LIMIT 5" in sql
+
+
+@pytest.mark.asyncio
+async def test_unique_key_duplicates_sanitizes_identifiers():
+    """Columns flow through safe_ident — a punctuation column can't
+    inject raw SQL into the preflight GROUP BY."""
+    conn = _RecordingConn(rows=[])
+    await table_data_repo.unique_key_duplicates(
+        conn, "vt_demo__t", ["a;DROP", "b"], limit=1,
+    )
+    assert ";DROP" not in conn.sql
+    assert "a_DROP" in conn.sql
+
+
+# ── DDL primitive identifier safety ───────────────────────────────
+
+
+class _ExecConn:
+    def __init__(self):
+        self.sql = None
+
+    async def execute(self, sql, *params):
+        self.sql = sql
+
+
+@pytest.mark.asyncio
+async def test_create_index_order_enum_only():
+    """`order` is a closed {ASC,DESC} enum — never interpolated raw."""
+    conn = _ExecConn()
+    await table_data_repo.create_index(
+        conn, "vt_d__t", "vt_d__t__a__idx",
+        [("a", "asc"), ("b", "desc")],
+    )
+    assert "ASC" in conn.sql and "DESC" in conn.sql
+    assert "CREATE INDEX" in conn.sql
+
+    with pytest.raises(ValidationError):
+        await table_data_repo.create_index(
+            conn, "vt_d__t", "n", [("a", "sideways")],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_unique_constraint_shape():
+    conn = _ExecConn()
+    await table_data_repo.create_unique_constraint(
+        conn, "vt_d__t", "vt_d__t__a_b__uk", ["a", "b"],
+    )
+    assert "ADD CONSTRAINT" in conn.sql.upper()
+    assert "UNIQUE" in conn.sql.upper()
+
+
+@pytest.mark.asyncio
+async def test_drop_constraint_and_index_are_if_exists():
+    conn = _ExecConn()
+    await table_data_repo.drop_constraint(conn, "vt_d__t", "vt_d__t__a__uk")
+    assert "DROP CONSTRAINT IF EXISTS" in conn.sql.upper()
+    await table_data_repo.drop_index(conn, "vt_d__t__a__idx")
+    assert "DROP INDEX IF EXISTS" in conn.sql.upper()
+
+
+# ── service-layer validation/resolution ───────────────────────────
+
+from app.services import table_service  # noqa: E402
+
+
+_DECLARED = [{"name": "actor", "type": "text"}, {"name": "ts", "type": "date"}]
+
+
+def test_resolve_unique_keys_generates_stable_name():
+    resolved = table_service._resolve_unique_keys(
+        [{"columns": ["actor", "ts"]}], _DECLARED, "vt_demo__events",
+    )
+    assert len(resolved) == 1
+    assert resolved[0]["columns"] == ["actor", "ts"]
+    assert resolved[0]["name"].endswith("__uk")
+
+
+def test_resolve_unique_keys_uses_caller_name_verbatim():
+    resolved = table_service._resolve_unique_keys(
+        [{"name": "uq_event", "columns": ["actor"]}], _DECLARED, "vt_demo__events",
+    )
+    assert resolved[0]["name"] == "uq_event"
+
+
+def test_resolve_unique_keys_rejects_unknown_column():
+    with pytest.raises(ValidationError):
+        table_service._resolve_unique_keys(
+            [{"columns": ["nope"]}], _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_unique_keys_column_match_is_case_insensitive():
+    resolved = table_service._resolve_unique_keys(
+        [{"columns": ["ACTOR"]}], _DECLARED, "vt_demo__events",
+    )
+    assert resolved[0]["columns"] == ["ACTOR"]
+
+
+def test_resolve_unique_keys_rejects_reserved_column():
+    for reserved in ("id", "created_at", "updated_at", "created_by"):
+        with pytest.raises(ValidationError):
+            table_service._resolve_unique_keys(
+                [{"columns": [reserved]}], _DECLARED, "vt_demo__events",
+            )
+
+
+def test_resolve_unique_keys_rejects_empty_columns():
+    with pytest.raises(ValidationError):
+        table_service._resolve_unique_keys(
+            [{"columns": []}], _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_unique_keys_rejects_duplicate_names():
+    with pytest.raises(ValidationError):
+        table_service._resolve_unique_keys(
+            [
+                {"name": "dup", "columns": ["actor"]},
+                {"name": "dup", "columns": ["ts"]},
+            ],
+            _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_indexes_accepts_bare_string_and_obj_columns():
+    resolved = table_service._resolve_indexes(
+        [{"columns": ["actor", {"name": "ts", "order": "desc"}]}],
+        _DECLARED, "vt_demo__events",
+    )
+    assert resolved[0]["columns"] == [
+        {"name": "actor", "order": "asc"},
+        {"name": "ts", "order": "desc"},
+    ]
+    assert resolved[0]["name"].endswith("__idx")
+
+
+def test_resolve_indexes_rejects_bad_order():
+    with pytest.raises(ValidationError):
+        table_service._resolve_indexes(
+            [{"columns": [{"name": "ts", "order": "upwards"}]}],
+            _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_indexes_rejects_unknown_column():
+    with pytest.raises(ValidationError):
+        table_service._resolve_indexes(
+            [{"columns": ["ghost"]}], _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_indexes_rejects_reserved_column():
+    with pytest.raises(ValidationError):
+        table_service._resolve_indexes(
+            [{"columns": ["id"]}], _DECLARED, "vt_demo__events",
+        )
+
+
+# ── registry JSON round-trip ──────────────────────────────────────
+
+
+def test_parse_json_list_handles_str_list_and_none():
+    payload = [{"name": "uq", "columns": ["a", "b"]}]
+    import json
+    assert parse_json_list(json.dumps(payload)) == payload  # legacy str row
+    assert parse_json_list(payload) == payload               # asyncpg pre-parsed
+    assert parse_json_list(None) == []                       # NULL/empty
+    assert parse_json_list("[]") == []
+
+
+# ── stable unique-violation contract (AC#2) ───────────────────────
+#
+# A duplicate INSERT against a declared unique key raises asyncpg
+# UniqueViolationError (SQLSTATE 23505). The executor must translate
+# that into our own UniqueViolationError carrying pg_sqlstate='23505',
+# and execute_sql must surface it under the dedicated stable
+# UNIQUE_VIOLATION code (NOT the generic SQL_ERROR catch-all) with
+# pg_sqlstate threaded into the envelope — mirroring PERMISSION_DENIED.
+
+
+class _FakeTxn:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    """Minimal asyncpg-conn stand-in whose .execute(SQL) raises 23505."""
+
+    def __init__(self, raise_on_sql: bool):
+        self._raise_on_sql = raise_on_sql
+
+    def transaction(self):
+        return _FakeTxn()
+
+    async def execute(self, sql, *args):
+        # SET LOCAL ... statements succeed; the user INSERT raises.
+        if self._raise_on_sql and not sql.upper().startswith("SET LOCAL"):
+            import asyncpg
+            raise asyncpg.exceptions.UniqueViolationError(
+                'duplicate key value violates unique constraint '
+                '"vt_demo__events__actor_ts__uk"'
+            )
+        return "INSERT 0 1"
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+async def test_executor_translates_pg_23505_to_stable_unique_violation():
+    from app.services.user_sql_executor import (
+        UniqueViolationError,
+        UserSqlExecutor,
+    )
+
+    pool = _FakePool(_FakeConn(raise_on_sql=True))
+    ex = UserSqlExecutor(pool)
+    with pytest.raises(UniqueViolationError) as ei:
+        await ex.execute(
+            user_id="00000000-0000-0000-0000-000000000001",
+            sql="INSERT INTO vt_demo__events (actor) VALUES ('x')",
+            is_admin=True,  # skip SET LOCAL ROLE (needs no real role)
+        )
+    # The contract: stable sqlstate is attached and the constraint name
+    # (here the generated name) rides along in the verbatim PG message.
+    assert ei.value.pg_sqlstate == "23505"
+    assert "unique constraint" in str(ei.value)
+
+
+async def test_execute_sql_surfaces_unique_violation_with_stable_code(monkeypatch):
+    """The service maps UniqueViolationError → UNIQUE_VIOLATION code with
+    pg_sqlstate, not the generic SQL_ERROR catch-all."""
+    from app.services import table_service
+    from app.services.user_sql_executor import UniqueViolationError
+    from app.util.errors import UNIQUE_VIOLATION
+
+    class _Executor:
+        async def execute(self, **kw):
+            raise UniqueViolationError("duplicate key value", pg_sqlstate="23505")
+
+    # Stub the pool/rewriter so we reach the executor call without a live DB.
+    class _Conn:
+        async def fetch(self, *a, **k):
+            return []
+
+    class _Acq:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, *e):
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _Acq()
+
+    async def _fake_pool():
+        return _Pool()
+
+    monkeypatch.setattr(table_service, "get_pool", _fake_pool)
+    monkeypatch.setattr(
+        table_service.table_data_repo, "build_table_name_map",
+        lambda conn, vaults: _async_return({"events": "vt_demo__events"}),
+    )
+    monkeypatch.setattr(
+        table_service.table_data_repo, "rewrite_table_names",
+        lambda sql, m: sql,
+    )
+    monkeypatch.setattr(table_service, "get_user_sql_executor", lambda: _Executor())
+
+    out = await table_service.execute_sql(
+        vault_names=["demo"],
+        user_id="u1",
+        sql="INSERT INTO events (actor) VALUES ('x')",
+        is_admin=True,
+    )
+    assert out["code"] == UNIQUE_VIOLATION
+    assert out["code"] != "sql_error"
+    assert out["details"]["pg_sqlstate"] == "23505"
+
+
+def _async_return(value):
+    async def _coro():
+        return value
+    return _coro()
+
+
+# ── REST create surface accepts unique_keys + indexes (#215) ──────
+
+
+def test_rest_create_table_request_accepts_unique_keys_and_indexes():
+    """CreateTableRequest must carry the declarative fields so a REST/web
+    POST is not silently dropped (asymmetric read/write contract bug)."""
+    from app.api.routes.tables import CreateTableRequest
+
+    req = CreateTableRequest(
+        name="events",
+        columns=[{"name": "actor", "type": "text"}, {"name": "ts", "type": "text"}],
+        unique_keys=[{"columns": ["actor", "ts"]}],
+        indexes=[{"columns": ["actor"]}],
+    )
+    assert req.unique_keys == [{"columns": ["actor", "ts"]}]
+    assert req.indexes == [{"columns": ["actor"]}]
+    # Defaults stay None (omitted) so create_table's own defaults apply.
+    req2 = CreateTableRequest(name="t", columns=[{"name": "a", "type": "text"}])
+    assert req2.unique_keys is None and req2.indexes is None

--- a/backend/tests/test_table_constraints_unit.py
+++ b/backend/tests/test_table_constraints_unit.py
@@ -135,6 +135,10 @@ async def test_unique_key_duplicates_query_shape():
     assert "COUNT(*)" in select_clause.upper()
     assert "ACTOR" in sql and "TS" in sql
     assert "LIMIT 5" in sql
+    # NULLS DISTINCT parity: rows with any NULL key value are excluded so the
+    # preflight is not STRICTER than the UNIQUE constraint it guards (#220 review).
+    assert "WHERE" in sql
+    assert sql.count("IS NOT NULL") == 2  # one per key column (actor, ts)
 
 
 @pytest.mark.asyncio
@@ -228,10 +232,39 @@ def test_resolve_unique_keys_rejects_unknown_column():
 
 
 def test_resolve_unique_keys_column_match_is_case_insensitive():
+    # A mixed-case reference matches the declared column case-insensitively AND
+    # is normalised to the CANONICAL declared name — so the stored metadata and
+    # the duplicate-preflight sample (row[safe_ident(name)]) use the real PG
+    # identifier, never the caller's casing (which would KeyError). (#220 review)
     resolved = table_service._resolve_unique_keys(
         [{"columns": ["ACTOR"]}], _DECLARED, "vt_demo__events",
     )
-    assert resolved[0]["columns"] == ["ACTOR"]
+    assert resolved[0]["columns"] == ["actor"]
+
+
+def test_resolve_rejects_duplicate_column_within_one_key():
+    # columns:["actor","actor"] must be a clean 422, not a DDL 500 (42701/42P16).
+    with pytest.raises(ValidationError):
+        table_service._resolve_unique_keys(
+            [{"columns": ["actor", "actor"]}], _DECLARED, "vt_demo__events",
+        )
+    # case-insensitive duplicate too
+    with pytest.raises(ValidationError):
+        table_service._resolve_unique_keys(
+            [{"columns": ["actor", "ACTOR"]}], _DECLARED, "vt_demo__events",
+        )
+    with pytest.raises(ValidationError):
+        table_service._resolve_indexes(
+            [{"columns": ["ts", "ts"]}], _DECLARED, "vt_demo__events",
+        )
+
+
+def test_resolve_indexes_canonicalises_column_case():
+    resolved = table_service._resolve_indexes(
+        [{"columns": [{"name": "TS", "order": "desc"}]}], _DECLARED, "vt_demo__events",
+    )
+    assert resolved[0]["columns"][0]["name"] == "ts"
+    assert resolved[0]["columns"][0]["order"] == "desc"
 
 
 def test_resolve_unique_keys_rejects_reserved_column():

--- a/backend/tests/test_table_constraints_unit.py
+++ b/backend/tests/test_table_constraints_unit.py
@@ -493,3 +493,37 @@ def test_rest_create_table_request_accepts_unique_keys_and_indexes():
     # Defaults stay None (omitted) so create_table's own defaults apply.
     req2 = CreateTableRequest(name="t", columns=[{"name": "a", "type": "text"}])
     assert req2.unique_keys is None and req2.indexes is None
+
+
+# ── AC#11 discovery surface: declared guarantees reach the search chunk ──
+
+
+def test_table_chunk_exposes_unique_keys_and_indexes():
+    """The hybrid-search metadata chunk must carry the declared unique_keys
+    + indexes (names AND columns) so an agent can DISCOVER a table's
+    guarantees by searching — AC#11's discovery surface (#220 review)."""
+    from app.services.index_service import build_table_chunk
+    c = build_table_chunk(
+        vault_name="v", name="customers", description="Customer records",
+        columns=[{"name": "email", "type": "text"}, {"name": "tenant", "type": "text"}],
+        unique_keys=[{"name": "uk_customers_email", "columns": ["email"]}],
+        indexes=[{"name": "idx_customers_tenant",
+                  "columns": [{"name": "tenant", "order": "desc"}]}],
+    )
+    assert "uk_customers_email" in c.content
+    assert "idx_customers_tenant" in c.content
+    assert "email" in c.content and "tenant" in c.content
+    # the index's non-default order is surfaced too
+    assert "desc" in c.content
+
+
+def test_table_chunk_backcompat_no_constraints():
+    """Omitting unique_keys/indexes must not crash and must not emit the
+    sections (older callers / tables without declared guarantees)."""
+    from app.services.index_service import build_table_chunk
+    c = build_table_chunk(
+        vault_name="v", name="t", description=None,
+        columns=[{"name": "a", "type": "text"}],
+    )
+    assert "UNIQUE_KEYS" not in c.content
+    assert "INDEXES" not in c.content


### PR DESCRIPTION
## Summary

Implements #215 (**PR 1 of 2**): declarative `unique_keys` + `indexes` on the table DDL tools. `check_constraints` — the raw-injection-heaviest surface — follows in a separate PR.

`akb_create_table` accepts optional `unique_keys` and `indexes` at create time; `akb_alter_table` gains `add_unique_keys` / `drop_unique_keys` / `add_indexes` / `drop_indexes`. Declarative JSON only — `akb_sql` stays DML-only.

## What's included

- **DDL primitives** (`table_data_repo`): `create_unique_constraint`, `drop_constraint`, `create_index`, `drop_index`, and a `unique_key_duplicates` preflight. Every identifier flows through `safe_ident`; index order is a closed `asc`/`desc` enum — no raw user value reaches a DDL string.
- **Deterministic name generation**: generated constraint/index names are namespaced by the physical table (index names are schema-global in PostgreSQL) and carry a `sha1` digest over the *structured* column list, so distinct column lists can never alias (`["a","b"]` vs `["a_b"]`) and names stay ≤ 63 bytes. Caller-supplied names are used verbatim.
- **Atomicity** (AC #4/#10): adding a unique key preflights existing rows for duplicates *before* `ADD CONSTRAINT`; preflight + DDL + registry write share one transaction, so a violation rolls back **both** physical schema and registry. Post-preflight races and schema-global name clashes surface as a clean `invalid_argument` (422), not a 500.
- **Stable duplicate error** (AC #2): a duplicate `INSERT` through `akb_sql` now returns a dedicated `unique_violation` code + `pg_sqlstate=23505` (was the generic `sql_error` catch-all).
- **Metadata** (AC #11): persisted on `vault_tables` (idempotent migration `037`, registered in the applier list) and exposed via `list_tables`, `akb_vault_info` introspection, and the create/alter return dicts. `init.sql` mirrors the columns for fresh installs.
- **REST parity**: `CreateTableRequest` now threads `unique_keys`/`indexes` (previously silently dropped — the REST surface could read them but not write them).

## Tests

- **DB-free unit** `test_table_constraints_unit.py` — name generation (deterministic / collision-safe / 63-byte truncation / column-list disambiguation), validation (column existence, reserved-column rejection, `asc`/`desc` enum, duplicate names), preflight query shape, registry JSON round-trip.
- **Live e2e** `test_table_constraints_e2e.sh` — AC #1–#6, #10, #11, the `akb_sql` DDL-only boundary, and the admin permission gate (AC #13). 18/18 pass against a local pgvector stack.

## Acceptance criteria

Covered: **#1, #2, #3, #4, #5, #6, #10, #11, #12, #13** (for `unique_keys` + `indexes`).
Deferred to the follow-up PR: **#7, #8, #9** (`check_constraints`) and the `akb_sql` `WITH`/CTE hardening follow-up the issue calls out.

## Note — pre-existing, out of scope

While testing the admin gate (AC #13) I noticed that a non-admin caller hitting **any** admin-gated MCP tool (`akb_alter_table`, `akb_drop_table`, `akb_grant`, …) has its `ForbiddenError` surfaced under `code=internal` by the central `call_tool` dispatch (it maps `NotFoundError`/`ValidationError`/`ConflictError`, but `ForbiddenError` falls to the generic `except Exception → internal`). The gate itself works — the call is rejected before any DDL — but the code is misleading. This predates #215 and affects many tools, so I left it for a focused follow-up (a one-line `except ForbiddenError → permission_denied` in `call_tool` would fix it uniformly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
