### PR TITLE
feat(okf): export AKB vaults to Open Knowledge Format + conformance validator

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -92,11 +92,85 @@ async def _repair_resource_hashes(args: list[str]) -> int:
     return 1 if report.get("errors") else 0
 
 
+def _okf_validate(args: list[str]) -> int:
+    """`okf-validate <bundle-dir>` — check a directory against OKF v0.1."""
+    from pathlib import Path
+
+    from app.services.okf import check_dir
+
+    if len(args) != 1:
+        print("Usage: python -m app.cli okf-validate <bundle-dir>", file=sys.stderr)
+        return 2
+    root = Path(args[0])
+    if not root.is_dir():
+        print(f"Not a directory: {root}", file=sys.stderr)
+        return 2
+    report = check_dir(root)
+    for finding in report.findings:
+        print(finding, file=sys.stderr)
+    print(report.summary())
+    return 0 if report.ok else 1
+
+
+def _okf_export(args: list[str]) -> int:
+    """`okf-export --from-git <worktree> --vault <name> --out <dir>`.
+
+    Exports an AKB vault git worktree as an OKF bundle and validates it.
+    """
+    from pathlib import Path
+
+    from app.services.okf import build_bundle, check_bundle, records_from_git_tree, write_bundle
+
+    usage = (
+        "Usage: python -m app.cli okf-export --from-git <worktree> "
+        "--vault <name> --out <dir>"
+    )
+    from_git = vault = out = None
+    index = 0
+    while index < len(args):
+        flag = args[index]
+        if flag in ("--from-git", "--vault", "--out"):
+            index += 1
+            if index >= len(args):
+                print(usage, file=sys.stderr)
+                return 2
+            if flag == "--from-git":
+                from_git = args[index]
+            elif flag == "--vault":
+                vault = args[index]
+            else:
+                out = args[index]
+        else:
+            print(f"Unknown okf-export option: {flag}", file=sys.stderr)
+            return 2
+        index += 1
+    if not (from_git and vault and out):
+        print(usage, file=sys.stderr)
+        return 2
+    worktree = Path(from_git)
+    if not worktree.is_dir():
+        print(f"Not a directory: {worktree}", file=sys.stderr)
+        return 2
+    records = records_from_git_tree(worktree, vault)
+    bundle = build_bundle(documents=records)
+    write_bundle(Path(out), bundle)
+    report = check_bundle(bundle)
+    for finding in report.findings:
+        print(finding, file=sys.stderr)
+    print(f"Wrote {len(bundle)} file(s) to {out}")
+    print(report.summary())
+    return 0 if report.ok else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     if not argv:
         print("Usage: python -m app.cli <subcommand> [args]", file=sys.stderr)
-        print("Subcommands: reset-password <username>, repair-resource-hashes", file=sys.stderr)
+        print(
+            "Subcommands: reset-password <username>, repair-resource-hashes, "
+            "okf-validate <dir>, okf-export --from-git <worktree> --vault <name> --out <dir>",
+            file=sys.stderr,
+        )
         return 2
     cmd = argv[0]
     if cmd == "reset-password":
@@ -106,6 +180,10 @@ def main(argv: list[str] | None = None) -> int:
         return asyncio.run(_reset_password(argv[1]))
     if cmd == "repair-resource-hashes":
         return asyncio.run(_repair_resource_hashes(argv[1:]))
+    if cmd == "okf-validate":
+        return _okf_validate(argv[1:])
+    if cmd == "okf-export":
+        return _okf_export(argv[1:])
     print(f"Unknown subcommand: {cmd}", file=sys.stderr)
     return 2
 

--- a/backend/app/services/okf.py
+++ b/backend/app/services/okf.py
@@ -1,0 +1,517 @@
+"""Open Knowledge Format (OKF) interop for AKB.
+
+OKF (https://github.com/GoogleCloudPlatform/knowledge-catalog, spec v0.1) is a
+vendor-neutral standard for sharing curated knowledge with AI agents: a
+directory tree of markdown files, each with a YAML frontmatter block whose only
+required field is ``type``. AKB's per-vault git repo is already a tree of
+``.md`` + YAML-frontmatter files, so an AKB vault is *almost* an OKF bundle
+already — this module makes the relationship exact and machine-checkable.
+
+Two halves, both pure (no DB / git / network), so they unit-test without infra:
+
+* **Export** — turn AKB records (documents, tables, files) into an OKF bundle:
+  remap AKB's frontmatter keys to OKF's recommended names (``summary`` →
+  ``description``, ``updated_at`` → ``timestamp``, add ``resource`` = the
+  ``akb://`` URI), render tables/files as *concept documents* (schema /
+  metadata + a ``resource`` pointer — OKF carries the description of an asset,
+  not its bytes/rows), and synthesise the reserved ``index.md`` (progressive
+  disclosure) and ``log.md`` (changelog) files plus a root ``okf_version``.
+
+* **Conformance** — validate any directory tree (or in-memory file map)
+  against the three OKF v0.1 MUST rules. Deliberately *permissive*: per the
+  spec a consumer MUST NOT reject a bundle for unknown ``type`` values, unknown
+  keys, broken cross-links, or missing ``index.md`` — so this checker never
+  flags those.
+
+See ``okf/README.md`` at the repo root for the AKB ↔ OKF positioning.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+OKF_VERSION = "0.1"
+
+# Reserved filenames carry directory-level structure, not concepts. They are
+# exempt from the "every .md needs frontmatter + type" rule.
+RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+
+# Frontmatter key order for emitted concept docs: OKF's required field first,
+# then its recommended fields in spec order, then AKB-specific extras (which
+# OKF treats as permitted additional keys a consumer must preserve, not reject).
+_OKF_KEY_ORDER = ("type", "title", "description", "resource", "tags", "timestamp")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+def _iso8601(value: Any) -> str | None:
+    """Normalise an AKB timestamp to an ISO-8601 string (``T`` separator).
+
+    AKB serialises timestamps as ``2026-06-12 01:36:48.823107+00:00`` (space
+    separator, from ``datetime.isoformat()`` round-tripped through asyncpg /
+    JSON). OKF recommends ISO-8601; ``datetime.isoformat`` already is, we only
+    need to swap the space the str form may carry for a ``T``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, _dt.datetime):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.replace(" ", "T", 1)
+
+
+def _iso_date(value: Any) -> str | None:
+    """First 10 chars of an ISO timestamp → ``YYYY-MM-DD`` (OKF log heading)."""
+    iso = _iso8601(value)
+    if iso is None:
+        return None
+    head = iso[:10]
+    try:
+        _dt.date.fromisoformat(head)
+    except ValueError:
+        return None
+    return head
+
+
+def _dump_frontmatter(meta: Mapping[str, Any]) -> str:
+    """Serialise a frontmatter mapping to a ``---``-delimited YAML block.
+
+    ``sort_keys=False`` preserves our intentional key order; ``allow_unicode``
+    keeps Korean/CJK titles readable rather than ``\\uXXXX``-escaped.
+    """
+    body = yaml.safe_dump(
+        dict(meta), sort_keys=False, allow_unicode=True, default_flow_style=False
+    )
+    return f"---\n{body}---\n"
+
+
+def _compose(meta: Mapping[str, Any], body: str) -> str:
+    return f"{_dump_frontmatter(meta)}\n{body.rstrip()}\n"
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, Any] | None, str, bool]:
+    """Split markdown into (frontmatter dict | None, body, had_delimited_block).
+
+    ``had_delimited_block`` distinguishes "no ``---`` fence at all" from "a
+    fence that parsed to something non-mapping" — the conformance checker needs
+    that distinction to report a useful message.
+    """
+    if not text.startswith("---"):
+        return None, text, False
+    # Frontmatter opens with a line that is exactly '---'.
+    lines = text.splitlines(keepends=True)
+    if lines[0].strip() != "---":
+        return None, text, False
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            raw = "".join(lines[1:idx])
+            body = "".join(lines[idx + 1 :])
+            try:
+                parsed = yaml.safe_load(raw)
+            except yaml.YAMLError:
+                return None, body, True
+            if isinstance(parsed, dict):
+                return parsed, body, True
+            return None, body, True
+    return None, text, False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Export: AKB records → OKF concept documents
+# ─────────────────────────────────────────────────────────────────────────────
+def okf_frontmatter(
+    *,
+    type_: str,
+    title: str | None = None,
+    description: str | None = None,
+    resource: str | None = None,
+    tags: Sequence[str] | None = None,
+    timestamp: Any = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an OKF frontmatter mapping in canonical key order.
+
+    ``type`` is always present (OKF's sole MUST). Recommended fields are
+    included only when non-empty. AKB-specific keys land after the recommended
+    block as permitted additional keys.
+    """
+    meta: dict[str, Any] = {"type": type_ or "note"}
+    if title:
+        meta["title"] = title
+    if description:
+        meta["description"] = description
+    if resource:
+        meta["resource"] = resource
+    if tags:
+        meta["tags"] = list(tags)
+    ts = _iso8601(timestamp)
+    if ts:
+        meta["timestamp"] = ts
+    if extra:
+        for key, value in extra.items():
+            if key in meta or value in (None, "", [], {}):
+                continue
+            meta[key] = value
+    # Re-order to spec order, extras trailing.
+    ordered = {k: meta[k] for k in _OKF_KEY_ORDER if k in meta}
+    for key, value in meta.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
+def _doc_extra(rec: Mapping[str, Any]) -> dict[str, Any]:
+    """AKB fields preserved as additional OKF keys (not lost in translation)."""
+    extra: dict[str, Any] = {}
+    for key in ("status", "domain"):
+        if rec.get(key):
+            extra[key] = rec[key]
+    created = _iso8601(rec.get("created_at"))
+    if created:
+        extra["created_at"] = created
+    if rec.get("uri"):
+        extra["akb_uri"] = rec["uri"]
+    return extra
+
+
+def concept_from_document(rec: Mapping[str, Any]) -> tuple[str, str]:
+    """An AKB document record → (bundle-relative path, OKF markdown)."""
+    path = _normalise_path(rec.get("path") or rec.get("name") or "untitled.md")
+    meta = okf_frontmatter(
+        type_=str(rec.get("type") or rec.get("doc_type") or "note"),
+        title=rec.get("title"),
+        description=rec.get("summary") or rec.get("description"),
+        resource=rec.get("uri"),
+        tags=rec.get("tags"),
+        timestamp=rec.get("updated_at") or rec.get("created_at"),
+        extra=_doc_extra(rec),
+    )
+    body = str(rec.get("content") or rec.get("body") or "").strip()
+    return path, _compose(meta, body)
+
+
+def _schema_table(columns: Iterable[Mapping[str, Any]]) -> str:
+    rows = ["| Column | Type | Description |", "| --- | --- | --- |"]
+    for col in columns:
+        name = str(col.get("name", "")).strip()
+        ctype = str(col.get("type", "")).strip()
+        desc = str(col.get("description", "") or "").strip().replace("\n", " ")
+        rows.append(f"| {name} | {ctype} | {desc} |")
+    return "\n".join(rows)
+
+
+def concept_from_table(rec: Mapping[str, Any]) -> tuple[str, str]:
+    """An AKB table record → an OKF *concept document* describing the table.
+
+    OKF carries the table's schema and a ``resource`` pointer to the live
+    asset, not its rows — exactly the BigQuery-table concept the spec models.
+    """
+    raw = rec.get("path") or rec.get("sql_name") or rec.get("name") or "table"
+    path = _normalise_path(str(raw))
+    columns = rec.get("columns") or []
+    parts: list[str] = []
+    if rec.get("description"):
+        parts.append(str(rec["description"]).strip())
+    if columns:
+        parts.append("# Schema\n\n" + _schema_table(columns))
+    row_count = rec.get("row_count")
+    if row_count is not None:
+        parts.append(f"# Rows\n\n{row_count} rows (data lives in AKB; this concept carries the schema).")
+    meta = okf_frontmatter(
+        type_="table",
+        title=rec.get("title") or rec.get("name") or rec.get("sql_name"),
+        description=rec.get("description"),
+        resource=rec.get("uri"),
+        tags=rec.get("tags"),
+        timestamp=rec.get("updated_at") or rec.get("created_at"),
+        extra={k: rec[k] for k in ("sql_name", "row_count") if rec.get(k) is not None},
+    )
+    return path, _compose(meta, "\n\n".join(parts))
+
+
+def concept_from_file(rec: Mapping[str, Any]) -> tuple[str, str]:
+    """An AKB file record → an OKF concept document referencing the asset.
+
+    OKF bundles are markdown-only; a binary file is represented by a concept
+    doc whose ``resource`` points at the file (e.g. its ``akb://`` URI), with
+    mime/size as metadata — the bytes themselves stay in AKB.
+    """
+    raw = rec.get("path") or rec.get("name") or "file"
+    path = _normalise_path(_with_md_suffix(str(raw)))
+    uri = rec.get("uri")
+    body_lines = ["This concept references a file asset stored in AKB."]
+    if uri:
+        body_lines.append("")
+        body_lines.append(f"Resource: [{rec.get('name') or raw}]({uri})")
+    meta = okf_frontmatter(
+        type_="file",
+        title=rec.get("title") or rec.get("name"),
+        description=rec.get("description") or rec.get("summary"),
+        resource=uri,
+        tags=rec.get("tags"),
+        timestamp=rec.get("updated_at") or rec.get("created_at"),
+        extra={k: rec[k] for k in ("mime_type", "size_bytes") if rec.get(k) is not None},
+    )
+    return path, _compose(meta, "\n".join(body_lines))
+
+
+def _with_md_suffix(path: str) -> str:
+    return path if path.endswith(".md") else f"{path}.md"
+
+
+def _normalise_path(path: str) -> str:
+    """Bundle-relative concept path: forward slashes, no leading slash, ``.md``."""
+    cleaned = path.strip().lstrip("/").replace("\\", "/")
+    cleaned = _with_md_suffix(cleaned)
+    return cleaned
+
+
+# ── reserved files: index.md (progressive disclosure) & log.md (changelog) ──
+@dataclass
+class _Entry:
+    path: str  # bundle-relative, e.g. "specs/api.md"
+    title: str
+    description: str
+    timestamp: str | None = None
+
+
+def _link_line(entry: _Entry) -> str:
+    desc = f" - {entry.description}" if entry.description else ""
+    # Absolute, bundle-root links are the OKF-recommended form.
+    return f"* [{entry.title}](/{entry.path}){desc}"
+
+
+def build_index(entries: Sequence[_Entry], *, okf_version: str | None = None) -> str:
+    """Render an ``index.md``. Only the bundle-root index may carry frontmatter
+    (and it is the only place ``okf_version`` is declared)."""
+    by_section: dict[str, list[_Entry]] = {}
+    for entry in entries:
+        section = entry.path.split("/", 1)[0] if "/" in entry.path else "Documents"
+        by_section.setdefault(section, []).append(entry)
+    parts: list[str] = []
+    for section in sorted(by_section):
+        parts.append(f"# {section}")
+        parts.append("")
+        for entry in sorted(by_section[section], key=lambda e: e.title.lower()):
+            parts.append(_link_line(entry))
+        parts.append("")
+    body = "\n".join(parts).rstrip() + "\n"
+    if okf_version is not None:
+        return _compose({"okf_version": okf_version}, body)
+    return body
+
+
+def build_log(entries: Sequence[_Entry]) -> str:
+    """Render a ``log.md``: date-grouped, newest first, ISO ``YYYY-MM-DD``."""
+    by_date: dict[str, list[_Entry]] = {}
+    for entry in entries:
+        day = _iso_date(entry.timestamp) or "0000-00-00"
+        by_date.setdefault(day, []).append(entry)
+    parts = ["# Directory Update Log", ""]
+    for day in sorted((d for d in by_date if d != "0000-00-00"), reverse=True):
+        parts.append(f"## {day}")
+        parts.append("")
+        for entry in sorted(by_date[day], key=lambda e: e.title.lower()):
+            parts.append(f"* **Update**: [{entry.title}](/{entry.path})")
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def build_bundle(
+    documents: Sequence[Mapping[str, Any]] | None = None,
+    tables: Sequence[Mapping[str, Any]] | None = None,
+    files: Sequence[Mapping[str, Any]] | None = None,
+    *,
+    okf_version: str = OKF_VERSION,
+    with_log: bool = True,
+) -> dict[str, str]:
+    """Assemble a complete OKF bundle (path → content) from AKB records."""
+    out: dict[str, str] = {}
+    entries: list[_Entry] = []
+
+    def _add(maker: Any, rec: Mapping[str, Any]) -> None:
+        path, content = maker(rec)
+        out[path] = content
+        meta, _, _ = split_frontmatter(content)
+        meta = meta or {}
+        entries.append(
+            _Entry(
+                path=path,
+                title=str(meta.get("title") or path[:-3]),
+                description=str(meta.get("description") or ""),
+                timestamp=meta.get("timestamp"),
+            )
+        )
+
+    for rec in documents or []:
+        _add(concept_from_document, rec)
+    for rec in tables or []:
+        _add(concept_from_table, rec)
+    for rec in files or []:
+        _add(concept_from_file, rec)
+
+    out["index.md"] = build_index(entries, okf_version=okf_version)
+    if with_log:
+        out["log.md"] = build_log(entries)
+    return out
+
+
+def write_bundle(out_dir: Path, files: Mapping[str, str]) -> int:
+    """Write a bundle (path → content) under ``out_dir``. Returns file count."""
+    for rel, content in files.items():
+        target = out_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return len(files)
+
+
+def _doc_uri(vault: str, rel_path: str) -> str:
+    """Reconstruct a document's ``akb://`` URI from its bundle-relative path."""
+    rel = rel_path.replace("\\", "/").lstrip("/")
+    if "/" in rel:
+        coll, filename = rel.rsplit("/", 1)
+        return f"akb://{vault}/coll/{coll}/doc/{filename}"
+    return f"akb://{vault}/doc/{rel}"
+
+
+def records_from_git_tree(worktree: Path, vault: str) -> list[dict[str, Any]]:
+    """Read an AKB vault git worktree into document records for ``build_bundle``.
+
+    An AKB vault repo is already a tree of ``.md`` + frontmatter files, so this
+    just parses each, lifts AKB's frontmatter keys, and reconstructs the
+    ``akb://`` resource URI from the path. (Tables/files live in PG/S3, not git;
+    include those via the record-based ``build_bundle`` path instead.)
+    """
+    records: list[dict[str, Any]] = []
+    for path in sorted(worktree.rglob("*.md")):
+        if ".git" in path.parts:
+            continue
+        rel = path.relative_to(worktree).as_posix()
+        if rel.rsplit("/", 1)[-1] in RESERVED_FILENAMES:
+            continue
+        meta, body, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+        meta = meta or {}
+        records.append(
+            {
+                "path": rel,
+                "uri": _doc_uri(vault, rel),
+                "title": meta.get("title"),
+                "type": meta.get("type"),
+                "status": meta.get("status"),
+                "summary": meta.get("summary"),
+                "domain": meta.get("domain"),
+                "tags": meta.get("tags"),
+                "created_at": meta.get("created_at"),
+                "updated_at": meta.get("updated_at"),
+                "content": body,
+            }
+        )
+    return records
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Conformance: validate a bundle against OKF v0.1 MUST rules
+# ─────────────────────────────────────────────────────────────────────────────
+@dataclass
+class Finding:
+    level: str  # "error" (a MUST violation) — the only level emitted today
+    path: str
+    code: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.level}] {self.path}: {self.message} ({self.code})"
+
+
+@dataclass
+class ConformanceReport:
+    files_checked: int = 0
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.level == "error" for f in self.findings)
+
+    def summary(self) -> str:
+        errors = sum(1 for f in self.findings if f.level == "error")
+        verdict = "CONFORMANT" if self.ok else "NON-CONFORMANT"
+        return f"OKF v{OKF_VERSION}: {verdict} — {self.files_checked} markdown file(s), {errors} error(s)"
+
+
+def _is_root_index(rel_path: str) -> bool:
+    return rel_path == "index.md"
+
+
+def _check_concept(rel: str, text: str, out: list[Finding]) -> None:
+    meta, _, had_block = split_frontmatter(text)
+    if meta is None:
+        if had_block:
+            out.append(Finding("error", rel, "okf.frontmatter.unparseable",
+                               "frontmatter block is not a parseable YAML mapping"))
+        else:
+            out.append(Finding("error", rel, "okf.frontmatter.missing",
+                               "concept document has no YAML frontmatter block"))
+        return
+    type_value = meta.get("type")
+    if type_value is None or (isinstance(type_value, str) and not type_value.strip()):
+        out.append(Finding("error", rel, "okf.type.missing",
+                           "frontmatter has no non-empty `type` field"))
+
+
+def _check_index(rel: str, text: str, out: list[Finding]) -> None:
+    meta, _, had_block = split_frontmatter(text)
+    if had_block and not _is_root_index(rel):
+        out.append(Finding("error", rel, "okf.index.frontmatter",
+                           "only the bundle-root index.md may carry frontmatter"))
+
+
+_DATE_PREFIX = "## "
+
+
+def _check_log(rel: str, text: str, out: list[Finding]) -> None:
+    _, _, had_block = split_frontmatter(text)
+    if had_block:
+        out.append(Finding("error", rel, "okf.log.frontmatter",
+                           "log.md must not carry frontmatter"))
+    for line in text.splitlines():
+        if line.startswith(_DATE_PREFIX):
+            heading = line[len(_DATE_PREFIX):].strip()
+            try:
+                _dt.date.fromisoformat(heading)
+            except ValueError:
+                out.append(Finding("error", rel, "okf.log.date",
+                                   f"date heading '{heading}' is not ISO 8601 YYYY-MM-DD"))
+
+
+def check_bundle(files: Mapping[str, str]) -> ConformanceReport:
+    """Validate an in-memory bundle (bundle-relative path → content)."""
+    report = ConformanceReport()
+    for rel, text in sorted(files.items()):
+        if not rel.endswith(".md"):
+            continue
+        report.files_checked += 1
+        name = rel.rsplit("/", 1)[-1]
+        if name == "index.md":
+            _check_index(rel, text, report.findings)
+        elif name == "log.md":
+            _check_log(rel, text, report.findings)
+        else:
+            _check_concept(rel, text, report.findings)
+    return report
+
+
+def check_dir(root: Path) -> ConformanceReport:
+    """Validate every ``.md`` under ``root`` (recursively)."""
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*.md")):
+        rel = path.relative_to(root).as_posix()
+        files[rel] = path.read_text(encoding="utf-8")
+    return check_bundle(files)

--- a/backend/tests/test_okf_unit.py
+++ b/backend/tests/test_okf_unit.py
@@ -1,0 +1,183 @@
+"""Unit tests for the OKF (Open Knowledge Format) interop module.
+
+Covers both halves of `app.services.okf` with no DB/git/network:
+  * export — AKB document/table/file records → OKF concept docs + the reserved
+    index.md / log.md, plus the round-trip invariant (anything we export must
+    pass our own conformance checker).
+  * conformance — the three OKF v0.1 MUST rules, and the *permissive* clauses
+    (unknown type, unknown keys, broken links, missing index.md never fail).
+
+Imports from `app.services.okf` only — pure, runs as a fast unit test.
+"""
+from __future__ import annotations
+
+from app.services.okf import (
+    OKF_VERSION,
+    build_bundle,
+    build_log,
+    check_bundle,
+    concept_from_document,
+    concept_from_file,
+    concept_from_table,
+    okf_frontmatter,
+    split_frontmatter,
+)
+
+# A document record shaped like akb_get's response.
+DOC = {
+    "uri": "akb://product/coll/akb/design/doc/api-v2.md",
+    "path": "akb/design/api-v2.md",
+    "title": "API v2 Design",
+    "type": "spec",
+    "status": "active",
+    "summary": "The v2 surface.",
+    "domain": "product",
+    "created_at": "2026-06-12 01:36:48.823107+00:00",
+    "updated_at": "2026-06-13 09:00:00+00:00",
+    "tags": ["api", "design"],
+    "content": "# API v2\n\nBody here.",
+}
+
+
+class TestFrontmatterMapping:
+    def test_required_type_always_present(self):
+        meta = okf_frontmatter(type_="")
+        assert meta["type"] == "note"  # empty → fallback, never absent
+
+    def test_akb_keys_remapped_to_okf_names(self):
+        path, md = concept_from_document(DOC)
+        meta, body, had = split_frontmatter(md)
+        assert had and meta is not None
+        # OKF recommended names:
+        assert meta["type"] == "spec"
+        assert meta["title"] == "API v2 Design"
+        assert meta["description"] == "The v2 surface."   # was AKB `summary`
+        assert meta["resource"] == DOC["uri"]
+        assert meta["tags"] == ["api", "design"]
+        assert meta["timestamp"] == "2026-06-13T09:00:00+00:00"  # was `updated_at`
+        # AKB extras preserved as additional keys (consumer must not reject):
+        assert meta["status"] == "active"
+        assert meta["domain"] == "product"
+        assert meta["akb_uri"] == DOC["uri"]
+        assert body.strip() == "# API v2\n\nBody here."
+
+    def test_key_order_is_spec_order(self):
+        _, md = concept_from_document(DOC)
+        meta, _, _ = split_frontmatter(md)
+        keys = list(meta)
+        assert keys[:6] == ["type", "title", "description", "resource", "tags", "timestamp"]
+
+    def test_concept_id_is_path_minus_md(self):
+        path, _ = concept_from_document(DOC)
+        assert path == "akb/design/api-v2.md"  # concept ID == "akb/design/api-v2"
+
+
+class TestTableAndFileConcepts:
+    def test_table_renders_schema_not_rows(self):
+        rec = {
+            "uri": "akb://product/coll/akb/table/orders",
+            "path": "akb/orders.md",
+            "name": "orders",
+            "sql_name": "vt_orders",
+            "row_count": 1200,
+            "columns": [
+                {"name": "id", "type": "uuid", "description": "PK"},
+                {"name": "total", "type": "numeric", "description": ""},
+            ],
+        }
+        _, md = concept_from_table(rec)
+        meta, body, _ = split_frontmatter(md)
+        assert meta["type"] == "table"
+        assert meta["resource"] == rec["uri"]
+        assert "# Schema" in body
+        assert "| id | uuid | PK |" in body
+        assert "1200 rows" in body  # row count noted, data not embedded
+
+    def test_file_concept_references_asset(self):
+        rec = {
+            "uri": "akb://product/file/reports/q2.pdf",
+            "path": "reports/q2.pdf",
+            "name": "q2.pdf",
+            "mime_type": "application/pdf",
+            "size_bytes": 4096,
+        }
+        path, md = concept_from_file(rec)
+        meta, body, _ = split_frontmatter(md)
+        assert path.endswith(".md")  # binary asset → .md concept doc
+        assert meta["type"] == "file"
+        assert meta["resource"] == rec["uri"]
+        assert meta["mime_type"] == "application/pdf"
+        assert rec["uri"] in body
+
+
+class TestBundleAndReservedFiles:
+    def test_bundle_has_root_index_with_version(self):
+        bundle = build_bundle(documents=[DOC])
+        assert "index.md" in bundle
+        meta, _, had = split_frontmatter(bundle["index.md"])
+        assert had and meta["okf_version"] == OKF_VERSION
+
+    def test_index_links_are_absolute(self):
+        bundle = build_bundle(documents=[DOC])
+        assert "(/akb/design/api-v2.md)" in bundle["index.md"]
+
+    def test_log_dates_are_iso(self):
+        bundle = build_bundle(documents=[DOC])
+        assert "## 2026-06-13" in bundle["log.md"]
+
+
+class TestConformance:
+    def test_exported_bundle_is_conformant(self):
+        rec_file = {"uri": "akb://v/file/a.bin", "path": "a.bin", "name": "a.bin"}
+        rec_table = {"uri": "akb://v/table/t", "path": "t.md", "name": "t",
+                     "columns": [{"name": "x", "type": "int"}]}
+        bundle = build_bundle(documents=[DOC], tables=[rec_table], files=[rec_file])
+        report = check_bundle(bundle)
+        assert report.ok, "\n".join(str(f) for f in report.findings)
+
+    def test_missing_frontmatter_is_error(self):
+        report = check_bundle({"a.md": "# No frontmatter here\n"})
+        assert not report.ok
+        assert any(f.code == "okf.frontmatter.missing" for f in report.findings)
+
+    def test_empty_type_is_error(self):
+        report = check_bundle({"a.md": "---\ntitle: x\ntype: ''\n---\nbody\n"})
+        assert not report.ok
+        assert any(f.code == "okf.type.missing" for f in report.findings)
+
+    def test_unparseable_frontmatter_is_error(self):
+        report = check_bundle({"a.md": "---\n: : :\nbad yaml\n---\nbody\n"})
+        assert not report.ok
+
+    def test_nonroot_index_frontmatter_is_error(self):
+        report = check_bundle({"sub/index.md": "---\nokf_version: '0.1'\n---\n# S\n"})
+        assert any(f.code == "okf.index.frontmatter" for f in report.findings)
+
+    def test_root_index_frontmatter_is_allowed(self):
+        report = check_bundle({"index.md": "---\nokf_version: '0.1'\n---\n# S\n"})
+        assert report.ok
+
+    def test_log_bad_date_is_error(self):
+        report = check_bundle({"log.md": "# Log\n\n## 2026/06/13\n* x\n"})
+        assert any(f.code == "okf.log.date" for f in report.findings)
+
+    def test_permissive_unknown_type_and_keys_ok(self):
+        # Unknown type value + unknown extra key + broken link → still conformant.
+        md = "---\ntype: WhateverCustomType\nweird_key: 1\n---\nSee [x](/nope.md).\n"
+        report = check_bundle({"a.md": md})
+        assert report.ok
+
+    def test_permissive_no_index_ok(self):
+        report = check_bundle({"a.md": "---\ntype: note\n---\nbody\n"})
+        assert report.ok  # missing index.md is never a failure
+
+
+class TestLogGrouping:
+    def test_newest_first(self):
+        from app.services.okf import _Entry  # noqa: PLC2701 — testing internal grouping
+        entries = [
+            _Entry(path="a.md", title="A", description="", timestamp="2026-01-01T00:00:00+00:00"),
+            _Entry(path="b.md", title="B", description="", timestamp="2026-03-01T00:00:00+00:00"),
+        ]
+        log = build_log(entries)
+        assert log.index("2026-03-01") < log.index("2026-01-01")

--- a/okf/README.md
+++ b/okf/README.md
@@ -1,0 +1,86 @@
+# AKB × Open Knowledge Format (OKF)
+
+[**Open Knowledge Format (OKF)**](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+is a vendor-neutral spec (v0.1, from Google Cloud) for sharing curated knowledge
+with AI agents. An OKF *bundle* is just a directory tree of markdown files, each
+with a YAML frontmatter block whose **only required field is `type`** — no SDK,
+no database, no server. "If you can `cat` a file, you can read OKF; if you can
+`git clone` a repo, you can ship it."
+
+AKB and OKF are **complementary**, in the same way MCP and OKF are: OKF
+standardises *how curated knowledge is written down*; AKB is a *platform* that
+stores, versions, searches, governs, and serves that knowledge to agents over
+MCP and REST. This directory makes AKB a first-class OKF citizen — AKB can
+**export** any vault as a conformant OKF bundle, and ships a standalone
+**conformance validator** anyone can run against any bundle.
+
+## Why AKB is already ~an OKF bundle
+
+An AKB vault is stored as a per-vault git repo of `.md` files with YAML
+frontmatter, and a document's identity is its path — exactly OKF's model
+(`tables/users.md` → concept ID `tables/users`). AKB independently arrived at
+OKF's core design before the spec existed; the remaining gaps are naming and a
+couple of reserved files, which the exporter closes.
+
+| OKF v0.1 | AKB native | Exporter does |
+| --- | --- | --- |
+| `type` (**required**) | `type` (defaults `note`) | passthrough |
+| `title` | `title` | passthrough |
+| `description` | `summary` | **rename** `summary` → `description` |
+| `resource` (asset URI) | `akb://` URI | emit `resource` = `akb://…` |
+| `tags` | `tags` | passthrough |
+| `timestamp` (ISO 8601) | `created_at` / `updated_at` | emit `timestamp` = `updated_at` |
+| *(additional keys allowed)* | `status`, `domain`, … | preserved as extra keys |
+| `index.md` (progressive disclosure) | — (lives in PG) | **generated** |
+| `log.md` (changelog) | — (lives in `git log`) | **generated** |
+| root `okf_version` | — | **generated** (`0.1`) |
+
+### Documents, tables, and files
+
+OKF bundles are markdown-only and represent an asset by a *concept document*
+(its description + a `resource` pointer), not by its bytes or rows. AKB's
+tri-store maps onto that cleanly:
+
+- **documents** → OKF concept docs (1:1).
+- **tables** → a concept doc with a `# Schema` section (columns) + `resource`;
+  the rows stay in AKB (OKF carries the schema, like its BigQuery-table example).
+- **files** → a concept doc referencing the asset via `resource` + mime/size;
+  the bytes stay in AKB.
+
+So an AKB → OKF export is a faithful *catalog* of the vault at OKF's intended
+abstraction level, not a lossy dump.
+
+## Conformance status
+
+AKB-authored bundles satisfy all three OKF v0.1 **MUST** rules (every
+non-reserved `.md` has a parseable YAML frontmatter block with a non-empty
+`type`; reserved files follow their structure). The validator in this repo
+proves it mechanically — see below. The recommended-field name differences
+(`summary` vs `description`, `created_at`/`updated_at` vs `timestamp`) are
+**SHOULD**-level and are reconciled by the exporter.
+
+## Usage
+
+The implementation lives in [`backend/app/services/okf.py`](../backend/app/services/okf.py)
+(pure, unit-tested in `backend/tests/test_okf_unit.py`) and is exposed via the
+backend CLI.
+
+```bash
+# Validate any directory tree against OKF v0.1
+python -m app.cli okf-validate path/to/bundle/
+
+# Export an AKB vault git worktree as an OKF bundle, then self-validate
+python -m app.cli okf-export --from-git /data/vaults/_worktrees/<vault> \
+    --vault <vault> --out ./okf-out/
+```
+
+A small, hand-written, conformant example bundle lives in
+[`sample-bundle/`](sample-bundle/) — run the validator against it to see a green
+report.
+
+## Feedback to the OKF project
+
+AKB is an independent implementation of the OKF pattern at platform scale; our
+operational notes (type vocabularies, typed relationships/graph edges beyond
+plain links, RBAC and hybrid search as the layer *above* the format) are offered
+upstream as spec feedback, not as a competing format. See the OKF repo's issues.

--- a/okf/sample-bundle/index.md
+++ b/okf/sample-bundle/index.md
@@ -1,0 +1,15 @@
+---
+okf_version: "0.1"
+---
+
+# Documents
+
+* [Acme Analytics — Overview](/overview.md) - What this bundle describes.
+
+# tables
+
+* [orders](/tables/orders.md) - One row per completed order.
+
+# runbooks
+
+* [Indexer stalled](/runbooks/indexer-stalled.md) - Recover a stuck embedding worker.

--- a/okf/sample-bundle/log.md
+++ b/okf/sample-bundle/log.md
@@ -1,0 +1,10 @@
+# Directory Update Log
+
+## 2026-06-13
+
+* **Update**: [orders](/tables/orders.md)
+
+## 2026-06-10
+
+* **Creation**: [Acme Analytics — Overview](/overview.md)
+* **Creation**: [Indexer stalled](/runbooks/indexer-stalled.md)

--- a/okf/sample-bundle/overview.md
+++ b/okf/sample-bundle/overview.md
@@ -1,0 +1,20 @@
+---
+type: note
+title: Acme Analytics — Overview
+description: What this bundle describes.
+resource: akb://acme-analytics/doc/overview.md
+tags:
+- overview
+- analytics
+timestamp: "2026-06-10T09:00:00+00:00"
+status: active
+---
+
+# Acme Analytics — Overview
+
+This is a small, hand-written OKF bundle that demonstrates the three concept
+shapes AKB exports: a plain document (this file), a [table](/tables/orders.md),
+and an operational [runbook](/runbooks/indexer-stalled.md).
+
+Cross-links use bundle-root-absolute paths (the OKF-recommended form). A link
+asserts a relationship; the kind of relationship is conveyed by this prose.

--- a/okf/sample-bundle/runbooks/indexer-stalled.md
+++ b/okf/sample-bundle/runbooks/indexer-stalled.md
@@ -1,0 +1,22 @@
+---
+type: runbook
+title: Indexer stalled
+description: Recover a stuck embedding worker.
+resource: akb://acme-analytics/coll/runbooks/doc/indexer-stalled.md
+tags:
+- ops
+- indexing
+timestamp: "2026-06-10T11:00:00+00:00"
+status: active
+---
+
+# Indexer stalled
+
+Symptom: documents written but `vector_indexed_at` stays `NULL`.
+
+1. Check the worker is draining the queue.
+2. Confirm the vector store is reachable.
+3. Re-enqueue the affected chunks.
+
+`type: runbook` is a producer-defined value — OKF requires no central type
+registry, and a consumer must accept unknown types.

--- a/okf/sample-bundle/tables/orders.md
+++ b/okf/sample-bundle/tables/orders.md
@@ -1,0 +1,27 @@
+---
+type: table
+title: orders
+description: One row per completed order.
+resource: akb://acme-analytics/coll/tables/table/orders
+tags:
+- sales
+- orders
+timestamp: "2026-06-13T14:30:00+00:00"
+sql_name: vt_orders
+row_count: 1200000
+---
+
+One row per completed order.
+
+# Schema
+
+| Column | Type | Description |
+| --- | --- | --- |
+| order_id | uuid | Unique identifier for the order |
+| customer_id | uuid | References the customer |
+| total | numeric | Order total in minor units |
+| created_at | timestamptz | When the order completed |
+
+# Rows
+
+1200000 rows (data lives in AKB; this concept carries the schema, not the rows).


### PR DESCRIPTION
## What

Adds interop with Google Cloud's **[Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog) v0.1** — a vendor-neutral markdown + YAML-frontmatter standard for sharing curated knowledge with AI agents (the only required frontmatter field is `type`).

An AKB vault is already stored as a per-vault git repo of `.md` + frontmatter files whose identity is the path — which is *exactly* OKF's model (`tables/users.md` → concept ID `tables/users`). AKB independently arrived at OKF's core design before the spec existed; the remaining gaps are field **naming** and two reserved files. This PR closes them and lets AKB act as an OKF producer + ships a standalone validator.

## Changes

- **`backend/app/services/okf.py`** (pure, no DB/git/network):
  - **Export** — remap AKB frontmatter to OKF recommended keys (`summary`→`description`, `updated_at`→`timestamp`, add `resource` = `akb://` URI), preserve AKB extras (`status`/`domain`/…) as permitted additional keys, render **documents/tables/files** as OKF *concept docs* (tables → `# Schema` from columns; files → `resource` pointer — OKF carries the description, not the bytes/rows), and synthesize the reserved `index.md` (progressive disclosure) + `log.md` (changelog) and a root `okf_version`.
  - **Conformance** — a *permissive* checker for the three OKF v0.1 MUST rules. Per spec it never flags unknown `type` values, unknown keys, broken links, or missing `index.md`.
- **CLI** (`backend/app/cli.py`): `okf-validate <dir>` and `okf-export --from-git <worktree> --vault <name> --out <dir>`.
- **`okf/README.md`** — AKB ↔ OKF positioning (complementary, like MCP ↔ OKF) + a hand-written conformant **`okf/sample-bundle/`**.

## Conformance status

AKB-authored bundles satisfy all three OKF v0.1 **MUST** rules (parseable YAML frontmatter + non-empty `type` on every non-reserved `.md`; reserved files follow their structure). The recommended-field name differences are SHOULD-level and reconciled by the exporter. The validator proves conformance mechanically.

## Test

- `backend/tests/test_okf_unit.py` — 19 unit tests (frontmatter remap, table/file concepts, reserved files, round-trip conformance, permissive clauses). All pass.
- `ruff` / `mypy --python-version 3.14` / `bandit` clean on the new module + CLI.
- `bash scripts/check.sh` green.
- End-to-end: exported a synthetic AKB worktree and validated `okf/sample-bundle/` → `CONFORMANT, 0 errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)