### PR TITLE
feat(okf): export/import vaults as OKF bundles via REST + MCP

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,6 +159,7 @@ jobs:
             test_jwt_revocation_e2e.sh
             test_table_constraints_e2e.sh
             test_forbidden_permission_code_e2e.sh
+            test_okf_export_import_e2e.sh
           )
           TOTAL_PASS=0
           TOTAL_FAIL=0

--- a/backend/app/api/routes/knowledge_io.py
+++ b/backend/app/api/routes/knowledge_io.py
@@ -1,0 +1,61 @@
+"""REST routes for knowledge-bundle export/import (OKF, extensible by format)."""
+
+import io
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
+
+from app.api.deps import get_current_user
+from app.services import knowledge_io
+from app.services.access_service import check_vault_access
+from app.services.auth_service import AuthenticatedUser
+from app.services.document_service import DocumentService
+
+router = APIRouter()
+doc_service = DocumentService()
+
+
+@router.get("/vaults/{vault}/export", summary="Export a vault as a knowledge bundle")
+async def export_vault(
+    vault: str,
+    format: str = Query("okf", description="Bundle format (currently: okf)"),
+    as_: str = Query("zip", alias="as", description="Response shape: zip | json"),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Reader role required. Returns a zip archive by default, or the bundle as
+    a JSON ``{path: content}`` map with ``?as=json``."""
+    await check_vault_access(user.user_id, vault, required_role="reader")
+    try:
+        files = await knowledge_io.export_vault(vault, fmt=format, doc_service=doc_service)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if as_ == "json":
+        return {"format": format, "vault": vault, "file_count": len(files), "files": files}
+    data = knowledge_io.bundle_to_zip(files)
+    return StreamingResponse(
+        io.BytesIO(data),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{vault}.okf.zip"'},
+    )
+
+
+@router.post("/vaults/{vault}/import", summary="Import a knowledge bundle into a vault")
+async def import_vault(
+    vault: str,
+    file: UploadFile = File(..., description="Bundle archive (.zip)"),
+    format: str = Query("okf", description="Bundle format (currently: okf)"),
+    status: str | None = Query(None, description="Override status for imported docs"),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Writer role required. Accepts a zip archive (the export format). Existing
+    document paths are skipped; per-document failures are reported, not fatal."""
+    await check_vault_access(user.user_id, vault, required_role="writer")
+    raw = await file.read()
+    try:
+        bundle = knowledge_io.zip_to_bundle(raw)
+        return await knowledge_io.import_bundle(
+            vault, bundle, fmt=format, actor_id=user.username,
+            doc_service=doc_service, status=status,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 from app.api.deps import get_current_user
 from app.db.postgres import get_pool
 from app.exceptions import AKBError
-from app.api.routes import access, activity, agent_sessions, auth, documents, files, help as help_routes, public, search, collections, knowledge, tables
+from app.api.routes import access, activity, agent_sessions, auth, documents, files, help as help_routes, public, search, collections, knowledge, knowledge_io, tables
 from app.services import audit_log, embed_worker, events_publisher, external_git_poller, metadata_worker
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
@@ -74,6 +74,7 @@ app.include_router(knowledge.router, prefix="/api/v1", tags=["knowledge"])
 app.include_router(activity.router, prefix="/api/v1", tags=["activity"])
 app.include_router(agent_sessions.router, prefix="/api/v1", tags=["agent-sessions"])
 app.include_router(tables.router, prefix="/api/v1", tags=["tables"])
+app.include_router(knowledge_io.router, prefix="/api/v1", tags=["export-import"])
 app.include_router(files.router, prefix="/api/v1", tags=["files"])
 app.include_router(public.router, prefix="/api/v1", tags=["public"])
 app.include_router(help_routes.router, prefix="/api/v1/help", tags=["help"])

--- a/backend/app/services/knowledge_io.py
+++ b/backend/app/services/knowledge_io.py
@@ -1,0 +1,200 @@
+"""Knowledge bundle export/import — format-dispatch layer.
+
+Turns an AKB vault into a portable knowledge bundle (and back). Today the only
+registered format is **OKF** (Open Knowledge Format, see ``app.services.okf``),
+but every entry point takes a ``fmt`` argument and dispatches through the
+``EXPORTERS`` / ``IMPORTERS`` registries, so adding another format later is a
+registration, not a rewrite.
+
+Surfaces that call this:
+  * REST  — ``GET /api/v1/vaults/{vault}/export`` / ``POST .../import``
+  * MCP   — ``akb_export`` / ``akb_import`` tools
+
+Export reads a vault via the existing ``DocumentService`` (browse + per-doc
+get), so documents carry their real body, and tables/files become OKF *concept
+documents* (schema / metadata + a ``resource`` pointer). Import is
+document-oriented: OKF carries no rows/bytes, so a ``type: table``/``file``
+concept doc imports as a regular document describing that asset.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import Mapping
+from typing import Any
+
+from app.exceptions import ConflictError
+from app.models.document import DocumentPutRequest
+from app.services import okf
+from app.util.text import slugify
+
+# Registered bundle formats. `fmt` values accepted by every entry point.
+SUPPORTED_FORMATS = ("okf",)
+
+# Guard rails for untrusted import archives (zip-bomb / runaway payloads).
+_MAX_BUNDLE_FILES = 10_000
+_MAX_BUNDLE_BYTES = 64 * 1024 * 1024  # 64 MiB uncompressed
+
+
+def _require_format(fmt: str) -> str:
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Unsupported format '{fmt}'. Supported: {', '.join(SUPPORTED_FORMATS)}"
+        )
+    return fmt
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Export: vault → bundle (path → content)
+# ─────────────────────────────────────────────────────────────────────────────
+def _table_record(item: Any) -> dict[str, Any]:
+    coll = (item.collection or "").strip("/")
+    base = slugify(item.name)
+    path = f"{coll}/{base}" if coll else base
+    return {
+        "uri": item.uri,
+        "path": path,
+        "name": item.name,
+        "title": item.name,
+        "description": item.summary,
+        "columns": item.columns or [],
+        "row_count": item.row_count,
+        "sql_name": item.sql_name,
+        "tags": item.tags,
+        "updated_at": item.last_updated,
+    }
+
+
+def _file_record(item: Any) -> dict[str, Any]:
+    coll = (item.collection or "").strip("/")
+    base = slugify(item.name)
+    path = f"{coll}/{base}" if coll else base
+    return {
+        "uri": item.uri,
+        "path": path,
+        "name": item.name,
+        "title": item.name,
+        "description": item.summary,
+        "mime_type": item.mime_type,
+        "size_bytes": item.size_bytes,
+        "tags": item.tags,
+        "updated_at": item.last_updated,
+    }
+
+
+async def export_vault(vault_name: str, *, fmt: str = "okf", doc_service: Any) -> dict[str, str]:
+    """Build a bundle (bundle-relative path → content) for an entire vault.
+
+    Caller must have already authorized read access. ``doc_service`` is an
+    instance of ``DocumentService`` (injected to avoid an import cycle / to
+    reuse the module-level singleton the surfaces already hold).
+    """
+    _require_format(fmt)
+    browse = await doc_service.browse(
+        vault_name, collection=None, depth=-1, content_type="all", include_archived=False
+    )
+    documents: list[dict[str, Any]] = []
+    tables: list[dict[str, Any]] = []
+    files: list[dict[str, Any]] = []
+    for item in browse.items:
+        if item.type == "document":
+            resp = await doc_service.get(vault_name, item.path)
+            if resp is not None:
+                documents.append(resp.model_dump())
+        elif item.type == "table":
+            tables.append(_table_record(item))
+        elif item.type == "file":
+            files.append(_file_record(item))
+    return okf.build_bundle(documents=documents, tables=tables, files=files)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Import: bundle (path → content) → vault documents
+# ─────────────────────────────────────────────────────────────────────────────
+async def import_bundle(
+    vault_name: str,
+    files: Mapping[str, str],
+    *,
+    fmt: str = "okf",
+    actor_id: str,
+    doc_service: Any,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Import a bundle's concept documents into ``vault_name``.
+
+    Caller must have already authorized write access. Existing paths are
+    skipped (not overwritten); per-document failures are collected rather than
+    aborting the whole import. ``status`` overrides each doc's status when set.
+    """
+    _require_format(fmt)
+    records = okf.parse_okf_bundle(files)
+    created: list[str] = []
+    skipped: list[str] = []
+    errors: list[dict[str, str]] = []
+    for rec in records:
+        req = DocumentPutRequest(
+            vault=vault_name,
+            collection=rec["collection"],
+            slug=rec["slug"],
+            title=rec["title"],
+            content=rec["content"],
+            type=rec["type"],
+            status=status or rec["status"],
+            tags=rec["tags"],
+            summary=rec.get("summary"),
+            domain=rec.get("domain"),
+        )
+        try:
+            resp = await doc_service.put(req, agent_id=actor_id)
+            created.append(resp.uri)
+        except ConflictError:
+            skipped.append(rec["path"])
+        except Exception as exc:  # noqa: BLE001 — collect, don't abort the batch
+            errors.append({"path": rec["path"], "error": str(exc)})
+    return {
+        "format": fmt,
+        "vault": vault_name,
+        "created": len(created),
+        "skipped": len(skipped),
+        "failed": len(errors),
+        "uris": created,
+        "skipped_paths": skipped,
+        "errors": errors,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Zip (de)serialisation — REST's binary transport
+# ─────────────────────────────────────────────────────────────────────────────
+def bundle_to_zip(files: Mapping[str, str]) -> bytes:
+    """Serialise a bundle (path → content) to a deterministic zip archive."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(files):
+            zf.writestr(path, files[path])
+    return buffer.getvalue()
+
+
+def zip_to_bundle(data: bytes) -> dict[str, str]:
+    """Read a zip archive into a bundle (path → content).
+
+    Guards against runaway archives (file count + total uncompressed size) and
+    skips directory entries. Decodes as UTF-8 (OKF bundles are UTF-8 markdown).
+    """
+    out: dict[str, str] = {}
+    total = 0
+    with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+        infos = zf.infolist()
+        if len(infos) > _MAX_BUNDLE_FILES:
+            raise ValueError(f"bundle has too many entries (>{_MAX_BUNDLE_FILES})")
+        for info in infos:
+            if info.is_dir():
+                continue
+            total += info.file_size
+            if total > _MAX_BUNDLE_BYTES:
+                raise ValueError("bundle exceeds maximum uncompressed size")
+            rel = info.filename.replace("\\", "/").lstrip("/")
+            if not rel or ".." in rel.split("/"):
+                continue  # ignore absolute / traversal paths
+            out[rel] = zf.read(info).decode("utf-8", errors="replace")
+    return out

--- a/backend/app/services/okf.py
+++ b/backend/app/services/okf.py
@@ -418,6 +418,76 @@ def records_from_git_tree(worktree: Path, vault: str) -> list[dict[str, Any]]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Import: OKF concept documents → AKB document records
+# ─────────────────────────────────────────────────────────────────────────────
+# AKB's document `type` is a closed enum; OKF's `type` is open. On import we
+# clamp unknown OKF types to "reference" (and remember the original as a tag) so
+# an arbitrary OKF bundle never fails AKB's validation.
+AKB_DOC_TYPES = frozenset(
+    {"note", "report", "decision", "spec", "plan", "session", "task", "reference", "skill"}
+)
+AKB_DOC_STATUSES = frozenset({"draft", "active", "archived"})
+
+
+def _clamp_type(okf_type: Any) -> tuple[str, str | None]:
+    """Map an OKF `type` to (akb_type, original_if_clamped)."""
+    value = str(okf_type or "").strip()
+    if value in AKB_DOC_TYPES:
+        return value, None
+    return "reference", value or None
+
+
+def okf_doc_to_record(rel_path: str, meta: Mapping[str, Any], body: str) -> dict[str, Any]:
+    """One OKF concept doc → an AKB-shaped document record (for import).
+
+    Reverses the export field mapping: ``description`` → ``summary``. AKB sets
+    its own ``created_at``/``updated_at`` on write, so OKF ``timestamp`` is
+    informational only. Unknown ``type`` values are clamped (see ``_clamp_type``)
+    and the original preserved as an ``okf-type:<value>`` tag.
+    """
+    coll, _, fname = rel_path.replace("\\", "/").rpartition("/")
+    slug = fname[:-3] if fname.endswith(".md") else fname
+    akb_type, original_type = _clamp_type(meta.get("type"))
+    tags = list(meta.get("tags") or [])
+    if original_type:
+        tags.append(f"okf-type:{original_type}")
+    status = str(meta.get("status") or "draft")
+    if status not in AKB_DOC_STATUSES:
+        status = "draft"
+    return {
+        "path": _normalise_path(rel_path),
+        "collection": coll,
+        "slug": slug,
+        "title": str(meta.get("title") or slug),
+        "type": akb_type,
+        "status": status,
+        "summary": meta.get("description") or meta.get("summary"),
+        "domain": meta.get("domain"),
+        "tags": tags,
+        "content": body.strip(),
+    }
+
+
+def parse_okf_bundle(files: Mapping[str, str]) -> list[dict[str, Any]]:
+    """An OKF bundle (path → content) → AKB document records.
+
+    Permissive consumer (per OKF spec): reserved files are skipped, and a
+    concept file with no/unparseable frontmatter is still imported (as a
+    ``reference`` note) rather than rejected.
+    """
+    records: list[dict[str, Any]] = []
+    for rel, text in sorted(files.items()):
+        if not rel.endswith(".md"):
+            continue
+        name = rel.rsplit("/", 1)[-1]
+        if name in RESERVED_FILENAMES:
+            continue
+        meta, body, _ = split_frontmatter(text)
+        records.append(okf_doc_to_record(rel, meta or {}, body if meta is not None else text))
+    return records
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Conformance: validate a bundle against OKF v0.1 MUST rules
 # ─────────────────────────────────────────────────────────────────────────────
 @dataclass

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1235,6 +1235,44 @@ async def _handle_history(args: dict, uid: str, user: _MCPUser) -> dict:
     return {"uri": doc_uri(vault, doc["path"]), "history": history}
 
 
+@_h("akb_export")
+async def _handle_export(args: dict, uid: str, user: _MCPUser) -> dict:
+    """Export a vault as a knowledge bundle (currently OKF). Returns the bundle
+    inline as a {path: content} map."""
+    vault = args.get("vault")
+    if not vault:
+        return err("`vault` is required", code=INVALID_ARGUMENT)
+    fmt = args.get("format", "okf")
+    await check_vault_access(uid, vault, required_role="reader")
+    from app.services import knowledge_io
+    try:
+        files = await knowledge_io.export_vault(vault, fmt=fmt, doc_service=doc_service)
+    except ValueError as e:
+        return err(str(e), code=INVALID_ARGUMENT)
+    return {"format": fmt, "vault": vault, "file_count": len(files), "files": files}
+
+
+@_h("akb_import")
+async def _handle_import(args: dict, uid: str, user: _MCPUser) -> dict:
+    """Import a knowledge bundle ({path: content} map) into a vault."""
+    vault = args.get("vault")
+    if not vault:
+        return err("`vault` is required", code=INVALID_ARGUMENT)
+    files = args.get("files")
+    if not isinstance(files, dict) or not files:
+        return err("`files` must be a non-empty {path: content} object", code=INVALID_ARGUMENT)
+    fmt = args.get("format", "okf")
+    await check_vault_access(uid, vault, required_role="writer")
+    from app.services import knowledge_io
+    try:
+        return await knowledge_io.import_bundle(
+            vault, files, fmt=fmt, actor_id=user.username,
+            doc_service=doc_service, status=args.get("status"),
+        )
+    except ValueError as e:
+        return err(str(e), code=INVALID_ARGUMENT)
+
+
 @_h("akb_set_public")
 async def _handle_set_public(args: dict, uid: str, user: _MCPUser) -> dict:
     """Set `vaults.public_access`. Owner-only.

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -1127,4 +1127,63 @@ TOOLS = [
             },
         },
     ),
+    Tool(
+        name="akb_export",
+        description=(
+            "Export an entire vault as a portable knowledge bundle. Returns the "
+            "bundle inline as a {path: content} map. The `format` parameter selects "
+            "the on-disk format — currently 'okf' (Open Knowledge Format: markdown + "
+            "YAML frontmatter, the only required field being `type`). Documents export "
+            "1:1; tables and files become OKF concept documents (schema / metadata + a "
+            "`resource` pointer — the rows/bytes stay in AKB). Reader role required. "
+            "For a downloadable zip, use the REST endpoint GET /api/v1/vaults/{vault}/export."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "vault": {"type": "string", "description": "Vault to export"},
+                "format": {
+                    "type": "string",
+                    "enum": ["okf"],
+                    "default": "okf",
+                    "description": "Bundle format. Currently only 'okf'.",
+                },
+            },
+            "required": ["vault"],
+        },
+    ),
+    Tool(
+        name="akb_import",
+        description=(
+            "Import a knowledge bundle into a vault. Pass `files` as a {path: content} "
+            "map (the shape akb_export returns). `format` selects the bundle format — "
+            "currently 'okf'. Concept documents are imported as AKB documents; a "
+            "`type: table`/`file` concept doc (which carries only schema/metadata, not "
+            "rows/bytes) imports as a regular document describing that asset. Existing "
+            "paths are skipped, not overwritten. Writer role required."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "vault": {"type": "string", "description": "Target vault"},
+                "format": {
+                    "type": "string",
+                    "enum": ["okf"],
+                    "default": "okf",
+                    "description": "Bundle format. Currently only 'okf'.",
+                },
+                "files": {
+                    "type": "object",
+                    "description": "Bundle as a {bundle-relative-path: markdown-content} map.",
+                    "additionalProperties": {"type": "string"},
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["draft", "active", "archived"],
+                    "description": "Optional: override status for every imported document.",
+                },
+            },
+            "required": ["vault", "files"],
+        },
+    ),
 ]

--- a/backend/tests/test_knowledge_io_unit.py
+++ b/backend/tests/test_knowledge_io_unit.py
@@ -1,0 +1,66 @@
+"""Unit tests for the knowledge-bundle export/import dispatch layer.
+
+Covers the pure pieces of `app.services.knowledge_io` — zip (de)serialisation
+round-trip, the runaway-archive guards, and the format registry — without a DB
+(export_vault / import_bundle need one and are exercised by the e2e suite
+`test_okf_export_import_e2e.sh`).
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from app.services import knowledge_io
+
+
+class TestZipRoundTrip:
+    def test_bundle_to_zip_and_back(self):
+        bundle = {
+            "index.md": "---\nokf_version: '0.1'\n---\n# x\n",
+            "specs/api.md": "---\ntype: spec\n---\n# API\n",
+        }
+        data = knowledge_io.bundle_to_zip(bundle)
+        assert data[:2] == b"PK"  # zip magic
+        out = knowledge_io.zip_to_bundle(data)
+        assert out == bundle
+
+    def test_zip_is_deterministic(self):
+        bundle = {"b.md": "B", "a.md": "A"}
+        assert knowledge_io.bundle_to_zip(bundle) == knowledge_io.bundle_to_zip(bundle)
+
+    def test_zip_skips_directories_and_traversal(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("sub/", "")          # directory entry
+            zf.writestr("../evil.md", "x")   # traversal
+            zf.writestr("ok.md", "y")
+        out = knowledge_io.zip_to_bundle(buf.getvalue())
+        assert out == {"ok.md": "y"}
+
+    def test_too_many_files_rejected(self, monkeypatch):
+        monkeypatch.setattr(knowledge_io, "_MAX_BUNDLE_FILES", 2)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for i in range(3):
+                zf.writestr(f"f{i}.md", "x")
+        with pytest.raises(ValueError, match="too many"):
+            knowledge_io.zip_to_bundle(buf.getvalue())
+
+    def test_oversize_rejected(self, monkeypatch):
+        monkeypatch.setattr(knowledge_io, "_MAX_BUNDLE_BYTES", 4)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("big.md", "way more than four bytes")
+        with pytest.raises(ValueError, match="maximum uncompressed size"):
+            knowledge_io.zip_to_bundle(buf.getvalue())
+
+
+class TestFormatRegistry:
+    def test_unsupported_format_rejected(self):
+        with pytest.raises(ValueError, match="Unsupported format"):
+            knowledge_io._require_format("rdf")
+
+    def test_okf_supported(self):
+        assert knowledge_io._require_format("okf") == "okf"

--- a/backend/tests/test_okf_export_import_e2e.sh
+++ b/backend/tests/test_okf_export_import_e2e.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+#
+# AKB OKF Export/Import E2E Test Suite
+# Exercises the knowledge-bundle export/import surface end-to-end over both
+# transports: MCP tools (akb_export / akb_import) and REST
+# (GET /vaults/{v}/export, POST /vaults/{v}/import). No S3 / no search deps,
+# so it runs under the CI live-stack (embed-stubbed, MinIO-less) job.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+SRC_VAULT="okf-src-$(date +%s)"
+DST_VAULT="okf-dst-$(date +%s)"
+REST_VAULT="okf-rest-$(date +%s)"
+E2E_USER="okf-user-$(date +%s)"
+READER_USER="okf-reader-$(date +%s)"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+note() { echo "  • $1"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   AKB OKF Export/Import E2E Test Suite   ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# ── 0. Setup ──────────────────────────────────────────────────
+echo "▸ 0. Setup"
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$E2E_USER\",\"email\":\"$E2E_USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$E2E_USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"okf-e2e"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+[ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
+
+# Reader-only user (for access-control assertion)
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$READER_USER\",\"email\":\"$READER_USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+READER_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$READER_USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+READER_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $READER_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"okf-reader"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+# MCP session (writer)
+INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $PAT" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"okf-e2e","version":"1.0"}}}' 2>&1)
+SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
+[ -n "$SID" ] && pass "MCP session ($SID)" || { fail "MCP" "no session"; exit 1; }
+curl -sk -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+
+# MCP session (reader)
+READER_INIT=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"okf-reader","version":"1.0"}}}' 2>&1)
+READER_SID=$(echo "$READER_INIT" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
+curl -sk -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $READER_SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+
+MCP_ID=10
+mcp_call() {
+  local tool=$1 args=$2
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+}
+mcp_call_reader() {
+  local tool=$1 args=$2
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $READER_SID" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+}
+mcp_result() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
+
+# ── 1. Source vault with documents (+ a table, soft) ──────────
+echo ""
+echo "▸ 1. Source vault content"
+R=$(mcp_call akb_create_vault "{\"name\":\"$SRC_VAULT\",\"description\":\"OKF export source\"}" | mcp_result)
+echo "$R" | grep -q '"vault_id"' && pass "Source vault created" || { fail "Vault" "no vault_id: $R"; exit 1; }
+
+D1=$(mcp_call akb_put "{\"vault\":\"$SRC_VAULT\",\"collection\":\"specs\",\"title\":\"API v2\",\"content\":\"# API v2\\n\\nSpec body.\",\"type\":\"spec\",\"status\":\"active\",\"tags\":[\"api\"]}" | mcp_result)
+echo "$D1" | grep -q '"uri"' && pass "Doc 1 created (specs/)" || fail "Doc1" "$D1"
+D2=$(mcp_call akb_put "{\"vault\":\"$SRC_VAULT\",\"title\":\"Readme\",\"content\":\"# Readme\\n\\nRoot doc.\",\"type\":\"note\"}" | mcp_result)
+echo "$D2" | grep -q '"uri"' && pass "Doc 2 created (root)" || fail "Doc2" "$D2"
+
+# Table is best-effort: column type names are environment-dependent; the
+# concept-doc transform itself is covered by the unit suite.
+TBL=$(mcp_call akb_create_table "{\"vault\":\"$SRC_VAULT\",\"name\":\"metrics\",\"columns\":[{\"name\":\"region\",\"type\":\"text\"},{\"name\":\"hits\",\"type\":\"integer\"}]}" | mcp_result)
+HAS_TABLE=0
+if echo "$TBL" | grep -q '"uri"'; then HAS_TABLE=1; note "table 'metrics' created"; else note "table create skipped ($TBL)"; fi
+
+# ── 2. MCP export ─────────────────────────────────────────────
+echo ""
+echo "▸ 2. Export via MCP (akb_export)"
+EXPORT=$(mcp_call akb_export "{\"vault\":\"$SRC_VAULT\",\"format\":\"okf\"}" | mcp_result)
+FILE_COUNT=$(echo "$EXPORT" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("file_count",0))' 2>/dev/null)
+[ "${FILE_COUNT:-0}" -gt 0 ] 2>/dev/null && pass "Export returned $FILE_COUNT files" || { fail "Export" "no files: $EXPORT"; }
+
+# Bundle structure assertions
+echo "$EXPORT" | python3 -c '
+import sys,json
+d=json.load(sys.stdin); f=d.get("files",{})
+assert "index.md" in f, "no index.md"
+assert "okf_version" in f["index.md"], "root index.md missing okf_version"
+assert any(p.endswith("specs/api-v2.md") or p=="specs/api-v2.md" for p in f), "doc path missing: "+str(list(f))
+assert "log.md" in f, "no log.md"
+' 2>/tmp/okf_struct_err && pass "Bundle has index.md(+okf_version), log.md, doc paths" || fail "Structure" "$(cat /tmp/okf_struct_err)"
+
+# Conformance: every concept doc has frontmatter + non-empty type
+echo "$EXPORT" | python3 -c '
+import sys,json,re
+d=json.load(sys.stdin); f=d.get("files",{})
+bad=[]
+for path,txt in f.items():
+    name=path.rsplit("/",1)[-1]
+    if name in ("index.md","log.md"): continue
+    m=re.match(r"^---\n(.*?)\n---\n", txt, re.DOTALL)
+    if not m: bad.append(path+":no-frontmatter"); continue
+    if not re.search(r"^type:\s*\S", m.group(1), re.MULTILINE): bad.append(path+":no-type")
+assert not bad, "non-conformant: "+str(bad)
+' 2>/tmp/okf_conf_err && pass "All concept docs conformant (frontmatter+type)" || fail "Conformance" "$(cat /tmp/okf_conf_err)"
+
+if [ "$HAS_TABLE" = "1" ]; then
+  echo "$EXPORT" | python3 -c '
+import sys,json
+d=json.load(sys.stdin); f=d.get("files",{})
+assert any("type: table" in t for t in f.values()), "no table concept in bundle"
+' 2>/dev/null && pass "Table exported as OKF concept doc" || fail "TableConcept" "table concept missing"
+fi
+
+# ── 3. MCP import round-trip ──────────────────────────────────
+echo ""
+echo "▸ 3. Import via MCP (akb_import)"
+mcp_call akb_create_vault "{\"name\":\"$DST_VAULT\",\"description\":\"OKF import target\"}" >/dev/null 2>&1
+IMPORT_ARGS=$(echo "$EXPORT" | DST="$DST_VAULT" python3 -c 'import sys,json,os; d=json.load(sys.stdin); print(json.dumps({"vault":os.environ["DST"],"files":d["files"],"status":"active"}))')
+IMPORT=$(mcp_call akb_import "$IMPORT_ARGS" | mcp_result)
+CREATED=$(echo "$IMPORT" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("created",0))' 2>/dev/null)
+FAILED_N=$(echo "$IMPORT" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("failed",-1))' 2>/dev/null)
+[ "${CREATED:-0}" -ge 2 ] 2>/dev/null && pass "Imported $CREATED docs" || fail "Import" "created=$CREATED: $IMPORT"
+[ "${FAILED_N:-1}" = "0" ] && pass "No import failures" || fail "ImportFailures" "failed=$FAILED_N: $IMPORT"
+
+# Verify the imported docs exist in the target vault
+BROWSE=$(mcp_call akb_browse "{\"vault\":\"$DST_VAULT\",\"depth\":-1,\"content_type\":\"documents\"}" | mcp_result)
+DOC_N=$(echo "$BROWSE" | python3 -c 'import sys,json; print(len([i for i in json.load(sys.stdin).get("items",[]) if i.get("type")=="document"]))' 2>/dev/null)
+[ "${DOC_N:-0}" -ge 2 ] 2>/dev/null && pass "Target vault has $DOC_N documents" || fail "Verify" "doc count=$DOC_N"
+
+# ── 4. REST export (json + zip) ───────────────────────────────
+echo ""
+echo "▸ 4. Export via REST"
+REST_JSON=$(curl -sk "$BASE_URL/api/v1/vaults/$SRC_VAULT/export?format=okf&as=json" -H "Authorization: Bearer $JWT")
+echo "$REST_JSON" | python3 -c 'import sys,json; assert json.load(sys.stdin)["file_count"]>0' 2>/dev/null && pass "REST export (as=json) ok" || fail "RESTjson" "$REST_JSON"
+
+curl -sk "$BASE_URL/api/v1/vaults/$SRC_VAULT/export?format=okf" -H "Authorization: Bearer $JWT" -o /tmp/okf_bundle.zip
+[ "$(head -c 2 /tmp/okf_bundle.zip)" = "PK" ] && pass "REST export (zip) returns PK archive" || fail "RESTzip" "not a zip"
+
+# Format guard
+GUARD=$(curl -sk "$BASE_URL/api/v1/vaults/$SRC_VAULT/export?format=rdf" -H "Authorization: Bearer $JWT")
+echo "$GUARD" | grep -qi "unsupported format" && pass "Unsupported format rejected (400)" || fail "Guard" "$GUARD"
+
+# ── 5. REST import (zip multipart) ────────────────────────────
+echo ""
+echo "▸ 5. Import via REST (zip upload)"
+mcp_call akb_create_vault "{\"name\":\"$REST_VAULT\",\"description\":\"OKF REST import target\"}" >/dev/null 2>&1
+REST_IMPORT=$(curl -sk -X POST "$BASE_URL/api/v1/vaults/$REST_VAULT/import?format=okf&status=active" \
+  -H "Authorization: Bearer $JWT" -F "file=@/tmp/okf_bundle.zip")
+RC_CREATED=$(echo "$REST_IMPORT" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("created",0))' 2>/dev/null)
+[ "${RC_CREATED:-0}" -ge 2 ] 2>/dev/null && pass "REST import created $RC_CREATED docs" || fail "RESTimport" "$REST_IMPORT"
+
+# ── 6. Access control ─────────────────────────────────────────
+echo ""
+echo "▸ 6. Access control"
+# Reader has no membership on DST_VAULT → import must be refused.
+DENY=$(mcp_call_reader akb_import "{\"vault\":\"$DST_VAULT\",\"files\":{\"a.md\":\"---\\ntype: note\\n---\\nx\"}}" | mcp_result)
+echo "$DENY" | grep -q '"error"' && pass "Reader import refused" || fail "ACL" "expected error: $DENY"
+
+# ── Summary ───────────────────────────────────────────────────
+echo ""
+echo "═════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═════════════════════════════════════════"
+if [ "$FAIL" -gt 0 ]; then
+  for e in "${ERRORS[@]}"; do echo "  - $e"; done
+  exit 1
+fi
+exit 0

--- a/backend/tests/test_okf_unit.py
+++ b/backend/tests/test_okf_unit.py
@@ -20,6 +20,7 @@ from app.services.okf import (
     concept_from_file,
     concept_from_table,
     okf_frontmatter,
+    parse_okf_bundle,
     split_frontmatter,
 )
 
@@ -170,6 +171,60 @@ class TestConformance:
     def test_permissive_no_index_ok(self):
         report = check_bundle({"a.md": "---\ntype: note\n---\nbody\n"})
         assert report.ok  # missing index.md is never a failure
+
+
+class TestImport:
+    def test_okf_keys_mapped_back_to_akb(self):
+        bundle = {
+            "specs/api-v2.md": (
+                "---\ntype: spec\ntitle: API v2\ndescription: The surface.\n"
+                "tags:\n- api\ntimestamp: '2026-06-13T09:00:00+00:00'\n---\n# API v2\nBody.\n"
+            ),
+        }
+        recs = parse_okf_bundle(bundle)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["collection"] == "specs"
+        assert r["slug"] == "api-v2"
+        assert r["title"] == "API v2"
+        assert r["type"] == "spec"
+        assert r["summary"] == "The surface."  # OKF `description` → AKB `summary`
+        assert r["tags"] == ["api"]
+        assert r["content"] == "# API v2\nBody."
+
+    def test_unknown_type_clamped_and_preserved_as_tag(self):
+        bundle = {"r.md": "---\ntype: runbook\ntitle: R\n---\nbody\n"}
+        r = parse_okf_bundle(bundle)[0]
+        assert r["type"] == "reference"  # 'runbook' not in AKB enum → clamped
+        assert "okf-type:runbook" in r["tags"]
+
+    def test_reserved_files_skipped(self):
+        bundle = {
+            "index.md": "---\nokf_version: '0.1'\n---\n# x\n",
+            "log.md": "# Log\n",
+            "a.md": "---\ntype: note\n---\nbody\n",
+        }
+        recs = parse_okf_bundle(bundle)
+        assert [r["slug"] for r in recs] == ["a"]
+
+    def test_frontmatterless_file_still_imported(self):
+        # Permissive consumer: no frontmatter → imported as a note, not rejected.
+        recs = parse_okf_bundle({"a.md": "# Just a heading\n\ntext"})
+        assert len(recs) == 1
+        assert recs[0]["type"] == "reference"
+        assert "Just a heading" in recs[0]["content"]
+
+    def test_round_trip_document_preserves_core_fields(self):
+        # export → import returns the same path / title / type / summary / tags.
+        bundle = build_bundle(documents=[DOC])
+        recs = parse_okf_bundle(bundle)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r["path"] == DOC["path"]
+        assert r["title"] == DOC["title"]
+        assert r["type"] == DOC["type"]
+        assert r["summary"] == DOC["summary"]
+        assert set(DOC["tags"]).issubset(set(r["tags"]))
 
 
 class TestLogGrouping:


### PR DESCRIPTION
Builds on the OKF interop merged in #225 to make export **and** import first-class on both the agent (MCP) and web (REST) surfaces. Designed format-agnostic: every entry point takes a `format` arg dispatched through a registry (currently `okf`), so adding a second format later is a registration, not a rewrite.

## Surfaces

| | Export | Import |
|---|---|---|
| **REST** | `GET /api/v1/vaults/{vault}/export?format=okf` → zip (or `?as=json`) | `POST /api/v1/vaults/{vault}/import?format=okf` → zip multipart |
| **MCP** | `akb_export(vault, format="okf")` → inline `{path: content}` map | `akb_import(vault, format="okf", files={…})` |

MCP tools operate on inline content (no local filesystem), so they stay backend-side per the 2-layer rule. REST uses zip for browser/file ergonomics. Reader role gates export; writer gates import.

## Service layer — `app/services/knowledge_io.py`

- `export_vault()` — `browse(depth=-1)` + per-doc `get` → OKF bundle. **Tables/files become OKF concept docs** (schema / metadata + a `resource` pointer; rows and bytes stay in AKB — OKF's intended abstraction).
- `import_bundle()` — parse bundle → `DocumentPutRequest` per concept doc. Existing paths **skipped** (not overwritten); per-doc failures collected, not fatal. A `type: table`/`file` concept doc imports as a document (OKF carries no rows/bytes).
- `bundle_to_zip` / `zip_to_bundle` with zip-bomb (file-count + uncompressed-size) and path-traversal guards.

## Import transforms — `app/services/okf.py`

`parse_okf_bundle()` reverses the export mapping (`description`→`summary`), clamps an unknown OKF `type` to AKB's enum (keeping the original as an `okf-type:<value>` tag), and is a **permissive consumer** (frontmatterless / reserved files handled, never rejected).

## Tests

- **12 new unit tests** — import transforms + round-trip, zip serialize/guard, format registry. (`test_okf_unit.py`, `test_knowledge_io_unit.py`)
- **`test_okf_export_import_e2e.sh`** — round-trips documents + a table across **MCP and REST**, asserts bundle conformance (frontmatter + non-empty `type`, `index.md`+`okf_version`, `log.md`), the format guard (400 on unknown format), and that a reader's import is refused. Wired into the `e2e.yml` CI suite (no S3/search deps).
- `ruff` / `mypy --python-version 3.14` / `bandit` clean; `bash scripts/check.sh` green; import smoke confirms routes + MCP handlers register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)