### PR TITLE
test(okf): exercise the table→OKF-concept path in the e2e (valid column type)

### DIFF
--- a/backend/tests/test_okf_export_import_e2e.sh
+++ b/backend/tests/test_okf_export_import_e2e.sh
@@ -112,9 +112,10 @@ echo "$D1" | grep -q '"uri"' && pass "Doc 1 created (specs/)" || fail "Doc1" "$D
 D2=$(mcp_call akb_put "{\"vault\":\"$SRC_VAULT\",\"title\":\"Readme\",\"content\":\"# Readme\\n\\nRoot doc.\",\"type\":\"note\"}" | mcp_result)
 echo "$D2" | grep -q '"uri"' && pass "Doc 2 created (root)" || fail "Doc2" "$D2"
 
-# Table is best-effort: column type names are environment-dependent; the
-# concept-doc transform itself is covered by the unit suite.
-TBL=$(mcp_call akb_create_table "{\"vault\":\"$SRC_VAULT\",\"name\":\"metrics\",\"columns\":[{\"name\":\"region\",\"type\":\"text\"},{\"name\":\"hits\",\"type\":\"integer\"}]}" | mcp_result)
+# Table column types are AKB's set: text | number | boolean | date | json.
+# Best-effort (the concept-doc transform itself is covered by the unit suite),
+# but with a valid type the table→OKF-concept path is exercised live too.
+TBL=$(mcp_call akb_create_table "{\"vault\":\"$SRC_VAULT\",\"name\":\"metrics\",\"columns\":[{\"name\":\"region\",\"type\":\"text\"},{\"name\":\"hits\",\"type\":\"number\"}]}" | mcp_result)
 HAS_TABLE=0
 if echo "$TBL" | grep -q '"uri"'; then HAS_TABLE=1; note "table 'metrics' created"; else note "table create skipped ($TBL)"; fi
 


### PR DESCRIPTION
Follow-up to #227. The OKF export/import e2e created its table with column type `integer`, which AKB rejects (valid: `text|number|boolean|date|json`), so the table was silently skipped and the **table → OKF concept doc** export path never ran in CI. Switching to `number` makes the table-concept assertion exercise live.

Verified locally against an isolated stack (throwaway pgvector + embed stub + uvicorn on current source): **17 passed, 0 failed**, including `table 'metrics' created` → `Table exported as OKF concept doc`.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)