### PR TITLE
feat(docs): open document type to free-form (recommended vocabulary)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 358,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1111,
+        "line_number": 1113,
         "is_secret": false
       }
     ],
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T09:38:13Z"
+  "generated_at": "2026-06-18T10:39:29Z"
 }

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -23,7 +23,7 @@ class DocumentFrontmatter(NFCModel):
 
     id: str | None = None
     title: str
-    type: str = "note"  # note, report, decision, spec, plan, session, task, reference, skill
+    type: str = "note"  # free-form; recommended: note, report, decision, spec, plan, session, task, reference, skill
     status: str = "draft"  # draft, active, archived
     created_by: str | None = None
     created_at: datetime | None = None

--- a/backend/app/services/okf.py
+++ b/backend/app/services/okf.py
@@ -420,21 +420,11 @@ def records_from_git_tree(worktree: Path, vault: str) -> list[dict[str, Any]]:
 # ─────────────────────────────────────────────────────────────────────────────
 # Import: OKF concept documents → AKB document records
 # ─────────────────────────────────────────────────────────────────────────────
-# AKB's document `type` is a closed enum; OKF's `type` is open. On import we
-# clamp unknown OKF types to "reference" (and remember the original as a tag) so
-# an arbitrary OKF bundle never fails AKB's validation.
-AKB_DOC_TYPES = frozenset(
-    {"note", "report", "decision", "spec", "plan", "session", "task", "reference", "skill"}
-)
+# AKB's document `type` is free-form (recommended vocabulary, not a hard enum),
+# matching OKF's open, producer-defined `type`. So an OKF type imports verbatim
+# — no clamping, no lossy `okf-type:` tag. `status` stays a small closed set
+# (it drives browse/archive semantics), so an unknown status falls back to draft.
 AKB_DOC_STATUSES = frozenset({"draft", "active", "archived"})
-
-
-def _clamp_type(okf_type: Any) -> tuple[str, str | None]:
-    """Map an OKF `type` to (akb_type, original_if_clamped)."""
-    value = str(okf_type or "").strip()
-    if value in AKB_DOC_TYPES:
-        return value, None
-    return "reference", value or None
 
 
 def okf_doc_to_record(rel_path: str, meta: Mapping[str, Any], body: str) -> dict[str, Any]:
@@ -442,15 +432,11 @@ def okf_doc_to_record(rel_path: str, meta: Mapping[str, Any], body: str) -> dict
 
     Reverses the export field mapping: ``description`` → ``summary``. AKB sets
     its own ``created_at``/``updated_at`` on write, so OKF ``timestamp`` is
-    informational only. Unknown ``type`` values are clamped (see ``_clamp_type``)
-    and the original preserved as an ``okf-type:<value>`` tag.
+    informational only. ``type`` is carried through unchanged (AKB types are
+    open); an unrecognised ``status`` falls back to ``draft``.
     """
     coll, _, fname = rel_path.replace("\\", "/").rpartition("/")
     slug = fname[:-3] if fname.endswith(".md") else fname
-    akb_type, original_type = _clamp_type(meta.get("type"))
-    tags = list(meta.get("tags") or [])
-    if original_type:
-        tags.append(f"okf-type:{original_type}")
     status = str(meta.get("status") or "draft")
     if status not in AKB_DOC_STATUSES:
         status = "draft"
@@ -459,11 +445,11 @@ def okf_doc_to_record(rel_path: str, meta: Mapping[str, Any], body: str) -> dict
         "collection": coll,
         "slug": slug,
         "title": str(meta.get("title") or slug),
-        "type": akb_type,
+        "type": str(meta.get("type") or "note").strip() or "note",
         "status": status,
         "summary": meta.get("description") or meta.get("summary"),
         "domain": meta.get("domain"),
-        "tags": tags,
+        "tags": list(meta.get("tags") or []),
         "content": body.strip(),
     }
 

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -127,7 +127,9 @@ Each document has: vault, collection (directory), title, content, type, tags, st
 | `akb_delete_collection` | Deleting a collection (with optional `recursive=true` cascade) |
 
 ## Document Types
-`note` (default), `report`, `decision`, `spec`, `plan`, `session`, `task`, `reference`
+Free-form — any string is accepted. Recommended vocabulary:
+`note` (default), `report`, `decision`, `spec`, `plan`, `session`, `task`, `reference`, `skill`.
+Use a custom value when none fit (e.g. an OKF concept type).
 
 ## Document Status
 `draft` (default) → `active` → `archived`. Soft lifecycle signal; `archived`
@@ -652,7 +654,7 @@ akb_help(topic="link-resources")    # Workflow guide
 | title | ✓ | Document title |
 | slug | | Optional filename slug. When omitted, the path is derived from `title`; pass this to pin a stable URI filename independently of the display title. |
 | content | ✓ | Markdown body |
-| type | | note, report, decision, spec, plan, session, task, reference |
+| type | | free-form; recommended: note, report, decision, spec, plan, session, task, reference, skill |
 | tags | | ["auth", "api"] |
 | domain | | engineering, product, ops, legal, etc. |
 | summary | | Brief summary (auto-generated if omitted) |
@@ -829,7 +831,7 @@ Combines vector similarity (meaning) with keyword matching.
 | query | ✓ | Natural language search query |
 | vault | | Limit to specific vault |
 | collection | | Limit to specific collection |
-| type | | Filter: note, report, decision, spec, plan, session, task, reference |
+| type | | Filter by type (any string); common: note, report, decision, spec, plan, session, task, reference, skill |
 | tags | | Filter by tags |
 | limit | | Max results (default 10, max 50) |
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -135,8 +135,12 @@ TOOLS = [
                 "content": {"type": "string", "description": "Document body in Markdown"},
                 "type": {
                     "type": "string",
-                    "description": "Document type",
-                    "enum": ["note", "report", "decision", "spec", "plan", "session", "task", "reference", "skill"],
+                    "description": (
+                        "Document type. Free-form — any string is accepted. "
+                        "Recommended vocabulary: note (default), report, decision, "
+                        "spec, plan, session, task, reference, skill. Use a custom "
+                        "value when none fit (e.g. an OKF concept type)."
+                    ),
                     "default": "note",
                 },
                 "status": {
@@ -378,8 +382,10 @@ TOOLS = [
                 "collection": {"type": "string", "description": "Limit search to a specific collection"},
                 "type": {
                     "type": "string",
-                    "description": "Filter by document type",
-                    "enum": ["note", "report", "decision", "spec", "plan", "session", "task", "reference", "skill"],
+                    "description": (
+                        "Filter by document type (any string). Common values: note, "
+                        "report, decision, spec, plan, session, task, reference, skill."
+                    ),
                 },
                 "tags": {"type": "array", "items": {"type": "string"}, "description": "Filter by tags"},
                 "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 50},

--- a/backend/tests/test_okf_unit.py
+++ b/backend/tests/test_okf_unit.py
@@ -192,11 +192,13 @@ class TestImport:
         assert r["tags"] == ["api"]
         assert r["content"] == "# API v2\nBody."
 
-    def test_unknown_type_clamped_and_preserved_as_tag(self):
-        bundle = {"r.md": "---\ntype: runbook\ntitle: R\n---\nbody\n"}
+    def test_custom_type_preserved_verbatim(self):
+        # AKB types are open — an OKF producer-defined type imports as-is,
+        # no clamping, no lossy tag.
+        bundle = {"r.md": "---\ntype: runbook\ntitle: R\ntags:\n- ops\n---\nbody\n"}
         r = parse_okf_bundle(bundle)[0]
-        assert r["type"] == "reference"  # 'runbook' not in AKB enum → clamped
-        assert "okf-type:runbook" in r["tags"]
+        assert r["type"] == "runbook"
+        assert r["tags"] == ["ops"]  # no synthetic okf-type tag added
 
     def test_reserved_files_skipped(self):
         bundle = {
@@ -211,7 +213,7 @@ class TestImport:
         # Permissive consumer: no frontmatter → imported as a note, not rejected.
         recs = parse_okf_bundle({"a.md": "# Just a heading\n\ntext"})
         assert len(recs) == 1
-        assert recs[0]["type"] == "reference"
+        assert recs[0]["type"] == "note"  # default when no type present
         assert "Just a heading" in recs[0]["content"]
 
     def test_round_trip_document_preserves_core_fields(self):

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -221,10 +221,19 @@ export default function SearchPage() {
   const showLiteralHint = mode === "dense" && isShortQuery && searched && !loading;
 
   const allTypesActive = activeTypes.size === ALL_TYPES.length;
+  // `type` is free-form on the backend (recommended vocabulary, not a closed
+  // enum), so a result may carry a type with no chip here (e.g. an OKF-imported
+  // concept type). The chips only gate the known/recommended types; an unknown
+  // type has no chip to toggle, so it must always pass — otherwise narrowing the
+  // filter would silently hide custom-typed docs with no way to bring them back.
+  const knownTypes = new Set<string>(ALL_TYPES);
   const filteredDense = allTypesActive
     ? denseResults
     : denseResults.filter(
-        (r) => !r.doc_type || activeTypes.has(r.doc_type as DocTypeFilter),
+        (r) =>
+          !r.doc_type ||
+          !knownTypes.has(r.doc_type) ||
+          activeTypes.has(r.doc_type as DocTypeFilter),
       );
   const groupedDense = groupByType(filteredDense);
   // Drive render gates off actual array length, not the count field (a falsy


### PR DESCRIPTION
Opens document `type` from a closed enum to free-form, keeping the canonical list as a strong recommendation — matching OKF's open, producer-defined `type`.

## Why this is low-risk

`type` was only ever **advisory-enum**. The data layer is already open:
- `DocumentPutRequest.type` is `str` (no pydantic validator)
- DB `documents.doc_type` is `TEXT` (no CHECK constraint)
- `document_service` does no type validation

The closed set lived **only** in the MCP `inputSchema` enum (`akb_put`, `akb_search` filter) and doc comments — advisory hints, not server-enforced (the MCP dispatch validates arg *names*, not enum *values*). REST callers could already persist any type. This PR makes the contract honest. **No migration, no breaking change.**

## Changes

- **MCP**: `akb_put` + `akb_search` `type` → free-form string; description lists the recommended vocabulary (note/report/decision/spec/plan/session/task/reference/skill).
- **OKF import**: drop the type-clamp + synthetic `okf-type:` tag — an OKF concept type imports **verbatim** (higher fidelity, less code). `status` stays a closed set (drives browse/archive); unknown → `draft`.
- **help.py / model comment**: "free-form; recommended: …".

## Deliberately unchanged

- **Frontend** create-doc `Select` keeps the curated list — the recommended vocabulary for humans. (Type is set only at creation; `akb_update` can't change it.)
- **`metadata_worker`** LLM-classification guardrail still constrains *auto-tagged external-git imports* to the canon set (quality guardrail on LLM output, orthogonal to user/agent/OKF type-setting).

## Verification

- 31 OKF / knowledge_io unit tests pass (incl. new `test_custom_type_preserved_verbatim`).
- Local live e2e (isolated stack, current source): **17/17** — the table concept now imports as `type: table` instead of clamped to `reference`.
- `bash scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)