### PR TITLE
feat(docs): expose document version history via REST

### DIFF
--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -14,12 +14,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from app.api.deps import get_current_user
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
+from app.services.document_service import DocumentService
 from app.services.git_service import GitService
 from app.db.postgres import get_pool
 from app.repositories.document_repo import DocumentRepository
 
 router = APIRouter()
 git = GitService()
+doc_service = DocumentService()
 
 
 def _is_uuid(value: str | None) -> bool:
@@ -177,3 +179,23 @@ async def document_diff(
             raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
 
     return git.file_diff(vault, doc["path"], commit)
+
+
+@router.get("/history/{vault}/{doc_id:path}", summary="Get document version history (Git-based)")
+async def document_history(
+    vault: str,
+    doc_id: str,
+    limit: int = Query(20, ge=1, le=100),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """REST mirror of the akb_history MCP tool.
+
+    Lives under /history/... (not nested in /documents/...) so the greedy
+    {doc_id:path} converter on GET /documents/{vault}/{doc_id} — registered
+    first — can't swallow the /history suffix. Business logic (doc lookup,
+    created_at lineage boundary, author_name annotation) is shared via
+    DocumentService.history(); a missing vault/doc raises NotFoundError,
+    which the global AKBError handler maps to 404.
+    """
+    await check_vault_access(user.user_id, vault, required_role="reader")
+    return await doc_service.history(vault, doc_id, limit=limit)

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -711,7 +711,10 @@ class DocumentService:
             name_by_key[r["id"]] = r["name"]
             name_by_key[r["username"]] = r["name"]
         for e in entries:
-            name = name_by_key.get(e.get("author"))
+            author = e.get("author")
+            if not author:
+                continue
+            name = name_by_key.get(author)
             if name:
                 e["author_name"] = name
         return entries

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -149,6 +149,7 @@ class EditError(AKBError):
 
 from app.util.text import normalize_collection_path as _normalize_collection
 from app.util.text import slugify
+from app.util.text import to_nfc
 from app.util.text import doc_path as _doc_path
 from app.util.text import split_doc_path as _split_doc_path
 from app.util.text import strip_own_suffix as _strip_own_suffix
@@ -641,6 +642,79 @@ class DocumentService:
             # banner alongside the historical body.
             metadata_is_current=True,
         )
+
+    async def history(self, vault: str, doc_ref: str, limit: int = 20) -> dict:
+        """Version history of a document — who changed it, when, and why.
+
+        Single source of truth behind both the ``akb_history`` MCP tool and
+        ``GET /api/v1/history/{vault}/{doc}``. Each entry is a git commit.
+
+        The doc's ``created_at`` is passed to git as a lineage boundary so
+        commits from a *previous* document at the same path (deleted-and-
+        recreated) don't leak into this doc's history — git keys by path,
+        not by document identity. Each entry is annotated with a human
+        ``author_name`` resolved from the git author.
+
+        Raises ``NotFoundError`` for a missing vault or document; callers
+        leave the HTTP/MCP mapping to the global error handlers.
+        """
+        doc_ref = to_nfc(doc_ref)
+        vault_repo, doc_repo, _ = await self._repos()
+
+        vault_id = await vault_repo.get_id_by_name(vault)
+        if not vault_id:
+            raise NotFoundError("Vault", vault)
+
+        row = await doc_repo.find_by_ref(vault_id, doc_ref)
+        if not row:
+            raise NotFoundError("Document", doc_ref)
+
+        since_epoch = None
+        created_at = row.get("created_at")
+        if created_at is not None:
+            since_epoch = int(created_at.timestamp())
+
+        entries = await asyncio.to_thread(
+            self.git.file_log,
+            vault, row["path"],
+            max_count=limit, since_epoch=since_epoch,
+        )
+        entries = await self._annotate_history_authors(entries)
+        return {"uri": doc_uri(row["vault_name"], row["path"]), "history": entries}
+
+    async def _annotate_history_authors(self, entries: list[dict]) -> list[dict]:
+        """Add a human ``author_name`` to each ``file_log`` entry.
+
+        The write path sets the git author name to the actor's ``agent_id``,
+        which is the user's ``username`` (see ``put``/``update``). Legacy or
+        external-git rows may instead carry a user UUID. Resolve *either*
+        form to ``display_name`` (falling back to username) in one batched
+        query so the UI shows a real name. Authors that match no user (e.g.
+        external-git imports) keep only the raw ``author``.
+        """
+        authors = {e["author"] for e in entries if e.get("author")}
+        if not authors:
+            return entries
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id::text AS id, username,
+                       COALESCE(display_name, username) AS name
+                  FROM users
+                 WHERE id::text = ANY($1) OR username = ANY($1)
+                """,
+                list(authors),
+            )
+        name_by_key: dict[str, str] = {}
+        for r in rows:
+            name_by_key[r["id"]] = r["name"]
+            name_by_key[r["username"]] = r["name"]
+        for e in entries:
+            name = name_by_key.get(e.get("author"))
+            if name:
+                e["author_name"] = name
+        return entries
 
     async def _get_public_slug(self, vault_name: str, doc_path: str) -> str | None:
         """Return the newest publication slug for a document, or None.

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1212,27 +1212,12 @@ async def _handle_delete_collection(args: dict, uid: str, user: _MCPUser) -> dic
 @_h("akb_history")
 async def _handle_history(args: dict, uid: str, user: _MCPUser) -> dict:
     vault, doc_path = split_uri(args["uri"], expected_type="doc")
-    doc_path = to_nfc(doc_path)
     await check_vault_access(uid, vault, required_role="reader")
-    doc = await _find_doc(vault, doc_path)
-    if not doc:
-        return err(f"Document not found: {args['uri']}", code=NOT_FOUND)
-    from app.services.git_service import GitService
-    git = GitService()
-    # Pass the doc's created_at as a lineage boundary so commits from a
-    # previous document at the same path (deleted-and-recreated) don't
-    # leak into this doc's history. created_at lives on the documents
-    # row; convert to Unix seconds for git's filter.
-    since_epoch = None
-    created_at = doc.get("created_at")
-    if created_at is not None:
-        since_epoch = int(created_at.timestamp())
-    history = git.file_log(
-        vault, doc["path"],
-        max_count=args.get("limit", 20),
-        since_epoch=since_epoch,
-    )
-    return {"uri": doc_uri(vault, doc["path"]), "history": history}
+    # Doc resolution, the created_at lineage boundary, and author
+    # annotation all live in DocumentService.history() so this tool and
+    # GET /history stay byte-for-byte identical. A missing doc raises
+    # NotFoundError, mapped to err(code=NOT_FOUND) by exception_envelope.
+    return await doc_service.history(vault, doc_path, limit=args.get("limit", 20))
 
 
 @_h("akb_export")

--- a/backend/tests/test_document_history_unit.py
+++ b/backend/tests/test_document_history_unit.py
@@ -1,0 +1,139 @@
+"""Unit tests for DocumentService.history() and its author annotation.
+
+history() is the single source of truth behind both the akb_history MCP
+tool and GET /api/v1/history/{vault}/{doc}. These tests pin the bits that
+are easy to regress without a live DB/git: the created_at lineage boundary,
+the NotFoundError surface, and the id-OR-username → display_name resolver.
+Full git integration is covered by the e2e suites.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.exceptions import NotFoundError
+from app.services.document_service import DocumentService
+
+
+def _service_with_repos(*, vault_id, doc_row):
+    """A DocumentService whose _repos() returns mocked vault/doc repos."""
+    svc = DocumentService(git=MagicMock())
+    vault_repo = MagicMock()
+    vault_repo.get_id_by_name = AsyncMock(return_value=vault_id)
+    doc_repo = MagicMock()
+    doc_repo.find_by_ref = AsyncMock(return_value=doc_row)
+    svc._repos = AsyncMock(return_value=(vault_repo, doc_repo, MagicMock()))
+    return svc
+
+
+def _patch_pool(monkeypatch, *, fetch_rows):
+    """Patch document_service.get_pool so a `async with pool.acquire()` block
+    yields a conn whose .fetch(...) returns `fetch_rows`."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=fetch_rows)
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = _acquire
+    monkeypatch.setattr(
+        "app.services.document_service.get_pool", AsyncMock(return_value=pool)
+    )
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_history_missing_vault_raises_not_found():
+    svc = DocumentService(git=MagicMock())
+    vault_repo = MagicMock()
+    vault_repo.get_id_by_name = AsyncMock(return_value=None)
+    svc._repos = AsyncMock(return_value=(vault_repo, MagicMock(), MagicMock()))
+
+    with pytest.raises(NotFoundError):
+        await svc.history("ghost-vault", "doc.md")
+
+
+@pytest.mark.asyncio
+async def test_history_missing_doc_raises_not_found():
+    svc = _service_with_repos(vault_id="v1", doc_row=None)
+
+    with pytest.raises(NotFoundError):
+        await svc.history("v", "nope.md")
+
+
+@pytest.mark.asyncio
+async def test_history_passes_created_at_as_lineage_boundary(monkeypatch):
+    """created_at must reach git.file_log as Unix seconds so a re-created
+    path doesn't inherit the prior document's commits."""
+    created = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    doc_row = {
+        "path": "notes/a.md",
+        "vault_name": "v",
+        "created_at": created,
+    }
+    svc = _service_with_repos(vault_id="v1", doc_row=doc_row)
+    svc.git.file_log = MagicMock(return_value=[])
+    _patch_pool(monkeypatch, fetch_rows=[])
+
+    out = await svc.history("v", "notes/a.md", limit=7)
+
+    assert out["uri"].endswith("/doc/a.md")
+    svc.git.file_log.assert_called_once()
+    _, kwargs = svc.git.file_log.call_args
+    assert kwargs["max_count"] == 7
+    assert kwargs["since_epoch"] == int(created.timestamp())
+
+
+@pytest.mark.asyncio
+async def test_history_null_created_at_no_boundary(monkeypatch):
+    doc_row = {"path": "a.md", "vault_name": "v", "created_at": None}
+    svc = _service_with_repos(vault_id="v1", doc_row=doc_row)
+    svc.git.file_log = MagicMock(return_value=[])
+    _patch_pool(monkeypatch, fetch_rows=[])
+
+    await svc.history("v", "a.md")
+
+    _, kwargs = svc.git.file_log.call_args
+    assert kwargs["since_epoch"] is None
+
+
+@pytest.mark.asyncio
+async def test_annotate_authors_resolves_username_and_uuid(monkeypatch):
+    """The git author is normally the actor's username; legacy rows may
+    carry a UUID. Both forms resolve to display_name in one query; an
+    unknown author keeps only its raw value."""
+    entries = [
+        {"hash": "a", "author": "younglo_kim"},
+        {"hash": "b", "author": "11111111-1111-1111-1111-111111111111"},
+        {"hash": "c", "author": "external-committer"},
+    ]
+    rows = [
+        {"id": "00000000-0000-0000-0000-000000000000",
+         "username": "younglo_kim", "name": "Younglo Kim"},
+        {"id": "11111111-1111-1111-1111-111111111111",
+         "username": "alice", "name": "Alice A"},
+    ]
+    svc = DocumentService(git=MagicMock())
+    _patch_pool(monkeypatch, fetch_rows=rows)
+
+    out = await svc._annotate_history_authors(entries)
+
+    by_hash = {e["hash"]: e for e in out}
+    assert by_hash["a"]["author_name"] == "Younglo Kim"   # by username
+    assert by_hash["b"]["author_name"] == "Alice A"       # by UUID
+    assert "author_name" not in by_hash["c"]              # unresolved
+
+
+@pytest.mark.asyncio
+async def test_annotate_authors_empty_skips_query(monkeypatch):
+    conn = _patch_pool(monkeypatch, fetch_rows=[])
+    svc = DocumentService(git=MagicMock())
+
+    out = await svc._annotate_history_authors([])
+
+    assert out == []
+    conn.fetch.assert_not_called()

--- a/backend/tests/test_history_rest_e2e.sh
+++ b/backend/tests/test_history_rest_e2e.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+#
+# AKB E2E: Document version history over HTTP REST.
+#
+# Covers GET /api/v1/history/{vault}/{doc} — the REST twin of the
+# akb_history MCP tool. Both surfaces share DocumentService.history(), so
+# this asserts parity: the version list, the `limit` bound, the created_at
+# lineage boundary (recreate-at-same-path drops old commits), author_name
+# resolution (git author username → display_name), and the access matrix
+# (reader 200 / non-member 403 / unauth 401 / missing 404).
+#
+# Docs are created via the REST write path (POST /documents) so the git
+# author is the actor's username — exercising the username branch of the
+# id-OR-username author resolver. Bootstrap mirrors test_relations_rest_e2e.sh.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+PASS=0
+FAIL=0
+ERRORS=()
+MCP_ID=10
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   Document History REST E2E              ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# ── Setup ────────────────────────────────────────────────────
+echo "▸ 0. Setup"
+
+setup_user() {
+  local user=$1
+  curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"email\":\"$user@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+  local jwt=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+    -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' \
+    -d '{"name":"e2e"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null
+}
+
+setup_mcp() {
+  local pat=$1
+  local tmpfile=$(mktemp)
+  curl -sk -i -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"hist-rest-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
+  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
+  rm -f "$tmpfile"
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" \
+    -H "mcp-session-id: $sid" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+  echo "$sid"
+}
+
+mc() {
+  local pat=$1 sid=$2 tool=$3 args=$4
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "mcp-session-id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+}
+mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
+
+# ── REST helpers (PAT-authenticated) ─────────────────────────
+rput()    { curl -sk -X POST "$BASE_URL/api/v1/documents" -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$2"; }
+rpatch()  { curl -sk -X PATCH "$BASE_URL/api/v1/documents/$2" -H "Authorization: Bearer $1" -H 'Content-Type: application/json' -d "$3"; }
+rdeldoc() { curl -sk -X DELETE "$BASE_URL/api/v1/documents/$2" -H "Authorization: Bearer $1"; }
+# GET /history/{vault}/{doc}[?query]
+hget()      { curl -sk "$BASE_URL/api/v1/history/$2${3:-}" -H "Authorization: Bearer $1"; }
+hget_code() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/history/$2${3:-}" -H "Authorization: Bearer $1"; }
+
+getpath()    { python3 -c "import sys,json; print(json.load(sys.stdin).get('path',''))" 2>/dev/null; }
+hist_count() { python3 -c "import sys,json
+try:
+  print(len(json.load(sys.stdin).get('history',[])))
+except Exception: print(-1)" 2>/dev/null; }
+first_field() { python3 -c "import sys,json
+try:
+  h=json.load(sys.stdin).get('history',[]); print(h[0].get('$1','') if h else '')
+except Exception: print('')" 2>/dev/null; }
+all_annotated() { python3 -c "import sys,json
+try:
+  h=json.load(sys.stdin).get('history',[]); print(bool(h) and all('author_name' in e for e in h))
+except Exception: print(False)" 2>/dev/null; }
+
+USER1="hist-rest-u1-$(date +%s)"     # owner (writer) of the vault
+USER2="hist-rest-u2-$(date +%s)"     # reader on the vault
+USER3="hist-rest-u3-$(date +%s)"     # no access
+PAT1=$(setup_user "$USER1")
+PAT2=$(setup_user "$USER2")
+PAT3=$(setup_user "$USER3")
+[ -n "$PAT1" ] && [ -n "$PAT2" ] && [ -n "$PAT3" ] && pass "3 users created" || { fail "Setup" "user creation failed"; exit 1; }
+
+SID1=$(setup_mcp "$PAT1")
+m1() { mc "$PAT1" "$SID1" "$1" "$2" | mr; }
+
+VAULT="hist-rest-$(date +%s)"
+m1 "akb_create_vault" "{\"name\":\"$VAULT\",\"description\":\"history rest test\"}" >/dev/null
+m1 "akb_grant" "{\"vault\":\"$VAULT\",\"user\":\"$USER2\",\"role\":\"reader\"}" >/dev/null
+pass "vault created, USER2 granted reader"
+
+# Create a doc via the REST write path (author = USER1 username), then
+# update it so the history has >= 2 commits.
+DOCPATH=$(rput "$PAT1" "{\"vault\":\"$VAULT\",\"collection\":\"history-test\",\"title\":\"History Doc\",\"content\":\"## V1\",\"slug\":\"hist-doc\"}" | getpath)
+[ -n "$DOCPATH" ] && pass "doc created via POST /documents ($DOCPATH)" || { fail "Doc" "POST /documents returned no path"; exit 1; }
+rpatch "$PAT1" "$VAULT/$DOCPATH" "{\"content\":\"## V2 updated\",\"message\":\"history rest e2e update\"}" >/dev/null
+pass "doc updated (v2)"
+
+# ── 1. GET /history — version list + entry shape ─────────────
+echo ""
+echo "▸ 1. GET /history (version list)"
+
+R=$(hget "$PAT1" "$VAULT/$DOCPATH")
+CNT=$(echo "$R" | hist_count)
+[ "$CNT" -ge 2 ] 2>/dev/null && pass "lists >= 2 versions (count=$CNT)" || fail "history list" "expected >=2, got $CNT"
+
+HASH=$(echo "$R" | first_field hash)
+DATE=$(echo "$R" | first_field date)
+[ -n "$HASH" ] && pass "entry carries a commit hash ($HASH)" || fail "entry hash" "missing"
+[ -n "$DATE" ] && pass "entry carries a date" || fail "entry date" "missing"
+
+# ── 2. author_name resolution (the new annotation) ───────────
+echo ""
+echo "▸ 2. author_name resolution"
+
+AUTHOR=$(echo "$R" | first_field author)
+AUTHORNAME=$(echo "$R" | first_field author_name)
+[ "$AUTHOR" = "$USER1" ] && pass "raw git author is the actor username" || fail "author" "expected $USER1, got '$AUTHOR'"
+# author_name is added ONLY by the resolver — raw file_log has no such key.
+# Its presence proves the username branch matched; no display_name set on the
+# user, so COALESCE(display_name, username) == username.
+[ "$AUTHORNAME" = "$USER1" ] && pass "author_name resolved (username→display_name)" || fail "author_name" "expected $USER1, got '$AUTHORNAME'"
+[ "$(echo "$R" | all_annotated)" = "True" ] && pass "every entry annotated with author_name" || fail "annotate all" "some entries missing author_name"
+
+# ── 3. limit bound ───────────────────────────────────────────
+echo ""
+echo "▸ 3. limit query"
+
+ONE=$(hget "$PAT1" "$VAULT/$DOCPATH" "?limit=1" | hist_count)
+[ "$ONE" = "1" ] && pass "limit=1 returns exactly 1 entry" || fail "limit=1" "got $ONE"
+CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH" "?limit=0")
+[ "$CODE" = "422" ] && pass "limit=0 → 422 (below ge=1)" || fail "limit=0" "got $CODE"
+CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH" "?limit=500")
+[ "$CODE" = "422" ] && pass "limit=500 → 422 (above le=100)" || fail "limit=500" "got $CODE"
+
+# ── 4. access matrix ─────────────────────────────────────────
+echo ""
+echo "▸ 4. access matrix"
+
+CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH")
+[ "$CODE" = "200" ] && pass "owner → 200" || fail "owner" "got $CODE"
+CODE=$(hget_code "$PAT2" "$VAULT/$DOCPATH")
+[ "$CODE" = "200" ] && pass "granted reader → 200" || fail "reader" "got $CODE"
+CODE=$(hget_code "$PAT3" "$VAULT/$DOCPATH")
+[ "$CODE" = "403" ] && pass "non-member → 403" || fail "non-member" "got $CODE"
+CODE=$(curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/history/$VAULT/$DOCPATH")
+[ "$CODE" = "401" ] && pass "unauthenticated → 401" || fail "no auth" "got $CODE"
+
+# ── 5. not found ─────────────────────────────────────────────
+echo ""
+echo "▸ 5. not found"
+
+CODE=$(hget_code "$PAT1" "$VAULT/history-test/does-not-exist.md")
+[ "$CODE" = "404" ] && pass "missing document → 404" || fail "missing doc" "got $CODE"
+CODE=$(hget_code "$PAT1" "ghost-vault-$(date +%s)/history-test/hist-doc.md")
+[ "$CODE" = "404" ] && pass "missing vault → 404" || fail "missing vault" "got $CODE"
+
+# ── 6. created_at lineage boundary (parity with MCP akb_history T6) ─
+# Delete the doc and recreate it at the same path; the new document's
+# created_at trims the prior lineage so only the recreate commit shows.
+# sleep 1 keeps the delete commit strictly older than the new created_at
+# (the boundary is `committed_date >= created_at`, second-granular).
+echo ""
+echo "▸ 6. lineage boundary (recreate at same path)"
+
+rdeldoc "$PAT1" "$VAULT/$DOCPATH" >/dev/null
+sleep 1
+rput "$PAT1" "{\"vault\":\"$VAULT\",\"collection\":\"history-test\",\"title\":\"History Doc\",\"content\":\"## reborn\",\"slug\":\"hist-doc\"}" >/dev/null
+AFTER=$(hget "$PAT1" "$VAULT/$DOCPATH" | hist_count)
+[ "$AFTER" = "1" ] && pass "recreate → count=1 (old commits trimmed, was $CNT)" || fail "lineage" "expected 1, got $AFTER"
+
+# ── Cleanup ──────────────────────────────────────────────────
+echo ""
+echo "▸ Cleanup"
+m1 "akb_delete_vault" "{\"name\":\"$VAULT\"}" >/dev/null 2>&1
+pass "Vault deleted"
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  for e in "${ERRORS[@]}"; do echo "    - $e"; done
+  echo "════════════════════════════════════════════"
+  exit 1
+fi
+echo "════════════════════════════════════════════"


### PR DESCRIPTION
## What

Exposes document version history over REST: `GET /api/v1/history/{vault}/{doc}` — the REST twin of the `akb_history` MCP tool.

## How

- **Shared logic**: extracted `DocumentService.history()` as the single source of truth behind both the MCP tool and the new REST route. It resolves the doc, applies the `created_at` lineage boundary (a deleted-and-recreated path no longer inherits the prior document's commits), and annotates each entry with `author_name`. `_handle_history` (MCP) is reduced to an access check plus a call to the shared method.
- **author_name resolution**: the git author is the actor's `username` on the normal write path (legacy/external rows may carry a UUID). A single batched `id OR username → COALESCE(display_name, username)` query resolves either form; unmatched authors (external-git imports) keep only the raw `author`.
- **Route placement**: under `/history/...` rather than nested in `/documents/...`, because the greedy `{doc_id:path}` converter on `GET /documents/{vault}/{doc_id}` (registered first) would otherwise swallow the `/history` suffix.
- **Errors**: the shared method raises `NotFoundError`; existing global handlers map it (REST `AKBError`→404, MCP `exception_envelope`→`NOT_FOUND`) with no per-call-site code.

## User-facing changes

- New endpoint `GET /api/v1/history/{vault}/{doc}?limit=N` (reader access; `limit` 1–100, default 20).
- `akb_history` MCP responses now additionally include `author_name` per entry (additive, backward-compatible).

## Tests

- 6 unit tests (`test_document_history_unit.py`): lineage boundary, NotFound surface, username + UUID author resolution.
- 21-assertion REST e2e (`test_history_rest_e2e.sh`): version list, `limit` bounds (422), `author_name`, lineage boundary parity with MCP, access matrix (200/403/401), 404s.
- Regression: `test_mcp_e2e.sh` 88/88 (incl. `akb_history`), MCP lineage T6 pass. autoreview (codex/gpt-5.5) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
