### PR TITLE
fix(docs): resolve author names by username, not just UUID

### DIFF
--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -7,7 +7,6 @@ management. The file was renamed accordingly.
 """
 
 import json
-import uuid as _uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -16,6 +15,7 @@ from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
 from app.services.document_service import DocumentService
 from app.services.git_service import GitService
+from app.services.user_directory import resolve_display_names
 from app.db.postgres import get_pool
 from app.repositories.document_repo import DocumentRepository
 
@@ -24,44 +24,23 @@ git = GitService()
 doc_service = DocumentService()
 
 
-def _is_uuid(value: str | None) -> bool:
-    if not value:
-        return False
-    try:
-        _uuid.UUID(str(value))
-        return True
-    except (ValueError, AttributeError, TypeError):
-        return False
-
-
 async def _resolve_activity_authors(entries: list[dict]) -> list[dict]:
     """Add a human `author_name` to each commit-log entry.
 
-    App commits set the git author to the actor's user UUID, so the raw log
-    shows raw ids. Batch-resolve the UUID author/agent values to display names
-    (display_name → username) so the UI can show a name instead. Non-UUID
-    authors (external-git imports) are left for the UI to show as-is.
+    The git author/agent token is the actor's username on the normal write
+    path (older rows / some lifecycle ops carry the user UUID). Resolve either
+    form to a display name so the UI shows a name instead of a raw token.
+    Authors that match no user (external-git imports) are left as-is.
     """
-    ids = {
-        v
-        for e in entries
-        for v in (e.get("agent"), e.get("author"))
-        if _is_uuid(v)
-    }
-    if not ids:
+    names = await resolve_display_names(
+        v for e in entries for v in (e.get("agent"), e.get("author"))
+    )
+    if not names:
         return entries
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            "SELECT id::text AS id, COALESCE(display_name, username) AS name "
-            "FROM users WHERE id::text = ANY($1)",
-            list(ids),
-        )
-    name_by_id = {r["id"]: r["name"] for r in rows}
     for e in entries:
         raw = e.get("agent") or e.get("author")
-        if raw in name_by_id:
-            e["author_name"] = name_by_id[raw]
+        if raw and raw in names:
+            e["author_name"] = names[raw]
     return entries
 
 

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -109,9 +109,10 @@ class DocumentResponse(BaseModel):
     summary: str | None = None
     domain: str | None = None
     created_by: str | None = None
-    # Human display name resolved from `created_by` (a user UUID) at read time,
-    # so the UI can show an author name instead of a raw id. Null for
-    # external-git imports (non-user author strings) or unknown ids.
+    # Human display name resolved from `created_by` (a username, or a UUID on
+    # older rows) at read time, so the UI can show an author name instead of a
+    # raw token. Null for external-git imports (non-user author strings) or
+    # unknown tokens.
     created_by_name: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -134,6 +134,7 @@ from app.services.kg_service import delete_document_relations, store_document_re
 from app.services.resource_hash import HASH_ALGORITHM, compute_text_content_hash
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
+from app.services.user_directory import resolve_display_names
 from app.repositories import table_data_repo
 from app.utils import ensure_list
 
@@ -226,28 +227,17 @@ class DocumentService:
         return VaultRepository(pool), DocumentRepository(pool), CollectionRepository(pool)
 
     async def _resolve_author_name(self, created_by: str | None) -> str | None:
-        """Resolve a `created_by` user id to a human display name for the UI.
+        """Resolve a `created_by` token to a human display name for the UI.
 
-        App-authored docs store a user UUID; external-git imports store a
-        non-UUID author string (left for the caller to show as-is). Returns the
-        user's display_name (falling back to username), or None when the id
-        isn't a UUID or doesn't match a user.
+        The write path stores the actor's ``username`` in ``created_by`` (it is
+        the ``agent_id`` passed to ``put``); older rows may store a user UUID.
+        Resolve either form to ``display_name`` (falling back to username), or
+        None when the token is empty or matches no user (external-git imports).
         """
         if not created_by:
             return None
-        try:
-            uuid.UUID(str(created_by))
-        except (ValueError, AttributeError, TypeError):
-            return None
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            row = await conn.fetchrow(
-                "SELECT display_name, username FROM users WHERE id::text = $1",
-                str(created_by),
-            )
-        if not row:
-            return None
-        return row["display_name"] or row["username"]
+        names = await resolve_display_names([created_by])
+        return names.get(created_by)
 
     async def _ensure_document_hash(
         self,
@@ -687,34 +677,18 @@ class DocumentService:
 
         The write path sets the git author name to the actor's ``agent_id``,
         which is the user's ``username`` (see ``put``/``update``). Legacy or
-        external-git rows may instead carry a user UUID. Resolve *either*
-        form to ``display_name`` (falling back to username) in one batched
-        query so the UI shows a real name. Authors that match no user (e.g.
-        external-git imports) keep only the raw ``author``.
+        external-git rows may instead carry a user UUID. ``resolve_display_names``
+        handles either form; authors that match no user keep only the raw
+        ``author``.
         """
-        authors = {e["author"] for e in entries if e.get("author")}
-        if not authors:
+        names = await resolve_display_names(e.get("author") for e in entries)
+        if not names:
             return entries
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(
-                """
-                SELECT id::text AS id, username,
-                       COALESCE(display_name, username) AS name
-                  FROM users
-                 WHERE id::text = ANY($1) OR username = ANY($1)
-                """,
-                list(authors),
-            )
-        name_by_key: dict[str, str] = {}
-        for r in rows:
-            name_by_key[r["id"]] = r["name"]
-            name_by_key[r["username"]] = r["name"]
         for e in entries:
             author = e.get("author")
             if not author:
                 continue
-            name = name_by_key.get(author)
+            name = names.get(author)
             if name:
                 e["author_name"] = name
         return entries

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -782,7 +782,11 @@ async def resolve_document_publication(publication: dict) -> dict:
                    COALESCE(u.display_name, u.username) AS created_by_name
             FROM documents d
             JOIN vaults v ON d.vault_id = v.id
-            LEFT JOIN users u ON u.id::text = d.created_by
+            -- created_by holds the actor's username on the normal write path
+            -- (older rows store a UUID); match either form, mirroring
+            -- user_directory.resolve_display_names.
+            LEFT JOIN users u
+                ON u.id::text = d.created_by OR u.username = d.created_by
             WHERE v.name = $1 AND d.path = $2
             """,
             uri_vault, doc_path,

--- a/backend/app/services/user_directory.py
+++ b/backend/app/services/user_directory.py
@@ -1,0 +1,47 @@
+"""Resolve actor identifiers to human display names.
+
+Across git-derived surfaces (document history, vault activity, ``created_by``)
+the stored actor token is sometimes the user's UUID (older rows and some
+lifecycle ops) and sometimes the username — the normal document write path
+sets ``GIT_AUTHOR_NAME`` to ``agent_id``, which is the user's ``username``
+(see ``DocumentService.put``/``update``). A single batched lookup keyed by
+**id OR username** resolves either form to ``display_name`` (falling back to
+``username``), so every surface shows a real name instead of a raw token.
+
+Tokens that match no user (e.g. external-git imports, which carry arbitrary
+author strings) are simply absent from the result; callers show them as-is.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from app.db.postgres import get_pool
+
+
+async def resolve_display_names(tokens: Iterable[str | None]) -> dict[str, str]:
+    """Map each actor token (user UUID or username) to a display name.
+
+    Returns a dict keyed by **both** the matched ``id`` and ``username`` so a
+    caller can look up by whichever token it holds. One batched query; falsy
+    tokens are dropped, and tokens that match no user are omitted from the map.
+    """
+    keys = [t for t in set(tokens) if t]
+    if not keys:
+        return {}
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id::text AS id, username,
+                   COALESCE(display_name, username) AS name
+              FROM users
+             WHERE id::text = ANY($1) OR username = ANY($1)
+            """,
+            keys,
+        )
+    out: dict[str, str] = {}
+    for r in rows:
+        out[r["id"]] = r["name"]
+        out[r["username"]] = r["name"]
+    return out

--- a/backend/tests/test_author_resolution_e2e.sh
+++ b/backend/tests/test_author_resolution_e2e.sh
@@ -34,7 +34,7 @@ echo "╚═══════════════════════�
 echo ""
 echo "▸ 0. Setup"
 
-DISPLAY="Younglo Display E2E"
+DISPLAY="Display Name E2E"
 
 # register → login → PAT; returns "PAT JWT"
 setup_user() {

--- a/backend/tests/test_author_resolution_e2e.sh
+++ b/backend/tests/test_author_resolution_e2e.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# AKB E2E: actor → display-name resolution across read surfaces.
+#
+# Regression for the latent gap where author/created_by resolution only
+# matched a user UUID. The document write path stores the actor's *username*
+# (GIT_AUTHOR_NAME = agent_id = username), so the UUID-only resolvers returned
+# nothing for app-authored content. The shared user_directory.resolve_display_names
+# (id OR username) now backs every surface:
+#   1. GET /api/v1/documents/{vault}/{doc}     → created_by_name
+#   2. GET /api/v1/activity/{vault}            → activity[].author_name
+#   3. GET /api/v1/history/{vault}/{doc}       → history[].author_name
+#   4. GET /api/v1/public/{slug} (document)    → created_by_name (publication)
+#
+# A distinct display_name (set via PATCH /auth/me) is used so each assertion
+# proves username→display_name resolution rather than just echoing the username.
+# Bootstrap mirrors test_history_rest_e2e.sh.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+PASS=0
+FAIL=0
+ERRORS=()
+MCP_ID=10
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   Author / display-name resolution E2E   ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+echo "▸ 0. Setup"
+
+DISPLAY="Younglo Display E2E"
+
+# register → login → PAT; returns "PAT JWT"
+setup_user() {
+  local user=$1
+  curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"email\":\"$user@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+  local jwt=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  local pat=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+    -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' \
+    -d '{"name":"e2e"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  echo "$pat"
+}
+
+setup_mcp() {
+  local pat=$1
+  local tmpfile=$(mktemp)
+  curl -sk -i -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"author-res-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
+  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
+  rm -f "$tmpfile"
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
+    -H "mcp-session-id: $sid" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+  echo "$sid"
+}
+
+mc() {
+  local pat=$1 sid=$2 tool=$3 args=$4
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+}
+mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
+
+jget() { python3 -c "import sys,json
+try:
+  d=json.load(sys.stdin)
+  for k in '$1'.split('.'):
+    d = d[int(k)] if k.lstrip('-').isdigit() else d.get(k)
+  print(d if d is not None else '')
+except Exception: print('')" 2>/dev/null; }
+
+USER1="authres-u1-$(date +%s)"
+PAT1=$(setup_user "$USER1")
+[ -n "$PAT1" ] && pass "user created" || { fail "Setup" "user creation failed"; exit 1; }
+
+# Set a distinct display_name so resolution is provable (not username echo).
+DN_OK=$(curl -sk -X PATCH "$BASE_URL/api/v1/auth/me" \
+  -H "Authorization: Bearer $PAT1" -H 'Content-Type: application/json' \
+  -d "{\"display_name\":\"$DISPLAY\"}" | jget display_name)
+[ "$DN_OK" = "$DISPLAY" ] && pass "display_name set to '$DISPLAY'" || fail "display_name" "got '$DN_OK'"
+
+SID1=$(setup_mcp "$PAT1")
+VAULT="authres-$(date +%s)"
+mc "$PAT1" "$SID1" "akb_create_vault" "{\"name\":\"$VAULT\",\"description\":\"author resolution test\"}" >/dev/null
+pass "vault created"
+
+# Create a doc via the REST write path → documents.created_by = USER1 username.
+PUT=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $PAT1" -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"authres\",\"title\":\"Author Doc\",\"content\":\"# Hi\",\"slug\":\"author-doc\"}")
+DOCPATH=$(echo "$PUT" | jget path)
+DOCURI=$(echo "$PUT" | jget uri)
+[ -n "$DOCPATH" ] && [ -n "$DOCURI" ] && pass "doc created ($DOCPATH)" || { fail "Doc" "POST /documents returned no path/uri"; exit 1; }
+
+# ── 1. GET /documents → created_by_name ──────────────────────
+echo ""
+echo "▸ 1. document created_by_name"
+CBN=$(curl -sk "$BASE_URL/api/v1/documents/$VAULT/$DOCPATH" -H "Authorization: Bearer $PAT1" | jget created_by_name)
+[ "$CBN" = "$DISPLAY" ] && pass "created_by_name resolves username→display_name" || fail "created_by_name" "expected '$DISPLAY', got '$CBN'"
+
+# ── 2. GET /activity → author_name ───────────────────────────
+echo ""
+echo "▸ 2. activity author_name"
+AN=$(curl -sk "$BASE_URL/api/v1/activity/$VAULT" -H "Authorization: Bearer $PAT1" | jget activity.0.author_name)
+[ "$AN" = "$DISPLAY" ] && pass "activity[0].author_name resolves to display_name" || fail "activity author_name" "expected '$DISPLAY', got '$AN'"
+
+# ── 3. GET /history → author_name (shared resolver, regression) ─
+echo ""
+echo "▸ 3. history author_name"
+HN=$(curl -sk "$BASE_URL/api/v1/history/$VAULT/$DOCPATH" -H "Authorization: Bearer $PAT1" | jget history.0.author_name)
+[ "$HN" = "$DISPLAY" ] && pass "history[0].author_name resolves to display_name" || fail "history author_name" "expected '$DISPLAY', got '$HN'"
+
+# ── 4. publication created_by_name (public viewer) ───────────
+echo ""
+echo "▸ 4. publication created_by_name"
+SLUG=$(curl -sk -X POST "$BASE_URL/api/v1/publications/$VAULT/create" \
+  -H "Authorization: Bearer $PAT1" -H 'Content-Type: application/json' \
+  -d "{\"resource_type\":\"document\",\"uri\":\"$DOCURI\"}" | jget slug)
+if [ -n "$SLUG" ]; then
+  pass "document published (slug=$SLUG)"
+  PCBN=$(curl -sk "$BASE_URL/api/v1/public/$SLUG" | jget created_by_name)
+  [ "$PCBN" = "$DISPLAY" ] && pass "public publication created_by_name resolves to display_name" || fail "pub created_by_name" "expected '$DISPLAY', got '$PCBN'"
+else
+  fail "publish" "no slug returned"
+fi
+
+# ── Cleanup ──────────────────────────────────────────────────
+echo ""
+echo "▸ Cleanup"
+mc "$PAT1" "$SID1" "akb_delete_vault" "{\"name\":\"$VAULT\"}" >/dev/null 2>&1
+pass "Vault deleted"
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo "  Failures:"
+  for e in "${ERRORS[@]}"; do echo "    - $e"; done
+  echo "════════════════════════════════════════════"
+  exit 1
+fi
+echo "════════════════════════════════════════════"

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -3,12 +3,26 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from hashlib import sha256
+from unittest.mock import AsyncMock
 
 import pytest
 
 from app.exceptions import ConflictError
 from app.models.document import BrowseItem, DocumentPutResponse, DocumentResponse, DocumentUpdateRequest
 from app.services.document_service import DocumentService
+
+
+@pytest.fixture(autouse=True)
+def _stub_author_resolution(monkeypatch):
+    """get()/get_at_commit() resolve created_by → display_name via a DB query
+    (user_directory.resolve_display_names). These hash-contract tests mock the
+    document repos but run without a DB, so stub the resolver to keep the read
+    path from opening a real pool. Resolution itself is covered in
+    test_user_directory_unit.py."""
+    monkeypatch.setattr(
+        "app.services.document_service.resolve_display_names",
+        AsyncMock(return_value={}),
+    )
 
 
 class _FakeVaultRepo:

--- a/backend/tests/test_document_history_unit.py
+++ b/backend/tests/test_document_history_unit.py
@@ -112,13 +112,13 @@ async def test_annotate_authors_resolves_username_and_uuid(monkeypatch):
     carry a UUID. Both forms resolve to display_name in one query; an
     unknown author keeps only its raw value."""
     entries = [
-        {"hash": "a", "author": "younglo_kim"},
+        {"hash": "a", "author": "carol"},
         {"hash": "b", "author": "11111111-1111-1111-1111-111111111111"},
         {"hash": "c", "author": "external-committer"},
     ]
     rows = [
         {"id": "00000000-0000-0000-0000-000000000000",
-         "username": "younglo_kim", "name": "Younglo Kim"},
+         "username": "carol", "name": "Carol Carter"},
         {"id": "11111111-1111-1111-1111-111111111111",
          "username": "alice", "name": "Alice A"},
     ]
@@ -128,7 +128,7 @@ async def test_annotate_authors_resolves_username_and_uuid(monkeypatch):
     out = await svc._annotate_history_authors(entries)
 
     by_hash = {e["hash"]: e for e in out}
-    assert by_hash["a"]["author_name"] == "Younglo Kim"   # by username
+    assert by_hash["a"]["author_name"] == "Carol Carter"   # by username
     assert by_hash["b"]["author_name"] == "Alice A"       # by UUID
     assert "author_name" not in by_hash["c"]              # unresolved
 
@@ -150,11 +150,11 @@ async def test_resolve_author_name_resolves_username(monkeypatch):
     resolve to display_name (the latent gap: the old UUID-only resolver
     returned None for usernames)."""
     rows = [{"id": "00000000-0000-0000-0000-000000000000",
-             "username": "younglo_kim", "name": "Younglo Kim"}]
+             "username": "carol", "name": "Carol Carter"}]
     _patch_pool(monkeypatch, fetch_rows=rows)
     svc = DocumentService(git=MagicMock())
 
-    assert await svc._resolve_author_name("younglo_kim") == "Younglo Kim"
+    assert await svc._resolve_author_name("carol") == "Carol Carter"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_document_history_unit.py
+++ b/backend/tests/test_document_history_unit.py
@@ -1,10 +1,13 @@
-"""Unit tests for DocumentService.history() and its author annotation.
+"""Unit tests for DocumentService.history(), author annotation, and
+_resolve_author_name.
 
 history() is the single source of truth behind both the akb_history MCP
 tool and GET /api/v1/history/{vault}/{doc}. These tests pin the bits that
 are easy to regress without a live DB/git: the created_at lineage boundary,
-the NotFoundError surface, and the id-OR-username → display_name resolver.
-Full git integration is covered by the e2e suites.
+the NotFoundError surface, and the id-OR-username → display_name resolver
+(shared via user_directory.resolve_display_names). Full git integration is
+covered by the e2e suites; the resolver itself is unit-tested in
+test_user_directory_unit.py.
 """
 
 from contextlib import asynccontextmanager
@@ -29,8 +32,10 @@ def _service_with_repos(*, vault_id, doc_row):
 
 
 def _patch_pool(monkeypatch, *, fetch_rows):
-    """Patch document_service.get_pool so a `async with pool.acquire()` block
-    yields a conn whose .fetch(...) returns `fetch_rows`."""
+    """Patch user_directory.get_pool (where author resolution queries) so a
+    `async with pool.acquire()` block yields a conn whose .fetch(...) returns
+    `fetch_rows`. Author annotation flows through resolve_display_names, so the
+    annotate/history tests exercise the real resolver against this mock."""
     conn = MagicMock()
     conn.fetch = AsyncMock(return_value=fetch_rows)
 
@@ -41,7 +46,7 @@ def _patch_pool(monkeypatch, *, fetch_rows):
     pool = MagicMock()
     pool.acquire = _acquire
     monkeypatch.setattr(
-        "app.services.document_service.get_pool", AsyncMock(return_value=pool)
+        "app.services.user_directory.get_pool", AsyncMock(return_value=pool)
     )
     return conn
 
@@ -137,3 +142,28 @@ async def test_annotate_authors_empty_skips_query(monkeypatch):
 
     assert out == []
     conn.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_author_name_resolves_username(monkeypatch):
+    """created_by holds the actor's username on the write path; it must
+    resolve to display_name (the latent gap: the old UUID-only resolver
+    returned None for usernames)."""
+    rows = [{"id": "00000000-0000-0000-0000-000000000000",
+             "username": "younglo_kim", "name": "Younglo Kim"}]
+    _patch_pool(monkeypatch, fetch_rows=rows)
+    svc = DocumentService(git=MagicMock())
+
+    assert await svc._resolve_author_name("younglo_kim") == "Younglo Kim"
+
+
+@pytest.mark.asyncio
+async def test_resolve_author_name_none_and_unknown(monkeypatch):
+    conn = _patch_pool(monkeypatch, fetch_rows=[])
+    svc = DocumentService(git=MagicMock())
+
+    # Empty token short-circuits before any query.
+    assert await svc._resolve_author_name(None) is None
+    conn.fetch.assert_not_called()
+    # Unknown token (external-git import) → no match → None.
+    assert await svc._resolve_author_name("ext-committer") is None

--- a/backend/tests/test_user_directory_unit.py
+++ b/backend/tests/test_user_directory_unit.py
@@ -31,20 +31,20 @@ def _patch_pool(monkeypatch, *, fetch_rows):
 async def test_resolves_by_username_and_uuid_dual_keyed(monkeypatch):
     rows = [
         {"id": "00000000-0000-0000-0000-000000000000",
-         "username": "younglo_kim", "name": "Younglo Kim"},
+         "username": "carol", "name": "Carol Carter"},
         {"id": "11111111-1111-1111-1111-111111111111",
          "username": "alice", "name": "Alice A"},
     ]
     conn = _patch_pool(monkeypatch, fetch_rows=rows)
 
     out = await user_directory.resolve_display_names(
-        ["younglo_kim", "11111111-1111-1111-1111-111111111111", "ghost"]
+        ["carol", "11111111-1111-1111-1111-111111111111", "ghost"]
     )
 
     # Each matched user is keyed by BOTH its id and its username, so a caller
     # resolves by whichever token it holds.
-    assert out["younglo_kim"] == "Younglo Kim"
-    assert out["00000000-0000-0000-0000-000000000000"] == "Younglo Kim"
+    assert out["carol"] == "Carol Carter"
+    assert out["00000000-0000-0000-0000-000000000000"] == "Carol Carter"
     assert out["11111111-1111-1111-1111-111111111111"] == "Alice A"
     assert out["alice"] == "Alice A"
     assert "ghost" not in out
@@ -52,7 +52,7 @@ async def test_resolves_by_username_and_uuid_dual_keyed(monkeypatch):
     conn.fetch.assert_called_once()
     keys = conn.fetch.call_args.args[1]
     assert set(keys) == {
-        "younglo_kim", "11111111-1111-1111-1111-111111111111", "ghost",
+        "carol", "11111111-1111-1111-1111-111111111111", "ghost",
     }
 
 

--- a/backend/tests/test_user_directory_unit.py
+++ b/backend/tests/test_user_directory_unit.py
@@ -1,0 +1,76 @@
+"""Unit tests for user_directory.resolve_display_names.
+
+The shared id-OR-username → display_name resolver behind document history,
+vault activity, and created_by_name. These pin the dual-keying (lookup by
+either id or username), the falsy-token drop, and the empty short-circuit
+without a live DB.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services import user_directory
+
+
+def _patch_pool(monkeypatch, *, fetch_rows):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=fetch_rows)
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = _acquire
+    monkeypatch.setattr(
+        "app.services.user_directory.get_pool", AsyncMock(return_value=pool)
+    )
+    return conn
+
+
+async def test_resolves_by_username_and_uuid_dual_keyed(monkeypatch):
+    rows = [
+        {"id": "00000000-0000-0000-0000-000000000000",
+         "username": "younglo_kim", "name": "Younglo Kim"},
+        {"id": "11111111-1111-1111-1111-111111111111",
+         "username": "alice", "name": "Alice A"},
+    ]
+    conn = _patch_pool(monkeypatch, fetch_rows=rows)
+
+    out = await user_directory.resolve_display_names(
+        ["younglo_kim", "11111111-1111-1111-1111-111111111111", "ghost"]
+    )
+
+    # Each matched user is keyed by BOTH its id and its username, so a caller
+    # resolves by whichever token it holds.
+    assert out["younglo_kim"] == "Younglo Kim"
+    assert out["00000000-0000-0000-0000-000000000000"] == "Younglo Kim"
+    assert out["11111111-1111-1111-1111-111111111111"] == "Alice A"
+    assert out["alice"] == "Alice A"
+    assert "ghost" not in out
+    # One batched query, passed the de-duplicated, non-falsy token list.
+    conn.fetch.assert_called_once()
+    keys = conn.fetch.call_args.args[1]
+    assert set(keys) == {
+        "younglo_kim", "11111111-1111-1111-1111-111111111111", "ghost",
+    }
+
+
+async def test_empty_and_falsy_tokens_skip_query(monkeypatch):
+    conn = _patch_pool(monkeypatch, fetch_rows=[])
+
+    assert await user_directory.resolve_display_names([]) == {}
+    assert await user_directory.resolve_display_names([None, "", None]) == {}
+    conn.fetch.assert_not_called()
+
+
+async def test_deduplicates_repeated_tokens(monkeypatch):
+    rows = [{"id": "00000000-0000-0000-0000-000000000000",
+             "username": "bob", "name": "Bob B"}]
+    conn = _patch_pool(monkeypatch, fetch_rows=rows)
+
+    out = await user_directory.resolve_display_names(["bob", "bob", "bob"])
+
+    assert out["bob"] == "Bob B"
+    keys = conn.fetch.call_args.args[1]
+    assert keys == ["bob"]


### PR DESCRIPTION
## What

Follow-up to #230. Resolves the latent gap where actor → display-name resolution matched only a user **UUID**, while the document write path stores the actor's **username** (`GIT_AUTHOR_NAME` = `agent_id` = username). The UUID-only resolvers were therefore no-ops for app-authored content: `created_by_name` was always null, and activity/history authors stayed as raw tokens.

## How

- New shared `app/services/user_directory.py::resolve_display_names()` — one batched `id OR username → COALESCE(display_name, username)` lookup, keyed by **both** id and username so callers resolve by whichever token they hold.
- Routed every surface through it:
  - `DocumentService._resolve_author_name` → `created_by_name` (akb_get / REST GET document)
  - `DocumentService._annotate_history_authors` → history (removes a duplicated inline query)
  - `activity._resolve_activity_authors` → vault activity (drops the now-dead `_is_uuid` + `uuid` import)
  - `publication_service.resolve_document_publication` JOIN → `ON u.id::text = d.created_by OR u.username = d.created_by`
- Updated the stale `created_by_name` doc comment (no longer "a user UUID").

Net: −82 lines of UUID-only/duplicated logic folded into one 47-line helper.

## User-facing changes

- `created_by_name` (document GET, publication public view) and `author_name` (activity, history) now populate for app-authored content (previously null/raw). External-git imports (non-user authors) remain unresolved, as before.

## Tests

- Unit: `test_user_directory_unit.py` (dual-keying, falsy/empty short-circuit, dedup) + `_resolve_author_name` username/none/unknown cases in `test_document_history_unit.py` — 11 unit tests pass.
- E2E: `test_author_resolution_e2e.sh` proves username→display_name across document `created_by_name`, activity `author_name`, history `author_name`, and publication `created_by_name`, using a **distinct** display_name so it isn't just echoing the username — 10/10.
- Regressions: history REST e2e 21/21, MCP e2e 88/88. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
