### PR TITLE
fix(tables): auto-bump updated_at on dynamic vault tables

### DIFF
--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -404,3 +404,24 @@ CREATE INDEX IF NOT EXISTS idx_todos_created_by ON todos(created_by);
 -- is now expressed as a vault (agent-memory-{username}) with per-session
 -- collections, driven by the /api/v1/agent-sessions REST endpoints.
 -- Existing rows are dropped by migration 031.
+
+-- ============================================================
+-- Shared trigger function: auto-bump `updated_at` on UPDATE.
+-- ============================================================
+-- PostgreSQL has no MySQL-style ON UPDATE CURRENT_TIMESTAMP, so the
+-- dynamic vault data tables (`vt_*`) attach a BEFORE UPDATE trigger that
+-- calls this function (see `table_data_repo.create_dynamic_table`).
+-- Defined here so init.sql-only bootstraps (unit tests, bare CI DBs) have
+-- the function BEFORE `create_dynamic_table` references it. Migration 038
+-- also CREATE OR REPLACEs it (for DBs provisioned before this line existed)
+-- and backfills the trigger onto pre-existing `vt_*` tables. SECURITY
+-- INVOKER (the default) is correct: the assignment needs no privilege
+-- beyond NOW(), so it runs unchanged under the per-user `akb_user_<uid>`
+-- role that `akb_sql` switches into.
+CREATE OR REPLACE FUNCTION akb_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/app/db/migrations/038_dynamic_table_updated_at_trigger.py
+++ b/backend/app/db/migrations/038_dynamic_table_updated_at_trigger.py
@@ -1,0 +1,125 @@
+"""Migration 038: auto-bump `updated_at` on dynamic vault tables.
+
+Vault data tables (`vt_<vault>__<table>`, created by
+`table_data_repo.create_dynamic_table`) carry a bookkeeping
+`updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` column. `DEFAULT NOW()`
+only fires on INSERT — PostgreSQL has no MySQL-style
+`ON UPDATE CURRENT_TIMESTAMP` — so without a trigger every UPDATE left
+`updated_at` frozen at insert time, making it an unreliable duplicate of
+`created_at`. User SQL flows through `execute_sql` verbatim (table-name
+rewrite only), so the app layer can't inject `SET updated_at = NOW()`
+either; the only robust place to enforce the invariant is the database.
+
+This migration:
+  1. Creates one shared trigger function `akb_set_updated_at()` that sets
+     `NEW.updated_at = NOW()`. It is SECURITY INVOKER (the default) — the
+     assignment needs no privilege beyond `NOW()`, so it runs unchanged
+     under the per-user `akb_user_<uid>` role that `akb_sql` switches into.
+  2. Backfills a `BEFORE UPDATE` trigger onto every existing `vt_*` table
+     that has an `updated_at` column. New tables get the trigger at create
+     time — see `table_data_repo.create_dynamic_table`.
+
+Idempotent: `CREATE OR REPLACE FUNCTION` + per-table
+`DROP TRIGGER IF EXISTS` → `CREATE TRIGGER`, so re-running is a no-op and
+self-heals a partially-applied state (e.g. some tables triggered, others
+not).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.038")
+
+# Defense-in-depth: only interpolate identifiers matching the `vt_*` shape
+# produced by `pg_table_name` (`_sanitize_pg_part` maps every
+# non-alphanumeric to `_`, so a conforming name is pure `[a-z0-9_]`). The
+# information_schema query already filters to the prefix, but the name is
+# formatted into DDL, so we re-validate before trusting it.
+_VT_NAME_RE = re.compile(r"^vt_[a-z0-9_]+$")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_set_updated_at()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                NEW.updated_at = NOW();
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+
+        # `~ '^vt_'` (regex) not `LIKE 'vt\_%'`: `_` is a literal in a
+        # regex but a wildcard in LIKE, so the regex form sidesteps the
+        # backslash-escaping footgun entirely.
+        rows = await conn.fetch(
+            """
+            SELECT t.table_name
+              FROM information_schema.tables t
+             WHERE t.table_schema = 'public'
+               AND t.table_name ~ '^vt_'
+               AND EXISTS (
+                   SELECT 1 FROM information_schema.columns c
+                    WHERE c.table_schema = 'public'
+                      AND c.table_name = t.table_name
+                      AND c.column_name = 'updated_at'
+               )
+             ORDER BY t.table_name
+            """
+        )
+
+        applied = 0
+        skipped: list[str] = []
+        for r in rows:
+            tbl = r["table_name"]
+            if not _VT_NAME_RE.fullmatch(tbl):
+                skipped.append(tbl)
+                continue
+            await conn.execute(
+                f"DROP TRIGGER IF EXISTS akb_set_updated_at_trigger ON {tbl}"
+            )
+            await conn.execute(
+                f"CREATE TRIGGER akb_set_updated_at_trigger "
+                f"BEFORE UPDATE ON {tbl} "
+                f"FOR EACH ROW EXECUTE FUNCTION akb_set_updated_at()"
+            )
+            applied += 1
+
+    logger.info(
+        "Migration 038 applied: akb_set_updated_at() + BEFORE UPDATE trigger "
+        "backfilled onto %d vt_* table(s)%s",
+        applied,
+        f" (skipped {len(skipped)} non-conforming: {skipped})" if skipped else "",
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -176,6 +176,7 @@ async def _apply_migrations() -> None:
         "035_fix_wikilink_alias_edges.py",      # repair edges whose target_uri carries a wikilink alias ([[…|label]] → …|label); strip alias, re-validate existence, drop orphans
         "036_resource_aliases.py",              # rename/move redirect table (old path/name → current resource id); old akb:// URIs keep resolving after a move
         "037_table_unique_keys_indexes.py",     # vault_tables.unique_keys + .indexes JSONB (declarative DDL metadata; AKB #215)
+        "038_dynamic_table_updated_at_trigger.py",  # akb_set_updated_at() + BEFORE UPDATE trigger on vt_* tables (PG has no ON UPDATE CURRENT_TIMESTAMP)
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -98,6 +98,17 @@ async def create_dynamic_table(conn, pg_name: str, columns: list[dict]) -> None:
     col_defs.append("created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()")
     col_defs.append("updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()")
     await conn.execute(f'CREATE TABLE {pg_name} ({", ".join(col_defs)})')
+    # Auto-bump `updated_at` on every UPDATE. PG has no MySQL-style
+    # `ON UPDATE CURRENT_TIMESTAMP`, and user SQL reaches the table verbatim
+    # through `execute_sql` (no app-layer `SET updated_at = NOW()` hook), so a
+    # BEFORE UPDATE trigger is the only robust place to enforce it. The shared
+    # `akb_set_updated_at()` function is created by migration 038 (and exists
+    # before any runtime create, since migrations run at startup).
+    await conn.execute(
+        f"CREATE TRIGGER akb_set_updated_at_trigger "
+        f"BEFORE UPDATE ON {pg_name} "
+        f"FOR EACH ROW EXECUTE FUNCTION akb_set_updated_at()"
+    )
 
 
 async def drop_dynamic_table(conn, pg_name: str) -> None:

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -199,6 +199,26 @@ mcp "$PAT" "$SID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/nul\",\"drop_un
 R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO nul (email) VALUES ('a@b')\"}")
 assert_ok "$R" "AC#3 dropped UK physically gone (dup INSERT now succeeds)"
 
+# ── updated_at auto-bump (migration 038) ──────────────────────────
+# PG has no MySQL-style ON UPDATE CURRENT_TIMESTAMP. A BEFORE UPDATE
+# trigger (akb_set_updated_at, attached by create_dynamic_table) must
+# keep updated_at fresh; without it updated_at stays frozen at insert
+# time (a useless duplicate of created_at). COUNT(*) over a predicate
+# keeps the assertion robust to clock formatting / row ordering.
+mcp "$PAT" "$SID" akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"ua\",\"columns\":[{\"name\":\"note\",\"type\":\"text\"}]}" >/dev/null
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO ua (note) VALUES ('v1')\"}" >/dev/null
+# right after INSERT both stamps share one NOW() → equal
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT COUNT(*) AS n FROM ua WHERE updated_at = created_at\"}")
+[ "$(echo "$R" | field "['items'][0]['n']")" = "1" ] && pass "updated_at == created_at right after INSERT" || fail "updated_at insert baseline" "$R"
+sleep 1
+mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"UPDATE ua SET note = 'v2'\"}" >/dev/null
+# trigger must have advanced updated_at strictly past created_at
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT COUNT(*) AS n FROM ua WHERE updated_at > created_at\"}")
+[ "$(echo "$R" | field "['items'][0]['n']")" = "1" ] && pass "updated_at auto-bumped on UPDATE (trigger fired)" || fail "updated_at not bumped on UPDATE" "$R"
+# sanity: the UPDATE itself took effect, and we did NOT touch created_at
+R=$(mcp "$PAT" "$SID" akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT note FROM ua\"}")
+echo "$R" | field "['items'][0]['note']" | grep -q "v2" && pass "UPDATE applied (note=v2)" || fail "update sanity" "$R"
+
 # ── cleanup: drop the ephemeral vault + ALL its tables ────────────
 # Required for idempotent re-runs: several tests use caller-supplied
 # constraint/index names, and a UNIQUE constraint's implicit index name is


### PR DESCRIPTION
## Problem

Dynamic vault data tables (`vt_*`) carry an `updated_at` column defined as `TIMESTAMPTZ NOT NULL DEFAULT NOW()`. `DEFAULT NOW()` only fires on INSERT, PostgreSQL has no MySQL-style `ON UPDATE CURRENT_TIMESTAMP`, and user SQL flows through `execute_sql` verbatim (table-name rewrite only). As a result `updated_at` stayed frozen at insert time — a useless duplicate of `created_at`.

## Change

Introduce a shared `BEFORE UPDATE` trigger function `akb_set_updated_at()` (`NEW.updated_at = NOW()`):

- **`init.sql`** defines the function so fresh / bootstrap DBs (including `init.sql`-only unit-test paths such as `test_alter_unique_race_unit.py`) have it before `create_dynamic_table` references the trigger.
- **Migration 038** `CREATE OR REPLACE`s it for pre-existing DBs and backfills the trigger onto every existing `vt_*` table (idempotent).
- **`create_dynamic_table`** attaches the trigger to every new table.

`SECURITY INVOKER` (the default) is sufficient: the assignment needs no privilege beyond `NOW()`, so it runs unchanged under the per-user `akb_user_<uid>` role that `akb_sql` switches into.

## User-facing behaviour change

`UPDATE`s issued through `akb_sql` on vault tables now advance `updated_at` automatically (it previously stayed at the insert timestamp). The trigger also overrides any user-supplied `updated_at` value.

## Testing

- Added `updated_at` auto-bump coverage to `test_table_constraints_e2e.sh` (32/32 pass against a local stack).
- Verified migration apply, existing-table backfill, idempotency, new-table trigger attach, and trigger precedence (overrides a user-set value) directly against a local PG.
- Reproduced the `init.sql`-only bootstrap path: function present + trigger DDL succeeds with migrations not run.
- Codex autoreview clean.

## PR checklist

- [x] Relevant E2E (`test_table_constraints_e2e.sh`) passes against the local stack; migration/backfill verified directly against PG. (Full suite not run for every file.)
- [x] No secrets, internal hostnames/IPs, or personal info in the diff.
- [x] No new `app.yaml` / `secret.yaml` config — DB-schema change only, so `config/*.yaml.example` is untouched.
- [x] User-facing behaviour change noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)