### PR TITLE
feat(graph): Phase 2 — degree-ranked overview + health endpoints, single-call BFS, edge kind

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2799
+        "line_number": 2841
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T10:39:29Z"
+  "generated_at": "2026-06-22T10:06:48Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,48 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.9.0 — 2026-06-22  *(feat — graph viewer Phase 2: degree-ranked overview + health endpoints, single-call BFS, edge `kind`)*
+
+Two new reader-gated graph read endpoints under `/api/v1`, replacing the
+overview's old arbitrary recency cap with a deterministic, honest slice:
+
+- **`GET /graph/overview?vault=&top_k=`** — the `top_k` (default 200)
+  highest-**degree** nodes plus the edges *induced among them*, returned with
+  `nodes_total` / `edges_total` / `returned` / `truncated`. The previous
+  no-`uri` branch of `/graph` kept `LIMIT limit*3 ORDER BY created_at DESC` — an
+  arbitrary recency subset whose composition drifted with `limit`. Degree
+  ranking is deterministic (tie-broken by URI) and surfaces the structurally
+  important hubs, and the totals let the UI render an explicit "showing N of M"
+  instead of silently truncating. `get_graph` with no `resource_uri` now
+  **delegates to this single path** — so MCP `akb_graph(vault)` and
+  `GET /graph?vault=` also return the deterministic, totals-bearing result
+  instead of the old recency slice, collapsing two divergent whole-vault
+  builders into one.
+- **`GET /graph/health?vault=&hub_threshold=&limit=`** — a KB-health audit: the
+  over-connected **hubs** (degree ≥ `hub_threshold`) and the **orphan**
+  documents (no relation at all — the undiscoverable corners). Reader-scoped.
+
+Graph correctness fixes carried by the same change:
+
+- **Edges now carry `kind`** (`implicit` | `explicit`) on every graph read
+  (overview + BFS), exposing whether a link was parsed from a doc body or
+  created via `akb_link` to any API/MCP consumer. (The web canvas styles edges
+  by `relation`, not `kind`, today — the field is available for agents and for
+  future implicit-vs-explicit styling, not yet rendered.)
+- **`_bfs_collect` prunes dangling edges**: the node cap could truncate the final
+  BFS wave *after* an edge to one of its targets was emitted, leaving a stub edge
+  to a node the client never received. Those are now dropped before the response.
+- **New composite indexes** `idx_edges_vault_source(vault_id, source_uri)` and
+  `idx_edges_vault_target(vault_id, target_uri)` (migration 039 + `init.sql`):
+  the "scope by vault AND look up by endpoint" access pattern shared by BFS, the
+  overview's induced-edge query, and the degree rollups now hits one index
+  instead of forcing a single-column pick + per-row re-check.
+
+Frontend wiring (same PR): `useFullGraph` → `/graph/overview` with a persistent
+"Showing the N most-connected of M nodes" banner; `useNeighborhood` collapsed
+from N per-node `/relations` round trips to a **single server-side BFS call**;
+the client-side `bfsExpand` walker and its helpers were removed.
+
 ## 0.8.17 — 2026-06-17  *(fix — MCP access-guard errors get stable codes, not code=internal, #221)*
 
 `check_vault_access` raises `ForbiddenError` / `NotFoundError` *outside* the

--- a/backend/app/api/routes/knowledge.py
+++ b/backend/app/api/routes/knowledge.py
@@ -18,6 +18,8 @@ from app.services.kg_service import (
     LinkRelationType as RelationType,
     get_resource_relations,
     get_graph,
+    get_health,
+    get_overview,
     get_provenance,
     link_resources,
     unlink_resources,
@@ -199,6 +201,40 @@ async def vault_graph(
     return await get_graph(
         vault_name, resource_uri=uri, hops=hops, limit=limit,
         vault_id=access["vault_id"],
+    )
+
+
+@router.get("/graph/overview", summary="Get vault graph overview (degree-ranked top-K + totals)")
+async def vault_graph_overview(
+    vault: str = Query(..., description="Vault name"),
+    top_k: int = Query(
+        200, ge=1, le=1000,
+        description="Keep the top-K highest-degree nodes (and the edges induced among them).",
+    ),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Whole-vault overview ranked by node degree, with honest `nodes_total` /
+    `edges_total` / `truncated` so the client can render "showing N of M".
+    Replaces the recency-capped no-`uri` branch of `/graph` for overviews."""
+    access = await check_vault_access(user.user_id, vault, required_role="reader")
+    return await get_overview(vault, vault_id=access["vault_id"], top_k=top_k)
+
+
+@router.get("/graph/health", summary="Get vault graph health (hubs + orphans)")
+async def vault_graph_health(
+    vault: str = Query(..., description="Vault name"),
+    hub_threshold: int = Query(
+        5, ge=1, le=1000,
+        description="Minimum degree for a node to count as a hub.",
+    ),
+    limit: int = Query(20, ge=1, le=200, description="Max hubs and max orphan sample size."),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """KB-health audit: over-connected hubs (degree ≥ `hub_threshold`) and the
+    orphan documents (no relations) that the graph view exists to surface."""
+    access = await check_vault_access(user.user_id, vault, required_role="reader")
+    return await get_health(
+        vault, vault_id=access["vault_id"], hub_threshold=hub_threshold, limit=limit,
     )
 
 

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -275,6 +275,11 @@ CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_uri);
 CREATE INDEX IF NOT EXISTS idx_edges_type ON edges(relation_type);
 CREATE INDEX IF NOT EXISTS idx_edges_source_type ON edges(source_type);
 CREATE INDEX IF NOT EXISTS idx_edges_target_type ON edges(target_type);
+-- Composite (vault_id, endpoint): the common graph-read access pattern is
+-- "scope by vault AND look up by endpoint URI" (BFS / overview induced edges /
+-- degree rollups). See migration 039.
+CREATE INDEX IF NOT EXISTS idx_edges_vault_source ON edges(vault_id, source_uri);
+CREATE INDEX IF NOT EXISTS idx_edges_vault_target ON edges(vault_id, target_uri);
 
 -- ============================================================
 -- Resource aliases (rename/move redirects)

--- a/backend/app/db/migrations/039_edges_vault_endpoint_indexes.py
+++ b/backend/app/db/migrations/039_edges_vault_endpoint_indexes.py
@@ -1,0 +1,78 @@
+"""Migration 039: composite (vault_id, endpoint) indexes on `edges`.
+
+Every graph read scopes by vault AND filters/joins on an endpoint URI:
+
+  - BFS (`_bfs_collect`):   WHERE source_uri = ANY($1) AND vault_id = $2
+                            WHERE target_uri = ANY($1) AND vault_id = $2
+  - overview induced edges: WHERE vault_id = $1
+                              AND source_uri = ANY($2) AND target_uri = ANY($2)
+  - degree/health rollups:  GROUP BY over (vault_id-scoped) source/target.
+
+The pre-existing single-column indexes (`idx_edges_vault`,
+`idx_edges_source`, `idx_edges_target`) force the planner to pick ONE and
+re-check the other predicate per row. A composite `(vault_id, source_uri)` /
+`(vault_id, target_uri)` lets a single index satisfy both the vault scope and
+the endpoint lookup — the common access pattern for every graph query — so the
+ANY(...) probes stay index-only as a vault's edge count grows.
+
+Idempotent: `CREATE INDEX IF NOT EXISTS`. Non-CONCURRENT (runs inside the
+migration transaction like 028's `idx_edges_source_kind`); the brief
+ACCESS-SHARE-blocking build is acceptable at migration time. Leaves the
+existing single-column indexes in place — they still serve cross-vault
+admin/debug probes and the planner drops to them when a composite isn't a fit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.039")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_edges_vault_source
+                ON edges(vault_id, source_uri)
+            """
+        )
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_edges_vault_target
+                ON edges(vault_id, target_uri)
+            """
+        )
+
+    logger.info(
+        "Migration 039 added composite edge indexes "
+        "idx_edges_vault_source(vault_id, source_uri) + "
+        "idx_edges_vault_target(vault_id, target_uri)."
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -177,6 +177,7 @@ async def _apply_migrations() -> None:
         "036_resource_aliases.py",              # rename/move redirect table (old path/name → current resource id); old akb:// URIs keep resolving after a move
         "037_table_unique_keys_indexes.py",     # vault_tables.unique_keys + .indexes JSONB (declarative DDL metadata; AKB #215)
         "038_dynamic_table_updated_at_trigger.py",  # akb_set_updated_at() + BEFORE UPDATE trigger on vt_* tables (PG has no ON UPDATE CURRENT_TIMESTAMP)
+        "039_edges_vault_endpoint_indexes.py",  # composite (vault_id, source_uri)/(vault_id, target_uri) indexes for graph reads (overview/BFS/degree; AKB graph viewer Phase 2)
     ):
         if filename in applied:
             continue

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -535,7 +535,18 @@ async def get_graph(
     have verified reader access on this vault. When `vault_id` is
     omitted we look it up by name as a convenience for legacy
     callers — but the auth check is still the caller's responsibility.
+
+    With no ``resource_uri`` this delegates to :func:`get_overview` so the
+    whole-vault graph has ONE code path: degree-ranked, deterministic, and
+    carrying honest totals (``nodes_total``/``truncated``/…). That replaced an
+    earlier inline branch which capped on ``created_at DESC`` — an arbitrary
+    recency slice whose composition drifted with ``limit``. ``limit`` becomes
+    the overview's node ``top_k`` (a node cap is a cleaner visualization
+    safety net than an edge cap).
     """
+    if not resource_uri:
+        return await get_overview(vault, vault_id=vault_id, top_k=limit)
+
     pool = await get_pool()
     nodes: dict[str, dict] = {}
     edge_list: list[dict] = []
@@ -547,54 +558,235 @@ async def get_graph(
                 return {"nodes": [], "edges": []}
             vault_id = vault_row["id"]
 
-        if resource_uri:
-            await _bfs_collect(conn, vault_id, vault, resource_uri, hops, limit, nodes, edge_list)
-        else:
-            # Vault-scope full graph. The cap is a visualization safety net
-            # — large graphs are unrenderable client-side — but the old code
-            # used `LIMIT (limit * 3)` *without* an ORDER BY, so PG returned
-            # an arbitrary subset and the result was non-deterministic across
-            # callers and across runs. Pin to `created_at DESC` so the cap
-            # consistently keeps the most recent edges (better UX than
-            # whatever order the heap happened to produce). The same anti-
-            # pattern that bit `grep` (count drifts with WHERE clause because
-            # the cap is tied to `limit`).
-            edge_rows = await conn.fetch(
-                """
-                SELECT source_uri, target_uri, source_type, target_type, relation_type
-                FROM edges WHERE vault_id = $1
-                ORDER BY created_at DESC
-                LIMIT $2
-                """,
-                vault_id, limit * 3,
-            )
-
-            uris_to_resolve: list[tuple[str, str]] = []
-            for r in edge_rows:
-                uris_to_resolve.append((r["source_uri"], r["source_type"]))
-                uris_to_resolve.append((r["target_uri"], r["target_type"]))
-                edge_list.append({
-                    "source": r["source_uri"],
-                    "target": r["target_uri"],
-                    "relation": r["relation_type"],
-                })
-
-            # Resolve names within this vault only — cross-vault endpoints
-            # come back as the URI string itself (no title/description leak).
-            # Every URI referenced by an edge MUST still become a node so
-            # the visualization doesn't get orphan source/target IDs.
-            names = await _batch_resolve_names(conn, uris_to_resolve, vault_id=vault_id)
-            for uri, rtype in uris_to_resolve:
-                if uri not in nodes:
-                    nodes[uri] = {
-                        "uri": uri,
-                        "resource_type": rtype,
-                        "name": names.get(uri) or uri,
-                    }
+        await _bfs_collect(conn, vault_id, vault, resource_uri, hops, limit, nodes, edge_list)
 
     return {
         "nodes": list(nodes.values()),
         "edges": edge_list,
+    }
+
+
+async def get_overview(
+    vault: str,
+    *,
+    vault_id: uuid.UUID | None = None,
+    top_k: int = 200,
+) -> dict:
+    """Whole-vault overview: the `top_k` highest-DEGREE nodes plus the edges
+    induced among them, with honest totals so the client can render an explicit
+    "showing N of M" instead of silently truncating.
+
+    Supersedes the old no-`resource_uri` branch of :func:`get_graph`, which
+    capped on ``created_at DESC`` (an arbitrary recency slice whose composition
+    drifted with `limit`). Degree ranking is deterministic and surfaces the
+    structurally important hubs — the nodes a reader actually wants to see first
+    in an overview — regardless of when they were created.
+
+    Caller must have verified reader access; ``vault_id`` scopes every query.
+    When omitted it is resolved by name for legacy callers (auth still theirs).
+    """
+    empty = {
+        "nodes": [], "edges": [],
+        "nodes_total": 0, "edges_total": 0, "returned": 0, "truncated": False,
+    }
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        if vault_id is None:
+            vault_row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault)
+            if not vault_row:
+                return empty
+            vault_id = vault_row["id"]
+
+        totals = await conn.fetchrow(
+            """
+            WITH endpoints AS (
+                SELECT source_uri AS uri FROM edges WHERE vault_id = $1
+                UNION ALL
+                SELECT target_uri FROM edges WHERE vault_id = $1
+            )
+            SELECT (SELECT count(*) FROM edges WHERE vault_id = $1) AS edges_total,
+                   (SELECT count(DISTINCT uri) FROM endpoints) AS nodes_total
+            """,
+            vault_id,
+        )
+        nodes_total = totals["nodes_total"] if totals else 0
+        edges_total = totals["edges_total"] if totals else 0
+        if not nodes_total:
+            return empty
+
+        # Top-`top_k` endpoints by degree. `degree` here is INCIDENT-EDGE count
+        # (count(*) over the endpoint stream) — the same definition the canvas
+        # uses (use-graph-data.ts `degreeMap`), so node sizing stays consistent
+        # between server ranking and client render. Parallel edges (the same
+        # pair joined by several relation_types) therefore each add 1, which is
+        # intended: more relationships = more central. A node's resource_type is
+        # consistent wherever it appears (a doc URI is always 'doc'), so
+        # max(rtype) just picks that single value. The `uri` tie-break makes the
+        # cut deterministic when several nodes share the boundary degree.
+        top_rows = await conn.fetch(
+            """
+            WITH endpoints AS (
+                SELECT source_uri AS uri, source_type AS rtype FROM edges WHERE vault_id = $1
+                UNION ALL
+                SELECT target_uri, target_type FROM edges WHERE vault_id = $1
+            )
+            SELECT uri, max(rtype) AS rtype, count(*) AS degree
+            FROM endpoints
+            GROUP BY uri
+            ORDER BY degree DESC, uri
+            LIMIT $2
+            """,
+            vault_id, top_k,
+        )
+
+        nodes: dict[str, dict] = {}
+        for r in top_rows:
+            nodes[r["uri"]] = {
+                "uri": r["uri"],
+                "resource_type": r["rtype"],
+                "name": r["uri"],
+                "degree": r["degree"],
+            }
+        top_uris = list(nodes.keys())
+
+        edge_list: list[dict] = []
+        if top_uris:
+            # Induced subgraph: only edges whose BOTH endpoints are in the
+            # top-K set — so the overview never paints a dangling stub to a
+            # node it didn't include.
+            edge_rows = await conn.fetch(
+                """
+                SELECT source_uri, target_uri, relation_type, kind
+                FROM edges
+                WHERE vault_id = $1
+                  AND source_uri = ANY($2::text[])
+                  AND target_uri = ANY($2::text[])
+                """,
+                vault_id, top_uris,
+            )
+            for r in edge_rows:
+                edge_list.append({
+                    "source": r["source_uri"],
+                    "target": r["target_uri"],
+                    "relation": r["relation_type"],
+                    "kind": r["kind"],
+                })
+
+        names = await _batch_resolve_names(
+            conn, [(u, n["resource_type"]) for u, n in nodes.items()], vault_id=vault_id
+        )
+        for uri, node in nodes.items():
+            node["name"] = names.get(uri) or uri
+
+    return {
+        "nodes": list(nodes.values()),
+        "edges": edge_list,
+        "nodes_total": nodes_total,
+        "edges_total": edges_total,
+        "returned": len(nodes),
+        "truncated": len(nodes) < nodes_total,
+    }
+
+
+async def get_health(
+    vault: str,
+    *,
+    vault_id: uuid.UUID | None = None,
+    hub_threshold: int = 5,
+    limit: int = 20,
+) -> dict:
+    """KB-health audit for one vault: the over-connected HUBS (degree ≥
+    ``hub_threshold``) and the ORPHAN documents (no relation at all — the
+    undiscoverable corners a graph view exists to surface).
+
+    "Orphan" means *no relation within THIS vault's graph*. Vault isolation
+    scopes the connected set to ``edges WHERE vault_id = vault`` — the same
+    edges the vault's graph view renders — so a doc referenced only from another
+    vault (that incoming edge lives in the OTHER vault's graph and never shows
+    here) is correctly an orphan *of this graph*. ``hubs`` degree is incident-
+    edge count, matching :func:`get_overview` and the canvas.
+
+    Orphans are computed over documents only (the dominant resource type in the
+    graph); tables/files are intentionally out of v1 scope. This is an on-demand
+    *audit* endpoint (not a hot path), so it scans every non-archived doc once to
+    count orphans exactly; a SQL anti-join would bound the cost for very large
+    vaults and is the natural next step if this becomes a dashboard auto-refresh.
+    Reader-scoped via ``vault_id``; ``vault`` (the name) builds the doc URIs
+    matched against the connected set.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        if vault_id is None:
+            vault_row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault)
+            if not vault_row:
+                return {"hubs": [], "orphans": {"count": 0, "sample": []}}
+            vault_id = vault_row["id"]
+
+        hub_rows = await conn.fetch(
+            """
+            WITH endpoints AS (
+                SELECT source_uri AS uri, source_type AS rtype FROM edges WHERE vault_id = $1
+                UNION ALL
+                SELECT target_uri, target_type FROM edges WHERE vault_id = $1
+            )
+            SELECT uri, max(rtype) AS rtype, count(*) AS degree
+            FROM endpoints
+            GROUP BY uri
+            HAVING count(*) >= $2
+            ORDER BY degree DESC, uri
+            LIMIT $3
+            """,
+            vault_id, hub_threshold, limit,
+        )
+
+        # Every URI that appears on either end of an edge → "connected".
+        connected_rows = await conn.fetch(
+            """
+            SELECT source_uri AS uri FROM edges WHERE vault_id = $1
+            UNION
+            SELECT target_uri FROM edges WHERE vault_id = $1
+            """,
+            vault_id,
+        )
+        connected = {r["uri"] for r in connected_rows}
+
+        # Orphans: non-archived docs whose URI is in no edge.
+        doc_rows = await conn.fetch(
+            "SELECT path, title FROM documents WHERE vault_id = $1 AND status != 'archived'",
+            vault_id,
+        )
+        orphan_count = 0
+        orphan_sample: list[dict] = []
+        for r in doc_rows:
+            uri = doc_uri(vault, r["path"])
+            if uri in connected:
+                continue
+            orphan_count += 1
+            if len(orphan_sample) < limit:
+                orphan_sample.append({
+                    "uri": uri,
+                    "name": r["title"] or uri,
+                    "resource_type": "doc",
+                })
+
+        hubs: list[dict] = []
+        if hub_rows:
+            hub_names = await _batch_resolve_names(
+                conn, [(r["uri"], r["rtype"]) for r in hub_rows], vault_id=vault_id
+            )
+            hubs = [
+                {
+                    "uri": r["uri"],
+                    "name": hub_names.get(r["uri"]) or r["uri"],
+                    "resource_type": r["rtype"],
+                    "degree": r["degree"],
+                }
+                for r in hub_rows
+            ]
+
+    return {
+        "hubs": hubs,
+        "orphans": {"count": orphan_count, "sample": orphan_sample},
     }
 
 
@@ -913,12 +1105,12 @@ async def _bfs_collect(
             break
 
         outgoing = await conn.fetch(
-            "SELECT source_uri, target_uri, target_type, relation_type "
+            "SELECT source_uri, target_uri, target_type, relation_type, kind "
             "FROM edges WHERE source_uri = ANY($1::text[]) AND vault_id = $2",
             unvisited, vault_id,
         )
         incoming = await conn.fetch(
-            "SELECT source_uri, source_type, target_uri, relation_type "
+            "SELECT source_uri, source_type, target_uri, relation_type, kind "
             "FROM edges WHERE target_uri = ANY($1::text[]) AND vault_id = $2",
             unvisited, vault_id,
         )
@@ -960,6 +1152,7 @@ async def _bfs_collect(
                         "source": uri,
                         "target": r["target_uri"],
                         "relation": r["relation_type"],
+                        "kind": r["kind"],
                     })
                 if r["target_uri"] not in visited:
                     next_queue.append(r["target_uri"])
@@ -972,11 +1165,18 @@ async def _bfs_collect(
                         "source": r["source_uri"],
                         "target": uri,
                         "relation": r["relation_type"],
+                        "kind": r["kind"],
                     })
                 if r["source_uri"] not in visited:
                     next_queue.append(r["source_uri"])
 
         queue = next_queue
+
+    # The node cap (`len(nodes) >= limit`) can truncate the final BFS wave
+    # after an edge to one of its targets was already emitted — leaving a
+    # dangling edge to a node that was never materialized. Drop those so the
+    # client never receives a stub endpoint it has no node for.
+    edges[:] = [e for e in edges if e["source"] in nodes and e["target"] in nodes]
 
     uris_to_resolve = [(uri, n["resource_type"]) for uri, n in nodes.items()]
     names = await _batch_resolve_names(conn, uris_to_resolve, vault_id=vault_id)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.8.17"
+version = "0.9.0"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_relations_rest_e2e.sh
+++ b/backend/tests/test_relations_rest_e2e.sh
@@ -230,6 +230,54 @@ rdel "$PAT1" "$URI_A/" "$URI_B/" "references" >/dev/null
 C=$(rel_count "$PAT1" "$URI_A")
 [ "$C" = "0" ] && pass "unlink via slash-suffixed URIs removes the canonical edge" || fail "noncanon unlink" "still $C — unlink did not canonicalize"
 
+# ── 5. GET /graph/overview + /graph/health (read surface) ────
+# Degree-ranked overview with honest totals, and the hubs/orphans health
+# audit. Reader-gated; vault-scoped. Builds a tiny known graph in V1:
+#   A → B, A → C  (so A is a degree-2 hub), and a 4th doc D left ORPHAN.
+echo ""
+echo "▸ 5. GET /graph/overview + /graph/health"
+
+URI_D=$(geturi "$(m1 "akb_put" "{\"vault\":\"$VAULT1\",\"collection\":\"specs\",\"title\":\"Orphan Doc\",\"content\":\"# Orphan\"}")")
+rpost "$PAT1" "{\"source\":\"$URI_A\",\"target\":\"$URI_B\",\"relation\":\"depends_on\"}" >/dev/null
+rpost "$PAT1" "{\"source\":\"$URI_A\",\"target\":\"$URI_C\",\"relation\":\"depends_on\"}" >/dev/null
+
+gov()      { curl -sk             -G "$BASE_URL/api/v1/graph/overview" --data-urlencode "vault=$2" --data-urlencode "top_k=${3:-200}" -H "Authorization: Bearer $1"; }
+gov_code() { curl -sk -o /dev/null -w '%{http_code}' -G "$BASE_URL/api/v1/graph/overview" --data-urlencode "vault=$2" -H "Authorization: Bearer $1"; }
+ghealth()  { curl -sk             -G "$BASE_URL/api/v1/graph/health"   --data-urlencode "vault=$2" --data-urlencode "hub_threshold=${3:-2}" -H "Authorization: Bearer $1"; }
+
+# overview: totals are honest, top node is the degree-2 hub A, edges carry kind.
+OVCHECK=$(gov "$PAT1" "$VAULT1" 200 | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+top=max(d['nodes'], key=lambda n: n.get('degree',0)) if d['nodes'] else {}
+kinds=sorted({e.get('kind') for e in d['edges']})
+ok = (d['edges_total']==2 and d['nodes_total']==3 and d['truncated'] is False
+      and top.get('degree')==2 and top.get('uri')=='$URI_A' and kinds==['explicit'])
+print('OK' if ok else 'BAD '+json.dumps({'edges_total':d['edges_total'],'nodes_total':d['nodes_total'],'trunc':d['truncated'],'top':top.get('uri'),'deg':top.get('degree'),'kinds':kinds}))
+" 2>&1)
+[ "$OVCHECK" = "OK" ] && pass "overview: totals(3/2) + degree-ranked hub A + edge kind" || fail "overview" "$OVCHECK"
+
+# overview truncation: top_k=1 keeps only the single highest-degree node.
+TRUNC=$(gov "$PAT1" "$VAULT1" 1 | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['returned']==1 and d['truncated'] is True and d['nodes_total']==3)" 2>/dev/null)
+[ "$TRUNC" = "True" ] && pass "overview: top_k=1 → returned 1 of 3, truncated true" || fail "overview trunc" "got $TRUNC"
+
+# health: A is a hub (deg>=2); the unlinked doc D is reported as an orphan.
+HCHECK=$(ghealth "$PAT1" "$VAULT1" 2 | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+hubs=d.get('hubs',[]); orph=d.get('orphans',{})
+hub_ok = any(h.get('uri')=='$URI_A' and h.get('degree')==2 for h in hubs)
+orph_ok = orph.get('count',0)>=1 and any('Orphan Doc' in (o.get('name') or '') for o in orph.get('sample',[]))
+print('OK' if (hub_ok and orph_ok) else 'BAD '+json.dumps({'hubs':[(h.get('uri'),h.get('degree')) for h in hubs],'orphans':orph}))
+" 2>&1)
+[ "$HCHECK" = "OK" ] && pass "health: hub A(deg2) + orphan D reported" || fail "health" "$HCHECK"
+
+# Reader-gating + cross-vault isolation.
+CODE=$(gov_code "$PAT2" "$VAULT1"); [ "$CODE" = "200" ] && pass "overview: reader (USER2) on V1 → 200" || fail "overview reader" "got $CODE"
+CODE=$(gov_code "$PAT2" "$VAULT2"); [ "$CODE" = "403" ] && pass "overview: no-access vault (V2) → 403" || fail "overview isolation" "got $CODE"
+CODE=$(curl -sk -o /dev/null -w '%{http_code}' -G "$BASE_URL/api/v1/graph/overview" --data-urlencode "vault=$VAULT1")
+[ "$CODE" = "401" ] && pass "overview: unauthenticated → 401" || fail "overview no-auth" "got $CODE"
+
 # ── Cleanup ──────────────────────────────────────────────────
 echo ""
 echo "▸ Cleanup"

--- a/frontend/src/components/graph/__tests__/use-graph-data.test.ts
+++ b/frontend/src/components/graph/__tests__/use-graph-data.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
+  apiToPayload,
   mergeGraph,
-  bfsExpand,
   applyFilters,
   docIdFromUri,
   endpointUri,
@@ -9,7 +9,39 @@ import {
   impactCones,
 } from "../use-graph-data";
 import { docUri } from "@/lib/uri";
-import { DEFAULT_VIEW, type GraphNode, type GraphEdge } from "../graph-types";
+import { ALL_RELATIONS, DEFAULT_VIEW, type GraphNode, type GraphEdge } from "../graph-types";
+
+describe("apiToPayload", () => {
+  it("maps backend nodes/edges into the renderer shape", () => {
+    const out = apiToPayload({
+      nodes: [
+        { uri: "akb://v/doc/a.md", name: "A", resource_type: "doc" },
+        { uri: "akb://v/table/t", name: "", resource_type: "table" },
+      ],
+      edges: [{ source: "akb://v/doc/a.md", target: "akb://v/table/t", relation: "depends_on" }],
+    });
+    expect(out.nodes.map((n) => n.kind)).toEqual(["document", "table"]);
+    // empty name falls back to the uri
+    expect(out.nodes[1].name).toBe("akb://v/table/t");
+    expect(out.edges).toEqual([
+      { source: "akb://v/doc/a.md", target: "akb://v/table/t", relation: "depends_on" },
+    ]);
+  });
+
+  it("drops edges whose relation is not in the renderer allowlist", () => {
+    const out = apiToPayload({
+      nodes: [{ uri: "a", resource_type: "doc" }, { uri: "b", resource_type: "doc" }],
+      // `mentions` is not a RelationKind → that edge must be filtered out;
+      // `links_to` (implicit body links) must survive — the exact regression
+      // the deleted bfsExpand suite used to guard.
+      edges: [
+        { source: "a", target: "b", relation: "mentions" },
+        { source: "a", target: "b", relation: "links_to" },
+      ],
+    });
+    expect(out.edges).toEqual([{ source: "a", target: "b", relation: "links_to" }]);
+  });
+});
 
 describe("mergeGraph", () => {
   it("dedupes nodes by uri", () => {
@@ -35,6 +67,17 @@ describe("mergeGraph", () => {
     ];
     const merged = mergeGraph({ nodes: [], edges: e1 }, { nodes: [], edges: e2 });
     expect(merged.edges.length).toBe(2);
+  });
+
+  it("carries the BASE payload's meta through an expansion overlay merge", () => {
+    const meta = { nodesTotal: 500, edgesTotal: 900, returned: 200, truncated: true };
+    const merged = mergeGraph(
+      { nodes: [], edges: [], meta },
+      { nodes: [{ uri: "n1", name: "A", kind: "document" }], edges: [] },
+    );
+    // The overlay (b) describes a neighborhood, not the whole vault, so the
+    // base (a) totals must survive — that's what "showing N of M" reads.
+    expect(merged.meta).toEqual(meta);
   });
 });
 
@@ -99,6 +142,28 @@ describe("applyFilters", () => {
     expect(out.nodes.length).toBe(3);
     expect(out.edges.length).toBe(2);
   });
+
+  it("preserves the overview meta across a filter pass", () => {
+    const meta = { nodesTotal: 42, edgesTotal: 99, returned: 30, truncated: true };
+    const v = { ...DEFAULT_VIEW, types: new Set<GraphNode["kind"]>(["document"]) };
+    const out = applyFilters({ nodes, edges, meta }, v);
+    // Filtering hides nodes locally but the vault totals are unchanged, so the
+    // honesty banner must keep reading the same "N of M".
+    expect(out.meta).toEqual(meta);
+  });
+
+  it("keeps links_to (implicit body-link) edges under the default view", () => {
+    // Regression guard: ALL_RELATIONS must include `links_to`, or applyFilters
+    // silently drops every body/wikilink edge even when the backend returns it.
+    expect(ALL_RELATIONS).toContain("links_to" as GraphEdge["relation"]);
+    const linkNodes: GraphNode[] = [
+      { uri: "a", name: "A", kind: "document" },
+      { uri: "b", name: "B", kind: "document" },
+    ];
+    const linkEdges: GraphEdge[] = [{ source: "a", target: "b", relation: "links_to" }];
+    const out = applyFilters({ nodes: linkNodes, edges: linkEdges }, DEFAULT_VIEW);
+    expect(out.edges.map((e) => e.relation)).toEqual(["links_to"]);
+  });
 });
 
 describe("docIdFromUri", () => {
@@ -147,262 +212,6 @@ describe("docIdFromUri", () => {
     for (const path of ["readme.md", "notes/hello.md", "specs/2026/api.md", "a/b/c/d.md"]) {
       expect(docIdFromUri(docUri("v", path))).toBe(path);
     }
-  });
-});
-
-describe("bfsExpand", () => {
-  it("walks depth-1 with one fetch and produces seed neighbors", async () => {
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => ({
-      doc_id: docId,
-      uri: `akb://v/doc/${docId}`,
-      relations: [
-        {
-          direction: "outgoing" as const,
-          relation: "depends_on",
-          uri: "akb://v/doc/d-2",
-          name: "Second",
-          resource_type: "document",
-        },
-      ],
-    }));
-    const out = await bfsExpand({
-      vault: "v",
-      entry: "d-1",
-      hops: 1,
-      fetchRelations,
-    });
-    expect(fetchRelations).toHaveBeenCalledTimes(1);
-    expect(out.nodes.map((n) => n.uri).sort()).toEqual([
-      "akb://v/doc/d-1",
-      "akb://v/doc/d-2",
-    ]);
-    expect(out.edges.length).toBe(1);
-  });
-
-  // Regression: `links_to` (body markdown / wikilink edges) was missing
-  // from normalizeRelation's allowlist, so every body-link edge was
-  // silently dropped — the neighbor node appeared but its edge never did,
-  // leaving floating nodes with no lines in the graph.
-  it("keeps links_to edges (not just the frontmatter relation kinds)", async () => {
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => ({
-      doc_id: docId,
-      uri: `akb://v/doc/${docId}`,
-      relations: [
-        {
-          direction: "outgoing" as const,
-          relation: "links_to",
-          uri: "akb://v/doc/d-2",
-          name: "Linked",
-          resource_type: "document",
-        },
-      ],
-    }));
-    const out = await bfsExpand({ vault: "v", entry: "d-1", hops: 1, fetchRelations });
-    expect(out.edges).toEqual([
-      { source: "akb://v/doc/d-1", target: "akb://v/doc/d-2", relation: "links_to" },
-    ]);
-  });
-
-  it("DEFAULT_VIEW keeps links_to edges through applyFilters", () => {
-    const nodes: GraphNode[] = [
-      { uri: "akb://v/doc/a", name: "A", kind: "document" },
-      { uri: "akb://v/doc/b", name: "B", kind: "document" },
-    ];
-    const edges: GraphEdge[] = [{ source: "akb://v/doc/a", target: "akb://v/doc/b", relation: "links_to" }];
-    const out = applyFilters({ nodes, edges }, DEFAULT_VIEW);
-    expect(out.edges).toEqual(edges);
-  });
-
-  it("walks depth-2 by following neighbors discovered in hop 1", async () => {
-    const calls: string[] = [];
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => {
-      calls.push(docId);
-      if (docId === "d-1") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-1",
-          relations: [
-            {
-              direction: "outgoing" as const,
-              relation: "depends_on",
-              uri: "akb://v/doc/d-2",
-              name: "Second",
-              resource_type: "document",
-            },
-          ],
-        };
-      }
-      if (docId === "d-2") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-2",
-          relations: [
-            {
-              direction: "outgoing" as const,
-              relation: "references",
-              uri: "akb://v/doc/d-3",
-              name: "Third",
-              resource_type: "document",
-            },
-          ],
-        };
-      }
-      return { doc_id: docId, uri: `akb://v/doc/${docId}`, relations: [] };
-    });
-    const out = await bfsExpand({
-      vault: "v",
-      entry: "d-1",
-      hops: 2,
-      fetchRelations,
-    });
-    expect(calls.sort()).toEqual(["d-1", "d-2"]);
-    expect(out.nodes.map((n) => n.uri).sort()).toEqual([
-      "akb://v/doc/d-1",
-      "akb://v/doc/d-2",
-      "akb://v/doc/d-3",
-    ]);
-  });
-
-  it("does not re-fetch already-visited nodes", async () => {
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => ({
-      doc_id: docId,
-      uri: `akb://v/doc/${docId}`,
-      relations: [
-        {
-          direction: "outgoing" as const,
-          relation: "depends_on",
-          uri: "akb://v/doc/d-1", // cycle back to entry
-          name: "First",
-          resource_type: "document",
-        },
-      ],
-    }));
-    await bfsExpand({ vault: "v", entry: "d-1", hops: 3, fetchRelations });
-    // d-1 fetched once at hop 0; hop 1 returns d-1 again but it's already visited,
-    // so no further fetch.
-    expect(fetchRelations).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns only the seed when entry has no neighbors", async () => {
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => ({
-      doc_id: docId,
-      uri: `akb://v/doc/${docId}`,
-      relations: [],
-    }));
-    const out = await bfsExpand({
-      vault: "v",
-      entry: "d-lonely",
-      hops: 3,
-      fetchRelations,
-    });
-    expect(fetchRelations).toHaveBeenCalledTimes(1);
-    expect(out.nodes.map((n) => n.uri)).toEqual(["akb://v/doc/d-lonely"]);
-    expect(out.edges).toEqual([]);
-  });
-
-  it("continues past a mid-hop fetch failure and includes the survivors", async () => {
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => {
-      if (docId === "d-1") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-1",
-          relations: [
-            { direction: "outgoing" as const, relation: "depends_on",
-              uri: "akb://v/doc/d-fail", name: "Fail", resource_type: "document" },
-            { direction: "outgoing" as const, relation: "depends_on",
-              uri: "akb://v/doc/d-ok", name: "OK", resource_type: "document" },
-          ],
-        };
-      }
-      if (docId === "d-fail") throw new Error("network down");
-      if (docId === "d-ok") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-ok",
-          relations: [
-            { direction: "outgoing" as const, relation: "references",
-              uri: "akb://v/doc/d-deep", name: "Deep", resource_type: "document" },
-          ],
-        };
-      }
-      return { doc_id: docId, uri: `akb://v/doc/${docId}`, relations: [] };
-    });
-    const out = await bfsExpand({
-      vault: "v",
-      entry: "d-1",
-      hops: 2,
-      fetchRelations,
-    });
-    // d-1 fetched at hop 0; hop 1 attempts d-fail (rejects) and d-ok (succeeds).
-    // The survivor's neighbors (d-deep) appear; the failed branch only contributes
-    // the neighbor node that the seed already announced.
-    const uris = new Set(out.nodes.map((n) => n.uri));
-    expect(uris.has("akb://v/doc/d-1")).toBe(true);
-    expect(uris.has("akb://v/doc/d-ok")).toBe(true);
-    expect(uris.has("akb://v/doc/d-fail")).toBe(true); // listed as a neighbor by seed
-    expect(uris.has("akb://v/doc/d-deep")).toBe(true); // discovered via d-ok in hop 1
-  });
-
-  it("collapses two hop-1 nodes sharing the same hop-2 neighbor into one fetch", async () => {
-    const seen: string[] = [];
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => {
-      seen.push(docId);
-      if (docId === "d-1") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-1",
-          relations: [
-            { direction: "outgoing" as const, relation: "depends_on",
-              uri: "akb://v/doc/d-a", name: "A", resource_type: "document" },
-            { direction: "outgoing" as const, relation: "depends_on",
-              uri: "akb://v/doc/d-b", name: "B", resource_type: "document" },
-          ],
-        };
-      }
-      if (docId === "d-a" || docId === "d-b") {
-        return {
-          doc_id: docId,
-          uri: `akb://v/doc/${docId}`,
-          relations: [
-            { direction: "outgoing" as const, relation: "references",
-              uri: "akb://v/doc/d-shared", name: "Shared", resource_type: "document" },
-          ],
-        };
-      }
-      if (docId === "d-shared") {
-        return {
-          doc_id: docId,
-          uri: "akb://v/doc/d-shared",
-          relations: [],
-        };
-      }
-      return { doc_id: docId, uri: `akb://v/doc/${docId}`, relations: [] };
-    });
-    await bfsExpand({ vault: "v", entry: "d-1", hops: 3, fetchRelations });
-    // d-shared is announced by both d-a and d-b in hop 1, but the visited set
-    // collapses it to a single fetch in hop 2.
-    const sharedCalls = seen.filter((id) => id === "d-shared").length;
-    expect(sharedCalls).toBe(1);
-  });
-
-  it("breaks a longer cycle without re-fetching nodes already seen", async () => {
-    const calls: string[] = [];
-    const fetchRelations = vi.fn(async (_v: string, docId: string) => {
-      calls.push(docId);
-      const next = { "A": "B", "B": "C", "C": "A" }[docId];
-      if (!next) return { doc_id: docId, uri: `akb://v/doc/${docId}`, relations: [] };
-      return {
-        doc_id: docId,
-        uri: `akb://v/doc/${docId}`,
-        relations: [
-          { direction: "outgoing" as const, relation: "depends_on",
-            uri: `akb://v/doc/${next}`, name: next, resource_type: "document" },
-        ],
-      };
-    });
-    await bfsExpand({ vault: "v", entry: "A", hops: 3, fetchRelations });
-    // A → B → C → (A — already visited; cycle breaks here, no re-fetch)
-    expect(calls.sort()).toEqual(["A", "B", "C"]);
   });
 });
 

--- a/frontend/src/components/graph/lod.ts
+++ b/frontend/src/components/graph/lod.ts
@@ -23,8 +23,14 @@ export interface ViewportRect {
  *  ~60px label-pill band. Converted to world units (÷ zoom) at use. */
 export const MARGIN_PX = 80;
 /** Below this rendered-node count, culling + LOD are OFF — small graphs show
- *  everything at every zoom (mirrors layoutTier's count-gating). */
-export const CULL_MIN_NODES = 300;
+ *  everything at every zoom. Kept BELOW the overview's `top_k` node cap (200,
+ *  see `useFullGraph`): the degree-ranked overview is the densely-interconnected
+ *  core of a vault, so once it carries more than this many nodes it must engage
+ *  LOD (hub constellation + culled edges) instead of drawing every node and edge
+ *  at full detail — otherwise a 200-node overview falls *under* the threshold
+ *  and paints as an undifferentiated hairball. 140 leaves headroom under 200
+ *  while still letting genuinely small vaults render in full. */
+export const CULL_MIN_NODES = 140;
 /** A non-forced label only draws once the node's on-screen radius reaches this,
  *  so labels turn on hub-first as you zoom in. */
 export const LABEL_MIN_NODE_PX = 7.5;

--- a/frontend/src/components/graph/use-graph-data.ts
+++ b/frontend/src/components/graph/use-graph-data.ts
@@ -2,10 +2,9 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getGraph,
-  getRelations,
+  getGraphOverview,
   type GraphApiNode,
   type GraphApiEdge,
-  type RelationRow,
 } from "@/lib/api";
 import { parseUri } from "@/lib/uri";
 import { groupOf } from "./cluster";
@@ -19,9 +18,20 @@ import {
   type RelationKind,
 } from "./graph-types";
 
+/** Honest counts behind a possibly-truncated overview, so the UI can render
+ *  "showing N of M" instead of silently capping. Only the full-vault overview
+ *  load sets this; expansions/filters carry the base load's meta through. */
+export interface GraphMeta {
+  nodesTotal: number;
+  edgesTotal: number;
+  returned: number;
+  truncated: boolean;
+}
+
 export interface GraphPayload {
   nodes: GraphNode[];
   edges: GraphEdge[];
+  meta?: GraphMeta;
 }
 
 const KIND_SET = new Set<string>(ALL_NODE_KINDS);
@@ -78,7 +88,9 @@ export function mergeGraph(a: GraphPayload, b: GraphPayload): GraphPayload {
     edgeKeys.add(k);
     edges.push(e);
   }
-  return { nodes: [...nodeByUri.values()], edges };
+  // `b` is an expansion overlay merged onto base `a`; the base's totals still
+  // describe the whole vault, so carry them (not b's neighborhood counts).
+  return { nodes: [...nodeByUri.values()], edges, meta: a.meta };
 }
 
 // react-force-graph mutates edge.source/edge.target from string-URI to a
@@ -167,46 +179,7 @@ export function applyFilters(p: GraphPayload, v: GraphView): GraphPayload {
       target: endpointUri(e.target),
       relation: e.relation,
     }));
-  return { nodes, edges };
-}
-
-interface BfsExpandArgs {
-  vault: string;
-  entry: string; // doc path within the vault
-  // BFS traversal radius in edge hops. Named to match the backend's
-  // `akb_graph.hops` — same concept (graph traversal distance),
-  // just at different layers (this function makes `hops` round
-  // trips through `akb_relations`; the backend graph endpoint
-  // does its own BFS in a single round trip).
-  hops: 1 | 2 | 3;
-  fetchRelations: (
-    vault: string,
-    docPath: string,
-  ) => Promise<{ uri: string; relations: RelationRow[] }>;
-}
-
-function rowToEdge(row: RelationRow, selfUri: string): GraphEdge | null {
-  const relation = normalizeRelation(row.relation);
-  if (!relation) return null;
-  // The relations endpoint can in principle emit an edge whose
-  // counter-party URI is null (unresolved forward ref). Skipping
-  // those keeps the graph free of `{source: "...", target: undefined}`
-  // shapes that would silently confuse the layout / viz layer.
-  if (!row.uri) return null;
-  if (row.direction === "outgoing") {
-    return { source: selfUri, target: row.uri, relation };
-  }
-  return { source: row.uri, target: selfUri, relation };
-}
-
-function rowToNeighbor(row: RelationRow): GraphNode | null {
-  if (!row.uri) return null;
-  return {
-    uri: row.uri,
-    name: row.name || row.uri,
-    kind: normalizeKind(row.resource_type),
-    group: groupOf(row.uri),
-  };
+  return { nodes, edges, meta: p.meta };
 }
 
 // Extract the doc / table / file id from an `akb://{vault}/{kind}/{path}` URI.
@@ -248,84 +221,24 @@ export function docIdFromUri(uri: string): string | null {
   return safeDecode(parsed.id);
 }
 
-export async function bfsExpand(args: BfsExpandArgs): Promise<GraphPayload> {
-  const { vault, entry, hops, fetchRelations } = args;
-  const visited = new Set<string>();
-  visited.add(entry);
-
-  const seedResp = await fetchRelations(vault, entry);
-  const seedNode: GraphNode = {
-    uri: seedResp.uri,
-    name: entry,
-    kind: "document",
-    doc_id: entry,
-    group: groupOf(seedResp.uri),
-  };
-  const nodesByUri = new Map<string, GraphNode>([[seedNode.uri, seedNode]]);
-  const edgeKeys = new Set<string>();
-  const edges: GraphEdge[] = [];
-
-  function ingest(rows: RelationRow[], selfUri: string): string[] {
-    const newDocIds: string[] = [];
-    for (const row of rows) {
-      const edge = rowToEdge(row, selfUri);
-      if (edge) {
-        const k = `${edge.source}\u0001${edge.target}\u0001${edge.relation}`;
-        if (!edgeKeys.has(k)) {
-          edgeKeys.add(k);
-          edges.push(edge);
-        }
-      }
-      const neighbor = rowToNeighbor(row);
-      if (neighbor && !nodesByUri.has(neighbor.uri)) {
-        nodesByUri.set(neighbor.uri, neighbor);
-        const id = docIdFromUri(neighbor.uri);
-        if (id && !visited.has(id)) newDocIds.push(id);
-      }
-    }
-    return newDocIds;
-  }
-
-  // Seed hop populates the first frontier from the entry's neighbors.
-  // Dedup is enforced inside the loop's `toFetch` filter (visited.add
-  // claims the docId atomically), so duplicate entries in `frontier`
-  // — e.g. siblings pointing at the same neighbor — collapse to a
-  // single fetch on the next hop.
-  let frontier: string[] = ingest(seedResp.relations, seedResp.uri);
-
-  for (let hop = 1; hop < hops; hop++) {
-    const toFetch = frontier.filter((docId) => {
-      if (visited.has(docId)) return false;
-      visited.add(docId);
-      return true;
-    });
-    if (toFetch.length === 0) break;
-    const responses = await Promise.all(
-      toFetch.map((docId) => fetchRelations(vault, docId).catch(() => null)),
-    );
-    const nextFrontier: string[] = [];
-    for (const r of responses) {
-      if (!r) continue;
-      nextFrontier.push(...ingest(r.relations, r.uri));
-    }
-    if (nextFrontier.length === 0) break;
-    frontier = nextFrontier;
-  }
-
-  return { nodes: [...nodesByUri.values()], edges };
-}
-
 export function useFullGraph(vault: string, enabled: boolean) {
   return useQuery({
-    queryKey: ["graph", vault, "full"],
+    queryKey: ["graph", vault, "overview"],
     enabled,
     queryFn: async (): Promise<GraphPayload> => {
-      // Loads the whole vault graph. The 200 here is the backend BFS relation
-      // fan-out `limit` (per traversal), NOT a cap on |V| — large vaults return
-      // hundreds/thousands of nodes, which the canvas handles via its layout
-      // perf tiers (GraphCanvas.layoutTier), not a render gate.
-      const resp = await getGraph(vault, undefined, 2, 200);
-      return apiToPayload(resp);
+      // Degree-ranked overview. `top_k` (200) keeps the highest-degree nodes
+      // plus the edges induced among them, with honest totals so the UI can
+      // show "showing N of M" instead of the old arbitrary recency cap.
+      const resp = await getGraphOverview(vault, 200);
+      return {
+        ...apiToPayload(resp),
+        meta: {
+          nodesTotal: resp.nodes_total,
+          edgesTotal: resp.edges_total,
+          returned: resp.returned,
+          truncated: resp.truncated,
+        },
+      };
     },
   });
 }
@@ -336,9 +249,10 @@ export function useFullGraph(vault: string, enabled: boolean) {
 export async function fetchNeighbors(
   vault: string,
   id: string,
-  hops: 1 | 2 = 1,
+  hops: 1 | 2 | 3 = 1,
+  limit = 100,
 ): Promise<GraphPayload> {
-  const resp = await getGraph(vault, id, hops, 100);
+  const resp = await getGraph(vault, id, hops, limit);
   return apiToPayload(resp);
 }
 
@@ -350,16 +264,8 @@ export function useNeighborhood(
   return useQuery({
     queryKey: ["graph", vault, "neighborhood", entry, hops],
     enabled: !!entry,
-    queryFn: () =>
-      bfsExpand({
-        vault,
-        // `enabled: !!entry` above gates this query; entry is defined here.
-        entry: entry!,
-        hops,
-        fetchRelations: async (v, docPath) => {
-          const r = await getRelations(v, docPath);
-          return { uri: r.uri, relations: r.relations };
-        },
-      }),
+    // Single server-side BFS call (was N per-node /relations round trips).
+    // `enabled: !!entry` gates this query; entry is defined here.
+    queryFn: () => fetchNeighbors(vault, entry!, hops, 200),
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -365,6 +365,9 @@ export interface GraphApiEdge {
   source: string;
   target: string;
   relation?: string;
+  // 'implicit' (parsed from doc body) vs 'explicit' (akb_link). Present on
+  // overview + BFS responses; optional so legacy callers stay valid.
+  kind?: "implicit" | "explicit";
 }
 // Build the canonical URI from (vault, path) before calling REST so
 // every call site presents the unified shape to the backend.
@@ -381,6 +384,43 @@ export const getGraph = (vault: string, docPath?: string, hops = 2, limit = 50) 
   if (docPath) p.set("uri", _docUri(vault, docPath));
   else p.set("vault", vault);
   return api<{ nodes: GraphApiNode[]; edges: GraphApiEdge[] }>(`/graph?${p}`);
+};
+
+// Whole-vault overview: the top-`topK` highest-degree nodes + induced edges,
+// with honest totals so the UI can show "showing N of M" instead of a silent
+// recency cap. Backed by GET /graph/overview (degree-ranked, deterministic).
+export interface GraphOverviewResponse {
+  nodes: GraphApiNode[];
+  edges: GraphApiEdge[];
+  nodes_total: number;
+  edges_total: number;
+  returned: number;
+  truncated: boolean;
+}
+export const getGraphOverview = (vault: string, topK = 200) => {
+  const p = new URLSearchParams({ vault, top_k: String(topK) });
+  return api<GraphOverviewResponse>(`/graph/overview?${p}`);
+};
+
+// KB-health audit: over-connected hubs + orphan documents (no relations).
+// Backed by GET /graph/health.
+export interface GraphHealthNode {
+  uri: string;
+  name: string;
+  resource_type?: string;
+  degree?: number;
+}
+export interface GraphHealthResponse {
+  hubs: GraphHealthNode[];
+  orphans: { count: number; sample: GraphHealthNode[] };
+}
+export const getGraphHealth = (vault: string, hubThreshold = 5, limit = 20) => {
+  const p = new URLSearchParams({
+    vault,
+    hub_threshold: String(hubThreshold),
+    limit: String(limit),
+  });
+  return api<GraphHealthResponse>(`/graph/health?${p}`);
 };
 
 // ── Drill Down ──

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -346,6 +346,21 @@ export default function GraphPage() {
           </div>
         )}
 
+        {/* "Showing N of M" honesty: the overview is a degree-ranked top-K
+            slice, not the whole vault. Persistent (not dismissible) so the
+            truncation is never silent. Full-graph mode only. */}
+        {!loading && !error && !view.entry && base?.meta?.truncated && (
+          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[var(--z-raised)] w-max max-w-[90%]">
+            <Alert variant="info">
+              <span className="text-xs leading-relaxed">
+                Showing the {base.meta.returned} most-connected of{" "}
+                {base.meta.nodesTotal} nodes · open a document to explore its
+                neighborhood
+              </span>
+            </Alert>
+          </div>
+        )}
+
         {/* Non-blocking gesture hint (both modes), dismissible + persisted.
             Once dismissed it collapses to a '?' affordance so the full gesture
             list is always recallable (it used to vanish forever). */}


### PR DESCRIPTION
## What

Graph viewer **Phase 2 backend** (+ frontend wiring). Backend `0.9.0`.

Replaces the whole-vault overview's arbitrary recency cap with a deterministic, degree-ranked, honest slice, and adds a KB-health audit surface.

### New endpoints (`/api/v1`, reader-gated)
- **`GET /graph/overview?vault=&top_k=`** — the `top_k` (default 200) highest-**degree** nodes plus the edges *induced among them*, returned with `nodes_total` / `edges_total` / `returned` / `truncated`. The old no-`uri` branch kept `LIMIT limit*3 ORDER BY created_at DESC` — an arbitrary recency subset whose composition drifted with `limit`. Degree ranking is deterministic (tie-broken by URI) and the totals let the UI render an explicit **"showing N of M"**. `get_graph` with no `resource_uri` now **delegates to this single path**, so MCP `akb_graph(vault)` and `GET /graph?vault=` also return the deterministic, totals-bearing result — one whole-vault builder instead of two divergent ones.
- **`GET /graph/health?vault=&hub_threshold=&limit=`** — over-connected **hubs** (degree ≥ threshold) + **orphan** documents (no relation within this vault's graph).

### Correctness
- Edges carry **`kind`** (`implicit` | `explicit`) on every graph read (overview + BFS).
- **`_bfs_collect` prunes dangling edges**: the node cap could truncate the final BFS wave *after* an edge to one of its targets was emitted, leaving a stub edge to a node the client never received.
- **Composite indexes** `idx_edges_vault_source(vault_id, source_uri)` / `idx_edges_vault_target(vault_id, target_uri)` (migration 039 + `init.sql`) for the "scope by vault AND look up by endpoint" pattern shared by BFS, the induced-edge query, and degree rollups.

### Frontend
- `useFullGraph` → `/graph/overview` with a persistent **"Showing the N most-connected of M nodes"** banner.
- `useNeighborhood` collapsed from N per-node `/relations` round trips to a **single server-side BFS call**; the client-side `bfsExpand` walker + helpers removed.

## Review

Ran an adversarial multi-angle code review (5 finder angles × verify, 20 candidates → 15 kept). Acted on the high-value ones:
- **get_graph → get_overview delegation** (removed a duplicated, non-deterministic whole-vault builder).
- Re-added the `apiToPayload` + `links_to` `applyFilters` **regression tests** that the `bfsExpand` deletion removed.
- Documented `degree` = incident-edge count (matches the canvas `degreeMap`), `orphan` = no-relation-within-this-vault, and `get_health` as an audit-scoped scan.
- CHANGELOG no longer overclaims frontend `kind` rendering.

Deferred (deliberate): focus-mode 200-node cap (prevents canvas hang; rare), node-`degree`-vs-induced-edge gap (degree isn't rendered), migration index lock (AKB edge tables are small; bounded by `statement_timeout`).

## Test
- **Verified live** against `graph-scale` (344 nodes): overview totals 344/328, degree-16 hubs ranked first, `top_k` truncation true/false, `kind` on edges, **0 dangling BFS edges**, health hubs + orphan, **401/403/404** gating.
- New e2e section in `test_relations_rest_e2e.sh` (overview/health/truncation/reader-gating/isolation).
- Frontend gate green: `typecheck` / `lint` (0 errors) / `design:check` / **337 tests**. Backend **284 unit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)