### PR TITLE
feat(auth): per-PAT vault scope (token-scoped vault restriction)

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -212,6 +212,11 @@ async def admin_reset_user_password(
 class AdminMintTokenRequest(NFCModel):
     name: str
     expires_days: int | None = None
+    # Per-PAT vault scope (Option B). Optional ``{prefixes, extra_vaults}``;
+    # ``None`` = unscoped. The admin-mint path provisions a managed agent's
+    # scoped PAT (e.g. a gardener token scoped to ``gdn-*`` ∪ an operator
+    # whitelist) without the member's password.
+    vault_scope: dict[str, list[str]] | None = None
 
 
 @router.post(
@@ -235,6 +240,7 @@ async def admin_mint_user_token(
     _require_admin(user)
     import uuid as _uuid
     from app.db.postgres import get_pool
+    from app.models.vault_scope import VaultScope
     from app.services.auth_service import create_pat
 
     pool = await get_pool()
@@ -249,7 +255,12 @@ async def admin_mint_user_token(
             )
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
-    return await create_pat(str(row["id"]), req.name, expires_days=req.expires_days)
+    return await create_pat(
+        str(row["id"]),
+        req.name,
+        expires_days=req.expires_days,
+        vault_scope=VaultScope.parse_input(req.vault_scope),
+    )
 
 
 @router.get(

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -42,11 +42,13 @@ class LoginRequest(NFCModel):
 class CreatePATRequest(NFCModel):
     name: str
     expires_days: int | None = None
-    # NOTE: scopes are stored on the `tokens` row but not enforced
-    # anywhere in the backend yet; accepting them as input would lie
-    # to the caller about a restriction that doesn't exist. When
-    # scope enforcement lands, re-expose this field with the matching
-    # check in the request handlers.
+    # Per-PAT vault scope (Option B). Optional ``{prefixes, extra_vaults}``;
+    # ``None`` = unscoped. Validated (well-formedness) + enforced (mutating
+    # access ∩ scope). Self-minting any scope is safe by construction
+    # (effective = user-ACL ∩ scope — only ever narrows). The read/write
+    # ``scopes`` remain non-tunable (the backend doesn't enforce those);
+    # ``vault_scope`` is the dimension that IS enforced.
+    vault_scope: dict[str, list[str]] | None = None
 
 
 class ChangePasswordRequest(NFCModel):
@@ -309,7 +311,12 @@ async def update_my_profile(
 
 @router.post("/auth/tokens", summary="Create a Personal Access Token")
 async def create_token(req: CreatePATRequest, user: AuthenticatedUser = Depends(get_current_user)):
-    return await create_pat(user.user_id, req.name, expires_days=req.expires_days)
+    from app.models.vault_scope import VaultScope
+
+    scope = VaultScope.parse_input(req.vault_scope)
+    return await create_pat(
+        user.user_id, req.name, expires_days=req.expires_days, vault_scope=scope
+    )
 
 
 @router.get("/auth/tokens", summary="List your PATs")

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS tokens (
     token_hash TEXT NOT NULL UNIQUE,   -- sha256 of the token
     token_prefix TEXT NOT NULL,        -- first 8 chars for identification (akb_xxxx)
     scopes TEXT[] DEFAULT '{read,write}',  -- read, write, admin
+    vault_scope JSONB,                     -- per-PAT vault scope {prefixes, extra_vaults}; NULL = unscoped (full user ACL). See migration 040.
     expires_at TIMESTAMPTZ,
     last_used_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/backend/app/db/migrations/040_tokens_vault_scope.py
+++ b/backend/app/db/migrations/040_tokens_vault_scope.py
@@ -1,0 +1,62 @@
+"""Migration 040: add `tokens.vault_scope` (per-PAT vault scope).
+
+A PAT may carry a vault scope (`{prefixes, extra_vaults}` JSONB) so a
+token can be restricted to a vault set independently of its user's ACL.
+A request's effective WRITE permission is `user-ACL ∩ vault_scope` — an
+intersection, so a scope only ever SUBTRACTS authority (escalation-
+impossible by construction). Enforcement intersects the target vault
+with this scope on mutating access checks; reads are unrestricted.
+
+NULL = unscoped (the historical full-ACL behaviour) — every pre-existing
+token row keeps NULL, so behaviour is unchanged.
+
+Idempotent: `ADD COLUMN IF NOT EXISTS` so re-running is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.040")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE tokens
+              ADD COLUMN IF NOT EXISTS vault_scope JSONB
+            """
+        )
+
+    logger.info(
+        "Migration 040 added tokens.vault_scope "
+        "(NULL = unscoped — existing tokens unaffected)"
+    )
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -178,6 +178,7 @@ async def _apply_migrations() -> None:
         "037_table_unique_keys_indexes.py",     # vault_tables.unique_keys + .indexes JSONB (declarative DDL metadata; AKB #215)
         "038_dynamic_table_updated_at_trigger.py",  # akb_set_updated_at() + BEFORE UPDATE trigger on vt_* tables (PG has no ON UPDATE CURRENT_TIMESTAMP)
         "039_edges_vault_endpoint_indexes.py",  # composite (vault_id, source_uri)/(vault_id, target_uri) indexes for graph reads (overview/BFS/degree; AKB graph viewer Phase 2)
+        "040_tokens_vault_scope.py",            # tokens.vault_scope JSONB (per-PAT vault scope; NULL = unscoped)
     ):
         if filename in applied:
             continue

--- a/backend/app/models/vault_scope.py
+++ b/backend/app/models/vault_scope.py
@@ -1,0 +1,123 @@
+"""Per-PAT vault scope — the token-scoping value model.
+
+A token MAY carry a vault scope: a set of vault-name ``prefixes`` plus an
+explicit ``extra_vaults`` whitelist. A request's effective WRITE
+permission is ``user-ACL ∩ vault_scope`` — an intersection, so a scope
+only ever SUBTRACTS authority and is escalation-impossible by
+construction.
+
+A NULL ``tokens.vault_scope`` column means *unscoped* (the historical
+full-ACL behaviour) and is represented as ``None`` — never as an empty
+``VaultScope`` (which permits nothing). The enforcement layer
+(``access_service.check_vault_access``) reads the request's scope from
+the ``current_vault_scope`` ContextVar (set once per request when the
+token is resolved) and treats ``None`` as "no restriction"; a concrete
+``VaultScope`` gates mutating roles (writer/admin/owner) only — reads are
+unrestricted (a scoped agent still READS broadly, it just can't WRITE
+outside its scope).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from app.exceptions import ValidationError
+
+# A vault-name token: lowercase alphanumerics + hyphens, leading alnum.
+# Used for both prefixes (e.g. "gdn-") and exact extra_vaults (e.g.
+# "slack-ops") at mint-time well-formedness validation.
+_SCOPE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+@dataclass(frozen=True)
+class VaultScope:
+    """An immutable (prefixes ∪ extra_vaults) membership gate."""
+
+    prefixes: tuple[str, ...]
+    extra_vaults: frozenset[str]
+
+    def permits(self, vault_name: str) -> bool:
+        """True iff ``vault_name`` is inside the scope (prefix match OR exact whitelist).
+
+        An empty prefix is ignored (it would otherwise match everything);
+        mint-time validation rejects empties, this is belt-and-suspenders.
+        """
+        if any(prefix and vault_name.startswith(prefix) for prefix in self.prefixes):
+            return True
+        return vault_name in self.extra_vaults
+
+    def to_db_json(self) -> dict[str, list[str]]:
+        """Canonical (sorted) JSONB shape for the ``tokens.vault_scope`` column."""
+        return {
+            "prefixes": sorted(self.prefixes),
+            "extra_vaults": sorted(self.extra_vaults),
+        }
+
+    @classmethod
+    def from_db_json(cls, raw: object) -> VaultScope | None:
+        """Parse the JSONB column. ``None`` (NULL column) ⇒ ``None`` (unscoped).
+
+        asyncpg may hand back a JSONB value as a parsed ``dict`` OR (legacy
+        rows / some configs) a JSON string literal — both are accepted
+        (mirrors ``table_registry_repo.parse_json_list``). Raises
+        ``ValueError`` on a malformed shape so a corrupt column surfaces
+        loudly rather than silently degrading to unscoped.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"vault_scope must be a JSON object, got {type(raw).__name__}"
+            )
+        prefixes = raw.get("prefixes", [])
+        extra = raw.get("extra_vaults", [])
+        if not isinstance(prefixes, list) or not isinstance(extra, list):
+            raise ValueError("vault_scope.prefixes and .extra_vaults must be arrays")
+        return cls(
+            prefixes=tuple(sorted(str(p) for p in prefixes)),
+            extra_vaults=frozenset(str(v) for v in extra),
+        )
+
+    @classmethod
+    def parse_input(cls, raw: object) -> VaultScope | None:
+        """Validate + build a scope from caller mint input (stricter than the DB read).
+
+        ``None`` ⇒ ``None`` (unscoped). Raises
+        :class:`app.exceptions.ValidationError` (→ 400) on a malformed or
+        empty scope so a caller cannot store a no-op or injection-shaped
+        scope. Note: a scope is escalation-impossible regardless (effective
+        = ACL ∩ scope), so this is input hygiene, not the security boundary.
+        """
+        if raw is None:
+            return None
+        try:
+            scope = cls.from_db_json(raw)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+        assert scope is not None  # raw is not None ⇒ from_db_json returns a scope
+        if not scope.prefixes and not scope.extra_vaults:
+            raise ValidationError(
+                "vault_scope must declare at least one prefix or extra_vault"
+            )
+        for prefix in scope.prefixes:
+            if not _SCOPE_NAME_RE.match(prefix):
+                raise ValidationError(f"invalid vault_scope prefix: {prefix!r}")
+        for vault in scope.extra_vaults:
+            if not _SCOPE_NAME_RE.match(vault):
+                raise ValidationError(f"invalid vault_scope extra_vault: {vault!r}")
+        return scope
+
+
+# Request-scoped carrier for the authenticated token's vault scope. Set once
+# per request in ``auth_service.resolve_token`` (the single chokepoint BOTH the
+# REST ``get_current_user`` dependency AND the MCP server's auth go through),
+# read in ``access_service.check_vault_access``. Default ``None`` (unscoped) —
+# tokenless internal/worker paths never set it.
+current_vault_scope: ContextVar[VaultScope | None] = ContextVar(
+    "current_vault_scope", default=None
+)

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -11,6 +11,7 @@ import uuid
 
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
+from app.models.vault_scope import current_vault_scope
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
@@ -21,6 +22,11 @@ logger = logging.getLogger("akb.access")
 ROLE_HIERARCHY = {"owner": 4, "admin": 3, "writer": 2, "reader": 1}
 VALID_ROLES = set(ROLE_HIERARCHY.keys())
 VALID_PUBLIC_ACCESS = {"none", "reader", "writer"}
+
+# Roles that MUTATE a vault — the Option B per-PAT vault-scope guard fires only
+# for these (reads are never scope-restricted: a scoped agent still reads
+# broadly, the scope bounds WRITES).
+_MUTATING_ROLES = frozenset({"writer", "admin", "owner"})
 
 
 def _role_level(role: str) -> int:
@@ -95,6 +101,25 @@ async def check_vault_access(
                 raise ForbiddenError(
                     f"Vault '{vault_name}' is a read-only external git mirror"
                 )
+
+        # Option B — per-PAT vault scope (token-scoping backstop). If this
+        # request's token carries a vault scope, a MUTATING access
+        # (writer/admin/owner) to a vault OUTSIDE the scope is refused here —
+        # BEFORE the is_admin / owner short-circuits below, so even a scoped
+        # admin token cannot escape its scope. Reads are unaffected (a scoped
+        # agent still reads broadly; the scope bounds WRITES only). Effective
+        # write permission = user-ACL ∩ scope, for the whole surface that
+        # routes through check_vault_access (REST + MCP). NULL token scope ⇒
+        # current_vault_scope is None ⇒ historical full-ACL behaviour.
+        scope = current_vault_scope.get()
+        if (
+            scope is not None
+            and required_role in _MUTATING_ROLES
+            and not scope.permits(vault_name)
+        ):
+            raise ForbiddenError(
+                f"Token scope does not permit '{required_role}' on vault '{vault_name}'"
+            )
 
         # System admin bypasses all vault ACL
         is_admin = await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -22,6 +22,7 @@ import jwt
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import AuthenticationError, ConflictError, NotFoundError, ValidationError
+from app.models.vault_scope import VaultScope
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
 
@@ -34,6 +35,9 @@ class AuthenticatedUser:
     display_name: str | None
     is_admin: bool
     auth_method: str  # "jwt" or "pat"
+    # Per-PAT vault scope (Option B). None = unscoped: JWT logins, and PATs
+    # minted without a scope. A concrete scope gates mutating vault access.
+    vault_scope: VaultScope | None = None
 
 
 # ── Password hashing ────────────────────────────────────────
@@ -470,16 +474,25 @@ async def update_profile(
 
 # ── PAT operations ──────────────────────────────────────────
 
-async def create_pat(user_id: str, name: str, *, expires_days: int | None = None) -> dict:
+async def create_pat(
+    user_id: str,
+    name: str,
+    *,
+    expires_days: int | None = None,
+    vault_scope: VaultScope | None = None,
+) -> dict:
     """Issue a Personal Access Token.
 
-    Scopes are NOT a caller-tunable knob: the backend doesn't enforce
-    them anywhere, so accepting a `scopes` argument would falsely
-    imply that a "read-only" PAT exists. Tokens always store the full
-    `[read, write]` default; the response surfaces it so listings stay
-    consistent. When scope enforcement is wired into the request
-    handlers, re-introduce the argument with the matching check.
+    The read/write `scopes` are still NOT a caller-tunable knob (the
+    backend doesn't enforce them); tokens always store the `[read, write]`
+    default. `vault_scope` (Option B) IS the tunable dimension: it restricts
+    the token to a vault set (prefixes ∪ extra_vaults), enforced for mutating
+    access in `check_vault_access`. It is escalation-impossible by
+    construction (effective = user-ACL ∩ scope — a scope only ever narrows).
+    `None` = unscoped (the historical full-ACL token).
     """
+    import json
+
     pool = await get_pool()
     raw_token, token_hash, token_prefix = generate_pat()
 
@@ -488,13 +501,14 @@ async def create_pat(user_id: str, name: str, *, expires_days: int | None = None
         expires_at = datetime.now(timezone.utc) + timedelta(days=expires_days)
 
     default_scopes = ["read", "write"]
+    vault_scope_json = json.dumps(vault_scope.to_db_json()) if vault_scope else None
 
     async with pool.acquire() as conn:
         token_id = uuid.uuid4()
         await conn.execute(
             """
-            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, scopes, expires_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, scopes, vault_scope, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             """,
             token_id,
             uuid.UUID(user_id),
@@ -502,6 +516,7 @@ async def create_pat(user_id: str, name: str, *, expires_days: int | None = None
             token_hash,
             token_prefix,
             default_scopes,
+            vault_scope_json,
             expires_at,
         )
 
@@ -511,6 +526,7 @@ async def create_pat(user_id: str, name: str, *, expires_days: int | None = None
         "name": name,
         "prefix": token_prefix,
         "scopes": default_scopes,
+        "vault_scope": vault_scope.to_db_json() if vault_scope else None,
         "expires_at": expires_at.isoformat() if expires_at else None,
         "note": "Save this token — it won't be shown again.",
     }
@@ -634,6 +650,13 @@ async def resolve_token(authorization: str) -> AuthenticatedUser | None:
     - Bearer <jwt>
     - Bearer akb_<pat>
     """
+    # Option B: reset the request-scoped vault scope on every resolve. Only a
+    # scoped PAT (set in _resolve_pat) carries a non-None value; JWT logins and
+    # tokenless/worker paths stay unscoped.
+    from app.models.vault_scope import current_vault_scope
+
+    current_vault_scope.set(None)
+
     if not authorization or not authorization.startswith("Bearer "):
         return None
 
@@ -712,13 +735,21 @@ async def _resolve_pat(raw_token: str) -> AuthenticatedUser | None:
              WHERE t.user_id = u.id
                AND t.token_hash = $1
                AND (t.expires_at IS NULL OR t.expires_at > NOW())
-            RETURNING t.id AS token_id, t.user_id, t.scopes, t.expires_at,
-                      u.username, u.email, u.display_name, u.is_admin
+            RETURNING t.id AS token_id, t.user_id, t.scopes, t.vault_scope,
+                      t.expires_at, u.username, u.email, u.display_name, u.is_admin
             """,
             token_hash,
         )
         if not row:
             return None
+
+        # Option B: carry the PAT's vault scope (NULL column ⇒ None = unscoped)
+        # on the request-scoped ContextVar so check_vault_access can intersect
+        # every mutation against it — REST and MCP alike resolve through here.
+        from app.models.vault_scope import current_vault_scope
+
+        scope = VaultScope.from_db_json(row["vault_scope"])
+        current_vault_scope.set(scope)
 
         return AuthenticatedUser(
             user_id=str(row["user_id"]),
@@ -727,4 +758,5 @@ async def _resolve_pat(raw_token: str) -> AuthenticatedUser | None:
             display_name=row["display_name"],
             is_admin=row["is_admin"],
             auth_method="pat",
+            vault_scope=scope,
         )

--- a/backend/tests/test_vault_scope_e2e.sh
+++ b/backend/tests/test_vault_scope_e2e.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# AKB per-PAT vault-scope (Option B) E2E
+#
+# Proves the token-scoping backstop end-to-end against a live backend:
+# a PAT minted with a vault_scope can only MUTATE vaults inside that
+# scope, even when its user OWNS the target vault. Reads are unaffected.
+# The user is the first-registered account (admin on a fresh DB), so the
+# out-of-scope-write denial ALSO demonstrates that a scoped admin token
+# does not bypass the scope.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+PASS=0
+FAIL=0
+ERRORS=()
+MCP_ID=10
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   AKB per-PAT vault-scope (Option B) E2E  ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+TS=$(date +%s)
+USER="scope-e2e-u-$TS"
+
+# ── 0. Setup: user + JWT ─────────────────────────────────────
+echo "▸ 0. Setup (user + scoped/unscoped PATs)"
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+[ -n "$JWT" ] && pass "user + JWT" || { fail "Setup" "login failed"; exit 1; }
+
+mint_pat() {  # $1 = json body → prints token (empty on non-200)
+  curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $JWT" \
+    -H 'Content-Type: application/json' -d "$1" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))' 2>/dev/null
+}
+
+SCOPED_PAT=$(mint_pat '{"name":"scoped","vault_scope":{"prefixes":["gdn-"],"extra_vaults":[]}}')
+UNSCOPED_PAT=$(mint_pat '{"name":"unscoped"}')
+[ -n "$SCOPED_PAT" ] && pass "scoped PAT minted (gdn-)" || fail "Mint scoped" "no token"
+[ -n "$UNSCOPED_PAT" ] && pass "unscoped PAT minted" || fail "Mint unscoped" "no token"
+
+# ── 0b. mint validation (malformed scope → 400) ──────────────
+CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"bad","vault_scope":{"prefixes":["BAD UPPER"],"extra_vaults":[]}}')
+[ "$CODE" = "422" ] && pass "malformed scope rejected at mint (422)" || fail "Mint validation" "expected 422, got $CODE"
+
+EMPTY_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"empty","vault_scope":{"prefixes":[],"extra_vaults":[]}}')
+[ "$EMPTY_CODE" = "422" ] && pass "empty scope rejected at mint (422)" || fail "Mint validation" "empty scope expected 422, got $EMPTY_CODE"
+
+# ── MCP session helpers ──────────────────────────────────────
+setup_mcp() {
+  local pat=$1 tmpfile sid
+  tmpfile=$(mktemp)
+  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"scope-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
+  sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
+  rm -f "$tmpfile"
+  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" -H "mcp-session-id: $sid" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+  echo "$sid"
+}
+mcp_as() {
+  local pat=$1 sid=$2 tool=$3 args=$4
+  MCP_ID=$((MCP_ID+1))
+  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "mcp-session-id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+}
+mr() { python3 -c "import sys,json; print(json.loads(sys.stdin.read())['result']['content'][0]['text'])" 2>/dev/null; }
+
+SID_S=$(setup_mcp "$SCOPED_PAT")
+SID_U=$(setup_mcp "$UNSCOPED_PAT")
+
+# ── Setup vaults (via UNSCOPED PAT → owner; scope must not gate setup) ──
+GDN_VAULT="gdn-scope-e2e-$TS"
+NONGDN_VAULT="scope-e2e-other-$TS"
+R=$(mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_create_vault" "{\"name\":\"$GDN_VAULT\"}" | mr)
+echo "$R" | python3 -c "import sys,json; json.load(sys.stdin)['vault_id']" >/dev/null 2>&1 && pass "gdn vault created ($GDN_VAULT)" || fail "gdn vault" "$R"
+R=$(mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_create_vault" "{\"name\":\"$NONGDN_VAULT\"}" | mr)
+echo "$R" | python3 -c "import sys,json; json.load(sys.stdin)['vault_id']" >/dev/null 2>&1 && pass "non-gdn vault created ($NONGDN_VAULT, owner=user)" || fail "non-gdn vault" "$R"
+
+# Seed a doc in the non-gdn vault (unscoped) so the scoped READ test has a target.
+mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_put" "{\"vault\":\"$NONGDN_VAULT\",\"collection\":\"c\",\"title\":\"Seed\",\"content\":\"# seed\\nhello\"}" >/dev/null 2>&1
+
+is_denied() {  # stdin = mr output; success iff it's a scope-denial error
+  python3 -c "import sys,json
+d=json.loads(sys.stdin.read())
+s=json.dumps(d).lower()
+print('error' in d and ('scope' in s or 'permit' in s))" 2>/dev/null
+}
+wrote_ok() {  # stdin = mr output; success iff a doc uri came back
+  python3 -c "import sys,json; print(bool(json.load(sys.stdin).get('uri')))" 2>/dev/null
+}
+
+# ── 1. In-scope write OK ─────────────────────────────────────
+echo ""
+echo "▸ 1. Scoped PAT — write INSIDE scope (gdn-*)"
+R=$(mcp_as "$SCOPED_PAT" "$SID_S" "akb_put" "{\"vault\":\"$GDN_VAULT\",\"collection\":\"c\",\"title\":\"In\",\"content\":\"# in\\nok\"}" | mr)
+[ "$(echo "$R" | wrote_ok)" = "True" ] && pass "scoped PAT CAN write gdn-* vault" || fail "in-scope write" "$R"
+
+# ── 2. KEY: out-of-scope write DENIED (even though user OWNS it) ──
+echo ""
+echo "▸ 2. Scoped PAT — write OUTSIDE scope (owned non-gdn) → DENIED"
+R=$(mcp_as "$SCOPED_PAT" "$SID_S" "akb_put" "{\"vault\":\"$NONGDN_VAULT\",\"collection\":\"c\",\"title\":\"Out\",\"content\":\"# out\\nnope\"}" | mr)
+[ "$(echo "$R" | is_denied)" = "True" ] && pass "scoped PAT DENIED non-gdn write (owner ACL ∩ scope) — #51 backstop" || fail "out-of-scope write" "expected scope-denial, got: $R"
+
+# ── 3. Control: unscoped PAT writes the SAME non-gdn vault OK ─
+echo ""
+echo "▸ 3. Control — unscoped PAT writes the same non-gdn vault"
+R=$(mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_put" "{\"vault\":\"$NONGDN_VAULT\",\"collection\":\"c\",\"title\":\"Ctl\",\"content\":\"# ctl\\nyes\"}" | mr)
+[ "$(echo "$R" | wrote_ok)" = "True" ] && pass "unscoped PAT CAN write non-gdn (proves denial = scope, not ACL)" || fail "control write" "$R"
+
+# ── 4. Reads are NOT scope-restricted ────────────────────────
+echo ""
+echo "▸ 4. Scoped PAT — READ a non-gdn vault (must be allowed)"
+R=$(mcp_as "$SCOPED_PAT" "$SID_S" "akb_browse" "{\"vault\":\"$NONGDN_VAULT\"}" | mr)
+echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'error' not in d else 1)" 2>/dev/null \
+  && pass "scoped PAT CAN read non-gdn (scope bounds WRITES only)" || fail "scoped read" "read was blocked: $R"
+
+# ── Cleanup ──────────────────────────────────────────────────
+mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_delete_vault" "{\"vault\":\"$GDN_VAULT\",\"confirm\":true}" >/dev/null 2>&1
+mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_delete_vault" "{\"vault\":\"$NONGDN_VAULT\",\"confirm\":true}" >/dev/null 2>&1
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════"
+echo "  PASS: $PASS    FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf '  %s\n' "${ERRORS[@]}"
+  exit 1
+fi
+echo "  ✓ vault-scope backstop verified end-to-end"

--- a/backend/tests/test_vault_scope_unit.py
+++ b/backend/tests/test_vault_scope_unit.py
@@ -1,0 +1,151 @@
+"""Unit coverage for the per-PAT VaultScope value model.
+
+DB-free by construction: VaultScope is a pure value type — the
+(prefixes ∪ extra_vaults) membership test that the authorization layer
+intersects against a token's effective WRITE permission. A NULL token
+scope means *unscoped* (the historical full-ACL behaviour) and is
+represented as ``None``, never an empty VaultScope (which permits
+nothing). These tests pin ``permits()``, the JSONB round-trip, the
+mint-input validation (``parse_input``), the request-scoped ContextVar,
+and the adversarial "a scope only ever SUBTRACTS — it never permits a
+vault outside its declared sets" invariant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.models.vault_scope import VaultScope, current_vault_scope
+
+
+class TestPermits:
+    def test_prefix_permits_matching_vaults(self) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset())
+        assert scope.permits("gdn-state")
+        assert scope.permits("gdn-lint")
+        assert scope.permits("gdn-")  # exact-prefix boundary
+
+    def test_prefix_denies_non_matching(self) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset())
+        assert not scope.permits("product")
+        assert not scope.permits("collector-dev")
+        assert not scope.permits("gd")  # shorter than the prefix
+        assert not scope.permits("xgdn-state")  # prefix not at the start
+
+    def test_extra_vaults_permit_exact_non_gdn(self) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset({"slack-ops"}))
+        assert scope.permits("slack-ops")  # whitelisted non-gdn
+        assert scope.permits("gdn-state")  # still permits the prefix
+        assert not scope.permits("slack-ops-2")  # whitelist is exact, not a prefix
+
+    def test_empty_scope_permits_nothing(self) -> None:
+        scope = VaultScope(prefixes=(), extra_vaults=frozenset())
+        assert not scope.permits("gdn-state")
+        assert not scope.permits("anything")
+
+    def test_multi_prefix(self) -> None:
+        scope = VaultScope(prefixes=("gdn-", "lint-"), extra_vaults=frozenset())
+        assert scope.permits("gdn-state")
+        assert scope.permits("lint-x")
+        assert not scope.permits("other")
+
+
+class TestJsonRoundTrip:
+    def test_to_db_json_shape(self) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset({"slack-ops"}))
+        assert scope.to_db_json() == {"prefixes": ["gdn-"], "extra_vaults": ["slack-ops"]}
+
+    def test_from_db_json_round_trip(self) -> None:
+        scope = VaultScope.from_db_json(
+            {"prefixes": ["gdn-"], "extra_vaults": ["slack-ops", "a-vault"]}
+        )
+        assert scope is not None
+        assert scope.permits("gdn-x")
+        assert scope.permits("slack-ops")
+        assert scope.permits("a-vault")
+        assert not scope.permits("nope")
+
+    def test_from_db_json_none_is_none(self) -> None:
+        # NULL column ⇒ None (unscoped), NOT an empty (deny-all) scope.
+        assert VaultScope.from_db_json(None) is None
+
+    def test_from_db_json_accepts_json_string(self) -> None:
+        # asyncpg may return a JSONB column as a JSON string literal (legacy /
+        # some configs); from_db_json must json.loads it, not choke.
+        scope = VaultScope.from_db_json('{"prefixes": ["gdn-"], "extra_vaults": []}')
+        assert scope is not None
+        assert scope.permits("gdn-state")
+        assert not scope.permits("product")
+
+    def test_from_db_json_canonicalizes_order(self) -> None:
+        # Deterministic serialize (sorted) so the stored column is stable.
+        scope = VaultScope.from_db_json(
+            {"prefixes": ["b-", "a-"], "extra_vaults": ["z", "a"]}
+        )
+        assert scope is not None
+        assert scope.to_db_json() == {"prefixes": ["a-", "b-"], "extra_vaults": ["a", "z"]}
+
+    def test_from_db_json_rejects_non_object(self) -> None:
+        with pytest.raises(ValueError):
+            VaultScope.from_db_json(["gdn-"])  # arrays / scalars are malformed
+
+    def test_from_db_json_rejects_non_array_fields(self) -> None:
+        with pytest.raises(ValueError):
+            VaultScope.from_db_json({"prefixes": "gdn-", "extra_vaults": []})
+
+
+class TestParseInput:
+    """Mint-time validation: stricter than the trusted DB read."""
+
+    def test_none_is_none(self) -> None:
+        assert VaultScope.parse_input(None) is None
+
+    def test_valid_scope_builds(self) -> None:
+        scope = VaultScope.parse_input({"prefixes": ["gdn-"], "extra_vaults": ["slack-ops"]})
+        assert scope is not None
+        assert scope.permits("gdn-state")
+        assert scope.permits("slack-ops")
+
+    def test_empty_scope_rejected(self) -> None:
+        # A scope that declares nothing is a no-op — reject it at mint.
+        with pytest.raises(ValidationError):
+            VaultScope.parse_input({"prefixes": [], "extra_vaults": []})
+
+    def test_malformed_shape_wrapped_as_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            VaultScope.parse_input(["gdn-"])
+
+    @pytest.mark.parametrize("bad", ["GDN-", "gdn_state", "gdn state", "-gdn", "", "x/y"])
+    def test_bad_prefix_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            VaultScope.parse_input({"prefixes": [bad], "extra_vaults": []})
+
+    @pytest.mark.parametrize("bad", ["Slack", "a_b", "a/b", "../x"])
+    def test_bad_extra_vault_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            VaultScope.parse_input({"prefixes": [], "extra_vaults": [bad]})
+
+
+class TestContextVar:
+    def test_default_is_none(self) -> None:
+        # A request that never set a scope (tokenless / JWT / worker) ⇒ unscoped.
+        assert current_vault_scope.get() is None
+
+    def test_set_and_get(self) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset())
+        token = current_vault_scope.set(scope)
+        try:
+            assert current_vault_scope.get() is scope
+        finally:
+            current_vault_scope.reset(token)
+        assert current_vault_scope.get() is None
+
+
+class TestAdversarialNeverWiden:
+    """A scope can only ever SUBTRACT — it never permits beyond its sets."""
+
+    @pytest.mark.parametrize("vault", ["product", "collector-dev", "users", "tokens", ""])
+    def test_gdn_scope_denies_arbitrary(self, vault: str) -> None:
+        scope = VaultScope(prefixes=("gdn-",), extra_vaults=frozenset())
+        assert not scope.permits(vault)


### PR DESCRIPTION
## Summary

Adds an optional **vault scope** to Personal Access Tokens: a token may carry a set of vault-name `prefixes` plus an exact-vault `extra_vaults` whitelist, restricting that token to a vault set **independently of its user's ACL**.

This finishes the hook the token code already reserved — `create_pat` and `CreatePATRequest` both noted *"when scope enforcement lands, re-expose this field with the matching check."* The read/write `scopes` stay non-tunable (the backend still doesn't enforce those); `vault_scope` is a separate, enforced dimension on a dedicated column.

## Design

- **Effective write permission = `user-ACL ∩ vault_scope`** — an intersection, so a scope only ever *narrows* authority. It is **escalation-impossible by construction**: scoping a token to vaults its user can't write grants nothing, so mint needs no ACL check (only well-formedness).
- **`NULL` scope = unscoped** — the historical full-ACL behaviour. Fully backward-compatible; every existing token is unaffected.
- **Writes only.** The guard fires for mutating roles (`writer`/`admin`/`owner`); reads stay unrestricted.
- **One chokepoint each, REST + MCP uniformly.** The scope is read once per request in `resolve_token` — which both the REST `get_current_user` dependency and the MCP server pass through — and carried on a request-scoped `ContextVar`; `check_vault_access` (the single authorization gate the whole doc-tool surface routes through) reads it. The check sits *before* the `is_admin`/owner short-circuits, so a scoped admin token is still scoped.

## Changes

- `tokens.vault_scope JSONB` — migration `038` for existing DBs, `init.sql` for fresh ones.
- `app/models/vault_scope.py` — `VaultScope` value model (`prefixes ∪ extra_vaults` membership) + strict mint-input validation + the request-scoped `ContextVar`.
- `auth_service.py` — `resolve_token` sets the scope ContextVar; `_resolve_pat` reads the column; `AuthenticatedUser.vault_scope`; `create_pat` accepts + stores it.
- `access_service.py` — `check_vault_access` intersects mutating access with the scope.
- `routes/auth.py` (`POST /auth/tokens`) + `routes/access.py` (admin user-mint) — accept `vault_scope`.

## Tests

- **Unit** (`tests/test_vault_scope_unit.py`, 33 cases) — `permits()`, JSONB round-trip (incl. string-encoded column), mint-input validation, the `ContextVar`, and an adversarial "a scope never permits beyond its sets".
- **E2E** (`tests/test_vault_scope_e2e.sh`) — against a live backend: a prefix-scoped PAT is **denied** an out-of-scope write *even to a vault its user owns* (the user is the first-registered admin, so this also shows a scoped admin token does not bypass); an in-scope write succeeds; an unscoped PAT writes the same vault (control — proving the denial is the scope, not the ACL); a scoped read is allowed; malformed/empty scopes are rejected at mint.

Locally verified: unit + e2e green (e2e against a local backend with migration `038` applied), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
