### PR TITLE
fix(graph): sidebar search-result click now focuses (was a silent no-op)

### DIFF
--- a/frontend/src/components/graph/GraphSidebar.tsx
+++ b/frontend/src/components/graph/GraphSidebar.tsx
@@ -14,6 +14,7 @@ import {
   type RelationKind,
 } from "./graph-types";
 import { KindSwatch, RelationSwatch } from "./graph-swatches";
+import { docIdFromUri } from "./use-graph-data";
 import { viewToQuery } from "./graph-state";
 import { Section } from "./Section";
 import { TooltipText } from "@/components/ui/tooltip-text";
@@ -99,11 +100,25 @@ export function GraphSidebar({
     searchDocs(debouncedQuery.trim(), vault, 8)
       .then((resp) => {
         if (cancelled) return;
-        const rows = (resp.results || []).slice(0, 8).map((r: any) => ({
-          doc_id: r.doc_id || r.id,
-          title: r.title || r.name || r.doc_id || "(untitled)",
-          type: (r.resource_type || r.type || "document") as NodeKind,
-        }));
+        // Search results identify a resource by `uri`/`path` — there is NO
+        // `doc_id`/`id` field — so derive the SAME id the graph uses for its
+        // nodes (docIdFromUri), or clicking a hit set `entry` to undefined and
+        // silently no-oped (stayed on the whole graph). `source_type` is the
+        // real kind field ('document'|'table'|'file' — already a NodeKind for
+        // doc/table/file); map it for the chip, defaulting unknown → document.
+        // Drop any hit we can't resolve an id for (can't focus on it).
+        const rows: SearchHit[] = (resp.results || [])
+          .slice(0, 8)
+          .map((r: any) => {
+            const st = r.source_type;
+            const type: NodeKind = st === "table" ? "table" : st === "file" ? "file" : "document";
+            return {
+              doc_id: docIdFromUri(r.uri) ?? r.path ?? "",
+              title: r.title || r.path || "(untitled)",
+              type,
+            };
+          })
+          .filter((h) => h.doc_id);
         setHits(rows);
       })
       .catch(() => { if (!cancelled) setHits([]); });

--- a/frontend/src/components/graph/__tests__/GraphSidebar.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphSidebar.test.tsx
@@ -1,7 +1,7 @@
 // frontend/src/components/graph/__tests__/GraphSidebar.test.tsx
 import type { ComponentProps } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GraphSidebar } from "../GraphSidebar";
 import { DEFAULT_VIEW, type GraphView } from "../graph-types";
@@ -152,8 +152,12 @@ describe("GraphSidebar · entry search", () => {
       total: 1,
       returned: 1,
       total_matches: 1,
+      // Real /search result shape: identifies a doc by uri/path (no doc_id/id);
+      // source_type is 'document'|'table'|'file'. `path` is deliberately set to
+      // a DIFFERENT value than the uri-derived id so the assertion pins the
+      // PRIMARY docIdFromUri(uri) branch (not the `?? r.path` fallback).
       results: [
-        { doc_id: "d-1", title: "Roadmap", resource_type: "document" },
+        { uri: "akb://akb/coll/specs/doc/roadmap.md", path: "ignored/fallback.md", title: "Roadmap", source_type: "document" },
       ],
     });
     vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -176,9 +180,9 @@ describe("GraphSidebar · entry search", () => {
     fireEvent.click(hit);
     expect(onChange).toHaveBeenCalled();
     const lastArg = onChange.mock.calls.at(-1)?.[0];
-    expect(lastArg?.entry).toBe("d-1");
+    expect(lastArg?.entry).toBe("specs/roadmap.md");
     const stored = localStorage.getItem("akb-graph-recent:akb");
-    expect(stored).toContain("d-1");
+    expect(stored).toContain("specs/roadmap.md");
     vi.useRealTimers();
   });
 
@@ -188,7 +192,7 @@ describe("GraphSidebar · entry search", () => {
       total: 1,
       returned: 1,
       total_matches: 1,
-      results: [{ doc_id: "d-1", title: "Roadmap", resource_type: "document" }],
+      results: [{ uri: "akb://akb/coll/specs/doc/roadmap.md", path: "specs/roadmap.md", title: "Roadmap", source_type: "document" }],
     });
     const u = userEvent.setup();
     const onChange = vi.fn();
@@ -208,8 +212,37 @@ describe("GraphSidebar · entry search", () => {
     await u.click(hit);
     expect(mockedSearchDocs).toHaveBeenCalledWith("road", "akb", 8);
     const lastArg = onChange.mock.calls.at(-1)?.[0];
-    expect(lastArg?.entry).toBe("d-1");
+    expect(lastArg?.entry).toBe("specs/roadmap.md");
     const stored = localStorage.getItem("akb-graph-recent:akb");
-    expect(stored).toContain("d-1");
+    expect(stored).toContain("specs/roadmap.md");
+  });
+
+  it("drops hits with no resolvable id and maps source_type to the chip kind", async () => {
+    mockedSearchDocs.mockResolvedValue({
+      query: "x", total: 3, returned: 3, total_matches: 3,
+      results: [
+        { uri: "akb://akb/coll/specs/doc/roadmap.md", path: "specs/roadmap.md", title: "Roadmap", source_type: "document" },
+        { uri: "akb://akb/coll/metrics/table/usage", path: "metrics/usage", title: "Usage Table", source_type: "table" },
+        // A collection URI resolves to no doc/table/file id and carries no path,
+        // so docIdFromUri()→null, doc_id→"" → must be filtered out (clicking it
+        // would set entry="" → the silent no-op this PR exists to kill).
+        { uri: "akb://akb/coll/specs", title: "Specs Collection" },
+      ],
+    });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    setup();
+    const input = screen.getByPlaceholderText(/search to focus/i);
+    fireEvent.change(input, { target: { value: "x" } });
+    await vi.advanceTimersByTimeAsync(300);
+    // Resolvable hits render…
+    expect(await screen.findByText("Roadmap")).toBeInTheDocument();
+    expect(screen.getByText("Usage Table")).toBeInTheDocument();
+    // …the unresolvable collection hit is dropped.
+    expect(screen.queryByText("Specs Collection")).toBeNull();
+    // source_type drives the chip kind — scope to the hit button so the chip
+    // isn't confused with the "table" type-filter toggle elsewhere in the rail.
+    const tableHit = screen.getByRole("button", { name: /Usage Table/i });
+    expect(within(tableHit).getByText("table")).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Problem

On the graph page, the sidebar **"Search to focus on a document"** filters correctly, but **clicking a result did nothing** — the graph stayed on the whole-graph overview, and the **Depth (hops) radios never enabled** (they're disabled until a focus exists), making Depth look like an unfinished feature.

## Root cause

`GraphSidebar` mapped each hit's `doc_id` from `r.doc_id || r.id`, but **search results carry neither field**. A real `/search` result identifies a resource by `uri` / `path`:

```
keys: collection, doc_type, matched_section, path, score, source_type, summary, tags, title, uri, vault
has doc_id: False | has id: False
```

So `hit.doc_id` was `undefined`, `commitEntry` set `view.entry = undefined`, and the click silently no-oped (stayed on the overview). Because focus never engaged, the Depth radios — gated on `view.entry` — stayed disabled.

## Fix

Derive the id the graph actually uses for its nodes via `docIdFromUri(r.uri)` (fallback `r.path`), read the real kind field (`source_type`) for the chip, and drop hits we can't resolve an id for.

## Verification (live, local stack)

Clicking a result now:
- sets `entry=<doc path>` (URL `?entry=auth%2Fauth-hub-00.md`)
- shows **"Focused on …"** + enables **Depth 1/2/3**
- loads the single-call BFS neighborhood (`GET /graph?uri=…&hops=2` → 200)
- **focus persists** through waits + hovering nodes (verified the earlier one-off "revert" was not reproducible — a stray interaction, not a bug)

Also updated the two `GraphSidebar.test.tsx` search tests, whose mock used the stale `{doc_id, resource_type}` shape, to the real `{uri, path, source_type}` shape.

Gate: typecheck / lint (0 errors) / design:check / **337 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)