### PR TITLE
security(health): gate sensitive /health internals (RBAC + audit) behind auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2841
+        "line_number": 2861
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T10:06:48Z"
+  "generated_at": "2026-06-23T03:09:52Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,26 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.9.1 — 2026-06-23  *(security — gate the sensitive `/health` internals (RBAC + audit) behind auth)*
+
+`GET /health` is unauthenticated (uptime monitors + many e2e callers poll it),
+and it exposed **operational security internals** to anyone who could reach the
+host: the **RBAC hook-failure counters** (`rbac` — reveals silent role-sync
+drift, i.e. security-infrastructure health) and the **audit-log stats**
+(`audit`). Those should not be world-readable.
+
+`/health` now takes **optional auth** (`get_optional_user`) and includes `rbac`
++ `audit` **only for authenticated callers**. The operational stats
+(`vector_store` reachability + indexing/backfill counts, BM25, `external_git` /
+`metadata_backfill` / `events` backlogs) stay anonymous — they are monitoring
+data the codebase already treats as world-readable (e2e suites and uptime checks
+poll them without auth), and they carry no per-vault names/IDs.
+`/health/vault/{name}` remains the per-vault, reader-gated surface.
+
+Scoped deliberately to the two sensitive internals (not the whole body) so the
+established unauthenticated `/health` monitoring contract — relied on across the
+e2e suite and by uptime probes — keeps working unchanged.
+
 ## 0.9.0 — 2026-06-22  *(feat — graph viewer Phase 2: degree-ranked overview + health endpoints, single-call BFS, edge `kind`)*
 
 Two new reader-gated graph read endpoints under `/api/v1`, replacing the

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, get_optional_user
 from app.db.postgres import get_pool
 from app.exceptions import AKBError
 from app.api.routes import access, activity, agent_sessions, auth, documents, files, help as help_routes, public, search, collections, knowledge, knowledge_io, tables
@@ -171,8 +171,17 @@ async def readyz():
 
 
 @app.get("/health")
-async def health():
+async def health(user: AuthenticatedUser | None = Depends(get_optional_user)):
     """Detailed system health for dashboards.
+
+    Auth posture: the operational stats (vector-store reachability, indexing /
+    backfill counts, BM25, external-git / metadata / events backlogs) are
+    monitoring data and stay readable by anyone — many e2e and uptime callers
+    poll them unauthenticated. The sensitive operational INTERNALS, though —
+    the RBAC hook-failure counters (which reveal role-sync security drift) and
+    the audit-log stats — are returned ONLY to authenticated callers, so they
+    are not world-readable. `/health/vault/{name}` remains the per-vault,
+    reader-gated surface.
 
     Indexing is a single stage post-Phase-4 (embed + sparse + upsert
     in one atomic worker), so backfill stats live under
@@ -205,26 +214,28 @@ async def health():
         except Exception as e:  # noqa: BLE001
             return {"error": str(e)}
 
-    # PG-RBAC subsystem: hook-failure counters + last reconcile
-    # outcome. Lets dashboards / oncall see silent role-sync drift
-    # without grepping logs.
-    rbac_info: dict
-    try:
-        from app.services.role_sync import get_role_sync
-        rbac_info = get_role_sync().metrics_snapshot()
-    except Exception as e:  # noqa: BLE001
-        rbac_info = {"error": str(e)}
-
-    return {
+    result: dict = {
         "status": "ok",
         "service": "akb",
         "external_git": await _safe(external_git_poller.pending_stats),
         "metadata_backfill": await _safe(metadata_worker.pending_stats),
         "events": await _safe(events_publisher.pending_stats),
         "vector_store": vs_info,
-        "rbac": rbac_info,
-        "audit": audit_log.stats(),
     }
+
+    # Sensitive operational internals — authenticated callers only:
+    #  - PG-RBAC hook-failure counters + last reconcile outcome (silent
+    #    role-sync drift); lets dashboards / oncall see it without grepping logs.
+    #  - audit-log stats.
+    if user is not None:
+        try:
+            from app.services.role_sync import get_role_sync
+            result["rbac"] = get_role_sync().metrics_snapshot()
+        except Exception as e:  # noqa: BLE001
+            result["rbac"] = {"error": str(e)}
+        result["audit"] = audit_log.stats()
+
+    return result
 
 
 @app.get("/health/vault/{name}", summary="Per-vault indexing health (auth required)")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.9.0"
+version = "0.9.1"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -207,6 +207,23 @@ HTTP=$(curl -sS -o /dev/null -w "%{http_code}" "$BASE_URL/health/vault/$VAULT1")
 HTTP=$(curl -sS -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $PAT1" "$BASE_URL/health/vault/nonexistent-vault-xyz")
 [ "$HTTP" = "404" ] && pass "Unknown vault returns 404" || fail "vault health 404" "got HTTP $HTTP"
 
+echo ""
+echo "▸ 1d. Global /health: sensitive internals (rbac/audit) gated"
+
+# Operational stats (vector_store, etc.) stay anon — they're monitoring data
+# many callers poll unauthenticated. But the sensitive internals (rbac
+# hook-failure counters, audit stats) must NOT be world-readable.
+ANON=$(curl -sk "$BASE_URL/health")
+HTTP=$(curl -sS -o /dev/null -w "%{http_code}" "$BASE_URL/health")
+[ "$HTTP" = "200" ] && pass "Anon /health → 200" || fail "anon health code" "got HTTP $HTTP"
+ANONOK=$(echo "$ANON" | python3 -c "import sys,json; d=json.load(sys.stdin); print('vector_store' in d and 'rbac' not in d and 'audit' not in d)" 2>/dev/null)
+[ "$ANONOK" = "True" ] && pass "Anon /health: operational stats present, rbac+audit withheld" || fail "anon health body" "$ANON"
+
+# Authenticated callers DO get the internals.
+AUTHED=$(curl -sk -H "Authorization: Bearer $PAT1" "$BASE_URL/health")
+AUTHOK=$(echo "$AUTHED" | python3 -c "import sys,json; d=json.load(sys.stdin); print('rbac' in d and 'audit' in d and 'vector_store' in d)" 2>/dev/null)
+[ "$AUTHOK" = "True" ] && pass "Authed /health: rbac + audit included" || fail "authed health body" "$AUTHED"
+
 # ── 2. Grep Regex Validation ─────────────────────────────────
 echo ""
 echo "▸ 2. Grep Regex Validation"


### PR DESCRIPTION
## Problem (from the graph/relations investigation)

`GET /health` is unauthenticated (uptime monitors + many e2e callers poll it), and it exposed **operational security internals** to anyone who could reach the host:
- **`rbac`** — RBAC hook-failure counters (reveal silent role-sync drift, i.e. security-infrastructure health)
- **`audit`** — audit-log stats

These should not be world-readable.

## Fix (scoped to the sensitive internals)

`/health` now takes **optional auth** (`get_optional_user`) and includes `rbac` + `audit` **only for authenticated callers**.

The **operational stats stay anonymous** — `vector_store` reachability + indexing/backfill counts, BM25, `external_git` / `metadata_backfill` / `events` backlogs. They are monitoring data the codebase already treats as world-readable: **~8 e2e suites + the shared `_wait_for_indexing` poller + uptime probes poll them unauthenticated**, and they carry no per-vault names/IDs. `/health/vault/{name}` remains the per-vault, reader-gated surface.

### Why not gate the whole body?
Investigated it — `/health`'s operational stats are a deeply-established unauthenticated monitoring contract (8+ e2e files read them without auth). Gating everything would break all of them and make every future `/health`-reading test need auth. Scoping to the two genuinely-sensitive internals removes the disclosure the investigation flagged while keeping that contract intact (zero test churn).

Backend **0.9.1**.

## Verified live (local)
- anon `/health` → 200, keys `{status, service, vector_store, external_git, metadata_backfill, events}` — **no `rbac`/`audit`**; `vector_store.backfill.upsert.pending` still readable (test infra unbroken)
- authed `/health` → adds `rbac` + `audit`
- existing `test_probes_e2e.sh` passes unchanged

New e2e `test_security_edge_e2e.sh §1d` pins both: anon (operational stats present, rbac+audit withheld) + authed (rbac+audit included).

## Follow-ups (deferred, same investigation)
- Header indexing badge shows a *global* corpus count to authenticated non-admins — could be driven from the user's own vaults. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)