### PR TITLE
feat(graph): surface unlinked resources as isolated nodes in the overview

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2861
+        "line_number": 2893
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T03:09:52Z"
+  "generated_at": "2026-06-23T05:14:14Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,38 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.9.2 — 2026-06-23  *(feat — graph overview surfaces unlinked resources as isolated nodes)*
+
+The graph overview was built purely from edge endpoints, so a resource in **no
+relation** (an unlinked table, file, or doc) never appeared anywhere in the
+graph — and a vault with **only unlinked resources** (e.g. a tables-only vault)
+rendered a **blank canvas** with no way to discover them.
+
+`get_overview` now appends unlinked resources as **degree-0 isolated nodes**
+(`include_orphans=True`, capped at `orphan_limit=500`): non-archived docs,
+tables, and files that appear in no edge. The early "no edges → empty" return is
+gone — a zero-edge vault still renders. Response adds `orphans_returned` (and
+`orphans_truncated`, the honest "the orphan set itself was capped" signal,
+parallel to the connected `truncated`); `nodes_total` / `returned` / `truncated`
+still describe the **connected** graph only, so `len(nodes) == returned +
+orphans_returned`.
+
+Orphan detection is a **SQL anti-join on each resource's own identity** — doc
+`path` / table `name` / file `id`, not the full URI:
+- the per-catalog `LIMIT` then caps the number of ORPHANS, not "recent rows", so
+  a vault whose newest rows are all linked still surfaces its older orphans;
+- identity (not URI) matching is robust to a non-canonical collection segment on
+  a stored edge URI — a table linked via a mis-cased `/coll/…/` can't reappear as
+  a phantom orphan duplicate of a node that's already connected;
+- the three types are round-robin **interleaved** before the cap, so a flood of
+  orphan docs never starves orphan tables/files (the motivating case).
+
+Client-side needs no change: the existing **"Hide orphans"** toggle already
+governs degree-0 nodes, so the overview defaults to showing everything and users
+declutter on demand. Since `get_graph(no resource_uri)` delegates to
+`get_overview`, MCP `akb_graph(vault)` and `GET /graph?vault=` inherit it; the
+BFS (`uri`) path is unaffected (a focused neighborhood stays connected-only).
+
 ## 0.9.1 — 2026-06-23  *(security — gate the sensitive `/health` internals (RBAC + audit) behind auth)*
 
 `GET /health` is unauthenticated (uptime monitors + many e2e callers poll it),

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 import uuid
+from itertools import zip_longest
 from typing import Literal, get_args
 
 from app.db.postgres import get_pool
@@ -566,15 +567,95 @@ async def get_graph(
     }
 
 
+async def _fetch_orphan_nodes(
+    conn, vault: str, vault_id, *,
+    doc_paths: set[str], table_names: set[str], file_ids: set[str], limit: int,
+) -> tuple[list[dict], bool]:
+    """Resources — non-archived docs, tables, files — that appear in NO edge,
+    returned as degree-0 isolated nodes. Without these, a vault whose resources
+    aren't linked yet (e.g. a tables-only vault) renders a BLANK canvas: the
+    overview is built from edge endpoints, so an unlinked resource is never an
+    endpoint and would otherwise be invisible everywhere in the graph.
+
+    The "is it connected?" test is pushed into SQL as an anti-join on the
+    resource's OWN IDENTITY column — doc ``path`` / table ``name`` / file ``id``,
+    NOT the full URI. Two reasons:
+      - The per-catalog ``LIMIT`` then caps the number of ORPHANS, not "recent
+        rows" — so a vault whose newest N rows are all linked still surfaces its
+        older orphans (a recency-windowed Python filter would miss them).
+      - Identity (not URI) matching is robust to a non-canonical collection
+        segment on a stored edge URI: a table is uniquely the vault's ``name``,
+        a file its ``id`` — so a link written with a mis-cased ``/coll/…/`` can't
+        make a linked table/file re-appear as a phantom orphan duplicate.
+
+    The three types are interleaved (round-robin) before the cap so a flood of
+    orphan docs never starves orphan tables/files (the motivating case).
+    """
+    per = max(0, limit)
+    doc_rows = await conn.fetch(
+        "SELECT path, title FROM documents "
+        "WHERE vault_id = $1 AND status != 'archived' AND path != ALL($2::text[]) "
+        "ORDER BY created_at DESC LIMIT $3",
+        vault_id, list(doc_paths), per,
+    )
+    tbl_rows = await conn.fetch(
+        "SELECT t.name, t.description, c.path AS coll "
+        "FROM vault_tables t LEFT JOIN collections c ON t.collection_id = c.id "
+        "WHERE t.vault_id = $1 AND t.name != ALL($2::text[]) "
+        "ORDER BY t.created_at DESC LIMIT $3",
+        vault_id, list(table_names), per,
+    )
+    file_rows = await conn.fetch(
+        "SELECT f.id::text AS id, f.name, c.path AS coll "
+        "FROM vault_files f LEFT JOIN collections c ON f.collection_id = c.id "
+        "WHERE f.vault_id = $1 AND f.id::text != ALL($2::text[]) "
+        "ORDER BY f.created_at DESC LIMIT $3",
+        vault_id, list(file_ids), per,
+    )
+
+    docs = [{"uri": doc_uri(vault, r["path"]), "resource_type": "doc",
+             "name": r["title"] or doc_uri(vault, r["path"]), "degree": 0} for r in doc_rows]
+    tables = [{"uri": table_uri(vault, r["name"], r["coll"]), "resource_type": "table",
+               "name": r["description"] or r["name"], "degree": 0} for r in tbl_rows]
+    files = [{"uri": file_uri(vault, r["id"], r["coll"]), "resource_type": "file",
+              "name": r["name"] or file_uri(vault, r["id"], r["coll"]), "degree": 0} for r in file_rows]
+
+    # Round-robin interleave, then cap at `limit` so each type is represented.
+    merged = [n for trio in zip_longest(docs, tables, files) for n in trio if n is not None]
+    # Honest truncation signal (parallel to the connected `truncated`): any
+    # catalog that hit its LIMIT may have more orphans we didn't fetch, or the
+    # interleaved set exceeded the cap. Lets the client say "+N more unlinked"
+    # instead of silently implying these are ALL the orphans.
+    truncated = (
+        len(doc_rows) >= per or len(tbl_rows) >= per or len(file_rows) >= per
+        or len(merged) > limit
+    )
+    return merged[:limit], truncated
+
+
 async def get_overview(
     vault: str,
     *,
     vault_id: uuid.UUID | None = None,
     top_k: int = 200,
+    include_orphans: bool = True,
+    orphan_limit: int = 500,
 ) -> dict:
     """Whole-vault overview: the `top_k` highest-DEGREE nodes plus the edges
     induced among them, with honest totals so the client can render an explicit
-    "showing N of M" instead of silently truncating.
+    "showing N of M" instead of silently truncating. With `include_orphans`,
+    unlinked resources (docs/tables/files in no edge) are appended as degree-0
+    isolated nodes so a vault with no relations yet still renders its resources
+    instead of a blank canvas; the client's "Hide orphans" toggle governs them.
+
+    Response contract: ``nodes_total`` / ``returned`` / ``truncated`` describe
+    the CONNECTED graph only (the degree-ranked slice), while the ``nodes`` array
+    additionally carries the orphan nodes. So ``len(nodes) == returned +
+    orphans_returned`` — do NOT assume ``len(nodes) <= nodes_total``. The
+    "showing N of M" banner reads ``returned``/``nodes_total`` (connected); the
+    orphans are extra and toggle-hideable, and ``orphans_truncated`` says whether
+    the orphan set itself was capped at ``orphan_limit`` (more unlinked resources
+    exist than returned).
 
     Supersedes the old no-`resource_uri` branch of :func:`get_graph`, which
     capped on ``created_at DESC`` (an arbitrary recency slice whose composition
@@ -588,6 +669,7 @@ async def get_overview(
     empty = {
         "nodes": [], "edges": [],
         "nodes_total": 0, "edges_total": 0, "returned": 0, "truncated": False,
+        "orphans_returned": 0, "orphans_truncated": False,
     }
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -611,8 +693,9 @@ async def get_overview(
         )
         nodes_total = totals["nodes_total"] if totals else 0
         edges_total = totals["edges_total"] if totals else 0
-        if not nodes_total:
-            return empty
+        # NB: do NOT early-return when nodes_total == 0 — a vault may have
+        # unlinked resources (orphans) to render even with zero edges. The
+        # degree query below simply yields nothing in that case.
 
         # Top-`top_k` endpoints by degree. `degree` here is INCIDENT-EDGE count
         # (count(*) over the endpoint stream) — the same definition the canvas
@@ -678,13 +761,65 @@ async def get_overview(
         for uri, node in nodes.items():
             node["name"] = names.get(uri) or uri
 
+        connected_count = len(nodes)
+
+        # Append unlinked resources as degree-0 isolated nodes (so a tables-only
+        # / freshly-seeded vault renders its resources, not a blank canvas).
+        # `_fetch_orphan_nodes` anti-joins each catalog against the set of
+        # connected IDENTITIES (doc paths / table names / file ids), so a
+        # linked-but-low-degree resource is never mistaken for an orphan — and
+        # identity (not URI) matching is robust to a non-canonical collection
+        # segment on a stored edge URI. Identities come from EVERY edge endpoint
+        # (not just the top-K shown); UNION ALL since the Python sets dedup.
+        orphans_truncated = False
+        if include_orphans and orphan_limit > 0:
+            doc_paths: set[str] = set()
+            table_names: set[str] = set()
+            file_ids: set[str] = set()
+            if nodes_total:
+                conn_rows = await conn.fetch(
+                    "SELECT source_uri AS uri FROM edges WHERE vault_id = $1 "
+                    "UNION ALL SELECT target_uri FROM edges WHERE vault_id = $1",
+                    vault_id,
+                )
+                for r in conn_rows:
+                    p = parse_uri(r["uri"])
+                    if not p or not p.identifier:
+                        # An edge endpoint we can't parse drops out of the
+                        # connected-identity set, so its resource could surface
+                        # as a phantom orphan — log it (matches the other
+                        # edge-skip debug lines in this module) rather than fail
+                        # silently. Validated edges don't hit this; legacy/
+                        # malformed URIs might.
+                        logger.debug(
+                            "overview orphan-partition: unparseable edge endpoint "
+                            "%r in vault %s", r["uri"], vault,
+                        )
+                        continue
+                    if p.kind == "doc":
+                        doc_paths.add(p.identifier)
+                    elif p.kind == "table":
+                        table_names.add(p.identifier)
+                    elif p.kind == "file":
+                        file_ids.add(p.identifier)
+            orphan_nodes, orphans_truncated = await _fetch_orphan_nodes(
+                conn, vault, vault_id,
+                doc_paths=doc_paths, table_names=table_names, file_ids=file_ids,
+                limit=orphan_limit,
+            )
+            for o in orphan_nodes:
+                if o["uri"] not in nodes:
+                    nodes[o["uri"]] = o
+
     return {
         "nodes": list(nodes.values()),
         "edges": edge_list,
         "nodes_total": nodes_total,
         "edges_total": edges_total,
-        "returned": len(nodes),
-        "truncated": len(nodes) < nodes_total,
+        "returned": connected_count,
+        "truncated": connected_count < nodes_total,
+        "orphans_returned": len(nodes) - connected_count,
+        "orphans_truncated": orphans_truncated,
     }
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.9.1"
+version = "0.9.2"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_relations_rest_e2e.sh
+++ b/backend/tests/test_relations_rest_e2e.sh
@@ -257,6 +257,19 @@ print('OK' if ok else 'BAD '+json.dumps({'edges_total':d['edges_total'],'nodes_t
 " 2>&1)
 [ "$OVCHECK" = "OK" ] && pass "overview: totals(3/2) + degree-ranked hub A + edge kind" || fail "overview" "$OVCHECK"
 
+# overview surfaces unlinked resources as degree-0 isolated nodes (so a vault
+# with orphans isn't a blank canvas). Orphan doc D must appear with degree 0,
+# and orphans_returned must count it. nodes_total stays the CONNECTED total (3).
+ORPHCHECK=$(gov "$PAT1" "$VAULT1" 200 | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+by_uri={n['uri']:n for n in d['nodes']}
+dn=by_uri.get('$URI_D')
+ok = (d.get('orphans_returned',0) >= 1 and dn is not None and dn.get('degree')==0 and d['nodes_total']==3)
+print('OK' if ok else 'BAD orphans_returned='+str(d.get('orphans_returned'))+' D='+json.dumps(dn))
+" 2>&1)
+[ "$ORPHCHECK" = "OK" ] && pass "overview: unlinked doc D surfaced as degree-0 orphan node" || fail "overview orphans" "$ORPHCHECK"
+
 # overview truncation: top_k=1 keeps only the single highest-degree node.
 TRUNC=$(gov "$PAT1" "$VAULT1" 1 | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['returned']==1 and d['truncated'] is True and d['nodes_total']==3)" 2>/dev/null)
 [ "$TRUNC" = "True" ] && pass "overview: top_k=1 → returned 1 of 3, truncated true" || fail "overview trunc" "got $TRUNC"
@@ -271,6 +284,32 @@ orph_ok = orph.get('count',0)>=1 and any('Orphan Doc' in (o.get('name') or '') f
 print('OK' if (hub_ok and orph_ok) else 'BAD '+json.dumps({'hubs':[(h.get('uri'),h.get('degree')) for h in hubs],'orphans':orph}))
 " 2>&1)
 [ "$HCHECK" = "OK" ] && pass "health: hub A(deg2) + orphan D reported" || fail "health" "$HCHECK"
+
+# Identity-based orphan matching (regression guard for the false-orphan-duplicate
+# bug): a collection-scoped TABLE linked via a NON-CANONICAL (mis-cased
+# collection) URI must NOT re-appear as a phantom orphan duplicate of its
+# connected self; an unlinked table must surface as a degree-0 'table' orphan.
+# Also pins the contract len(nodes) == returned + orphans_returned. (Placed last
+# in §5 — linking a table changes the connected count the checks above assert.)
+curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT1" -H "Authorization: Bearer $PAT1" -H 'Content-Type: application/json' \
+  -d '{"name":"linked_tbl","columns":[{"name":"k","type":"text"}],"collection":"specs"}' >/dev/null
+curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT1" -H "Authorization: Bearer $PAT1" -H 'Content-Type: application/json' \
+  -d '{"name":"lonely_tbl","columns":[{"name":"k","type":"text"}],"collection":"specs"}' >/dev/null
+# link doc A -> table via a MIS-CASED collection segment (canonical is 'specs')
+rpost "$PAT1" "{\"source\":\"$URI_A\",\"target\":\"akb://$VAULT1/coll/SPECS/table/linked_tbl\",\"relation\":\"references\"}" >/dev/null
+TBLCHECK=$(gov "$PAT1" "$VAULT1" 200 | python3 -c "
+import sys,json,collections
+d=json.load(sys.stdin)
+dups=[u for u,c in collections.Counter(n['uri'] for n in d['nodes']).items() if c>1]
+linked=[n for n in d['nodes'] if n['uri'].endswith('/table/linked_tbl')]
+lonely=[n for n in d['nodes'] if n['uri'].endswith('/table/lonely_tbl')]
+ok = (not dups
+      and len(linked)==1 and (linked[0].get('degree') or 0)>=1
+      and len(lonely)==1 and lonely[0].get('degree')==0 and lonely[0].get('resource_type')=='table'
+      and len(d['nodes'])==d['returned']+d['orphans_returned'])
+print('OK' if ok else 'BAD dups='+str(dups)+' linked='+json.dumps(linked)+' lonely='+json.dumps(lonely))
+" 2>&1)
+[ "$TBLCHECK" = "OK" ] && pass "overview: non-canonical-linked table not duplicated; unlinked table is degree-0 orphan" || fail "overview table orphan" "$TBLCHECK"
 
 # Reader-gating + cross-vault isolation.
 CODE=$(gov_code "$PAT2" "$VAULT1"); [ "$CODE" = "200" ] && pass "overview: reader (USER2) on V1 → 200" || fail "overview reader" "got $CODE"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -396,6 +396,17 @@ export interface GraphOverviewResponse {
   edges_total: number;
   returned: number;
   truncated: boolean;
+  // Count of unlinked resources appended as degree-0 isolated nodes (so a vault
+  // with no relations still renders its resources, governed by the "Hide
+  // orphans" toggle). nodes_total/returned/truncated describe the CONNECTED
+  // graph only; `nodes` additionally holds the orphans (len(nodes) = returned +
+  // orphans_returned). INFORMATIONAL — the canvas recomputes its own orphan
+  // count from edge connectivity (graph.tsx), it does not read this field.
+  orphans_returned?: number;
+  // True when the orphan set was capped (orphan_limit) — more unlinked
+  // resources exist than were returned. Parallel to `truncated` for the
+  // connected graph.
+  orphans_truncated?: boolean;
 }
 export const getGraphOverview = (vault: string, topK = 200) => {
   const p = new URLSearchParams({ vault, top_k: String(topK) });


### PR DESCRIPTION
## Problem

The graph overview was built **purely from edge endpoints**, so a resource in **no relation** (an unlinked table/file/doc) never appeared anywhere in the graph. A vault with **only unlinked resources** (e.g. a tables-only vault) rendered a **blank canvas** — and the "Hide orphans" toggle couldn't help, because the orphan resources were never fetched in the first place.

> Reported: *"a table-only vault has no way to see the orphans."* — correct; my earlier "it's not a bug, just need linked data" was only half right.

## Fix

`get_overview` now appends unlinked resources as **degree-0 isolated nodes** (`include_orphans=True`, capped at `orphan_limit=500`):
- non-archived **docs**, **tables**, **files** that appear in no edge
- collection-correct URIs (tables/files join their collection path; a doc's `path` already embeds it)
- checked against the **full** connected set (every edge endpoint, not just the top-K shown) so a linked-but-low-degree resource is never mistaken for an orphan
- the early `no edges → empty` return is gone, so a **zero-edge vault still renders** its resources

Response adds `orphans_returned`; `nodes_total` / `returned` / `truncated` still describe the **connected** graph only.

**No client change needed**: the existing **"Hide orphans"** toggle already governs degree-0 nodes, so the overview defaults to showing everything and users declutter on demand. Since `get_graph(no resource_uri)` delegates to `get_overview`, MCP `akb_graph(vault)` + `GET /graph?vault=` inherit it; the **BFS (`uri`) path is unaffected** (a focused neighborhood stays connected-only).

Bounded for the hot path: the orphan fetch reads at most `orphan_limit` recent rows per catalog and stops once the cap is met.

Backend **0.9.2**.

## Verified live
- a **tables-only vault** (2 tables + 2 docs, no links) now renders 4 isolated nodes (table = rounded square, doc = circle) + sidebar shows **"Hide orphans (4 unconnected)"**; toggling it empties the canvas (all 4 are orphans)
- `get_graph(no-uri)` delegation includes orphans (`orphans_returned: 4`); BFS (`uri`) does **not** (focused neighborhood = connected only)
- existing node-count assertions safe (BFS paths exclude orphans; `>= N` lower bounds only increase)

New e2e (`test_relations_rest_e2e.sh §5`): the unlinked doc D is surfaced as a degree-0 orphan node with `orphans_returned >= 1`. Frontend gate (typecheck/lint 0/design-check/338 tests) green; backend 20 unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)