### PR TITLE
fix(frontend/ui): keep Badge pills on one line (whitespace-nowrap)

### DIFF
--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -3,7 +3,10 @@ import type { HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] tracking-normal font-medium",
+  // whitespace-nowrap: a pill must never wrap its label — without it, a chip
+  // like "indexing 1,234" breaks at the space when the row is tight and the
+  // count drops onto a second line, ballooning the pill vertically.
+  "inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-2 py-0.5 text-[11px] tracking-normal font-medium",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## What

The header **Indexing chip** (`indexing 1,234`) wrapped: when the top nav row got tight, the count dropped onto a second line below the word, ballooning the pill vertically — reported as "숫자 부분이 텍스트 아래로 내려가서 이쁘지 않은 현상".

## Cause

The `Badge` primitive base class was `inline-flex items-center gap-1 …` with **no `whitespace-nowrap`**. A flex item's `min-width: auto` resolves to min-content (the longest word), so under horizontal pressure the label can shrink and wrap at its internal space.

## Fix

Add `whitespace-nowrap` to the **shared `Badge` primitive** (not just the one chip) — a pill should never wrap its label, so this also immunizes every other badge (role/status/count chips) against the same bug. The right altitude: generalize the primitive rather than special-case the indexing chip.

## Verification

Measured in the app's compiled Tailwind CSS (Playwright, 74px-constrained flex parent, label `indexing 1,234`):

| | `white-space` | pill height |
|---|---|---|
| before | `normal` | **39px** (two lines — bug reproduced) |
| after | `nowrap` | **23px** (one line) |

- `npm run design:check` ✓ · `npm run typecheck` ✓ (0 errors) · `npm run lint` ✓ (0 errors) · `npm run test` 338/338 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)