### PR TITLE
fix(frontend): Recent-activity click no longer opens docs as "historical"

### DIFF
--- a/frontend/src/lib/__tests__/commit.test.ts
+++ b/frontend/src/lib/__tests__/commit.test.ts
@@ -1,30 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { sameCommitRef } from "../commit";
 
-describe("sameCommitRef", () => {
-  const full = "72a6a3d7bedeb1514923c157017c72373e21cb16";
-  const short = "72a6a3d7bede"; // 12-char abbreviation the commit log emits
+// Fixtures are git commit SHAs, not secrets — the allowlist pragmas silence
+// detect-secrets' high-entropy-hex heuristic.
+const FULL = "72a6a3d7bedeb1514923c157017c72373e21cb16"; // pragma: allowlist secret
+const SHORT = FULL.slice(0, 12); // the 12-char abbreviation the commit log emits
+const OTHER = "1f994a7021b3"; // pragma: allowlist secret — a different commit
 
+describe("sameCommitRef", () => {
   it("matches identical full SHAs", () => {
-    expect(sameCommitRef(full, full)).toBe(true);
+    expect(sameCommitRef(FULL, FULL)).toBe(true);
   });
 
   it("matches a short hash that prefixes the full SHA (the bug fix)", () => {
-    expect(sameCommitRef(short, full)).toBe(true);
+    expect(sameCommitRef(SHORT, FULL)).toBe(true);
   });
 
   it("matches regardless of argument order", () => {
-    expect(sameCommitRef(full, short)).toBe(true);
+    expect(sameCommitRef(FULL, SHORT)).toBe(true);
   });
 
   it("rejects a different commit that shares no prefix", () => {
-    expect(sameCommitRef("1f994a7021b3", full)).toBe(false);
+    expect(sameCommitRef(OTHER, FULL)).toBe(false);
   });
 
   it("rejects when HEAD is missing — stays conservative while loading", () => {
-    expect(sameCommitRef(short, undefined)).toBe(false);
-    expect(sameCommitRef(short, null)).toBe(false);
-    expect(sameCommitRef(undefined, full)).toBe(false);
+    expect(sameCommitRef(SHORT, undefined)).toBe(false);
+    expect(sameCommitRef(SHORT, null)).toBe(false);
+    expect(sameCommitRef(undefined, FULL)).toBe(false);
   });
 
   it("rejects when both refs are empty", () => {

--- a/frontend/src/lib/__tests__/commit.test.ts
+++ b/frontend/src/lib/__tests__/commit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sameCommitRef } from "../commit";
+
+describe("sameCommitRef", () => {
+  const full = "72a6a3d7bedeb1514923c157017c72373e21cb16";
+  const short = "72a6a3d7bede"; // 12-char abbreviation the commit log emits
+
+  it("matches identical full SHAs", () => {
+    expect(sameCommitRef(full, full)).toBe(true);
+  });
+
+  it("matches a short hash that prefixes the full SHA (the bug fix)", () => {
+    expect(sameCommitRef(short, full)).toBe(true);
+  });
+
+  it("matches regardless of argument order", () => {
+    expect(sameCommitRef(full, short)).toBe(true);
+  });
+
+  it("rejects a different commit that shares no prefix", () => {
+    expect(sameCommitRef("1f994a7021b3", full)).toBe(false);
+  });
+
+  it("rejects when HEAD is missing — stays conservative while loading", () => {
+    expect(sameCommitRef(short, undefined)).toBe(false);
+    expect(sameCommitRef(short, null)).toBe(false);
+    expect(sameCommitRef(undefined, full)).toBe(false);
+  });
+
+  it("rejects when both refs are empty", () => {
+    expect(sameCommitRef("", "")).toBe(false);
+  });
+});

--- a/frontend/src/lib/commit.ts
+++ b/frontend/src/lib/commit.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether two git commit refs point at the SAME commit, tolerating
+ * abbreviated hashes.
+ *
+ * AKB surfaces commit refs at different widths: the vault commit log links
+ * 12-char short hashes, while a document's `current_commit` is the full
+ * 40-char SHA. A git short hash is always a prefix of its full SHA, so exact
+ * string equality would wrongly compare the newest commit (short) against HEAD
+ * (full) and flag a live document as "historical". Prefix matching fixes that.
+ *
+ * Returns false when either ref is missing (e.g. HEAD still loading) so callers
+ * can stay conservative (treat as historical / read-only until HEAD is known).
+ */
+export function sameCommitRef(a?: string | null, b?: string | null): boolean {
+  if (!a || !b) return false;
+  return a.startsWith(b) || b.startsWith(a);
+}

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -25,6 +25,7 @@ import {
 import { timeAgo } from "@/lib/utils";
 import { docUri } from "@/lib/uri";
 import { parseHeadings } from "@/lib/markdown";
+import { sameCommitRef } from "@/lib/commit";
 import { DocumentOutline } from "@/components/doc-outline";
 import { DocumentView } from "@/components/document-view";
 import { SummaryFold } from "@/components/summary-fold";
@@ -91,9 +92,6 @@ export default function DocumentPage() {
   const hydratedKey = useRef<number | null>(null);
   const isDirty = editingContent !== originalContent;
   const docId = id ? decodeURIComponent(id) : "";
-  const canEdit =
-    !commitHash &&
-    (vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner");
 
   const applyView = (next: DocView) => {
     const p = new URLSearchParams(searchParams);
@@ -127,6 +125,28 @@ export default function DocumentPage() {
   });
 
   const doc = docOverride ?? docQuery.data ?? null;
+
+  // A versioned read reports current_commit = the requested version (not HEAD),
+  // so `doc` alone can't reveal the doc's true latest commit. While a commit is
+  // pinned, fetch HEAD separately so we can tell a pin that IS the latest (a
+  // Recent-activity / commit-log click on the newest commit) apart from a
+  // genuinely older one. The key matches the un-pinned docQuery key so the two
+  // share a cache entry rather than double-fetching HEAD.
+  const headQuery = useQuery({
+    queryKey: ["document", name, docId, undefined],
+    queryFn: () => getDocument(name!, docId),
+    enabled: !!name && !!docId && !!commitHash,
+    retry: false,
+  });
+  const headCommit = commitHash ? headQuery.data?.current_commit : doc?.current_commit;
+  // Genuinely historical only when the pin points at a commit OTHER than HEAD.
+  // sameCommitRef does a prefix-tolerant compare (the commit log links 12-char
+  // short hashes; current_commit is the full SHA) and returns false while HEAD
+  // is still loading — so a real older version is never briefly editable.
+  const isHistorical = !!commitHash && !sameCommitRef(commitHash, headCommit);
+  const canEdit =
+    !isHistorical &&
+    (vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner");
   // Parse headings once for the outline-tab count (the outline + renderer each
   // re-scan internally; this removes the third pass that ran on every render).
   const headingSlugs = useMemo(() => parseHeadings(doc?.content || ""), [doc?.content]);
@@ -334,7 +354,7 @@ export default function DocumentPage() {
     }
   }
 
-  const commitShort = doc.current_commit?.slice(0, 7);
+  const commitShort = headCommit?.slice(0, 7);
   const inEditMode = view === "edit";
 
   return (
@@ -350,7 +370,7 @@ export default function DocumentPage() {
         aria-labelledby="doc-title"
         className="min-w-0 w-full max-w-none"
       >
-        {commitHash && (
+        {isHistorical && (
           <div
             role="status"
             aria-live="polite"
@@ -612,7 +632,7 @@ export default function DocumentPage() {
 
       {!inEditMode && (
       <aside className="lg:sticky lg:top-4 lg:self-start lg:max-h-[calc(100dvh-9rem)] flex flex-col text-sm min-h-0">
-        {!commitHash && (() => {
+        {!isHistorical && (() => {
           const canWrite = vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner";
           const rowCls =
             "w-full flex items-center gap-2.5 px-3 py-2.5 text-sm transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset";

--- a/frontend/src/pages/vault.tsx
+++ b/frontend/src/pages/vault.tsx
@@ -448,8 +448,11 @@ export default function VaultPage() {
       {/* Recent writes — primary. Same grammar as the Home dashboard's Recent
           activity (loading flag → skeleton, type-tinted leading chip,
           fresh-token spark, card-hover lift) so a change reads identically
-          across the app. Single-vault context here, so no per-row VaultChip;
-          the git commit ref stays (demoted) since the href is commit-pinned. */}
+          across the app. Single-vault context here, so no per-row VaultChip.
+          The row links to the LIVE document (no ?commit pin): /recent returns
+          each doc's current_commit, so pinning it opened the latest version in
+          read-only "historical" mode. The commit ref still shows (demoted) as
+          an at-a-glance HEAD label. */}
       <section
         className="mt-10"
         aria-labelledby="recent-heading"
@@ -521,10 +524,7 @@ export default function VaultPage() {
                 return (
                   <li key={`${c.doc_id}:${c.commit ?? ""}:${i}`}>
                     <Link
-                      to={
-                        `/vault/${name}/doc/${encodeURIComponent(c.path || c.doc_id)}` +
-                        (c.commit ? `?commit=${encodeURIComponent(c.commit)}` : "")
-                      }
+                      to={`/vault/${name}/doc/${encodeURIComponent(c.path || c.doc_id)}`}
                       className="group card-hover relative z-0 hover:z-10 grid grid-cols-[20px_minmax(0,1fr)_auto] items-center gap-x-3 px-3 py-2.5 bg-surface hover:bg-surface-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     >
                       <span


### PR DESCRIPTION
## Symptom

Clicking a document in a vault's **Recent activity** opened it read-only with a `Viewing version <hash> — writes are disabled until you return to the latest version.` banner — even though it was the **latest** version. Opening the same document from the collection list worked normally.

## Root cause (3-link chain)

1. **`GET /recent`** (`activity.py:137`) returns each doc's **`current_commit`** (its HEAD) as the `commit` field — not an older revision.
2. **`vault.tsx`** pinned that into the Recent row href as `?commit=<current_commit>`.
3. **`document.tsx`** treated *any* `?commit` as historical — `canEdit = !commitHash`, banner `{commitHash && …}` — **without comparing it to HEAD**. So a pin that *equals* HEAD still locked the page.

The collection list links have no `?commit`, which is why they were fine.

## Fix (both ends)

- **(A) `vault.tsx`** — Recent rows link to the live document (no `?commit` pin). The short commit ref still shows as a demoted label.
- **(B) `document.tsx`** — derive `isHistorical` by comparing the pinned commit against the doc's **true HEAD**, and drive the banner / edit-lock / action panel off that instead of mere presence of `?commit`.
  - HEAD is fetched separately because a versioned read reports `current_commit = the requested version, not HEAD` (`document_service.py:623`), so `doc` alone can't reveal the latest commit. The query key matches the un-pinned `docQuery` key so they share a cache entry.
  - The compare is **prefix-tolerant** via a new `sameCommitRef` helper: the commit log emits 12-char short hashes while `current_commit` is the full 40-char SHA, and a git short hash is a prefix of the full one — exact equality would wrongly flag the newest commit (clicked from the commit log) as historical.
  - While HEAD is still loading, it stays locked (conservative — a real older version is never briefly editable).
  - The HEAD meta line now shows the real HEAD even while viewing an older version.

## Verification (Playwright, 2-commit doc)

| Scenario | Banner | Edit | Body | HEAD label |
|---|---|---|---|---|
| Recent-activity click | none ✓ | on ✓ | latest (v2) | true head |
| pin **newest** short hash | none ✓ | on ✓ | latest (v2) | true head |
| pin **older** short hash | shown ✓ | off ✓ | older (v1) | true head ✓ |

- `+6` unit tests for `sameCommitRef` (equal / short-prefix / order / different / loading / empty).
- Gate: `design:check` ✓ · `typecheck` ✓ · `lint` ✓ · `test` **344** ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)