### PR TITLE
fix(search): tokenize on a ProcessPool, not to_thread (event-loop starvation → 503)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2893
+        "line_number": 2918
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-23T05:14:14Z"
+  "generated_at": "2026-06-24T07:33:47Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,31 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.9.3 — 2026-06-24  *(fix — tokenize on a ProcessPool to stop event-loop starvation / 503)*
+
+Kiwi (the BM25 sparse tokenizer) is a CPU-bound C++ extension that does **not**
+release the GIL during native `tokenize()` — the long-standing claim that it did
+was wrong. Running it via `asyncio.to_thread` therefore did not parallelize it:
+concurrent tokenizations serialized on the GIL and the worker threads starved the
+single event-loop thread, so even `/livez` (a no-dependency coroutine) couldn't
+be scheduled → readiness/liveness probes timed out → the pod was pulled from the
+Service → intermittent **503 flapping** under search + indexing load.
+
+`sparse_encoder.tokenize()` now offloads `_tokenize_sync` to a dedicated `spawn`
+**`ProcessPoolExecutor`** (each worker process has its own GIL; an `initializer`
+warms Kiwi per worker), created/torn-down in the lifespan. It falls back to
+`asyncio.to_thread` when the pool isn't started (tests). The one shared
+`tokenize()` means query encoding (`encode_query`), the indexing worker
+(`encode_document`) and the corpus BM25 stats refresher all benefit. Search
+results are unchanged; single-replica / RWO git storage is unaffected.
+
+Measured locally (32 concurrent tokenizations of a chunk-sized text): event-loop
+max stall dropped from ~472 ms (`to_thread`, ≈ total tokenize wall-time → fully
+serial) to ~13–34 ms (`ProcessPool`), with ~4× tokenization throughput. This is
+the classic GIL rule — CPU-bound work that doesn't release the GIL must use
+multiprocessing, not threading; the I/O-bound embed/rerank HTTP calls were
+already async and were left as-is.
+
 ## 0.9.2 — 2026-06-23  *(feat — graph overview surfaces unlinked resources as isolated nodes)*
 
 The graph overview was built purely from edge endpoints, so a resource in **no

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -114,8 +114,15 @@ def start_workers() -> None:
     # once at startup and then on a configurable cadence so the sparse
     # leg of hybrid search isn't silently degraded on fresh installs or
     # after long periods without manual init.
+    # Dedicated Kiwi tokenizer process pool. Kiwi's native tokenize() holds the
+    # GIL, so asyncio.to_thread can't parallelize it and concurrent tokenization
+    # (search + this corpus-wide stats refresher + embed_worker) starves the
+    # event loop → probe timeouts → 503. Run it off-process. Start it BEFORE the
+    # stats refresher, which tokenizes the whole corpus on first tick. (Serving
+    # also depends on it — move to the always-run path if API/worker tiers split.)
+    sparse_encoder.start_tokenizer_pool()
     sparse_encoder.start_stats_refresher(settings.bm25_recompute_interval_secs)
-    started = ["embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher", "vault_backfill"]
+    started = ["tokenizer_pool", "embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher", "vault_backfill"]
     # s3_delete_worker drains s3_delete_outbox into S3 deletes. Only
     # makes sense when S3 is configured; otherwise file uploads are
     # disabled altogether and the outbox stays empty forever.
@@ -176,6 +183,7 @@ async def stop_workers() -> None:
     await embed_worker.stop()
     await vault_backfill.stop()
     await sparse_encoder.stop_stats_refresher()
+    sparse_encoder.stop_tokenizer_pool()
 
 
 async def shutdown_storage() -> None:

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -41,8 +41,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import multiprocessing
+import os
 import time
 from collections import Counter, OrderedDict
+from concurrent.futures import ProcessPoolExecutor
 from typing import Iterable
 
 import kiwipiepy
@@ -248,12 +251,63 @@ _TOKEN_CACHE_MAX = 2048
 _token_cache: "OrderedDict[str, list[str]]" = OrderedDict()
 
 
+# ── Dedicated tokenizer process pool ──────────────────────────────────
+# Kiwi's native tokenize() is CPU-bound and does NOT release the GIL (the old
+# claim that it did was wrong for kiwipiepy). Running it via asyncio.to_thread
+# therefore does NOT parallelize it: concurrent tokenizations serialize on the
+# GIL and the worker threads starve the event-loop thread, so even /livez can't
+# be scheduled → readiness/liveness probes time out → the pod is pulled from the
+# Service → 503 flapping under search/indexing load. A ProcessPool gives each
+# worker its own interpreter + GIL, so tokenization runs truly off the serving
+# loop. Measured locally: 32 concurrent tokenizations froze the loop ~470ms via
+# to_thread vs ~13ms via this pool (and ran ~4x faster).
+_tokenizer_pool: ProcessPoolExecutor | None = None
+
+
+def _init_tokenizer_worker() -> None:
+    """Run once per child process: warm the Kiwi model so the first real
+    tokenize() in that worker doesn't pay the model-load cost."""
+    _get_kiwi()
+
+
+def start_tokenizer_pool(processes: int | None = None) -> None:
+    """Create the dedicated Kiwi tokenizer process pool. Idempotent.
+
+    `spawn` is forced — forking a multithreaded asyncio server is unsafe. This
+    is a SERVING dependency (query encode_query) as well as a worker dependency,
+    so if API and indexing-worker tiers are ever split it must be started on the
+    always-run path, not behind a worker gate.
+    """
+    global _tokenizer_pool
+    if _tokenizer_pool is not None:
+        return
+    n = processes if (processes and processes > 0) else max(2, min(4, os.cpu_count() or 2))
+    _tokenizer_pool = ProcessPoolExecutor(
+        max_workers=n,
+        mp_context=multiprocessing.get_context("spawn"),
+        initializer=_init_tokenizer_worker,
+    )
+    logger.info("Kiwi tokenizer ProcessPool started (workers=%d, spawn)", n)
+
+
+def stop_tokenizer_pool() -> None:
+    """Tear down the tokenizer pool. Idempotent."""
+    global _tokenizer_pool
+    pool, _tokenizer_pool = _tokenizer_pool, None
+    if pool is not None:
+        pool.shutdown(wait=False, cancel_futures=True)
+        logger.info("Kiwi tokenizer ProcessPool stopped")
+
+
 async def tokenize(text: str) -> list[str]:
     """Tokenize text into content-bearing terms (lemma form for verbs).
 
-    Async because Kiwi is sync C++ and would otherwise block the event loop;
-    we offload to a worker thread (Kiwi releases the GIL during native work).
-    Result is LRU-cached by source text.
+    Kiwi is a sync C++ tokenizer that does NOT release the GIL during native
+    work, so running it on the loop — or via asyncio.to_thread, which shares the
+    loop process's GIL — starves request handling and health probes. We offload
+    to a dedicated ProcessPool (each worker has its own GIL) when one is running;
+    otherwise (tests / pool not started) we fall back to a thread. Result is
+    LRU-cached by source text.
     """
     if not text:
         return []
@@ -261,7 +315,13 @@ async def tokenize(text: str) -> list[str]:
     if cached is not None:
         _token_cache.move_to_end(text)
         return cached
-    tokens = await asyncio.to_thread(_tokenize_sync, text)
+    pool = _tokenizer_pool
+    if pool is not None:
+        loop = asyncio.get_running_loop()
+        tokens = await loop.run_in_executor(pool, _tokenize_sync, text)
+    else:
+        # No pool (tests / not started): thread fallback — correct but GIL-bound.
+        tokens = await asyncio.to_thread(_tokenize_sync, text)
     _token_cache[text] = tokens
     _token_cache.move_to_end(text)
     while len(_token_cache) > _TOKEN_CACHE_MAX:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.9.2"
+version = "0.9.3"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"


### PR DESCRIPTION
## Symptom

Prod backend returned **intermittent 503 + slowness** (`GET /api/v1/my/vaults` etc.). The app was healthy in-pod, but its readiness/liveness probes intermittently timed out (`context deadline exceeded`) → kubelet pulled the pod from the Service → ingress had 0 upstream → 503 → recovered → flapping. Even `/livez` (a no-dependency coroutine) stalled, meaning the **single event loop was being starved**.

## Root cause (confirmed by local reproduction)

`sparse_encoder.tokenize()` ran the Kiwi tokenizer via `asyncio.to_thread`. Kiwi is a **CPU-bound C++ extension that does NOT release the GIL** during native `tokenize()` — the comment claiming *"Kiwi releases the GIL during native work"* was wrong. So `to_thread` (threading) does **not** parallelize it: concurrent tokenizations serialize on the GIL and the worker threads starve the event-loop thread. Under search + indexing load (the `embed_worker` drain + the corpus-wide BM25 `recompute_stats`, both tokenizing), the loop froze long enough for probes to time out.

This is the classic GIL rule: **CPU-bound + GIL-not-released → use multiprocessing, not threading.** (I/O-bound parts of search — query embedding, rerank — are HTTP/`httpx` and were already correctly async; only the GIL-bound tokenization needed moving.)

### Measured locally (32 concurrent tokenizations, chunk-sized text)

| path | event-loop max stall | tokenize wall |
|---|---|---|
| `to_thread` (before) | **~472 ms** (== total wall → fully serial) | 472 ms |
| `ProcessPool` (after) | **~13–34 ms** | ~4× faster (true parallelism) |

The stall tracking total wall-time 1:1 is the smoking gun: 18 worker threads, but GIL serializes them and the loop gets zero time.

## Fix

Offload `_tokenize_sync` to a dedicated **`ProcessPoolExecutor`** (each worker process has its own GIL), created/torn down in the lifespan (`spawn` — forking a multithreaded asyncio server is unsafe; `initializer` warms Kiwi per worker). `tokenize()` falls back to `to_thread` when the pool isn't started (tests). One shared `tokenize()` → search (`encode_query`), `embed_worker` (`encode_document`) and the stats refresher all benefit. **Search results unchanged**; RWO/single-replica unaffected.

## Local verification

- Backend boots: `Kiwi tokenizer ProcessPool started (workers=4, spawn)`, no errors.
- Real `tokenize()` via the spawn pool: tokens identical to before; loop max stall 13–34 ms across concurrency 1–32 (vs 472 ms).
- `ruff` clean · `mypy` clean on changed files (the one mypy error is pre-existing in `keycloak_oidc.py`, unrelated) · **28 sparse/search unit tests pass**.

## Follow-ups (separate, documented)

P0-B liveness-probe isolation, P0-C tokenize admission control, P0-D guardrails (keep `indexing_concurrency=1`, never `--workers N` on RWO), and structural P1/P2 (API vs worker tiers, RWX + replicas). Probe-tolerance mitigation (readiness failThresh 6/timeout 8s, liveness failThresh 5) is already applied in prod as a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)