### PR TITLE
feat(search): scope a search to multiple vaults

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 2918
+        "line_number": 2934
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5216,5 +5216,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-24T07:33:47Z"
+  "generated_at": "2026-06-24T08:19:11Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,22 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## 0.9.4 — 2026-06-24  *(feat — search can be scoped to multiple vaults)*
+
+`GET /search` and `GET /grep` now accept a **repeatable** `vault` query param
+(`?vault=a&vault=b`), so a search can be scoped to a CHOSEN SUBSET of vaults —
+not just one vault or all of them. The chosen names are intersected with the
+caller's accessible set (a vault you can't read simply drops out — no leak), via
+`v.name = ANY($)` in both the metadata pre-filter and the `_accessible_vault_ids`
+vector-ACL path (and the `grep` SQL, which now always applies the access
+predicate alongside the name filter). `vault` still accepts a single name for
+MCP / legacy callers (normalized to a one-element list internally), so nothing
+else changes.
+
+On the web, the `/search` page gains a **multi-vault scope picker** — a checkbox
+dropdown (search-filterable) plus removable chips for the current selection;
+empty = "All vaults". The scope is deep-linkable via `?v=a,b,c`.
+
 ## 0.9.3 — 2026-06-24  *(fix — tokenize on a ProcessPool to stop event-loop starvation / 503)*
 
 Kiwi (the BM25 sparse tokenizer) is a CPU-bound C++ extension that does **not**

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -16,7 +16,7 @@ search_service = SearchService()
 @router.get("/search", response_model=SearchResponse, summary="Search documents")
 async def search_documents(
     q: str = Query(..., description="Search query"),
-    vault: str | None = Query(None),
+    vault: list[str] | None = Query(None, description="Limit to one or more vaults (repeat the param); omit for all accessible vaults."),
     collection: str | None = Query(None),
     type: str | None = Query(None),
     tags: list[str] | None = Query(None),
@@ -57,7 +57,7 @@ async def drill_down(
 @router.get("/grep", summary="Literal substring / regex search across documents")
 async def grep_documents(
     q: str = Query(..., description="Pattern to search for"),
-    vault: str | None = Query(None),
+    vault: list[str] | None = Query(None, description="Limit to one or more vaults (repeat the param); omit for all accessible vaults."),
     collection: str | None = Query(None),
     regex: bool = Query(False),
     case_sensitive: bool = Query(False),

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -140,7 +140,7 @@ class SearchService:
     async def search(
         self,
         query: str,
-        vault: str | None = None,
+        vault: str | list[str] | None = None,
         collection: str | None = None,
         doc_type: str | None = None,
         tags: list[str] | None = None,
@@ -156,13 +156,21 @@ class SearchService:
         intersected with the other filters, so retrieval runs only inside that
         set. An empty/omitted list means no restriction (default behaviour).
         """
+        # `vault` accepts a single name (MCP / legacy callers) or a list (the
+        # REST multi-vault scope picker). Normalize to a list of names, or None
+        # for "no vault scope" → search every vault the user can access.
+        vaults: list[str] | None = (
+            [vault] if isinstance(vault, str)
+            else ([v for v in vault if v] or None) if vault
+            else None
+        )
         # ACL guard mirroring `grep` below: when neither vault nor
         # user_id scopes the query, the prefilter block ends up
         # skipped (has_filters=False) and `_run_vector_search` runs
         # unscoped — a cross-vault scan. The MCP and REST handlers
         # both forward user_id today (see issue #66 / PR #67), but
         # this self-defends against any future caller that forgets.
-        if vault is None and user_id is None:
+        if not vaults and user_id is None:
             raise ValidationError("vault or user_id required")
 
         # Server-side limit clamp (issue #189): the MCP schema caps `limit` at
@@ -194,7 +202,7 @@ class SearchService:
 
         # Always pre-filter when user_id is provided so we never leak
         # documents from vaults the user can't read.
-        has_filters = any([vault, collection, doc_type, tags, user_id, source_uris])
+        has_filters = any([vaults, collection, doc_type, tags, user_id, source_uris])
         candidate_source_ids: list[str] | None = None
         candidate_vault_ids: list[str] | None = None
 
@@ -220,7 +228,7 @@ class SearchService:
                     "SELECT is_admin FROM users WHERE id = $1", user_uuid,
                 )) if user_uuid is not None else False
                 candidate_vault_ids = await self._accessible_vault_ids(
-                    conn, user_uuid=user_uuid, is_admin=is_admin, vault=vault,
+                    conn, user_uuid=user_uuid, is_admin=is_admin, vaults=vaults,
                 )
             # None  → admin / anon-with-named-vault → unscoped (mirrors the
             #         source path's no-ACL admin behavior; admin sees all).
@@ -270,9 +278,9 @@ class SearchService:
                 conditions = []
                 params: list = []
                 idx = 1
-                if vault:
-                    conditions.append(f"v.name = ${idx}")
-                    params.append(vault); idx += 1
+                if vaults:
+                    conditions.append(f"v.name = ANY(${idx})")
+                    params.append(vaults); idx += 1
                 if collection:
                     conditions.append(f"d.path LIKE ${idx} || '%'")
                     params.append(collection); idx += 1
@@ -439,7 +447,7 @@ class SearchService:
         )
 
     async def _accessible_vault_ids(
-        self, conn, *, user_uuid: uuid.UUID | None, is_admin: bool, vault: str | None,
+        self, conn, *, user_uuid: uuid.UUID | None, is_admin: bool, vaults: list[str] | None,
     ) -> list[str] | None:
         """The vault ids the user may read — the VAULT-path ACL (issue #189
         Phase 2). Mirrors the per-vault `_vault_acl` predicate exactly so the
@@ -454,21 +462,25 @@ class SearchService:
         """
         # admin / anon mirror `_vault_acl` returning (None, []): no predicate.
         if user_uuid is None or is_admin:
-            if vault:
-                vid = await conn.fetchval("SELECT id FROM vaults WHERE name = $1", vault)
-                return [str(vid)] if vid is not None else []
+            if vaults:
+                rows = await conn.fetch(
+                    "SELECT id FROM vaults WHERE name = ANY($1)", vaults,
+                )
+                return [str(r["id"]) for r in rows]
             return None  # admin, no named vault → unscoped
         # Authenticated non-admin: owner / explicit grant / public.
         acl = (
             "v.id IN (SELECT vault_id FROM vault_access WHERE user_id = $1) "
             "OR v.owner_id = $1 OR v.public_access IN ('reader', 'writer')"
         )
-        if vault:
-            vid = await conn.fetchval(
-                f"SELECT v.id FROM vaults v WHERE v.name = $2 AND ({acl})",
-                user_uuid, vault,
+        if vaults:
+            # Intersect the chosen vault names with the user's accessible set —
+            # a name the user can't read simply drops out (no leak).
+            rows = await conn.fetch(
+                f"SELECT v.id FROM vaults v WHERE v.name = ANY($2) AND ({acl})",
+                user_uuid, vaults,
             )
-            return [str(vid)] if vid is not None else []
+            return [str(r["id"]) for r in rows]
         rows = await conn.fetch(f"SELECT v.id FROM vaults v WHERE {acl}", user_uuid)
         return [str(r["id"]) for r in rows]
 
@@ -753,7 +765,7 @@ class SearchService:
     async def grep(
         self,
         pattern: str,
-        vault: str | None = None,
+        vault: str | list[str] | None = None,
         collection: str | None = None,
         regex: bool = False,
         case_sensitive: bool = False,
@@ -806,10 +818,17 @@ class SearchService:
                     "results": [],
                 }
 
+        # `vault` accepts a single name (MCP / legacy) or a list (REST multi-
+        # vault scope). Normalize to a list of names, or None for "no scope".
+        vaults: list[str] | None = (
+            [vault] if isinstance(vault, str)
+            else ([v for v in vault if v] or None) if vault
+            else None
+        )
         # ACL guard: when no vault is given we MUST have a user_id so the
         # SQL can scope to the vaults that user can access. A None user_id
         # in that branch would silently produce a cross-vault scan.
-        if vault is None and user_id is None:
+        if not vaults and user_id is None:
             raise ValidationError("vault or user_id required")
 
         # Server-side limit clamp (issue #189) — same ceiling as search().
@@ -834,13 +853,14 @@ class SearchService:
                 params.append(pattern)
             idx += 1
 
-            if vault:
-                conditions.append(f"v.name = ${idx}")
-                params.append(vault)
+            if vaults:
+                conditions.append(f"v.name = ANY(${idx})")
+                params.append(vaults)
                 idx += 1
-            elif user_id:
-                # No vault specified: restrict to vaults the user can access
-                # (vault_access for explicit grants OR owner OR public_access)
+            if user_id:
+                # Restrict to vaults the user can access (vault_access grant OR
+                # owner OR public). Applied even when `vaults` is given so the
+                # named set is intersected with the accessible set (no leak).
                 conditions.append(
                     f"(v.id IN (SELECT vault_id FROM vault_access WHERE user_id = ${idx}) "
                     f"OR v.owner_id = ${idx} "

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -135,6 +135,19 @@ def resolve_first_stage_unique_limit(
     return max(configured, limit)
 
 
+def _normalize_vault_scope(vault: str | list[str] | None) -> list[str] | None:
+    """Canonicalize the `vault` arg to a list of names, or None for "no scope".
+
+    `vault` accepts a single name (MCP / legacy callers) or a list (the REST
+    multi-vault scope picker). Blank/empty entries are dropped, and an empty
+    result collapses to None ("search every vault the user can read") — so a
+    stray `?vault=&vault=` can't be read as a real (empty-named) vault.
+    """
+    if isinstance(vault, str):
+        vault = [vault]
+    return [v for v in (vault or []) if v] or None
+
+
 class SearchService:
 
     async def search(
@@ -156,14 +169,9 @@ class SearchService:
         intersected with the other filters, so retrieval runs only inside that
         set. An empty/omitted list means no restriction (default behaviour).
         """
-        # `vault` accepts a single name (MCP / legacy callers) or a list (the
-        # REST multi-vault scope picker). Normalize to a list of names, or None
-        # for "no vault scope" → search every vault the user can access.
-        vaults: list[str] | None = (
-            [vault] if isinstance(vault, str)
-            else ([v for v in vault if v] or None) if vault
-            else None
-        )
+        # Single name (MCP/legacy) or list (REST multi-vault scope) → canonical
+        # list, or None for "every accessible vault". See _normalize_vault_scope.
+        vaults = _normalize_vault_scope(vault)
         # ACL guard mirroring `grep` below: when neither vault nor
         # user_id scopes the query, the prefilter block ends up
         # skipped (has_filters=False) and `_run_vector_search` runs
@@ -230,9 +238,10 @@ class SearchService:
                 candidate_vault_ids = await self._accessible_vault_ids(
                     conn, user_uuid=user_uuid, is_admin=is_admin, vaults=vaults,
                 )
-            # None  → admin / anon-with-named-vault → unscoped (mirrors the
-            #         source path's no-ACL admin behavior; admin sees all).
-            # []    → the user can read no matching vault → no results.
+            # None  → admin / anon with NO named vault → unscoped (mirrors the
+            #         source path's no-ACL admin behavior; admin sees all). A
+            #         named scope always resolves to ids (a list), never None.
+            # []    → the named vaults are all unreadable → no results.
             if candidate_vault_ids is not None and not candidate_vault_ids:
                 return SearchResponse(
                     query=query, total=0, returned=0, total_matches=0, results=[],
@@ -322,9 +331,9 @@ class SearchService:
                 if not doc_type or doc_type == "table":
                     t_params: list = []
                     t_conds: list[str] = []
-                    if vault:
-                        t_conds.append("v.name = $1")
-                        t_params.append(vault)
+                    if vaults:
+                        t_conds.append("v.name = ANY($1)")
+                        t_params.append(vaults)
                     acl_sql, acl_params = _vault_acl(len(t_params) + 1)
                     if acl_sql:
                         t_conds.append(acl_sql)
@@ -341,9 +350,9 @@ class SearchService:
                 if not doc_type or doc_type == "file":
                     f_params: list = []
                     f_conds: list[str] = []
-                    if vault:
-                        f_conds.append("v.name = $1")
-                        f_params.append(vault)
+                    if vaults:
+                        f_conds.append("v.name = ANY($1)")
+                        f_params.append(vaults)
                     if collection:
                         # vault_files.collection (TEXT) was dropped in
                         # migration 020 → collection_id FK. Filter via the
@@ -454,10 +463,11 @@ class SearchService:
         flag is a pure performance change, never a security change.
 
         Returns:
-          - ``None``  → no ACL filter needed (admin, or an anon caller scoped by
-            an explicit vault name) → an unscoped vector search, same as the
-            source path's no-ACL admin behavior.
-          - ``[]``    → the user can read no matching vault → caller returns [].
+          - ``None``  → no ACL filter needed: admin / anon with NO named scope
+            → an unscoped vector search (same as the source path's no-ACL admin
+            behavior). A named scope ALWAYS resolves to ids (never None).
+          - ``[]``    → the named vaults are all unreadable (or don't exist) →
+            caller returns [].
           - ``[id…]`` → the accessible vault id(s) to filter on.
         """
         # admin / anon mirror `_vault_acl` returning (None, []): no predicate.
@@ -818,13 +828,9 @@ class SearchService:
                     "results": [],
                 }
 
-        # `vault` accepts a single name (MCP / legacy) or a list (REST multi-
-        # vault scope). Normalize to a list of names, or None for "no scope".
-        vaults: list[str] | None = (
-            [vault] if isinstance(vault, str)
-            else ([v for v in vault if v] or None) if vault
-            else None
-        )
+        # Single name (MCP/legacy) or list (REST multi-vault scope) → canonical
+        # list, or None for "every accessible vault". See _normalize_vault_scope.
+        vaults = _normalize_vault_scope(vault)
         # ACL guard: when no vault is given we MUST have a user_id so the
         # SQL can scope to the vaults that user can access. A None user_id
         # in that branch would silently produce a cross-vault scan.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.9.3"
+version = "0.9.4"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"

--- a/backend/tests/test_search_multi_vault_unit.py
+++ b/backend/tests/test_search_multi_vault_unit.py
@@ -1,0 +1,87 @@
+"""Unit tests for the multi-vault search scope (PR #245).
+
+- `_normalize_vault_scope`: str | list | None → canonical list-or-None, with
+  blank/empty entries dropped (the type invariant the whole feature rests on).
+- `_accessible_vault_ids`: the no-leak ACL INTERSECTION — a named vault the
+  caller can't read must drop out, never error or leak. Mocks the DB conn
+  (routing fetch() by SQL substring, same as test_search_source_uris_unit.py)
+  so the intersection is asserted without a live database.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.services.search_service import SearchService, _normalize_vault_scope
+
+# asyncio_mode = "auto" (pyproject) marks the async tests; the sync
+# `_normalize_vault_scope` test must NOT carry an asyncio mark.
+
+
+def test_normalize_vault_scope():
+    # single name (MCP / legacy) → one-element list
+    assert _normalize_vault_scope("eng") == ["eng"]
+    # list (REST multi-vault scope) → kept
+    assert _normalize_vault_scope(["a", "b"]) == ["a", "b"]
+    # None / empty / all-blank / blanks-mixed → None ("every accessible vault")
+    assert _normalize_vault_scope(None) is None
+    assert _normalize_vault_scope([]) is None
+    assert _normalize_vault_scope([""]) is None
+    assert _normalize_vault_scope(["", ""]) is None
+    # a stray empty entry (e.g. `?v=a,,b`) is dropped, the rest kept
+    assert _normalize_vault_scope(["a", "", "b"]) == ["a", "b"]
+
+
+class _AclConn:
+    """asyncpg-conn stand-in for _accessible_vault_ids. `accessible` is the set
+    of vault names the (non-admin) user may read; `all_vaults` maps name→id."""
+
+    def __init__(self, all_vaults: dict, accessible: set):
+        self._all = all_vaults
+        self._acc = accessible
+
+    async def fetch(self, sql: str, *params):
+        if "vault_access" in sql:
+            # authenticated path: WHERE v.name = ANY($2) AND (<acl>)
+            _user, names = params
+            return [{"id": self._all[n]} for n in names if n in self._all and n in self._acc]
+        # admin / anon path: WHERE name = ANY($1)
+        (names,) = params
+        return [{"id": self._all[n]} for n in names if n in self._all]
+
+
+async def test_accessible_vault_ids_intersects_with_acl_no_leak():
+    """A named vault the user can't read drops out (no leak); the readable one stays."""
+    mine, theirs = uuid.uuid4(), uuid.uuid4()
+    conn = _AclConn(all_vaults={"mine": mine, "theirs": theirs}, accessible={"mine"})
+    ids = await SearchService()._accessible_vault_ids(
+        conn, user_uuid=uuid.uuid4(), is_admin=False, vaults=["mine", "theirs"],
+    )
+    assert ids == [str(mine)]  # "theirs" intersected away
+
+
+async def test_accessible_vault_ids_all_unreadable_returns_empty():
+    """Scoping ONLY to unreadable vaults → [] (caller short-circuits to no results)."""
+    conn = _AclConn(all_vaults={"theirs": uuid.uuid4()}, accessible=set())
+    ids = await SearchService()._accessible_vault_ids(
+        conn, user_uuid=uuid.uuid4(), is_admin=False, vaults=["theirs"],
+    )
+    assert ids == []
+
+
+async def test_accessible_vault_ids_no_scope_returns_none_for_admin():
+    """admin with no named scope → None (unscoped)."""
+    conn = _AclConn(all_vaults={}, accessible=set())
+    ids = await SearchService()._accessible_vault_ids(
+        conn, user_uuid=uuid.uuid4(), is_admin=True, vaults=None,
+    )
+    assert ids is None
+
+
+async def test_accessible_vault_ids_admin_named_scope_resolves_to_ids():
+    """A named scope ALWAYS resolves to ids (a list), never None — even for admin."""
+    a, b = uuid.uuid4(), uuid.uuid4()
+    conn = _AclConn(all_vaults={"a": a, "b": b}, accessible=set())
+    ids = await SearchService()._accessible_vault_ids(
+        conn, user_uuid=None, is_admin=True, vaults=["a", "b"],
+    )
+    assert sorted(ids) == sorted([str(a), str(b)])

--- a/frontend/src/components/vault-scope-picker.tsx
+++ b/frontend/src/components/vault-scope-picker.tsx
@@ -1,0 +1,126 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronDown, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { MenuFilter } from "@/components/ui/menu-filter";
+import { MENU_FILTER_THRESHOLD, filterByText } from "@/components/ui/menu-filter-utils";
+
+interface VaultScopePickerProps {
+  vaults: { name: string }[];
+  /** Selected vault names. Empty = "all accessible vaults" (the default). */
+  selected: string[];
+  onChange: (next: string[]) => void;
+  className?: string;
+}
+
+/**
+ * Multi-vault search scope. A checkbox dropdown (same Radix DropdownMenu +
+ * MenuFilter pattern as SelectMenu, but CheckboxItem instead of RadioItem so
+ * the menu stays open across toggles) plus removable chips for the current
+ * selection. Empty selection means "search every accessible vault", so the
+ * trigger reads "All vaults (N)" and there are no chips — the calm default.
+ */
+export function VaultScopePicker({ vaults, selected, onChange, className }: VaultScopePickerProps) {
+  const [filter, setFilter] = useState("");
+  const names = useMemo(() => vaults.map((v) => v.name), [vaults]);
+  const showFilter = names.length > MENU_FILTER_THRESHOLD;
+  const filtered = useMemo(
+    () => (showFilter ? filterByText(names, filter, (n) => n) : names),
+    [names, filter, showFilter],
+  );
+  const selectedSet = new Set(selected);
+
+  function toggle(name: string) {
+    onChange(selectedSet.has(name) ? selected.filter((s) => s !== name) : [...selected, name]);
+  }
+
+  const triggerLabel =
+    selected.length === 0
+      ? `All vaults (${vaults.length})`
+      : `${selected.length} vault${selected.length === 1 ? "" : "s"}`;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger
+          aria-label={`Search scope: ${triggerLabel}`}
+          className={cn(
+            "inline-flex h-9 shrink-0 items-center gap-2 rounded-[var(--radius-md)] border border-border bg-surface px-3 text-sm text-foreground",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            "data-[state=open]:border-border-strong cursor-pointer transition-colors duration-150",
+          )}
+        >
+          <span className={cn(selected.length === 0 && "text-foreground-muted")}>{triggerLabel}</span>
+          <ChevronDown className="h-4 w-4 shrink-0 text-foreground-muted" aria-hidden />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="start"
+            sideOffset={6}
+            onCloseAutoFocus={showFilter ? () => setFilter("") : undefined}
+            className="z-[var(--z-popover)] flex max-h-[min(60vh,20rem)] min-w-[15rem] flex-col overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
+          >
+            {showFilter && (
+              <div className="-mx-1 -mt-1 mb-0.5 shrink-0 border-b border-border bg-surface px-1 pt-1">
+                <MenuFilter value={filter} onChange={setFilter} placeholder="Filter vaults" />
+              </div>
+            )}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {filtered.length === 0 && (
+                <div className="px-3 py-2 text-xs text-foreground-muted">No matches</div>
+              )}
+              {filtered.map((name) => (
+                <DropdownMenu.CheckboxItem
+                  key={name}
+                  checked={selectedSet.has(name)}
+                  onCheckedChange={() => toggle(name)}
+                  onSelect={(e) => e.preventDefault()}
+                  className={cn(
+                    "relative flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] py-1.5 pl-7 pr-3 text-sm text-foreground outline-none",
+                    "data-[highlighted]:bg-surface-hover data-[state=checked]:text-link",
+                  )}
+                >
+                  <DropdownMenu.ItemIndicator className="absolute left-2 inline-flex">
+                    <Check className="h-3.5 w-3.5" aria-hidden />
+                  </DropdownMenu.ItemIndicator>
+                  <span className="truncate">{name}</span>
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </div>
+            {selected.length > 0 && (
+              <div className="-mx-1 -mb-1 mt-0.5 flex shrink-0 items-center justify-between border-t border-border bg-surface px-2 py-1.5">
+                <span className="text-xs text-foreground-muted tabular-nums">{selected.length} selected</span>
+                <DropdownMenu.Item
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    onChange([]);
+                  }}
+                  className="cursor-pointer rounded-[var(--radius-sm)] px-2 py-1 text-xs text-foreground-muted outline-none data-[highlighted]:bg-surface-hover data-[highlighted]:text-link"
+                >
+                  Clear
+                </DropdownMenu.Item>
+              </div>
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+
+      {selected.map((name) => (
+        <span
+          key={name}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-muted px-2 py-0.5 text-xs text-foreground"
+        >
+          <span className="max-w-[12rem] truncate">{name}</span>
+          <button
+            type="button"
+            aria-label={`Remove ${name} from search scope`}
+            onClick={() => toggle(name)}
+            className="inline-flex shrink-0 items-center rounded-full text-foreground-muted transition-colors hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
+          >
+            <X className="h-3 w-3" aria-hidden />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -315,9 +315,14 @@ export interface SearchResponse {
   degradation_reason?: string | null;
   results: any[];
 }
-export const searchDocs = (query: string, vault?: string, limit = 10) => {
+// Scope a search to one or more vaults. The backend `vault` query param is
+// repeatable (`?vault=a&vault=b`); omit it for all accessible vaults.
+const vaultScopeParams = (vaults?: string[] | string): string[] =>
+  (Array.isArray(vaults) ? vaults : vaults ? [vaults] : []).filter(Boolean);
+
+export const searchDocs = (query: string, vaults?: string[] | string, limit = 10) => {
   const p = new URLSearchParams({ q: query, limit: String(limit) });
-  if (vault) p.set("vault", vault);
+  for (const v of vaultScopeParams(vaults)) p.append("vault", v);
   return api<SearchResponse>(`/search?${p}`);
 };
 
@@ -348,10 +353,10 @@ export interface GrepResponse {
   hint?: string | null;
   results: GrepDoc[];
 }
-export const grepDocs = (query: string, vault?: string, limit = 20) =>
+export const grepDocs = (query: string, vaults?: string[] | string, limit = 20) =>
   api<GrepResponse>(`/grep?${(() => {
     const p = new URLSearchParams({ q: query, limit: String(limit) });
-    if (vault) p.set("vault", vault);
+    for (const v of vaultScopeParams(vaults)) p.append("vault", v);
     return p;
   })()}`);
 

--- a/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
+++ b/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
@@ -8,6 +8,7 @@
 //   - a selection renders the count label + a removable chip per vault
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
 import SearchPage from "../search";
@@ -65,5 +66,46 @@ describe("SearchPage · multi-vault scope", () => {
     expect(
       screen.getByRole("button", { name: "Remove beta from search scope" }),
     ).toBeTruthy();
+  });
+});
+
+describe("SearchPage · multi-vault scope · interactions (write path)", () => {
+  it("checking a vault in the picker adds it to the scope and re-searches", async () => {
+    const user = userEvent.setup();
+    renderAt("/search?q=x&v=alpha");
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha"], 25),
+    );
+    await user.click(await screen.findByRole("button", { name: /Search scope/ }));
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: "beta" }));
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["alpha", "beta"], 25),
+    );
+  });
+
+  it("removing a chip drops that vault from the scope and re-searches", async () => {
+    const user = userEvent.setup();
+    renderAt("/search?q=x&v=alpha,beta");
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha", "beta"], 25),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Remove alpha from search scope" }),
+    );
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["beta"], 25),
+    );
+  });
+
+  it("Clear resets to all vaults (searchDocs called with undefined scope)", async () => {
+    const user = userEvent.setup();
+    renderAt("/search?q=x&v=alpha,beta");
+    await waitFor(() => expect(mockedSearch).toHaveBeenCalled());
+    await user.click(await screen.findByRole("button", { name: /Search scope/ }));
+    await user.click(await screen.findByRole("menuitem", { name: /Clear/ }));
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", undefined, 25),
+    );
+    expect(await screen.findByText("All vaults (3)")).toBeTruthy();
   });
 });

--- a/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
+++ b/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
@@ -1,0 +1,69 @@
+// RTL coverage for the multi-vault search scope (VaultScopePicker + search.tsx).
+//
+// Why this file: the global /search page lets you scope a query to one OR MORE
+// vaults via `?v=a,b,c` (the multi-select scope picker). These cases lock the
+// contract:
+//   - a comma-joined `?v=` drives searchDocs with a string[] of those vaults
+//   - the scope trigger reads "All vaults (N)" with no selection (the default)
+//   - a selection renders the count label + a removable chip per vault
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import SearchPage from "../search";
+import { searchDocs, grepDocs, listVaults } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  searchDocs: vi.fn(),
+  grepDocs: vi.fn(),
+  listVaults: vi.fn(),
+}));
+
+const mockedSearch = vi.mocked(searchDocs);
+const mockedListVaults = vi.mocked(listVaults);
+
+const EMPTY = { query: "", total: 0, returned: 0, total_matches: 0, results: [] };
+
+afterEach(cleanup);
+beforeEach(() => {
+  mockedSearch.mockReset().mockResolvedValue(EMPTY);
+  vi.mocked(grepDocs).mockReset();
+  mockedListVaults.mockReset().mockResolvedValue({
+    vaults: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+  });
+});
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <SearchPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("SearchPage · multi-vault scope", () => {
+  it("passes the comma-joined ?v= as a string[] to searchDocs", async () => {
+    renderAt("/search?q=postgres&v=alpha,beta");
+    await waitFor(() =>
+      expect(mockedSearch).toHaveBeenCalledWith("postgres", ["alpha", "beta"], 25),
+    );
+  });
+
+  it("shows 'All vaults (N)' when nothing is scoped", async () => {
+    renderAt("/search");
+    expect(await screen.findByText("All vaults (3)")).toBeTruthy();
+  });
+
+  it("renders the count label + a removable chip per selected vault", async () => {
+    renderAt("/search?q=x&v=alpha,beta");
+    // trigger reflects the selection count
+    expect(await screen.findByText("2 vaults")).toBeTruthy();
+    // each selection is a removable chip
+    expect(
+      screen.getByRole("button", { name: "Remove alpha from search scope" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Remove beta from search scope" }),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -82,8 +82,8 @@ export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   // `/vault/:name/search` routes the vault in via URL params — that
   // scope is implicit and cannot be changed from the scope picker
-  // (you'd navigate to /search for cross-vault). The legacy `?v=`
-  // query param is honored only on the global `/search` route.
+  // (you'd navigate to /search for cross-vault). The `?v=` scope param
+  // (below) is honored only on the global `/search` route.
   const { name: scopedVault } = useParams<{ name: string }>();
   const q = searchParams.get("q") || "";
   // Sanitize instead of a bare cast: an unknown ?mode= must fall back to dense,
@@ -139,7 +139,12 @@ export default function SearchPage() {
 
   useEffect(() => {
     if (!scopedVault) {
-      listVaults().then((d) => setVaults(d.vaults || [])).catch(() => {});
+      // On failure the scope picker just won't render (the search still runs,
+      // unscoped or with whatever `?v=` is in the URL) — but don't swallow the
+      // error silently: log it so a broken /my/vaults is diagnosable.
+      listVaults()
+        .then((d) => setVaults(d.vaults || []))
+        .catch((e) => console.error("Failed to load vaults for the scope picker", e));
     }
   }, [scopedVault]);
 

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -6,7 +6,7 @@ import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { SelectMenu } from "@/components/ui/select-menu";
+import { VaultScopePicker } from "@/components/vault-scope-picker";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { EmptyState } from "@/components/empty-state";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -90,8 +90,16 @@ export default function SearchPage() {
   // not slip through as a truthy non-dense value that routes to grep with
   // neither toggle highlighted.
   const mode: Mode = searchParams.get("mode") === "literal" ? "literal" : "dense";
-  const queryVault = searchParams.get("v") || "";
-  const vault = scopedVault || queryVault;
+  // `?v=` is a comma-joined list of vault names — the multi-vault search scope.
+  // On the scoped `/vault/:name/search` route the vault is fixed by the URL
+  // param (single). Empty list = search every accessible vault.
+  const queryVaults = (searchParams.get("v") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const scopeVaults: string[] = scopedVault ? [scopedVault] : queryVaults;
+  // Stable string key for effect deps (the array identity changes each render).
+  const vaultKey = scopeVaults.join(",");
 
   const [denseResults, setDenseResults] = useState<DenseResult[]>([]);
   const [literalResults, setLiteralResults] = useState<GrepDoc[]>([]);
@@ -136,14 +144,14 @@ export default function SearchPage() {
   }, [scopedVault]);
 
   useEffect(() => {
-    if (q) doSearch(q, mode, vault);
+    if (q) doSearch(q, mode, scopeVaults);
     // Bump the epoch on cleanup so an in-flight resolve after a param change
     // or unmount is ignored (reqId is a request counter, not a DOM ref).
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return () => { reqId.current++; };
-  }, [q, mode, vault]);
+  }, [q, mode, vaultKey]);
 
-  async function doSearch(s: string, m: Mode, v: string) {
+  async function doSearch(s: string, m: Mode, vs: string[]) {
     if (!s.trim()) return;
     const id = ++reqId.current;
     setLoading(true);
@@ -153,7 +161,7 @@ export default function SearchPage() {
       if (m === "dense") {
         // Web shows a fuller page than the agent default (10). 25 stays under
         // the server-side ceiling (search_limit_max, 50).
-        const d = await searchDocs(s, v || undefined, 25);
+        const d = await searchDocs(s, vs.length ? vs : undefined, 25);
         if (id !== reqId.current) return; // superseded
         setDenseResults(d.results);
         setLiteralResults([]);
@@ -164,7 +172,7 @@ export default function SearchPage() {
         setTruncated(Boolean(d.truncated));
         setDegraded(Boolean(d.degraded));
       } else {
-        const d = await grepDocs(s, v || undefined);
+        const d = await grepDocs(s, vs.length ? vs : undefined);
         if (id !== reqId.current) return;
         setLiteralResults(d.results);
         setDenseResults([]);
@@ -208,11 +216,11 @@ export default function SearchPage() {
     setSearchParams(next, { replace: true });
   }
 
-  function switchVault(v: string) {
+  function setScopeVaults(vs: string[]) {
     const next = new URLSearchParams(searchParams);
     const trimmed = draft.trim();
     if (trimmed) next.set("q", trimmed);
-    if (v) next.set("v", v);
+    if (vs.length) next.set("v", vs.join(","));
     else next.delete("v");
     setSearchParams(next, { replace: true });
   }
@@ -397,28 +405,13 @@ export default function SearchPage() {
       )}
 
       {!scopedVault && vaults.length > 0 && (
-        <div className="flex items-center gap-3 mb-6">
-          <span className="coord shrink-0">Scope</span>
-          <SelectMenu
-            value={vault}
-            onValueChange={switchVault}
-            aria-label="Search scope — limit to a vault"
-            className="h-9 w-auto min-w-[220px] max-w-sm"
-            searchable
-            searchPlaceholder="Filter vaults"
-            options={[
-              { value: "", label: `All vaults (${vaults.length})` },
-              ...vaults.map((v) => ({ value: v.name, label: v.name })),
-            ]}
+        <div className="flex items-start gap-3 mb-6">
+          <span className="coord shrink-0 mt-2">Scope</span>
+          <VaultScopePicker
+            vaults={vaults}
+            selected={scopeVaults}
+            onChange={setScopeVaults}
           />
-          {vault && (
-            <button
-              onClick={() => switchVault("")}
-              className="coord hover:text-link transition-token cursor-pointer rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            >
-              clear
-            </button>
-          )}
         </div>
       )}
 
@@ -464,7 +457,7 @@ export default function SearchPage() {
         <Alert variant="destructive" className="mt-6">
           Search failed — {error}.{" "}
           <button
-            onClick={() => doSearch(q, mode, vault)}
+            onClick={() => doSearch(q, mode, scopeVaults)}
             className="underline font-medium hover:text-link cursor-pointer rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             Retry


### PR DESCRIPTION
## What

Search could only target **one vault** or **all accessible vaults**. This adds a **multi-vault scope** — pick a subset and search just those.

Asked for via `/ui-ux-pro-max`; design chosen: **Popover + checkbox list + removable chips** (Option A).

## Backend

`GET /search` and `GET /grep` now accept a **repeatable** `vault` query param (`?vault=a&vault=b`). The chosen names are **intersected with the caller's accessible set** — a vault you can't read simply drops out (no leak) — via `v.name = ANY($)` in:
- the metadata pre-filter (`search_service.search`),
- the vector-ACL path (`_accessible_vault_ids`, now `WHERE name = ANY($) AND <acl>`),
- the `grep` SQL, which now **always applies the access predicate alongside** the name filter (closing the old "named vault skips ACL" gap).

`vault` still accepts a **single string** for MCP / legacy callers (normalized to a one-element list internally), so nothing else changes.

## Frontend

The `/search` page replaces the single-vault scope dropdown with a **`VaultScopePicker`** — a Radix DropdownMenu checkbox list (search-filterable, the same pattern as `SelectMenu` but `CheckboxItem` + stay-open) plus **removable chips** for the current selection. Empty = **"All vaults (N)"** (the calm default). Deep-linkable via `?v=a,b,c`. `searchDocs`/`grepDocs` take `string[]`.

Applied UX rules: progressive-disclosure (popover), autocomplete/search-accessible (filter), color-not-only + visual-hierarchy (chips), deep-linking + state-preservation (URL), informative `aria-label` (purpose + current value).

## Verified locally

- **Multi-vault API** (grep, 3-vault fixture): `?vault=a&vault=b` → only `a,b`; `?vault=a` → only `a`; no param → all. ✓
- Backend `ruff` clean · `mypy` clean · 22 search unit tests pass.
- Frontend `design:check` · `typecheck` · `lint` · **347 tests** (incl. 3 new scope tests: `?v=a,b` → `searchDocs(q,[a,b],25)`, "All vaults (N)", count label + removable chips).
- Visual: picker trigger "All vaults (2)" / "1 vault + ⟨graph-demo ×⟩" chip on the dev server.

backend **0.9.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)