### PR TITLE
chore(search): /simplify cleanups on multi-vault scope (#245 follow-up)

### DIFF
--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -169,9 +169,7 @@ class SearchService:
         intersected with the other filters, so retrieval runs only inside that
         set. An empty/omitted list means no restriction (default behaviour).
         """
-        # Single name (MCP/legacy) or list (REST multi-vault scope) → canonical
-        # list, or None for "every accessible vault". See _normalize_vault_scope.
-        vaults = _normalize_vault_scope(vault)
+        vaults = _normalize_vault_scope(vault)  # str | list | None → canonical list | None
         # ACL guard mirroring `grep` below: when neither vault nor
         # user_id scopes the query, the prefilter block ends up
         # skipped (has_filters=False) and `_run_vector_search` runs
@@ -828,9 +826,7 @@ class SearchService:
                     "results": [],
                 }
 
-        # Single name (MCP/legacy) or list (REST multi-vault scope) → canonical
-        # list, or None for "every accessible vault". See _normalize_vault_scope.
-        vaults = _normalize_vault_scope(vault)
+        vaults = _normalize_vault_scope(vault)  # str | list | None → canonical list | None
         # ACL guard: when no vault is given we MUST have a user_id so the
         # SQL can scope to the vaults that user can access. A None user_id
         # in that branch would silently produce a cross-vault scan.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -353,12 +353,11 @@ export interface GrepResponse {
   hint?: string | null;
   results: GrepDoc[];
 }
-export const grepDocs = (query: string, vaults?: string[] | string, limit = 20) =>
-  api<GrepResponse>(`/grep?${(() => {
-    const p = new URLSearchParams({ q: query, limit: String(limit) });
-    for (const v of vaultScopeParams(vaults)) p.append("vault", v);
-    return p;
-  })()}`);
+export const grepDocs = (query: string, vaults?: string[] | string, limit = 20) => {
+  const p = new URLSearchParams({ q: query, limit: String(limit) });
+  for (const v of vaultScopeParams(vaults)) p.append("vault", v);
+  return api<GrepResponse>(`/grep?${p}`);
+};
 
 // ── Graph ──
 export interface GraphApiNode {

--- a/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
+++ b/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
@@ -65,7 +65,7 @@ describe("SearchPage · semantic (dense) mode", () => {
       ],
     });
     renderAt("/search?q=postgres");
-    await waitFor(() => expect(mockedSearch).toHaveBeenCalledWith("postgres", undefined, 25));
+    await waitFor(() => expect(mockedSearch).toHaveBeenCalledWith("postgres", [], 25));
     expect(await screen.findByText("PostgreSQL tuning")).toBeTruthy();
     expect(mockedGrep).not.toHaveBeenCalled();
   });
@@ -124,6 +124,6 @@ describe("SearchPage · mode toggle re-issues the correct call", () => {
       .find((b) => b.hasAttribute("aria-pressed"));
     if (!toggle) throw new Error("Literal toggle button not found");
     await u.click(toggle);
-    await waitFor(() => expect(mockedGrep).toHaveBeenCalledWith("k8s", undefined));
+    await waitFor(() => expect(mockedGrep).toHaveBeenCalledWith("k8s", []));
   });
 });

--- a/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
+++ b/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
@@ -97,14 +97,14 @@ describe("SearchPage · multi-vault scope · interactions (write path)", () => {
     );
   });
 
-  it("Clear resets to all vaults (searchDocs called with undefined scope)", async () => {
+  it("Clear resets to all vaults (searchDocs called with empty scope)", async () => {
     const user = userEvent.setup();
     renderAt("/search?q=x&v=alpha,beta");
     await waitFor(() => expect(mockedSearch).toHaveBeenCalled());
     await user.click(await screen.findByRole("button", { name: /Search scope/ }));
     await user.click(await screen.findByRole("menuitem", { name: /Clear/ }));
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenLastCalledWith("x", undefined, 25),
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", [], 25),
     );
     expect(await screen.findByText("All vaults (3)")).toBeTruthy();
   });

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -166,7 +166,7 @@ export default function SearchPage() {
       if (m === "dense") {
         // Web shows a fuller page than the agent default (10). 25 stays under
         // the server-side ceiling (search_limit_max, 50).
-        const d = await searchDocs(s, vs.length ? vs : undefined, 25);
+        const d = await searchDocs(s, vs, 25);
         if (id !== reqId.current) return; // superseded
         setDenseResults(d.results);
         setLiteralResults([]);
@@ -177,7 +177,7 @@ export default function SearchPage() {
         setTruncated(Boolean(d.truncated));
         setDegraded(Boolean(d.degraded));
       } else {
-        const d = await grepDocs(s, vs.length ? vs : undefined);
+        const d = await grepDocs(s, vs);
         if (id !== reqId.current) return;
         setLiteralResults(d.results);
         setDenseResults([]);


### PR DESCRIPTION
No behavior change — three cosmetic cleanups surfaced by `/simplify` on PR #245's diff (4 cleanup angles: reuse, simplification, efficiency, altitude).

## Applied
- **`api.ts`** — drop the gratuitous IIFE in `grepDocs`; build params with a plain block, identical in shape to its sibling `searchDocs`.
- **`search.tsx`** — drop the `vs.length ? vs : undefined` ternary at both call sites. `vaultScopeParams` already collapses `[]` to "emit zero `vault` params" (== `undefined` on the wire), so the **"empty = all vaults"** transport rule now lives in exactly one place (`api.ts`) instead of being restated per call site.
- **`search_service.py`** — collapse the duplicated 2-line shim-call comment at both `search()`/`grep()` sites to one line; `_normalize_vault_scope`'s docstring already documents the `str | list | None → canonical` contract.

Tests updated to assert the now-array-native no-scope call (`[]` instead of `undefined`) — behavior is identical (both produce an unscoped query).

## Deliberately NOT done
Cleanup agents agreed these are right as-is or out of scope for a cleanup pass:
- generalizing `VaultScopePicker` into a `ui/` multi-select primitive (N=1 caller — premature abstraction)
- extracting the `SelectMenu` menu-shell fork (defer until a 3rd dropdown variant appears)
- factoring the 3-place `v.name = ANY()` filter (independent param lists per branch → costs more than it saves)
- memoizing the picker's per-render `new Set` (negligible runtime cost)
- using `VaultChip` monograms in the chips (visual change = behavior, not cleanup)

## Verification
- Frontend: `design:check` + `typecheck` + `lint` (0 errors) + the two search suites (10/10)
- Backend: `ruff` + `test_search_multi_vault_unit` (5/5)

No deploy needed — behaviorally identical to #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)