### PR TITLE
feat(mcp): OAuth Resource Server + delegated DCR (Keycloak as AS)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -299,7 +299,7 @@
         "filename": "docker-compose.keycloak.yaml",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 57
       }
     ],
     "docker-compose.yaml": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-25T12:03:27Z"
+  "generated_at": "2026-06-25T13:32:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -284,6 +284,13 @@
         "hashed_secret": "7ebcd33ad53137998032087330237a975658f563",
         "is_verified": false,
         "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/keycloak-dev/akb-realm.json",
+        "hashed_secret": "68c114871fdf0d526f8500506080843416456625",
+        "is_verified": false,
+        "line_number": 38
       }
     ],
     "docker-compose.keycloak.yaml": [
@@ -292,7 +299,7 @@
         "filename": "docker-compose.keycloak.yaml",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 58
       }
     ],
     "docker-compose.yaml": [
@@ -319,7 +326,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f8c3bceb2fd5655f1c6e2c8b68c19ccc62e2ccd0",
         "is_verified": false,
-        "line_number": 178,
+        "line_number": 181,
         "is_secret": false
       },
       {
@@ -327,7 +334,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bbe89f60c4958c87251488db559df22ee23af1d6",
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 184,
         "is_secret": false
       },
       {
@@ -335,7 +342,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76ae5510aad8e0ef1e4b4bb236a81431460c3e14",
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 188,
         "is_secret": false
       },
       {
@@ -343,7 +350,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "df4ed24356e7fc85ece12773e32b1336f9e49221",
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 192,
         "is_secret": false
       },
       {
@@ -351,7 +358,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "359ac5bd61cb9c32b418f71877fad37f3f8cfd0e",
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 195,
         "is_secret": false
       },
       {
@@ -359,7 +366,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9e14c0dd90b7fd1c6eb295812747e6df9f68524e",
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 199,
         "is_secret": false
       },
       {
@@ -367,7 +374,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d3541691a358a503965df61d03a03b145283e1f6",
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 203,
         "is_secret": false
       },
       {
@@ -375,7 +382,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cf9d8563e81a99bb393c8ce3dedee23909dc0652",
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 207,
         "is_secret": false
       },
       {
@@ -383,7 +390,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cbf41ed160d723d2d3e9b3a7efca841b6bcf6f88",
         "is_verified": false,
-        "line_number": 208,
+        "line_number": 211,
         "is_secret": false
       },
       {
@@ -391,7 +398,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5cb278a68156ae376bea48fb0f872cbc5dfd0a63",
         "is_verified": false,
-        "line_number": 212,
+        "line_number": 215,
         "is_secret": false
       },
       {
@@ -399,7 +406,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d5266ed941af1b1d15330dbd1d3a875c4bc9c81",
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 219,
         "is_secret": false
       },
       {
@@ -407,7 +414,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dfce026d4d3a3c07f4b1217d9f8218c7a659648c",
         "is_verified": false,
-        "line_number": 220,
+        "line_number": 223,
         "is_secret": false
       },
       {
@@ -415,7 +422,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8319864fae2ce720a9588f890930b4dd3f736a4f",
         "is_verified": false,
-        "line_number": 226,
+        "line_number": 229,
         "is_secret": false
       },
       {
@@ -423,7 +430,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96393754ecdf525c798560bfe0e751502aa16dd1",
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 233,
         "is_secret": false
       },
       {
@@ -431,7 +438,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6302a9750ba626bf9d98ea2b93c8044c2c13dd03",
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 237,
         "is_secret": false
       },
       {
@@ -439,7 +446,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "88ca4f0d28c7143e72cc9cfecaf9901c26711cb5",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 241,
         "is_secret": false
       },
       {
@@ -447,7 +454,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d940d64a49d7ffa54290a8c7258e0f4adf5dbb65",
         "is_verified": false,
-        "line_number": 242,
+        "line_number": 245,
         "is_secret": false
       },
       {
@@ -455,7 +462,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8ce6977002b5073e86067ab6571cbcfa3f770a1e",
         "is_verified": false,
-        "line_number": 247,
+        "line_number": 250,
         "is_secret": false
       },
       {
@@ -463,7 +470,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "261bb1dcc263df7ecdd01a0c01dadf24d04b170e",
         "is_verified": false,
-        "line_number": 251,
+        "line_number": 254,
         "is_secret": false
       },
       {
@@ -471,7 +478,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8a3e5ca7ff5701e917511e537ae08cf06085e3ca",
         "is_verified": false,
-        "line_number": 255,
+        "line_number": 258,
         "is_secret": false
       },
       {
@@ -479,7 +486,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "180e848f306ee232593ddf09bf8f13cb01648197",
         "is_verified": false,
-        "line_number": 259,
+        "line_number": 262,
         "is_secret": false
       },
       {
@@ -487,7 +494,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e498b588b82623a989bc184233b01bd904b0ffe8",
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 266,
         "is_secret": false
       },
       {
@@ -495,7 +502,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "72ad9b29d84be5893947b31eab1b18c6a8708b9c",
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 270,
         "is_secret": false
       },
       {
@@ -503,7 +510,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "77697b83c3a3cae58eeb4ac4d64658f94bcc8ac0",
         "is_verified": false,
-        "line_number": 271,
+        "line_number": 274,
         "is_secret": false
       },
       {
@@ -511,7 +518,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "54fa8774d395c4b5321b2dedb260b72d4b371b38",
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 281,
         "is_secret": false
       },
       {
@@ -519,7 +526,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "09404efe0c697675f28ac49e2df4736fb4ba6614",
         "is_verified": false,
-        "line_number": 285,
+        "line_number": 288,
         "is_secret": false
       },
       {
@@ -527,7 +534,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "015001278a609b8806a56281e175ddce9fe657ab",
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 294,
         "is_secret": false
       },
       {
@@ -535,7 +542,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6458cb491193acf3fd23e2431345406d864182a8",
         "is_verified": false,
-        "line_number": 299,
+        "line_number": 302,
         "is_secret": false
       },
       {
@@ -543,7 +550,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "61eba76f624f3965458fbcb475d516dd79e3b277",
         "is_verified": false,
-        "line_number": 303,
+        "line_number": 306,
         "is_secret": false
       },
       {
@@ -551,7 +558,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bce2211dbea063d611777b8914263104c8ecb803",
         "is_verified": false,
-        "line_number": 306,
+        "line_number": 309,
         "is_secret": false
       },
       {
@@ -559,7 +566,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e8cc5935afdfd3788eae945e3db3f42e2c3acee6",
         "is_verified": false,
-        "line_number": 309,
+        "line_number": 312,
         "is_secret": false
       },
       {
@@ -567,7 +574,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3fe801d380c7196c8da01d8e53ecfaf12fda8d21",
         "is_verified": false,
-        "line_number": 312,
+        "line_number": 315,
         "is_secret": false
       },
       {
@@ -575,7 +582,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d3405ba928268e4228a3dccdc89600d0a896c339",
         "is_verified": false,
-        "line_number": 318,
+        "line_number": 321,
         "is_secret": false
       },
       {
@@ -583,7 +590,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6dc38584efb3a63a07cb8d862c8701cd66acae33",
         "is_verified": false,
-        "line_number": 322,
+        "line_number": 325,
         "is_secret": false
       },
       {
@@ -591,7 +598,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1783efab5b4a6f7ce65c346b422f0afd6b3e74f2",
         "is_verified": false,
-        "line_number": 326,
+        "line_number": 329,
         "is_secret": false
       },
       {
@@ -599,7 +606,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "28a5ad3c3c89735a3e8b507c0f1b22c62bc87111",
         "is_verified": false,
-        "line_number": 330,
+        "line_number": 333,
         "is_secret": false
       },
       {
@@ -607,7 +614,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9ea0cbc8c451603171a7b5c0b2aa47374123a6d3",
         "is_verified": false,
-        "line_number": 334,
+        "line_number": 337,
         "is_secret": false
       },
       {
@@ -615,7 +622,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "16d23c0fa1859adb090c34f7eed667ca262f3f66",
         "is_verified": false,
-        "line_number": 343,
+        "line_number": 346,
         "is_secret": false
       },
       {
@@ -623,7 +630,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fd5a95d1ea888cede210d010fbb956e559a3d0da",
         "is_verified": false,
-        "line_number": 347,
+        "line_number": 350,
         "is_secret": false
       },
       {
@@ -631,7 +638,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5ac4308bf107df4b3ecb4beb323481d62adb9087",
         "is_verified": false,
-        "line_number": 351,
+        "line_number": 354,
         "is_secret": false
       },
       {
@@ -639,7 +646,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c623aa06523a4f1fa3fa7ab1df7db62b378b9432",
         "is_verified": false,
-        "line_number": 360,
+        "line_number": 363,
         "is_secret": false
       },
       {
@@ -647,7 +654,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "63bec2ac98d4c5fcc58ccf35344e251308f56cf9",
         "is_verified": false,
-        "line_number": 363,
+        "line_number": 366,
         "is_secret": false
       },
       {
@@ -655,7 +662,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f03b3090ec0f6bcc310df37baf29aff7ea3af1da",
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 369,
         "is_secret": false
       },
       {
@@ -663,20 +670,12 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fa45202b508365cf1d1f73dc49a8df7f227d202e",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 375
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4792a7cb5f934441b51f39e719c89698cd8819b0",
-        "is_verified": false,
-        "line_number": 378,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "36ae1463d92ef753166eda3cf0a370b330d86e0e",
         "is_verified": false,
         "line_number": 381,
         "is_secret": false
@@ -692,7 +691,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "79852f8b416f009897ece7a8354ea56e48a6fba0",
+        "hashed_secret": "70e0115878cbcfa3933ef674125fe6edc40b1ddd",
         "is_verified": false,
         "line_number": 387,
         "is_secret": false
@@ -700,25 +699,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "6b0ef9c6d74adabafd3ddba33111caf0213669c1",
-        "is_verified": false,
-        "line_number": 390,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "70e0115878cbcfa3933ef674125fe6edc40b1ddd",
-        "is_verified": false,
-        "line_number": 393,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6158060fd3a28e3bdf7b7e37bcc8c8f3348147f0",
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 391,
         "is_secret": false
       },
       {
@@ -726,7 +709,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b18a51ff2b05238234261f264ee4810ddb31a3ab",
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 395,
         "is_secret": false
       },
       {
@@ -734,7 +717,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d2162ede46b32d726584142e374458026c95c209",
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 399,
         "is_secret": false
       },
       {
@@ -742,7 +725,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7252305e0579e7dd1ebf234edb891484f3ac7a71",
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 403,
         "is_secret": false
       },
       {
@@ -750,7 +733,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "efb5975d20ddfdefd6f1dbae9cad42004f415db4",
         "is_verified": false,
-        "line_number": 413,
+        "line_number": 407,
         "is_secret": false
       },
       {
@@ -758,7 +741,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "00412064d66076b9c76ff3c3a3d6561ac4e9a7c9",
         "is_verified": false,
-        "line_number": 417,
+        "line_number": 411,
         "is_secret": false
       },
       {
@@ -766,7 +749,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9a0af39ecc21dd47b0b1dfb9483190e0370245b1",
         "is_verified": false,
-        "line_number": 426,
+        "line_number": 420,
         "is_secret": false
       },
       {
@@ -774,7 +757,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f6e4240256e2f10f445d8f1bd041ac7e76ead7fe",
         "is_verified": false,
-        "line_number": 435,
+        "line_number": 429,
         "is_secret": false
       },
       {
@@ -782,7 +765,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cbd3d8e48755b4cf61348fffa0850f7dfc54cc1e",
         "is_verified": false,
-        "line_number": 439,
+        "line_number": 433,
         "is_secret": false
       },
       {
@@ -790,7 +773,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 442,
         "is_secret": false
       },
       {
@@ -798,7 +781,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
         "is_verified": false,
-        "line_number": 451,
+        "line_number": 445,
         "is_secret": false
       },
       {
@@ -806,7 +789,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 448,
         "is_secret": false
       },
       {
@@ -814,7 +797,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
         "is_verified": false,
-        "line_number": 458,
+        "line_number": 452,
         "is_secret": false
       },
       {
@@ -822,7 +805,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
         "is_verified": false,
-        "line_number": 461,
+        "line_number": 455,
         "is_secret": false
       },
       {
@@ -830,14 +813,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "14ac3697296e2c49906c591edf4b732c3b9a5beb",
         "is_verified": false,
-        "line_number": 464
+        "line_number": 458
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1eda99989faa6ffef8eaad6e29dc992f36c91eb7",
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 461,
         "is_secret": false
       },
       {
@@ -845,7 +828,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "849d850746ddf94e2552051b64ad5817dc377516",
         "is_verified": false,
-        "line_number": 471,
+        "line_number": 465,
         "is_secret": false
       },
       {
@@ -853,7 +836,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e86e4979d9d712e11a75b4ebec1b901732124d77",
         "is_verified": false,
-        "line_number": 477,
+        "line_number": 471,
         "is_secret": false
       },
       {
@@ -861,7 +844,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "860024dc69fce7531fd68cac0382949ebce3602b",
         "is_verified": false,
-        "line_number": 480,
+        "line_number": 474,
         "is_secret": false
       },
       {
@@ -869,7 +852,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e7a300573911dfc80ae0808f6cd3ddc96c90975d",
         "is_verified": false,
-        "line_number": 483,
+        "line_number": 477,
         "is_secret": false
       },
       {
@@ -877,7 +860,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "af21ea4772d3ec7feac09cde495c71292fb69903",
         "is_verified": false,
-        "line_number": 486,
+        "line_number": 480,
         "is_secret": false
       },
       {
@@ -885,7 +868,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dc782422b02b55cab4ac3a691ad1a7796b5090c2",
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 483,
         "is_secret": false
       },
       {
@@ -893,98 +876,98 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2275bc01362cf148fb9d602c7aa4d50e3579ea8b",
         "is_verified": false,
-        "line_number": 492
+        "line_number": 486
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "deec0a4326de1d985f728e3663ee1ee778955e48",
         "is_verified": false,
-        "line_number": 499
+        "line_number": 493
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4d42d25f34197ac24085066fd8525d580b4821b8",
         "is_verified": false,
-        "line_number": 506
+        "line_number": 500
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "754919ceb5e47881598179a8f68f51b0d0bb993b",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 506
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f9f0414023ae73321a6a70929db2fed0e6983156",
         "is_verified": false,
-        "line_number": 519
+        "line_number": 513
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3f478b43c918be4df42505be14787d4a70f6f2ee",
         "is_verified": false,
-        "line_number": 526
+        "line_number": 520
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7e175ebc63196ab5496401d491463a0b92e85f16",
         "is_verified": false,
-        "line_number": 533
+        "line_number": 527
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bfc406bacac978a3801d8ef75ebe61719bb9ab3d",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 534
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1f23c277e83472a8a62ac645621686d04ada4bdb",
         "is_verified": false,
-        "line_number": 547
+        "line_number": 541
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1b9c17047f466d9841ea37c54273d72f415abb14",
         "is_verified": false,
-        "line_number": 554
+        "line_number": 548
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e5b5cbf08463f0d1d16fee86fa03cdbd80fefde1",
         "is_verified": false,
-        "line_number": 561
+        "line_number": 555
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5afb012326a0b28a4c8393ebf415fadeb65904d2",
         "is_verified": false,
-        "line_number": 564
+        "line_number": 558
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b2d55a52a2634ec112e7006f69338e64617b8399",
         "is_verified": false,
-        "line_number": 571
+        "line_number": 565
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b5b6d48460f3ce7c0ee71c156fa178805b4b632c",
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 571,
         "is_secret": false
       },
       {
@@ -992,7 +975,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bcb82578fa8e86968c7019febdeab3965c19ff41",
         "is_verified": false,
-        "line_number": 582,
+        "line_number": 576,
         "is_secret": false
       },
       {
@@ -1000,7 +983,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 579,
         "is_secret": false
       },
       {
@@ -1008,7 +991,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
         "is_verified": false,
-        "line_number": 588,
+        "line_number": 582,
         "is_secret": false
       },
       {
@@ -1016,7 +999,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d68cebb7dafe5db1971f5fa821be0e8a901290ad",
         "is_verified": false,
-        "line_number": 601,
+        "line_number": 595,
         "is_secret": false
       },
       {
@@ -1024,7 +1007,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
         "is_verified": false,
-        "line_number": 614,
+        "line_number": 608,
         "is_secret": false
       },
       {
@@ -1032,7 +1015,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
         "is_verified": false,
-        "line_number": 627,
+        "line_number": 621,
         "is_secret": false
       },
       {
@@ -1040,7 +1023,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 630,
         "is_secret": false
       },
       {
@@ -1048,7 +1031,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b2334902f0134767ef634449f1b4ad0a6fe4830b",
         "is_verified": false,
-        "line_number": 645,
+        "line_number": 639,
         "is_secret": false
       },
       {
@@ -1056,7 +1039,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 648,
         "is_secret": false
       },
       {
@@ -1064,7 +1047,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
         "is_verified": false,
-        "line_number": 667,
+        "line_number": 661,
         "is_secret": false
       },
       {
@@ -1072,7 +1055,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
         "is_verified": false,
-        "line_number": 676,
+        "line_number": 670,
         "is_secret": false
       },
       {
@@ -1080,7 +1063,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cfe0bd31a00a41920823c76d517fe7d062e5337c",
         "is_verified": false,
-        "line_number": 689,
+        "line_number": 683,
         "is_secret": false
       },
       {
@@ -1088,7 +1071,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b16b457c3af8581fda0aad82df8a4d25d56b72f5",
         "is_verified": false,
-        "line_number": 702,
+        "line_number": 696,
         "is_secret": false
       },
       {
@@ -1096,7 +1079,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "28f0a338a11c78c8b77f06940e97fd7242579d23",
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 705,
         "is_secret": false
       },
       {
@@ -1104,7 +1087,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bfb1d8f7fcfdc3951f2a407606332dd0561ea889",
         "is_verified": false,
-        "line_number": 724,
+        "line_number": 718,
         "is_secret": false
       },
       {
@@ -1112,7 +1095,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ecb78fb017219f11f062b663841d42dfad9bd607",
         "is_verified": false,
-        "line_number": 733,
+        "line_number": 727,
         "is_secret": false
       },
       {
@@ -1120,7 +1103,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "380016634dca8718e45627a3e887a33cfdbf9583",
         "is_verified": false,
-        "line_number": 746,
+        "line_number": 740,
         "is_secret": false
       },
       {
@@ -1128,7 +1111,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c93cfee749f39a6731bd90e3b8bfc1c2f39dd0bb",
         "is_verified": false,
-        "line_number": 759,
+        "line_number": 753,
         "is_secret": false
       },
       {
@@ -1136,7 +1119,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "384119563704c0a0c154cfa3a7fb2f1b6e403e4d",
         "is_verified": false,
-        "line_number": 772,
+        "line_number": 766,
         "is_secret": false
       },
       {
@@ -1144,7 +1127,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a9799e49f2382f864dab19d97df038fbcc760f79",
         "is_verified": false,
-        "line_number": 785,
+        "line_number": 779,
         "is_secret": false
       },
       {
@@ -1152,7 +1135,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "237858a86350af1517b45ec07878dc64d875b973",
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 792,
         "is_secret": false
       },
       {
@@ -1160,7 +1143,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e3f56ef687b947b63f8ea90c3f3fcdc7687c0584",
         "is_verified": false,
-        "line_number": 811,
+        "line_number": 805,
         "is_secret": false
       },
       {
@@ -1168,7 +1151,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "938a7b1d49a0c2692666797b3a00b607ba1912d4",
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 818,
         "is_secret": false
       },
       {
@@ -1176,7 +1159,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d2fd9728d554534f81a587647c925c735087ae31",
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 831,
         "is_secret": false
       },
       {
@@ -1184,7 +1167,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8400bcab54bbc669cbe44b013fd300ec181ae04",
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 844,
         "is_secret": false
       },
       {
@@ -1192,7 +1175,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "31625b2b743843d6e5bfb31cd4899c540146d0f8",
         "is_verified": false,
-        "line_number": 859,
+        "line_number": 853,
         "is_secret": false
       },
       {
@@ -1200,7 +1183,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "249cc7d6ea282d76f5efff9fb4ed6ed5d3058d08",
         "is_verified": false,
-        "line_number": 868,
+        "line_number": 862,
         "is_secret": false
       },
       {
@@ -1208,7 +1191,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "446546bba84a6355c159d0562c57c670fea13d34",
         "is_verified": false,
-        "line_number": 881,
+        "line_number": 875,
         "is_secret": false
       },
       {
@@ -1216,7 +1199,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d3f1b8d6e4eca6f79dbaf3cdfbca069ab37a6e8",
         "is_verified": false,
-        "line_number": 894,
+        "line_number": 888,
         "is_secret": false
       },
       {
@@ -1224,7 +1207,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1cfc669b4a91926a20a0c195e64a33fddfc28636",
         "is_verified": false,
-        "line_number": 903,
+        "line_number": 897,
         "is_secret": false
       },
       {
@@ -1232,7 +1215,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "089409fd943a2fb3a5a50b4725a4c96a16bc5d19",
         "is_verified": false,
-        "line_number": 912,
+        "line_number": 906,
         "is_secret": false
       },
       {
@@ -1240,7 +1223,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ccf9afc9b093a34274214374a841c68216c23105",
         "is_verified": false,
-        "line_number": 921,
+        "line_number": 915,
         "is_secret": false
       },
       {
@@ -1248,7 +1231,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "29094c26e288b5cebbc5262a1996e29057328f1f",
         "is_verified": false,
-        "line_number": 930,
+        "line_number": 924,
         "is_secret": false
       },
       {
@@ -1256,7 +1239,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "95362ad9b076707c159a81577f1695dea0ed2eb3",
         "is_verified": false,
-        "line_number": 939,
+        "line_number": 933,
         "is_secret": false
       },
       {
@@ -1264,7 +1247,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dfea0993e072e2f30d0a2cac0b7bda5f6e7f980",
         "is_verified": false,
-        "line_number": 948,
+        "line_number": 942,
         "is_secret": false
       },
       {
@@ -1272,7 +1255,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "15432d91ade7f228054c5d23ceac8d48711a5853",
         "is_verified": false,
-        "line_number": 957,
+        "line_number": 951,
         "is_secret": false
       },
       {
@@ -1280,7 +1263,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "69ae791ca6d7814550c0af06cc57217e4e1388ea",
         "is_verified": false,
-        "line_number": 966,
+        "line_number": 960,
         "is_secret": false
       },
       {
@@ -1288,7 +1271,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "647690124fbe1ff7811211b1ec8ec14c9800de35",
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 973,
         "is_secret": false
       },
       {
@@ -1296,7 +1279,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "167d061ff6451f673f8b7b23cfc556872e86613e",
         "is_verified": false,
-        "line_number": 982,
+        "line_number": 976,
         "is_secret": false
       },
       {
@@ -1304,7 +1287,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a3c9978139549b7ad6ed9366409ef125d1dd51a7",
         "is_verified": false,
-        "line_number": 988,
+        "line_number": 982,
         "is_secret": false
       },
       {
@@ -1312,7 +1295,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf028ac7f6ef311d2c3fa6deac3d8d21ee78d221",
         "is_verified": false,
-        "line_number": 994,
+        "line_number": 988,
         "is_secret": false
       },
       {
@@ -1320,7 +1303,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e03e6bf75e6125b7a1b5615288920c220a709665",
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 994,
         "is_secret": false
       },
       {
@@ -1328,7 +1311,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "042b174c95d67dbeec1db71bb039b3df82ccbc29",
         "is_verified": false,
-        "line_number": 1006,
+        "line_number": 1000,
         "is_secret": false
       },
       {
@@ -1336,7 +1319,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2959fd05231107d39fca7e4a60b08f74b842d512",
         "is_verified": false,
-        "line_number": 1012,
+        "line_number": 1006,
         "is_secret": false
       },
       {
@@ -1344,7 +1327,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e5d6a7186daa3461faa5d61d4fddb9b81f69e436",
         "is_verified": false,
-        "line_number": 1019,
+        "line_number": 1013,
         "is_secret": false
       },
       {
@@ -1352,7 +1335,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3f1a6c32aef28e208c0a281e4b524dcd62955b11",
         "is_verified": false,
-        "line_number": 1026,
+        "line_number": 1020,
         "is_secret": false
       },
       {
@@ -1360,7 +1343,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4760a1ddccbdba27f5ec36f07aac3a0ea707be84",
         "is_verified": false,
-        "line_number": 1033,
+        "line_number": 1027,
         "is_secret": false
       },
       {
@@ -1368,7 +1351,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0eac7498a07401ef92ae05e36edeca2b136babc6",
         "is_verified": false,
-        "line_number": 1040,
+        "line_number": 1034,
         "is_secret": false
       },
       {
@@ -1376,7 +1359,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9ae74726accd48e3f3045891f87235c86b7994d7",
         "is_verified": false,
-        "line_number": 1047,
+        "line_number": 1041,
         "is_secret": false
       },
       {
@@ -1384,7 +1367,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2bee4fa5b83c7b3e6e78ac518e9003967ba9dda0",
         "is_verified": false,
-        "line_number": 1054,
+        "line_number": 1048,
         "is_secret": false
       },
       {
@@ -1392,7 +1375,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7d8199a971d414e6a1d7992529dd393898d0269d",
         "is_verified": false,
-        "line_number": 1060,
+        "line_number": 1054,
         "is_secret": false
       },
       {
@@ -1400,7 +1383,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "128f864d3fbfcbf15f57405d65e23123851b46ef",
         "is_verified": false,
-        "line_number": 1065,
+        "line_number": 1059,
         "is_secret": false
       },
       {
@@ -1408,7 +1391,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "29ff50f03a6585d60742f622b04648a4a8fc1026",
         "is_verified": false,
-        "line_number": 1071,
+        "line_number": 1065,
         "is_secret": false
       },
       {
@@ -1416,7 +1399,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1b863a5c2935b250e1e1e6ac25be01f5237fc955",
         "is_verified": false,
-        "line_number": 1077,
+        "line_number": 1071,
         "is_secret": false
       },
       {
@@ -1424,7 +1407,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6e8f503bb9ad54aa4fb260437f0c4d99786da42b",
         "is_verified": false,
-        "line_number": 1080,
+        "line_number": 1074,
         "is_secret": false
       },
       {
@@ -1432,7 +1415,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1e9ff9fee5ad181d3f63618e0267e8ad42826e83",
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1077,
         "is_secret": false
       },
       {
@@ -1440,7 +1423,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a4104c6b768798df1dcee3268a07bf52d78be029",
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1080,
         "is_secret": false
       },
       {
@@ -1448,7 +1431,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f915d279eb4e6304b7d59253aac5f2c03998ba37",
         "is_verified": false,
-        "line_number": 1089,
+        "line_number": 1083,
         "is_secret": false
       },
       {
@@ -1456,7 +1439,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "18175133a0bfbd55464c73ace84c47069590c74b",
         "is_verified": false,
-        "line_number": 1095,
+        "line_number": 1089,
         "is_secret": false
       },
       {
@@ -1464,7 +1447,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "508d40b3672cfb13f23a36745e715b415e68c762",
         "is_verified": false,
-        "line_number": 1101,
+        "line_number": 1095,
         "is_secret": false
       },
       {
@@ -1472,7 +1455,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "97a759eaa90dd533faa5241f1d5ca0fd833e9dd4",
         "is_verified": false,
-        "line_number": 1107,
+        "line_number": 1101,
         "is_secret": false
       },
       {
@@ -1480,7 +1463,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1fa20c52cdd98d61e2b04f486121b191f8ed7a6d",
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1107,
         "is_secret": false
       },
       {
@@ -1488,7 +1471,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "191584feecc1fa3c9d768dc786436555baa8b550",
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1113,
         "is_secret": false
       },
       {
@@ -1496,7 +1479,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "19e045891a75dee829b5af516116c137836fc558",
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1120,
         "is_secret": false
       },
       {
@@ -1504,7 +1487,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "54f68de89504035455c345ef1254fd2992f01787",
         "is_verified": false,
-        "line_number": 1133,
+        "line_number": 1127,
         "is_secret": false
       },
       {
@@ -1512,7 +1495,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8f7bc474ed82152a7558b5ff7d337fdce4978a79",
         "is_verified": false,
-        "line_number": 1140,
+        "line_number": 1134,
         "is_secret": false
       },
       {
@@ -1520,7 +1503,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0568a8e75541d5c0aaf3a47affa876cd94ad7169",
         "is_verified": false,
-        "line_number": 1147,
+        "line_number": 1141,
         "is_secret": false
       },
       {
@@ -1528,7 +1511,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "65303232cd0a1806a21bcdc777bd43a3a06b3d5e",
         "is_verified": false,
-        "line_number": 1159,
+        "line_number": 1153,
         "is_secret": false
       },
       {
@@ -1536,7 +1519,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "92b34295d7111179b606bf11dd4ebadacca6b34d",
         "is_verified": false,
-        "line_number": 1165,
+        "line_number": 1159,
         "is_secret": false
       },
       {
@@ -1544,7 +1527,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c94b32b9d3038396e5129332f00d51911447db62",
         "is_verified": false,
-        "line_number": 1171,
+        "line_number": 1165,
         "is_secret": false
       },
       {
@@ -1552,7 +1535,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
         "is_verified": false,
-        "line_number": 1175,
+        "line_number": 1169,
         "is_secret": false
       },
       {
@@ -1560,7 +1543,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dd5948fc19318420c8e6994af64244f453a89847",
         "is_verified": false,
-        "line_number": 1180,
+        "line_number": 1174,
         "is_secret": false
       },
       {
@@ -1568,7 +1551,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e2226607ced9f63450bc3224adaf9337e1b35cb6",
         "is_verified": false,
-        "line_number": 1185,
+        "line_number": 1179,
         "is_secret": false
       },
       {
@@ -1576,7 +1559,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a6183e78b0d1c48d3521e3eed540b5521a878c12",
         "is_verified": false,
-        "line_number": 1188,
+        "line_number": 1182,
         "is_secret": false
       },
       {
@@ -1584,7 +1567,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "206be2afac54dd74162b994ffcb40e893e90a26a",
         "is_verified": false,
-        "line_number": 1193,
+        "line_number": 1187,
         "is_secret": false
       },
       {
@@ -1592,7 +1575,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed9421935f627a1a97c9aa87a3b63c2f95f0b0f5",
         "is_verified": false,
-        "line_number": 1199,
+        "line_number": 1193,
         "is_secret": false
       },
       {
@@ -1600,7 +1583,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e0cad2c1c2babcee39a4c25ea773656432e980b5",
         "is_verified": false,
-        "line_number": 1202,
+        "line_number": 1196,
         "is_secret": false
       },
       {
@@ -1608,7 +1591,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4f30f4179bf6aad2e2db264609aca318cddd0299",
         "is_verified": false,
-        "line_number": 1206,
+        "line_number": 1200,
         "is_secret": false
       },
       {
@@ -1616,7 +1599,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b09adb7e7627fd788edd03017f0e834f5647d5a6",
         "is_verified": false,
-        "line_number": 1210,
+        "line_number": 1204,
         "is_secret": false
       },
       {
@@ -1624,7 +1607,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ce235376083b3facbdd2cda6a4aefd5225f0d76e",
         "is_verified": false,
-        "line_number": 1225,
+        "line_number": 1219,
         "is_secret": false
       },
       {
@@ -1632,7 +1615,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "047379831d05cb76cb6e5e3e70b7994a465065e5",
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1225,
         "is_secret": false
       },
       {
@@ -1640,7 +1623,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "23980ce90dce595369dff677108c4861655709ec",
         "is_verified": false,
-        "line_number": 1234,
+        "line_number": 1228,
         "is_secret": false
       },
       {
@@ -1648,7 +1631,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "23b847f3370f612113c53bca00cffae8e46fb58b",
         "is_verified": false,
-        "line_number": 1237,
+        "line_number": 1231,
         "is_secret": false
       },
       {
@@ -1656,7 +1639,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7739c7a36e8b5c9759887d54c3d3a252d017cb71",
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1234,
         "is_secret": false
       },
       {
@@ -1664,7 +1647,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c2fa7f2e1f8c5eb1df08c76cc8a209e90f90717d",
         "is_verified": false,
-        "line_number": 1243,
+        "line_number": 1237,
         "is_secret": false
       },
       {
@@ -1672,7 +1655,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d4dda0583372eb865e22ea00ae160ceb315aa0df",
         "is_verified": false,
-        "line_number": 1246,
+        "line_number": 1240,
         "is_secret": false
       },
       {
@@ -1680,7 +1663,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4a447bd154e2e23510078adbe2ce49f48b0bf2e4",
         "is_verified": false,
-        "line_number": 1249,
+        "line_number": 1243,
         "is_secret": false
       },
       {
@@ -1688,7 +1671,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
         "is_verified": false,
-        "line_number": 1252,
+        "line_number": 1246,
         "is_secret": false
       },
       {
@@ -1696,7 +1679,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
         "is_verified": false,
-        "line_number": 1255,
+        "line_number": 1249,
         "is_secret": false
       },
       {
@@ -1704,7 +1687,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
         "is_verified": false,
-        "line_number": 1258,
+        "line_number": 1252,
         "is_secret": false
       },
       {
@@ -1712,15 +1695,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "545a34d82a69ee367dc06267bd30705fc686e387",
         "is_verified": false,
-        "line_number": 1261,
+        "line_number": 1255,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d22be2532e58c391a4752ef1b9e90de5f1589db9",
+        "is_verified": false,
+        "line_number": 1258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
         "is_verified": false,
-        "line_number": 1264,
+        "line_number": 1261,
         "is_secret": false
       },
       {
@@ -1728,7 +1718,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
         "is_verified": false,
-        "line_number": 1267,
+        "line_number": 1264,
         "is_secret": false
       },
       {
@@ -1736,7 +1726,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e8168720998b3abca33b151b928077d00829c634",
         "is_verified": false,
-        "line_number": 1270,
+        "line_number": 1267,
         "is_secret": false
       },
       {
@@ -1744,7 +1734,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "315f040aced6f2876d3822561a1f658a735f0327",
         "is_verified": false,
-        "line_number": 1273,
+        "line_number": 1270,
         "is_secret": false
       },
       {
@@ -1752,7 +1742,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fb450f08e517ca471d1ed41ef8c713864baf5483",
         "is_verified": false,
-        "line_number": 1278,
+        "line_number": 1275,
         "is_secret": false
       },
       {
@@ -1760,7 +1750,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f9e9b7a46fd5e9ecfcefb6346174990fce029f76",
         "is_verified": false,
-        "line_number": 1281,
+        "line_number": 1278,
         "is_secret": false
       },
       {
@@ -1768,7 +1758,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "91ac182754770244539b3544b6e3a16f33f7a622",
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1281,
         "is_secret": false
       },
       {
@@ -1776,7 +1766,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
         "is_verified": false,
-        "line_number": 1287,
+        "line_number": 1284,
         "is_secret": false
       },
       {
@@ -1784,7 +1774,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
         "is_verified": false,
-        "line_number": 1290,
+        "line_number": 1287,
         "is_secret": false
       },
       {
@@ -1792,7 +1782,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c4508adf2251f0c067f121878dd2e652e7d12fdf",
         "is_verified": false,
-        "line_number": 1293,
+        "line_number": 1290,
         "is_secret": false
       },
       {
@@ -1800,7 +1790,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f28b65ed11eaca443d09b1886fffafba4bc91fc4",
         "is_verified": false,
-        "line_number": 1301,
+        "line_number": 1298,
         "is_secret": false
       },
       {
@@ -1808,7 +1798,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b60280065d793e59e962d0664662789d8bcf726f",
         "is_verified": false,
-        "line_number": 1308,
+        "line_number": 1305,
         "is_secret": false
       },
       {
@@ -1816,7 +1806,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fc5261f9b81175148bb34db06e7e200ed45e2bea",
         "is_verified": false,
-        "line_number": 1314,
+        "line_number": 1311,
         "is_secret": false
       },
       {
@@ -1824,7 +1814,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a50d089f18d903f5cebfa525a6f9af7f1d08c6dd",
         "is_verified": false,
-        "line_number": 1318,
+        "line_number": 1315,
         "is_secret": false
       },
       {
@@ -1832,7 +1822,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "36ff793214a4a43138d87bdf3a2093abbc311d56",
         "is_verified": false,
-        "line_number": 1324,
+        "line_number": 1321,
         "is_secret": false
       },
       {
@@ -1840,7 +1830,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b415b302a50e49d81ef709b69641bd4913bd2f7",
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1328,
         "is_secret": false
       },
       {
@@ -1848,7 +1838,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c0aa546007a52ddaa78f0f5d8233acbbd6e9b43b",
         "is_verified": false,
-        "line_number": 1335,
+        "line_number": 1332,
         "is_secret": false
       },
       {
@@ -1856,7 +1846,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e212327cfd6033d6256a51abd3932ccc47df3b36",
         "is_verified": false,
-        "line_number": 1341,
+        "line_number": 1338,
         "is_secret": false
       },
       {
@@ -1864,7 +1854,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b333857f3bcd93ff2120b75697b29920db5490c3",
         "is_verified": false,
-        "line_number": 1348,
+        "line_number": 1345,
         "is_secret": false
       },
       {
@@ -1872,28 +1862,28 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c7783ffbc6047d282a940a08f8149a73bfde8f4d",
         "is_verified": false,
-        "line_number": 1352
+        "line_number": 1349
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf5fd3db00e8fed584b599f6ef1d591738e104c2",
         "is_verified": false,
-        "line_number": 1358
+        "line_number": 1355
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ec24023060b25fd622cd7d6ba844f56bb4ccd6f4",
         "is_verified": false,
-        "line_number": 1364
+        "line_number": 1361
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
         "is_verified": false,
-        "line_number": 1367,
+        "line_number": 1364,
         "is_secret": false
       },
       {
@@ -1901,7 +1891,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c55afbe74fbb1c0236127b02c4c00815e04244a9",
         "is_verified": false,
-        "line_number": 1370,
+        "line_number": 1367,
         "is_secret": false
       },
       {
@@ -1909,7 +1899,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96bcbd5509b2939bfe5c641c0df3863b79b6d8ff",
         "is_verified": false,
-        "line_number": 1383,
+        "line_number": 1380,
         "is_secret": false
       },
       {
@@ -1917,7 +1907,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a07406dd5a9fe5c13cf9a915057e45666d7b386d",
         "is_verified": false,
-        "line_number": 1386,
+        "line_number": 1383,
         "is_secret": false
       },
       {
@@ -1925,7 +1915,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3240395f6aea7846fbcb340eff5ed612e70761c0",
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1394,
         "is_secret": false
       },
       {
@@ -1933,7 +1923,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99fed6667fcafb20f46b5b42f69f448871cb0b9c",
         "is_verified": false,
-        "line_number": 1400,
+        "line_number": 1397,
         "is_secret": false
       },
       {
@@ -1941,7 +1931,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4334db9823b546a567f051d3bbb19b008d4f1bfd",
         "is_verified": false,
-        "line_number": 1403,
+        "line_number": 1400,
         "is_secret": false
       },
       {
@@ -1949,7 +1939,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7f0be5c6564fee17d341cd13469fb880b761d4a8",
         "is_verified": false,
-        "line_number": 1406,
+        "line_number": 1403,
         "is_secret": false
       },
       {
@@ -1957,7 +1947,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a7b774ea3190f1218d025af8edff4e9b085f81fb",
         "is_verified": false,
-        "line_number": 1409,
+        "line_number": 1406,
         "is_secret": false
       },
       {
@@ -1965,7 +1955,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c9deed84332364a2f0d212d36462413167391e17",
         "is_verified": false,
-        "line_number": 1414,
+        "line_number": 1411,
         "is_secret": false
       },
       {
@@ -1973,7 +1963,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "441677734d0b21c40aecefdecbf37c2f0040bef3",
         "is_verified": false,
-        "line_number": 1417,
+        "line_number": 1414,
         "is_secret": false
       },
       {
@@ -1981,7 +1971,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2f582518a7d025e7efbc4ef2cf8cc5cf9487b200",
         "is_verified": false,
-        "line_number": 1421,
+        "line_number": 1418,
         "is_secret": false
       },
       {
@@ -1989,7 +1979,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b2c03df0ed8f8caded3abab58c3b2e3b645dbb28",
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1423,
         "is_secret": false
       },
       {
@@ -1997,7 +1987,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f2d08166d55f8cb2912054fc3b1243f2255fac48",
         "is_verified": false,
-        "line_number": 1431,
+        "line_number": 1428,
         "is_secret": false
       },
       {
@@ -2005,7 +1995,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "35ca90e5fa9b87427a5ff8b3f333a7b7d45fc260",
         "is_verified": false,
-        "line_number": 1434,
+        "line_number": 1431,
         "is_secret": false
       },
       {
@@ -2013,7 +2003,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d15b82853a984c45aab87399878c98082bac85ba",
         "is_verified": false,
-        "line_number": 1438,
+        "line_number": 1435,
         "is_secret": false
       },
       {
@@ -2021,7 +2011,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "371ce323d657e273939fdad274085642a4da69de",
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1439,
         "is_secret": false
       },
       {
@@ -2029,7 +2019,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
         "is_verified": false,
-        "line_number": 1446,
+        "line_number": 1443,
         "is_secret": false
       },
       {
@@ -2037,7 +2027,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d032728a18c71c0a8e3f18b060f12d1ab9755c47",
         "is_verified": false,
-        "line_number": 1450,
+        "line_number": 1447,
         "is_secret": false
       },
       {
@@ -2045,7 +2035,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b8434babdebe87a28a32c342a9ed215e5fe43378",
         "is_verified": false,
-        "line_number": 1453,
+        "line_number": 1450,
         "is_secret": false
       },
       {
@@ -2053,7 +2043,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
         "is_verified": false,
-        "line_number": 1457,
+        "line_number": 1454,
         "is_secret": false
       },
       {
@@ -2061,7 +2051,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
         "is_verified": false,
-        "line_number": 1461,
+        "line_number": 1458,
         "is_secret": false
       },
       {
@@ -2069,7 +2059,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e0ed71a4c2836a6a251bef5e00b00401cfac286d",
         "is_verified": false,
-        "line_number": 1464,
+        "line_number": 1461,
         "is_secret": false
       },
       {
@@ -2077,7 +2067,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "247df9c18e18d5126f09f28a433b7c9d2bee21dc",
         "is_verified": false,
-        "line_number": 1468,
+        "line_number": 1465,
         "is_secret": false
       },
       {
@@ -2085,7 +2075,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e92b0b06949b35e8983aee47a7648629b7bfc30a",
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1470,
         "is_secret": false
       },
       {
@@ -2093,7 +2083,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0445deb44be67d9973df3ad6d4d78bca844eaa83",
         "is_verified": false,
-        "line_number": 1476,
+        "line_number": 1473,
         "is_secret": false
       },
       {
@@ -2101,7 +2091,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f3ce430d4c1e91228db9002ad1d3ef9a4847a568",
         "is_verified": false,
-        "line_number": 1479,
+        "line_number": 1476,
         "is_secret": false
       },
       {
@@ -2109,7 +2099,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b83c83894d873c027ba4615d15104944324378f4",
         "is_verified": false,
-        "line_number": 1483,
+        "line_number": 1480,
         "is_secret": false
       },
       {
@@ -2117,7 +2107,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e60ec2921d287de0ac22831deed001823740f61c",
         "is_verified": false,
-        "line_number": 1488,
+        "line_number": 1485,
         "is_secret": false
       },
       {
@@ -2125,7 +2115,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7feb84e7bac9f8cb60fff500f80285507a14318d",
         "is_verified": false,
-        "line_number": 1491,
+        "line_number": 1488,
         "is_secret": false
       },
       {
@@ -2133,7 +2123,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
         "is_verified": false,
-        "line_number": 1495,
+        "line_number": 1492,
         "is_secret": false
       },
       {
@@ -2141,7 +2131,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bc23715592b7602434c2776230d19f43fc479898",
         "is_verified": false,
-        "line_number": 1498,
+        "line_number": 1495,
         "is_secret": false
       },
       {
@@ -2149,7 +2139,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
         "is_verified": false,
-        "line_number": 1502,
+        "line_number": 1499,
         "is_secret": false
       },
       {
@@ -2157,7 +2147,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1502,
         "is_secret": false
       },
       {
@@ -2165,7 +2155,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
         "is_verified": false,
-        "line_number": 1508,
+        "line_number": 1505,
         "is_secret": false
       },
       {
@@ -2173,7 +2163,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
         "is_verified": false,
-        "line_number": 1511,
+        "line_number": 1508,
         "is_secret": false
       },
       {
@@ -2181,7 +2171,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
         "is_verified": false,
-        "line_number": 1514,
+        "line_number": 1511,
         "is_secret": false
       },
       {
@@ -2189,7 +2179,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "690af56af1384793272c233c11ffb5d354b49fc0",
         "is_verified": false,
-        "line_number": 1517,
+        "line_number": 1514,
         "is_secret": false
       },
       {
@@ -2197,7 +2187,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "43e69c85090264b5501c0964aaa3d048ee08fd37",
         "is_verified": false,
-        "line_number": 1521,
+        "line_number": 1518,
         "is_secret": false
       },
       {
@@ -2205,7 +2195,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
         "is_verified": false,
-        "line_number": 1525,
+        "line_number": 1522,
         "is_secret": false
       },
       {
@@ -2213,7 +2203,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4ed49acfbd180533265d2099f3043963c4a24443",
         "is_verified": false,
-        "line_number": 1529,
+        "line_number": 1526,
         "is_secret": false
       },
       {
@@ -2221,7 +2211,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "428e72f71455a785963f1df5f85c26c6d6ae519b",
         "is_verified": false,
-        "line_number": 1533,
+        "line_number": 1530,
         "is_secret": false
       },
       {
@@ -2229,22 +2219,29 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
         "is_verified": false,
-        "line_number": 1536,
+        "line_number": 1533,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "4e737227d8a4ff0c87704616f4c0c457fa6bf550",
+        "is_verified": false,
+        "line_number": 1536
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "621b26766bdddc2a2e0f7eff42ad8426b4b8198d",
         "is_verified": false,
-        "line_number": 1539
+        "line_number": 1540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
         "is_verified": false,
-        "line_number": 1542,
+        "line_number": 1543,
         "is_secret": false
       },
       {
@@ -2252,7 +2249,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8f16039bc2ed9b93d8e319897b70cb25f25dfcc4",
         "is_verified": false,
-        "line_number": 1545,
+        "line_number": 1546,
         "is_secret": false
       },
       {
@@ -2260,7 +2257,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "862951cd71d0412b5e52bae3e952725486a655b0",
         "is_verified": false,
-        "line_number": 1549,
+        "line_number": 1550,
         "is_secret": false
       },
       {
@@ -2268,7 +2265,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3752b70c2c4391586cfb164832e45682b1ecfc22",
         "is_verified": false,
-        "line_number": 1553,
+        "line_number": 1554,
         "is_secret": false
       },
       {
@@ -2276,7 +2273,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf2a7aa50ec6063cbb616daadb50eec0213fa61f",
         "is_verified": false,
-        "line_number": 1557,
+        "line_number": 1558,
         "is_secret": false
       },
       {
@@ -2284,7 +2281,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
         "is_verified": false,
-        "line_number": 1560,
+        "line_number": 1561,
         "is_secret": false
       },
       {
@@ -2292,7 +2289,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a35cbc541c025ba5ccef5ca780a743f94848a218",
         "is_verified": false,
-        "line_number": 1565,
+        "line_number": 1566,
         "is_secret": false
       },
       {
@@ -2300,7 +2297,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
         "is_verified": false,
-        "line_number": 1568,
+        "line_number": 1569,
         "is_secret": false
       },
       {
@@ -2308,7 +2305,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ff435d07ef4cb4267aaa7adfdfd11d80984bc826",
         "is_verified": false,
-        "line_number": 1572,
+        "line_number": 1573,
         "is_secret": false
       },
       {
@@ -2316,7 +2313,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
         "is_verified": false,
-        "line_number": 1575,
+        "line_number": 1576,
         "is_secret": false
       },
       {
@@ -2324,7 +2321,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
         "is_verified": false,
-        "line_number": 1579,
+        "line_number": 1580,
         "is_secret": false
       },
       {
@@ -2332,7 +2329,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
         "is_verified": false,
-        "line_number": 1583,
+        "line_number": 1584,
         "is_secret": false
       },
       {
@@ -2340,7 +2337,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
         "is_verified": false,
-        "line_number": 1587,
+        "line_number": 1588,
         "is_secret": false
       },
       {
@@ -2348,7 +2345,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dedc9b22d5635183aab2822ddc8216ffb7bec66",
         "is_verified": false,
-        "line_number": 1591,
+        "line_number": 1592,
         "is_secret": false
       },
       {
@@ -2356,7 +2353,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "07365202aa196d356df406db75704c4807ad833e",
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1596,
         "is_secret": false
       },
       {
@@ -2364,7 +2361,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
         "is_verified": false,
-        "line_number": 1599,
+        "line_number": 1600,
         "is_secret": false
       },
       {
@@ -2372,7 +2369,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0b7b9ea94e8e5f945f8ffa476ae48f3060bbed15",
         "is_verified": false,
-        "line_number": 1603,
+        "line_number": 1604,
         "is_secret": false
       },
       {
@@ -2380,7 +2377,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
         "is_verified": false,
-        "line_number": 1606,
+        "line_number": 1607,
         "is_secret": false
       },
       {
@@ -2388,7 +2385,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
         "is_verified": false,
-        "line_number": 1610,
+        "line_number": 1611,
         "is_secret": false
       },
       {
@@ -2396,7 +2393,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
         "is_verified": false,
-        "line_number": 1614,
+        "line_number": 1615,
         "is_secret": false
       },
       {
@@ -2404,7 +2401,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
         "is_verified": false,
-        "line_number": 1618,
+        "line_number": 1619,
         "is_secret": false
       },
       {
@@ -2412,7 +2409,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
         "is_verified": false,
-        "line_number": 1622,
+        "line_number": 1623,
         "is_secret": false
       },
       {
@@ -2420,7 +2417,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
         "is_verified": false,
-        "line_number": 1626,
+        "line_number": 1627,
         "is_secret": false
       },
       {
@@ -2428,7 +2425,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
         "is_verified": false,
-        "line_number": 1630,
+        "line_number": 1631,
         "is_secret": false
       },
       {
@@ -2436,7 +2433,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
         "is_verified": false,
-        "line_number": 1634,
+        "line_number": 1635,
         "is_secret": false
       },
       {
@@ -2444,7 +2441,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
         "is_verified": false,
-        "line_number": 1640,
+        "line_number": 1641,
         "is_secret": false
       },
       {
@@ -2452,7 +2449,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1259773a720ff6c462f3fff70a0881f503563c9e",
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1645,
         "is_secret": false
       },
       {
@@ -2460,7 +2457,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
         "is_verified": false,
-        "line_number": 1648,
+        "line_number": 1649,
         "is_secret": false
       },
       {
@@ -2468,7 +2465,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cf3e48f5af3fca6bb9135acdee135247bcae1307",
         "is_verified": false,
-        "line_number": 1657,
+        "line_number": 1658,
         "is_secret": false
       },
       {
@@ -2476,7 +2473,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9565b61bcf2aafa2128576569978e338bdd1a0bc",
         "is_verified": false,
-        "line_number": 1660,
+        "line_number": 1661,
         "is_secret": false
       },
       {
@@ -2484,7 +2481,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b0f6a9f09dd8a0ebc50e6d4a7a81e126cd64ac6a",
         "is_verified": false,
-        "line_number": 1663,
+        "line_number": 1664,
         "is_secret": false
       },
       {
@@ -2492,7 +2489,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
         "is_verified": false,
-        "line_number": 1666,
+        "line_number": 1667,
         "is_secret": false
       },
       {
@@ -2500,7 +2497,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
         "is_verified": false,
-        "line_number": 1670,
+        "line_number": 1671,
         "is_secret": false
       },
       {
@@ -2508,7 +2505,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
         "is_verified": false,
-        "line_number": 1674,
+        "line_number": 1675,
         "is_secret": false
       },
       {
@@ -2516,7 +2513,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1678,
         "is_secret": false
       },
       {
@@ -2524,14 +2521,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0a200afe0142c8d73f691b9b48ad5930e422ed3f",
         "is_verified": false,
-        "line_number": 1680
+        "line_number": 1681
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c02b39bafb6389010b678e8a4714d2ddfb10fe59",
         "is_verified": false,
-        "line_number": 1684,
+        "line_number": 1685,
         "is_secret": false
       },
       {
@@ -2539,7 +2536,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "46a4e83f9f3f3670ec1cf4445789431038008dc2",
         "is_verified": false,
-        "line_number": 1687,
+        "line_number": 1688,
         "is_secret": false
       },
       {
@@ -2547,7 +2544,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0fa428c8d3a332eb3100743c0ffc3883c4d6500e",
         "is_verified": false,
-        "line_number": 1690,
+        "line_number": 1691,
         "is_secret": false
       },
       {
@@ -2555,7 +2552,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fc7b2f07f919c3f8e20aa78a1756d2bcca252fb9",
         "is_verified": false,
-        "line_number": 1693,
+        "line_number": 1694,
         "is_secret": false
       },
       {
@@ -2563,7 +2560,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8ba4df7f64f94ef4347bf0d9b894f9075f3b7b69",
         "is_verified": false,
-        "line_number": 1696,
+        "line_number": 1697,
         "is_secret": false
       },
       {
@@ -2571,7 +2568,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
         "is_verified": false,
-        "line_number": 1700,
+        "line_number": 1701,
         "is_secret": false
       },
       {
@@ -2579,7 +2576,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d9c1f677ee5e5af2247aaa0ab352291ef98e5ea3",
         "is_verified": false,
-        "line_number": 1704,
+        "line_number": 1705,
         "is_secret": false
       },
       {
@@ -2587,7 +2584,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
         "is_verified": false,
-        "line_number": 1707,
+        "line_number": 1708,
         "is_secret": false
       },
       {
@@ -2595,7 +2592,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6c88ecf20f9dc070ee18f0cf59f58b0025f6ec55",
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1712,
         "is_secret": false
       },
       {
@@ -2603,7 +2600,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
         "is_verified": false,
-        "line_number": 1715,
+        "line_number": 1716,
         "is_secret": false
       },
       {
@@ -2611,7 +2608,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "abcb73825dfa960775d6eafa968d65b9180d36c5",
         "is_verified": false,
-        "line_number": 1719,
+        "line_number": 1720,
         "is_secret": false
       },
       {
@@ -2619,7 +2616,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "45c675dd5218ee48913576fba5016553db08668f",
         "is_verified": false,
-        "line_number": 1725,
+        "line_number": 1726,
         "is_secret": false
       },
       {
@@ -2627,7 +2624,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "598fd2d32e89e81b375b0ad0273fb1f17c9ba7d5",
         "is_verified": false,
-        "line_number": 1730,
+        "line_number": 1731,
         "is_secret": false
       },
       {
@@ -2635,7 +2632,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2a5c1a897332b7652d1daeb248e27b29123ca884",
         "is_verified": false,
-        "line_number": 1734,
+        "line_number": 1735,
         "is_secret": false
       },
       {
@@ -2643,7 +2640,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "99e3e5f5d9f570cf4d4af4bc1c43544b0b2392ef",
         "is_verified": false,
-        "line_number": 1738,
+        "line_number": 1739,
         "is_secret": false
       },
       {
@@ -2651,7 +2648,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5f036eebfbd4414e9ff18073bd76d55b22376e33",
         "is_verified": false,
-        "line_number": 1742,
+        "line_number": 1743,
         "is_secret": false
       },
       {
@@ -2659,7 +2656,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ad3044be6fc2905d62a5af9d3efa1a83e7c9389b",
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1753,
         "is_secret": false
       },
       {
@@ -2667,7 +2664,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8566f6301c749c574462db3cef2c1f3a10a03c0",
         "is_verified": false,
-        "line_number": 1756,
+        "line_number": 1757,
         "is_secret": false
       },
       {
@@ -2675,7 +2672,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "51e9263c74493cd77c2d25adb255b15647d84512",
         "is_verified": false,
-        "line_number": 1760,
+        "line_number": 1761,
         "is_secret": false
       },
       {
@@ -2683,7 +2680,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1790c1f42e3416e31561c46b258d2f69c1608c85",
         "is_verified": false,
-        "line_number": 1764,
+        "line_number": 1765,
         "is_secret": false
       },
       {
@@ -2691,7 +2688,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
         "is_verified": false,
-        "line_number": 1768,
+        "line_number": 1769,
         "is_secret": false
       },
       {
@@ -2699,14 +2696,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ceac1beaa3e65d484e1fce7f4a47b1c1bb1bbec5",
         "is_verified": false,
-        "line_number": 1771
+        "line_number": 1772
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1775,
         "is_secret": false
       },
       {
@@ -2714,7 +2711,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2fcbf434b04ba0a49ae29f1d9ea0edc30881350b",
         "is_verified": false,
-        "line_number": 1777,
+        "line_number": 1778,
         "is_secret": false
       },
       {
@@ -2722,7 +2719,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "16d0c877fca994fd1c43bd7f131be967bf4f87b6",
         "is_verified": false,
-        "line_number": 1781,
+        "line_number": 1782,
         "is_secret": false
       },
       {
@@ -2730,7 +2727,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
         "is_verified": false,
-        "line_number": 1785,
+        "line_number": 1786,
         "is_secret": false
       },
       {
@@ -2738,7 +2735,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c0f64a532897bbd5497996fdfec7cfcd087540ce",
         "is_verified": false,
-        "line_number": 1788,
+        "line_number": 1789,
         "is_secret": false
       },
       {
@@ -2746,7 +2743,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fea0d9c5b0c53c41e6a0a961a49cccc170847120",
         "is_verified": false,
-        "line_number": 1791,
+        "line_number": 1792,
         "is_secret": false
       },
       {
@@ -2754,7 +2751,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "283a181bd9971789ceaee59c32a0f93e31a7a2a8",
         "is_verified": false,
-        "line_number": 1794,
+        "line_number": 1795,
         "is_secret": false
       },
       {
@@ -2762,7 +2759,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4fb28b14ff2c4dfd32138126666d09b3b4779da5",
         "is_verified": false,
-        "line_number": 1797,
+        "line_number": 1798,
         "is_secret": false
       },
       {
@@ -2770,7 +2767,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7e1d085812721297b6a5540f3b2d9416d2f57efb",
         "is_verified": false,
-        "line_number": 1800,
+        "line_number": 1801,
         "is_secret": false
       },
       {
@@ -2778,7 +2775,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fa3e6343640bdfc534111bedad8e4be8658cb0b0",
         "is_verified": false,
-        "line_number": 1803,
+        "line_number": 1804,
         "is_secret": false
       },
       {
@@ -2786,7 +2783,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
         "is_verified": false,
-        "line_number": 1806,
+        "line_number": 1807,
         "is_secret": false
       },
       {
@@ -2794,7 +2791,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76ecd72b3dad674722024145ada2c3d7763456e3",
         "is_verified": false,
-        "line_number": 1815,
+        "line_number": 1816,
         "is_secret": false
       },
       {
@@ -2802,7 +2799,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c5b9224d6550ddd6a9d3e700fd0a58360b11ca0d",
         "is_verified": false,
-        "line_number": 1818,
+        "line_number": 1819,
         "is_secret": false
       },
       {
@@ -2810,7 +2807,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3594781b38f5d70bb1b747317347cf06b2a0cc01",
         "is_verified": false,
-        "line_number": 1822,
+        "line_number": 1823,
         "is_secret": false
       },
       {
@@ -2818,7 +2815,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "76332214739a4c7dd7c65873aa473b0b918d47e4",
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1827,
         "is_secret": false
       },
       {
@@ -2826,7 +2823,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6469b5be81ddc9f74fdb35bb646526db702e0f3d",
         "is_verified": false,
-        "line_number": 1830,
+        "line_number": 1831,
         "is_secret": false
       },
       {
@@ -2834,7 +2831,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "35e9b52d7a5604a386ad789c8c7b5234361ce18e",
         "is_verified": false,
-        "line_number": 1833,
+        "line_number": 1834,
         "is_secret": false
       },
       {
@@ -2842,7 +2839,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1a3a9dc68ebcd975166450d240ed228e050a3e8a",
         "is_verified": false,
-        "line_number": 1837,
+        "line_number": 1838,
         "is_secret": false
       },
       {
@@ -2850,7 +2847,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9c422f6dfca5f8acb3d3923f7aed45865b8e1168",
         "is_verified": false,
-        "line_number": 1841,
+        "line_number": 1842,
         "is_secret": false
       },
       {
@@ -2858,7 +2855,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
         "is_verified": false,
-        "line_number": 1846,
+        "line_number": 1847,
         "is_secret": false
       },
       {
@@ -2866,7 +2863,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
         "is_verified": false,
-        "line_number": 1851,
+        "line_number": 1852,
         "is_secret": false
       },
       {
@@ -2874,7 +2871,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "184476d985c0d799b82544165cb4d456129f594c",
         "is_verified": false,
-        "line_number": 1855,
+        "line_number": 1856,
         "is_secret": false
       },
       {
@@ -2882,7 +2879,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
         "is_verified": false,
-        "line_number": 1859,
+        "line_number": 1860,
         "is_secret": false
       },
       {
@@ -2890,7 +2887,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "89345a033a4ecac54d56210d7fb9533fddc58490",
         "is_verified": false,
-        "line_number": 1863,
+        "line_number": 1864,
         "is_secret": false
       },
       {
@@ -2898,7 +2895,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9a2925939d58c126684a6bc23cb398ee48ae47fb",
         "is_verified": false,
-        "line_number": 1867,
+        "line_number": 1868,
         "is_secret": false
       },
       {
@@ -2906,7 +2903,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
         "is_verified": false,
-        "line_number": 1871,
+        "line_number": 1872,
         "is_secret": false
       },
       {
@@ -2914,23 +2911,58 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "631f4dfe80235f956760243a084b52119f9380ab",
         "is_verified": false,
-        "line_number": 1874,
+        "line_number": 1875,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "9ac633e9766159806b447d7be2d84067548764f4",
+        "is_verified": false,
+        "line_number": 1879
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "fffff370595b6f4803e610b7519dbb1bb9923c8a",
+        "is_verified": false,
+        "line_number": 1882
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3300960d885e191e93efbb20d444a625bddcfe90",
+        "is_verified": false,
+        "line_number": 1885
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a0540a26c42e0189fb536e1a42e879429302f9a8",
+        "is_verified": false,
+        "line_number": 1888
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
         "is_verified": false,
-        "line_number": 1878,
+        "line_number": 1891,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "c73d5fe546a436b30bdec90b571803faa29161c0",
+        "is_verified": false,
+        "line_number": 1894
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
         "is_verified": false,
-        "line_number": 1881,
+        "line_number": 1897,
         "is_secret": false
       },
       {
@@ -2938,7 +2970,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
         "is_verified": false,
-        "line_number": 1884,
+        "line_number": 1900,
         "is_secret": false
       },
       {
@@ -2946,15 +2978,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
         "is_verified": false,
-        "line_number": 1887,
+        "line_number": 1903,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d3063fb8878cd870d06706fb7de1fbf791b78dd8",
+        "is_verified": false,
+        "line_number": 1906
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "492f7af72b8ed205d898deb4e73463b7077e70a9",
         "is_verified": false,
-        "line_number": 1890,
+        "line_number": 1909,
         "is_secret": false
       },
       {
@@ -2962,7 +3001,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b47624d97ee05cf142ba92c5dc738615ef86b0a6",
         "is_verified": false,
-        "line_number": 1893,
+        "line_number": 1912,
         "is_secret": false
       },
       {
@@ -2970,15 +3009,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "10872e4d4d8973d18c0af1bd651122c8d5693369",
         "is_verified": false,
-        "line_number": 1896,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "dfa61d24a9c1a574fb520ffd45b1b2ffe8e92658",
-        "is_verified": false,
-        "line_number": 1899,
+        "line_number": 1915,
         "is_secret": false
       },
       {
@@ -2986,7 +3017,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0d96d45dd8e09cb4633cd3318f47162fc2257667",
         "is_verified": false,
-        "line_number": 1903,
+        "line_number": 1918,
         "is_secret": false
       },
       {
@@ -2994,14 +3025,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d0127fd3500968634abcfba5a45d8d9d8a0628dc",
         "is_verified": false,
-        "line_number": 1907
+        "line_number": 1922
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
         "is_verified": false,
-        "line_number": 1910,
+        "line_number": 1925,
         "is_secret": false
       },
       {
@@ -3009,7 +3040,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c6ee5cc9425c6e106fad752bf1f79925d0f8d332",
         "is_verified": false,
-        "line_number": 1913,
+        "line_number": 1928,
         "is_secret": false
       },
       {
@@ -3017,7 +3048,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f09b00d00e74c891c9bbc0614a19d47015e616c1",
         "is_verified": false,
-        "line_number": 1917,
+        "line_number": 1932,
         "is_secret": false
       },
       {
@@ -3025,44 +3056,12 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aa3274ac7d69b31bff9519c6ded94b252aa90a81",
         "is_verified": false,
-        "line_number": 1921
+        "line_number": 1936
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e25be230742364f1ee60067a756da19dc7572126",
-        "is_verified": false,
-        "line_number": 1924,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1109544447e298af75035b2bbfc851610f963a65",
-        "is_verified": false,
-        "line_number": 1928,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7495ab514349a9c665180d198d97406b00971d06",
-        "is_verified": false,
-        "line_number": 1932,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "cb41740c5bbb34bb9e00283d48dbf4a56f15d251",
-        "is_verified": false,
-        "line_number": 1936,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
         "is_verified": false,
         "line_number": 1939,
         "is_secret": false
@@ -3070,7 +3069,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
+        "hashed_secret": "1109544447e298af75035b2bbfc851610f963a65",
         "is_verified": false,
         "line_number": 1943,
         "is_secret": false
@@ -3078,9 +3077,41 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "7495ab514349a9c665180d198d97406b00971d06",
+        "is_verified": false,
+        "line_number": 1947,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "cb41740c5bbb34bb9e00283d48dbf4a56f15d251",
+        "is_verified": false,
+        "line_number": 1951,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
+        "is_verified": false,
+        "line_number": 1954,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
+        "is_verified": false,
+        "line_number": 1958,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
         "is_verified": false,
-        "line_number": 1946,
+        "line_number": 1961,
         "is_secret": false
       },
       {
@@ -3088,7 +3119,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
         "is_verified": false,
-        "line_number": 1949,
+        "line_number": 1964,
         "is_secret": false
       },
       {
@@ -3096,7 +3127,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e9ce08fb0922eb7b6fd8078a79f948726b9b756e",
         "is_verified": false,
-        "line_number": 1952,
+        "line_number": 1967,
         "is_secret": false
       },
       {
@@ -3104,7 +3135,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d5ec021cbb92c3486e38fac176f4f59a6c1d92e8",
         "is_verified": false,
-        "line_number": 1956,
+        "line_number": 1971,
         "is_secret": false
       },
       {
@@ -3112,7 +3143,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0168f03d6f1748d5d7ae624a93f711333b69d01c",
         "is_verified": false,
-        "line_number": 1960,
+        "line_number": 1975,
         "is_secret": false
       },
       {
@@ -3120,7 +3151,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
         "is_verified": false,
-        "line_number": 1964,
+        "line_number": 1979,
         "is_secret": false
       },
       {
@@ -3128,14 +3159,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "27ac029c63fd4a79febe4493812e5fd87d1e0ba8",
         "is_verified": false,
-        "line_number": 1967
+        "line_number": 1982
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f88f23dafd3c868018f752bc0f0b816603b8fdcf",
         "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1985,
         "is_secret": false
       },
       {
@@ -3143,7 +3174,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
         "is_verified": false,
-        "line_number": 1973,
+        "line_number": 1988,
         "is_secret": false
       },
       {
@@ -3151,14 +3182,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c6fac4fc8845592652235008b20d705167bb64c8",
         "is_verified": false,
-        "line_number": 1977
+        "line_number": 1992
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e907e408e8ac716a2dc03c3a56283b57e5bb5c73",
         "is_verified": false,
-        "line_number": 1981,
+        "line_number": 1996,
         "is_secret": false
       },
       {
@@ -3166,7 +3197,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4e5e279b264f80f6302507f3bc02028118a5381f",
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 1999,
         "is_secret": false
       },
       {
@@ -3174,7 +3205,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8027d593202ac7fe9ecb516b44ed6ee4788bfa5a",
         "is_verified": false,
-        "line_number": 1987,
+        "line_number": 2002,
         "is_secret": false
       },
       {
@@ -3182,7 +3213,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
         "is_verified": false,
-        "line_number": 1991,
+        "line_number": 2006,
         "is_secret": false
       },
       {
@@ -3190,28 +3221,28 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b78dedf3b731da4d2939780bf688cc250d6d7803",
         "is_verified": false,
-        "line_number": 1995
+        "line_number": 2010
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "34ac8d1f4eeb025b1ab1e5b7be252f49a06d3678",
         "is_verified": false,
-        "line_number": 2001
+        "line_number": 2016
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c28a77a2c09fc919ec71532ac06775e2d357f682",
         "is_verified": false,
-        "line_number": 2013
+        "line_number": 2028
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
         "is_verified": false,
-        "line_number": 2025,
+        "line_number": 2040,
         "is_secret": false
       },
       {
@@ -3219,7 +3250,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "08d197c68a2ed20b47b376a98f1968aa5966e035",
         "is_verified": false,
-        "line_number": 2028,
+        "line_number": 2043,
         "is_secret": false
       },
       {
@@ -3227,7 +3258,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
         "is_verified": false,
-        "line_number": 2037,
+        "line_number": 2052,
         "is_secret": false
       },
       {
@@ -3235,7 +3266,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "32f166e925f96dafcba74b3787246df2a06a9e19",
         "is_verified": false,
-        "line_number": 2042,
+        "line_number": 2057,
         "is_secret": false
       },
       {
@@ -3243,7 +3274,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
         "is_verified": false,
-        "line_number": 2045,
+        "line_number": 2060,
         "is_secret": false
       },
       {
@@ -3251,7 +3282,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "518c6e09c048b1b3cdbcc4ed47df84e0552aba4c",
         "is_verified": false,
-        "line_number": 2048,
+        "line_number": 2063,
         "is_secret": false
       },
       {
@@ -3259,7 +3290,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
         "is_verified": false,
-        "line_number": 2051,
+        "line_number": 2066,
         "is_secret": false
       },
       {
@@ -3267,15 +3298,29 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "987bd819de5601830bd2d22b74c9243d57f14aec",
         "is_verified": false,
-        "line_number": 2056,
+        "line_number": 2071,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "21b1367dd5cbd3d607ccd3174f5c0e4178956a9d",
+        "is_verified": false,
+        "line_number": 2075
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "3aa4164dda99cf93c72f25a010920b9c533abce8",
+        "is_verified": false,
+        "line_number": 2079
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4c565e2b5132b7df2d3126654bee51cf449f5d8f",
         "is_verified": false,
-        "line_number": 2060,
+        "line_number": 2083,
         "is_secret": false
       },
       {
@@ -3283,7 +3328,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0ec89f07004a01dda54b29e48a86c84f8098fdb6",
         "is_verified": false,
-        "line_number": 2063,
+        "line_number": 2086,
         "is_secret": false
       },
       {
@@ -3291,7 +3336,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ecca8c8ee1920fbd6387220767bdecf3635a3741",
         "is_verified": false,
-        "line_number": 2067,
+        "line_number": 2090,
         "is_secret": false
       },
       {
@@ -3299,7 +3344,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b48b7cde42a2442c78c359b776b516d8127006c6",
         "is_verified": false,
-        "line_number": 2073,
+        "line_number": 2096,
         "is_secret": false
       },
       {
@@ -3307,7 +3352,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2fb4be4f309d24f5064ac5496b8c7f59df0bf966",
         "is_verified": false,
-        "line_number": 2079,
+        "line_number": 2102,
         "is_secret": false
       },
       {
@@ -3315,7 +3360,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b6acf38d09475b54b197ff0574abc4a7e86c3543",
         "is_verified": false,
-        "line_number": 2085,
+        "line_number": 2108,
         "is_secret": false
       },
       {
@@ -3323,7 +3368,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "405ac79c3832190ec6bd61bce50e9390a026af72",
         "is_verified": false,
-        "line_number": 2091,
+        "line_number": 2114,
         "is_secret": false
       },
       {
@@ -3331,7 +3376,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5f3d1367a38ac4e76290f44b6dc26d3555bbabf5",
         "is_verified": false,
-        "line_number": 2097,
+        "line_number": 2120,
         "is_secret": false
       },
       {
@@ -3339,7 +3384,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d86912fe91c497e31a4344f459a68586ce096966",
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2127,
         "is_secret": false
       },
       {
@@ -3347,7 +3392,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1509ab36ebf61526ec42f40016db32b0925e96bc",
         "is_verified": false,
-        "line_number": 2111,
+        "line_number": 2134,
         "is_secret": false
       },
       {
@@ -3355,7 +3400,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2139b734b30d5642cf104ea814b455bf3f08ca4c",
         "is_verified": false,
-        "line_number": 2118,
+        "line_number": 2141,
         "is_secret": false
       },
       {
@@ -3363,7 +3408,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ef73b9a0b786d2e003921cc9967a0a7cd6ae1913",
         "is_verified": false,
-        "line_number": 2125,
+        "line_number": 2148,
         "is_secret": false
       },
       {
@@ -3371,7 +3416,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2ffc317e2ecc11d98e3e05bf565c6575c4cbfd51",
         "is_verified": false,
-        "line_number": 2131,
+        "line_number": 2154,
         "is_secret": false
       },
       {
@@ -3379,7 +3424,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "432730c731e24c084f98525d5e133e358dc47b2f",
         "is_verified": false,
-        "line_number": 2137,
+        "line_number": 2160,
         "is_secret": false
       },
       {
@@ -3387,7 +3432,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1c386996454f57fad765143b1a1393b4fd15dceb",
         "is_verified": false,
-        "line_number": 2141,
+        "line_number": 2164,
         "is_secret": false
       },
       {
@@ -3395,7 +3440,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "af1761dddd338a777dabd8eb8f1ae8955205a116",
         "is_verified": false,
-        "line_number": 2145,
+        "line_number": 2168,
         "is_secret": false
       },
       {
@@ -3403,21 +3448,21 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "38441b3738707765cf9c96bac8bc8cc1ae34037d",
         "is_verified": false,
-        "line_number": 2148
+        "line_number": 2171
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2cb277435cb97d4859d0d0ae4d891a9f3cd17bef",
         "is_verified": false,
-        "line_number": 2151
+        "line_number": 2174
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
         "is_verified": false,
-        "line_number": 2154,
+        "line_number": 2177,
         "is_secret": false
       },
       {
@@ -3425,15 +3470,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
         "is_verified": false,
-        "line_number": 2157,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d0bc72b892bf793034931ddf0bdccf8cae2c4164",
-        "is_verified": false,
-        "line_number": 2161,
+        "line_number": 2180,
         "is_secret": false
       },
       {
@@ -3441,7 +3478,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dc1b9f847614c5a40208a767d4cc7cf0f9b2282a",
         "is_verified": false,
-        "line_number": 2164,
+        "line_number": 2184,
         "is_secret": false
       },
       {
@@ -3449,7 +3486,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
         "is_verified": false,
-        "line_number": 2168,
+        "line_number": 2188,
         "is_secret": false
       },
       {
@@ -3457,7 +3494,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96af205313d448bfac749d7820179b113d06c232",
         "is_verified": false,
-        "line_number": 2171,
+        "line_number": 2191,
         "is_secret": false
       },
       {
@@ -3465,7 +3502,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7aa924d4aef9f14c78acee8a31bcbd78b26e9898",
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2196,
         "is_secret": false
       },
       {
@@ -3473,7 +3510,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1e2228f0d8e0fc2bc3b8740a8ff3d287006b9a38",
         "is_verified": false,
-        "line_number": 2180,
+        "line_number": 2200,
         "is_secret": false
       },
       {
@@ -3481,7 +3518,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
         "is_verified": false,
-        "line_number": 2183,
+        "line_number": 2203,
         "is_secret": false
       },
       {
@@ -3489,14 +3526,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8fd991cd05ad3f6a7f265fc37db4fe1baaea8997",
         "is_verified": false,
-        "line_number": 2186
+        "line_number": 2206
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
         "is_verified": false,
-        "line_number": 2191,
+        "line_number": 2211,
         "is_secret": false
       },
       {
@@ -3504,7 +3541,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "72a79417ad2fe4b674820c0d880ce5119131e9cc",
         "is_verified": false,
-        "line_number": 2194,
+        "line_number": 2214,
         "is_secret": false
       },
       {
@@ -3512,7 +3549,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
         "is_verified": false,
-        "line_number": 2197,
+        "line_number": 2217,
         "is_secret": false
       },
       {
@@ -3520,7 +3557,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
         "is_verified": false,
-        "line_number": 2200,
+        "line_number": 2220,
         "is_secret": false
       },
       {
@@ -3528,7 +3565,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
         "is_verified": false,
-        "line_number": 2203,
+        "line_number": 2223,
         "is_secret": false
       },
       {
@@ -3536,7 +3573,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
         "is_verified": false,
-        "line_number": 2206,
+        "line_number": 2226,
         "is_secret": false
       },
       {
@@ -3544,7 +3581,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
         "is_verified": false,
-        "line_number": 2209,
+        "line_number": 2229,
         "is_secret": false
       },
       {
@@ -3552,7 +3589,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
         "is_verified": false,
-        "line_number": 2212,
+        "line_number": 2232,
         "is_secret": false
       },
       {
@@ -3560,14 +3597,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
         "is_verified": false,
-        "line_number": 2215
+        "line_number": 2235
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
         "is_verified": false,
-        "line_number": 2218,
+        "line_number": 2238,
         "is_secret": false
       },
       {
@@ -3575,7 +3612,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
         "is_verified": false,
-        "line_number": 2221,
+        "line_number": 2241,
         "is_secret": false
       },
       {
@@ -3583,14 +3620,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9bd0ccdc3670e20b60461bac42b2431894ad8879",
         "is_verified": false,
-        "line_number": 2224
+        "line_number": 2244
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
         "is_verified": false,
-        "line_number": 2227,
+        "line_number": 2247,
         "is_secret": false
       },
       {
@@ -3598,7 +3635,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
         "is_verified": false,
-        "line_number": 2230,
+        "line_number": 2250,
         "is_secret": false
       },
       {
@@ -3606,7 +3643,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a43d82b1bb02a76982f03708a4c77d9717f5f5c1",
         "is_verified": false,
-        "line_number": 2233,
+        "line_number": 2253,
         "is_secret": false
       },
       {
@@ -3614,7 +3651,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
         "is_verified": false,
-        "line_number": 2236,
+        "line_number": 2256,
         "is_secret": false
       },
       {
@@ -3622,7 +3659,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
         "is_verified": false,
-        "line_number": 2239,
+        "line_number": 2259,
         "is_secret": false
       },
       {
@@ -3630,7 +3667,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8e193ad7099ffd82fbb600c11c8e057de00db18a",
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2262,
         "is_secret": false
       },
       {
@@ -3638,7 +3675,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
         "is_verified": false,
-        "line_number": 2245,
+        "line_number": 2265,
         "is_secret": false
       },
       {
@@ -3646,7 +3683,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
         "is_verified": false,
-        "line_number": 2248,
+        "line_number": 2268,
         "is_secret": false
       },
       {
@@ -3654,7 +3691,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
         "is_verified": false,
-        "line_number": 2251,
+        "line_number": 2271,
         "is_secret": false
       },
       {
@@ -3662,7 +3699,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
         "is_verified": false,
-        "line_number": 2254,
+        "line_number": 2274,
         "is_secret": false
       },
       {
@@ -3670,7 +3707,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
         "is_verified": false,
-        "line_number": 2257,
+        "line_number": 2277,
         "is_secret": false
       },
       {
@@ -3678,7 +3715,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
         "is_verified": false,
-        "line_number": 2260,
+        "line_number": 2280,
         "is_secret": false
       },
       {
@@ -3686,7 +3723,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
         "is_verified": false,
-        "line_number": 2263,
+        "line_number": 2283,
         "is_secret": false
       },
       {
@@ -3694,50 +3731,57 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
         "is_verified": false,
-        "line_number": 2266,
+        "line_number": 2286,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "e3b8bd39c0d74b5489473733b30f2ff0c21beb55",
+        "is_verified": false,
+        "line_number": 2289
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3c2938cb5f484c6e9d50335bc9975c0b78acf0e9",
         "is_verified": false,
-        "line_number": 2269
+        "line_number": 2292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4a1f2398aa3ec32cdf9982a59dbfc250cd7386df",
         "is_verified": false,
-        "line_number": 2272
+        "line_number": 2295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cdd288b967597b72fde4c8101168b2c9fcf12b1e",
         "is_verified": false,
-        "line_number": 2275
+        "line_number": 2298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e1b05b747457b4823af87aa8d516e1a30492ef30",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2301
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f075b69049314fdac9e21c366ff425ed8d0786e2",
         "is_verified": false,
-        "line_number": 2281
+        "line_number": 2304
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
         "is_verified": false,
-        "line_number": 2284,
+        "line_number": 2307,
         "is_secret": false
       },
       {
@@ -3745,7 +3789,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
         "is_verified": false,
-        "line_number": 2287,
+        "line_number": 2310,
         "is_secret": false
       },
       {
@@ -3753,14 +3797,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "01de106bcf1c964113bb4ecedc192963fe2a3d9d",
         "is_verified": false,
-        "line_number": 2290
+        "line_number": 2313
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
         "is_verified": false,
-        "line_number": 2293,
+        "line_number": 2316,
         "is_secret": false
       },
       {
@@ -3768,7 +3812,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
         "is_verified": false,
-        "line_number": 2296,
+        "line_number": 2319,
         "is_secret": false
       },
       {
@@ -3776,7 +3820,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
         "is_verified": false,
-        "line_number": 2299,
+        "line_number": 2322,
         "is_secret": false
       },
       {
@@ -3784,7 +3828,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
         "is_verified": false,
-        "line_number": 2302,
+        "line_number": 2325,
         "is_secret": false
       },
       {
@@ -3792,7 +3836,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
         "is_verified": false,
-        "line_number": 2305,
+        "line_number": 2328,
         "is_secret": false
       },
       {
@@ -3800,7 +3844,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
         "is_verified": false,
-        "line_number": 2308,
+        "line_number": 2331,
         "is_secret": false
       },
       {
@@ -3808,7 +3852,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
         "is_verified": false,
-        "line_number": 2311,
+        "line_number": 2334,
         "is_secret": false
       },
       {
@@ -3816,7 +3860,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
         "is_verified": false,
-        "line_number": 2314,
+        "line_number": 2337,
         "is_secret": false
       },
       {
@@ -3824,7 +3868,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
         "is_verified": false,
-        "line_number": 2317,
+        "line_number": 2340,
         "is_secret": false
       },
       {
@@ -3832,7 +3876,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
         "is_verified": false,
-        "line_number": 2320,
+        "line_number": 2343,
         "is_secret": false
       },
       {
@@ -3840,14 +3884,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "48d459b0d80c0a20b52e2cdf9ec1f9e0e0ab642f",
         "is_verified": false,
-        "line_number": 2323
+        "line_number": 2346
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
         "is_verified": false,
-        "line_number": 2326,
+        "line_number": 2349,
         "is_secret": false
       },
       {
@@ -3855,7 +3899,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
         "is_verified": false,
-        "line_number": 2329,
+        "line_number": 2352,
         "is_secret": false
       },
       {
@@ -3863,7 +3907,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
         "is_verified": false,
-        "line_number": 2332,
+        "line_number": 2355,
         "is_secret": false
       },
       {
@@ -3871,7 +3915,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
         "is_verified": false,
-        "line_number": 2335,
+        "line_number": 2358,
         "is_secret": false
       },
       {
@@ -3879,7 +3923,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
         "is_verified": false,
-        "line_number": 2338,
+        "line_number": 2361,
         "is_secret": false
       },
       {
@@ -3887,7 +3931,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
         "is_verified": false,
-        "line_number": 2341,
+        "line_number": 2364,
         "is_secret": false
       },
       {
@@ -3895,7 +3939,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
         "is_verified": false,
-        "line_number": 2344,
+        "line_number": 2367,
         "is_secret": false
       },
       {
@@ -3903,7 +3947,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
         "is_verified": false,
-        "line_number": 2347,
+        "line_number": 2370,
         "is_secret": false
       },
       {
@@ -3911,7 +3955,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "06c654850ce93559d42fd5f657cbee6c4d9b47c5",
         "is_verified": false,
-        "line_number": 2350,
+        "line_number": 2373,
         "is_secret": false
       },
       {
@@ -3919,7 +3963,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "31d6671bbf40210dfde8e313a9c03ab41489691d",
         "is_verified": false,
-        "line_number": 2354,
+        "line_number": 2377,
         "is_secret": false
       },
       {
@@ -3927,7 +3971,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aa2add0e083112de14c80fd8d81ec606de67ee43",
         "is_verified": false,
-        "line_number": 2358,
+        "line_number": 2381,
         "is_secret": false
       },
       {
@@ -3935,7 +3979,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
         "is_verified": false,
-        "line_number": 2362,
+        "line_number": 2385,
         "is_secret": false
       },
       {
@@ -3943,7 +3987,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "782837135014880dce3fa077d0c71f42b61e4614",
         "is_verified": false,
-        "line_number": 2365,
+        "line_number": 2388,
         "is_secret": false
       },
       {
@@ -3951,14 +3995,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d2669fec82ff8075e9f930c01ee84e8546138d80",
         "is_verified": false,
-        "line_number": 2375
+        "line_number": 2398
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e6790cf37e1bb89911a301e911658358eb18670e",
         "is_verified": false,
-        "line_number": 2379,
+        "line_number": 2402,
         "is_secret": false
       },
       {
@@ -3966,7 +4010,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
         "is_verified": false,
-        "line_number": 2383,
+        "line_number": 2406,
         "is_secret": false
       },
       {
@@ -3974,67 +4018,12 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "92c55301d403c2ad767661c948e81d7415bf2bde",
         "is_verified": false,
-        "line_number": 2388
+        "line_number": 2411
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "508ffd78a7522f83c630d98474d58ccf406bd25e",
-        "is_verified": false,
-        "line_number": 2393,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "8956daf032bb5c85a1bdbe5b2827259fbce65ae2",
-        "is_verified": false,
-        "line_number": 2396,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
-        "is_verified": false,
-        "line_number": 2399,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "fd987a3583a86961bbb3db9e742c93a837cd5bf6",
-        "is_verified": false,
-        "line_number": 2403,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ac146bf602874ae179ea81ab6f29853c9b37834e",
-        "is_verified": false,
-        "line_number": 2406
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "b5a6f2a2101ff7f7af8d0c6c87c554acea27e0c9",
-        "is_verified": false,
-        "line_number": 2409,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "7356a0be2ffe123fd4b708a6d09ecdddaa038c22",
-        "is_verified": false,
-        "line_number": 2413,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "d69c03a6c481565a321e7b90776918eaad16e532",
         "is_verified": false,
         "line_number": 2416,
         "is_secret": false
@@ -4042,9 +4031,64 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8956daf032bb5c85a1bdbe5b2827259fbce65ae2",
+        "is_verified": false,
+        "line_number": 2419,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
+        "is_verified": false,
+        "line_number": 2422,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "fd987a3583a86961bbb3db9e742c93a837cd5bf6",
+        "is_verified": false,
+        "line_number": 2426,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ac146bf602874ae179ea81ab6f29853c9b37834e",
+        "is_verified": false,
+        "line_number": 2429
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "b5a6f2a2101ff7f7af8d0c6c87c554acea27e0c9",
+        "is_verified": false,
+        "line_number": 2432,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "7356a0be2ffe123fd4b708a6d09ecdddaa038c22",
+        "is_verified": false,
+        "line_number": 2436,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d69c03a6c481565a321e7b90776918eaad16e532",
+        "is_verified": false,
+        "line_number": 2439,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "316bf5ed09ed2d2511c54a3e60e047e26550c82c",
         "is_verified": false,
-        "line_number": 2420,
+        "line_number": 2443,
         "is_secret": false
       },
       {
@@ -4052,15 +4096,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
         "is_verified": false,
-        "line_number": 2424,
+        "line_number": 2447,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "d25f38e564eeda6402f558b3ad020bd05220df32",
+        "is_verified": false,
+        "line_number": 2450
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0135f1c09e6e6c23cd762374520078171e7bd09e",
         "is_verified": false,
-        "line_number": 2427,
+        "line_number": 2453,
         "is_secret": false
       },
       {
@@ -4068,7 +4119,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "533573708ed3eabce514432cd26d532218222659",
         "is_verified": false,
-        "line_number": 2430,
+        "line_number": 2456,
         "is_secret": false
       },
       {
@@ -4076,7 +4127,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "61ff5c8a702d8ffe28063c06487a3a5a0db2ed70",
         "is_verified": false,
-        "line_number": 2434,
+        "line_number": 2460,
         "is_secret": false
       },
       {
@@ -4084,7 +4135,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e1beff0b39929c9538a683456356f4b7da203723",
         "is_verified": false,
-        "line_number": 2438,
+        "line_number": 2464,
         "is_secret": false
       },
       {
@@ -4092,7 +4143,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
         "is_verified": false,
-        "line_number": 2441,
+        "line_number": 2467,
         "is_secret": false
       },
       {
@@ -4100,7 +4151,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
         "is_verified": false,
-        "line_number": 2444,
+        "line_number": 2470,
         "is_secret": false
       },
       {
@@ -4108,7 +4159,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
         "is_verified": false,
-        "line_number": 2447,
+        "line_number": 2473,
         "is_secret": false
       },
       {
@@ -4116,14 +4167,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "363be5c48e7bb351b455c53ca48cc2859064a753",
         "is_verified": false,
-        "line_number": 2451
+        "line_number": 2477
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9dd8b7bcb847f86a200200adcb41ae1230319c9a",
         "is_verified": false,
-        "line_number": 2457,
+        "line_number": 2483,
         "is_secret": false
       },
       {
@@ -4131,7 +4182,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ba8a4a4ea1707cd9c5a04000ad2a40c0890c22c6",
         "is_verified": false,
-        "line_number": 2462,
+        "line_number": 2488,
         "is_secret": false
       },
       {
@@ -4139,7 +4190,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
         "is_verified": false,
-        "line_number": 2467,
+        "line_number": 2493,
         "is_secret": false
       },
       {
@@ -4147,7 +4198,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "15fe871ffc303bd4cf6edbc775f1af448c258e69",
         "is_verified": false,
-        "line_number": 2471,
+        "line_number": 2497,
         "is_secret": false
       },
       {
@@ -4155,7 +4206,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ddd88fae03505e64f6647d5587d4c3e5fd6b78b1",
         "is_verified": false,
-        "line_number": 2475,
+        "line_number": 2501,
         "is_secret": false
       },
       {
@@ -4163,15 +4214,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "740c72e48345f65f0deefba812581017bd57c614",
         "is_verified": false,
-        "line_number": 2478,
+        "line_number": 2504,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "47c857580c0e23be81d42d3b133c42c2e8270f88",
+        "is_verified": false,
+        "line_number": 2508
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "21ce40fa7b942491db7f5babb19538e726c27e8d",
         "is_verified": false,
-        "line_number": 2482,
+        "line_number": 2511,
         "is_secret": false
       },
       {
@@ -4179,7 +4237,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
         "is_verified": false,
-        "line_number": 2486,
+        "line_number": 2515,
         "is_secret": false
       },
       {
@@ -4187,7 +4245,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
         "is_verified": false,
-        "line_number": 2489,
+        "line_number": 2518,
         "is_secret": false
       },
       {
@@ -4195,14 +4253,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "319f5729ebb658741e755609688744d9c09d28d8",
         "is_verified": false,
-        "line_number": 2492
+        "line_number": 2521
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "706884687450108cef742ef7b12010f29167a501",
         "is_verified": false,
-        "line_number": 2495,
+        "line_number": 2524,
         "is_secret": false
       },
       {
@@ -4210,60 +4268,12 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5e7a9cd9685dffe0f398decec2cf82bf4d4c979c",
         "is_verified": false,
-        "line_number": 2499
+        "line_number": 2528
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "33d460d596f1c7ea50a5b8b7b96e0035e398826a",
-        "is_verified": false,
-        "line_number": 2504,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "623c0b595f4739e5a9e2eabcde54a72be42d9964",
-        "is_verified": false,
-        "line_number": 2509,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
-        "is_verified": false,
-        "line_number": 2515,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "ef92e3e90926767f04ea05b4fc58e71019cf68d5",
-        "is_verified": false,
-        "line_number": 2518,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "a19482a8f22f3815a3e677a5235a013b2f83db69",
-        "is_verified": false,
-        "line_number": 2521,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "16615d4a3177908c029aff2e170755a99ece101f",
-        "is_verified": false,
-        "line_number": 2527,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
         "is_verified": false,
         "line_number": 2533,
         "is_secret": false
@@ -4271,9 +4281,57 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "623c0b595f4739e5a9e2eabcde54a72be42d9964",
+        "is_verified": false,
+        "line_number": 2538,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
+        "is_verified": false,
+        "line_number": 2544,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ef92e3e90926767f04ea05b4fc58e71019cf68d5",
+        "is_verified": false,
+        "line_number": 2547,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "a19482a8f22f3815a3e677a5235a013b2f83db69",
+        "is_verified": false,
+        "line_number": 2550,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "16615d4a3177908c029aff2e170755a99ece101f",
+        "is_verified": false,
+        "line_number": 2556,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
+        "is_verified": false,
+        "line_number": 2562,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "ac7754e0faf25c9d2f4ee8e116d76278bd94bf92",
         "is_verified": false,
-        "line_number": 2543,
+        "line_number": 2572,
         "is_secret": false
       },
       {
@@ -4281,7 +4339,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d73a56a508095d0d1e21f8c1562879ddc2f7c76b",
         "is_verified": false,
-        "line_number": 2553,
+        "line_number": 2582,
         "is_secret": false
       },
       {
@@ -4289,7 +4347,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "47aa4da18e189137c0be167ad618663a420e0a8f",
         "is_verified": false,
-        "line_number": 2560,
+        "line_number": 2589,
         "is_secret": false
       },
       {
@@ -4297,7 +4355,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
         "is_verified": false,
-        "line_number": 2570,
+        "line_number": 2599,
         "is_secret": false
       },
       {
@@ -4305,14 +4363,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3abd1bb82453e63ef7279a5b3ba6a45889748374",
         "is_verified": false,
-        "line_number": 2580
+        "line_number": 2609
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0caeac5cc3573ecc311cd03aa836916728d0d98f",
         "is_verified": false,
-        "line_number": 2593,
+        "line_number": 2622,
         "is_secret": false
       },
       {
@@ -4320,38 +4378,44 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8eb603f181d16409922883159c02899b089f6d60",
         "is_verified": false,
-        "line_number": 2597,
+        "line_number": 2626,
         "is_secret": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
-        "hashed_secret": "821c1f3714302cd33664d01f2b9720a19fb53601",
+        "hashed_secret": "d253be4a7c019ad20bcb9cf5a4073ef85ce70854",
         "is_verified": false,
-        "line_number": 2601,
-        "is_secret": false
+        "line_number": 2630
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
         "is_verified": false,
-        "line_number": 2604,
+        "line_number": 2633,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "1a39ece38101be692eca60b18570d82d9b78a26e",
+        "is_verified": false,
+        "line_number": 2636
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2395bac8424bd0df1dd4e6f7845a1fcce94eddc3",
         "is_verified": false,
-        "line_number": 2607
+        "line_number": 2639
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
         "is_verified": false,
-        "line_number": 2610,
+        "line_number": 2642,
         "is_secret": false
       },
       {
@@ -4359,7 +4423,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
         "is_verified": false,
-        "line_number": 2613,
+        "line_number": 2645,
         "is_secret": false
       },
       {
@@ -4367,7 +4431,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
         "is_verified": false,
-        "line_number": 2616,
+        "line_number": 2648,
         "is_secret": false
       },
       {
@@ -4375,7 +4439,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3c48660b66db6687c2ba1b7ffbac279614eead6e",
         "is_verified": false,
-        "line_number": 2619,
+        "line_number": 2651,
         "is_secret": false
       },
       {
@@ -4383,7 +4447,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5a485a4915f94231f9dc5b355ddda367442ba450",
         "is_verified": false,
-        "line_number": 2623,
+        "line_number": 2655,
         "is_secret": false
       },
       {
@@ -4391,7 +4455,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8749a5afedf4a51c2227b00d41d8b94611d8745",
         "is_verified": false,
-        "line_number": 2627,
+        "line_number": 2659,
         "is_secret": false
       },
       {
@@ -4399,7 +4463,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a622ef066916d153a2c3501013238f36dde578fb",
         "is_verified": false,
-        "line_number": 2630,
+        "line_number": 2662,
         "is_secret": false
       },
       {
@@ -4407,7 +4471,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6c8d2de91b8087bf6f18c9b505ec528e2bafb7c4",
         "is_verified": false,
-        "line_number": 2635,
+        "line_number": 2667,
         "is_secret": false
       },
       {
@@ -4415,7 +4479,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
         "is_verified": false,
-        "line_number": 2639,
+        "line_number": 2671,
         "is_secret": false
       },
       {
@@ -4423,14 +4487,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "693b111ce8b1c51840a5cd5ea8d7d3ac7186daa4",
         "is_verified": false,
-        "line_number": 2642
+        "line_number": 2674
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
         "is_verified": false,
-        "line_number": 2645,
+        "line_number": 2677,
         "is_secret": false
       },
       {
@@ -4438,7 +4502,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "56029dbb81dfe27cd4bf72c8cfb3213657ce6d56",
         "is_verified": false,
-        "line_number": 2649,
+        "line_number": 2681,
         "is_secret": false
       },
       {
@@ -4446,7 +4510,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2fd4d093008863345a56756800819a01bf8e0451",
         "is_verified": false,
-        "line_number": 2654,
+        "line_number": 2686,
         "is_secret": false
       },
       {
@@ -4454,7 +4518,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f9fd81843f2a26e1be00fb6acfcb3895cffedfe6",
         "is_verified": false,
-        "line_number": 2657,
+        "line_number": 2689,
         "is_secret": false
       },
       {
@@ -4462,7 +4526,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3b7990b0f82bc9bc6c4ec02744f9c02e76aac827",
         "is_verified": false,
-        "line_number": 2660,
+        "line_number": 2692,
         "is_secret": false
       },
       {
@@ -4470,7 +4534,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9072ebcbad57a1ae4256c5ae37c1e7c7ae5325de",
         "is_verified": false,
-        "line_number": 2664,
+        "line_number": 2696,
         "is_secret": false
       },
       {
@@ -4478,7 +4542,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
         "is_verified": false,
-        "line_number": 2668,
+        "line_number": 2700,
         "is_secret": false
       },
       {
@@ -4486,7 +4550,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e0c6ae09dd70fa25056d591ada0ad32df0dfe873",
         "is_verified": false,
-        "line_number": 2671,
+        "line_number": 2703,
         "is_secret": false
       },
       {
@@ -4494,7 +4558,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9209916909e5ac952f74625bba8de9998c89e832",
         "is_verified": false,
-        "line_number": 2675,
+        "line_number": 2707,
         "is_secret": false
       },
       {
@@ -4502,35 +4566,35 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0f2bb303ba79216a01f706b96e835927a4d8b0e4",
         "is_verified": false,
-        "line_number": 2679
+        "line_number": 2711
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a9a99d9ebf0fb2317634f8ee63e4266b6ea65d80",
         "is_verified": false,
-        "line_number": 2684
+        "line_number": 2716
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "af3e11c2aa0eb775dd773c890eaa2d39ae5a713b",
         "is_verified": false,
-        "line_number": 2689
+        "line_number": 2721
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8321ecc8c6c3f9988c4ea88ccee5347f080ddb82",
         "is_verified": false,
-        "line_number": 2697
+        "line_number": 2729
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
         "is_verified": false,
-        "line_number": 2700,
+        "line_number": 2732,
         "is_secret": false
       },
       {
@@ -4538,7 +4602,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
         "is_verified": false,
-        "line_number": 2704,
+        "line_number": 2736,
         "is_secret": false
       },
       {
@@ -4546,7 +4610,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
         "is_verified": false,
-        "line_number": 2707,
+        "line_number": 2739,
         "is_secret": false
       },
       {
@@ -4554,7 +4618,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4dcc5c09923b9c0c9014f1f416f58aed8360e584",
         "is_verified": false,
-        "line_number": 2710,
+        "line_number": 2742,
         "is_secret": false
       },
       {
@@ -4562,7 +4626,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "64573a1f0df3a66351888c28a0fd9f46793d5d8f",
         "is_verified": false,
-        "line_number": 2714,
+        "line_number": 2746,
         "is_secret": false
       },
       {
@@ -4570,7 +4634,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "178a2a33e0c0d75178a413e0aac2f8cbab930635",
         "is_verified": false,
-        "line_number": 2717,
+        "line_number": 2749,
         "is_secret": false
       },
       {
@@ -4578,7 +4642,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bdaf8b094715fef6fc9d26c411bc0f51e1f4d6bd",
         "is_verified": false,
-        "line_number": 2720,
+        "line_number": 2752,
         "is_secret": false
       },
       {
@@ -4586,7 +4650,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
         "is_verified": false,
-        "line_number": 2724,
+        "line_number": 2756,
         "is_secret": false
       },
       {
@@ -4594,7 +4658,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "4c8a960439864672cef22edf28a40c8a3749ed68",
         "is_verified": false,
-        "line_number": 2727,
+        "line_number": 2759,
         "is_secret": false
       },
       {
@@ -4602,7 +4666,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bd781c148f26d1f4846c44ad3eb29636a326b436",
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2763,
         "is_secret": false
       },
       {
@@ -4610,7 +4674,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "39d8cd5856eca22616f5ebddde39509c2326f49a",
         "is_verified": false,
-        "line_number": 2735,
+        "line_number": 2767,
         "is_secret": false
       },
       {
@@ -4618,7 +4682,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "13dbd7fe03595ffcb7e3426dfa277d73c8fafea2",
         "is_verified": false,
-        "line_number": 2738,
+        "line_number": 2770,
         "is_secret": false
       },
       {
@@ -4626,7 +4690,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "eeacdd78906304066ade634711edfa3120b26515",
         "is_verified": false,
-        "line_number": 2741,
+        "line_number": 2773,
         "is_secret": false
       },
       {
@@ -4634,14 +4698,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e330a0321dd0fd5aa661cb9df9be6bf37c606a14",
         "is_verified": false,
-        "line_number": 2744
+        "line_number": 2776
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f00390dc74fe6fbe3521da94d3a490c245a42b67",
         "is_verified": false,
-        "line_number": 2747,
+        "line_number": 2779,
         "is_secret": false
       },
       {
@@ -4649,7 +4713,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3110d13a9b5ea115c92df755b6960ba2930c2063",
         "is_verified": false,
-        "line_number": 2751,
+        "line_number": 2783,
         "is_secret": false
       },
       {
@@ -4657,7 +4721,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "20b8ce96348a33cfab4c0ab0d01dfb153a3df2ec",
         "is_verified": false,
-        "line_number": 2754,
+        "line_number": 2786,
         "is_secret": false
       },
       {
@@ -4665,7 +4729,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "6fb3ba9348e0ff5943ba7aa7073403264fd2f8c2",
         "is_verified": false,
-        "line_number": 2757,
+        "line_number": 2789,
         "is_secret": false
       },
       {
@@ -4673,14 +4737,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "417279a3d4b01a908cff96961ce78f96a84813dc",
         "is_verified": false,
-        "line_number": 2761
+        "line_number": 2793
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
         "is_verified": false,
-        "line_number": 2764,
+        "line_number": 2796,
         "is_secret": false
       },
       {
@@ -4688,7 +4752,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "7ba6164e769259c13c516ef17747dd9324baa3da",
         "is_verified": false,
-        "line_number": 2767,
+        "line_number": 2799,
         "is_secret": false
       },
       {
@@ -4696,7 +4760,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "409a34f4b6de0183a007f444dabf33085ef8bf50",
         "is_verified": false,
-        "line_number": 2770,
+        "line_number": 2802,
         "is_secret": false
       },
       {
@@ -4704,7 +4768,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
         "is_verified": false,
-        "line_number": 2774,
+        "line_number": 2806,
         "is_secret": false
       },
       {
@@ -4712,7 +4776,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f0661775df2ce05e6c49ee07d6003c0e831cda30",
         "is_verified": false,
-        "line_number": 2778,
+        "line_number": 2810,
         "is_secret": false
       },
       {
@@ -4720,7 +4784,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "565f3763242a541920df2583874a5f95829080f0",
         "is_verified": false,
-        "line_number": 2782,
+        "line_number": 2814,
         "is_secret": false
       },
       {
@@ -4728,7 +4792,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "833fa4ba1671f98715e4450c7fa39b2983ed51ee",
         "is_verified": false,
-        "line_number": 2785,
+        "line_number": 2817,
         "is_secret": false
       },
       {
@@ -4736,7 +4800,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c2cfd88522dc79c5d1764af80e11fb966935bee0",
         "is_verified": false,
-        "line_number": 2789,
+        "line_number": 2821,
         "is_secret": false
       },
       {
@@ -4744,7 +4808,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bf3e3cda4d110e6f625eae7b1bc8bd5d9e1cd8d5",
         "is_verified": false,
-        "line_number": 2793,
+        "line_number": 2825,
         "is_secret": false
       },
       {
@@ -4752,7 +4816,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d285b26b3ab9fd0767eb725dd5607b8dda63cf6f",
         "is_verified": false,
-        "line_number": 2797,
+        "line_number": 2829,
         "is_secret": false
       },
       {
@@ -4760,7 +4824,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
         "is_verified": false,
-        "line_number": 2801,
+        "line_number": 2833,
         "is_secret": false
       },
       {
@@ -4768,7 +4832,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
         "is_verified": false,
-        "line_number": 2804,
+        "line_number": 2836,
         "is_secret": false
       },
       {
@@ -4776,7 +4840,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "019caa87257397d1720cb9ea2634186b43d47704",
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2839,
         "is_secret": false
       },
       {
@@ -4784,14 +4848,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d4884001560a07736d778829274e452a06089ffa",
         "is_verified": false,
-        "line_number": 2813
+        "line_number": 2845
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
         "is_verified": false,
-        "line_number": 2821,
+        "line_number": 2853,
         "is_secret": false
       },
       {
@@ -4799,7 +4863,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a09ac4be578a7b177bc5f823f8624e32f10751fb",
         "is_verified": false,
-        "line_number": 2824,
+        "line_number": 2856,
         "is_secret": false
       },
       {
@@ -4807,7 +4871,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "141f1e477a1c43147cfd2dba506a8b057a1acdc4",
         "is_verified": false,
-        "line_number": 2828,
+        "line_number": 2860,
         "is_secret": false
       },
       {
@@ -4815,7 +4879,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aa2771bf9f4991b2a31ddbb9cb8e7176e37cc542",
         "is_verified": false,
-        "line_number": 2832,
+        "line_number": 2864,
         "is_secret": false
       },
       {
@@ -4823,7 +4887,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "8239574b4263502316ae4af75858c8537b8f9dc2",
         "is_verified": false,
-        "line_number": 2839,
+        "line_number": 2871,
         "is_secret": false
       },
       {
@@ -4831,7 +4895,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3894350d13957352daa8660e7b56bf06e05e494c",
         "is_verified": false,
-        "line_number": 2844,
+        "line_number": 2876,
         "is_secret": false
       },
       {
@@ -4839,7 +4903,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e7430d96b3b3f414afb42221d68622d9c9728e1d",
         "is_verified": false,
-        "line_number": 2847,
+        "line_number": 2879,
         "is_secret": false
       },
       {
@@ -4847,7 +4911,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
         "is_verified": false,
-        "line_number": 2851,
+        "line_number": 2883,
         "is_secret": false
       },
       {
@@ -4855,7 +4919,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
         "is_verified": false,
-        "line_number": 2854,
+        "line_number": 2886,
         "is_secret": false
       },
       {
@@ -4863,7 +4927,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
         "is_verified": false,
-        "line_number": 2857,
+        "line_number": 2889,
         "is_secret": false
       },
       {
@@ -4871,14 +4935,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "158291819a7a643d9b2260cba777de2b33682c18",
         "is_verified": false,
-        "line_number": 2860
+        "line_number": 2892
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
         "is_verified": false,
-        "line_number": 2863,
+        "line_number": 2895,
         "is_secret": false
       },
       {
@@ -4886,14 +4950,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
         "is_verified": false,
-        "line_number": 2866
+        "line_number": 2898
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
         "is_verified": false,
-        "line_number": 2869,
+        "line_number": 2901,
         "is_secret": false
       },
       {
@@ -4901,7 +4965,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
         "is_verified": false,
-        "line_number": 2872,
+        "line_number": 2904,
         "is_secret": false
       },
       {
@@ -4909,14 +4973,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
         "is_verified": false,
-        "line_number": 2875
+        "line_number": 2907
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "cfea511a0cbba9944cabfbd30103ce21434865ed",
         "is_verified": false,
-        "line_number": 2878,
+        "line_number": 2910,
         "is_secret": false
       },
       {
@@ -4924,7 +4988,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "62c2af8b17725ed8d9e7c506d7975998b6a1a367",
         "is_verified": false,
-        "line_number": 2881,
+        "line_number": 2913,
         "is_secret": false
       },
       {
@@ -4932,7 +4996,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f2f138a5ead5a6a39c60b357eada0cb5a3ef1179",
         "is_verified": false,
-        "line_number": 2884,
+        "line_number": 2916,
         "is_secret": false
       },
       {
@@ -4940,7 +5004,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "390113d1af6b5ece9a90ea6db402a0008b2a9d08",
         "is_verified": false,
-        "line_number": 2890,
+        "line_number": 2922,
         "is_secret": false
       },
       {
@@ -4948,7 +5012,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
         "is_verified": false,
-        "line_number": 2893,
+        "line_number": 2925,
         "is_secret": false
       },
       {
@@ -4956,21 +5020,21 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "0b2e44ed44bd55fd203dd349370908ded345dec5",
         "is_verified": false,
-        "line_number": 2903
+        "line_number": 2935
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1f4f661f8f8639d43ca48fc811858d8451cba434",
         "is_verified": false,
-        "line_number": 2916
+        "line_number": 2948
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
         "is_verified": false,
-        "line_number": 2921,
+        "line_number": 2953,
         "is_secret": false
       },
       {
@@ -4978,14 +5042,14 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fa052b540b5ac7bfca7e3f2a5cdf081e343a3c76",
         "is_verified": false,
-        "line_number": 2931
+        "line_number": 2963
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
         "is_verified": false,
-        "line_number": 2936,
+        "line_number": 2968,
         "is_secret": false
       },
       {
@@ -4993,15 +5057,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
         "is_verified": false,
-        "line_number": 2941,
+        "line_number": 2973,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "8dde1ebef344011f9e6ac282be903ab5cc8cdcdf",
+        "is_verified": false,
+        "line_number": 2976
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
         "is_verified": false,
-        "line_number": 2944,
+        "line_number": 2979,
         "is_secret": false
       },
       {
@@ -5009,7 +5080,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
         "is_verified": false,
-        "line_number": 2947,
+        "line_number": 2982,
         "is_secret": false
       },
       {
@@ -5017,7 +5088,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "b31bb92bf7baf1d65f14ab82c953a441fffe1b65",
         "is_verified": false,
-        "line_number": 2950,
+        "line_number": 2985,
         "is_secret": false
       },
       {
@@ -5025,7 +5096,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d9cf5d0777adb9d631c26beb399e9290933483ae",
         "is_verified": false,
-        "line_number": 2993,
+        "line_number": 3028,
         "is_secret": false
       },
       {
@@ -5033,15 +5104,22 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5c81cb3bbf077a30ebeea809bdba83483c8d5dd8",
         "is_verified": false,
-        "line_number": 3034,
+        "line_number": 3069,
         "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "frontend/pnpm-lock.yaml",
+        "hashed_secret": "ee4887dad945f60487dbcadc8e688259e0f670ae",
+        "is_verified": false,
+        "line_number": 3073
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "05080d4369a5e3691eccb28e69d6988b360bcd22",
         "is_verified": false,
-        "line_number": 3038,
+        "line_number": 3076,
         "is_secret": false
       },
       {
@@ -5049,7 +5127,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "710e27fa7e2d80bebfa5cb9a0e3e2833021eab40",
         "is_verified": false,
-        "line_number": 3042,
+        "line_number": 3080,
         "is_secret": false
       },
       {
@@ -5057,7 +5135,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a2424039e79b5ea18e0d0b22f78cc7e6624fa4ad",
         "is_verified": false,
-        "line_number": 3046,
+        "line_number": 3084,
         "is_secret": false
       },
       {
@@ -5065,7 +5143,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f0257d02d23f53e799476af74cf0386375d4b6c2",
         "is_verified": false,
-        "line_number": 3050,
+        "line_number": 3088,
         "is_secret": false
       },
       {
@@ -5073,7 +5151,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
         "is_verified": false,
-        "line_number": 3055,
+        "line_number": 3093,
         "is_secret": false
       },
       {
@@ -5081,7 +5159,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "749184805a59b4e245165000ff76d7e916f3efa5",
         "is_verified": false,
-        "line_number": 3060,
+        "line_number": 3098,
         "is_secret": false
       },
       {
@@ -5089,7 +5167,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "47f61db9968d9147373f9919fb2d39f044af96d4",
         "is_verified": false,
-        "line_number": 3064,
+        "line_number": 3102,
         "is_secret": false
       },
       {
@@ -5097,7 +5175,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "60f62b99a14507fe2d275d65d1bc793565396724",
         "is_verified": false,
-        "line_number": 3068,
+        "line_number": 3106,
         "is_secret": false
       },
       {
@@ -5105,7 +5183,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "d534a8643166b53f9b72f567856071d026b7d454",
         "is_verified": false,
-        "line_number": 3072,
+        "line_number": 3110,
         "is_secret": false
       },
       {
@@ -5113,7 +5191,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "fd979750316587a434d421119fe616d5325ac2fb",
         "is_verified": false,
-        "line_number": 3075,
+        "line_number": 3113,
         "is_secret": false
       },
       {
@@ -5121,7 +5199,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
         "is_verified": false,
-        "line_number": 3079,
+        "line_number": 3117,
         "is_secret": false
       },
       {
@@ -5129,7 +5207,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f517feec4703cacc2629b34a71b6c4f71dcaaacb",
         "is_verified": false,
-        "line_number": 3082,
+        "line_number": 3120,
         "is_secret": false
       },
       {
@@ -5137,7 +5215,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "5888d1b730d17d304b51d9ac433812c153d85b55",
         "is_verified": false,
-        "line_number": 3086,
+        "line_number": 3124,
         "is_secret": false
       },
       {
@@ -5145,7 +5223,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "bc001a988dc93a1d9f0b811c8b6f5ed71cd922e8",
         "is_verified": false,
-        "line_number": 3090,
+        "line_number": 3128,
         "is_secret": false
       },
       {
@@ -5153,7 +5231,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "e8dcd9d9891c3dea7c5a1d671b950c1cb05d681d",
         "is_verified": false,
-        "line_number": 3094,
+        "line_number": 3132,
         "is_secret": false
       },
       {
@@ -5161,7 +5239,7 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "a36905f939ee26516ab756c0896b7e65328989dc",
         "is_verified": false,
-        "line_number": 3100,
+        "line_number": 3138,
         "is_secret": false
       },
       {
@@ -5169,21 +5247,21 @@
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "62c3e21d5adb13e93e5d3f1d29713d0f45e2696a",
         "is_verified": false,
-        "line_number": 3103
+        "line_number": 3141
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "f7db6410f7251082f54e1ac509d653878d66fc6c",
         "is_verified": false,
-        "line_number": 3108
+        "line_number": 3146
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "frontend/pnpm-lock.yaml",
         "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
         "is_verified": false,
-        "line_number": 3126,
+        "line_number": 3164,
         "is_secret": false
       }
     ],
@@ -5216,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-24T08:19:11Z"
+  "generated_at": "2026-06-25T12:03:27Z"
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Any agent client that speaks **MCP (Streamable HTTP or stdio)**:
   [`akb-mcp`](https://www.npmjs.com/package/akb-mcp) stdio proxy
 - Custom agents — direct HTTP `POST /mcp/` with a Bearer token
 
+The default flow uses a Personal Access Token. Deployments with the
+optional **MCP OAuth Resource Server** path turned on (via Keycloak as
+the AS — see [`docs/mcp-clients/web-connectors.md`](./docs/mcp-clients/web-connectors.md))
+also accept Claude Code's `mcp add --transport http` + `mcp login` flow
+end-to-end, without a PAT.
+
 ## Plugins
 
 Beyond raw MCP access, AKB ships ready-made **agent plugins** for **Claude Code**

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -76,13 +76,18 @@ async def login_user(req: LoginRequest):
 @router.get("/auth/config", summary="Public auth configuration")
 async def auth_config():
     """Unauthenticated. Tells the frontend whether the optional Keycloak
-    SSO button should be shown and where it points. Reveals no secrets."""
+    SSO button should be shown and where it points, and whether the
+    optional MCP-OAuth path is live so connector UIs can offer the
+    OAuth snippet alongside the PAT one. Reveals no secrets."""
     return {
         "keycloak": {
             "enabled": settings.keycloak_enabled,
             # SPA appends ?redirect=<path> when navigating here.
             "login_url": "/api/v1/auth/keycloak/login" if settings.keycloak_enabled else None,
-        }
+        },
+        "mcp_oauth": {
+            "enabled": settings.mcp_oauth_enabled,
+        },
     }
 
 

--- a/backend/app/api/routes/oauth_metadata.py
+++ b/backend/app/api/routes/oauth_metadata.py
@@ -1,0 +1,74 @@
+"""OAuth 2.0 Protected Resource Metadata (RFC 9728).
+
+A single read-only endpoint that points a remote-MCP client at the
+authorization server it should authenticate against before calling
+``/mcp``. AKB is a Resource Server here; the AS — including DCR,
+authorize, consent, token, refresh — lives in the OIDC IdP
+(Keycloak in the reference deployment).
+
+This route is only meaningful when ``mcp_oauth_enabled`` is true. When
+the deployment has not opted in, the metadata is 404 so a probing
+client cleanly falls through to PAT-only behaviour without seeing
+half-configured discovery data.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.config import settings
+
+router = APIRouter(include_in_schema=False)
+
+
+@router.get("/.well-known/oauth-protected-resource")
+async def protected_resource_metadata() -> dict:
+    """RFC 9728 §3 — describe the AKB ``/mcp`` resource.
+
+    Fields:
+
+    - ``resource`` is the canonical identifier the access token's
+      ``aud`` claim must match; we keep it as the publicly-advertised
+      ``/mcp`` URL.
+    - ``authorization_servers`` lists the issuer URL(s) the client
+      may use to obtain an access token. For Keycloak this is
+      ``<server>/realms/<realm>``; the client appends
+      ``/.well-known/openid-configuration`` to discover endpoints
+      (RFC 8414 + OIDC Discovery).
+    - ``scopes_supported`` declares the scope vocabulary the client
+      may request. ``offline_access`` is advertised so Claude Code
+      (and any spec-compliant client) appends it to the pinned
+      scopes; without that, the access token cannot be refreshed
+      silently and the user gets a re-consent browser pop on every
+      expiry. (akb realm's ``defaultOptionalClientScopes`` makes
+      these requestable on a DCR-registered client.)
+    - ``bearer_methods_supported`` follows §3 and limits acceptance
+      to the ``Authorization`` header.
+    """
+    if not settings.mcp_oauth_enabled:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if not settings.keycloak_enabled:
+        # mcp_oauth without an IdP is a config bug (the lifecycle
+        # validator catches it at startup, but be defensive here so a
+        # mis-toggled live cluster still returns a usable 503 rather
+        # than a misleading metadata document.
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "MCP OAuth is enabled but no IdP (keycloak_enabled) is configured",
+        )
+
+    resource = settings.mcp_oauth_audience_effective
+    return {
+        "resource": resource,
+        "authorization_servers": [settings.keycloak_issuer],
+        "scopes_supported": [
+            "akb:vault:read",
+            "akb:vault:write",
+            "offline_access",
+        ],
+        "bearer_methods_supported": ["header"],
+        "resource_documentation": (
+            f"{settings.public_base_url.rstrip('/')}/docs/mcp-clients/web-connectors"
+            if settings.public_base_url
+            else None
+        ),
+    }

--- a/backend/app/api/routes/oauth_metadata.py
+++ b/backend/app/api/routes/oauth_metadata.py
@@ -60,7 +60,19 @@ async def protected_resource_metadata() -> dict:
     return {
         "resource": resource,
         "authorization_servers": [settings.keycloak_issuer],
+        # Includes the OIDC base scopes (`openid`, `profile`, `email`)
+        # in addition to AKB's resource scopes. Spec-compliant MCP
+        # clients (Claude Code, claude.ai) read scopes_supported and
+        # request exactly those at DCR + authorize time — so listing
+        # OIDC base scopes here is the right way to get `email` and
+        # `profile` claims into the access token AKB then keys user
+        # identity on. Without these, the token only carries `sub` and
+        # AKB rejects with "no email claim". `offline_access` enables
+        # silent refresh on Claude Code's 5-min token TTL.
         "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
             "akb:vault:read",
             "akb:vault:write",
             "offline_access",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -250,6 +250,31 @@ class Settings(BaseModel):
     # POST so the token never rides in a URL. Keep this small.
     keycloak_exchange_code_ttl_secs: int = 60
 
+    # === MCP OAuth Resource Server (optional, separate from SSO) ===
+    # When true, AKB's /mcp endpoint accepts Keycloak-issued access tokens
+    # (RS256) in addition to the existing PAT (`akb_*`) and AKB JWT (HS256)
+    # paths. Web-hosted LLM clients (claude.ai / ChatGPT Custom Connectors,
+    # Claude Code's HTTP transport) discover the authorization server via
+    # `/.well-known/oauth-protected-resource` (RFC 9728), register
+    # themselves via DCR (RFC 7591) against Keycloak, and obtain an access
+    # token with the `akb:vault:read` / `akb:vault:write` scopes.
+    #
+    # Requires `keycloak_enabled = true` — AKB is a Resource Server only;
+    # the Authorization Server (DCR / authorize / consent / token /
+    # refresh) is the OIDC IdP. AKB never registers clients or issues
+    # OAuth access tokens itself.
+    #
+    # Disabled (the default) keeps /mcp on PAT-only behaviour
+    # bit-for-bit — stdio clients (Claude Desktop, Codex CLI via
+    # akb-mcp) are unaffected even when this is left off.
+    #
+    # See docs/designs/mcp-oauth-dcr/00-overview.md.
+    mcp_oauth_enabled: bool = False
+    # Audience claim the access token must carry to be usable at /mcp.
+    # Defaults to `<public_base_url>/mcp`; override only if you front the
+    # MCP endpoint at a separate hostname.
+    mcp_oauth_audience: str = ""
+
     # Server
     host: str = "0.0.0.0"
     port: int = 8000
@@ -411,6 +436,19 @@ class Settings(BaseModel):
     def keycloak_end_session_endpoint(self) -> str:
         # Browser-facing → public issuer.
         return f"{self.keycloak_issuer}/protocol/openid-connect/logout"
+
+    @property
+    def mcp_oauth_audience_effective(self) -> str:
+        """Resolved audience claim required on Keycloak access tokens
+        presented at /mcp. Empty string when MCP-OAuth is off."""
+        if not self.mcp_oauth_enabled:
+            return ""
+        if self.mcp_oauth_audience:
+            return self.mcp_oauth_audience
+        # Default: <public_base_url>/mcp. public_base_url is required at
+        # startup (lifecycle validates it), so by the time this property
+        # is read in a request path it will be non-empty.
+        return f"{self.public_base_url.rstrip('/')}/mcp"
 
     @property
     def database_url(self) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 from app.api.deps import get_current_user, get_optional_user
 from app.db.postgres import get_pool
 from app.exceptions import AKBError
-from app.api.routes import access, activity, agent_sessions, auth, documents, files, help as help_routes, public, search, collections, knowledge, knowledge_io, tables
+from app.api.routes import access, activity, agent_sessions, auth, documents, files, help as help_routes, oauth_metadata, public, search, collections, knowledge, knowledge_io, tables
 from app.services import audit_log, embed_worker, events_publisher, external_git_poller, metadata_worker
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
@@ -78,6 +78,11 @@ app.include_router(knowledge_io.router, prefix="/api/v1", tags=["export-import"]
 app.include_router(files.router, prefix="/api/v1", tags=["files"])
 app.include_router(public.router, prefix="/api/v1", tags=["public"])
 app.include_router(help_routes.router, prefix="/api/v1/help", tags=["help"])
+
+# RFC 9728 — well-known protected-resource metadata for /mcp. Mounted
+# at the root (not under /api/v1) because the spec requires
+# `/.well-known/...` literally on the resource's own origin.
+app.include_router(oauth_metadata.router)
 
 # Mount MCP Streamable HTTP at /mcp
 app.mount("/mcp", mcp_app)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -34,13 +34,20 @@ class AuthenticatedUser:
     email: str
     display_name: str | None
     is_admin: bool
-    auth_method: str  # "jwt" or "pat"
+    auth_method: str  # "jwt" | "pat" | "oauth"
     # Per-PAT vault scope (Option B). None = unscoped: JWT logins, and PATs
     # minted without a scope. A concrete scope gates mutating vault access.
     vault_scope: VaultScope | None = None
     # The authenticating PAT's id (None for JWT logins). The PG-native akb_sql
     # executor switches to akb_token_<tid> when this PAT is ALSO scoped.
     token_id: str | None = None
+    # OAuth 2.1 scopes carried by a Keycloak access token at /mcp. None
+    # for any non-OAuth path (PAT, AKB JWT) — those are unscoped at the
+    # OAuth layer, and the MCP dispatcher skips its scope check when this
+    # is None. A list is meaningful even when empty: an OAuth caller that
+    # presented a valid token with zero scopes is rejected by the
+    # dispatcher's `vault:read|write` requirement.
+    oauth_scopes: list[str] | None = None
 
 
 # ── Password hashing ────────────────────────────────────────
@@ -210,16 +217,21 @@ async def _unique_username(conn, base: str | None) -> str:
     return f"{base}-{secrets.token_hex(4)}"
 
 
-async def login_with_keycloak_claims(claims: dict) -> dict:
-    """Map a verified Keycloak ID token to an AKB session.
+async def _resolve_or_provision_keycloak_user(claims: dict) -> dict:
+    """Map a verified Keycloak claim set (ID token *or* access token) to
+    an AKB user row, JIT-provisioning on first sight. Shared by the SSO
+    browser callback and the MCP OAuth Resource Server path.
 
-    First login JIT-provisions an AKB user (keyed by email) and its
-    per-user PG role; subsequent logins reuse the row. Returns the same
-    ``{token, user}`` shape as :func:`login` so the SSO callback path is
-    indistinguishable downstream.
+    Returns a dict with keys:
+        user_id, username, email, display_name, is_admin,
+        not_before (datetime | None — pin for AKB JWT iat when caller
+                    is minting one; ignored on the MCP path),
+        newly_provisioned (bool — caller must run RoleSync.on_user_create
+                           when True, outside the DB connection scope).
 
-    Keycloak is authentication only — ``realm_access.roles`` are NOT
-    mapped to AKB ``is_admin`` or vault grants here (see the design doc).
+    Raises ``AuthenticationError`` / ``ConflictError`` on the same
+    conditions the SSO callback does (missing email, unverified email
+    with strict policy on, cross-provider account conflict).
     """
     email = (claims.get("email") or "").strip().lower()
     if not email:
@@ -272,13 +284,9 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
             user_id = row["id"]
             uname = row["username"]
             not_before = row["tokens_revoked_before"] + timedelta(seconds=1)
-            user_payload = {
-                "id": str(row["id"]),
-                "username": row["username"],
-                "email": row["email"],
-                "display_name": row["display_name"],
-                "is_admin": row["is_admin"],
-            }
+            display_name_out = row["display_name"]
+            email_out = row["email"]
+            is_admin_out = row["is_admin"]
         else:
             user_id = uuid.uuid4()
             uname = await _unique_username(conn, preferred_username)
@@ -310,13 +318,9 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
                     )
                 new_user_id = user_id
                 not_before = None
-                user_payload = {
-                    "id": str(user_id),
-                    "username": uname,
-                    "email": email,
-                    "display_name": display_name,
-                    "is_admin": is_admin,
-                }
+                display_name_out = display_name
+                email_out = email
+                is_admin_out = is_admin
             except asyncpg.UniqueViolationError:
                 # Concurrent first-login for the same email won the race.
                 # Re-fetch and treat as the existing user (idempotent JIT)
@@ -354,22 +358,105 @@ async def login_with_keycloak_claims(claims: dict) -> dict:
                 user_id = row["id"]
                 uname = row["username"]
                 not_before = row["tokens_revoked_before"] + timedelta(seconds=1)
-                user_payload = {
-                    "id": str(row["id"]),
-                    "username": row["username"],
-                    "email": row["email"],
-                    "display_name": row["display_name"],
-                    "is_admin": row["is_admin"],
-                }
+                display_name_out = row["display_name"]
+                email_out = row["email"]
+                is_admin_out = row["is_admin"]
 
-    # PG-native RBAC: create the per-user role outside the insert's
-    # connection, mirroring register(). Best-effort — the reconciler at
-    # next startup rebuilds any role this misses.
-    if new_user_id is not None:
-        await get_role_sync().on_user_create(new_user_id)
+    return {
+        "user_id": user_id,
+        "username": uname,
+        "email": email_out,
+        "display_name": display_name_out,
+        "is_admin": is_admin_out,
+        "not_before": not_before,
+        "newly_provisioned": new_user_id is not None,
+    }
 
-    token = create_jwt(str(user_id), uname, not_before=not_before)
-    return {"token": token, "user": user_payload}
+
+async def login_with_keycloak_claims(claims: dict) -> dict:
+    """Map a verified Keycloak ID token to an AKB session.
+
+    First login JIT-provisions an AKB user (keyed by email) and its
+    per-user PG role; subsequent logins reuse the row. Returns the same
+    ``{token, user}`` shape as :func:`login` so the SSO callback path is
+    indistinguishable downstream.
+
+    Keycloak is authentication only — ``realm_access.roles`` are NOT
+    mapped to AKB ``is_admin`` or vault grants here (see the design doc).
+    """
+    resolved = await _resolve_or_provision_keycloak_user(claims)
+
+    # PG-native RBAC: create the per-user role outside the resolve helper's
+    # connection scope, mirroring register(). Best-effort — the reconciler
+    # at next startup rebuilds any role this misses.
+    if resolved["newly_provisioned"]:
+        await get_role_sync().on_user_create(resolved["user_id"])
+
+    token = create_jwt(
+        str(resolved["user_id"]),
+        resolved["username"],
+        not_before=resolved["not_before"],
+    )
+    return {
+        "token": token,
+        "user": {
+            "id": str(resolved["user_id"]),
+            "username": resolved["username"],
+            "email": resolved["email"],
+            "display_name": resolved["display_name"],
+            "is_admin": resolved["is_admin"],
+        },
+    }
+
+
+async def resolve_keycloak_access_token(token: str) -> AuthenticatedUser | None:
+    """Resolve a Keycloak-issued access token to an :class:`AuthenticatedUser`
+    for the MCP OAuth Resource Server path. Returns ``None`` on any failure
+    (gating disabled, signature/audience/issuer mismatch, claim refusal).
+
+    The OAuth scopes are surfaced on ``user.oauth_scopes``; the MCP
+    dispatcher uses them to enforce per-tool ``vault:read`` / ``vault:write``
+    requirements. ``oauth_scopes is None`` everywhere else (PAT, AKB JWT)
+    means "skip the scope check" — current behaviour for those paths.
+    """
+    if not settings.mcp_oauth_enabled or not settings.keycloak_enabled:
+        return None
+    audience = settings.mcp_oauth_audience_effective
+    if not audience:
+        return None
+
+    from app.services.keycloak_oidc import get_keycloak_oidc
+
+    claims = await get_keycloak_oidc().verify_access_token(token, audience)
+    if not claims:
+        return None
+
+    try:
+        resolved = await _resolve_or_provision_keycloak_user(claims)
+    except (AuthenticationError, ConflictError) as e:
+        # Refuse rather than crash — the caller maps this to 401.
+        logging.getLogger("akb.auth").info(
+            "MCP access token: user resolution rejected (%s)", e
+        )
+        return None
+
+    if resolved["newly_provisioned"]:
+        await get_role_sync().on_user_create(resolved["user_id"])
+
+    # RFC 6749 §3.3 — scopes are a space-delimited list in the `scope`
+    # claim. Defensive split: any empty fragments are dropped.
+    scope_str = claims.get("scope", "") or ""
+    scopes = [s for s in scope_str.split(" ") if s]
+
+    return AuthenticatedUser(
+        user_id=str(resolved["user_id"]),
+        username=resolved["username"],
+        email=resolved["email"] or "",
+        display_name=resolved["display_name"],
+        is_admin=resolved["is_admin"],
+        auth_method="oauth",
+        oauth_scopes=scopes,
+    )
 
 
 class BadPasswordChange(Exception):
@@ -665,9 +752,14 @@ async def revoke_all_sessions(
 async def resolve_token(authorization: str) -> AuthenticatedUser | None:
     """Resolve an Authorization header to an authenticated user.
 
-    Supports:
-    - Bearer <jwt>
-    - Bearer akb_<pat>
+    Supports three token shapes:
+    - ``Bearer akb_<pat>`` — Personal Access Token (always)
+    - ``Bearer <hs256-jwt>`` — AKB-issued session JWT (always)
+    - ``Bearer <rs256-jwt>`` — Keycloak-issued access token for the MCP
+      Resource Server path (only when ``mcp_oauth_enabled`` AND
+      ``keycloak_enabled``; rejected to ``None`` otherwise so deployments
+      that have not opted in cannot have an external token accidentally
+      accepted).
     """
     # Option B: reset the request-scoped vault scope + token id on every
     # resolve. Only a PAT (set in _resolve_pat) carries non-None values; JWT
@@ -686,7 +778,27 @@ async def resolve_token(authorization: str) -> AuthenticatedUser | None:
     if token.startswith("akb_"):
         return await _resolve_pat(token)
 
-    # JWT
+    # JWT — discriminate by `alg` header. AKB-issued JWTs are HS256;
+    # Keycloak access tokens are RS256. We pick the verifier from the
+    # token's own header so a single Bearer surface accepts both without
+    # an O(2) verify attempt per request.
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except (jwt.InvalidTokenError, Exception):
+        return None
+    alg = unverified_header.get("alg")
+
+    if alg == "RS256":
+        # Keycloak access token. Gated on mcp_oauth_enabled inside.
+        return await resolve_keycloak_access_token(token)
+
+    if alg != "HS256":
+        # Neither AKB nor Keycloak — reject rather than fall through to
+        # decode_jwt, which would attempt HS256 verify against an RS256
+        # token and (correctly) refuse but only after burning CPU.
+        return None
+
+    # AKB-issued session JWT (existing path)
     payload = decode_jwt(token)
     if not payload:
         return None

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -295,11 +295,20 @@ class KeycloakOIDC:
         if not kid:
             return None
 
-        jwks = await self._fetch_jwks()
-        key = self._find_key(jwks, kid)
-        if key is None:
-            jwks = await self._fetch_jwks(force=True)
+        # `_fetch_jwks` raises `AKBError` on IdP unreachability — catch
+        # it here so a transient JWKS blip surfaces as a clean 401
+        # (with the RFC 9728 `WWW-Authenticate` header the MCP handler
+        # adds) rather than a bare 502. The 401 lets a spec-compliant
+        # client re-run discovery; a 502 has no such affordance.
+        try:
+            jwks = await self._fetch_jwks()
             key = self._find_key(jwks, kid)
+            if key is None:
+                jwks = await self._fetch_jwks(force=True)
+                key = self._find_key(jwks, kid)
+        except AKBError as e:
+            logger.warning("MCP access token: JWKS unavailable (%s)", e)
+            return None
         if key is None:
             return None
 

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -259,6 +259,66 @@ class KeycloakOIDC:
 
         return claims
 
+    # ── Access-token verification (MCP OAuth Resource Server) ────────
+    async def verify_access_token(
+        self, token: str, audience: str
+    ) -> dict[str, Any] | None:
+        """Verify a Keycloak-issued access token for the MCP Resource
+        Server path. Returns the claim set on success, ``None`` on any
+        verification failure.
+
+        Distinct from :meth:`verify_id_token` in three ways:
+        - The expected ``aud`` is the *resource* (``<host>/mcp``), not the
+          OIDC client id, because Keycloak emits the audience via the
+          scope-level hardcoded-audience mapper set up by the realm
+          bootstrap script.
+        - Returns ``None`` rather than raising on failure: the caller is
+          an MCP request handler that distinguishes "no auth" from "bad
+          auth" via response codes, not exceptions.
+        - Stricter required-claims set: ``exp``, ``iat``, ``iss``, ``aud``,
+          ``sub`` (a Keycloak access token may carry no ``scope`` claim
+          when no scopes were requested — the scope check is enforced
+          downstream in the MCP dispatcher, not here).
+        """
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as e:
+            logger.debug("MCP access token: malformed header (%s)", e)
+            return None
+
+        # AKB-issued JWTs are HS256; only RS256 (Keycloak) reaches this
+        # path. The caller already discriminated by alg, but defend in
+        # depth so a config flip doesn't silently downgrade trust.
+        if header.get("alg") != "RS256":
+            return None
+        kid = header.get("kid")
+        if not kid:
+            return None
+
+        jwks = await self._fetch_jwks()
+        key = self._find_key(jwks, kid)
+        if key is None:
+            jwks = await self._fetch_jwks(force=True)
+            key = self._find_key(jwks, kid)
+        if key is None:
+            return None
+
+        try:
+            public_key = RSAAlgorithm.from_jwk(json.dumps(key))
+            claims = jwt.decode(
+                token,
+                public_key,
+                algorithms=["RS256"],
+                audience=audience,
+                issuer=settings.keycloak_issuer,
+                options={"require": ["exp", "iat", "aud", "iss", "sub"]},
+            )
+        except jwt.InvalidTokenError as e:
+            logger.debug("MCP access token verification failed: %s", e)
+            return None
+
+        return claims
+
     # ── Logout URL ───────────────────────────────────────────────────
     def logout_url(self, id_token_hint: str | None, post_logout_redirect: str | None) -> str:
         params: dict[str, str] = {}

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -49,6 +49,18 @@ def _validate_required_settings() -> None:
                 "keycloak_client_secret (confidential client — set it in "
                 "secret.yaml, or set keycloak_public_client: true for PKCE)"
             )
+    # MCP-OAuth (the Resource Server path) reuses the Keycloak JWKS,
+    # issuer, and audience-mapped scopes — so it's only meaningful when
+    # `keycloak_enabled` is also true. A deployment with mcp_oauth on +
+    # keycloak off would 503 mid-discovery and silently reject every
+    # RS256 token. Fail the boot instead so the misconfig surfaces at
+    # deploy time.
+    if settings.mcp_oauth_enabled and not settings.keycloak_enabled:
+        missing.append(
+            "keycloak_enabled (mcp_oauth_enabled is true — the OAuth "
+            "Resource Server path keys on the realm's JWKS + issuer; "
+            "either turn keycloak on, or turn mcp_oauth off)"
+        )
     if missing:
         raise RuntimeError(
             "Required configuration missing:\n  - " + "\n  - ".join(missing)

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -51,6 +51,11 @@ NOT_FOUND = "not_found"
 # Authorization / permission
 PERMISSION_DENIED = "permission_denied"
 VAULT_ARCHIVED = "vault_archived"
+# RFC 6750 §3.1 — OAuth scope check failed at MCP tool dispatch
+# (caller is authenticated but the access token lacks the scope the
+# tool requires). PERMISSION_DENIED is for AKB-internal access (vault
+# role, public visibility); this is the OAuth-layer counterpart.
+INSUFFICIENT_SCOPE = "insufficient_scope"
 
 # Caller-side input
 INVALID_ARGUMENT = "invalid_argument"      # generic argument shape problem

--- a/backend/mcp_server/http_app.py
+++ b/backend/mcp_server/http_app.py
@@ -1,9 +1,14 @@
 """MCP Streamable HTTP — mounts MCP server as ASGI app at /mcp.
 
 Each authenticated session gets its own transport + server loop.
-Agents connect via:
+Agents connect via one of:
   POST http://localhost:8000/mcp/
-  Authorization: Bearer akb_<pat>
+  Authorization: Bearer akb_<pat>              # PAT (always)
+  Authorization: Bearer <hs256-jwt>            # AKB session JWT (always)
+  Authorization: Bearer <rs256-jwt>            # Keycloak access token,
+                                               # when mcp_oauth_enabled=true.
+                                               # Discovery + DCR via
+                                               # /.well-known/oauth-protected-resource.
 """
 
 from __future__ import annotations
@@ -18,9 +23,30 @@ from starlette.types import Receive, Scope, Send
 
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 
+from app.config import settings
 from app.services.auth_service import resolve_token
 
 logger = logging.getLogger("akb.mcp")
+
+
+def _www_authenticate_header() -> str:
+    """Build the RFC 9728 §5 `WWW-Authenticate` header value for 401s.
+
+    When MCP-OAuth is enabled the header carries a `resource_metadata`
+    parameter pointing the client at the protected-resource metadata
+    document, so a standards-compliant MCP client (Claude Code,
+    claude.ai, ChatGPT) can autodiscover the authorization server and
+    initiate DCR + the auth-code flow. When disabled (PAT-only), we
+    emit the plain `Bearer` challenge — there is no AS to discover.
+    """
+    base = 'Bearer realm="akb-mcp"'
+    if settings.mcp_oauth_enabled and settings.public_base_url:
+        meta_url = (
+            f"{settings.public_base_url.rstrip('/')}"
+            "/.well-known/oauth-protected-resource"
+        )
+        return f'{base}, resource_metadata="{meta_url}"'
+    return base
 
 # Active transports keyed by session ID
 _transports: dict[str, StreamableHTTPServerTransport] = {}
@@ -65,19 +91,34 @@ class MCPApp:
 
         request = Request(scope, receive, send)
 
-        # Auth check
+        # Auth check. resolve_token handles all three Bearer shapes
+        # (PAT, AKB JWT, Keycloak access token); MCP-OAuth gating is
+        # internal to it. 401s carry an RFC 9728 WWW-Authenticate
+        # header so a standards-compliant MCP client can autodiscover
+        # the AS and complete OAuth without an out-of-band tip-off.
         auth_header = request.headers.get("authorization", "")
+        www_auth = _www_authenticate_header()
         if not auth_header:
+            hint = (
+                "Authorization required."
+                if settings.mcp_oauth_enabled
+                else "Authorization required. Use: Bearer akb_<your-pat>"
+            )
             response = JSONResponse(
-                {"error": "Authorization required. Use: Bearer akb_<your-pat>"},
+                {"error": hint},
                 status_code=401,
+                headers={"WWW-Authenticate": www_auth},
             )
             await response(scope, receive, send)
             return
 
         user = await resolve_token(auth_header)
         if not user:
-            response = JSONResponse({"error": "Invalid or expired token"}, status_code=401)
+            response = JSONResponse(
+                {"error": "Invalid or expired token"},
+                status_code=401,
+                headers={"WWW-Authenticate": www_auth},
+            )
             await response(scope, receive, send)
             return
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1406,14 +1406,18 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
     # authenticated via a Keycloak access token (oauth_scopes is a
     # concrete list, possibly empty). PAT and AKB JWT keep
     # `oauth_scopes is None` so this check is a no-op for them, which
-    # preserves stdio/CLI behaviour bit-for-bit. The required scope is
-    # the static per-tool map; tools not in the map are open by default
-    # so a newly added tool that forgets a scope mapping fails open at
-    # this layer (and stays gated by PG-RBAC + vault role, which is the
-    # authoritative access boundary).
+    # preserves stdio/CLI behaviour bit-for-bit.
+    #
+    # Tools not present in `_TOOL_SCOPES` fail CLOSED to the write
+    # scope. A newly added tool that forgets a scope mapping is almost
+    # always a write tool (the new tools shipped this PR cycle are);
+    # writing for OAuth requires `akb:vault:write`, which the user has
+    # to have explicitly consented to, so the closed default is safe.
+    # A test in `test_mcp_oauth_unit` asserts every registered handler
+    # has an explicit mapping so CI catches the omission anyway.
     if user.oauth_scopes is not None:
-        required = _TOOL_SCOPES.get(name)
-        if required and required not in user.oauth_scopes:
+        required = _TOOL_SCOPES.get(name, _WRITE_SCOPE)
+        if required not in user.oauth_scopes:
             return err(
                 f"OAuth token is missing required scope '{required}' for tool '{name}'",
                 code=INSUFFICIENT_SCOPE,

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -45,6 +45,7 @@ from app.util.errors import (
     exception_envelope,
     CONFLICT,
     EDIT_FAILED,
+    INSUFFICIENT_SCOPE,
     INTERNAL,
     INVALID_ARGUMENT,
     INVALID_PATH,
@@ -90,10 +91,17 @@ class _MCPUser:
         user_id: str = "00000000-0000-0000-0000-000000000000",
         username: str = "system",
         is_admin: bool = False,
+        oauth_scopes: list[str] | None = None,
     ):
         self.user_id = user_id
         self.username = username
         self.is_admin = is_admin
+        # OAuth scopes when the call came in via a Keycloak access token
+        # at /mcp; None for PAT / AKB JWT / fallback. The scope check in
+        # `_dispatch` is no-op when this is None — current behaviour for
+        # everyone who has not opted into the MCP-OAuth Resource Server
+        # path.
+        self.oauth_scopes = oauth_scopes
 
 _FALLBACK_USER = _MCPUser()
 
@@ -113,7 +121,12 @@ async def _get_user() -> _MCPUser:
             if auth_header:
                 user = await resolve_token(auth_header)
                 if user:
-                    return _MCPUser(user.user_id, user.username, is_admin=user.is_admin)
+                    return _MCPUser(
+                        user.user_id,
+                        user.username,
+                        is_admin=user.is_admin,
+                        oauth_scopes=user.oauth_scopes,
+                    )
                 # A credential was presented and rejected — that's a
                 # security-relevant event, so audit the denial. No token
                 # material is recorded.
@@ -131,6 +144,75 @@ search_service = SearchService()
 # ── Handler Registry ────────────────────────────────────────────
 
 _HANDLERS: dict[str, Any] = {}
+
+# OAuth scope required to invoke each tool — checked in _dispatch when
+# the caller authenticated via the MCP OAuth Resource Server path (a
+# Keycloak access token with a non-None `oauth_scopes`). PAT and AKB
+# JWT callers carry `oauth_scopes is None` and skip the check entirely,
+# preserving current behaviour for stdio / CLI clients.
+#
+# The vocabulary is deliberately coarse — read vs write at the vault
+# level. Finer-grained access (per-vault role, public visibility,
+# collection ACL) stays in PG-RBAC + `vault_access`; surfacing those as
+# OAuth scopes would force users to consent to a list of vaults the
+# realm cannot know about. Two scopes are the right altitude for the
+# consent screen.
+#
+# Categorisation rule of thumb: any tool that mutates a vault, table,
+# document, file, edge, publication, vault membership, or vault
+# settings → `akb:vault:write`. Everything else (read / browse /
+# search / metadata / introspection) → `akb:vault:read`. `akb_sql` is
+# write-grade because the surface accepts INSERT/UPDATE/DELETE; the
+# safer "read-only SQL" cut would need a separate tool, deferred.
+_READ_SCOPE = "akb:vault:read"
+_WRITE_SCOPE = "akb:vault:write"
+_TOOL_SCOPES: dict[str, str] = {
+    # --- read ---
+    "akb_help": _READ_SCOPE,
+    "akb_whoami": _READ_SCOPE,
+    "akb_list_vaults": _READ_SCOPE,
+    "akb_vault_info": _READ_SCOPE,
+    "akb_vault_members": _READ_SCOPE,
+    "akb_search_users": _READ_SCOPE,
+    "akb_browse": _READ_SCOPE,
+    "akb_get": _READ_SCOPE,
+    "akb_search": _READ_SCOPE,
+    "akb_grep": _READ_SCOPE,
+    "akb_drill_down": _READ_SCOPE,
+    "akb_activity": _READ_SCOPE,
+    "akb_diff": _READ_SCOPE,
+    "akb_history": _READ_SCOPE,
+    "akb_relations": _READ_SCOPE,
+    "akb_graph": _READ_SCOPE,
+    "akb_provenance": _READ_SCOPE,
+    "akb_publications": _READ_SCOPE,
+    "akb_publication_snapshot": _READ_SCOPE,
+    "akb_export": _READ_SCOPE,
+    # --- write ---
+    "akb_put": _WRITE_SCOPE,
+    "akb_update": _WRITE_SCOPE,
+    "akb_move": _WRITE_SCOPE,
+    "akb_edit": _WRITE_SCOPE,
+    "akb_delete": _WRITE_SCOPE,
+    "akb_link": _WRITE_SCOPE,
+    "akb_unlink": _WRITE_SCOPE,
+    "akb_create_collection": _WRITE_SCOPE,
+    "akb_delete_collection": _WRITE_SCOPE,
+    "akb_create_vault": _WRITE_SCOPE,
+    "akb_delete_vault": _WRITE_SCOPE,
+    "akb_archive_vault": _WRITE_SCOPE,
+    "akb_create_table": _WRITE_SCOPE,
+    "akb_alter_table": _WRITE_SCOPE,
+    "akb_drop_table": _WRITE_SCOPE,
+    "akb_sql": _WRITE_SCOPE,
+    "akb_grant": _WRITE_SCOPE,
+    "akb_revoke": _WRITE_SCOPE,
+    "akb_publish": _WRITE_SCOPE,
+    "akb_unpublish": _WRITE_SCOPE,
+    "akb_set_public": _WRITE_SCOPE,
+    "akb_transfer_ownership": _WRITE_SCOPE,
+    "akb_import": _WRITE_SCOPE,
+}
 
 # Schema-derived: {tool_name: set(allowed_arg_names)}. Used by _dispatch
 # to reject unknown arguments with a fuzzy hint. Built once at import
@@ -1319,6 +1401,25 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
     handler = _HANDLERS.get(name)
     if not handler:
         return err(f"Unknown tool: {name}", code=UNKNOWN_TOOL)
+
+    # OAuth scope enforcement — only when the caller's session is
+    # authenticated via a Keycloak access token (oauth_scopes is a
+    # concrete list, possibly empty). PAT and AKB JWT keep
+    # `oauth_scopes is None` so this check is a no-op for them, which
+    # preserves stdio/CLI behaviour bit-for-bit. The required scope is
+    # the static per-tool map; tools not in the map are open by default
+    # so a newly added tool that forgets a scope mapping fails open at
+    # this layer (and stays gated by PG-RBAC + vault role, which is the
+    # authoritative access boundary).
+    if user.oauth_scopes is not None:
+        required = _TOOL_SCOPES.get(name)
+        if required and required not in user.oauth_scopes:
+            return err(
+                f"OAuth token is missing required scope '{required}' for tool '{name}'",
+                code=INSUFFICIENT_SCOPE,
+                required_scope=required,
+                granted_scopes=list(user.oauth_scopes),
+            )
 
     # Reject unknown arguments before the handler sees them. Without
     # this, a typo like `akb_activity(user=...)` (real name: `author`)

--- a/backend/tests/test_mcp_oauth_e2e.sh
+++ b/backend/tests/test_mcp_oauth_e2e.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+#
+# AKB MCP OAuth Resource Server — E2E
+#
+# Exercises the new /mcp OAuth path against the local-dev Keycloak overlay
+# WITHOUT needing a browser DCR roundtrip: the test realm ships an
+# `akb-mcp-test` service-account client (client_credentials grant) whose
+# default scopes are `akb:vault:read|write`, so we can mint a real
+# Keycloak access token from a shell script and present it at /mcp.
+#
+# What this script proves (in order):
+#   1. `/.well-known/oauth-protected-resource` returns the expected shape
+#   2. `/mcp` rejects no-auth with 401 + WWW-Authenticate including a
+#      `resource_metadata=` parameter (RFC 9728 §5 client tip-off)
+#   3. `/mcp` rejects a syntactically-valid but wrong-audience token
+#      with 401
+#   4. `/mcp` accepts a service-account access token with both scopes
+#      and dispatches a read-grade tool (akb_list_vaults)
+#   5. PAT path still works unchanged (regression guard)
+#   6. A token with only `akb:vault:read` is refused at a write-grade
+#      tool with `insufficient_scope`
+#
+# Stack required:
+#   docker compose -f docker-compose.yaml -f docker-compose.keycloak.yaml up -d
+#   # config/app.yaml must have:
+#   #   keycloak_enabled: true
+#   #   mcp_oauth_enabled: true
+#   #   public_base_url: http://localhost:8000
+#
+# Run:
+#   bash backend/tests/test_mcp_oauth_e2e.sh
+#
+# Tunable via env:
+#   AKB_URL=http://localhost:8000
+#   KC_URL=http://localhost:8080
+#   KC_REALM=akb
+#   KC_TEST_CLIENT_ID=akb-mcp-test
+#   KC_TEST_CLIENT_SECRET=local-akb-mcp-test-secret
+set -uo pipefail
+
+AKB_URL="${AKB_URL:-http://localhost:8000}"
+KC_URL="${KC_URL:-http://localhost:8080}"
+KC_REALM="${KC_REALM:-akb}"
+KC_TEST_CLIENT_ID="${KC_TEST_CLIENT_ID:-akb-mcp-test}"
+KC_TEST_CLIENT_SECRET="${KC_TEST_CLIENT_SECRET:-local-akb-mcp-test-secret}"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+section() { echo; echo "── $1 ──"; }
+
+# ── Helpers ──────────────────────────────────────────────────
+
+mint_token() {
+  # $1 = scope (space-delimited). Empty → realm-default scopes only.
+  local scope="$1"
+  local data="grant_type=client_credentials&client_id=${KC_TEST_CLIENT_ID}&client_secret=${KC_TEST_CLIENT_SECRET}"
+  if [ -n "$scope" ]; then data="${data}&scope=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))" "$scope")"; fi
+  curl -s -X POST "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/token" \
+       -H "Content-Type: application/x-www-form-urlencoded" \
+       -d "$data" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))"
+}
+
+mcp_initialize_call() {
+  # Sends a minimal MCP `initialize` then a `tools/list` call.
+  local token="$1"
+  curl -s -X POST "${AKB_URL}/mcp/" \
+       -H "Authorization: Bearer ${token}" \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/json, text/event-stream" \
+       -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}'
+}
+
+mcp_tool_call() {
+  # $1 = bearer token, $2 = MCP method (tools/call etc.), $3 = JSON args
+  local token="$1" method="$2" args="$3"
+  curl -s -X POST "${AKB_URL}/mcp/" \
+       -H "Authorization: Bearer ${token}" \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/json, text/event-stream" \
+       -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"${method}\",\"params\":${args}}"
+}
+
+# ── 1. Protected-resource metadata shape ─────────────────────
+
+section "Protected-resource metadata"
+meta=$(curl -s "${AKB_URL}/.well-known/oauth-protected-resource")
+echo "    ${meta}"
+res=$(echo "$meta" | python3 -c "import sys,json; print(json.load(sys.stdin).get('resource',''))" 2>/dev/null) || true
+if [ -n "$res" ]; then pass "metadata served"; else fail "metadata served" "empty/missing"; fi
+as=$(echo "$meta" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('authorization_servers',[])))" 2>/dev/null) || true
+case "$as" in *"realms/${KC_REALM}"*) pass "authorization_servers points at realm" ;;
+                  *) fail "authorization_servers points at realm" "got '$as'" ;;
+esac
+scopes=$(echo "$meta" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('scopes_supported',[])))" 2>/dev/null) || true
+case "$scopes" in *"akb:vault:read"*) pass "scopes_supported lists akb:vault:read" ;;
+                      *) fail "scopes_supported lists akb:vault:read" "got '$scopes'" ;; esac
+case "$scopes" in *"akb:vault:write"*) pass "scopes_supported lists akb:vault:write" ;;
+                       *) fail "scopes_supported lists akb:vault:write" "got '$scopes'" ;; esac
+case "$scopes" in *"offline_access"*) pass "scopes_supported lists offline_access" ;;
+                      *) fail "scopes_supported lists offline_access" "got '$scopes'" ;; esac
+
+# ── 2. No-auth → 401 + WWW-Authenticate with resource_metadata ──
+
+section "401 carries WWW-Authenticate (RFC 9728 §5)"
+hdrs=$(curl -s -i -X POST "${AKB_URL}/mcp/" -H "Content-Type: application/json" -d '{}' | tr -d '\r')
+status=$(echo "$hdrs" | head -1 | awk '{print $2}')
+wa=$(echo "$hdrs" | grep -i "^WWW-Authenticate:" | head -1 | sed 's/^[Ww][Ww][Ww]-[Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ee]:[[:space:]]*//')
+if [ "$status" = "401" ]; then pass "no-auth → 401"; else fail "no-auth → 401" "got $status"; fi
+case "$wa" in *"resource_metadata="*) pass "WWW-Authenticate carries resource_metadata=" ;;
+                  *) fail "WWW-Authenticate carries resource_metadata=" "got '$wa'" ;; esac
+
+# ── 3. Token minted for a different audience → 401 ─────────────
+
+section "Wrong-audience token → 401"
+# Mint a token without our vault scopes — its `aud` should NOT include
+# our resource (the audience mapper only fires when an akb:vault:* scope
+# is requested). So an unscoped token from the same realm is a useful
+# wrong-audience proxy.
+bad_token=$(mint_token "")
+if [ -z "$bad_token" ]; then fail "mint unscoped token" "Keycloak returned no access_token"; else
+  status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${AKB_URL}/mcp/" \
+             -H "Authorization: Bearer ${bad_token}" \
+             -H "Content-Type: application/json" \
+             -H "Accept: application/json, text/event-stream" \
+             -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}')
+  if [ "$status" = "401" ]; then pass "wrong-aud → 401"; else fail "wrong-aud → 401" "got $status"; fi
+fi
+
+# ── 4. Service-account token with both scopes → 200 + tool list ─
+
+section "Read+write token → /mcp accepts, tools/list returns AKB tools"
+good_token=$(mint_token "akb:vault:read akb:vault:write")
+if [ -z "$good_token" ]; then fail "mint scoped token" "Keycloak returned no access_token"; else
+  init_resp=$(mcp_initialize_call "$good_token")
+  # Streamable HTTP returns SSE; just check the response carried a JSON-RPC frame
+  case "$init_resp" in *'"jsonrpc"'*) pass "initialize accepted" ;;
+                            *) fail "initialize accepted" "got '${init_resp:0:200}'" ;; esac
+  list_resp=$(mcp_tool_call "$good_token" "tools/list" "{}")
+  case "$list_resp" in *"akb_list_vaults"*) pass "tools/list includes akb_list_vaults" ;;
+                            *) fail "tools/list includes akb_list_vaults" "got '${list_resp:0:200}'" ;; esac
+fi
+
+# ── 5. PAT path still works (regression) ───────────────────────
+
+section "Regression — PAT path unchanged"
+# Register a throwaway local user + PAT.
+ts=$(date +%s)
+user="mcp-oauth-e2e-${ts}"
+email="${user}@example.com"
+pat=$(curl -s -X POST "${AKB_URL}/api/v1/auth/register" \
+        -H "Content-Type: application/json" \
+        -d "{\"username\":\"${user}\",\"email\":\"${email}\",\"password\":\"test-password-1\"}" \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))")
+if [ -z "$pat" ]; then fail "register local user" "no token returned"; else
+  # Use the AKB JWT as Bearer at /mcp — PAT prefix not strictly required,
+  # AKB JWT works at /mcp too.
+  init_resp=$(mcp_initialize_call "$pat")
+  case "$init_resp" in *'"jsonrpc"'*) pass "PAT/JWT initialize still works" ;;
+                            *) fail "PAT/JWT initialize still works" "got '${init_resp:0:200}'" ;; esac
+fi
+
+# ── 6. Read-only token → write tool returns insufficient_scope ──
+
+section "Read-only token → write tool refused with insufficient_scope"
+read_only=$(mint_token "akb:vault:read")
+if [ -z "$read_only" ]; then fail "mint read-only token" "no access_token"; else
+  # Try akb_put — should fail with insufficient_scope at dispatch.
+  put_args='{"name":"akb_put","arguments":{"vault":"nope","title":"x","content":"y"}}'
+  put_resp=$(mcp_tool_call "$read_only" "tools/call" "$put_args")
+  case "$put_resp" in *"insufficient_scope"*) pass "akb_put refused with insufficient_scope" ;;
+                          *) fail "akb_put refused with insufficient_scope" "got '${put_resp:0:300}'" ;; esac
+fi
+
+# ── Summary ───────────────────────────────────────────────────
+
+echo
+echo "════════════════════════════════════════"
+echo "MCP OAuth E2E — ${PASS} passed, ${FAIL} failed"
+echo "════════════════════════════════════════"
+if [ "$FAIL" -gt 0 ]; then
+  for e in "${ERRORS[@]}"; do echo "  - $e"; done
+  exit 1
+fi

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -434,6 +434,13 @@ def test_metadata_route_full_shape_when_enabled(monkeypatch):
     assert "akb:vault:read" in body["scopes_supported"]
     assert "akb:vault:write" in body["scopes_supported"]
     assert "offline_access" in body["scopes_supported"]
+    # OIDC base scopes are also advertised so spec-compliant MCP
+    # clients (which request exactly scopes_supported) include them in
+    # DCR + authorize. Without these the access token carries `sub`
+    # only and AKB's email-keyed user matching falls through.
+    assert "openid" in body["scopes_supported"]
+    assert "profile" in body["scopes_supported"]
+    assert "email" in body["scopes_supported"]
     assert body["bearer_methods_supported"] == ["header"]
 
 

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -1,0 +1,457 @@
+"""Unit tests for the MCP OAuth Resource Server path.
+
+Covers the pure-function and pydantic-mockable surfaces — no DB, no
+real Keycloak. Concretely:
+
+- ``settings.mcp_oauth_audience_effective`` derives from ``public_base_url``
+- ``KeycloakOIDC.verify_access_token`` accepts a freshly-signed RS256
+  token, rejects wrong audience / wrong issuer / expired / wrong alg
+- ``resolve_token`` dispatches on JWT ``alg``: PAT → _resolve_pat,
+  HS256 → existing AKB JWT path, RS256 → Keycloak access-token path
+  (gated on ``mcp_oauth_enabled``)
+- ``_dispatch`` scope enforcement: ``oauth_scopes is None`` bypasses,
+  missing scope returns ``insufficient_scope``, sufficient passes
+- ``/.well-known/oauth-protected-resource`` shape: 404 when disabled,
+  full document when enabled
+- ``_www_authenticate_header`` carries ``resource_metadata`` when MCP
+  OAuth is on, plain Bearer challenge when off
+"""
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.config import settings
+
+# server.py instantiates DocumentService() at module load, which creates
+# the git storage path via mkdir. Tests don't write any documents; we
+# just need somewhere writable so the import doesn't blow up on the
+# default `/data/vaults`. Override once at test-module load so every
+# lazy `from mcp_server.server import …` inside a test finds a working
+# path.
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-mcp-oauth-test-vaults-")
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rsa_keypair():
+    """A throwaway 2048-bit RSA keypair for signing test access tokens."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_numbers = private.public_key().public_numbers()
+    # JWK shape Keycloak uses for the JWKS feed.
+    import base64
+
+    def _b64u(n: int) -> str:
+        length = (n.bit_length() + 7) // 8
+        return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+
+    jwk = {
+        "kty": "RSA",
+        "kid": "test-key-1",
+        "use": "sig",
+        "alg": "RS256",
+        "n": _b64u(public_numbers.n),
+        "e": _b64u(public_numbers.e),
+    }
+    return {"private_pem": private_pem, "jwk": jwk}
+
+
+def _mint_access_token(
+    *,
+    private_pem: bytes,
+    kid: str,
+    audience: str,
+    issuer: str,
+    sub: str = "test-sub",
+    email: str = "alice@example.com",
+    email_verified: bool = True,
+    preferred_username: str = "alice",
+    scope: str = "akb:vault:read akb:vault:write",
+    exp_delta: int = 300,
+    extra: dict | None = None,
+    alg: str = "RS256",
+) -> str:
+    now = int(datetime.now(timezone.utc).timestamp())
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": sub,
+        "iat": now,
+        "exp": now + exp_delta,
+        "email": email,
+        "email_verified": email_verified,
+        "preferred_username": preferred_username,
+        "scope": scope,
+    }
+    if extra:
+        payload.update(extra)
+    return jwt.encode(payload, private_pem, algorithm=alg, headers={"kid": kid})
+
+
+# ── settings.mcp_oauth_audience_effective ──────────────────────────
+
+
+def test_audience_effective_off_returns_empty(monkeypatch):
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    assert settings.mcp_oauth_audience_effective == ""
+
+
+def test_audience_effective_default_derives_from_public_base_url(monkeypatch):
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_audience", "", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    assert settings.mcp_oauth_audience_effective == "https://akb.example.com/mcp"
+
+
+def test_audience_effective_explicit_override(monkeypatch):
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_audience", "https://alt.example.com/mcp", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    assert settings.mcp_oauth_audience_effective == "https://alt.example.com/mcp"
+
+
+# ── KeycloakOIDC.verify_access_token ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_happy_path(monkeypatch, rsa_keypair):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    issuer = "https://kc.example.com/realms/akb"
+    audience = "https://akb.example.com/mcp"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    # Inject JWKS rather than hit the network.
+    svc._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience=audience,
+        issuer=issuer,
+    )
+    claims = await svc.verify_access_token(token, audience)
+    assert claims is not None
+    assert claims["email"] == "alice@example.com"
+    assert "akb:vault:read" in claims.get("scope", "")
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_wrong_audience(monkeypatch, rsa_keypair):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    issuer = "https://kc.example.com/realms/akb"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    svc._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    # Token minted for resource A, validated for resource B → None.
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience="https://other.example.com/mcp",
+        issuer=issuer,
+    )
+    assert await svc.verify_access_token(token, "https://akb.example.com/mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_wrong_issuer(monkeypatch, rsa_keypair):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    audience = "https://akb.example.com/mcp"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    svc._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    # Token claims a different issuer than the one settings advertise.
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience=audience,
+        issuer="https://attacker.example.com/realms/akb",
+    )
+    assert await svc.verify_access_token(token, audience) is None
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_expired(monkeypatch, rsa_keypair):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    issuer = "https://kc.example.com/realms/akb"
+    audience = "https://akb.example.com/mcp"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    svc._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience=audience,
+        issuer=issuer,
+        exp_delta=-60,  # already expired
+    )
+    assert await svc.verify_access_token(token, audience) is None
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_rejects_hs256(monkeypatch):
+    """An HS256-signed token (AKB JWT shape) must NOT be accepted by the
+    OAuth Resource Server verifier — even if alg were spoofed, the JWKS
+    is RSA-only. This guards against an alg-confusion attempt."""
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    svc._jwks = {"keys": []}  # irrelevant — alg check fires first
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    token = jwt.encode(
+        {"sub": "x", "aud": "y", "iss": "z", "iat": now, "exp": now + 60},
+        "shared-secret",
+        algorithm="HS256",
+    )
+    assert await svc.verify_access_token(token, "https://akb.example.com/mcp") is None
+
+
+# ── resolve_token dispatch ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_routes_rs256_to_keycloak_path(monkeypatch, rsa_keypair):
+    """An RS256 JWT must route to ``resolve_keycloak_access_token``, not
+    fall through to the HS256 AKB JWT decoder."""
+    from app.services import auth_service
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_audience", "", raising=False)
+
+    calls = []
+
+    async def _stub(token):
+        calls.append(token)
+        return auth_service.AuthenticatedUser(
+            user_id="00000000-0000-0000-0000-000000000001",
+            username="alice",
+            email="alice@example.com",
+            display_name="Alice",
+            is_admin=False,
+            auth_method="oauth",
+            oauth_scopes=["akb:vault:read"],
+        )
+
+    monkeypatch.setattr(auth_service, "resolve_keycloak_access_token", _stub)
+
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience="https://akb.example.com/mcp",
+        issuer="https://kc.example.com/realms/akb",
+    )
+    result = await auth_service.resolve_token(f"Bearer {token}")
+    assert result is not None
+    assert result.auth_method == "oauth"
+    assert result.oauth_scopes == ["akb:vault:read"]
+    assert calls == [token]
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_pat_unchanged(monkeypatch):
+    """The PAT prefix path must not be perturbed by the new RS256 branch."""
+    from app.services import auth_service
+
+    seen = []
+
+    async def _stub(t):
+        seen.append(t)
+        return None  # we only care that the PAT path is taken
+
+    monkeypatch.setattr(auth_service, "_resolve_pat", _stub)
+    await auth_service.resolve_token("Bearer akb_some_pat_value")
+    assert seen == ["akb_some_pat_value"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_rs256_rejected_when_mcp_oauth_off(monkeypatch, rsa_keypair):
+    """Resource-server gating: with ``mcp_oauth_enabled = false`` an
+    RS256 token is rejected to None, not silently honoured."""
+    from app.services import auth_service
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience="https://akb.example.com/mcp",
+        issuer="https://kc.example.com/realms/akb",
+    )
+    assert await auth_service.resolve_token(f"Bearer {token}") is None
+
+
+# ── _dispatch scope enforcement ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_scope_check_when_oauth_scopes_none():
+    """PAT and AKB JWT callers carry ``oauth_scopes is None`` and must
+    NOT be gated by the OAuth scope check — only by PG-RBAC downstream."""
+    from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
+
+    captured = []
+
+    async def _stub_handler(args, uid, user):
+        captured.append((uid, args))
+        return {"ok": True}
+
+    _HANDLERS["__test_tool__"] = _stub_handler
+    try:
+        user = _MCPUser(user_id="u-1", oauth_scopes=None)
+        result = await _dispatch("__test_tool__", {}, user)
+        assert result == {"ok": True}
+        assert captured == [("u-1", {})]
+    finally:
+        _HANDLERS.pop("__test_tool__", None)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_insufficient_scope_for_write_with_only_read():
+    """An OAuth caller with ``akb:vault:read`` must be refused at a
+    write-grade tool with the canonical ``insufficient_scope`` code."""
+    from mcp_server.server import _dispatch, _MCPUser
+
+    user = _MCPUser(user_id="u-1", oauth_scopes=["akb:vault:read"])
+    result = await _dispatch("akb_put", {"vault": "v", "title": "t", "content": "c"}, user)
+    assert result.get("error") is not None
+    assert result.get("code") == "insufficient_scope"
+    # `err()` wraps arbitrary kwargs under `details`, so the per-tool
+    # scope hints surface there rather than at the top level.
+    assert result.get("details", {}).get("required_scope") == "akb:vault:write"
+    assert result.get("details", {}).get("granted_scopes") == ["akb:vault:read"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sufficient_scope_passes_through(monkeypatch):
+    """With both scopes present, the dispatch must run the handler (we
+    stub it so this stays a unit test, not a DB-backed integration)."""
+    from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
+
+    called = []
+
+    async def _stub(args, uid, user):
+        called.append(user.oauth_scopes)
+        return {"ok": True}
+
+    original = _HANDLERS.get("akb_put")
+    _HANDLERS["akb_put"] = _stub
+    try:
+        user = _MCPUser(user_id="u-1", oauth_scopes=["akb:vault:read", "akb:vault:write"])
+        result = await _dispatch("akb_put", {"vault": "v", "title": "t", "content": "c"}, user)
+        assert result == {"ok": True}
+        assert called == [["akb:vault:read", "akb:vault:write"]]
+    finally:
+        if original is not None:
+            _HANDLERS["akb_put"] = original
+        else:
+            _HANDLERS.pop("akb_put", None)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_empty_oauth_scopes_rejects_scoped_tool():
+    """A caller authenticated via OAuth but with zero scopes (token was
+    minted without any vault scopes requested) must be refused at any
+    tool that has a scope mapping. Empty list ≠ None."""
+    from mcp_server.server import _dispatch, _MCPUser
+
+    user = _MCPUser(user_id="u-1", oauth_scopes=[])
+    result = await _dispatch("akb_search", {"query": "x"}, user)
+    assert result.get("code") == "insufficient_scope"
+    assert result.get("details", {}).get("required_scope") == "akb:vault:read"
+
+
+# ── /.well-known/oauth-protected-resource ──────────────────────────
+
+
+def test_metadata_route_404_when_disabled(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    from app.api.routes import oauth_metadata
+
+    app = FastAPI()
+    app.include_router(oauth_metadata.router)
+    client = TestClient(app)
+    resp = client.get("/.well-known/oauth-protected-resource")
+    assert resp.status_code == 404
+
+
+def test_metadata_route_full_shape_when_enabled(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_audience", "", raising=False)
+
+    from app.api.routes import oauth_metadata
+
+    app = FastAPI()
+    app.include_router(oauth_metadata.router)
+    client = TestClient(app)
+    resp = client.get("/.well-known/oauth-protected-resource")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resource"] == "https://akb.example.com/mcp"
+    assert body["authorization_servers"] == ["https://kc.example.com/realms/akb"]
+    assert "akb:vault:read" in body["scopes_supported"]
+    assert "akb:vault:write" in body["scopes_supported"]
+    assert "offline_access" in body["scopes_supported"]
+    assert body["bearer_methods_supported"] == ["header"]
+
+
+# ── WWW-Authenticate header ────────────────────────────────────────
+
+
+def test_www_authenticate_plain_bearer_when_oauth_off(monkeypatch):
+    from mcp_server.http_app import _www_authenticate_header
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    assert _www_authenticate_header() == 'Bearer realm="akb-mcp"'
+
+
+def test_www_authenticate_carries_resource_metadata_when_oauth_on(monkeypatch):
+    from mcp_server.http_app import _www_authenticate_header
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    h = _www_authenticate_header()
+    assert h.startswith("Bearer realm=")
+    assert 'resource_metadata="https://akb.example.com/.well-known/oauth-protected-resource"' in h

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -462,3 +462,108 @@ def test_www_authenticate_carries_resource_metadata_when_oauth_on(monkeypatch):
     h = _www_authenticate_header()
     assert h.startswith("Bearer realm=")
     assert 'resource_metadata="https://akb.example.com/.well-known/oauth-protected-resource"' in h
+
+
+# ── _TOOL_SCOPES completeness (CI guard) ──────────────────────────
+
+
+def test_every_registered_tool_has_an_explicit_scope_mapping():
+    """A new tool added to `_HANDLERS` without an entry in `_TOOL_SCOPES`
+    would silently fail closed to write (which is safe) — but the
+    intent is that every tool's scope is an explicit, reviewed choice.
+    Lock that down here so a PR adding a read-grade tool can't
+    inadvertently promote it to write-grade by forgetting the map."""
+    from mcp_server.server import _HANDLERS, _TOOL_SCOPES
+
+    unmapped = sorted(set(_HANDLERS.keys()) - set(_TOOL_SCOPES.keys()))
+    assert unmapped == [], (
+        f"Tools registered without a _TOOL_SCOPES entry: {unmapped}. "
+        "Add each to _TOOL_SCOPES with the appropriate read/write scope."
+    )
+
+
+@pytest.mark.asyncio
+async def test_unmapped_tool_falls_back_to_write_scope_when_oauth_caller():
+    """A defensive check for the fail-closed path: even with the
+    completeness test above in place, if a future tool slips through
+    (test bypass / dynamic registration), an OAuth caller without
+    `akb:vault:write` must NOT be able to invoke it."""
+    from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
+
+    # Register a fake tool that's deliberately NOT in _TOOL_SCOPES.
+    async def _stub(args, uid, user):
+        return {"ok": True}
+
+    _HANDLERS["__unmapped_test_tool__"] = _stub
+    try:
+        # Read-only OAuth caller — must be refused at unmapped tool.
+        read_user = _MCPUser(user_id="u-1", oauth_scopes=["akb:vault:read"])
+        result = await _dispatch("__unmapped_test_tool__", {}, read_user)
+        assert result.get("code") == "insufficient_scope"
+        assert result.get("details", {}).get("required_scope") == "akb:vault:write"
+        # Write-grade OAuth caller — allowed through.
+        write_user = _MCPUser(user_id="u-1", oauth_scopes=["akb:vault:write"])
+        result = await _dispatch("__unmapped_test_tool__", {}, write_user)
+        assert result == {"ok": True}
+    finally:
+        _HANDLERS.pop("__unmapped_test_tool__", None)
+
+
+# ── verify_access_token resilience ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_returns_none_on_jwks_unreachable(monkeypatch, rsa_keypair):
+    """JWKS endpoint flap must not surface as 502 — return None so the
+    MCP handler issues a clean 401 with the RFC 9728 hint and the
+    client retries discovery."""
+    from app.services.keycloak_oidc import KeycloakOIDC
+    from app.exceptions import AKBError
+
+    issuer = "https://kc.example.com/realms/akb"
+    audience = "https://akb.example.com/mcp"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    # Stub _fetch_jwks to simulate "Keycloak unreachable".
+    async def _boom(*_a, **_kw):
+        raise AKBError("Keycloak unreachable fetching JWKS", status_code=502)
+    monkeypatch.setattr(svc, "_fetch_jwks", _boom)
+
+    token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience=audience,
+        issuer=issuer,
+    )
+    assert await svc.verify_access_token(token, audience) is None
+
+
+# ── SPA-audience token must not be usable at /mcp ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_spa_audience_token(monkeypatch, rsa_keypair):
+    """The existing `akb-web` SSO client mints ID tokens with
+    aud=akb-web for the browser login flow. Those tokens must NOT be
+    accepted at /mcp — the audience binding is what stops cross-client
+    confusion."""
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    issuer = "https://kc.example.com/realms/akb"
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://kc.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+
+    svc = KeycloakOIDC()
+    svc._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    # Token minted with the SPA's audience (the client_id).
+    spa_token = _mint_access_token(
+        private_pem=rsa_keypair["private_pem"],
+        kid="test-key-1",
+        audience="akb-web",
+        issuer=issuer,
+    )
+    # Validated against the MCP resource audience → rejected.
+    assert await svc.verify_access_token(spa_token, "https://akb.example.com/mcp") is None

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -37,6 +37,20 @@ spec:
                 name: backend
                 port:
                   number: 8000
+          # OAuth 2.0 Protected Resource Metadata (RFC 9728) — and any
+          # other `/.well-known/*` an MCP client probes for discovery
+          # (RFC 8414 oauth-authorization-server, openid-configuration).
+          # We route the whole prefix to the backend so unknown paths
+          # return a proper 404 JSON instead of being caught by the
+          # frontend SPA's index.html catch-all (which would deliver a
+          # 200 HTML page that breaks the client's JSON parser).
+          - path: /.well-known/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000
           # Health endpoints (detailed, liveness, readiness)
           - path: /health
             pathType: Exact

--- a/deploy/keycloak-dev/akb-realm.json
+++ b/deploy/keycloak-dev/akb-realm.json
@@ -28,8 +28,134 @@
       "attributes": {
         "post.logout.redirect.uris": "http://localhost:3000/*##http://localhost:5173/*"
       }
+    },
+    {
+      "clientId": "akb-mcp-test",
+      "name": "AKB MCP test client (service account, E2E only)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-akb-mcp-test-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "redirectUris": [],
+      "webOrigins": [],
+      "defaultClientScopes": [
+        "akb:vault:read",
+        "akb:vault:write"
+      ],
+      "attributes": {
+        "use.refresh.tokens": "true"
+      }
     }
   ],
+  "clientScopes": [
+    {
+      "name": "akb:vault:read",
+      "description": "Read AKB documents, tables, files, and search across accessible vaults",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "Read your AKB vaults (documents, tables, files, search)",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "akb-mcp-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "http://localhost:8000/mcp",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "name": "akb:vault:write",
+      "description": "Create, edit, delete, and publish AKB content",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "Create, edit, and delete AKB content",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "akb-mcp-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "http://localhost:8000/mcp",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "web-origins",
+    "acr",
+    "profile",
+    "roles",
+    "email",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "akb:vault:read",
+    "akb:vault:write"
+  ],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "config": {
+          "trusted-hosts": ["localhost", "127.0.0.1"],
+          "host-sending-registration-request-must-match": ["true"],
+          "client-uris-must-match": ["true"]
+        }
+      },
+      {
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "config": {}
+      },
+      {
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "config": {}
+      },
+      {
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "config": {
+          "max-clients": ["200"]
+        }
+      },
+      {
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "config": {
+          "allow-default-scopes": ["true"]
+        }
+      }
+    ]
+  },
   "users": [
     {
       "username": "alice",

--- a/deploy/keycloak-dev/akb-realm.json
+++ b/deploy/keycloak-dev/akb-realm.json
@@ -122,7 +122,7 @@
         "subType": "anonymous",
         "config": {
           "trusted-hosts": ["localhost", "127.0.0.1"],
-          "host-sending-registration-request-must-match": ["true"],
+          "host-sending-registration-request-must-match": ["false"],
           "client-uris-must-match": ["true"]
         }
       },
@@ -144,14 +144,6 @@
         "subType": "anonymous",
         "config": {
           "max-clients": ["200"]
-        }
-      },
-      {
-        "name": "Allowed Client Scopes",
-        "providerId": "allowed-client-templates",
-        "subType": "anonymous",
-        "config": {
-          "allow-default-scopes": ["true"]
         }
       }
     ]

--- a/docker-compose.keycloak.yaml
+++ b/docker-compose.keycloak.yaml
@@ -39,10 +39,9 @@
 # Real Claude Code / claude.ai validation: the local Keycloak overlay
 # works for headless E2E but Claude Code's OAuth discovery requires
 # the AS metadata URL to be HTTPS. Easiest path is to point a local
-# AKB backend at the prod Keycloak realm at
-# `https://auth.seahorse.dnotitia.com/realms/akb` — already https, DCR
-# trusted-hosts already include `localhost`/`127.0.0.1`. See
-# `docs/mcp-clients/web-connectors.md` for the walkthrough.
+# AKB backend at an already-deployed HTTPS Keycloak realm (e.g. a
+# staging instance). See `docs/mcp-clients/web-connectors.md` for the
+# walkthrough.
 #
 # The realm import ships FIXED dev client secrets ("local-akb-dev-secret",
 # "local-akb-mcp-test-secret"). Throwaway local values (same spirit as

--- a/docker-compose.keycloak.yaml
+++ b/docker-compose.keycloak.yaml
@@ -1,10 +1,11 @@
 # OPTIONAL local Keycloak overlay — for developing/testing the optional
-# Keycloak SSO login path. NOT part of the default stack.
+# Keycloak SSO login path AND the MCP OAuth Resource Server path
+# (claude.ai / Claude Code Custom Connectors). NOT part of the default stack.
 #
 # Usage:
 #   docker compose -f docker-compose.yaml -f docker-compose.keycloak.yaml up
 #
-# Then enable SSO in config/app.yaml (these match the imported realm
+# === SSO path === enable in config/app.yaml (matches the imported realm
 # `deploy/keycloak-dev/akb-realm.json` and the split localhost/container URLs):
 #
 #   keycloak_enabled: true
@@ -20,9 +21,33 @@
 #
 # Test user (in the imported realm): alice / alice-password (alice@example.com).
 #
-# The realm import ships a FIXED dev client secret ("local-akb-dev-secret").
-# That is a throwaway local value (same spirit as the hard-coded `akb`
-# Postgres password in docker-compose.yaml) — never reuse it anywhere real.
+# === MCP OAuth path === additionally:
+#
+#   mcp_oauth_enabled: true
+#   public_base_url: "http://localhost:8000"
+#   mcp_oauth_audience: ""    # default → "http://localhost:8000/mcp"
+#                             # MUST match the audience baked into the
+#                             # akb:vault:* scope mappers in akb-realm.json
+#
+# For E2E / CI (`backend/tests/test_mcp_oauth_e2e.sh`) the realm ships
+# `akb-mcp-test` — a confidential service-account client (secret
+# "local-akb-mcp-test-secret") with `akb:vault:read|write` as default
+# scopes. It mints access tokens via the client_credentials grant so
+# the test exercises the Resource Server path headlessly, without a
+# browser DCR roundtrip.
+#
+# Real Claude Code / claude.ai validation: the local Keycloak overlay
+# works for headless E2E but Claude Code's OAuth discovery requires
+# the AS metadata URL to be HTTPS. Easiest path is to point a local
+# AKB backend at the prod Keycloak realm at
+# `https://auth.seahorse.dnotitia.com/realms/akb` — already https, DCR
+# trusted-hosts already include `localhost`/`127.0.0.1`. See
+# `docs/mcp-clients/web-connectors.md` for the walkthrough.
+#
+# The realm import ships FIXED dev client secrets ("local-akb-dev-secret",
+# "local-akb-mcp-test-secret"). Throwaway local values (same spirit as
+# the hard-coded `akb` Postgres password in docker-compose.yaml) — never
+# reuse them anywhere real.
 
 services:
   keycloak:

--- a/docs/designs/mcp-oauth-dcr/00-overview.md
+++ b/docs/designs/mcp-oauth-dcr/00-overview.md
@@ -1,0 +1,323 @@
+# MCP OAuth + DCR — Resource Server, delegated AS
+
+**Status**: design draft (no code yet)
+**Started**: 2026-06-25
+**Related**: [`keycloak-oidc/00-overview.md`](../keycloak-oidc/00-overview.md) — existing optional Keycloak login path that this design reuses
+
+## Statement
+
+AKB gains an **optional** OAuth 2.1 path so that web-hosted LLM clients
+(claude.ai Custom Connectors, ChatGPT Custom Connectors, future Gemini
+Connectors) can register themselves against an AKB deployment and call
+`/mcp` with an access token instead of a Personal Access Token.
+
+AKB serves as an **OAuth Resource Server (RS) only**. The Authorization
+Server (AS) — including Dynamic Client Registration (RFC 7591),
+`/authorize`, consent UI, `/token`, PKCE, refresh rotation — is
+**delegated to a standards-compliant OIDC provider** (Keycloak in
+Dnotitia's reference deployment; any DCR-capable OIDC IdP works).
+
+When the operator does not configure an IdP, nothing changes — `/mcp`
+keeps accepting `Bearer akb_<PAT>` only, and stdio-based clients
+(Claude Desktop, Codex CLI via the `akb-mcp` proxy) work unchanged.
+
+## Why Resource Server only (the core constraint)
+
+Implementing a full OAuth 2.1 AS inside AKB would mean:
+
+- `/.well-known/oauth-authorization-server`
+- `POST /register` (DCR) + abuse mitigation (rate limit, software
+  statement, optional Protected DCR via initial access tokens)
+- `GET /authorize` + a hosted consent UI ("Claude wants to access
+  vault X with scopes Y, Z")
+- `POST /token` + PKCE enforcement + refresh token rotation
+- Token revocation (RFC 7009) + introspection (RFC 7662)
+- JWKS publication + key rotation
+
+This is 1–2 KLOC of carefully reviewed security-sensitive code, and an
+attack surface AKB is not in a position to harden faster than a
+mainstream IdP. The AS surface area is also where the catastrophic
+OAuth bugs live (consent bypass, redirect URI manipulation, PKCE
+downgrade, refresh replay, open registration abuse). Keycloak — and
+Auth0/Okta/etc. — have spent a decade specifically maturing this
+surface.
+
+By contrast, the Resource Server role is small and well-bounded:
+
+1. Validate the inbound JWT (signature against IdP JWKS, `iss`, `aud`,
+   `exp`).
+2. Map the JWT subject to an internal AKB `users.id`.
+3. Enforce the existing PG-native RBAC.
+
+Steps 1 and 2 already exist in
+[`backend/app/services/keycloak_oidc.py`](../../backend/app/services/keycloak_oidc.py)
+for the SSO login path. This design extends them to a second caller
+(the MCP HTTP handler) without changing their semantics.
+
+## Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| AKB role in OAuth | Resource Server only | Keep AKB out of consent/registration/token-rotation security surface. |
+| AS provider | Any RFC 7591-capable OIDC IdP (reference: Keycloak) | Already integrated; swappable per deployment. No code dep on Keycloak specifically. |
+| DCR handling | Delegated to IdP entirely | AKB advertises the IdP's registration endpoint via `oauth-protected-resource` metadata; clients register there directly. |
+| Identity mapping | Reuse `keycloak_oidc.resolve_jwt()` + `find_or_provision_user(claims)` | Same JIT path the SSO callback already uses; one helper, two callers. |
+| Default state | OAuth path disabled | When `oidc.enabled = false`, `/mcp` still accepts PAT only — current behavior preserved bit-for-bit. |
+| Scope model | `akb:vault:read`, `akb:vault:write` (vault-wide); finer grain deferred | Matches existing vault-level role grants. Per-collection scopes are not in OAuth — they stay in AKB's authorization layer. |
+| PAT compatibility | `/mcp` accepts BOTH `Bearer akb_<pat>` AND `Bearer <jwt>` | No breaking change for stdio/CLI users. Detected by token prefix. |
+| Consent UI | Hosted by IdP, not AKB | AKB does not render or own the consent screen. Scope names and i18n strings live in the IdP realm config. |
+| Audience claim | AKB validates `aud` includes its `resource` identifier | Prevents tokens issued for other RSes (or for the SPA itself) from being usable at `/mcp`. |
+
+## What AKB ships
+
+### 1. Protected-resource metadata endpoint
+
+Per RFC 9728 (OAuth 2.0 Protected Resource Metadata). New file
+`backend/app/api/routes/oauth_metadata.py`:
+
+```http
+GET /.well-known/oauth-protected-resource
+
+200 OK
+{
+  "resource": "https://akb.example.com/mcp",
+  "authorization_servers": ["https://kc.example.com/realms/akb"],
+  "scopes_supported": ["akb:vault:read", "akb:vault:write"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "https://akb.example.com/docs/mcp"
+}
+```
+
+When `oidc.enabled = false`, this endpoint returns `404 Not Found`. No
+`authorization_servers` advertised means clients fall through to
+PAT-only behavior.
+
+### 2. MCP handler accepts both token types
+
+`backend/mcp_server/http_app.py:69` is the sole change point. Pseudocode
+of the patch:
+
+```python
+auth_header = request.headers.get("authorization", "")
+token = auth_header.removeprefix("Bearer ").strip()
+
+if token.startswith("akb_"):
+    user = await resolve_token(auth_header)               # PAT path (existing)
+elif settings.oidc.enabled and token:
+    user = await resolve_oidc_jwt(token, audience=MCP_RESOURCE)   # new
+else:
+    user = None
+
+if not user:
+    return _unauthorized_with_resource_metadata_hint()
+```
+
+The `WWW-Authenticate` response header on 401 includes a
+`resource_metadata=` parameter (RFC 9728 §5) pointing clients at the
+`.well-known` URL above so they can complete discovery.
+
+### 3. `resolve_oidc_jwt` helper
+
+Added to `backend/app/services/auth_service.py` (or co-located in
+`keycloak_oidc.py`). Wraps the existing JWT verifier plus the existing
+user lookup:
+
+```python
+async def resolve_oidc_jwt(token: str, audience: str) -> User | None:
+    claims = await keycloak_oidc.verify_jwt(token, audience=audience)
+    if not claims:
+        return None
+    return await find_or_provision_user(claims)            # extracted from
+                                                            # current SSO callback
+```
+
+The extraction of `find_or_provision_user` from the SSO callback into a
+standalone helper is the only meaningful refactor — both call sites
+(SSO browser flow + MCP machine-to-machine flow) then share one path.
+
+### 4. Audience constant
+
+`MCP_RESOURCE = f"{settings.public_url}/mcp"` exposed from config so the
+JWKS verifier can enforce `aud` matches. Tokens minted for the SPA login
+flow (audience = `"akb-web"`) MUST NOT be usable at `/mcp`, and vice
+versa.
+
+### 5. Scope enforcement (optional in v1)
+
+A small middleware that reads `scope` claim and maps to required
+operation:
+
+| MCP tool family | Required scope |
+|---|---|
+| `akb_search`, `akb_get`, `akb_browse`, `akb_grep`, `akb_drill_down`, `akb_history`, `akb_relations`, `akb_graph` | `akb:vault:read` |
+| `akb_put`, `akb_update`, `akb_delete`, `akb_edit`, `akb_link`, `akb_unlink`, `akb_create_collection`, `akb_create_table`, `akb_alter_table`, `akb_publish`, `akb_unpublish`, file tools | `akb:vault:write` |
+
+If neither scope is present, return `403 insufficient_scope`. The
+existing PG-RBAC layer still gates per-vault access; scopes are an
+additional coarse gate that the IdP can present at consent time.
+
+## What the operator configures (Keycloak example)
+
+This is **realm configuration**, not AKB code:
+
+- Realm: `akb` (the existing realm from the `keycloak-oidc` design)
+- Client scopes:
+  - `akb:vault:read` — consent text: *"Read your AKB vaults"*
+  - `akb:vault:write` — consent text: *"Create, edit, and delete AKB content"*
+- DCR: enable "Trusted Hosts" policy (default Keycloak DCR is open;
+  Trusted Hosts limits which client `redirect_uris` are accepted at
+  registration time — set to `claude.ai`, `chat.openai.com`, etc.)
+- Optional: Initial Access Token requirement (Protected DCR) for hostile
+  internet exposure. Mint a one-shot token per partner.
+- Optional: client policies forcing PKCE S256 on all dynamically
+  registered clients.
+
+Recommended: ship `deploy/k8s/internal/keycloak-realm-akb.json` with the
+above scopes + policies pre-defined so operators only need to import it.
+
+## Flow
+
+### Discovery + DCR (one time per client)
+
+```
+[claude.ai backend]
+    GET https://akb.example.com/.well-known/oauth-protected-resource
+        → { authorization_servers: ["https://kc.example.com/realms/akb"], ... }
+
+    GET https://kc.example.com/realms/akb/.well-known/openid-configuration
+        → { registration_endpoint: ".../clients-registrations/openid-connect",
+            authorization_endpoint, token_endpoint, jwks_uri, ... }
+
+    POST .../clients-registrations/openid-connect
+        Body: { "client_name": "Claude",
+                "redirect_uris": ["https://claude.ai/api/oauth/callback"],
+                "token_endpoint_auth_method": "none",      # public client
+                "grant_types": ["authorization_code","refresh_token"] }
+        → { "client_id": "kc-generated-uuid", ... }
+```
+
+AKB never sees any of this. AKB code did not run.
+
+### User authorization (per user, once per token lifetime)
+
+```
+[Claude UI]  user clicks "Connect AKB"
+             → Claude redirects browser to Keycloak /authorize
+                 with PKCE, scope="akb:vault:read akb:vault:write",
+                 audience=https://akb.example.com/mcp
+
+[Keycloak]   user logs in (or uses existing SSO session)
+             consent screen lists the two scopes with the configured
+             human-readable text
+             → 302 back to claude.ai/api/oauth/callback?code=…
+
+[Claude backend]
+             POST kc/.../token  (code + verifier)
+             → { access_token (JWT, aud=akb-mcp), refresh_token, expires_in }
+```
+
+### MCP request (every tool call)
+
+```
+[Claude]     POST https://akb.example.com/mcp
+             Authorization: Bearer <jwt>
+             body: { "method": "tools/call", "params": { "name": "akb_search", ... } }
+
+[AKB /mcp]   token prefix ≠ "akb_" + oidc.enabled → resolve_oidc_jwt(jwt, aud=MCP_RESOURCE)
+             verify_jwt: JWKS sig + iss + aud + exp + scope contains akb:vault:read
+             find_or_provision_user(claims.email) → users.id
+             SET LOCAL ROLE akb_user_<uid>          (existing PG-RBAC path)
+             dispatch tool
+             → 200
+```
+
+## What this design explicitly does not do
+
+- **Does not implement an AS inside AKB.** No `/register`, `/authorize`,
+  `/token`, consent UI, refresh rotation, or JWKS publication is added.
+- **Does not change PAT behavior.** All current stdio/CLI/Desktop flows
+  continue to work. PAT and JWT coexist on `/mcp`.
+- **Does not change the SPA login.** Web UI continues to use the existing
+  AKB-issued JWT via `/api/v1/auth/login` (or `/auth/keycloak/exchange`
+  when SSO is on). The OAuth path here is exclusively for **third-party
+  MCP clients**.
+- **Does not add per-collection scopes.** OAuth scope vocabulary stays
+  coarse (`vault:read` / `vault:write`); fine-grained access continues
+  to live in AKB's PG-RBAC + `vault_access` table.
+- **Does not solve the "internal-only AKB + cloud LLM" reachability
+  problem.** If AKB is not reachable from claude.ai's egress, OAuth
+  cannot help — operator must expose via tunnel or public hostname. See
+  the connector reachability matrix in the project memory.
+
+## Open questions (resolve before implementation)
+
+1. **Resource Indicators (RFC 8707).** Should AKB require clients to
+   pass `resource=https://akb.example.com/mcp` on the token request so
+   Keycloak can mint a narrow-audience token? Strong yes if Keycloak
+   version supports it; defer if it forces a Keycloak upgrade.
+2. **Token introspection vs. JWT-only.** Pure JWT validation is simpler
+   and stateless. Introspection would let AKB see live revocation but
+   adds a hop per request. Decision: JWT-only in v1; introspection
+   deferred.
+3. **PAT lifecycle parity.** PATs can be revoked instantly via
+   `tokens_revoked_before`. OAuth access tokens cannot, short of
+   shrinking TTL. Recommend `access_token` TTL ≤ 15 min + refresh, to
+   keep blast radius small without introducing introspection.
+4. **Multi-tenant deployments.** If a single AKB serves multiple
+   tenants, do we want one realm per tenant or one realm with multiple
+   audiences? Keep out of v1 — single realm assumed.
+5. **OAuth Dynamic Client Registration Metadata extensions.** MCP spec
+   has been adding optional fields (e.g. `software_id` per server).
+   Track upstream spec PRs before locking metadata shape.
+6. **Migration story for existing PAT users.** None needed — PAT path
+   stays. Optional: surface "connect via OAuth" CTA in the AKB web UI
+   for users who want to use claude.ai connectors.
+
+## Out of scope
+
+- ChatGPT/Anthropic "verified publisher" listing — orthogonal product
+  decision, not a code concern.
+- A first-party AKB consent screen — IdP owns it. If we ever decide we
+  want AKB-branded consent, that becomes a separate design and pulls
+  the consent surface onto the AS we'd then have to build.
+- Replacing PAT entirely — not on the table; PAT is the right primitive
+  for headless/CI and stdio proxy use.
+
+## Implementation plan (sketch)
+
+Sized rough; refine in implementation PR.
+
+1. Add `MCP_RESOURCE` to `config.py`; gate everything on
+   `settings.oidc.enabled`.
+2. Extract `find_or_provision_user(claims)` from
+   `keycloak_oidc.callback()` into `auth_service`.
+3. Add `verify_jwt(token, audience)` to `keycloak_oidc` (audience param
+   already validatable — the SSO path passes `audience=None` today;
+   refactor to thread an explicit audience).
+4. Add `resolve_oidc_jwt` to `auth_service`.
+5. Patch `backend/mcp_server/http_app.py` token branch + 401
+   `WWW-Authenticate` header.
+6. Add `oauth_metadata.py` route + mount in `main.py`.
+7. Realm config bundle in `deploy/k8s/internal/keycloak-realm-akb.json`
+   (scopes + Trusted Hosts policy).
+8. Tests:
+   - Unit: JWT with wrong `aud` rejected; missing scope → 403;
+     PAT still works; both token types in mixed traffic; metadata
+     endpoint shape.
+   - E2E (`backend/tests/test_mcp_oauth_e2e.sh`): mint a token via
+     real Keycloak fixture, call `/mcp`, exercise a read + a write
+     tool, exercise revocation by shortening TTL.
+9. Docs:
+   - `docs/mcp-clients/web-connectors.md` — how to add AKB as a custom
+     connector in claude.ai / ChatGPT.
+   - Update `README.md` connector section.
+
+## References
+
+- RFC 7591 — Dynamic Client Registration
+- RFC 7592 — DCR Management Protocol (probably out of scope for v1)
+- RFC 8707 — Resource Indicators
+- RFC 9728 — Protected Resource Metadata
+- RFC 9700 — OAuth 2.0 Security Best Current Practice
+- MCP spec, "Authorization" section (current revision)
+- Existing AKB design: [`keycloak-oidc/00-overview.md`](../keycloak-oidc/00-overview.md)

--- a/docs/mcp-clients/web-connectors.md
+++ b/docs/mcp-clients/web-connectors.md
@@ -86,8 +86,14 @@ Should return JSON with `resource`, `authorization_servers`, and
 ## Add AKB to Claude Code
 
 ```bash
-claude mcp add --transport http akb https://akb.example.com/mcp
+claude mcp add --transport http akb https://akb.example.com/mcp/
 ```
+
+> **Trailing slash matters.** Register with the trailing `/mcp/`, not
+> bare `/mcp`. Backend issues a 307 redirect from `/mcp` → `/mcp/`,
+> which drops the POST body and breaks the session/initialize
+> handshake — the connector then appears as "Failed to connect" in
+> `claude mcp list` even though OAuth succeeded.
 
 The command itself does **not** open a browser. `claude mcp list` will
 show:

--- a/docs/mcp-clients/web-connectors.md
+++ b/docs/mcp-clients/web-connectors.md
@@ -1,0 +1,212 @@
+# Connecting AKB to a Web LLM Client (OAuth + DCR)
+
+This guide is for connecting AKB to an MCP client that speaks the
+**MCP OAuth Resource Server path** — Claude Code (HTTP transport),
+claude.ai Custom Connectors, and ChatGPT Custom Connectors. For
+stdio-based clients (Claude Desktop, Codex CLI via `akb-mcp`,
+Claude Code via the stdio proxy), see the project README: the PAT
+flow there is unchanged.
+
+## What you need
+
+| Piece | Why |
+|---|---|
+| AKB backend ≥ the version that ships `mcp_oauth_enabled` | Adds the Resource Server code path |
+| An OIDC IdP — Keycloak in the reference deployment | AKB does NOT host an Authorization Server; the IdP issues access tokens |
+| Realm configuration: `akb:vault:read`, `akb:vault:write` scopes (each with an audience mapper) + DCR trusted hosts + `offline_access` exposed | Lets clients DCR-register and request the scopes the consent screen presents |
+| `config/app.yaml`: `mcp_oauth_enabled: true`, a non-empty `public_base_url` | Activates the new path. Default keeps it off so PAT-only deployments are bit-for-bit unchanged |
+
+## Configure the IdP (one-shot)
+
+Either run the realm setup script (recommended) or hand-edit the realm
+in the Keycloak admin console. The script is idempotent — re-running
+it is a no-op.
+
+```bash
+KC_ADMIN_USER=admin KC_ADMIN_PASS=<...> \
+    python3 scripts/keycloak/setup-akb-mcp-oauth.py \
+        --kc https://auth.example.com \
+        --realm akb \
+        --audience https://akb.example.com/mcp
+```
+
+It will:
+
+1. Add `localhost`, `127.0.0.1` to the realm's DCR `trusted-hosts`
+   policy (so Claude Code on the operator's laptop can DCR-register).
+2. Create `akb:vault:read` and `akb:vault:write` scopes with audience
+   mappers pinned to the AKB `/mcp` URL.
+3. Add both scopes to `defaultOptionalClientScopes` so DCR clients can
+   request them.
+
+If the realm already had any of the above, those steps no-op.
+
+### Hand-edit checklist (if you skip the script)
+
+In the Keycloak admin console, in your realm:
+
+- **Realm Settings → Client Registration → Policies**: open `Trusted
+  Hosts` and add `localhost`, `127.0.0.1` to the trusted hosts list.
+- **Client Scopes → Create**: add `akb:vault:read` and `akb:vault:write`
+  with the listed display + consent text. Add an `oidc-audience-mapper`
+  protocol mapper to each, with `Included Custom Audience` set to your
+  AKB `/mcp` URL (e.g. `https://akb.example.com/mcp`).
+- **Realm Settings → Client Scopes → Default Client Scopes** (Optional
+  column): assign both new scopes as Optional.
+
+## Configure the backend
+
+In `config/app.yaml`:
+
+```yaml
+# Existing SSO settings (required — MCP OAuth piggybacks on the JWKS
+# config). If your deployment already has SSO on, leave these as-is.
+keycloak_enabled: true
+keycloak_server_url: "https://auth.example.com"      # browser-facing → token `iss`
+keycloak_internal_url: "https://auth.example.com"    # backend → IdP backchannel
+keycloak_realm: "akb"
+
+# The new MCP OAuth path
+mcp_oauth_enabled: true
+public_base_url: "https://akb.example.com"
+# mcp_oauth_audience defaults to <public_base_url>/mcp — only set this
+# if the MCP endpoint lives on a different hostname than public_base_url.
+```
+
+Restart the backend. Sanity check the metadata document:
+
+```bash
+curl https://akb.example.com/.well-known/oauth-protected-resource
+```
+
+Should return JSON with `resource`, `authorization_servers`, and
+`scopes_supported` (including `akb:vault:read`, `akb:vault:write`,
+`offline_access`).
+
+## Add AKB to Claude Code
+
+```bash
+claude mcp add --transport http akb https://akb.example.com/mcp
+```
+
+The command itself does **not** open a browser. `claude mcp list` will
+show:
+
+```
+akb   ! Needs authentication
+```
+
+Complete OAuth one of two ways:
+
+- **Up-front, before the session**:
+  ```bash
+  claude mcp login akb
+  ```
+  (requires Claude Code ≥ v2.1.186). A browser opens, prompts you to
+  log in to Keycloak, presents the consent screen, and stores the
+  resulting tokens on your machine (macOS keychain, or
+  `~/.claude/mcp-credentials` on other platforms).
+
+- **Lazily, inside a session**: run `/mcp` in the session, select `akb`,
+  and choose `Authenticate`. A browser opens for the same flow.
+
+Once authenticated, Claude Code calls `https://akb.example.com/mcp`
+with `Authorization: Bearer <access_token>`. The access token is
+auto-refreshed silently as long as the IdP advertises `offline_access`
+in its `scopes_supported` — which the AKB realm does.
+
+If the IdP fails to advertise `offline_access`, tokens expire (default
+Keycloak access TTL is 5 minutes) and Claude Code re-opens the browser
+mid-session. Verify with:
+```bash
+curl https://auth.example.com/realms/akb/.well-known/openid-configuration \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print("scopes_supported:", d.get("scopes_supported"))'
+```
+
+## Add AKB to claude.ai or ChatGPT (Custom Connector)
+
+For claude.ai / ChatGPT, AKB must be reachable from the cloud LLM's
+egress — i.e. on a public hostname with TLS. If your deployment is
+internal-only, see the next section.
+
+Settings → Connectors → *Add custom connector* → URL
+`https://akb.example.com/mcp`. The client auto-discovers
+`/.well-known/oauth-protected-resource`, DCR-registers itself against
+Keycloak, and runs the consent flow on the next user interaction.
+
+## Internal-only deployments
+
+If AKB is not reachable from the public internet (which is the
+Dnotitia reference deployment), Claude Code is the right client:
+the OAuth flow runs entirely between **your laptop** ↔ **AKB backend
+on the internal network** ↔ **Keycloak on the internal network**.
+No tunnel, no public hostname. The browser that opens for consent
+runs on the same laptop, so it can reach the internal Keycloak just
+like the rest of your session.
+
+claude.ai and ChatGPT Custom Connectors cannot reach an internal-only
+backend — the discovery call originates from their cloud. Use Claude
+Code (or a stdio client + PAT) for those deployments.
+
+## Troubleshooting
+
+### Claude Code shows "Needs authentication" but `claude mcp login` says "Incompatible auth server"
+
+The realm does not have DCR enabled, or the requesting host is not in
+the `trusted-hosts` policy. Re-run `setup-akb-mcp-oauth.py` (or check
+that step in the hand-edit checklist).
+
+### Tokens expire and the browser keeps reopening mid-session
+
+The realm is not advertising `offline_access`. Check
+`/.well-known/openid-configuration` on the IdP — `scopes_supported`
+must include `offline_access`. Keycloak ships it by default; if it is
+missing, your realm export removed it.
+
+### `/.well-known/oauth-protected-resource` returns 404
+
+`mcp_oauth_enabled` is not true in the running backend's
+`config/app.yaml`. Check `curl https://akb.example.com/readyz` first
+to confirm you are hitting the right deployment, then check the
+ConfigMap / app.yaml the live backend is reading.
+
+### `/mcp` returns 401 with an OAuth token that worked yesterday
+
+Audience mismatch — the token was minted with `aud` baked from the
+scope-level mapper. If you changed `public_base_url` (or
+`mcp_oauth_audience`) without re-running `setup-akb-mcp-oauth.py`,
+the realm still emits the old audience and the backend rejects it.
+Re-run the setup script with the new `--audience` and have users
+`claude mcp logout akb && claude mcp login akb` to get a token with
+the corrected `aud`.
+
+## How the pieces fit (recap)
+
+```
+[Claude Code]                [AKB backend]               [Keycloak]
+
+claude mcp add http://akb/mcp
+                       (saves config; no browser)
+
+claude mcp login akb
+  ────────── GET /.well-known/oauth-protected-resource ─→
+  ←──────────── { authorization_servers: [...] } ──────────
+  ─────────────── GET .../openid-configuration ─────────────────→
+  ←─────────── { registration_endpoint, ... } ────────────────────
+  ──────────────────── POST .../clients-registrations (DCR) ────→
+  ←───────────────────── { client_id: ... } ───────────────────────
+  [browser opens]
+                                                     /authorize?…
+                                                     [user logs in + consents]
+  ────────────────────────── POST .../token (code + PKCE) ─────→
+  ←─────────────── { access_token, refresh_token } ────────────────
+                       (tokens stored locally)
+
+claude > "list my AKB vaults"
+  ───────────── POST http://akb/mcp  Bearer <access_token> ────→
+                                  verify_access_token (JWKS, aud, iss, exp)
+                                  resolve_or_provision_keycloak_user
+                                  scope check (akb:vault:read)
+                                  dispatch akb_list_vaults
+                              ←──── { vaults: [...] } ────
+```

--- a/docs/mcp-clients/web-connectors.md
+++ b/docs/mcp-clients/web-connectors.md
@@ -45,8 +45,21 @@ If the realm already had any of the above, those steps no-op.
 
 In the Keycloak admin console, in your realm:
 
-- **Realm Settings → Client Registration → Policies**: open `Trusted
-  Hosts` and add `localhost`, `127.0.0.1` to the trusted hosts list.
+- **Realm Settings → Client Registration → Policies → Trusted Hosts**:
+  - Add `localhost`, `127.0.0.1` to the trusted hosts list (the
+    redirect-URI guard).
+  - **Turn OFF** `Host sending registration request must match` —
+    MCP clients DCR from dynamic IPs (a laptop on the move,
+    claude.ai's egress) that can't be allowlisted upfront. The
+    redirect-URI guard is the meaningful check; the sender-IP check
+    rejects every legitimate registration if left on.
+- **Realm Settings → Client Registration → Policies → Allowed Client
+  Scopes (anonymous)**: **Delete this policy.** Keycloak does not
+  list the OIDC sentinel scope `openid` in its client-scope catalog,
+  so the default policy rejects every spec-compliant DCR request
+  (Claude Code, claude.ai, ChatGPT all include `openid` in the DCR
+  scope field). The `Consent Required`, `Trusted Hosts` (URI), and
+  `Max Clients Limit` policies stay as the meaningful guards.
 - **Client Scopes → Create**: add `akb:vault:read` and `akb:vault:write`
   with the listed display + consent text. Add an `oidc-audience-mapper`
   protocol mapper to each, with `Included Custom Audience` set to your

--- a/frontend/src/components/quickstart-dialog.tsx
+++ b/frontend/src/components/quickstart-dialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Rocket, Plus, Copy, Check, Eye, EyeOff } from "lucide-react";
 import {
   Dialog,
@@ -13,8 +13,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CodeSnippet } from "@/components/ui/code-snippet";
-import { createPAT } from "@/lib/api";
-import { mcpInstallSnippets, MCP_AGENT_LABELS, MCP_AGENT_FILES, type McpAgent } from "@/lib/mcp-snippets";
+import { createPAT, getAuthConfig } from "@/lib/api";
+import {
+  mcpInstallSnippets,
+  mcpOAuthSnippets,
+  MCP_AGENT_LABELS,
+  MCP_AGENT_FILES,
+  type McpAgent,
+} from "@/lib/mcp-snippets";
+
+type ConnectMode = "pat" | "oauth";
 
 export const QUICKSTART_DISMISS_KEY = "akb.quickstartDismissed";
 
@@ -39,6 +47,22 @@ export function QuickstartDialog({
   const [showPat, setShowPat] = useState(true);
   const [copied, setCopied] = useState(false);
   const [agent, setAgent] = useState<McpAgent>("claude");
+  // Surface the OAuth path alongside PAT mint when the backend has
+  // mcp_oauth_enabled. Default mode = `pat` for parity with the rest of
+  // the quickstart flow, but a fresh user with OAuth available can flip
+  // and skip Step 1 entirely.
+  const [oauthEnabled, setOauthEnabled] = useState(false);
+  const [connectMode, setConnectMode] = useState<ConnectMode>("pat");
+  useEffect(() => {
+    let cancelled = false;
+    getAuthConfig().then((cfg) => {
+      if (!cancelled) setOauthEnabled(!!cfg.mcp_oauth?.enabled);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const oauthSnippetsMap = useMemo(() => mcpOAuthSnippets(), []);
 
   const snippets = useMemo(() => mcpInstallSnippets(pat || "<YOUR_PAT>"), [pat]);
 
@@ -149,6 +173,36 @@ export function QuickstartDialog({
         {/* Step 2 — install snippet */}
         <div className="space-y-2">
           <div className="coord-spark">Step 2 · Add it to your agent</div>
+          {/* Same Token/OAuth toggle as Settings → Tokens — hidden when
+              the backend doesn't advertise the OAuth path. */}
+          {oauthEnabled && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="coord">Auth</span>
+              <div className="inline-flex rounded-[var(--radius-sm)] border border-border overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setConnectMode("pat")}
+                  className={`px-3 py-1 ${connectMode === "pat" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                  aria-pressed={connectMode === "pat"}
+                >
+                  Token (PAT)
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConnectMode("oauth")}
+                  className={`px-3 py-1 ${connectMode === "oauth" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                  aria-pressed={connectMode === "oauth"}
+                >
+                  OAuth
+                </button>
+              </div>
+              <span className="text-foreground-muted">
+                {connectMode === "oauth"
+                  ? "Skip Step 1 — sign in via browser."
+                  : "Use the PAT minted in Step 1."}
+              </span>
+            </div>
+          )}
           <Tabs value={agent} onValueChange={(v) => setAgent(v as McpAgent)}>
             <TabsList className="flex-wrap">
               {(Object.keys(MCP_AGENT_LABELS) as McpAgent[]).map((a) => (
@@ -156,9 +210,25 @@ export function QuickstartDialog({
               ))}
             </TabsList>
             <TabsContent value={agent} className="pt-2">
-              <CodeSnippet code={snippets[agent]} filename={MCP_AGENT_FILES[agent]} />
-              {!pat && (
-                <p className="mt-2 coord">Mint a token above to drop a ready-to-paste command.</p>
+              {connectMode === "oauth" ? (
+                oauthSnippetsMap[agent] !== undefined ? (
+                  <CodeSnippet
+                    code={oauthSnippetsMap[agent] as string}
+                    filename={MCP_AGENT_FILES[agent]}
+                  />
+                ) : (
+                  <div className="rounded-[var(--radius-md)] border border-border px-4 py-3 text-sm text-foreground-muted">
+                    {MCP_AGENT_LABELS[agent]} uses the stdio path — switch the
+                    toggle to <span className="text-accent-strong">Token (PAT)</span> for its snippet.
+                  </div>
+                )
+              ) : (
+                <>
+                  <CodeSnippet code={snippets[agent]} filename={MCP_AGENT_FILES[agent]} />
+                  {!pat && (
+                    <p className="mt-2 coord">Mint a token above to drop a ready-to-paste command.</p>
+                  )}
+                </>
               )}
             </TabsContent>
           </Tabs>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,14 +155,25 @@ export const authLogin = (username: string, password: string) =>
 
 export interface AuthConfig {
   keycloak: { enabled: boolean; login_url: string | null };
+  // Optional — present on newer backends. Tells the connect-snippet UI
+  // whether the OAuth Resource Server path is live so it can offer
+  // `claude mcp add --transport http … && claude mcp login` alongside
+  // the PAT snippet.
+  mcp_oauth?: { enabled: boolean };
 }
 
-/** Public auth config — drives whether the optional SSO button shows.
- * Falls back to SSO-disabled if the endpoint is unreachable/old. */
+const _AUTH_CONFIG_FALLBACK: AuthConfig = {
+  keycloak: { enabled: false, login_url: null },
+  mcp_oauth: { enabled: false },
+};
+
+/** Public auth config — drives whether the optional SSO button shows
+ * and whether the connect-snippet UI offers the OAuth path. Falls back
+ * to all-disabled if the endpoint is unreachable/old. */
 export const getAuthConfig = (): Promise<AuthConfig> =>
   fetch(`${API_BASE}/auth/config`)
-    .then((r) => (r.ok ? r.json() : { keycloak: { enabled: false, login_url: null } }))
-    .catch(() => ({ keycloak: { enabled: false, login_url: null } }));
+    .then((r) => (r.ok ? r.json() : _AUTH_CONFIG_FALLBACK))
+    .catch(() => _AUTH_CONFIG_FALLBACK);
 
 /** Redeem the one-time SSO code from the Keycloak callback for an AKB JWT. */
 export const keycloakExchange = (code: string) =>

--- a/frontend/src/lib/mcp-snippets.ts
+++ b/frontend/src/lib/mcp-snippets.ts
@@ -36,3 +36,32 @@ export function mcpInstallSnippets(pat: string): Record<McpAgent, string> {
     openclaw: JSON.stringify({ mcp: { servers: { akb: { command: "npx", args } } } }, null, 2),
   };
 }
+
+/**
+ * Per-agent install snippet for the OAuth Resource Server path — no PAT
+ * required, the agent does Dynamic Client Registration + an OAuth 2.1
+ * authorization-code flow against the AKB-configured OIDC provider (Keycloak
+ * in the reference deployment) and stores the resulting tokens itself.
+ *
+ * Only meaningful when the backend has `mcp_oauth_enabled = true`. Surfaced
+ * from `/api/v1/auth/config.mcp_oauth.enabled` so the UI can pick which
+ * snippet to render.
+ *
+ * Agents that don't support remote-HTTP MCP at all (e.g. stdio-only
+ * clients) are not present in the result — callers should treat keys as
+ * optional and fall back to the PAT snippet.
+ */
+export function mcpOAuthSnippets(): Partial<Record<McpAgent, string>> {
+  return {
+    // Claude Code's `mcp add` registers the server config; the separate
+    // `mcp login` opens a browser for the OAuth flow. The two-step shape
+    // matches the documented Claude Code UX and produces a clear copy-
+    // and-paste pair the user can run back-to-back.
+    claude: [
+      `claude mcp add --scope user --transport http akb ${MCP_URL}`,
+      `claude mcp login akb`,
+    ].join("\n"),
+    cursor: JSON.stringify({ mcpServers: { akb: { url: MCP_URL } } }, null, 2),
+    vscode: JSON.stringify({ servers: { akb: { type: "http", url: MCP_URL } } }, null, 2),
+  };
+}

--- a/frontend/src/pages/__tests__/settings-tokens-setup.test.tsx
+++ b/frontend/src/pages/__tests__/settings-tokens-setup.test.tsx
@@ -16,6 +16,13 @@ vi.mock("@/lib/api", () => ({
   adminDeleteUser: vi.fn(),
   changePassword: vi.fn(),
   updateProfile: vi.fn(),
+  // tokens-section calls this on mount to decide whether to show the
+  // OAuth toggle alongside the PAT snippet. Mock as "OAuth off" so
+  // these tests stay focused on the PAT-mint UX they were written for.
+  getAuthConfig: vi.fn().mockResolvedValue({
+    keycloak: { enabled: false, login_url: null },
+    mcp_oauth: { enabled: false },
+  }),
 }));
 
 vi.mock("@/hooks/use-theme", () => ({

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -39,10 +39,17 @@ import {
   createPAT,
   listPATs,
   revokePAT,
+  getAuthConfig,
 } from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
 import { recentIcon, recentTone } from "@/lib/recent";
-import { mcpInstallSnippets, MCP_AGENT_FILES } from "@/lib/mcp-snippets";
+import {
+  mcpInstallSnippets,
+  mcpOAuthSnippets,
+  MCP_AGENT_FILES,
+} from "@/lib/mcp-snippets";
+
+type ConnectMode = "pat" | "oauth";
 
 type Tab = "claude" | "cursor" | "codex" | "vscode" | "openclaw";
 
@@ -189,6 +196,20 @@ export default function HomePage() {
 
   const pat = activePat || "<YOUR_PAT>";
   const snippets = useMemo(() => mcpInstallSnippets(pat), [pat]);
+  const oauthSnippetsMap = useMemo(() => mcpOAuthSnippets(), []);
+  // Toggle gated on the backend advertising mcp_oauth.enabled. Default
+  // mode = PAT for parity with the rest of the home CONNECT UX.
+  const [oauthEnabled, setOauthEnabled] = useState(false);
+  const [connectMode, setConnectMode] = useState<ConnectMode>("pat");
+  useEffect(() => {
+    let cancelled = false;
+    getAuthConfig().then((cfg) => {
+      if (!cancelled) setOauthEnabled(!!cfg.mcp_oauth?.enabled);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Home shows a preview of the vault directory; the full list (with filter)
   // lives on /vault. Memoized so <VaultList> doesn't re-fetch metrics on every
@@ -483,6 +504,31 @@ export default function HomePage() {
               {/* Snippet — compact tabs, one panel. */}
               <div className="p-4 border-b border-border">
                 <div className="coord-spark mb-2">Drop snippet</div>
+                {oauthEnabled && (
+                  <div className="flex items-center gap-2 text-[10px] mb-2">
+                    <div className="inline-flex rounded-[var(--radius-sm)] border border-border overflow-hidden">
+                      <button
+                        type="button"
+                        onClick={() => setConnectMode("pat")}
+                        className={`px-2 py-0.5 ${connectMode === "pat" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                        aria-pressed={connectMode === "pat"}
+                      >
+                        PAT
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConnectMode("oauth")}
+                        className={`px-2 py-0.5 ${connectMode === "oauth" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                        aria-pressed={connectMode === "oauth"}
+                      >
+                        OAuth
+                      </button>
+                    </div>
+                    <span className="text-foreground-muted">
+                      {connectMode === "oauth" ? "Browser sign-in." : "Paste a minted token."}
+                    </span>
+                  </div>
+                )}
                 <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
                   <TabsList className="flex-wrap gap-0 mb-2">
                     <TabsTrigger value="claude" className="px-2 py-1 text-[10px]">Claude Code</TabsTrigger>
@@ -492,7 +538,20 @@ export default function HomePage() {
                     <TabsTrigger value="openclaw" className="px-2 py-1 text-[10px]">OpenClaw</TabsTrigger>
                   </TabsList>
                   <TabsContent value={tab}>
-                    <CodeSnippet code={snippets[tab]} filename={MCP_AGENT_FILES[tab]} />
+                    {connectMode === "oauth" ? (
+                      oauthSnippetsMap[tab] !== undefined ? (
+                        <CodeSnippet
+                          code={oauthSnippetsMap[tab] as string}
+                          filename={MCP_AGENT_FILES[tab]}
+                        />
+                      ) : (
+                        <div className="rounded-[var(--radius-md)] border border-border px-3 py-2 text-[10px] text-foreground-muted">
+                          stdio path — switch to PAT for this client.
+                        </div>
+                      )
+                    ) : (
+                      <CodeSnippet code={snippets[tab]} filename={MCP_AGENT_FILES[tab]} />
+                    )}
                   </TabsContent>
                 </Tabs>
               </div>

--- a/frontend/src/pages/settings/tokens-section.tsx
+++ b/frontend/src/pages/settings/tokens-section.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { createPAT, revokePAT } from "@/lib/api";
+import { createPAT, getAuthConfig, revokePAT } from "@/lib/api";
 import { formatDate, timeAgo } from "@/lib/utils";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -21,13 +21,16 @@ import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  MCP_URL,
   mcpInstallSnippets,
+  mcpOAuthSnippets,
   MCP_AGENT_FILES,
   MCP_AGENT_LABELS,
   type McpAgent,
 } from "@/lib/mcp-snippets";
 
 type ClientTab = McpAgent;
+type ConnectMode = "pat" | "oauth";
 
 export interface PAT {
   token_id: string;
@@ -60,6 +63,26 @@ export function TokensSection({ pats, patsError, onReloadPats }: Props) {
   const [pendingRevokePat, setPendingRevokePat] = useState<PAT | null>(null);
 
   const [clientTab, setClientTab] = useState<ClientTab>("claude");
+  // OAuth path is gated on the backend advertising mcp_oauth.enabled.
+  // Fetched once on mount; stays `false` if the auth-config endpoint is
+  // a pre-MCP-OAuth backend (the field will be absent and the optional
+  // chain falls through).
+  const [oauthEnabled, setOauthEnabled] = useState(false);
+  const [connectMode, setConnectMode] = useState<ConnectMode>("pat");
+  useEffect(() => {
+    let cancelled = false;
+    getAuthConfig().then((cfg) => {
+      if (!cancelled) setOauthEnabled(!!cfg.mcp_oauth?.enabled);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  // OAuth snippets cover only the agents whose remote-HTTP MCP support
+  // is solid (Claude Code, Cursor, VS Code). Codex / OpenClaw still
+  // route through the stdio PAT proxy, so a tab in OAuth mode that has
+  // no snippet falls back to a hint pointing the user back to PAT.
+  const oauthSnippetsMap = useMemo(() => mcpOAuthSnippets(), []);
   const [setupOpen, setSetupOpen] = useState<boolean | null>(() => {
     const saved = localStorage.getItem("akb:tokens-setup-open");
     if (saved === "true") return true;
@@ -401,6 +424,40 @@ export function TokensSection({ pats, patsError, onReloadPats }: Props) {
                   next launch.
                 </p>
 
+                {/* PAT vs OAuth mode toggle — only visible when this AKB
+                    deployment has the OAuth Resource Server path enabled.
+                    OAuth is the lighter UX (no token to mint or rotate) but
+                    requires a configured OIDC provider on the backend; the
+                    PAT flow keeps working unchanged in either mode. */}
+                {oauthEnabled && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="coord">Auth</span>
+                    <div className="inline-flex rounded-[var(--radius-sm)] border border-border overflow-hidden">
+                      <button
+                        type="button"
+                        onClick={() => setConnectMode("pat")}
+                        className={`px-3 py-1 ${connectMode === "pat" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                        aria-pressed={connectMode === "pat"}
+                      >
+                        Token (PAT)
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConnectMode("oauth")}
+                        className={`px-3 py-1 ${connectMode === "oauth" ? "bg-primary text-primary-foreground" : "bg-surface text-foreground-muted hover:text-foreground"}`}
+                        aria-pressed={connectMode === "oauth"}
+                      >
+                        OAuth
+                      </button>
+                    </div>
+                    <span className="text-foreground-muted">
+                      {connectMode === "oauth"
+                        ? "Agent signs in via browser — no PAT needed."
+                        : "Mint a token in Step 01 above and paste below."}
+                    </span>
+                  </div>
+                )}
+
                 {/* Client picker + snippet — Tabs gives roving tabindex,
                     role=tab/aria-selected, arrow-key nav, and the teal
                     raised-pill active state for free. CodeSnippet supplies
@@ -414,11 +471,30 @@ export function TokensSection({ pats, patsError, onReloadPats }: Props) {
                     ))}
                   </TabsList>
                   <TabsContent value={clientTab} className="space-y-2">
-                    <CodeSnippet
-                      code={snippets[clientTab]}
-                      filename={MCP_AGENT_FILES[clientTab]}
-                    />
-                    {clientTab === "cursor" && (
+                    {connectMode === "oauth" ? (
+                      oauthSnippetsMap[clientTab] !== undefined ? (
+                        <CodeSnippet
+                          code={oauthSnippetsMap[clientTab] as string}
+                          filename={MCP_AGENT_FILES[clientTab]}
+                        />
+                      ) : (
+                        // Agents without a known remote-HTTP-OAuth integration
+                        // (Codex / OpenClaw at the time of writing) — bounce
+                        // the user back to PAT for that tab specifically,
+                        // rather than rendering an empty snippet box.
+                        <div className="rounded-[var(--radius-md)] border border-border px-4 py-3 text-sm text-foreground-muted">
+                          {MCP_AGENT_LABELS[clientTab]} uses the stdio path —
+                          switch the toggle to <span className="text-accent-strong">Token (PAT)</span>
+                          {" "}to see its snippet.
+                        </div>
+                      )
+                    ) : (
+                      <CodeSnippet
+                        code={snippets[clientTab]}
+                        filename={MCP_AGENT_FILES[clientTab]}
+                      />
+                    )}
+                    {connectMode === "pat" && clientTab === "cursor" && (
                       <div className="rounded-[var(--radius-md)] border border-border px-4 py-2 text-[11px] font-mono bg-surface-muted text-foreground-muted space-y-0.5">
                         <div><span className="coord mr-2">Cursor</span>~/.cursor/mcp.json</div>
                         <div><span className="coord mr-2">Windsurf</span>~/.codeium/windsurf/mcp_config.json</div>
@@ -430,9 +506,16 @@ export function TokensSection({ pats, patsError, onReloadPats }: Props) {
                         </div>
                       </div>
                     )}
+                    {connectMode === "oauth" && clientTab === "claude" && (
+                      <div className="rounded-[var(--radius-md)] border border-border px-4 py-2 text-[11px] font-mono bg-surface-muted text-foreground-muted">
+                        First line registers the server, second opens a browser
+                        for the OAuth + consent flow. Run them back-to-back.
+                        Resource: <span className="text-foreground">{MCP_URL}</span>
+                      </div>
+                    )}
                   </TabsContent>
                 </Tabs>
-                {snippetPat === "<YOUR_PAT>" && (
+                {connectMode === "pat" && snippetPat === "<YOUR_PAT>" && (
                   <p className="coord text-foreground-muted">
                     ↑ Replace <span className="text-accent-strong">&lt;YOUR_PAT&gt;</span> with the
                     token string shown after Step 01.

--- a/scripts/keycloak/setup-akb-mcp-oauth.py
+++ b/scripts/keycloak/setup-akb-mcp-oauth.py
@@ -158,14 +158,50 @@ def main() -> int:
     current = set(th.get("config", {}).get("trusted-hosts", []) or [])
     print(f"    current: {sorted(current)}")
     desired = current | set(args.trusted_host)
+    changed = False
     if desired != current:
         th["config"]["trusted-hosts"] = sorted(desired)
+        changed = True
+    # The sender-host check rejects every legitimate DCR from a moving
+    # client (Claude Code on a laptop, claude.ai's egress, etc.) because
+    # those hosts can't be allowlisted upfront. The redirect-URI check
+    # below is the meaningful guard; turn the sender-host check off so
+    # DCR actually works from anywhere a client lives.
+    if th.get("config", {}).get("host-sending-registration-request-must-match") != ["false"]:
+        th["config"]["host-sending-registration-request-must-match"] = ["false"]
+        changed = True
+    if changed:
         s, r, _ = http("PUT", f"{base}/components/{th['id']}", token, body=th)
         if s not in (200, 204):
             sys.exit(f"PUT trusted-hosts failed: {s} {r}")
-        print(f"    updated: {th['config']['trusted-hosts']}")
+        print(f"    updated: trusted-hosts={th['config']['trusted-hosts']} sender-check=off")
     else:
-        print("    no-op (already contains requested hosts)")
+        print("    no-op (already permissive on sender + contains requested hosts)")
+
+    # ── 1b. allowed-client-templates ──────────────────────────
+    # The default "Allowed Client Scopes" anonymous-DCR policy rejects
+    # any DCR body that includes `scope=openid` because Keycloak does
+    # not list `openid` in the realm's client-scope catalog (it is the
+    # OIDC sentinel, not a Keycloak scope). MCP-spec clients (Claude
+    # Code, claude.ai, ChatGPT) always send `openid` in the DCR scope
+    # field, so this policy must be removed for anonymous DCR. The
+    # `consent-required`, `trusted-hosts` (URI), and `max-clients`
+    # policies remain as the meaningful guards. The [authenticated]
+    # variant of this policy stays — it gates registrations made with
+    # an Initial Access Token, which is the operator-controlled path.
+    print("\n[1b] allowed-client-templates policy (anonymous)")
+    actp = next(
+        (c for c in comps if c.get("providerId") == "allowed-client-templates"
+         and c.get("subType") == "anonymous"),
+        None,
+    )
+    if actp:
+        s, r, _ = http("DELETE", f"{base}/components/{actp['id']}", token)
+        if s not in (200, 204):
+            sys.exit(f"DELETE allowed-client-templates failed: {s} {r}")
+        print("    removed (was rejecting DCR bodies that include scope=openid)")
+    else:
+        print("    no-op (already removed)")
 
     # ── 2. client scopes + audience mappers ───────────────────
     created_ids: dict[str, str] = {}

--- a/scripts/keycloak/setup-akb-mcp-oauth.py
+++ b/scripts/keycloak/setup-akb-mcp-oauth.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Apply MCP OAuth Resource Server changes to a Keycloak realm.
+
+Idempotent — running this twice is a no-op on the second call. Survives
+partial state from a prior interrupted run.
+
+What it does (in order):
+
+1. Add ``localhost`` / ``127.0.0.1`` to the realm's DCR ``trusted-hosts``
+   policy so a local Claude Code (or another DCR-capable MCP client
+   running on the operator's laptop) can register itself dynamically.
+2. Create the ``akb:vault:read`` client scope (if absent) with an
+   ``oidc-audience-mapper`` whose ``included.custom.audience`` is the
+   AKB ``/mcp`` URL the realm should mint tokens for.
+3. Create the ``akb:vault:write`` client scope the same way.
+4. Add both scopes to ``defaultOptionalClientScopes`` so a DCR-registered
+   public client can request them at the authorize endpoint.
+5. Verify everything by re-reading state.
+
+Reads admin credentials from ``KC_ADMIN_USER`` / ``KC_ADMIN_PASS`` env
+vars; never accepts them on the command line so they cannot land in
+shell history or process listings.
+
+Usage:
+    KC_ADMIN_USER=admin KC_ADMIN_PASS=... \\
+        python3 scripts/keycloak/setup-akb-mcp-oauth.py \\
+            --kc https://auth.example.com \\
+            --realm akb \\
+            --audience https://akb.example.com/mcp
+
+See docs/designs/mcp-oauth-dcr/00-overview.md for the rationale and
+docs/mcp-clients/web-connectors.md for the end-to-end client walkthrough.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def http(method: str, url: str, token: str | None = None, body=None,
+         ctype: str = "application/json") -> tuple[int, object, dict]:
+    """Tiny stdlib HTTP wrapper — keeps the script dependency-free."""
+    data = None
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if body is not None:
+        if ctype == "application/json":
+            data = json.dumps(body).encode()
+        else:
+            data = urllib.parse.urlencode(body).encode()
+        headers["Content-Type"] = ctype
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            payload = json.loads(raw) if raw and r.headers.get_content_type() == "application/json" else raw
+            return r.status, payload, dict(r.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(), dict(e.headers)
+
+
+def get_admin_token(kc_url: str, user: str, password: str) -> str:
+    status, payload, _ = http(
+        "POST",
+        f"{kc_url}/realms/master/protocol/openid-connect/token",
+        body={
+            "grant_type": "password",
+            "client_id": "admin-cli",
+            "username": user,
+            "password": password,
+        },
+        ctype="application/x-www-form-urlencoded",
+    )
+    if status != 200 or not isinstance(payload, dict):
+        sys.exit(f"admin auth failed: {status} {payload}")
+    tok = payload.get("access_token")
+    if not tok:
+        sys.exit(f"admin auth: no access_token in {payload}")
+    return tok
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--kc", required=True, help="Keycloak base URL, e.g. https://auth.example.com")
+    p.add_argument("--realm", required=True, help="Keycloak realm name, e.g. akb")
+    p.add_argument(
+        "--audience", required=True,
+        help="MCP resource identifier baked into the audience mapper, e.g. https://akb.example.com/mcp",
+    )
+    p.add_argument(
+        "--trusted-host", action="append", default=["localhost", "127.0.0.1"],
+        help="Hostname(s) to add to the DCR trusted-hosts policy (repeatable; defaults: localhost, 127.0.0.1)",
+    )
+    p.add_argument(
+        "--scope-read", default="akb:vault:read",
+        help="Read scope name (default: akb:vault:read)",
+    )
+    p.add_argument(
+        "--scope-write", default="akb:vault:write",
+        help="Write scope name (default: akb:vault:write)",
+    )
+    args = p.parse_args()
+
+    user = os.environ.get("KC_ADMIN_USER")
+    pwd = os.environ.get("KC_ADMIN_PASS")
+    if not user or not pwd:
+        sys.exit(
+            "KC_ADMIN_USER and KC_ADMIN_PASS env vars are required. "
+            "Set them temporarily for this run; the script never persists them."
+        )
+
+    kc = args.kc.rstrip("/")
+    base = f"{kc}/admin/realms/{args.realm}"
+
+    def fresh_token() -> str:
+        # Admin tokens default to 300s; refresh on each section so a
+        # long run does not stall halfway through.
+        return get_admin_token(kc, user, pwd)
+
+    scopes_to_create = [
+        {
+            "name": args.scope_read,
+            "description": (
+                "Read AKB documents, tables, files, and search across vaults "
+                "you are a member of"
+            ),
+            "consent": "Read your AKB vaults (documents, tables, files, search)",
+        },
+        {
+            "name": args.scope_write,
+            "description": (
+                "Create, edit, delete, and publish AKB content in vaults "
+                "where you have writer/admin role"
+            ),
+            "consent": "Create, edit, and delete AKB content",
+        },
+    ]
+
+    # ── 1. trusted-hosts ──────────────────────────────────────
+    token = fresh_token()
+    print("\n[1] trusted-hosts policy")
+    status, comps, _ = http(
+        "GET",
+        f"{base}/components?type=org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+        token,
+    )
+    if status != 200 or not isinstance(comps, list):
+        sys.exit(f"failed to list registration policies: {status} {comps}")
+    th = next((c for c in comps if c.get("providerId") == "trusted-hosts"), None)
+    if not th:
+        sys.exit("trusted-hosts policy missing from realm (unexpected — Keycloak ships it by default)")
+    current = set(th.get("config", {}).get("trusted-hosts", []) or [])
+    print(f"    current: {sorted(current)}")
+    desired = current | set(args.trusted_host)
+    if desired != current:
+        th["config"]["trusted-hosts"] = sorted(desired)
+        s, r, _ = http("PUT", f"{base}/components/{th['id']}", token, body=th)
+        if s not in (200, 204):
+            sys.exit(f"PUT trusted-hosts failed: {s} {r}")
+        print(f"    updated: {th['config']['trusted-hosts']}")
+    else:
+        print("    no-op (already contains requested hosts)")
+
+    # ── 2. client scopes + audience mappers ───────────────────
+    created_ids: dict[str, str] = {}
+    for sp in scopes_to_create:
+        token = fresh_token()
+        print(f"\n[2] client scope '{sp['name']}'")
+        s, scopes, _ = http("GET", f"{base}/client-scopes", token)
+        if not isinstance(scopes, list):
+            sys.exit(f"failed to list scopes: {s} {scopes}")
+        existing = next((x for x in scopes if x.get("name") == sp["name"]), None)
+        if existing:
+            print(f"    already exists id={existing['id']}")
+            scope_id = existing["id"]
+        else:
+            payload = {
+                "name": sp["name"],
+                "description": sp["description"],
+                "protocol": "openid-connect",
+                "attributes": {
+                    "consent.screen.text": sp["consent"],
+                    "display.on.consent.screen": "true",
+                    "include.in.token.scope": "true",
+                },
+            }
+            s, r, headers = http("POST", f"{base}/client-scopes", token, body=payload)
+            if s not in (201, 204):
+                sys.exit(f"create scope failed: {s} {r}")
+            loc = headers.get("Location", "")
+            scope_id = loc.rstrip("/").split("/")[-1]
+            print(f"    created id={scope_id}")
+        created_ids[sp["name"]] = scope_id
+
+        # Audience mapper attached to the scope.
+        s, mappers, _ = http(
+            "GET", f"{base}/client-scopes/{scope_id}/protocol-mappers/models", token,
+        )
+        if not isinstance(mappers, list):
+            sys.exit(f"failed to read mappers: {s} {mappers}")
+        aud = next(
+            (m for m in mappers if m.get("protocolMapper") == "oidc-audience-mapper"),
+            None,
+        )
+        if aud:
+            current_aud = aud.get("config", {}).get("included.custom.audience")
+            if current_aud != args.audience:
+                aud["config"]["included.custom.audience"] = args.audience
+                aud["config"]["id.token.claim"] = "false"
+                aud["config"]["access.token.claim"] = "true"
+                s, r, _ = http(
+                    "PUT",
+                    f"{base}/client-scopes/{scope_id}/protocol-mappers/models/{aud['id']}",
+                    token, body=aud,
+                )
+                if s not in (200, 204):
+                    sys.exit(f"PUT audience mapper failed: {s} {r}")
+                print(f"    updated audience → {args.audience}")
+            else:
+                print(f"    audience mapper already → {args.audience}")
+        else:
+            mapper = {
+                "name": "akb-mcp-audience",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": False,
+                "config": {
+                    "included.custom.audience": args.audience,
+                    "id.token.claim": "false",
+                    "access.token.claim": "true",
+                },
+            }
+            s, r, _ = http(
+                "POST",
+                f"{base}/client-scopes/{scope_id}/protocol-mappers/models",
+                token, body=mapper,
+            )
+            if s not in (201, 204):
+                sys.exit(f"create audience mapper failed: {s} {r}")
+            print(f"    created audience mapper → {args.audience}")
+
+    # ── 3. defaultOptionalClientScopes ────────────────────────
+    token = fresh_token()
+    print("\n[3] realm defaultOptionalClientScopes")
+    s, current_opt, _ = http("GET", f"{base}/default-optional-client-scopes", token)
+    if not isinstance(current_opt, list):
+        sys.exit(f"failed to read optional scopes: {s} {current_opt}")
+    have = {x["name"] for x in current_opt}
+    for name, sid in created_ids.items():
+        if name in have:
+            print(f"    {name} already optional — skip")
+            continue
+        s, r, _ = http(
+            "PUT", f"{base}/default-optional-client-scopes/{sid}",
+            token, body={},
+        )
+        if s not in (200, 204):
+            sys.exit(f"PUT default-optional-client-scope failed: {s} {r}")
+        print(f"    added {name}")
+
+    # ── 4. Verify ─────────────────────────────────────────────
+    token = fresh_token()
+    print("\n[verify]")
+    s, comps, _ = http(
+        "GET",
+        f"{base}/components?type=org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+        token,
+    )
+    th2 = next(c for c in comps if c.get("providerId") == "trusted-hosts")
+    print(f"    trusted-hosts: {th2['config'].get('trusted-hosts')}")
+    s, scopes, _ = http("GET", f"{base}/client-scopes", token)
+    by_name = {x["name"]: x for x in scopes if isinstance(x, dict)}
+    for sp in scopes_to_create:
+        x = by_name.get(sp["name"])
+        if not x:
+            print(f"    {sp['name']}: MISSING"); continue
+        s2, m, _ = http(
+            "GET", f"{base}/client-scopes/{x['id']}/protocol-mappers/models", token,
+        )
+        a = next(
+            (mm for mm in m if mm.get("protocolMapper") == "oidc-audience-mapper"),
+            None,
+        )
+        print(f"    {sp['name']}: id={x['id'][:8]}.. aud={a['config'].get('included.custom.audience') if a else 'MISSING'}")
+    s, opt, _ = http("GET", f"{base}/default-optional-client-scopes", token)
+    print(f"    defaultOptionalClientScopes: {sorted(x['name'] for x in opt)}")
+    print("\nDONE.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds an **optional** OAuth Resource Server path on `/mcp` so web-hosted LLM clients (Claude Code's HTTP transport, claude.ai / ChatGPT Custom Connectors) can register themselves against AKB without an out-of-band PAT. AKB stays a **Resource Server only**; the AS — DCR, authorize, consent, token, refresh — is delegated to the existing optional Keycloak IdP.
- **No new OAuth AS code in AKB.** Reuses the optional Keycloak SSO path (PR #149) — extracts the JIT user-provisioning helper so the SSO browser callback and the MCP machine-to-machine flow share one path.
- Gated on `mcp_oauth_enabled = false` by default: PAT-only deployments and stdio clients (Claude Desktop, Codex CLI via `akb-mcp`) are bit-for-bit unchanged.
- When enabled, `/mcp` accepts three Bearer shapes — PAT, AKB JWT (HS256), Keycloak access token (RS256) — discriminated by the JWT `alg` header. `_dispatch` enforces per-tool `vault:read` / `vault:write` scope on OAuth callers (fails CLOSED on unmapped tools); PAT/AKB-JWT callers (`oauth_scopes is None`) skip the check.
- `/.well-known/oauth-protected-resource` (RFC 9728) advertises the AS + scopes (incl. `openid`, `profile`, `email`, `offline_access`); `/mcp` 401s carry `WWW-Authenticate: Bearer ..., resource_metadata=...` (RFC 9728 §5).
- UI: `Settings → Tokens`, home CONNECT panel, and the first-run Quickstart dialog all gain the same `Token (PAT) | OAuth` toggle, gated on `/api/v1/auth/config.mcp_oauth.enabled`. PAT-only deployments see no UI change.

Tracked in reef-akb: **AKB-018**. Design: `docs/designs/mcp-oauth-dcr/00-overview.md` (in this PR).

## End-to-end validated against prod

The whole loop was driven against the on-prem `akb` Keycloak realm + an internal deployment of this branch:
- `claude mcp add --transport http akb-prod https://<host>/mcp/` + `claude mcp login akb-prod` → browser consent → tokens stored
- Tools authenticated as the Keycloak user, JIT-provisioned an AKB account, `_dispatch` honoured `vault:read` / `vault:write` per tool
- PAT flow regression-tested against live prod traffic (other users on the cluster) — 200 OK throughout

## Realm + ops

- **`scripts/keycloak/setup-akb-mcp-oauth.py`** — idempotent realm setup: adds `localhost` / `127.0.0.1` to DCR trusted-hosts AND turns off the sender-host check (sender IPs are unknowable for moving MCP clients), creates `akb:vault:read` / `akb:vault:write` scopes (each with an `oidc-audience-mapper` pinned to the `/mcp` URL), registers them as optional default scopes, and deletes the anonymous `allowed-client-templates` policy (rejects every spec-compliant DCR that includes the `openid` sentinel scope). Admin creds via env vars only (`KC_ADMIN_USER` / `KC_ADMIN_PASS`).
- **`deploy/keycloak-dev/akb-realm.json`** — local-dev overlay matches what the prod script produces.
- **`deploy/k8s/ingress.yaml`** — routes the entire `/.well-known/` prefix to backend so any discovery probe (RFC 8414 `oauth-authorization-server`, OIDC `openid-configuration`) gets a real 404 JSON instead of the frontend SPA's HTML 200 (which an MCP client would JSON-parse and reject as a discovery failure).

## What the prod walk-through caught (all fixed in this PR)

1. Ingress routed `/.well-known/oauth-authorization-server` to the frontend → JSON-parse failure on the client. Now routes the whole prefix to backend.
2. Keycloak trusted-hosts sender check rejected DCR from a dynamic client IP. Now off; the redirect-URI guard remains.
3. Keycloak `allowed-client-templates` policy rejected DCR bodies containing `openid` (not in the realm's client-scope catalog). Now deleted; consent + max-clients + trusted-hosts remain.
4. `/mcp` (no trailing slash) 307-redirects POST → drops body. Doc note now points users at `/mcp/`.
5. Metadata's `scopes_supported` listed only resource scopes → DCR clients had no `email`/`profile` in their assigned scopes → access tokens lacked `email` → AKB rejected with "no email claim". Now `scopes_supported` advertises the OIDC base scopes, the spec-compliant client requests them at DCR + authorize, the token carries the claims AKB needs.

## Review-pass fixes (post code-review)

- **Blocker** — internal hostname leaked into `docker-compose.keycloak.yaml` comment block. Generalised.
- **Major** — `verify_access_token` propagated `AKBError` (502) on JWKS unreachability instead of returning `None` (so the MCP handler couldn't emit the RFC 9728 `WWW-Authenticate` hint). Now catches and falls through to a clean 401.
- **Major** — `lifecycle._validate_required_settings` didn't enforce the documented `mcp_oauth_enabled ⇒ keycloak_enabled` precondition. Now fails the boot with a clear message.
- **Major** — `_dispatch` fell OPEN on tools missing from `_TOOL_SCOPES`. Now falls CLOSED to `akb:vault:write`, plus a unit test asserts every registered handler has an explicit mapping so CI catches the omission.
- **Doc** — hand-edit Keycloak checklist now includes the sender-check flip and the policy deletion the script applies.

## Test plan

- [x] `cd backend && uv run pytest tests/test_mcp_oauth_unit.py` — 23/23 pass (added: JWKS-unreachable returns None, SPA-audience rejected, `_TOOL_SCOPES` completeness, unmapped tool fail-closed)
- [x] `bash scripts/check.sh` — green (ruff + mypy + bandit + frontend lint/type/vitest 350/350 + detect-secrets)
- [x] CI on this branch — all four jobs green (static analysis, backend unit, pgvector e2e, shell e2e)
- [x] End-to-end against prod — `claude mcp login` + tool call + JIT-provision + 한병전 session assignment + scope enforcement
- [x] PAT regression — live prod traffic on the new image stayed 200 OK throughout the rollout

## Known follow-ups (not blocking)

Out of scope for this PR; each is small and bounded:

- `oauth-protected-resource` advertises a `resource_documentation` URL that isn't served. Either drop the field or add a frontend `/docs/*` route.
- Audit log (`audit_log.record_tool`) drops `auth_method` and `oauth_scopes` on the floor. Adding these is the dimension a SIEM needs to distinguish "user pasted a PAT in their CI" from "Claude Code's OAuth session at the time of the action".
- `_dispatch` runs the OAuth scope check before the unknown-argument check, so an OAuth caller with a typo'd arg sees `insufficient_scope` instead of the fuzzy "Did you mean…" hint.
- `email_verified` strict bool comparison (`is not True`) is brittle if an IdP proxy munges the claim. Keycloak emits proper bool today; switching to `bool(claims.get("email_verified"))` would be more portable.

## What this PR does NOT do

- No OAuth AS inside AKB (no `/register`, `/authorize`, `/token`, consent UI, refresh rotation).
- No PAT behaviour change. Stdio / CLI / Desktop flows continue to work unchanged.
- No auto-enabling MCP-OAuth on existing deployments — `mcp_oauth_enabled` defaults to `false`, operator opts in.
- No per-collection OAuth scopes. Coarse `vault:read` / `vault:write` only; finer access stays in PG-RBAC + `vault_access`.
- No solution for internal-only AKB + cloud LLM client reachability — Claude Code (local) works against an internal AKB; claude.ai / ChatGPT still need public exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)