### PR TITLE
feat(auth): SSO-only mode toggle + ?local=1 escape hatch

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -84,6 +84,12 @@ async def auth_config():
             "enabled": settings.keycloak_enabled,
             # SPA appends ?redirect=<path> when navigating here.
             "login_url": "/api/v1/auth/keycloak/login" if settings.keycloak_enabled else None,
+            # SSO-only mode — when true the SPA skips the local login
+            # form and redirects straight to Keycloak (with `?local=1`
+            # as an escape hatch). Forced to false when SSO itself is
+            # off so a mis-toggled deployment can't trap users at a
+            # broken redirect.
+            "sso_only": settings.keycloak_sso_only and settings.keycloak_enabled,
         },
         "mcp_oauth": {
             "enabled": settings.mcp_oauth_enabled,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -179,6 +179,18 @@ class Settings(BaseModel):
     #
     # See docs/designs/keycloak-oidc/00-overview.md.
     keycloak_enabled: bool = False
+    # When true AND `keycloak_enabled` is also true, the AKB sign-in page
+    # bypasses the local username/password form entirely and redirects an
+    # unauthenticated browser straight to Keycloak. Use this on
+    # deployments where every account is provisioned through SSO and the
+    # local form is more confusing than useful.
+    #
+    # The login page still honours `?local=1` as an escape hatch so a
+    # local administrator can recover if the IdP is down. The /auth/login
+    # API remains live either way — the gate is purely a UX one.
+    #
+    # Ignored when `keycloak_enabled = false`.
+    keycloak_sso_only: bool = False
     keycloak_server_url: str = ""          # e.g. https://auth.example.com (no /realms suffix)
     # Optional backchannel base URL for server→Keycloak calls (token
     # exchange + JWKS). Defaults to keycloak_server_url. Set this only

--- a/backend/tests/test_auth_config_shape_unit.py
+++ b/backend/tests/test_auth_config_shape_unit.py
@@ -1,0 +1,54 @@
+"""Pure-function tests for the `/api/v1/auth/config` payload shape.
+
+The endpoint drives the SPA's render decisions (show local form vs
+redirect to Keycloak; show OAuth toggle on connector UIs) so a wrong
+shape ships a UX regression. These tests pin the contract directly
+against the route handler.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from app.config import settings
+
+
+def _call() -> dict:
+    from app.api.routes.auth import auth_config
+
+    return asyncio.run(auth_config())
+
+
+def test_sso_only_field_present_and_true_when_both_flags_on(monkeypatch):
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+
+    cfg = _call()
+    assert cfg["keycloak"]["enabled"] is True
+    assert cfg["keycloak"]["sso_only"] is True
+    assert cfg["keycloak"]["login_url"] == "/api/v1/auth/keycloak/login"
+
+
+def test_sso_only_forced_false_when_keycloak_disabled(monkeypatch):
+    """An operator who mis-toggles `keycloak_sso_only: true` while
+    Keycloak itself is off would otherwise strand every user at a
+    broken redirect. The endpoint clamps sso_only to false here so
+    the SPA stays on the local form."""
+    monkeypatch.setattr(settings, "keycloak_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+
+    cfg = _call()
+    assert cfg["keycloak"]["enabled"] is False
+    assert cfg["keycloak"]["sso_only"] is False
+    assert cfg["keycloak"]["login_url"] is None
+
+
+def test_sso_only_default_false_in_hybrid_mode(monkeypatch):
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", False, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+
+    cfg = _call()
+    assert cfg["keycloak"]["enabled"] is True
+    assert cfg["keycloak"]["sso_only"] is False

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -50,6 +50,7 @@ keyed on it — is preserved.
 | First login | **JIT auto-provision** by email | Any realm member who authenticates gets an AKB user + `akb_user_<uid>` role via the existing `on_user_create` hook. |
 | Token delivery to SPA | **one-time code exchange** (60s TTL) | Keeps AKB's Bearer + localStorage model; no token in URL history; no cookie-auth rewrite of the API client. |
 | Default | `enabled = false` | Local auth is the baseline; Keycloak is opt-in per deployment. |
+| SSO-only mode | Optional `keycloak_sso_only` toggle, default false | Deployments where every account is provisioned through SSO can hide the local form entirely. The `/auth/login` API stays live (gate is UX-only); `?local=1` on the sign-in URL is the escape hatch so a local admin can recover when the IdP is down. |
 
 ## Flow
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -154,7 +154,15 @@ export const authLogin = (username: string, password: string) =>
   }).then(parseAuthResponse);
 
 export interface AuthConfig {
-  keycloak: { enabled: boolean; login_url: string | null };
+  keycloak: {
+    enabled: boolean;
+    login_url: string | null;
+    // Optional — present on newer backends. When true the SPA
+    // bypasses the local form and redirects straight to Keycloak. A
+    // `?local=1` query param on the auth page is the escape hatch
+    // for local admins.
+    sso_only?: boolean;
+  };
   // Optional — present on newer backends. Tells the connect-snippet UI
   // whether the OAuth Resource Server path is live so it can offer
   // `claude mcp add --transport http … && claude mcp login` alongside
@@ -163,7 +171,7 @@ export interface AuthConfig {
 }
 
 const _AUTH_CONFIG_FALLBACK: AuthConfig = {
-  keycloak: { enabled: false, login_url: null },
+  keycloak: { enabled: false, login_url: null, sso_only: false },
   mcp_oauth: { enabled: false },
 };
 

--- a/frontend/src/pages/__tests__/auth-sso-only.test.tsx
+++ b/frontend/src/pages/__tests__/auth-sso-only.test.tsx
@@ -1,0 +1,145 @@
+// RTL coverage for the AuthPage `sso_only` mode: when the backend
+// advertises `keycloak.sso_only = true`, the page must redirect to
+// Keycloak immediately without rendering the local username/password
+// form. `?local=1` is the escape hatch that keeps the form alive.
+//
+// Both checks pin down the documented contract — drift here would
+// either trap admins (no escape) or strand SSO-only deployments with
+// a confusing local form they were configured to hide.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import AuthPage from "../auth";
+import { getAuthConfig } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  authLogin: vi.fn(),
+  authRegister: vi.fn(),
+  setToken: vi.fn(),
+  getToken: vi.fn(() => null),
+  getAuthConfig: vi.fn(),
+  clearSsoSession: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+// jsdom's `window.location.href` setter triggers a real "navigation"
+// that aborts the test. Stub it so we can ASSERT the destination
+// without taking the navigation. The `search` getter reads a mutable
+// outer variable, so a test can set the query string AFTER beforeEach
+// (which is when `?local=1` cases naturally do so).
+const originalLocation = window.location;
+let hrefAssignments: string[] = [];
+let stubbedSearch = "";
+
+beforeEach(() => {
+  hrefAssignments = [];
+  stubbedSearch = "";
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      pathname: "/auth",
+      get search() {
+        return stubbedSearch;
+      },
+      get href() {
+        return originalLocation.href;
+      },
+      set href(v: string) {
+        hrefAssignments.push(v);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  cleanup();
+  navigate.mockReset();
+});
+
+function renderAuth() {
+  return render(
+    <MemoryRouter>
+      <AuthPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthPage — SSO-only mode", () => {
+  it("redirects to Keycloak immediately and never renders the form", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      keycloak: {
+        enabled: true,
+        login_url: "/api/v1/auth/keycloak/login",
+        sso_only: true,
+      },
+    });
+
+    renderAuth();
+
+    await waitFor(() => expect(hrefAssignments.length).toBeGreaterThan(0));
+    expect(hrefAssignments[0]).toMatch(
+      /\/api\/v1\/auth\/keycloak\/login\?redirect=/,
+    );
+    // Form is never rendered — `Sign in` button (which the form owns)
+    // must not appear, and the "Redirecting to SSO…" placeholder must.
+    expect(screen.queryByRole("button", { name: /^Sign in$/ })).toBeNull();
+    expect(screen.getByText(/Redirecting to SSO/i)).toBeInTheDocument();
+  });
+
+  it("`?local=1` keeps the local form visible even when sso_only is on", async () => {
+    stubbedSearch = "?local=1";
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      keycloak: {
+        enabled: true,
+        login_url: "/api/v1/auth/keycloak/login",
+        sso_only: true,
+      },
+    });
+
+    renderAuth();
+
+    // Form renders with both Username + Sign-in-with-SSO option.
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Username/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Sign in with SSO/i }),
+    ).toBeInTheDocument();
+    // No redirect dispatched.
+    expect(hrefAssignments).toEqual([]);
+  });
+
+  it("does not redirect when sso_only is false (hybrid mode)", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      keycloak: {
+        enabled: true,
+        login_url: "/api/v1/auth/keycloak/login",
+        sso_only: false,
+      },
+    });
+
+    renderAuth();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Username/i)).toBeInTheDocument(),
+    );
+    expect(hrefAssignments).toEqual([]);
+  });
+});

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -34,6 +34,14 @@ export default function AuthPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [ssoLoginUrl, setSsoLoginUrl] = useState<string | null>(null);
+  // True while we're navigating away to Keycloak in sso_only mode — used
+  // to suppress the form flash that would otherwise render between the
+  // useEffect dispatching the redirect and the browser actually leaving.
+  const [redirectingToSso, setRedirectingToSso] = useState(false);
+  // The escape hatch — `?local=1` forces the local form even when the
+  // backend has SSO-only mode on. Evaluated once at mount so a stale
+  // tab doesn't lose its escape after a config reload.
+  const localEscape = new URLSearchParams(window.location.search).has("local");
   const next = safeNext(new URLSearchParams(window.location.search).get("next"));
 
   useEffect(() => {
@@ -44,8 +52,15 @@ export default function AuthPage() {
     }
     // Optional Keycloak SSO: show the button only if the backend reports it on.
     getAuthConfig().then((cfg) => {
-      if (cfg.keycloak.enabled && cfg.keycloak.login_url) {
-        setSsoLoginUrl(cfg.keycloak.login_url);
+      if (!cfg.keycloak.enabled || !cfg.keycloak.login_url) return;
+      setSsoLoginUrl(cfg.keycloak.login_url);
+      // SSO-only mode — every account goes through Keycloak, so skip
+      // the local form entirely. Honor `?local=1` so an admin can
+      // recover if the IdP is down. The /auth/login API stays live
+      // either way; the gate is purely UX.
+      if (cfg.keycloak.sso_only && !localEscape) {
+        setRedirectingToSso(true);
+        window.location.href = `${cfg.keycloak.login_url}?redirect=${encodeURIComponent(next)}`;
       }
     });
     // Surface a friendly message if the SSO callback bounced back, then strip
@@ -113,6 +128,20 @@ export default function AuthPage() {
     } finally {
       setLoading(false);
     }
+  }
+
+  // SSO-only redirect in flight — suppress the form flash. The browser
+  // is leaving in milliseconds; rendering the form would show it for a
+  // beat and look like a UI glitch. Local-escape (?local=1) bypasses
+  // this block via `redirectingToSso` staying false.
+  if (redirectingToSso) {
+    return (
+      <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
+        <div className="text-center coord" role="status" aria-live="polite">
+          Redirecting to SSO…
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

- Adds `keycloak_sso_only` config flag that lets a Keycloak-backed deployment **hide the local username/password form entirely** — the sign-in page redirects an unauthenticated browser straight to Keycloak. Useful on internal deployments where every account is provisioned through SSO and the local form is more confusing than useful.
- Defaults preserve current hybrid behaviour (`keycloak_sso_only: false`); the SPA renders both local form + SSO button.
- Backend force-clamps `sso_only` to `false` in `/auth/config` when `keycloak_enabled=false`, so a mis-toggled deployment can't strand users at a broken redirect.
- **Escape hatch**: `https://akb.example.com/auth?local=1` keeps the local form visible even in sso_only mode — for a local admin to recover when the IdP is down. The `/auth/login` API stays live unconditionally (the gate is purely UX).

Tracked in reef-akb: **AKB-019**.

## Implementation

- `backend/app/config.py` — new `keycloak_sso_only: bool = False`
- `backend/app/api/routes/auth.py` — `/auth/config.keycloak.sso_only` field, clamped to false when `keycloak_enabled` is false
- `frontend/src/lib/api.ts` — `AuthConfig.keycloak.sso_only?: boolean`
- `frontend/src/pages/auth.tsx` — mount-time check dispatches the redirect (with a "Redirecting to SSO…" placeholder to suppress the form flash) when sso_only is true and `?local=1` is absent

## Test plan

- [x] `bash scripts/check.sh` — 353/353 frontend + green ruff/mypy/bandit/detect-secrets
- [x] Backend `tests/test_auth_config_shape_unit.py` (3 tests) — sso_only present+true when both flags on; clamped false when SSO off; default false in hybrid mode
- [x] Frontend `auth-sso-only.test.tsx` (3 tests) — redirects + suppresses form in sso_only; `?local=1` keeps form; hybrid mode renders form without redirect
- [ ] Manual: deploy to internal cluster with `keycloak_sso_only: true` → unauthenticated browser bypasses form → Keycloak login → callback completes; then `?local=1` still shows form
- [ ] Manual: with `keycloak_sso_only: false` (default) → existing hybrid view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)