### PR TITLE
fix(auth): break the sso_only redirect loop when callback fails

### DIFF
--- a/frontend/src/pages/__tests__/auth-sso-only.test.tsx
+++ b/frontend/src/pages/__tests__/auth-sso-only.test.tsx
@@ -126,6 +126,35 @@ describe("AuthPage — SSO-only mode", () => {
     expect(hrefAssignments).toEqual([]);
   });
 
+  it("`?sso_error=…` suppresses the auto-redirect even in sso_only mode", async () => {
+    // Without this guard an SSO-only deployment whose callback fails
+    // (realm misconfig, IdP downtime, email_verified rejection) would
+    // loop forever: /auth?sso_error → auto-redirect → IdP same fail →
+    // /auth?sso_error → … The user can never see the error or escape.
+    stubbedSearch = "?sso_error=invalid_state";
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      keycloak: {
+        enabled: true,
+        login_url: "/api/v1/auth/keycloak/login",
+        sso_only: true,
+      },
+    });
+
+    renderAuth();
+
+    // Form renders with the error; the SSO button stays available
+    // for a manual retry.
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Username/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/SSO login failed/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Sign in with SSO/i }),
+    ).toBeInTheDocument();
+    // Critical: no auto-redirect was dispatched.
+    expect(hrefAssignments).toEqual([]);
+  });
+
   it("does not redirect when sso_only is false (hybrid mode)", async () => {
     vi.mocked(getAuthConfig).mockResolvedValue({
       keycloak: {

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -50,21 +50,10 @@ export default function AuthPage() {
       navigate(next, { replace: true });
       return;
     }
-    // Optional Keycloak SSO: show the button only if the backend reports it on.
-    getAuthConfig().then((cfg) => {
-      if (!cfg.keycloak.enabled || !cfg.keycloak.login_url) return;
-      setSsoLoginUrl(cfg.keycloak.login_url);
-      // SSO-only mode — every account goes through Keycloak, so skip
-      // the local form entirely. Honor `?local=1` so an admin can
-      // recover if the IdP is down. The /auth/login API stays live
-      // either way; the gate is purely UX.
-      if (cfg.keycloak.sso_only && !localEscape) {
-        setRedirectingToSso(true);
-        window.location.href = `${cfg.keycloak.login_url}?redirect=${encodeURIComponent(next)}`;
-      }
-    });
-    // Surface a friendly message if the SSO callback bounced back, then strip
-    // the param so a refresh / bookmark doesn't replay a stale error.
+    // Read sso_error BEFORE the async getAuthConfig() so the captured
+    // value is available to the auto-redirect branch below — without
+    // this, an SSO-only deployment whose callback fails would loop:
+    // /auth?sso_error → auto-redirect → IdP same failure → /auth?sso_error → …
     const params = new URLSearchParams(window.location.search);
     const ssoErr = params.get("sso_error");
     if (ssoErr) {
@@ -73,6 +62,24 @@ export default function AuthPage() {
       const qs = params.toString();
       window.history.replaceState({}, "", window.location.pathname + (qs ? `?${qs}` : ""));
     }
+    // Optional Keycloak SSO: show the button only if the backend reports it on.
+    getAuthConfig().then((cfg) => {
+      if (!cfg.keycloak.enabled || !cfg.keycloak.login_url) return;
+      setSsoLoginUrl(cfg.keycloak.login_url);
+      // SSO-only mode — every account goes through Keycloak, so skip
+      // the local form entirely. Three things turn the auto-redirect
+      // off so the user can recover instead of looping:
+      //   - `?local=1` (admin escape hatch)
+      //   - landing here with `?sso_error=…` (we just bounced from a
+      //     failed callback; immediately re-firing the redirect would
+      //     re-attempt the same failure)
+      // When auto-redirect is suppressed, the hybrid view renders
+      // with the error message + the manual SSO retry button.
+      if (cfg.keycloak.sso_only && !localEscape && !ssoErr) {
+        setRedirectingToSso(true);
+        window.location.href = `${cfg.keycloak.login_url}?redirect=${encodeURIComponent(next)}`;
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary

PR #249 introduced the SSO-only auto-redirect but didn't gate it on `?sso_error=…`. Self-audit caught the gap before prod traffic hit it.

## Bug

If `keycloak_sso_only = true` and the Keycloak callback rejects (realm misconfig, IdP downtime, `email_verified` refusal, etc.):

1. Backend redirects user to `/auth?sso_error=invalid_state`
2. Frontend mounts → `getAuthConfig()` → sso_only=true + no `?local=1` → auto-redirect to Keycloak
3. Keycloak retries → same failure → callback bounces back to `/auth?sso_error=…`
4. Goto 2 — infinite loop. User never sees the error, can't recover unless they know about `?local=1`.

## Fix

Read `sso_error` synchronously **before** the async `getAuthConfig()` so the captured value is available to the auto-redirect branch. When `sso_error` is present, suppress the auto-redirect — the hybrid view renders instead, showing the error in the form's Alert and the SSO button for a manual retry. `?local=1` remains the broader admin escape.

3 conditions now suppress the SSO-only auto-redirect:
- `?local=1` (admin escape hatch)
- `?sso_error=…` (this fix — break the loop)
- `keycloak_enabled = false` (backend clamp from PR #249)

## Test plan

- [x] New test in `auth-sso-only.test.tsx`: `?sso_error=invalid_state` + `sso_only=true` must NOT redirect; form + error + SSO retry button all render. 4/4 pass.
- [x] `bash scripts/check.sh` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)