### PR TITLE
fix(external-git): make mirror bootstrap self-heal any bad local repo state

### DIFF
--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -90,36 +90,45 @@ class ExternalGitService:
         reconcile reads blobs from it. Returns 'cloned', 'fetched', or
         'unchanged'.
 
-        The decision keys on DB sync state (`last_synced_sha`), NOT on the
-        on-disk path:
+        Trust is decided by DB sync state + a local integrity probe, NOT
+        by on-disk path existence. Any untrustworthy local state
+        self-heals via a fresh clone:
 
         - No local repo -> clone.
-        - A repo exists but `last_synced_sha is None` -> it is UNTRUSTED:
-          either a stale dir left by a prior same-named vault (whose
-          delete cleanup raced an in-flight clone) or a clone that crashed
-          before recording success. Remove it and clone fresh so a
-          partial/corrupt dir can never be adopted. reconcile is
-          idempotent and the first successful sync sets `last_synced_sha`,
-          so this re-clone happens at most once.
-        - A trusted repo exists -> 'unchanged' on sha match, else fetch.
+        - A repo exists but is UNTRUSTED -> remove it and clone fresh.
+          Untrusted means either:
+            * `last_synced_sha is None` (never recorded a success): a stale
+              dir left by a prior same-named vault whose delete cleanup
+              raced an in-flight clone, or a clone that crashed before
+              recording success; or
+            * `not git.is_healthy_repo(...)`: a previously-synced repo that
+              is now structurally broken (partial fetch, disk error, kill
+              mid-write).
+          reconcile is idempotent and the first success sets
+          `last_synced_sha`, so a stale-dir re-clone happens at most once;
+          a corruption re-clone only fires while the repo is actually
+          broken.
+        - A trusted, healthy repo -> 'unchanged' on sha match, else fetch.
 
         Keying on `vault_exists()` alone (the previous behaviour) silently
         adopted a stale/corrupt dir: the clone was skipped and the
         subsequent fetch ran against a broken repo, failing on every
-        retry. This is the second half of the
-        delete-mid-sync -> stale-bare hazard; the first half (the race
-        that creates the stale dir) is closed by serializing
-        `cleanup_vault_dirs` under `_vault_lock`.
+        retry. The companion serialization of `cleanup_vault_dirs` under
+        `_vault_lock` closes the race that *creates* the stale dir; this
+        method closes its *adoption* (and corruption from any other
+        cause). The integrity probe inspects only local state, so a
+        transient network fetch failure is never mistaken for corruption.
         """
         host = _host_only(remote_url)
         if not self.git.vault_exists(vault_name):
             logger.info("Bootstrap clone: vault=%s host=%s", vault_name, host)
             self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
             return "cloned"
-        if last_synced_sha is None:
+        if last_synced_sha is None or not self.git.is_healthy_repo(vault_name):
+            reason = "never-synced" if last_synced_sha is None else "corrupt"
             logger.warning(
-                "Untrusted bare repo for never-synced mirror %s; re-cloning from %s",
-                vault_name, host,
+                "Untrusted bare repo for mirror %s (%s); re-cloning from %s",
+                vault_name, reason, host,
             )
             self.git.cleanup_vault_dirs(vault_name)
             self.git.clone_mirror(vault_name, remote_url, branch, auth_token)

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -75,6 +75,60 @@ class ExternalGitService:
     def __init__(self, git: GitService | None = None):
         self.git = git or GitService()
 
+    # ── Bootstrap (local bare repo) ──────────────────────────
+
+    def ensure_local_bare(
+        self,
+        vault_name: str,
+        last_synced_sha: str | None,
+        new_sha: str,
+        remote_url: str,
+        branch: str,
+        auth_token: str | None,
+    ) -> str:
+        """Make the local bare repo present and trustworthy before
+        reconcile reads blobs from it. Returns 'cloned', 'fetched', or
+        'unchanged'.
+
+        The decision keys on DB sync state (`last_synced_sha`), NOT on the
+        on-disk path:
+
+        - No local repo -> clone.
+        - A repo exists but `last_synced_sha is None` -> it is UNTRUSTED:
+          either a stale dir left by a prior same-named vault (whose
+          delete cleanup raced an in-flight clone) or a clone that crashed
+          before recording success. Remove it and clone fresh so a
+          partial/corrupt dir can never be adopted. reconcile is
+          idempotent and the first successful sync sets `last_synced_sha`,
+          so this re-clone happens at most once.
+        - A trusted repo exists -> 'unchanged' on sha match, else fetch.
+
+        Keying on `vault_exists()` alone (the previous behaviour) silently
+        adopted a stale/corrupt dir: the clone was skipped and the
+        subsequent fetch ran against a broken repo, failing on every
+        retry. This is the second half of the
+        delete-mid-sync -> stale-bare hazard; the first half (the race
+        that creates the stale dir) is closed by serializing
+        `cleanup_vault_dirs` under `_vault_lock`.
+        """
+        host = _host_only(remote_url)
+        if not self.git.vault_exists(vault_name):
+            logger.info("Bootstrap clone: vault=%s host=%s", vault_name, host)
+            self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
+            return "cloned"
+        if last_synced_sha is None:
+            logger.warning(
+                "Untrusted bare repo for never-synced mirror %s; re-cloning from %s",
+                vault_name, host,
+            )
+            self.git.cleanup_vault_dirs(vault_name)
+            self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
+            return "cloned"
+        if new_sha == last_synced_sha:
+            return "unchanged"
+        self.git.fetch_remote(vault_name, remote_url, branch, auth_token)
+        return "fetched"
+
     # ── Reconcile (called by poller) ─────────────────────────
 
     async def reconcile(self, vault_id: uuid.UUID, vault_name: str) -> dict:
@@ -104,31 +158,23 @@ class ExternalGitService:
                 f"Remote branch '{cfg['remote_branch']}' not found at {cfg['remote_url']}"
             )
 
-        # Bootstrap: first poll after vault creation has no local bare repo yet.
-        if not self.git.vault_exists(vault_name):
-            logger.info(
-                "Bootstrap clone: vault=%s host=%s",
-                vault_name, _host_only(cfg["remote_url"]),
-            )
-            await asyncio.to_thread(
-                self.git.clone_mirror,
-                vault_name=vault_name,
-                remote_url=cfg["remote_url"],
-                branch=cfg["remote_branch"],
-                auth_token=cfg["auth_token"],
-            )
-        elif new_sha == cfg["last_synced_sha"]:
+        # Ensure a trusted local bare repo exists. The clone-vs-fetch
+        # decision keys on DB sync state (last_synced_sha), not on-disk
+        # path existence — see ensure_local_bare. 'unchanged' short-
+        # circuits the rest of the reconcile.
+        action = await asyncio.to_thread(
+            self.ensure_local_bare,
+            vault_name,
+            cfg["last_synced_sha"],
+            new_sha,
+            cfg["remote_url"],
+            cfg["remote_branch"],
+            cfg["auth_token"],
+        )
+        if action == "unchanged":
             await ext_repo.mark_success(vault_id, cfg["poll_interval_secs"])
             return {"status": "unchanged", "sha": new_sha}
-        else:
-            # Fetch objects so the reconcile can read blobs locally.
-            await asyncio.to_thread(
-                self.git.fetch_remote,
-                vault_name=vault_name,
-                remote_url=cfg["remote_url"],
-                branch=cfg["remote_branch"],
-                auth_token=cfg["auth_token"],
-            )
+
         remote_tree = await asyncio.to_thread(self.git.ls_tree, vault_name, new_sha)
 
         doc_repo = DocumentRepository(pool)

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -256,11 +256,23 @@ class GitService:
         Errors during cleanup propagate — callers handle via their
         own try/except so a rollback failure doesn't hide the
         original exception.
+
+        Held under `_vault_lock(vault_name)` so teardown serializes with
+        any in-flight clone/fetch/commit on the same vault. This is the
+        only git-touching op that mutates the on-disk repo outside the
+        lock, so without it a `delete_vault` rmtree can race a poller
+        `clone_mirror` writing the same bare dir — leaving a partial /
+        corrupt repo that a same-named recreate then adopts
+        (`vault_exists()` is True → bootstrap clone skipped → fetch into a
+        broken repo, failing every retry). No caller holds the lock when
+        invoking this (delete_vault, create-vault rollback, rename
+        rollback), so re-entry is safe.
         """
         import shutil
-        for path in (self._bare_path(vault_name), self._worktree_path(vault_name)):
-            if path.exists():
-                shutil.rmtree(path)
+        with _vault_lock(vault_name):
+            for path in (self._bare_path(vault_name), self._worktree_path(vault_name)):
+                if path.exists():
+                    shutil.rmtree(path)
 
     # ── External remote operations ───────────────────────────
 

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -168,6 +168,28 @@ class GitService:
     def vault_exists(self, vault_name: str) -> bool:
         return self._bare_path(vault_name).exists()
 
+    def is_healthy_repo(self, vault_name: str) -> bool:
+        """Cheap structural soundness check on the bare repo: does it exist
+        as a git repo whose HEAD resolves to a real commit?
+
+        Catches the gross corruption a partial clone, partial fetch, disk
+        error, or non-git leftover dir produces (no valid HEAD, missing
+        root object). Fine-grained missing-blob corruption is caught
+        downstream by the reconciler's per-file error handling. Used to
+        decide self-heal-by-reclone vs. a normal fetch — and it never
+        false-positives a transient network fetch failure as corruption,
+        because it only inspects local on-disk state.
+        """
+        bare = self._bare_path(vault_name)
+        if not bare.exists():
+            return False
+        try:
+            with _vault_lock(vault_name):
+                Repo(str(bare)).git.rev_parse("--verify", "HEAD^{commit}")
+            return True
+        except Exception:  # noqa: BLE001 — any failure means "not sound"
+            return False
+
     def cleanup_stale_locks(self, max_age_seconds: float = 60.0) -> int:
         """Remove `index.lock` files for every vault that are older than
         `max_age_seconds`.

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -8,6 +8,7 @@ tests never touch the real `/data/vaults` directory.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import threading
 import uuid
@@ -376,3 +377,44 @@ def test_ensure_local_bare_unchanged_when_synced_and_sha_matches(tmp_path):
     # Now synced at `head`: a matching sha must short-circuit.
     action = svc.ensure_local_bare(name, head, head, url, "main", None)
     assert action == "unchanged"
+
+
+def test_is_healthy_repo(tmp_path):
+    """Structural soundness probe: absent → False, healthy clone → True,
+    objects dropped → False."""
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    svc = ExternalGitService(git=git)
+    url, head = _make_upstream(tmp_path)
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+
+    assert git.is_healthy_repo(name) is False  # absent
+    svc.ensure_local_bare(name, None, head, url, "main", None)
+    assert git.is_healthy_repo(name) is True  # healthy clone
+    shutil.rmtree(git._bare_path(name) / "objects")  # corrupt
+    assert git.is_healthy_repo(name) is False
+
+
+def test_ensure_local_bare_reclones_corrupt_synced_repo(tmp_path):
+    """A previously-synced repo (last_synced_sha set) that is now corrupt
+    must be re-cloned, not fetched-into. Closes the 'post-sync corruption'
+    self-heal gap: keying on last_synced_sha alone would take the fetch /
+    unchanged branch and never recover the broken repo.
+    """
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    svc = ExternalGitService(git=git)
+    url, head = _make_upstream(tmp_path)
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+
+    assert svc.ensure_local_bare(name, None, head, url, "main", None) == "cloned"
+    assert git.is_healthy_repo(name)
+
+    # Corrupt the now-synced repo (partial fetch / disk error shape).
+    shutil.rmtree(git._bare_path(name) / "objects")
+    assert not git.is_healthy_repo(name)
+
+    # last_synced_sha set AND sha unchanged, but the repo is broken — the
+    # integrity gate must still force a clean re-clone.
+    action = svc.ensure_local_bare(name, head, head, url, "main", None)
+    assert action == "cloned"
+    assert git.is_healthy_repo(name)
+    assert "doc.md" in git.ls_tree(name, head)

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -8,12 +8,38 @@ tests never touch the real `/data/vaults` directory.
 from __future__ import annotations
 
 import os
+import subprocess
 import threading
 import uuid
 
 import pytest
 
+from app.services.external_git_service import ExternalGitService
 from app.services.git_service import GitService
+
+
+def _make_upstream(tmp_path) -> tuple[str, str]:
+    """Create a real on-disk git repo with one commit on `main`, usable as
+    a clone source. Returns (clone_url, head_sha)."""
+    up = tmp_path / "upstream"
+    up.mkdir()
+
+    def g(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=str(up), check=True, capture_output=True, text=True
+        )
+
+    g("init", "-b", "main")
+    g("config", "user.email", "t@example.com")
+    g("config", "user.name", "Test")
+    (up / "doc.md").write_text("# Hello\n")
+    g("add", ".")
+    g("commit", "-m", "init")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(up), check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    return str(up), head
 
 
 @pytest.fixture
@@ -291,3 +317,62 @@ def test_cleanup_vault_dirs_serializes_with_vault_lock(git_service, vault):
     assert cleanup_done.wait(timeout=3.0)
     worker.join(timeout=3.0)
     assert not git_service.vault_exists(vault)
+
+
+def test_ensure_local_bare_clones_when_absent(tmp_path):
+    """No local repo → fresh clone of the upstream head."""
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    svc = ExternalGitService(git=git)
+    url, head = _make_upstream(tmp_path)
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+
+    assert not git.vault_exists(name)
+    action = svc.ensure_local_bare(name, None, head, url, "main", None)
+
+    assert action == "cloned"
+    assert git.vault_exists(name)
+    assert "doc.md" in git.ls_tree(name, head)
+
+
+def test_ensure_local_bare_reclones_untrusted_stale_dir(tmp_path):
+    """A bare dir present for a NEVER-synced mirror (last_synced_sha=None)
+    is untrusted — a stale leftover (e.g. a prior same-named vault whose
+    delete cleanup raced an in-flight clone) or a clone that crashed before
+    recording success. ensure_local_bare must REMOVE it and clone fresh,
+    never adopt it.
+
+    Reproduces the failure the old `vault_exists()`-only bootstrap caused:
+    the path existed → clone was skipped → fetch ran against a broken repo
+    → the mirror retried forever with document_count stuck at 0.
+    """
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    svc = ExternalGitService(git=git)
+    url, head = _make_upstream(tmp_path)
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+
+    # Plant a stale / corrupt bare dir where the vault's repo would live.
+    stale = git._bare_path(name)
+    stale.mkdir(parents=True)
+    (stale / "garbage").write_text("not a git repo")
+    assert git.vault_exists(name)  # path present → old code would SKIP clone
+
+    action = svc.ensure_local_bare(name, None, head, url, "main", None)
+
+    assert action == "cloned"
+    # Stale garbage gone, replaced by a valid clone at the upstream head.
+    assert not (git._bare_path(name) / "garbage").exists()
+    assert "doc.md" in git.ls_tree(name, head)
+
+
+def test_ensure_local_bare_unchanged_when_synced_and_sha_matches(tmp_path):
+    """A trusted repo (last_synced_sha set) at the current head → no git
+    work, just 'unchanged'."""
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    svc = ExternalGitService(git=git)
+    url, head = _make_upstream(tmp_path)
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+
+    assert svc.ensure_local_bare(name, None, head, url, "main", None) == "cloned"
+    # Now synced at `head`: a matching sha must short-circuit.
+    action = svc.ensure_local_bare(name, head, head, url, "main", None)
+    assert action == "unchanged"

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -8,6 +8,7 @@ tests never touch the real `/data/vaults` directory.
 from __future__ import annotations
 
 import os
+import threading
 import uuid
 
 import pytest
@@ -248,3 +249,45 @@ def test_delete_paths_bulk_dedupes_input(git_service, vault):
     assert sha is not None
     assert after == before + 1
     assert git_service.read_file(vault, "dup.md") is None
+
+
+def test_cleanup_vault_dirs_serializes_with_vault_lock(git_service, vault):
+    """On-disk teardown must hold `_vault_lock` so it cannot race an
+    in-flight clone/fetch writing the same bare repo.
+
+    `cleanup_vault_dirs` is the only git-touching op that mutates the
+    on-disk repo; before this it ran lock-free, so a `delete_vault`
+    rmtree could race a poller `clone_mirror` and leave a partial bare
+    dir that a same-named recreate then adopts (`vault_exists()` True →
+    bootstrap clone skipped → fetch into a broken repo, failing every
+    retry). Here we hold the lock and assert teardown blocks until it is
+    released — proving the serialization.
+    """
+    from app.services import git_service as gs
+
+    assert git_service.vault_exists(vault)  # bare + worktree present
+
+    cleanup_started = threading.Event()
+    cleanup_done = threading.Event()
+
+    def _cleanup() -> None:
+        cleanup_started.set()
+        git_service.cleanup_vault_dirs(vault)
+        cleanup_done.set()
+
+    lock = gs._vault_lock(vault)
+    lock.acquire()
+    worker = threading.Thread(target=_cleanup)
+    try:
+        worker.start()
+        assert cleanup_started.wait(timeout=2.0)
+        # Lock held → teardown is hard-blocked: dirs stay intact.
+        assert not cleanup_done.wait(timeout=0.3)
+        assert git_service.vault_exists(vault)
+    finally:
+        lock.release()
+
+    # Lock released → teardown completes and removes everything.
+    assert cleanup_done.wait(timeout=3.0)
+    worker.join(timeout=3.0)
+    assert not git_service.vault_exists(vault)


### PR DESCRIPTION
A re-registered / restarted `external_git` mirror could get stuck at `document_count = 0` / `retrying` forever. Root cause is a bootstrap that trusts the **on-disk path** instead of the **DB sync state + repo integrity**, plus a lock-coverage gap that can leave a bad repo on disk in the first place.

This makes the bootstrap self-heal **every** untrustworthy local-repo state.

## How a bad on-disk repo arises (all production-reachable)

- **Crash/kill mid initial-clone** (OOMKill, eviction, rollout, node drain) → partial bare dir + `last_synced_sha IS NULL`. No race needed. This directly contradicts the reconciler's own documented guarantee ("a server restart mid-bootstrap is harmless: the worker retries").
- **Delete a mirror mid-sync** → `delete_vault`'s `rmtree` raced the poller's in-flight `clone_mirror` (cleanup was the only git-mutating op outside `_vault_lock`) → partial/corrupt dir adopted by a same-named recreate.
- **Disk error / partial fetch / kill mid-write** on an already-synced repo → structurally broken repo.

In each case the old `vault_exists()`-only bootstrap **skipped the clone** and fetched into the broken repo, failing on every retry.

## Fix (3 commits)

1. **Serialize teardown** — wrap `cleanup_vault_dirs`'s `rmtree` in `_vault_lock(vault_name)` so it can't race an in-flight clone/fetch/commit. Closes the race that *creates* a stale dir. (No caller holds the lock → no deadlock.)
2. **Don't adopt an untrusted dir** — extract the bootstrap decision into `ExternalGitService.ensure_local_bare`, keyed on `last_synced_sha` (DB), not path existence: a never-synced vault with a dir on disk is untrusted → remove + re-clone.
3. **Heal a corrupt synced repo** — add `GitService.is_healthy_repo` (cheap local probe: HEAD resolves to a commit; inspects only local state, so a transient *network* failure is never mistaken for corruption). `ensure_local_bare` treats a repo as untrusted when `last_synced_sha IS NULL` **or** it fails the probe.

Net: `absent → clone`, `stale/never-synced → reclone`, `corrupt-synced → reclone`, `healthy → fetch/unchanged`. reconcile is idempotent and the first success sets `last_synced_sha`, so re-clones are bounded (stale: at most once; corruption: only while actually broken).

## Reproduce → fix → verify (deterministic, DB-free)

`tests/test_git_service.py` — **14 passed**:
- `test_cleanup_vault_dirs_serializes_with_vault_lock` — teardown hard-blocks while the lock is held (commit 1).
- `test_ensure_local_bare_reclones_untrusted_stale_dir` — plants a corrupt bare dir + `last_synced_sha=None`; asserts re-clone, not adoption (commit 2). **Verified before/after**: with commit 2 reverted this test fails with `InvalidGitRepositoryError` (the bug); restored, it passes.
- `test_is_healthy_repo` + `test_ensure_local_bare_reclones_corrupt_synced_repo` — corrupt a synced repo (drop `objects/`), assert re-clone fires even on an unchanged sha (commit 3).
- `test_ensure_local_bare_clones_when_absent` / `…_unchanged_when_synced_and_sha_matches` — the remaining branches.

## Verification

- `backend/tests/test_git_service.py` — **14 passed**.
- Full `bash scripts/check.sh` green: ruff / mypy (183 files) / bandit / eslint (0 errors) / tsc / vitest (354) / detect-secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)