### PR TITLE
fix(frontend/home): contain the Workspace aurora wash to its header band

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -407,9 +407,9 @@ body::before {
    Static (no motion), pointer-events:none, behind the header content (z-0). */
 .aurora-header {
   position: relative;
-  /* Own stacking context so ::before (z-0) can never paint over the
-     content grid that follows in normal flow — without this the wash
-     tinted the top of "Recent activity". */
+  /* Own stacking context so the ::before wash (z-0) stays strictly behind
+     header content and — paired with the bounded inset below — can't paint
+     over the content grid that follows (it tinted "Recent activity" before). */
   isolation: isolate;
 }
 .aurora-header::before {
@@ -423,6 +423,7 @@ body::before {
   z-index: 0;
   pointer-events: none;
   background:
+    /* teal core anchored inside the band (was 115% → sat below it) */
     radial-gradient(30rem 16rem at 10% 85%, rgba(0, 64, 89, 0.07), transparent 62%),
     radial-gradient(24rem 14rem at 94% -12%, rgba(229, 94, 44, 0.06), transparent 60%);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -407,21 +407,28 @@ body::before {
    Static (no motion), pointer-events:none, behind the header content (z-0). */
 .aurora-header {
   position: relative;
+  /* Own stacking context so ::before (z-0) can never paint over the
+     content grid that follows in normal flow — without this the wash
+     tinted the top of "Recent activity". */
+  isolation: isolate;
 }
 .aurora-header::before {
   content: "";
   position: absolute;
-  inset: -1.5rem -1rem auto -1rem;
-  height: 200%;
+  /* Bound all four edges to the header band (+ small bleed). Previously
+     `bottom: auto; height: 200%` let the box run ~1× header-height past
+     the band, unclipped, so the teal bloom's core landed in the content
+     area below — now it fades within its own box as intended. */
+  inset: -1.5rem -1rem -1rem -1rem;
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(30rem 16rem at 10% 115%, rgba(0, 64, 89, 0.07), transparent 62%),
+    radial-gradient(30rem 16rem at 10% 85%, rgba(0, 64, 89, 0.07), transparent 62%),
     radial-gradient(24rem 14rem at 94% -12%, rgba(229, 94, 44, 0.06), transparent 60%);
 }
 .dark .aurora-header::before {
   background:
-    radial-gradient(30rem 16rem at 10% 115%, rgba(10, 111, 134, 0.13), transparent 62%),
+    radial-gradient(30rem 16rem at 10% 85%, rgba(10, 111, 134, 0.13), transparent 62%),
     radial-gradient(24rem 14rem at 94% -12%, rgba(229, 94, 44, 0.1), transparent 60%);
 }
 .aurora-header > * {


### PR DESCRIPTION
The home masthead's `.aurora-header::before` wash bled into the content grid below the header, so the teal bloom's core rendered on top of "Recent activity" instead of behind the title — the "weirdly painted" region the owner spotted.

## Root cause (3 coupled facets, all in one home-only CSS block)
- **Geometry/clip** — `bottom: auto; height: 200%` with no `overflow` let the pseudo-element run ~1× header-height past the band, unclipped, spilling into the content grid.
- **Radial anchor** — the teal gradient was centered at `10% 115%` (below the doubled box = in the content area), so the most-saturated part landed off the header.
- **Stacking** — `.aurora-header` created no stacking context, so the positioned `::before` (z-0) painted *over* the following static grid (tinting Recent activity), not behind the header.

## Fix
- `inset: -1.5rem -1rem -1rem -1rem` (bound all four edges; drop `height: 200%`) → fades within its own box as the comment always claimed.
- teal radial `10% 115%` → `10% 85%` (light + dark) → bloom sits inside the band.
- `.aurora-header { isolation: isolate }` → `::before` stays strictly behind header content.

CSS-only, scoped to the home masthead; no token/API/behavior change. Other pages use `PageHeader` without the wash and are unaffected.

## Verification
`design:check` ✓ · `typecheck` clean · `lint` 0 errors · `vitest` 354/354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)