### PR TITLE
feat(frontend/vault): drag-resizable vault rail + wider default

### DIFF
--- a/frontend/src/components/vault-rail.tsx
+++ b/frontend/src/components/vault-rail.tsx
@@ -29,8 +29,9 @@ import { cn } from "@/lib/utils";
  * in its OWN column / scroll axis, separate from the collection tree to its
  * right. Two modes the user toggles:
  *
- *   • expanded (w-44): VaultChip + NAME + a hover star (pin) + a trailing role
- *     glyph, grouped Favorites-first, with a name filter + a role-scope filter;
+ *   • expanded (drag-resizable, default 240px): VaultChip + NAME + a hover star
+ *     (pin) + a trailing role glyph, grouped Favorites-first, with a name filter
+ *     + a role-scope filter;
  *   • collapsed (w-14): an icon RAIL of monograms, favorites first, a teal
  *     corner dot on pinned vaults, role + favorite surfaced via the tooltip.
  *
@@ -49,8 +50,9 @@ export function VaultRail({
   onRefetchReady?: (refetch: () => void) => void;
   collapsed: boolean;
   onToggleCollapsed: () => void;
-  /** Expanded-mode width (px), driven by VaultShell's drag-resize. The
-   *  right divider is drawn by the shell's resize handle, not this nav. */
+  /** Requested rail width (px) from VaultShell's drag-resize; applied only in
+   *  expanded mode — the collapsed branch is a fixed w-14 icon rail and ignores
+   *  it. The right divider is drawn by the shell's resize handle, not this nav. */
   width?: number;
 }) {
   const { vaults, loading, refetch } = useVaults();

--- a/frontend/src/components/vault-rail.tsx
+++ b/frontend/src/components/vault-rail.tsx
@@ -43,11 +43,15 @@ export function VaultRail({
   onRefetchReady,
   collapsed,
   onToggleCollapsed,
+  width,
 }: {
   current: string;
   onRefetchReady?: (refetch: () => void) => void;
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** Expanded-mode width (px), driven by VaultShell's drag-resize. The
+   *  right divider is drawn by the shell's resize handle, not this nav. */
+  width?: number;
 }) {
   const { vaults, loading, refetch } = useVaults();
   const { isFavorite, toggleFavorite, favOrder } = useVaultFavorites();
@@ -247,7 +251,8 @@ export function VaultRail({
   return (
     <nav
       aria-label="Vaults"
-      className="w-44 shrink-0 h-full flex flex-col bg-surface border-r border-border"
+      style={{ width }}
+      className="shrink-0 h-full flex flex-col bg-surface"
     >
       <div className="flex items-center justify-between h-9 px-3 shrink-0 border-b border-border">
         <span className="coord-ink">Vaults</span>

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -27,6 +27,9 @@ export function VaultShell() {
     return window.localStorage.getItem(TREE_VISIBLE_KEY) !== "0";
   });
   const tree = useColumnResize({ storageKey: "akb.treeWidth", min: 240, max: 640, default: 300 });
+  // Vault switcher rail (expanded mode) — drag-resizable like the tree, its own
+  // persisted width. Collapsed mode stays a fixed w-14 icon rail.
+  const rail = useColumnResize({ storageKey: "akb.vaultRailWidth", min: 192, max: 360, default: 240 });
 
   // The vault column can simplify to a thin icon rail (persisted) when the user
   // wants the space back; the tree column collapses independently via ⌘\.
@@ -154,7 +157,24 @@ export function VaultShell() {
                 onRefetchReady={onVaultsRefetchReady}
                 collapsed={vaultCollapsed}
                 onToggleCollapsed={toggleVaultCollapsed}
+                width={rail.width}
               />
+              {/* Rail resize handle — sits between the vault rail and the tree
+                  column INSIDE the card, and is the divider for the two. Only
+                  in expanded mode with a tree region to its right (off /graph);
+                  the collapsed icon rail is a fixed strip. */}
+              {!vaultCollapsed && !isGraph && (
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label="Resize vault list"
+                  title="Drag to resize · double-click to reset"
+                  {...rail.handlers}
+                  className="group relative z-10 w-2 shrink-0 cursor-col-resize touch-none"
+                >
+                  <div className="mx-auto h-full w-px bg-border transition-colors group-hover:bg-primary group-active:bg-primary" />
+                </div>
+              )}
               {/* Collection tree column — expanded: a "Collections" header (with
                   a « collapse toggle that mirrors the vault column's) over the
                   tree. Collapsed: it doesn't vanish — it leaves a thin strip

--- a/frontend/src/hooks/use-column-resize.ts
+++ b/frontend/src/hooks/use-column-resize.ts
@@ -10,8 +10,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * leaves the thin hit area, and locks body cursor/selection for the
  * duration. Double-clicking the handle resets to `default`.
  *
- * Used by VaultShell to resize the collection-tree column (the vault rail
- * to its left is fixed-width).
+ * Used by VaultShell to resize both the vault rail and the collection-tree
+ * column (each with its own storage key); the collapsed icon rail is fixed.
  */
 export interface ColumnResizeOptions {
   storageKey: string;


### PR DESCRIPTION
The vault switcher rail was a fixed `w-44` (176px) — long vault names truncated and the width couldn't be adjusted. This makes the expanded rail drag-resizable and widens the default. (Requested: "볼트 사이드바도 길이 조절 + 기본 width 확대")

## Approach — reuse, don't reinvent
The collection tree already resizes via `useColumnResize` + a divider handle. Rather than a new mechanism, the rail reuses the **same hook and the same handle visual** so both left columns behave identically (design consistency / low learning cost):
- 8px hit area, 1px `bg-border` divider that highlights `bg-primary` on hover/active
- `role="separator"` + `aria-orientation="vertical"`, double-click-to-reset
- width persisted in `localStorage` (`akb.vaultRailWidth`)

## Changes
- **`vault-rail.tsx`** — expanded `<nav>` drops the hardcoded `w-44` + `border-r` (the shell's handle now draws the divider) and takes a `width` prop. Collapsed mode unchanged (fixed `w-14` icon rail).
- **`vault-shell.tsx`** — second `useColumnResize` (min 192 / max 360 / **default 240**, up from 176) + a resize handle between the rail and the tree, shown only in expanded mode off `/graph` (where a tree region exists to its right; the rail width still applies on `/graph` via the persisted value, just not draggable there).
- **`use-column-resize.ts`** — doc comment updated (no longer "the rail is fixed-width").

CSS/layout only; no API/behavior change. Other pages unaffected.

## Verification
`design:check` ✓ · `typecheck` clean · `lint` 0 errors · `vitest` 354/354. Verified locally via Vite dev against the docker backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)