### PR TITLE
feat(backend): make PG pool sizing configurable (env > app.yaml > default), raise default max to 30

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,7 +9,11 @@ Lookup order (first hit wins):
 The split exists so that `app.yaml` is safe to commit/share (no
 secrets) and `secret.yaml` stays out of source control. Both files
 are flat YAML mappings using the same keys as the Settings model
-below — no environment variables are read.
+below — no environment variables are read, with one deliberate
+exception: the AKB_PG_POOL_MIN_SIZE / AKB_PG_POOL_MAX_SIZE pool-sizing
+overrides read in app/db/postgres.py, a deployment-layer knob so
+k8s operators and the akb-platform control plane can tune the pool
+per deployment without re-rendering config files.
 """
 
 from pathlib import Path
@@ -77,6 +81,15 @@ class Settings(BaseModel):
     db_name: str = "akb"
     db_user: str = "akb"
     db_password: str = ""
+
+    # Main asyncpg pool sizing (app/db/postgres.py). max_size was hardcoded
+    # at 20 until 0.9.x; 30 keeps a conservative default — a vanilla PG's
+    # max_connections is 100 and the pgvector driver holds its own pool of
+    # up to 8 — while giving concurrent write bursts more headroom. The
+    # AKB_PG_POOL_MIN_SIZE / AKB_PG_POOL_MAX_SIZE env vars take precedence
+    # over these keys (the one deliberate env exception; module docstring).
+    pg_pool_min_size: int = 2
+    pg_pool_max_size: int = 30
 
     # Git storage root (bare repos live here)
     git_storage_path: str = "/data/vaults"

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import asyncpg
 from pathlib import Path
 
@@ -10,15 +11,45 @@ logger = logging.getLogger(__name__)
 _pool: asyncpg.Pool | None = None
 
 
+def _pool_sizes() -> tuple[int, int]:
+    """Resolve main-pool sizing: env > app.yaml > defaults.
+
+    AKB_PG_POOL_MIN_SIZE / AKB_PG_POOL_MAX_SIZE are the one deliberate
+    env-var exception to the YAML-only config rule (see app.config): the
+    akb-platform operator and k8s operators tune pool size per deployment
+    without re-rendering config files. Invalid values fail startup loudly
+    rather than silently falling back — same philosophy as Settings'
+    extra="forbid".
+    """
+    def resolve(env_key: str, fallback: int) -> int:
+        raw = os.getenv(env_key)
+        if raw is None or raw.strip() == "":
+            return fallback
+        try:
+            return int(raw)
+        except ValueError:
+            raise RuntimeError(f"{env_key} must be an integer, got {raw!r}") from None
+
+    min_size = resolve("AKB_PG_POOL_MIN_SIZE", settings.pg_pool_min_size)
+    max_size = resolve("AKB_PG_POOL_MAX_SIZE", settings.pg_pool_max_size)
+    if min_size < 0 or max_size < 1 or min_size > max_size:
+        raise RuntimeError(
+            f"invalid PG pool sizing: min_size={min_size}, max_size={max_size} "
+            "(need 0 <= min_size <= max_size and max_size >= 1)"
+        )
+    return min_size, max_size
+
+
 async def get_pool() -> asyncpg.Pool:
     global _pool
     if _pool is None:
+        min_size, max_size = _pool_sizes()
         for attempt in range(10):
             try:
                 _pool = await asyncpg.create_pool(
                     dsn=settings.asyncpg_dsn,
-                    min_size=2,
-                    max_size=20,
+                    min_size=min_size,
+                    max_size=max_size,
                     # Per-statement timeout. Without this a hung query holds
                     # its pool slot forever; an upstream service freeze can
                     # drain the pool in minutes (observed 2026-04-16).

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -8,6 +8,11 @@ db_host: postgres
 db_port: 5432
 db_name: akb
 db_user: akb
+# Main asyncpg pool sizing (optional; defaults shown). The env vars
+# AKB_PG_POOL_MIN_SIZE / AKB_PG_POOL_MAX_SIZE take precedence over these
+# keys — the deployment-layer knob for k8s / akb-platform.
+# pg_pool_min_size: 2
+# pg_pool_max_size: 30
 
 # === Git storage (bare repos per vault live under this path) ===
 git_storage_path: /data/vaults


### PR DESCRIPTION
## What

The main asyncpg pool was hardcoded at `min_size=2, max_size=20` in `backend/app/db/postgres.py`. This PR makes it configurable with a strict precedence chain, resolved once at pool creation by `_pool_sizes()`:

```
AKB_PG_POOL_MIN_SIZE / AKB_PG_POOL_MAX_SIZE   (env — deployment layer)
  > pg_pool_min_size / pg_pool_max_size       (app.yaml)
  > 2 / 30                                     (defaults)
```

Default max goes **20 → 30**.

## Why

- `max_size=20` is the documented ceiling behind the v0.4.1 pool-deadlock incident class, and the first binding constraint in a 100-concurrent-user load analysis (2026-07-02). PG itself has 10x headroom (`max_connections=200` in the k8s manifest) — the app pool was the bottleneck.
- The env vars are the **one deliberate exception** to the repo's YAML-only config rule (now documented in the `app.config` module docstring): they let k8s operators and the akb-platform control plane (per-tenant operator render) tune the pool per deployment without re-rendering config files.
- 30 stays conservative against a vanilla PG's `max_connections=100` (the pgvector driver holds its own pool of up to 8) while giving concurrent write bursts ~50% more headroom.

## Behavior notes

- Invalid values (non-integer, `min > max`, `max < 1`) **fail startup loudly** instead of silently falling back — same philosophy as `Settings`' `extra="forbid"`.
- Empty-string env values fall through to the YAML/default (so an unset `value:` in a manifest is harmless).
- Pool size alone doesn't fix the hot-vault exhaustion path (a writer still holds its pool connection across the serialized git commit) — tracked separately.

## Testing

- `_pool_sizes()` smoke-verified across 6 cases: defaults / env-max only / env-min+max / non-integer → RuntimeError / min>max → RuntimeError / empty strings → fallback.
- `ruff`, `mypy --python-version 3.14`, `bandit -c pyproject.toml --severity-level medium` all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NufEDvj8bi6412aBpGWyeP