### PR TITLE
feat(backend): write-lane admission for git-committing writes (command-lane round-05)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -391,6 +391,34 @@ class Settings(BaseModel):
     # legacy single-task behavior; 4-8 is the typical production knob.
     indexing_concurrency: int = 1
 
+    # ── Write-lane admission (design/proposal/command-lane-write-path,
+    # round-05). Git-committing writes pass a two-stage gate BEFORE
+    # acquiring any scarce resource (pool connection, executor thread):
+    # per-vault gate (hardwired to 1 — git serializes per vault anyway)
+    # then a global lane semaphore. Waiting happens as suspended
+    # coroutines, so a hot vault's backlog costs memory only and cannot
+    # starve reads or other vaults.
+    #
+    # Global concurrency for git-committing writes. Also sizes the
+    # dedicated commit ThreadPoolExecutor. Bounds the pool connections
+    # writes can hold at once — keep well under pg_pool_max_size (30) so
+    # reads always have headroom.
+    write_lane_concurrency: int = 8
+    # Total admission deadline (both gate stages). Exceeded → 429 with
+    # Retry-After; the request performed no work. Sized so a normal
+    # multi-file ingest burst (commits are ~50-200ms) rides it out,
+    # while nothing ever reaches the ingress 120s proxy timeout.
+    write_lane_queue_timeout_secs: float = 10.0
+    # Global cap on concurrently-waiting writers — a memory/socket
+    # backstop, not a policy knob. Normal operation never reaches it;
+    # arrivals beyond it fail fast instead of accumulating state.
+    write_lane_max_waiters: int = 512
+    # kill_after_timeout for git commands on the write path (reset/add/
+    # rm/mv/write-tree/commit-tree/update-ref). A wedged git process
+    # otherwise pins a lane slot + commit thread + pool connection until
+    # the 60s idle-in-transaction reaper fires.
+    git_write_timeout_secs: float = 30.0
+
     # BM25 corpus tuning (driver-neutral; lives in main PG vocab).
     bm25_k1: float = 1.5
     bm25_b: float = 0.75

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -33,6 +33,25 @@ class ForbiddenError(AKBError):
         super().__init__(message, status_code=403)
 
 
+class WriteBusyError(AKBError):
+    """Write admission timed out → HTTP 429.
+
+    Raised by the write lane (services/write_lane.py) when a git-committing
+    write waited out its queue deadline (per-vault gate + global lane), or
+    when the global waiter backstop is full. The request performed no work —
+    retrying after a short backoff is always safe. ``retry_after_secs`` is
+    surfaced as the HTTP ``Retry-After`` header and in the MCP error envelope.
+    """
+
+    def __init__(self, vault: str, waited_secs: float, retry_after_secs: int = 5):
+        self.retry_after_secs = retry_after_secs
+        super().__init__(
+            f"Write queue for vault '{vault}' is saturated "
+            f"(gave up after {waited_secs:.0f}s); retry shortly",
+            status_code=429,
+        )
+
+
 class ValidationError(AKBError, ValueError):
     """Client-input error → HTTP 422.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,9 +52,17 @@ app = FastAPI(
 # Global exception handler
 @app.exception_handler(AKBError)
 async def akb_error_handler(request: Request, exc: AKBError):
+    # WriteBusyError (429) carries a retry hint; RFC 6585 wants it as a
+    # Retry-After header so well-behaved clients back off without parsing
+    # the body.
+    headers = None
+    retry_after = getattr(exc, "retry_after_secs", None)
+    if retry_after is not None:
+        headers = {"Retry-After": str(int(retry_after))}
     return JSONResponse(
         status_code=exc.status_code,
         content={"error": exc.message},
+        headers=headers,
     )
 
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -15,6 +15,7 @@ from app.models.vault_scope import current_vault_scope
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
+from app.services.write_lane import run_compensation, run_git_write
 from app.util.errors import NOT_FOUND, err
 
 logger = logging.getLogger("akb.access")
@@ -903,13 +904,37 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
     # On-disk cleanup: bare repo + persistent worktree. Both must go,
     # otherwise a same-named recreate hits stale state on its second
     # commit (the first that materialises the worktree).
-    GitService().cleanup_vault_dirs(vault_name)
+    #
+    # Commit executor, NOT inline: cleanup_vault_dirs blocks on the
+    # per-vault threading.Lock and then rmtree's the whole repo —
+    # running that on the event loop stalls every request (and /livez)
+    # for the duration; running it on the shared to_thread pool lets a
+    # lock wait eat a thread reads need. No write-lane gate on purpose:
+    # PG cascade above already committed, and a lane-timeout 429 here
+    # would strand orphan dirs that block a same-named recreate.
+    # must_complete: the DB rows are gone — if a client disconnect
+    # cancelled us while queueing for a slot, the dirs would otherwise
+    # survive as orphans this request can never come back to repair.
+    # A cancellation surfaced AFTER the cleanup completed must not skip
+    # the role cleanup below either — park it, finish, then re-raise.
+    pending_cancel: BaseException | None = None
+    try:
+        await run_git_write(GitService().cleanup_vault_dirs, vault_name, must_complete=True)
+    except asyncio.CancelledError as ce:
+        pending_cancel = ce  # cleanup DID complete (must_complete)
 
     # PG-native RBAC: drop the three vault group roles. Memberships
-    # auto-clean as part of DROP ROLE.
-    await get_role_sync().on_vault_delete(vault_id)
+    # auto-clean as part of DROP ROLE. run_compensation: a cancel mid-DDL
+    # is absorbed until the drop COMPLETES — a bare shield would detach it
+    # and strand the roles if shutdown closes the pool underneath.
+    try:
+        await run_compensation(get_role_sync().on_vault_delete(vault_id))
+    except asyncio.CancelledError as ce:
+        pending_cancel = ce
 
     logger.info("Deleted vault: %s", vault_name)
+    if pending_cancel is not None:
+        raise pending_cancel
     return {"deleted": True, "vault": vault_name}
 
 

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -9,7 +9,6 @@ and emits `collection.delete`. Anything that would mutate git happens
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 
@@ -26,6 +25,7 @@ from app.services.index_service import (
 from app.services.kg_service import delete_document_relations
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
 from app.services.uri_service import file_uri, table_uri
+from app.services.write_lane import run_git_write, write_lane
 
 logger = logging.getLogger("akb.collections")
 
@@ -397,12 +397,19 @@ class CollectionService:
         # correct. Logged loudly so an operator can reconcile.
         if doc_paths_for_git:
             try:
-                await asyncio.to_thread(
-                    self.git.delete_paths_bulk,
-                    vault_name=vault,
-                    file_paths=doc_paths_for_git,
-                    message=commit_msg_for_git,
-                )
+                # Write-lane gate + commit executor: this commit contends on
+                # the vault git lock like any writer, and must never wait for
+                # it inside a shared executor thread. It holds no PG
+                # connection here (TX already committed), so a lane timeout
+                # (WriteBusyError) simply falls into the operator-reconcile
+                # path below — the API call still succeeds.
+                async with write_lane(vault):
+                    await run_git_write(
+                        self.git.delete_paths_bulk,
+                        vault_name=vault,
+                        file_paths=doc_paths_for_git,
+                        message=commit_msg_for_git,
+                    )
             except FileNotFoundError:
                 # No bare repo (test fixtures, fresh vault) — DB is
                 # already consistent, nothing to clean up.

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -105,7 +105,7 @@ def _safe_remote_host(url: str) -> str:
 import frontmatter
 
 from app.db.postgres import get_pool
-from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
+from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError, WriteBusyError
 from app.models.document import (
     DOC_STATUSES,
     BrowseItem,
@@ -129,16 +129,35 @@ from app.services.index_service import (
     chunk_markdown,
     write_source_chunks,
     delete_document_chunks,
+    delete_vault_chunks,
 )
 from app.services.kg_service import delete_document_relations, store_document_relations
 from app.services.resource_hash import HASH_ALGORITHM, compute_text_content_hash
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
 from app.services.user_directory import resolve_display_names
+from app.services.write_lane import run_compensation, run_git_write, write_lane
 from app.repositories import table_data_repo
 from app.utils import ensure_list
 
 logger = logging.getLogger("akb.documents")
+
+# Serializes create_vault attempts per vault name — including their rollback
+# — so the rollback's "did THIS request create the on-disk repo?" ownership
+# probe can't misfire on a concurrent same-name create (which would delete
+# the winner's repo). Deliberately separate from write_lane's vault gates:
+# the seed put() inside create_vault takes the lane gate, and this lock
+# nests outside it. Entries are never reaped (same precedent as
+# git_service._VAULT_LOCKS — a few idle bytes per name ever created here).
+_CREATE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _create_lock(name: str) -> asyncio.Lock:
+    lock = _CREATE_LOCKS.get(name)
+    if lock is None:
+        lock = asyncio.Lock()
+        _CREATE_LOCKS[name] = lock
+    return lock
 
 
 class EditError(AKBError):
@@ -268,7 +287,7 @@ class DocumentService:
         return content_hash, HASH_ALGORITHM
 
     @asynccontextmanager
-    async def _path_lock(self, vault_id: uuid.UUID, file_path: str):
+    async def _path_lock(self, vault_id: uuid.UUID, file_path: str, *, vault_name: str):
         """Hold an exclusive (vault_id, path) advisory lock for the duration
         of the with-block. Serializes concurrent put/update/edit/delete on
         the same logical document path so git HEAD never diverges from
@@ -284,23 +303,33 @@ class DocumentService:
         (and any read needing the pool) stalled until PG's 60s
         ``idle_in_transaction_session_timeout`` killed the lock transactions.
         One connection per writer makes the pool a clean backpressure queue.
+
+        Write-lane admission (``vault_name``) comes FIRST — before the pool
+        connection is even requested. Waiting for a busy vault happens as a
+        suspended coroutine, so a same-vault backlog holds zero connections
+        and zero executor threads; the connection is only occupied for the
+        actual work span. Deadline exceeded → WriteBusyError (429), with no
+        resources acquired. See services/write_lane.py (round-05).
         """
-        pool = await get_pool()
-        async with pool.acquire() as lock_conn:
-            async with lock_conn.transaction():
-                await acquire_path_lock(lock_conn, vault_id, file_path)
-                yield lock_conn
+        async with write_lane(vault_name):
+            pool = await get_pool()
+            async with pool.acquire() as lock_conn:
+                async with lock_conn.transaction():
+                    await acquire_path_lock(lock_conn, vault_id, file_path)
+                    yield lock_conn
 
     @asynccontextmanager
-    async def _move_lock(self, vault_id: uuid.UUID, path_a: str, path_b: str):
+    async def _move_lock(self, vault_id: uuid.UUID, path_a: str, path_b: str, *, vault_name: str):
         """Lock BOTH the source and destination paths for a move, in a stable
-        (sorted) order so two concurrent moves can't deadlock on each other."""
-        pool = await get_pool()
-        async with pool.acquire() as lock_conn:
-            async with lock_conn.transaction():
-                for p in sorted({path_a, path_b}):
-                    await acquire_path_lock(lock_conn, vault_id, p)
-                yield lock_conn
+        (sorted) order so two concurrent moves can't deadlock on each other.
+        Same write-lane admission discipline as ``_path_lock``."""
+        async with write_lane(vault_name):
+            pool = await get_pool()
+            async with pool.acquire() as lock_conn:
+                async with lock_conn.transaction():
+                    for p in sorted({path_a, path_b}):
+                        await acquire_path_lock(lock_conn, vault_id, p)
+                    yield lock_conn
 
     async def _resolve_free_path(
         self, doc_repo, vault_id: uuid.UUID, base_path: str,
@@ -387,7 +416,7 @@ class DocumentService:
         normalized_collection = _normalize_collection(req.collection)
         base_path = _doc_path(normalized_collection, base_slug)
 
-        async with self._path_lock(vault_id, base_path) as conn:
+        async with self._path_lock(vault_id, base_path, vault_name=req.vault) as conn:
             return await self._put_locked(
                 req=req, agent_id=agent_id, vault_id=vault_id, doc_id=doc_id,
                 base_path=base_path, base_slug=base_slug,
@@ -435,7 +464,7 @@ class DocumentService:
 
         # Git commit
         commit_msg = f"[put] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: create\nsummary: {req.title}"
-        commit_hash = await asyncio.to_thread(
+        commit_hash = await run_git_write(
             self.git.commit_file,
             vault_name=req.vault, file_path=file_path,
             content=md_content, message=commit_msg,
@@ -729,7 +758,7 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path) as conn:
+        async with self._path_lock(vault_id, file_path, vault_name=vault) as conn:
             # Re-read under the lock so we observe any commit that landed
             # between the initial resolution and lock acquisition. Uses the
             # lock connection so the whole update holds one pool connection.
@@ -794,7 +823,7 @@ class DocumentService:
 
         message = req.message or f"Update {file_path}"
         commit_msg = f"[update] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: update\nsummary: {message}"
-        commit_hash = await asyncio.to_thread(
+        commit_hash = await run_git_write(
             self.git.commit_file,
             vault_name=vault, file_path=file_path,
             content=new_md, message=commit_msg,
@@ -917,7 +946,7 @@ class DocumentService:
 
         _, _, est_new_path = _target(old_path, row["id"])
 
-        async with self._move_lock(vault_id, old_path, est_new_path) as conn:
+        async with self._move_lock(vault_id, old_path, est_new_path, vault_name=vault) as conn:
             # Re-read under the lock and recompute the target from fresh state.
             row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
@@ -957,7 +986,7 @@ class DocumentService:
                 f"agent: {agent_id or 'unknown'}\naction: move\nsummary: {summary}"
             )
             try:
-                commit_hash = await asyncio.to_thread(
+                commit_hash = await run_git_write(
                     self.git.move_file,
                     vault_name=vault, old_path=old_path, new_path=new_path,
                     message=commit_msg, author_name=agent_id or "AKB System",
@@ -1098,7 +1127,7 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path) as conn:
+        async with self._path_lock(vault_id, file_path, vault_name=vault) as conn:
             row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
                 raise NotFoundError("Document", doc_ref)
@@ -1169,7 +1198,7 @@ class DocumentService:
 
         msg = message or f"Edit {file_path}"
         commit_msg = f"[edit] {file_path}\n\nagent: {agent_id or 'unknown'}\naction: edit\nsummary: {msg}"
-        commit_hash = await asyncio.to_thread(
+        commit_hash = await run_git_write(
             self.git.commit_file,
             vault_name=vault, file_path=file_path,
             content=new_md, message=commit_msg,
@@ -1251,7 +1280,7 @@ class DocumentService:
             raise NotFoundError("Document", doc_ref)
         file_path = row["path"]
 
-        async with self._path_lock(vault_id, file_path) as conn:
+        async with self._path_lock(vault_id, file_path, vault_name=vault) as conn:
             # Re-resolve under the lock — a concurrent delete may have run.
             row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_ref)
             if not row:
@@ -1272,7 +1301,7 @@ class DocumentService:
         # Without this, a partial-delete leaves an undeletable document
         # row that needs operator intervention.
         try:
-            await asyncio.to_thread(
+            await run_git_write(
                 self.git.delete_file, vault_name=vault, file_path=file_path, message=commit_msg,
             )
         except FileNotFoundError:
@@ -1645,19 +1674,56 @@ class DocumentService:
             return str(vault_id)
 
         # Standard path: init_vault writes a bare directory to disk
-        # *before* the DB INSERT. If anything fails between the two
+        # *before* the DB INSERT. If anything fails in between
         # (commit_file crashes, request gets cancelled mid-flight, DB
-        # write hits a constraint), the bare directory orphans and
+        # write hits a constraint, the seed put() is rejected by a
+        # saturated write lane), the bare directory orphans and
         # init_vault's existence check permanently blocks the same
-        # name. Wrap as a transaction; cleanup_vault_dirs is the
-        # rollback. BaseException so SIGTERM and KeyboardInterrupt
-        # also unwind cleanly.
-        git_path = await asyncio.to_thread(self.git.init_vault, name)
+        # name. Wrap as a transaction: cleanup_vault_dirs undoes the
+        # disk side, _rollback_vault_rows undoes the DB side once the
+        # vaults row exists. BaseException so SIGTERM and
+        # KeyboardInterrupt also unwind cleanly.
+        #
+        # `_create_lock(name)` serializes same-name creates in-process for
+        # the WHOLE section including rollback. Without it the ownership
+        # probe below is unsound: A and B race the same name, A's init
+        # wins, B's fails, and B's rollback would see the dir "appear
+        # during its attempt" and delete A's repo. (Distinct from the
+        # write-lane vault gate on purpose — the seed put() below takes
+        # that gate, and this lock nests outside it.)
+        #
+        # `existed_before` guards the cancellation edge: an absorbed
+        # cancel inside run_git_write discards init_vault's outcome —
+        # including a FileExistsError for a name that already has a
+        # vault. Cleaning up in that state would delete the EXISTING
+        # vault's repo. Only ever clean up a directory this request
+        # itself brought into existence — and under the create lock,
+        # "appeared during this section and wasn't there before" implies
+        # exactly that.
+        async with _create_lock(name):
+            return await self._create_vault_standard(
+                name=name, description=description, template=template,
+                public_access=public_access, owner_id=owner_id, uid=uid,
+                external_git=external_git, vault_repo=vault_repo,
+                coll_repo=coll_repo,
+            )
+
+    async def _create_vault_standard(
+        self, *, name, description, template, public_access, owner_id, uid,
+        external_git, vault_repo, coll_repo,
+    ) -> str:
+        existed_before = self.git.vault_exists(name)
+        git_path: str | None = None
+        created_vault_id: uuid.UUID | None = None
         try:
+            git_path = await run_git_write(self.git.init_vault, name)
             vault_yaml = f"name: {name}\ndescription: {description}\n"
             if template:
                 vault_yaml += f"template: {template}\n"
-            await asyncio.to_thread(
+            # Commit executor (not the shared to_thread pool), but NO write-
+            # lane gate: the vault is mid-creation so nobody can contend, and
+            # gating would let a saturated lane fail vault creation with 429.
+            await run_git_write(
                 self.git.commit_file,
                 vault_name=name, file_path=".vault.yaml",
                 content=vault_yaml,
@@ -1666,6 +1732,7 @@ class DocumentService:
             vault_id = await vault_repo.create(
                 name, description, git_path, owner_id=uid, public_access=public_access,
             )
+            created_vault_id = vault_id
             # PG-native RBAC: create vault group roles + grant admin to owner,
             # then mirror public_access (no-op if 'none'). Done before template
             # application so any tables the template creates inherit grants
@@ -1701,17 +1768,211 @@ class DocumentService:
                 )
                 await self.put(seed_req, agent_id=str(owner_id) if owner_id else None)
         except BaseException:
+            # run_compensation: the whole rollback runs to COMPLETION even
+            # if the cancellation that may be unwinding us keeps firing;
+            # the cancel is re-delivered afterwards. Any rollback-internal
+            # failure is logged inside, never masks the original error.
             try:
-                await asyncio.to_thread(self.git.cleanup_vault_dirs, name)
-            except Exception as cleanup_err:  # noqa: BLE001
-                logger.warning(
-                    "create_vault rollback cleanup failed for %s: %s — operator must "
-                    "rm -rf the orphan bare/worktree dir manually before retrying",
-                    name, cleanup_err,
-                )
+                await run_compensation(self._rollback_vault_create(
+                    name=name,
+                    existed_before=existed_before,
+                    git_path=git_path,
+                    created_vault_id=created_vault_id,
+                    template=template,
+                ))
+            except asyncio.CancelledError:
+                raise
+            except Exception as rb_err:  # noqa: BLE001 — defense in depth; _rollback logs its own failures
+                logger.error("create_vault rollback itself failed for %s: %s", name, rb_err)
             raise
         logger.info("Vault created: %s (owner: %s, template: %s)", name, owner_id, template)
         return str(vault_id)
+
+    async def _rollback_vault_create(
+        self, *, name: str, existed_before: bool,
+        git_path: str | None, created_vault_id: uuid.UUID | None,
+        template: str | None,
+    ) -> None:
+        """Compensation for a failed create_vault.
+
+        SAFETY RULE — never destroy foreign data: the vaults row becomes
+        visible the moment it commits, so the owner can already be writing
+        documents to the new vault while creation is still seeding. If any
+        such write is detected, the destructive rollback is ABORTED and the
+        (functional, partially-seeded) vault is left in place; the creation
+        error still surfaces to the caller. Enforced by taking the vault's
+        write-lane gate — in-flight foreign writers drain first (they hold
+        the gate), new ones are excluded while we check and purge.
+
+        Runs under `_create_lock(name)` (caller holds it) and inside
+        run_compensation (no cancellation lands here). Order: DB purge
+        BEFORE disk — "orphan dirs blocking a recreate" (logged, operator
+        rm -rf) beats "live vaults row whose repo is gone" (500 on every
+        write).
+        """
+        if created_vault_id is None:
+            # Nothing visible yet — at most an on-disk dir we own.
+            await self._rollback_vault_disk(name, existed_before, git_path)
+            return
+        # Collection paths this creation owns: the seed's 'overview' plus
+        # whatever the template declares. Anything else is a foreign
+        # akb_create_collection and vetoes the purge.
+        from app.services import template_registry
+        owned_paths = {"overview"}
+        if template:
+            tmpl = template_registry.get(template) or {}
+            owned_paths.update(
+                c["path"] for c in tmpl.get("collections", []) if c.get("path")
+            )
+        try:
+            async with write_lane(name):
+                # The lane gate drains in-flight DOCUMENT writers before the
+                # repo dirs get removed below; row-level exclusion against
+                # ALL writers (tables/files don't take the lane) happens
+                # inside the purge transaction via FOR UPDATE.
+                purged = await self._rollback_vault_rows(
+                    created_vault_id, name, owned_paths=owned_paths,
+                )
+                if purged:
+                    await self._rollback_vault_disk(name, existed_before, git_path)
+        except WriteBusyError:
+            logger.error(
+                "create_vault rollback for %s SKIPPED: write lane saturated — "
+                "the half-created vault is left in place; delete it manually.",
+                name,
+            )
+
+    async def _rollback_vault_disk(
+        self, name: str, existed_before: bool, git_path: str | None,
+    ) -> None:
+        """Disk rollback — only for a directory THIS request created.
+        `git_path is not None` covers the normal case; the extra
+        vault_exists() probe covers an absorbed-cancel during init where
+        the thread completed but the coroutine never received git_path —
+        sound only because `_create_lock(name)` excludes concurrent
+        same-name creates.
+        """
+        if existed_before or (git_path is None and not self.git.vault_exists(name)):
+            return
+        try:
+            # Commit executor: cleanup blocks on the vault threading.Lock
+            # and rmtree's the repo — keep it off the shared read pool.
+            await run_git_write(self.git.cleanup_vault_dirs, name, must_complete=True)
+        except Exception as cleanup_err:  # noqa: BLE001
+            logger.warning(
+                "create_vault rollback cleanup failed for %s: %s — operator must "
+                "rm -rf the orphan bare/worktree dir manually before retrying",
+                name, cleanup_err,
+            )
+
+    async def _rollback_vault_rows(
+        self, vault_id: uuid.UUID, name: str, *, owned_paths: set[str],
+    ) -> bool:
+        """Best-effort DB purge for a failed create_vault. Returns True when
+        the purge ran (safe to remove the repo dirs too), False when it was
+        aborted or failed (the vault must be LEFT IN PLACE).
+
+        TOCTOU-free foreign-write detection: the transaction first locks the
+        vaults row with SELECT ... FOR UPDATE. Every FK writer — documents,
+        vault_tables (akb_create_table takes no write lane), vault_files —
+        holds FOR KEY SHARE on that row until its transaction ends, which
+        conflicts with FOR UPDATE. So in-flight foreign writes commit BEFORE
+        our lock is granted (the re-check below then sees them and aborts),
+        and later ones block until this transaction ends and then fail their
+        FK cleanly against the deleted row — the ON DELETE CASCADE on
+        vault_tables can never swallow an acknowledged foreign row.
+
+        Foreign = any document off the pinned seed path; any file / table /
+        publication / todo (creation makes none of those); any OTHER vault's
+        table_query publication referencing this vault by name
+        (query_vault_names); any collection outside ``owned_paths`` (seed
+        'overview' + template paths). The remaining vaults-FK tables are
+        creation-derived or consistent to purge: chunks (derived from the
+        seed), edges/resource_aliases (endpoints can only be the seed doc
+        once the doc guard passes), vault_access (access metadata shares
+        the vault's fate — round-8 disposition). Accepted residual
+        ambiguity: a foreign write landing exactly at
+        overview/vault-skill.md inside the creation window is
+        indistinguishable from our seed.
+
+        Never raises: the original create failure must stay the surfaced
+        error; a failed purge is logged for operator follow-up.
+        """
+        try:
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    locked = await conn.fetchrow(
+                        "SELECT id FROM vaults WHERE id = $1 FOR UPDATE", vault_id,
+                    )
+                    if locked is None:
+                        # Row already gone (competing manual delete) — the
+                        # disk dirs are still ours to clean.
+                        return True
+                    # xvault_pubs: table_query publications OWNED BY OTHER
+                    # vaults can reference this vault by NAME via
+                    # query_vault_names (TEXT[], no FK) — purging the vault
+                    # would break their already-shared public URLs at
+                    # resolution time. Name-based, so the FOR UPDATE
+                    # serialization does NOT cover it: a publish committing
+                    # inside the check→purge window still dangles. Accepted
+                    # residual — the window is microseconds and delete_vault
+                    # has the identical (pre-existing) dangling hazard.
+                    foreign = await conn.fetchrow(
+                        """
+                        SELECT
+                          (SELECT COUNT(*) FROM documents
+                            WHERE vault_id = $1 AND path <> 'overview/vault-skill.md') AS docs,
+                          (SELECT COUNT(*) FROM vault_files WHERE vault_id = $1) AS files,
+                          (SELECT COUNT(*) FROM vault_tables WHERE vault_id = $1) AS tables,
+                          (SELECT COUNT(*) FROM publications WHERE vault_id = $1) AS pubs,
+                          (SELECT COUNT(*) FROM publications
+                            WHERE $3 = ANY(query_vault_names)) AS xvault_pubs,
+                          (SELECT COUNT(*) FROM todos WHERE vault_id = $1) AS todos,
+                          (SELECT COUNT(*) FROM collections
+                            WHERE vault_id = $1 AND path <> ALL($2::text[])) AS colls
+                        """,
+                        vault_id, list(owned_paths), name,
+                    )
+                    foreign_keys = ("docs", "files", "tables", "pubs", "xvault_pubs", "todos", "colls")
+                    if any(foreign[k] for k in foreign_keys):
+                        logger.error(
+                            "create_vault rollback for %s ABORTED: the vault already "
+                            "accepted writes from other requests (%s) — leaving it in "
+                            "place (partially seeded). The creation error still "
+                            "propagates; delete the vault manually if it is unwanted.",
+                            name,
+                            ", ".join(f"{k}={foreign[k]}" for k in foreign_keys),
+                        )
+                        return False
+                    # events first: the seed put() emitted document.put rows
+                    # (events has no vault FK cascade) — leaving them would
+                    # feed consumers an event for a vault this rollback is
+                    # about to erase.
+                    await conn.execute("DELETE FROM events WHERE vault_id = $1", vault_id)
+                    await conn.execute("DELETE FROM edges WHERE vault_id = $1", vault_id)
+                    await delete_vault_chunks(conn, vault_id)
+                    await conn.execute("DELETE FROM documents WHERE vault_id = $1", vault_id)
+                    await conn.execute("DELETE FROM collections WHERE vault_id = $1", vault_id)
+                    await conn.execute("DELETE FROM todos WHERE vault_id = $1", vault_id)
+                    await conn.execute("DELETE FROM vault_access WHERE vault_id = $1", vault_id)
+                    await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                "create_vault rollback: DB purge failed for vault %s (%s): %s — "
+                "the half-created vault (rows AND repo) is left in place; "
+                "delete the vault manually",
+                name, vault_id, e,
+            )
+            return False
+        try:
+            await get_role_sync().on_vault_delete(vault_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "create_vault rollback: role cleanup failed for vault %s (%s): %s",
+                name, vault_id, e,
+            )
+        return True
 
     async def _apply_template(self, vault_name: str, vault_id: uuid.UUID, template: str, coll_repo) -> None:
         """Apply a vault template via the shared TemplateRegistry."""
@@ -1746,7 +2007,7 @@ class DocumentService:
                 if suggested:
                     guide_content += f"\n\nSuggested document types: {', '.join(suggested)}"
 
-                await asyncio.to_thread(
+                await run_git_write(
                     self.git.commit_file,
                     vault_name=vault_name,
                     file_path=f"{path}/_guide.md",

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -53,6 +53,18 @@ def _vault_lock(vault_name: str) -> threading.Lock:
         return lock
 
 
+def _write_kt() -> dict:
+    """`kill_after_timeout` kwarg for write-path git commands.
+
+    A wedged git process (disk stall, huge `reset --hard` stat sweep)
+    otherwise pins the vault lock + a commit-executor thread + the caller's
+    pool connection until PG's 60s idle-in-transaction reaper fires. Killing
+    the command fails just that one request (transaction rolls back; the
+    next write's `reset --hard` reconciles the worktree) and frees the lane.
+    """
+    return {"kill_after_timeout": settings.git_write_timeout_secs}
+
+
 
 class GitService:
     def __init__(self, storage_path: str | None = None):
@@ -98,10 +110,10 @@ class GitService:
         working directory instead, so writes remain safe across thread-pool
         workers and vaults.
         """
-        tree_sha = work_repo.git.write_tree()
+        tree_sha = work_repo.git.write_tree(**_write_kt())
         parent_args: list[str] = []
         if parent_required:
-            work_repo.git.rev_parse("--verify", "HEAD")
+            work_repo.git.rev_parse("--verify", "HEAD", **_write_kt())
             parent_args = ["-p", "HEAD"]
 
         with work_repo.git.custom_environment(**self._git_author_env(author_name, author_email)):
@@ -111,9 +123,10 @@ class GitService:
                 *parent_args,
                 "-m",
                 message,
+                **_write_kt(),
             ).strip()
-        work_repo.git.update_ref("HEAD", commit_sha)
-        return work_repo.git.rev_parse("HEAD").strip()
+        work_repo.git.update_ref("HEAD", commit_sha, **_write_kt())
+        return work_repo.git.rev_parse("HEAD", **_write_kt()).strip()
 
     def _ensure_worktree(self, vault_name: str) -> Path | None:
         """Create a persistent worktree for this vault if one doesn't exist.
@@ -135,7 +148,7 @@ class GitService:
             return None  # empty repo; caller falls back to the clone path
         wt.parent.mkdir(parents=True, exist_ok=True)
         try:
-            bare_repo.git.worktree("add", str(wt), branch_name)
+            bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
         except GitError as e:
             # A previous `worktree add` killed mid-write (SIGKILL, OOM,
             # container restart) can leave the bare's
@@ -150,8 +163,8 @@ class GitService:
                 "worktree add for vault %s tripped stale registration; pruning and retrying: %s",
                 vault_name, msg,
             )
-            bare_repo.git.worktree("prune")
-            bare_repo.git.worktree("add", str(wt), branch_name)
+            bare_repo.git.worktree("prune", **_write_kt())
+            bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
         logger.info("Worktree created for vault %s at %s (branch=%s)", vault_name, wt, branch_name)
         return wt
 
@@ -573,13 +586,13 @@ class GitService:
             # bare ref (e.g., a previous crash mid-commit), sync to HEAD
             # before writing. With a single writer this is a no-op in the
             # steady state.
-            work_repo.git.reset("--hard", "HEAD")
+            work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
             full_path = wt / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(content, encoding="utf-8")
 
-            work_repo.git.add("--", file_path)
+            work_repo.git.add("--", file_path, **_write_kt())
             return self._stage_and_commit(
                 work_repo,
                 message,
@@ -603,13 +616,13 @@ class GitService:
                 raise FileNotFoundError(f"File not found in vault: {file_path}")
 
             work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD")
+            work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
             full_path = wt / file_path
             if not full_path.exists():
                 raise FileNotFoundError(f"File not found in vault: {file_path}")
 
-            work_repo.git.rm("--", file_path)
+            work_repo.git.rm("--", file_path, **_write_kt())
             return self._stage_and_commit(
                 work_repo,
                 message,
@@ -642,7 +655,7 @@ class GitService:
                 raise FileNotFoundError(f"File not found in vault: {old_path}")
 
             work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD")
+            work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
             src = wt / old_path
             if not src.exists():
@@ -656,7 +669,7 @@ class GitService:
                 raise FileExistsError(f"Destination already exists in vault: {new_path}")
             dst.parent.mkdir(parents=True, exist_ok=True)
 
-            work_repo.git.mv("--", old_path, new_path)
+            work_repo.git.mv("--", old_path, new_path, **_write_kt())
             return self._stage_and_commit(
                 work_repo,
                 message,
@@ -702,7 +715,7 @@ class GitService:
                 return None
 
             work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD")
+            work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
             # Dedupe while preserving caller order so log output is stable
             # and so a doubled path doesn't make `git rm` fail on
@@ -716,7 +729,7 @@ class GitService:
                 )
                 return None
 
-            work_repo.git.rm("--", *present)
+            work_repo.git.rm("--", *present, **_write_kt())
             return self._stage_and_commit(
                 work_repo,
                 message,
@@ -761,21 +774,22 @@ class GitService:
         # Stable parent for the tmp dir so we don't depend on the
         # process cwd to resolve a relative name. ``storage_path``
         # always exists on a healthy deploy.
+        clone_timeout = settings.git_write_timeout_secs
         with tempfile.TemporaryDirectory(dir=str(self.storage_path)) as tmp:
             try:
                 subprocess.run(
                     ["git", "clone", "--quiet", str(bare_path), tmp],
-                    check=True, cwd=tmp, timeout=60,
+                    check=True, cwd=tmp, timeout=clone_timeout,
                 )
             except subprocess.TimeoutExpired as e:
                 raise GitError(
-                    f"git clone timed out after 60s for vault {vault_name}"
+                    f"git clone timed out after {clone_timeout:.0f}s for vault {vault_name}"
                 ) from e
             work_repo = Repo(tmp)
             full_path = Path(tmp) / file_path
             full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_text(content, encoding="utf-8")
-            work_repo.git.add("--", file_path)
+            work_repo.git.add("--", file_path, **_write_kt())
             commit_hash = self._stage_and_commit(
                 work_repo,
                 message,
@@ -783,11 +797,11 @@ class GitService:
                 author_email,
                 parent_required=False,
             )
-            # Push is local-to-local (bare repo on the same disk), so
-            # 60s is generous; if it hangs the timeout still releases
-            # the vault lock for the next caller.
+            # Push is local-to-local (bare repo on the same disk), so the
+            # standard write timeout is generous; if it hangs the timeout
+            # still releases the vault lock for the next caller.
             try:
-                work_repo.git.push("origin", kill_after_timeout=60)
+                work_repo.git.push("origin", **_write_kt())
             except GitError as e:
                 raise GitError(
                     f"git push failed for vault {vault_name}: {e}"

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -10,7 +10,7 @@ import logging
 
 from app.config import settings
 from app.db.postgres import close_pool, get_pool, init_db
-from app.services import audit_log, delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker, sparse_encoder, vault_backfill
+from app.services import audit_log, delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, metadata_worker, s3_delete_worker, sparse_encoder, vault_backfill, write_lane
 from app.services.git_service import GitService
 from app.services.role_sync import RoleSync, get_role_sync, set_role_sync
 from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
@@ -134,7 +134,11 @@ def start_workers() -> None:
     # also depends on it — move to the always-run path if API/worker tiers split.)
     sparse_encoder.start_tokenizer_pool()
     sparse_encoder.start_stats_refresher(settings.bm25_recompute_interval_secs)
-    started = ["tokenizer_pool", "embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher", "vault_backfill"]
+    # Dedicated git-commit executor (write-lane, command-lane round-05).
+    # Git mutations run here so blocked/slow commits can never crowd git
+    # READS out of asyncio.to_thread's shared default executor.
+    write_lane.start_commit_pool()
+    started = ["tokenizer_pool", "git_commit_pool", "embed_worker", "delete_worker", "external_git_poller", "bm25_stats_refresher", "vault_backfill"]
     # s3_delete_worker drains s3_delete_outbox into S3 deletes. Only
     # makes sense when S3 is configured; otherwise file uploads are
     # disabled altogether and the outbox stays empty forever.
@@ -196,6 +200,7 @@ async def stop_workers() -> None:
     await vault_backfill.stop()
     await sparse_encoder.stop_stats_refresher()
     sparse_encoder.stop_tokenizer_pool()
+    write_lane.stop_commit_pool()
 
 
 async def shutdown_storage() -> None:

--- a/backend/app/services/write_lane.py
+++ b/backend/app/services/write_lane.py
@@ -1,0 +1,349 @@
+"""Write-lane admission control for git-committing write paths.
+
+Design: docs/design/proposal/command-lane-write-path (round-05).
+
+Two independent starvation paths existed on the write path, both caused by
+the same mistake — WAITING while holding a scarce resource:
+
+1. Pool poisoning: a writer queued for the per-vault git lock while holding
+   a pool connection inside an open transaction. Enough same-vault writers
+   drained the global pool and stalled every read on every vault.
+2. Executor starvation: that queueing happened INSIDE a thread of the shared
+   asyncio.to_thread executor (``min(32, cpu+4)`` — 12 on an 8-core node).
+   Blocked waiters ate the pool that document reads (also to_thread) need,
+   so a hot vault froze git reads service-wide before the PG pool even ran dry.
+
+The fix moves admission in front of resource acquisition, into event-loop
+space where waiting is a suspended coroutine (a few KB of memory, no thread,
+no connection):
+
+    request → per-vault gate (1 concurrent; FIFO)        ← coroutine wait
+            → global lane semaphore (write_lane_concurrency)
+            → only now: pool connection + advisory lock + transaction
+            → git commit via the DEDICATED commit executor
+            → PG writes → transaction commit → release everything
+
+Order matters: the per-vault gate comes FIRST. If the global slots were
+taken first, a hot vault's waiters would camp on them while queueing for
+their own vault gate — re-creating cross-vault contagion at the lane level.
+
+The per-vault ``threading.Lock`` in git_service stays as the last-line
+correctness guard (worker paths — external_git poller, vault seeding —
+commit without passing this lane); with API traffic gated here it is
+uncontended in the steady state.
+
+Both gate stages share one deadline (``write_lane_queue_timeout_secs``);
+exceeding it raises :class:`~app.exceptions.WriteBusyError` → HTTP 429 +
+Retry-After / MCP ``write_busy`` envelope. No work has been performed at
+that point, so retrying is always safe. ``write_lane_max_waiters`` is a
+global memory/socket backstop, not a policy knob — normal operation never
+reaches it.
+
+Like git_service's ``_VAULT_LOCKS``, gate entries are keyed by vault name
+and never reaped; a deleted vault leaves a few idle bytes behind, bounded
+by the total number of vaults ever written to in this process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, TypeVar
+
+from app.config import settings
+from app.exceptions import WriteBusyError
+
+logger = logging.getLogger("akb.write_lane")
+
+T = TypeVar("T")
+
+# True while the current task holds a global lane slot (set inside
+# write_lane). run_git_write consults it so ungated callers (vault
+# lifecycle: init/seed/template/cleanup) transparently acquire a slot of
+# their own before touching the commit executor — the executor therefore
+# only ever receives slot holders and can never build a queue that
+# admitted writers (holding PG connections) would have to sit in.
+_slot_held: ContextVar[bool] = ContextVar("akb_write_slot_held", default=False)
+
+# Per-vault admission gates (1 concurrent writer per vault — git commits
+# serialize per vault anyway, so more buys nothing while git is on the
+# synchronous path; see round-05 "granularity").
+_vault_gates: dict[str, asyncio.Lock] = {}
+
+# Global write-lane semaphore — caps writes as a CLASS, so the connections
+# and commit threads they can occupy are bounded no matter how many vaults
+# are active at once.
+_global_slots: asyncio.Semaphore | None = None
+
+# Writers currently inside the admission wait (both stages). Backstop only.
+_waiters: int = 0
+
+# Ungated (vault-lifecycle) calls currently waiting for a global slot in
+# run_git_write. Observability only — no backstop: these are rare
+# operator-grade operations and must not fail with 429 at saturation.
+_lifecycle_waiters: int = 0
+
+# Dedicated executor for git-MUTATING operations. Git reads keep using
+# asyncio.to_thread's default executor; commits physically cannot crowd
+# them out. Sized to write_lane_concurrency — admitted writers only, so
+# there is never queueing here in the steady state.
+_commit_pool: ThreadPoolExecutor | None = None
+
+
+def _vault_gate(vault: str) -> asyncio.Lock:
+    gate = _vault_gates.get(vault)
+    if gate is None:
+        gate = asyncio.Lock()
+        _vault_gates[vault] = gate
+    return gate
+
+
+def _global_sem() -> asyncio.Semaphore:
+    global _global_slots
+    if _global_slots is None:
+        _global_slots = asyncio.Semaphore(max(1, settings.write_lane_concurrency))
+    return _global_slots
+
+
+@asynccontextmanager
+async def write_lane(vault: str):
+    """Admit one git-committing write for ``vault``.
+
+    Enter BEFORE acquiring any pool connection / advisory lock; hold for
+    the whole critical section (git commit + PG transaction). Raises
+    :class:`WriteBusyError` (→ 429) when the deadline or the global waiter
+    backstop is exceeded — in both cases no work has been done yet.
+    """
+    global _waiters
+    if _waiters >= settings.write_lane_max_waiters:
+        logger.warning(
+            "write lane backstop hit (%d waiters) — rejecting write for vault %s",
+            _waiters, vault,
+        )
+        raise WriteBusyError(vault, 0.0)
+
+    gate = _vault_gate(vault)
+    sem = _global_sem()
+    timeout = settings.write_lane_queue_timeout_secs
+    got_gate = got_slot = False
+    slot_token = None
+    _waiters += 1
+    try:
+        try:
+            async with asyncio.timeout(timeout):
+                await gate.acquire()
+                got_gate = True
+                await sem.acquire()
+                got_slot = True
+        except TimeoutError:
+            logger.warning(
+                "write admission timed out after %.0fs for vault %s (%d waiters)",
+                timeout, vault, _waiters,
+            )
+            raise WriteBusyError(vault, timeout) from None
+        finally:
+            _waiters -= 1
+        slot_token = _slot_held.set(True)
+        yield
+    finally:
+        if slot_token is not None:
+            _slot_held.reset(slot_token)
+        if got_slot:
+            sem.release()
+        if got_gate:
+            gate.release()
+
+
+def start_commit_pool() -> None:
+    """Create the dedicated git-commit executor. Idempotent."""
+    global _commit_pool
+    if _commit_pool is not None:
+        return
+    n = max(1, settings.write_lane_concurrency)
+    _commit_pool = ThreadPoolExecutor(
+        max_workers=n, thread_name_prefix="akb-git-commit",
+    )
+    logger.info("git commit executor started (workers=%d)", n)
+
+
+def stop_commit_pool() -> None:
+    """Shut down the commit executor.
+
+    ``wait=False``: by the time lifespan shutdown runs, uvicorn has drained
+    in-flight requests, so the pool is idle; any straggler thread is joined
+    at interpreter exit (ThreadPoolExecutor threads are non-daemon).
+    """
+    global _commit_pool
+    if _commit_pool is None:
+        return
+    _commit_pool.shutdown(wait=False)
+    _commit_pool = None
+    logger.info("git commit executor stopped")
+
+
+async def run_git_write(
+    fn: Callable[..., T], /, *args: Any, must_complete: bool = False, **kwargs: Any,
+) -> T:
+    """Run a git-MUTATING call on the dedicated commit executor.
+
+    Use for commit_file / delete_file / move_file / delete_paths_bulk and
+    the vault-lifecycle mutations (init/seed/template/cleanup). Git READS
+    stay on asyncio.to_thread — the whole point is that these two classes
+    of work never share a thread pool.
+
+    Slot discipline: callers inside ``write_lane`` already hold a global
+    lane slot (tracked via ContextVar); everyone else transparently
+    acquires one here first, as a plain coroutine wait with no deadline —
+    vault-lifecycle operations are rare and must not 429, but they must
+    also never occupy the executor beyond the lane's global budget.
+    Invariant: the commit executor only ever runs slot holders, so its
+    internal queue stays empty and an admitted writer (holding a PG
+    connection) never waits behind ungated work.
+
+    Cancellation: an executor thread cannot be interrupted. If the caller
+    is cancelled mid-commit we absorb the cancellation until the thread
+    finishes (bounded by ``git_write_timeout_secs`` on the git side) and
+    only then propagate it. Unwinding immediately would release the lane
+    and the caller's resources while the commit still holds the per-vault
+    threading.Lock — the next admitted writer would then block on that
+    lock inside the executor holding a PG connection, which is the exact
+    pathology the lane exists to prevent.
+
+    ``must_complete=True`` extends that absorption to the slot WAIT as
+    well: cancellation while queueing does not abort the call — the work
+    still runs to completion and only then is the cancellation delivered.
+    For compensation writes that must not be lost once their caller has
+    passed a point of no return (delete_vault's on-disk cleanup after the
+    DB cascade committed; create_vault's rollback cleanup). Without it, a
+    client disconnect in the queueing gap strands state the request can
+    never repair (e.g. orphan bare dirs that block a same-name recreate).
+    """
+    if _slot_held.get():
+        return await _dispatch_to_pool(fn, *args, **kwargs)
+
+    global _lifecycle_waiters
+    sem = _global_sem()
+    pending_cancel = False
+    _lifecycle_waiters += 1
+    try:
+        while True:
+            try:
+                await sem.acquire()
+                break
+            except asyncio.CancelledError:
+                if not must_complete:
+                    raise
+                pending_cancel = True
+    finally:
+        _lifecycle_waiters -= 1
+    try:
+        result = await _dispatch_to_pool(fn, *args, **kwargs)
+    finally:
+        sem.release()
+    if pending_cancel:
+        # The work is done; now deliver the cancellation we absorbed
+        # during the slot wait.
+        raise asyncio.CancelledError()
+    return result
+
+
+async def _dispatch_to_pool(fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    if _commit_pool is None:
+        # Lazy fallback for tests and callers outside the app lifespan.
+        start_commit_pool()
+    loop = asyncio.get_running_loop()
+    assert _commit_pool is not None
+    fut = loop.run_in_executor(_commit_pool, functools.partial(fn, *args, **kwargs))
+    try:
+        return await asyncio.shield(fut)
+    except asyncio.CancelledError:
+        if fut.cancelled():
+            # Never started (still queued when cancelled) — nothing runs,
+            # nothing to wait for.
+            raise
+        # Thread is (or may be) running: hold our lane/slot until it
+        # finishes, absorbing any further cancellation attempts.
+        while not fut.done():
+            try:
+                await asyncio.wait([fut])
+            except asyncio.CancelledError:
+                continue
+        # The fn's outcome is discarded in favor of the cancellation —
+        # log it so an absorbed failure (e.g. FileExistsError from
+        # init_vault on an existing name) stays diagnosable.
+        discarded = fut.exception()
+        logger.info(
+            "git write %s finished after caller cancellation; %s discarded "
+            "(a stray commit may exist until the next write reconciles the worktree)",
+            getattr(fn, "__name__", str(fn)),
+            f"exception {discarded!r}" if discarded else "result",
+        )
+        raise
+
+
+async def run_compensation(coro) -> Any:
+    """Run a compensation coroutine to COMPLETION, absorbing cancellation
+    until it finishes, then re-delivering the cancellation.
+
+    ``asyncio.shield`` alone is not enough for compensation steps: on
+    cancellation it raises immediately and lets the inner work continue as
+    a DETACHED task — during shutdown the pool can close underneath it,
+    leaving the compensation half-done with nobody watching. This helper
+    keeps the caller parked (as a coroutine, holding whatever locks the
+    compensation relies on) until the inner task actually completes.
+
+    If the inner work raises while a cancellation was absorbed, the
+    cancellation wins and the work's exception is logged (mirrors
+    ``_dispatch_to_pool``'s discard rule).
+    """
+    task = asyncio.ensure_future(coro)
+    absorbed: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as ce:
+            if task.cancelled():
+                raise  # the inner task itself was cancelled — nothing to wait for
+            absorbed = ce  # outer cancel; keep waiting for the inner task
+        except BaseException:  # noqa: BLE001 — task's own error; task is done, loop exits
+            break
+    if absorbed is not None:
+        exc = task.exception() if not task.cancelled() else None
+        if exc is not None:
+            logger.error(
+                "compensation step failed while absorbing a cancellation: %r "
+                "(cancellation takes precedence; state may need operator review)",
+                exc,
+            )
+        raise absorbed
+    return task.result()
+
+
+def snapshot() -> dict:
+    """Cheap observability hook (health/debug): current admission state."""
+    return {
+        "waiters": _waiters,
+        "lifecycle_waiters": _lifecycle_waiters,
+        "capacity": max(1, settings.write_lane_concurrency),
+        "vault_gates": len(_vault_gates),
+        "commit_pool_started": _commit_pool is not None,
+    }
+
+
+def _reset_for_tests() -> None:
+    """Drop all lane state. Tests only — never call in production code.
+
+    asyncio primitives bind to the loop they first wait on; pytest creates
+    a fresh loop per test, so module-level gates must be discarded between
+    tests or cross-loop reuse raises RuntimeError.
+    """
+    global _global_slots, _waiters, _lifecycle_waiters
+    stop_commit_pool()
+    _vault_gates.clear()
+    _global_slots = None
+    _waiters = 0
+    _lifecycle_waiters = 0

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -36,6 +36,7 @@ from app.exceptions import (
     ForbiddenError,
     NotFoundError,
     ValidationError,
+    WriteBusyError,
 )
 
 
@@ -64,6 +65,7 @@ INVALID_PATH = "invalid_path"              # collection / file path failure
 UNKNOWN_ARGUMENT = "unknown_argument"      # arg key not in tool schema (0.5.4)
 UNKNOWN_TOOL = "unknown_tool"
 CONFLICT = "conflict"                      # version / expected-state mismatch
+WRITE_BUSY = "write_busy"                  # write-lane admission timed out — retry after backoff
 UNIQUE_VIOLATION = "unique_violation"      # PG 23505 — INSERT/UPDATE breaks a unique key
 NO_OP = "no_op"                            # nothing to update / already in state
 EDIT_FAILED = "edit_failed"                # akb_edit: old_string match / uniqueness failure
@@ -135,6 +137,12 @@ def exception_envelope(e: Exception) -> dict:
         return err(str(e), code=NOT_FOUND)
     if isinstance(e, ConflictError):
         return err(str(e), code=CONFLICT)
+    if isinstance(e, WriteBusyError):
+        return err(
+            str(e), code=WRITE_BUSY,
+            hint="The vault is under heavy write load. Wait a few seconds and retry; no partial write occurred.",
+            retry_after_secs=e.retry_after_secs,
+        )
     if isinstance(e, ValidationError):
         return err(str(e), code=INVALID_ARGUMENT)
     return err(str(e), code=INTERNAL)

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -29,7 +29,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent
 
 from app.db.postgres import get_pool, init_db, close_pool
-from app.exceptions import ConflictError, NotFoundError, ValidationError
+from app.exceptions import ConflictError, NotFoundError, ValidationError, WriteBusyError
 from app.services.document_service import DocumentService, EditError
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
@@ -53,6 +53,7 @@ from app.util.errors import (
     NOT_FOUND,
     UNKNOWN_ARGUMENT,
     UNKNOWN_TOOL,
+    WRITE_BUSY,
 )
 from app.util.text import fuzzy_hint, to_nfc
 from app.services import publication_service, table_service
@@ -1442,7 +1443,18 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
                 available_arguments=sorted(allowed),
             )
 
-    return await handler(args, uid, user)
+    try:
+        return await handler(args, uid, user)
+    except WriteBusyError as e:
+        # Write-lane admission timed out (429-class). Precise code +
+        # machine-readable backoff so agents retry instead of treating
+        # it as an internal failure. No partial write occurred.
+        return err(
+            str(e),
+            code=WRITE_BUSY,
+            hint="The vault is under heavy write load. Wait a few seconds and retry; no partial write occurred.",
+            retry_after_secs=e.retry_after_secs,
+        )
 
 
 # ── Entry point ──────────────────────────────────────────────

--- a/backend/tests/test_write_lane_unit.py
+++ b/backend/tests/test_write_lane_unit.py
@@ -1,0 +1,509 @@
+"""Unit tests for write-lane admission (command-lane round-05).
+
+Covers the gate semantics in isolation — no DB, no git:
+
+- per-vault serialization (1 concurrent writer per vault)
+- cross-vault independence (a hot vault's backlog never parks another vault)
+- global lane cap (writes as a class are bounded)
+- deadline → WriteBusyError(429) with no leaked gate state
+- waiter backstop
+- cancellation while queued leaves no residue
+- FIFO admission order
+- invariants under a mixed-vault stress burst
+- run_git_write executes on the dedicated commit executor
+- REST (Retry-After header) and MCP (write_busy envelope) error surfaces
+"""
+
+import asyncio
+import tempfile
+import threading
+from collections import defaultdict
+
+import pytest
+
+from app.config import settings
+from app.exceptions import NotFoundError, WriteBusyError
+from app.services import write_lane
+
+# app.main / mcp_server.server instantiate DocumentService() at module load,
+# which mkdirs the git storage path — point it somewhere writable so the
+# lazy imports inside the error-surface tests don't blow up on `/data/vaults`
+# (same pattern as test_mcp_oauth_unit).
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-write-lane-test-vaults-")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_lane():
+    # asyncio primitives bind to the first loop that awaits them; pytest
+    # gives each test its own loop, so lane state must be dropped around
+    # every test.
+    write_lane._reset_for_tests()
+    yield
+    write_lane._reset_for_tests()
+
+
+async def test_same_vault_serializes():
+    order = []
+    first_in = asyncio.Event()
+    release = asyncio.Event()
+
+    async def first():
+        async with write_lane.write_lane("v"):
+            order.append("first-in")
+            first_in.set()
+            await release.wait()
+        order.append("first-out")
+
+    async def second():
+        await first_in.wait()
+        async with write_lane.write_lane("v"):
+            order.append("second-in")
+
+    t1 = asyncio.create_task(first())
+    t2 = asyncio.create_task(second())
+    await first_in.wait()
+    await asyncio.sleep(0.05)  # give `second` a chance to (wrongly) enter
+    assert order == ["first-in"], "second writer entered a held vault gate"
+    release.set()
+    await asyncio.gather(t1, t2)
+    assert order == ["first-in", "first-out", "second-in"]
+
+
+async def test_other_vault_not_blocked_by_hot_vault():
+    release = asyncio.Event()
+    hog_in = asyncio.Event()
+
+    async def hog():
+        async with write_lane.write_lane("hot"):
+            hog_in.set()
+            await release.wait()
+
+    task = asyncio.create_task(hog())
+    await hog_in.wait()
+    # Must acquire promptly — the hot vault's occupancy is irrelevant.
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("cold"):
+            pass
+    release.set()
+    await task
+
+
+async def test_global_cap_bounds_concurrent_writers(monkeypatch):
+    monkeypatch.setattr(settings, "write_lane_concurrency", 2)
+    active = 0
+    peak = 0
+    release = asyncio.Event()
+
+    async def writer(vault: str):
+        nonlocal active, peak
+        async with write_lane.write_lane(vault):
+            active += 1
+            peak = max(peak, active)
+            await release.wait()
+            active -= 1
+
+    tasks = [asyncio.create_task(writer(f"v{i}")) for i in range(4)]
+    await asyncio.sleep(0.05)
+    assert active == 2, "global lane admitted more than write_lane_concurrency"
+    release.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2
+
+
+async def test_deadline_raises_write_busy_and_releases_state(monkeypatch):
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 0.05)
+    release = asyncio.Event()
+    hog_in = asyncio.Event()
+
+    async def hog():
+        async with write_lane.write_lane("v"):
+            hog_in.set()
+            await release.wait()
+
+    task = asyncio.create_task(hog())
+    await hog_in.wait()
+    with pytest.raises(WriteBusyError) as ei:
+        async with write_lane.write_lane("v"):
+            pass
+    assert ei.value.status_code == 429
+    assert ei.value.retry_after_secs >= 1
+    release.set()
+    await task
+    # The timed-out waiter must not leak the gate: reacquire promptly.
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+    assert write_lane.snapshot()["waiters"] == 0
+
+
+async def test_global_slot_timeout_releases_vault_gate(monkeypatch):
+    # Vault gate acquired, then the wait for the (exhausted) global slot
+    # times out — the vault gate must be handed back.
+    monkeypatch.setattr(settings, "write_lane_concurrency", 1)
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 0.05)
+    release = asyncio.Event()
+    hog_in = asyncio.Event()
+
+    async def hog():
+        async with write_lane.write_lane("a"):
+            hog_in.set()
+            await release.wait()
+
+    task = asyncio.create_task(hog())
+    await hog_in.wait()
+    with pytest.raises(WriteBusyError):
+        async with write_lane.write_lane("b"):
+            pass
+    release.set()
+    await task
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("b"):
+            pass
+
+
+async def test_waiter_backstop_rejects_immediately(monkeypatch):
+    monkeypatch.setattr(settings, "write_lane_max_waiters", 0)
+    with pytest.raises(WriteBusyError):
+        async with write_lane.write_lane("v"):
+            pass
+
+
+async def test_exception_inside_lane_releases_gate():
+    with pytest.raises(ValueError):
+        async with write_lane.write_lane("v"):
+            raise ValueError("boom")
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+
+
+async def test_cancellation_while_waiting_releases_state():
+    release = asyncio.Event()
+    hog_in = asyncio.Event()
+
+    async def hog():
+        async with write_lane.write_lane("v"):
+            hog_in.set()
+            await release.wait()
+
+    t = asyncio.create_task(hog())
+    await hog_in.wait()
+
+    async def waiter():
+        async with write_lane.write_lane("v"):
+            pass
+
+    w = asyncio.create_task(waiter())
+    await asyncio.sleep(0.05)  # let the waiter actually park on the gate
+    w.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await w
+    assert write_lane.snapshot()["waiters"] == 0
+    release.set()
+    await t
+    # Cancelled waiter must not have corrupted the gate.
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+
+
+async def test_fifo_admission_order():
+    order: list[int] = []
+    release = asyncio.Event()
+    hog_in = asyncio.Event()
+
+    async def hog():
+        async with write_lane.write_lane("v"):
+            hog_in.set()
+            await release.wait()
+
+    t = asyncio.create_task(hog())
+    await hog_in.wait()
+
+    async def writer(i: int):
+        async with write_lane.write_lane("v"):
+            order.append(i)
+
+    tasks = []
+    for i in range(5):
+        tasks.append(asyncio.create_task(writer(i)))
+        await asyncio.sleep(0.01)  # deterministic arrival order
+    release.set()
+    await asyncio.gather(t, *tasks)
+    assert order == [0, 1, 2, 3, 4], "vault gate is not FIFO — starvation possible"
+
+
+async def test_stress_invariants_hold_and_state_drains(monkeypatch):
+    """150 writers over 7 vaults: per-vault ≤ 1, global ≤ M, and after the
+    burst every gate is reacquirable with zero waiters — no leaked state."""
+    monkeypatch.setattr(settings, "write_lane_concurrency", 4)
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 5.0)
+
+    per_vault_active: dict[str, int] = defaultdict(int)
+    global_active = 0
+    violations: list[tuple] = []
+
+    async def writer(vault: str):
+        nonlocal global_active
+        async with write_lane.write_lane(vault):
+            per_vault_active[vault] += 1
+            global_active += 1
+            if per_vault_active[vault] > 1:
+                violations.append(("per-vault", vault, per_vault_active[vault]))
+            if global_active > 4:
+                violations.append(("global", global_active))
+            await asyncio.sleep(0.001)
+            per_vault_active[vault] -= 1
+            global_active -= 1
+
+    tasks = [asyncio.create_task(writer(f"v{i % 7}")) for i in range(150)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    hard_errors = [
+        r for r in results
+        if isinstance(r, BaseException) and not isinstance(r, WriteBusyError)
+    ]
+    assert not violations, f"concurrency invariant violated: {violations[:5]}"
+    assert not hard_errors, f"unexpected errors: {hard_errors[:5]}"
+    assert write_lane.snapshot()["waiters"] == 0
+    async with asyncio.timeout(1.0):
+        for i in range(7):
+            async with write_lane.write_lane(f"v{i}"):
+                pass
+
+
+async def test_cancel_during_commit_absorbs_until_thread_done(monkeypatch):
+    """Cancelling a writer mid-commit must NOT release the lane while the
+    executor thread still runs (the thread holds the vault threading.Lock;
+    releasing early would let the next writer block on it holding a PG
+    connection — codex round-1 finding 1)."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_commit():
+        started.set()
+        release.wait(5)
+        return "sha"
+
+    async def writer():
+        async with write_lane.write_lane("v"):
+            await write_lane.run_git_write(slow_commit)
+
+    t = asyncio.create_task(writer())
+    await asyncio.to_thread(started.wait, 5)
+    t.cancel()
+    await asyncio.sleep(0.05)
+    # The writer must be absorbing the cancellation, not unwound.
+    assert not t.done(), "writer unwound while its git thread was still running"
+    # And the vault gate must still be held on its behalf.
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 0.05)
+    with pytest.raises(WriteBusyError):
+        async with write_lane.write_lane("v"):
+            pass
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await t
+    # Once the thread finished, cancellation propagated and the lane drained.
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 10.0)
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+    assert write_lane.snapshot()["waiters"] == 0
+
+
+async def test_lifecycle_write_consumes_global_slot(monkeypatch):
+    """Ungated run_git_write callers (vault lifecycle) must acquire a global
+    lane slot before touching the executor, so the executor never queues
+    work that admitted writers would wait behind (codex round-1 finding 2)."""
+    monkeypatch.setattr(settings, "write_lane_concurrency", 1)
+    monkeypatch.setattr(settings, "write_lane_queue_timeout_secs", 0.1)
+    started = threading.Event()
+    release = threading.Event()
+
+    def lifecycle_op():
+        started.set()
+        release.wait(5)
+
+    task = asyncio.create_task(write_lane.run_git_write(lifecycle_op))
+    await asyncio.to_thread(started.wait, 5)
+    # The single global slot is occupied by the lifecycle op → admission
+    # times out instead of queueing in the executor.
+    with pytest.raises(WriteBusyError):
+        async with write_lane.write_lane("v"):
+            pass
+    release.set()
+    await task
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+    snap = write_lane.snapshot()
+    assert snap["waiters"] == 0 and snap["lifecycle_waiters"] == 0
+
+
+async def test_must_complete_survives_cancel_during_slot_wait(monkeypatch):
+    """A must_complete lifecycle write (delete_vault cleanup, create_vault
+    rollback) cancelled while QUEUEING for a slot must still run to
+    completion, then deliver the cancellation (codex round-2 finding 2)."""
+    monkeypatch.setattr(settings, "write_lane_concurrency", 1)
+    ran = threading.Event()
+    hog_release = threading.Event()
+    hog_started = threading.Event()
+
+    def hog_op():
+        hog_started.set()
+        hog_release.wait(5)
+
+    def compensation_op():
+        ran.set()
+
+    hog = asyncio.create_task(write_lane.run_git_write(hog_op))
+    await asyncio.to_thread(hog_started.wait, 5)
+
+    comp = asyncio.create_task(
+        write_lane.run_git_write(compensation_op, must_complete=True)
+    )
+    await asyncio.sleep(0.05)  # comp is now parked on the slot wait
+    comp.cancel()
+    await asyncio.sleep(0.05)
+    assert not comp.done(), "must_complete task aborted during slot wait"
+    assert not ran.is_set()
+    hog_release.set()
+    await hog
+    with pytest.raises(asyncio.CancelledError):
+        await comp
+    assert ran.is_set(), "compensation work was lost despite must_complete"
+    assert write_lane.snapshot()["lifecycle_waiters"] == 0
+
+
+async def test_default_lifecycle_cancel_during_slot_wait_aborts(monkeypatch):
+    """Without must_complete, cancellation while queueing aborts cleanly —
+    the work never runs and no slot state leaks."""
+    monkeypatch.setattr(settings, "write_lane_concurrency", 1)
+    ran = threading.Event()
+    hog_release = threading.Event()
+    hog_started = threading.Event()
+
+    def hog_op():
+        hog_started.set()
+        hog_release.wait(5)
+
+    hog = asyncio.create_task(write_lane.run_git_write(hog_op))
+    await asyncio.to_thread(hog_started.wait, 5)
+
+    task = asyncio.create_task(write_lane.run_git_write(ran.set))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    hog_release.set()
+    await hog
+    assert not ran.is_set()
+    assert write_lane.snapshot()["lifecycle_waiters"] == 0
+    # Slot fully returned: a fresh acquisition succeeds promptly.
+    async with asyncio.timeout(1.0):
+        async with write_lane.write_lane("v"):
+            pass
+
+
+async def test_run_compensation_absorbs_cancel_until_done():
+    """run_compensation must keep the caller parked until the inner work
+    completes even when cancelled — a bare shield detaches the work and
+    lets shutdown close resources underneath it (codex round-4 finding 1)."""
+    release = asyncio.Event()
+    completed = asyncio.Event()
+
+    async def compensation():
+        await release.wait()
+        completed.set()
+        return "done"
+
+    async def caller():
+        await write_lane.run_compensation(compensation())
+
+    t = asyncio.create_task(caller())
+    await asyncio.sleep(0.02)
+    t.cancel()
+    await asyncio.sleep(0.02)
+    assert not t.done(), "caller unwound while the compensation was still running"
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await t
+    assert completed.is_set(), "compensation was abandoned mid-flight"
+
+
+async def test_run_compensation_returns_result_without_cancel():
+    async def compensation():
+        return 42
+
+    assert await write_lane.run_compensation(compensation()) == 42
+
+
+async def test_run_compensation_propagates_inner_error():
+    async def compensation():
+        raise RuntimeError("purge failed")
+
+    with pytest.raises(RuntimeError, match="purge failed"):
+        await write_lane.run_compensation(compensation())
+
+
+async def test_lane_holder_dispatch_does_not_double_acquire(monkeypatch):
+    """A writer already holding a lane slot must dispatch directly — if
+    run_git_write re-acquired the semaphore, M=1 would deadlock here."""
+    monkeypatch.setattr(settings, "write_lane_concurrency", 1)
+    async with asyncio.timeout(2.0):
+        async with write_lane.write_lane("v"):
+            out = await write_lane.run_git_write(lambda: 7)
+    assert out == 7
+
+
+async def test_run_git_write_uses_dedicated_pool():
+    def probe(x: int):
+        return threading.current_thread().name, x * 2
+
+    name, val = await write_lane.run_git_write(probe, 21)
+    assert val == 42
+    assert name.startswith("akb-git-commit")
+
+
+async def test_run_git_write_propagates_exception():
+    def boom():
+        raise RuntimeError("kaput")
+
+    with pytest.raises(RuntimeError, match="kaput"):
+        await write_lane.run_git_write(boom)
+
+
+def test_write_busy_error_envelope():
+    from app.util.errors import WRITE_BUSY, exception_envelope
+
+    env = exception_envelope(WriteBusyError("v", 10.0))
+    assert env["code"] == WRITE_BUSY
+    assert env["details"]["retry_after_secs"] == 5
+    assert env["hint"]
+
+
+async def test_rest_handler_maps_429_with_retry_after():
+    from app.main import akb_error_handler
+
+    resp = await akb_error_handler(None, WriteBusyError("v", 10.0))
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "5"
+
+    # Non-write-busy AKBErrors must not grow a Retry-After header.
+    resp2 = await akb_error_handler(None, NotFoundError("Vault", "x"))
+    assert resp2.status_code == 404
+    assert "Retry-After" not in resp2.headers
+
+
+async def test_mcp_dispatch_maps_write_busy(monkeypatch):
+    from mcp_server import server as srv
+    from app.util.errors import WRITE_BUSY
+
+    async def busy_handler(args, uid, user):
+        raise WriteBusyError("v", 10.0)
+
+    monkeypatch.setitem(srv._HANDLERS, "akb_fake_busy_tool", busy_handler)
+    out = await srv._dispatch("akb_fake_busy_tool", {}, srv._MCPUser())
+    assert out["code"] == WRITE_BUSY
+    assert out["details"]["retry_after_secs"] == 5
+    assert out["hint"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.8.9"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/docs/design/proposal/command-lane-write-path/README.md
+++ b/docs/design/proposal/command-lane-write-path/README.md
@@ -1,7 +1,7 @@
 # Command-lane 쓰기 경로: 문서별 lane + PG-first git + overflow 프로토콜
 
-**상태**: Proposal (round-04까지 반영)
-**날짜**: 2026-06-10
+**상태**: Proposal — 단, **round-05의 admission 게이트(Phase 0 대체)는 PM 승인·구현 완료, codex 10라운드 리뷰 종결(NO OBJECTIONS)** (2026-07-03). Phase 2·3은 미결.
+**날짜**: 2026-06-10 (갱신 2026-07-03)
 **목표**: 동시 ~1000 에이전트. 특정 문서에 쓰기가 몰리는 폭주(~80 writes/s)
 에서도 피해가 **그 문서 하나로 한정**되어야 한다 — 지금은 서비스 전체가 멈춘다.
 
@@ -231,8 +231,8 @@ SKIP LOCKED` — 기존 관용구). write-behind 자체가 확장의 열쇠: 읽
 
 | Phase | 내용 | 비고 |
 |---|---|---|
-| **0** | try-lock + 429(Retry-After) — 풀 중독만 즉시 차단 | ~1일, 스키마 변경 없음, 단독 출하 |
-| **1** | 인메모리 lane (락 대기 → 큐 대기) | lane 수명주기·graceful shutdown. 단일 프로세스 확인됨 |
+| **0 (개정)** | ~~try-lock 즉시 429~~ → **2단 admission 게이트**: per-vault(1) + 글로벌 write lane(M=8), 코루틴 대기 10s 후 429, 전용 커밋 executor, git write kill-timeout | **round-05로 대체·승인·구현** — executor 기아(제2 전염 경로) 발견이 계기. 스키마 변경 없음 |
+| **1** | 인메모리 lane의 per-document 세분화 | **연기** (round-05) — git이 동기 경로에 있는 한 vault 게이트 대비 처리량 이득 없음. Phase 2 이후 재평가 |
 | **2** | PG-first git: `documents.content` + outbox + 아카이버(inline/deferred), 읽기 이전 전수(§2.4-4), 토큰 마이그레이션, 미러 제외, bulk 톰스톤, parentless 커밋, pending 오버레이 | **최대 공사**. source-of-truth 재정의 승인 필요 |
 | **3** | 큐 상한 + coalescing + 202 + 상태 조회 툴 + MCP description | additive 계약 변경 |
 

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-1.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-1.md
@@ -1,0 +1,46 @@
+# codex 리뷰 라운드 1 — write-lane admission (round-05 구현)
+
+**도구**: codex-cli 0.132.0, read-only 샌드박스, 워킹트리 diff 전체 + round-05 문서
+**결과**: BLOCKING 1 · MAJOR 2 → **전부 수용, 수정 완료** (아래 disposition)
+**원문**: 세 findings 요약 후 각 조치 병기. VERDICT: OBJECTIONS → 라운드 2로.
+
+## Finding 1 [BLOCKING] — 취소 시 레인 조기 해제, git 스레드는 계속 실행
+
+`run_git_write` 대기 중 호출 태스크가 취소되면(클라이언트 타임아웃/단절)
+executor 스레드는 중단 불가라 커밋이 계속 도는데, 코루틴은 즉시 unwind되어
+레인·커넥션이 풀린다. 다음 admitted writer가 커넥션을 쥔 채 executor 안에서
+`_vault_lock`에 블록 — 레인이 막으려던 병리가 취소 폭주(에이전트 클라이언트
+타임아웃 스톰) 시 그대로 재유입.
+
+**조치**: `_dispatch_to_pool`에서 `asyncio.shield` + 취소 흡수 루프.
+취소가 와도 스레드 종료까지(git `kill_after_timeout`으로 상한) 레인을 쥔 채
+코루틴으로 대기 후 취소를 전파. 결과는 폐기하고 INFO 로그(스트레이 커밋
+가능성 명시 — 다음 쓰기의 reset --hard가 수습, 기존 to_thread 시절과 동일
+시맨틱). 테스트: `test_cancel_during_commit_absorbs_until_thread_done`.
+
+## Finding 2 [MAJOR] — 게이트 없는 라이프사이클 작업이 커밋 executor를 선점 가능
+
+vault 생성(.vault.yaml/템플릿 가이드)·삭제(cleanup)는 의도적으로 레인을 안
+타는데, 이들이 M개 executor 스레드를 다 차지하면 admitted writer(커넥션
+보유)가 executor 큐에서 대기 — "희소 자원 보유 중 대기 금지" 불변식 위반.
+
+**조치**: ContextVar `_slot_held` 기반 슬롯 규율. `write_lane` 내부 호출자는
+이미 슬롯 보유 → 직행; 그 외(라이프사이클)는 `run_git_write`가 글로벌
+세마포어를 **데드라인 없이**(429 불가 요건) 코루틴 대기로 선획득. 결과:
+executor에는 슬롯 보유자만 도달 → 내부 큐 구조적으로 0. 이중 획득
+데드락은 ContextVar로 원천 차단. 테스트:
+`test_lifecycle_write_consumes_global_slot`,
+`test_lane_holder_dispatch_does_not_double_acquire`.
+
+## Finding 3 [MAJOR] — kill_after_timeout 커버리지 구멍
+
+`_ensure_worktree`의 `worktree add`/`prune`, clone 폴백의 `add`, 하드코딩
+60s인 clone/push가 미커버 — 첫 커밋/worktree 재생성 경로에서 git이 wedge되면
+vault 락+슬롯+커밋 스레드+커넥션을 무기한 점유.
+
+**조치**: 해당 명령 전부 `_write_kt()` 적용, clone/push의 하드코딩 60s를
+`git_write_timeout_secs` 설정으로 통일.
+
+## 검증
+
+write-lane 유닛 18개 + 전체 스위트 451 passed, ruff clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-10.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-10.md
@@ -1,0 +1,29 @@
+# codex 리뷰 라운드 10 — 종결
+
+**결과**: **VERDICT: NO OBJECTIONS** — 신규 발견 0. 라운드 9의 xvault_pubs
+가드(SQL·NULL 시맨틱·파라미터) 검증 통과, 문서화된 수용 리스크 3건(round-8
+접근 메타데이터 disposition, round-9 잔여 TOCTOU, seed 경로 모호성)은
+documented-accepted로 인정.
+
+## 라운드 전체 요약 (1~10)
+
+| 라운드 | 발견 | 처리 |
+|---|---|---|
+| 1 | B1+M2: 취소 시 레인 조기해제 / 라이프사이클 executor 선점 / git 타임아웃 구멍 | 수용 3 |
+| 2 | B1+M3: create 롤백 비대칭 / cleanup 취소 유실 / init 위치 / rev_parse | 수용 4 (+파생 1 자체 발견) |
+| 3 | B2: 소유권 프로브 레이스 / 취소가 DB 롤백 관통 | 수용 2 (+delete_vault 동류 선제) |
+| 4 | B1+M1: shield detach / events 미퍼지 | 수용 2 |
+| 5 | B1: 롤백이 동시 유입 외부 문서 파괴 | 수용 1 (불파괴 규칙 도입) |
+| 6 | B1: 비-레인 writer TOCTOU | 수용 1 (FOR UPDATE 원자화) |
+| 7 | B1: publications 캐스케이드 | 수용 1 (스키마 전수 가드) |
+| 8 | M1: vault_access | **기각** (접근 메타데이터 원칙, r9에서 인정됨) |
+| 9 | M1: 교차-vault query_vault_names 참조 | 수용 1 |
+| 10 | — | **NO OBJECTIONS, 종결** |
+
+수용 15 · 기각(사유 인정) 1. 매 라운드 후 전체 스위트·ruff·mypy 그린 유지.
+
+## 후속 과제 (본 diff 범위 밖, 별도 추진)
+
+- delete_vault에도 교차-vault `query_vault_names` 참조 검사(경고/거부) 검토
+  — PRE-EXISTING dangling 위험 (r9 기록).
+- 스테이징 핫 vault burst E2E (round-05 §6-3).

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-2.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-2.md
@@ -1,0 +1,48 @@
+# codex 리뷰 라운드 2 — round-1 fix 검증 + 신규 발굴
+
+**결과**: BLOCKING 1 · MAJOR 3 → **전부 수용, 수정 완료**. 라운드 1의 세 fix
+자체는 유효 판정(관련 신규 이슈만 위 4건). VERDICT: OBJECTIONS → 라운드 3으로.
+
+## Finding 1 [BLOCKING] — create_vault 롤백 비대칭 (DB row 잔존)
+
+seed `put()`이 이제 레인을 타므로 포화 시 WriteBusyError로 실패할 수 있는데,
+롤백은 git 디렉토리만 지우고 vaults row·RBAC 롤은 남긴다 → "repo 없는 vault"
+가 영구 잔존, 같은 이름 재생성 불가. (409-류 실패로도 재현 가능한 기존
+비대칭이었으나, 레인이 실패 확률을 실질화함.)
+
+**조치**: `_rollback_vault_rows()` 신설 — fresh-vault 부분집합 캐스케이드
+(edges → chunks → documents → collections → todos → vault_access → vaults)
++ `role_sync.on_vault_delete` best-effort. `created_vault_id` 바인딩 후 실패
+시에만 실행. 기존 비대칭 버그도 함께 해소.
+
+**파생 발견 (자체)**: 취소 흡수가 fn 예외를 폐기하므로, 기존 이름으로의
+create가 init 중 취소되면 FileExistsError가 사라져 롤백이 **기존 vault의
+디렉토리를 삭제**할 수 있는 경로 확인. `existed_before` 사전 프로브 +
+"이 요청이 만든 디렉토리만 청소" 가드로 차단. 흡수 시 폐기되는 예외는
+로그에 남기도록 `_dispatch_to_pool` 보강.
+
+## Finding 2 [MAJOR] — delete_vault cleanup이 슬롯 대기 중 취소로 유실 가능
+
+DB 캐스케이드 커밋 후 슬롯 대기라는 취소 가능 갭이 생김(라운드 1 fix의
+부작용). 클라이언트 단절 시 고아 bare/worktree가 남아 같은 이름 재생성을
+막는다.
+
+**조치**: `run_git_write(..., must_complete=True)` 모드 신설 — 슬롯 **대기
+중** 취소도 흡수해 보상 작업을 반드시 완료한 뒤 취소를 전파. delete_vault
+cleanup과 create_vault 롤백 cleanup에 적용. 테스트:
+`test_must_complete_survives_cancel_during_slot_wait`,
+`test_default_lifecycle_cancel_during_slot_wait_aborts`.
+
+## Finding 3 [MAJOR] — init_vault가 롤백 try 밖
+
+init 중 흡수-취소되면 스레드는 디렉토리를 만들었는데 코루틴은 git_path를
+못 받아 orphan → 같은 이름 create가 영구 실패. **조치**: init을 try 안으로
++ 위의 `existed_before`/`vault_exists` 이중 가드로 "우리가 만든 것만" 청소.
+
+## Finding 4 [MAJOR] — `_stage_and_commit`의 rev_parse 2곳 타임아웃 누락
+
+**조치**: 두 rev_parse에 `_write_kt()` 적용.
+
+## 검증
+
+write-lane 유닛 20개 + 전체 스위트 453 passed, ruff clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-3.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-3.md
@@ -1,0 +1,32 @@
+# codex 리뷰 라운드 3 — round-2 fix 검증
+
+**결과**: BLOCKING 2 → **전부 수용, 수정 완료**. 두 건 모두 라운드 2에서
+내가 넣은 롤백 코드의 결함. VERDICT: OBJECTIONS → 라운드 4로.
+
+## Finding 1 [BLOCKING] — `vault_exists` 소유권 프로브가 동시 같은-이름 create에 불건전
+
+A·B가 같은 이름으로 동시 create → A의 init이 승리, B의 init은
+FileExistsError(git_path=None) → B의 롤백이 "디렉토리가 내 시도 중 생겼다"
+고 판단해 **A의 repo를 삭제**. 데이터 손실 레이스.
+
+**조치**: `_CREATE_LOCKS` — 이름별 asyncio.Lock으로 create 표준 경로 전체
+(롤백 포함)를 직렬화(`_create_vault_standard`로 추출). 락 안에서는 "전에
+없었고 이 구간에서 생긴 디렉토리 = 내 것"이 참이 되어 프로브가 건전해진다.
+write-lane vault 게이트와 의도적으로 별도 락 — seed put()이 게이트를 타므로
+같은 락이면 자기-데드락.
+
+## Finding 2 [BLOCKING] — must_complete의 사후 CancelledError가 DB 롤백을 관통
+
+롤백 중 cleanup(must_complete)이 완료 후 재전파한 CancelledError는
+`except Exception`에 안 잡혀 `_rollback_vault_rows`를 건너뜀 → repo는
+지워졌는데 vaults row·롤 잔존.
+
+**조치**: 롤백 핸들러에 `pending_cancel` 파킹 패턴 — cleanup의 취소를
+붙잡고, DB 퍼지는 `asyncio.shield`로 중도 취소에도 완주시킨 뒤, 모든 보상
+완료 후 취소를 재전파. **동류 버그 선제 수정**: delete_vault에서도 cleanup
+사후 취소가 `role_sync.on_vault_delete`를 건너뛰는 같은 관통 경로를 동일
+패턴(파킹 + shield)으로 차단.
+
+## 검증
+
+전체 스위트 453 passed, ruff clean, 변경 4개 파일 mypy clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-4.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-4.md
@@ -1,0 +1,31 @@
+# codex 리뷰 라운드 4 — round-3 fix 검증
+
+**결과**: BLOCKING 1 · MAJOR 1 → **전부 수용, 수정 완료**.
+codex가 shield의 detach 동작을 실행 실험으로 증명함. VERDICT: OBJECTIONS →
+라운드 5로.
+
+## Finding 1 [BLOCKING] — bare `asyncio.shield`는 취소 후 완주를 안 기다림
+
+shield는 취소 시 즉시 raise하고 내부 코루틴을 **detached task**로 계속
+돌린다. 셧다운 취소가 퍼지 중에 오면 create 락이 풀리고 풀이 먼저 닫혀
+퍼지가 반쯤 된 채 증발 — repo는 지워졌는데 vaults row/롤 잔존.
+
+**조치**: `write_lane.run_compensation(coro)` 신설 — shield 재시도 루프로
+내부 태스크가 **실제 완료될 때까지** 호출자를 파킹(락·자원 유지)하고,
+그 후 취소 재전파. 흡수 중 내부 작업이 실패하면 취소 우선 + 에러 로그
+(`_dispatch_to_pool`의 폐기 규칙과 동일). create 롤백 퍼지와 delete_vault의
+role 정리 두 곳에 적용. 테스트:
+`test_run_compensation_absorbs_cancel_until_done` 외 2개.
+
+## Finding 2 [MAJOR] — `_rollback_vault_rows`가 events 미퍼지
+
+seed put()이 `document.put` 이벤트를 커밋하는데 events엔 vault FK 캐스케이드
+가 없어, 롤백 후에도 컨슈머가 지워진 vault/doc의 이벤트를 수신.
+
+**조치**: 퍼지 캐스케이드 맨 앞에 `DELETE FROM events WHERE vault_id=$1`
+추가. (delete_vault 본경로는 events를 감사 목적상 보존하지만, 롤백은
+"공식적으로 존재한 적 없는" vault이므로 퍼지가 옳다.)
+
+## 검증
+
+write-lane 유닛 23개 + 전체 스위트 456 passed, ruff clean, 변경 파일 mypy clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-5.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-5.md
@@ -1,0 +1,34 @@
+# codex 리뷰 라운드 5 — round-4 fix 검증
+
+**결과**: BLOCKING 1 → **수용, 수정 완료**. VERDICT: OBJECTIONS → 라운드 6으로.
+
+## Finding 1 [BLOCKING] — 롤백 퍼지가 동시 유입된 외부 쓰기를 파괴
+
+vaults row는 커밋 즉시 외부에 보인다(owner 단축 경로) → 생성이 seed 단계에
+있는 동안 owner의 동시 put이 가능. 그 경합으로 seed put이 10초 데드라인을
+넘겨 WriteBusyError가 나면, 롤백이 vault_id 전체를 퍼지하면서 **타 요청의
+이미 성공(ack)된 문서·chunks·이벤트까지 삭제**. create-후-즉시-ingest는
+에이전트의 현실적인 사용 패턴이라 발생 가능성도 실질적.
+
+**조치 — 안전 규칙 "롤백은 외부 데이터를 절대 파괴하지 않는다"**:
+`_rollback_vault_create`로 재구조화.
+
+1. 롤백이 해당 vault의 **write-lane 게이트를 획득** — in-flight 외부
+   writer는 게이트를 쥐고 있으므로 먼저 드레인되고, 신규 writer는 검사·퍼지
+   동안 배제된다(TOCTOU 차단).
+2. **foreign-write 가드**: seed 경로(`overview/vault-skill.md`) 외 문서,
+   또는 임의의 file/table row가 존재하면 파괴적 롤백을 **통째로 포기** —
+   vault는 (부분 시드 상태로) 존치, 생성 에러는 그대로 전파, ERROR 로그로
+   수동 정리 안내. 게이트 획득이 WriteBusyError로 실패해도 같은 방향
+   (존치·스킵)으로 퇴화 — 안전한 쪽으로만 실패한다.
+3. 퍼지 순서 재정렬: **DB 퍼지 → 디스크** ("repo 없는 살아있는 row"보다
+   "재생성 막는 고아 디렉토리(로그+수동 rm)"가 덜 해롭다).
+4. 롤백 전체를 `run_compensation`으로 감싸 반복 취소에도 완주.
+
+**잔여 코너(문서화, 수용)**: 생성 윈도우 안에 외부 writer가 정확히
+`overview/vault-skill.md` 경로로 쓴 경우 seed와 구별 불가. 요청 신원
+추적 없이는 판별 불가능하며 발생 확률이 무시 가능한 수준.
+
+## 검증
+
+전체 스위트 456 passed, ruff clean, 변경 파일 mypy clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-6.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-6.md
@@ -1,0 +1,31 @@
+# codex 리뷰 라운드 6 — round-5 fix 검증
+
+**결과**: BLOCKING 1 → **수용, 수정 완료**. VERDICT: OBJECTIONS → 라운드 7로.
+
+## Finding 1 [BLOCKING] — 롤백 가드의 TOCTOU (레인을 안 타는 writer)
+
+write-lane 게이트는 문서 writer만 배제한다. `akb_create_table`
+(table_service, 레인 미경유)이나 파일 업로드(vault_files)가 foreign 검사
+**직후**에 커밋되면, `DELETE FROM vaults`의 `ON DELETE CASCADE`가 방금
+ack된 vault_tables row를 삼키고 물리 `vt_*` 테이블은 고아가 된다.
+
+**조치 — DB 레벨 원자화**: 검사를 퍼지 트랜잭션 **안**으로 이동하고,
+트랜잭션 첫 문장으로 `SELECT id FROM vaults WHERE id=$1 FOR UPDATE`.
+근거: 모든 FK writer(documents·vault_tables·vault_files INSERT)는 부모
+vaults row에 `FOR KEY SHARE`를 트랜잭션 종료까지 쥐는데, 이는 `FOR UPDATE`
+와 충돌한다. 따라서 —
+
+- in-flight foreign 쓰기는 우리 락 승인 **전에** 커밋 → 트랜잭션 내 재검사가
+  이를 보고 퍼지를 abort (vault 존치)
+- 이후 foreign 쓰기는 우리 트랜잭션 종료까지 블록 → row 삭제 후 FK 위반으로
+  **깨끗하게 실패** (PG의 트랜잭셔널 DDL로 물리 테이블 생성도 함께 롤백)
+- 캐스케이드가 ack된 foreign row를 삼키는 시나리오는 구조적으로 불가능
+
+`_rollback_vault_rows`는 bool(purged)을 반환하고, 디스크 정리는 퍼지가
+실제 수행된 경우에만 뒤따른다. 퍼지 실패 시에도 존치 방향(rows+repo 모두
+유지 = 기능하는 vault)으로만 퇴화. write-lane 게이트는 rmtree 전 in-flight
+문서 커밋 드레인 용도로 유지.
+
+## 검증
+
+전체 스위트 456 passed, ruff clean, 변경 파일 mypy clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-7.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-7.md
@@ -1,0 +1,29 @@
+# codex 리뷰 라운드 7 — round-6 fix 검증
+
+**결과**: BLOCKING 1 → **수용, 수정 완료**. VERDICT: OBJECTIONS → 라운드 8로.
+
+## Finding 1 [BLOCKING] — foreign 가드 목록 불완전 (publications 캐스케이드)
+
+`akb_publish(table_query)`는 doc/file/table 없이도 publications row를 만들
+수 있고(공개 URL이 사용자에게 반환됨), `DELETE FROM vaults`의
+`ON DELETE CASCADE`(init.sql:343)가 이를 삼킨다. 가드는 docs/files/tables만
+보고 있었다.
+
+**조치 — 스키마 전수 기반 가드 확장**: init.sql의 `REFERENCES vaults` 전수
+조사(10개 테이블) 후, 생성 창 안에서 "사용자 생성 가능 + 파괴 시 실질 손실"
+기준으로 분류:
+
+- **가드 추가**: `publications`(공개 URL), `todos`, `collections`(생성 소유
+  경로 = 'overview' + 템플릿 경로 밖의 것 — `akb_create_collection`으로 생성
+  가능; 템플릿 정보를 롤백에 전달)
+- **가드 불요(퍼지 일관)**: chunks(파생), edges/resource_aliases(doc 가드
+  통과 시 엔드포인트가 seed뿐), vault_access(사라지는 vault에 대한 권한),
+  vault_external_git(미러 분기 전용, 표준 경로 무관), events(FK 없음, 퍼지
+  대상)
+
+FOR UPDATE 원자화(라운드 6)는 이들 전부에 동일하게 적용된다 — 모든 FK
+INSERT가 vaults row에 FOR KEY SHARE를 잡기 때문.
+
+## 검증
+
+전체 스위트 456 passed, ruff clean, document_service mypy clean.

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-8.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-8.md
@@ -1,0 +1,37 @@
+# codex 리뷰 라운드 8 — round-7 fix 검증
+
+**결과**: MAJOR 1 → **기각 (reasoned rejection, 아래 disposition)**.
+라운드 7의 가드 확장(publications/todos/collections)과 FOR UPDATE 원자화
+자체는 유효 판정. VERDICT: OBJECTIONS → disposition 명문화 후 라운드 9에서
+재평가.
+
+## Finding 1 [MAJOR] — 롤백이 동시 유입된 vault_access(akb_grant)를 파괴 → 기각
+
+지적: 생성 창 안에 owner가 `akb_grant`로 권한을 부여(ack됨)한 뒤 생성이
+실패하면, 롤백 퍼지가 그 grant를 vault와 함께 삭제 — "ack된 외부 쓰기 파괴".
+
+**기각 사유 — 콘텐츠와 접근 메타데이터의 구분 (설계 결정)**:
+
+1. **접근권한은 vault 존재에 종속된 메타데이터다.** grant의 유일한 referent는
+   vault 자신이고, "creation 실패 = vault는 존재한 적 없음"이 확정되면 그
+   grant는 지시 대상을 잃는다. `delete_vault`(정상 삭제 경로)도 vault_access
+   를 동일하게 캐스케이드 퍼지한다 — 롤백이 이보다 보수적일 이유가 없다.
+2. **가드에 넣으면 결과가 더 나쁘다.** grant 하나가 롤백을 거부하면
+   half-created vault(시드 미완, 잠재적 롤 불완전)가 잔존하고, 재생성은
+   ConflictError로 막히며, 운영자 수동 정리가 필요해진다. 실피해( 재생성 후
+   grant 재발급 한 번) 대비 과잉 방어다.
+3. **실질 피해 경로는 이미 가드가 막는다.** grantee가 실제로 뭔가를 쓰면
+   그 순간 documents/files/tables/publications/todos/collections 가드가
+   롤백을 거부한다. 파괴되는 것은 "빈 vault에 대한 권한 행"뿐이다.
+4. 같은 원리로 **ownership transfer**(생성 창 내 소유권 이전 + 콘텐츠 0)도
+   퍼지 허용 — 콘텐츠가 있으면 어차피 가드가 거부한다.
+
+**원칙 명문화**: 롤백 가드의 보호 대상은 *사용자가 vault에 맡긴 콘텐츠와
+외부로 노출된 산출물*(문서·파일·테이블·발행물·todo·컬렉션)이다. *vault
+자신에 대한 접근 메타데이터*(vault_access, RBAC 롤, 소유권)는 vault의
+생사와 운명을 같이한다.
+
+## 검증
+
+코드 변경 없음 (disposition만). 스위트 상태는 라운드 7 시점과 동일
+(456 passed, ruff/mypy clean).

--- a/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-9.md
+++ b/docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-9.md
@@ -1,0 +1,28 @@
+# codex 리뷰 라운드 9 — round-8 disposition 판정 + 최종 패스
+
+**결과**: round-8 disposition(접근 메타데이터 vs 콘텐츠 구분)은 **인정** —
+vault_access 건 재제기 없음. 신규 MAJOR 1 → **수용, 수정 완료**.
+VERDICT: OBJECTIONS → 라운드 10으로.
+
+## Finding 1 [MAJOR] — 타 vault 소유 publication의 이름 참조(query_vault_names) 미가드
+
+`akb_publish(table_query, vault="stable", query_vault_names=[..., "new-vault"])`
+— publication row는 **다른 vault 소유**로 저장되지만 TEXT[] 컬럼에 이 vault
+를 **이름으로** 참조한다. 롤백 가드는 `publications.vault_id = 이 vault`만
+보므로 이를 놓치고, 퍼지 후 그 publication의 공개 URL이 해석 시점에
+NotFoundError로 깨진다. 외부 노출 산출물 파괴 → round-8 원칙상 보호 대상.
+
+**조치**: 가드에 `$name = ANY(query_vault_names)` 교차-vault 검사
+(`xvault_pubs`) 추가 — 존재 시 롤백 포기(vault 존치).
+
+**수용된 잔여 리스크 (문서화)**: 이 참조는 FK가 아니라서 vaults row
+FOR UPDATE 직렬화가 커버하지 못함 — 검사→퍼지 사이 마이크로초 창에 커밋되는
+publish는 여전히 dangling 가능. 단 **동일한 dangling 위험이 delete_vault
+정상 경로에 이미 존재**(PRE-EXISTING — vault 삭제는 타 vault publication의
+query_vault_names 참조를 검사하지 않음)하므로, 이 창을 닫는 것은 본 diff
+범위 밖의 별도 과제로 남긴다. → 후속 과제: delete_vault에도 동일 검사(경고
+또는 거부) 추가 검토.
+
+## 검증
+
+전체 스위트 456 passed, ruff clean, document_service mypy clean.

--- a/docs/design/proposal/command-lane-write-path/rounds/round-05.md
+++ b/docs/design/proposal/command-lane-write-path/rounds/round-05.md
@@ -1,0 +1,191 @@
+# round-05 — executor 기아 발견, admission 게이트 확정 (Phase 0 대체)
+
+**날짜**: 2026-07-02
+**참여**: PM(사용자) + Claude (별도 세션에서 PG 풀 세팅 #255와 병행 토의)
+**결론**: 아래 설계를 PM이 승인, 즉시 구현. round-01~04의 Phase 0(try-lock
+즉시 429)을 **대체**하고, Phase 1의 per-document 세분화는 **연기**,
+Phase 2(PG-first)·Phase 3은 **미결 유지**.
+
+---
+
+## 1. 새 발견: 두 번째 전염 경로 — executor 기아
+
+round-01~04는 풀 중독(§1.2-B)만 식별했다. 이번 토의에서 코드 재검증 중
+**독립적인 두 번째 전염 경로**를 확인했다:
+
+- 문서 read도 전부 `asyncio.to_thread(git.read_file, …)`로 간다
+  (document_service.py:543, :759, :1447 등). **read와 write가 같은 기본
+  ThreadPoolExecutor를 공유**한다.
+- write는 executor 스레드 **안에서** `_vault_lock`(threading.Lock)을
+  blocking으로 기다린다 (git_service.py:566). 대기자 1명 = 스레드 1개 점유.
+- 기본 풀 크기는 `min(32, cpu+4)` — round-04까지 "~32"로 적었으나 이는
+  상한이고, CPU limit 없는 파드는 노드 코어 수를 따르므로 8코어 노드면
+  **12개**다.
+- 따라서 핫 vault에 writer 12명(8코어 기준)이 몰리면 — PG 풀(30)이 마르기
+  **전에** — executor가 잠든 waiter로 가득 차고, **모든 vault의 모든 git
+  read가 executor 큐에서 시작조차 못 한다.**
+
+즉 round-04까지의 "read는 락을 안 잡으므로 write에 안 막힌다"는 git 락
+레벨에서만 참이고, executor 레벨에서는 거짓이다. **풀 중독을 고쳐도(#255)
+같은 사용자 가시 장애가 executor 경로로 재현된다.** 두 경로는 한 설계로
+같이 막아야 한다.
+
+## 2. 확정 설계: 2단 admission 게이트 + 전용 커밋 executor
+
+핵심 원리(round-01의 통찰 유지): **대기를 희소 자원(스레드·커넥션) 위에서
+하지 말 것.** 대기는 이벤트루프의 suspend된 코루틴으로 — 비용은 메모리
+몇 KB + waiter 리스트 엔트리뿐이다.
+
+```
+요청 → ① per-vault 게이트 (vault당 동시 1, FIFO)     ← 코루틴 대기, 자원 0
+      → ② 글로벌 write lane 세마포어 (동시 M)         ← 〃
+      → ③ PG 커넥션 + (vault,path) advisory lock + 트랜잭션   ← 여기서 처음 자원 획득
+      → ④ git 커밋: 전용 커밋 executor로 디스패치      ← 락은 이미 무경합
+      → ⑤ PG 반영 → 트랜잭션 커밋 → 전부 반납
+```
+
+- **①이 ②보다 먼저다** — 순서가 바뀌면 핫 vault의 대기자들이 글로벌 슬롯
+  M개를 쥔 채 자기 vault 게이트를 기다려, 다른 vault로 전염이 재발한다.
+- ②는 write라는 **작업 부류 전체**의 총량 상한. 활성 vault가 M개를 넘어도
+  write가 쥐는 커넥션 ≤ M, 커밋 스레드 ≤ M이 어떤 시나리오에서도 보장된다.
+  read에는 항상 커넥션 (풀−M)개 + read 스레드 풀이 남는다.
+- **④ 전용 executor** — 커밋이 read의 스레드 풀을 침범할 수 없게 물리
+  절연. 크기 = M (게이트 통과자만 도달하므로 큐잉 없음).
+- 기존 `_vault_lock`(threading.Lock)은 **제거하지 않는다**. external_git
+  poller 등 API 밖 커밋 경로가 있으므로 최후의 정합성 가드로 남긴다.
+  평상시엔 게이트 덕에 무경합 통과.
+
+### 게이트 granularity: per-vault (per-document 아님)
+
+round-01~04의 lane은 `(vault_id, path)` 단위였다. 이번 라운드에서
+**vault 단위로 결정**: git 커밋이 vault 단위로 직렬화되는 이상(worktree
+구조), per-document lane은 같은 vault 문서들의 PG 구간(10~20ms)만 겹치게
+할 뿐 지배 비용(git ~73ms)은 어차피 직렬이다. per-document 세분화가 의미를
+가지는 것은 git이 동기 경로에서 빠지는 Phase 2(PG-first) 이후다. 그때
+lane을 쪼개면 된다 — admission 모듈은 키 문자열만 바꾸면 된다.
+
+### 실패 모드: 대기 후 429 (즉시 429 아님) — PM 결정
+
+- 게이트 대기 총 데드라인 **T = 10초** (PM: "30초는 너무 길다").
+  초과 시 **HTTP 429 + Retry-After** / MCP 캐논 에러 envelope
+  (`code=write_busy`, hint에 재시도 안내).
+- 즉시 429를 버린 이유: 에이전트의 정상 패턴(멀티파일 인제스트의 연속
+  put)을 처벌한다. 커밋 ~73ms면 대기 몇 건은 1~2초에 빠진다 — 대기가
+  코루틴이라 공짜이므로 기다리게 하는 것이 안전해졌다(이 선택지는
+  admission 이동 없이는 고를 수 없었다).
+- 깊이 상한 K로 조기 거부하지 않는다(PM 결정). 대신 **글로벌 waiter
+  백스톱**(기본 512)만 둔다 — 메모리·소켓 가드일 뿐 정책이 아니며,
+  정상 운영에서 도달하지 않는 값.
+
+### 트랜잭션 경계: 불변 — "커넥션 조기 해제" 기각
+
+"git 커밋 전에 커넥션을 놓는" 변형을 검토 후 **기각**(PM 동의):
+
+1. advisory lock이 커넥션/트랜잭션 수명에 묶여 있어 반납 순간 path 상호
+   배제가 사라진다.
+2. git 커밋 순서(vault 락 보장)와 PG 반영 순서가 역전될 수 있다 — A가
+   sha1, B가 sha2를 커밋한 뒤 B→A 순으로 DB에 쓰면 `current_commit`이
+   과거(sha1)로 되돌아가 B의 쓰기가 메타데이터에서 증발(lost update).
+   막으려면 tx2 CAS + 보상 로직 + 고아 커밋 처리가 필요 — Phase 2의
+   outbox 설계가 바로 그것이므로, 어중간한 중간형을 만들지 않는다.
+
+병리는 "커밋 ~100ms 동안 커넥션을 쥐는 것"이 아니라 "**대기자 N명이
+커넥션을 쥔 채 줄 서는 것**"이었다. 대기를 ③ 앞으로 옮기면 커넥션 점유
+시간 = 실제 작업 시간이 되고, 그런 writer는 전역 ≤ M명이다. 기존
+단일-트랜잭션 원자성(§1.3)과 크래시 의미론은 오늘과 동일하게 유지된다.
+
+### 꼬리 보강: git write 타임아웃
+
+커밋을 쥔 채 git이 wedge되면(디스크, 대형 vault의 reset --hard 스윕)
+lane 슬롯 1 + 커밋 스레드 1 + 커넥션 1이 잠긴다. PG 쪽 백스톱
+(`idle_in_transaction_session_timeout` 60s)에 더해 git 쓰기 경로의 각
+명령에 `kill_after_timeout`(기본 30s)을 건다. 발동 시 해당 요청은 실패
+(트랜잭션 롤백 — PG는 깨끗, worktree는 다음 쓰기의 reset --hard가 수습)
+하고 자원은 회수된다.
+
+## 3. 파라미터 (config)
+
+| 설정 | 기본 | 의미 |
+|---|---|---|
+| `write_lane_concurrency` (M) | 8 | write 부류의 전역 동시성 = 커밋 executor 크기. 커넥션 상한도 겸함 (풀 30 중 read에 최소 22 보장) |
+| `write_lane_queue_timeout_secs` (T) | 10.0 | ①+② 합산 대기 데드라인 → 초과 시 429 |
+| `write_lane_max_waiters` | 512 | 글로벌 waiter 백스톱 (메모리 가드, 정책 아님) |
+| `git_write_timeout_secs` | 30.0 | git 쓰기 명령별 kill 타임아웃 |
+
+## 4. 적용 범위
+
+| 경로 | 게이트 | 커밋 executor | 비고 |
+|---|---|---|---|
+| put / update / edit / delete / move | ✓ (`_path_lock`/`_move_lock` 진입 전) | ✓ | 표준 write 경로 |
+| collection 삭제의 `delete_paths_bulk` | ✓ | ✓ | PG 커밋 후 실행 — lane 타임아웃 시 기존 "고아 파일 로그 후 계속" 경로로 (요청은 성공 유지) |
+| create_vault 시드 / 템플릿 가이드 커밋 | ✗ | ✓ | 생성 중 vault라 경합 불가 — 타임아웃 실패 모드를 vault 생성에 도입하지 않음 |
+| external_git poller / 워커 | ✗ | ✗ (기존 유지) | 저동시성, `_vault_lock`이 가드 |
+| files / tables | — | — | git 무관 (round-04 확인) |
+
+## 5. round-01~04와의 관계
+
+- **Phase 0 (try-lock 즉시 429) → 본 설계로 대체.** try-lock은 버스트를
+  처벌하고 재시도 폭풍을 유발한다. "코루틴 대기 10초 후 429"가 상위 호환.
+- **Phase 1 (per-document in-memory lane) → 연기.** vault 게이트가 동일한
+  풀 보호를 주고, git이 동기 경로에 있는 한 세분화의 처리량 이득이 없다.
+- **Phase 2 (PG-first git) / Phase 3 (coalescing·202) → 미결 유지.**
+  §5의 PM 결정 1~4는 여전히 열려 있다. 본 설계는 Phase 2를 막지 않는다 —
+  admission 게이트는 PG-first에서도 그대로 앞단이 된다.
+- 100명(에이전트 동반) 규모에서는 본 설계 + #255로 충분하다는 것이
+  이번 토의의 용량 판단. Phase 2 게이트는 "80 writes/s/문서가 진짜 제품
+  케이스인가"(§5-4) 답이 나올 때 연다.
+
+## 5.5 리뷰 보강 (codex round 1 → 시맨틱 3건 추가)
+
+feedback/2026-07-02-codex-round-1.md에서 수용한 설계 수정:
+
+1. **취소 흡수** — executor 스레드는 중단 불가이므로, 커밋 중 호출자
+   취소 시 레인을 쥔 채 스레드 종료까지 대기 후 취소 전파. 조기 unwind는
+   "레인은 비었는데 vault 락은 잡힌" 거짓 신호로 병리를 재유입시킨다.
+2. **슬롯 규율(ContextVar)** — 커밋 executor에는 글로벌 슬롯 보유자만
+   도달한다. 레인 admitted writer는 보유 슬롯으로 직행, 게이트를 안 타는
+   vault 라이프사이클 작업은 `run_git_write`가 슬롯을 무데드라인 코루틴
+   대기로 선획득(라이프사이클은 429 불가). executor 내부 큐 = 구조적 0.
+3. **타임아웃 전면화** — worktree add/prune, clone 폴백 add/clone/push,
+   `_stage_and_commit`의 rev_parse까지 `git_write_timeout_secs`로 통일
+   (하드코딩 60s 제거).
+
+codex round 2~7 (feedback/2026-07-02-codex-round-{2..7}.md)에서 추가 수용:
+
+4. **`must_complete` 보상-쓰기 모드** (r2) — 슬롯 대기 중 취소도 흡수해
+   반드시 완료 후 취소 전파. point-of-no-return 이후의 보상 작업
+   (delete_vault 디스크 정리, create_vault 롤백 정리)이 클라이언트 단절로
+   유실되지 않게.
+5. **create_vault 롤백 완결화** (r2→r7에 걸쳐 수렴) — git 디렉토리 정리에
+   더해 DB 보상. 최종 형태:
+   - `_CREATE_LOCKS`(이름별)로 같은-이름 create 직렬화 → 디스크 소유권
+     프로브 건전화 (r3)
+   - `run_compensation` — bare shield의 detach 문제를 흡수 루프로 대체,
+     보상이 실제 완료될 때까지 파킹 (r4)
+   - **"롤백은 외부 데이터를 절대 파괴하지 않는다"**: 퍼지 트랜잭션 안에서
+     vaults row `FOR UPDATE`(모든 FK writer의 FOR KEY SHARE와 충돌 →
+     TOCTOU 원천 차단) + foreign-write 가드(seed 외 문서·파일·테이블·
+     publications·todos·소유 경로 밖 collections) — foreign 발견 시 파괴적
+     롤백 포기, vault 존치, 에러만 전파 (r5·r6·r7)
+   - 퍼지 순서 DB→디스크, 모든 실패는 "존치" 방향으로만 퇴화
+6. **delete_vault 취소 관통 차단** (r3) — cleanup 완료 후 재전파된 취소가
+   RBAC 롤 정리를 건너뛰지 않도록 파킹 + `run_compensation`.
+7. **롤백 가드의 보호 범위 원칙** (r8, reasoned rejection으로 확정; r9에서
+   codex 인정) — 가드가 지키는 것은 *사용자가 vault에 맡긴 콘텐츠와 외부
+   노출 산출물*(docs·files·tables·publications·todos·collections + 타 vault
+   publication의 `query_vault_names` 이름 참조, r9). *vault 자신에 대한
+   접근 메타데이터*(vault_access·RBAC 롤·소유권)는 vault와 운명을 같이한다
+   — delete_vault 캐스케이드와 동일 시맨틱. grant 때문에 롤백을 거부하면
+   half-created vault 잔존이라는 더 나쁜 결과가 된다.
+
+**리뷰 종결**: codex 라운드 10 — **NO OBJECTIONS** (2026-07-03,
+feedback/2026-07-02-codex-round-10.md에 전체 요약). 수용 15 · 기각(사유
+인정) 1.
+
+## 6. 검증 계획
+
+1. 유닛: per-vault 직렬화(동시 2 → 순차), 타 vault 비차단, 글로벌 M 상한,
+   T 초과 → `WriteBusyError`(429), 백스톱 즉시 거부.
+2. 기존 스위트 회귀 (`pytest -k 'not _e2e'`).
+3. (후속, 스테이징) 핫 vault burst E2E — round-04 검증 항목의 축소판:
+   단일 vault 100 PUT 폭주 중 타 vault GET p95 무영향 + 풀/스레드 비소진.


### PR DESCRIPTION
## What

Two-stage admission control in front of every git-committing document write, replacing thread/connection-holding waits with suspended-coroutine queueing:

```
request → per-vault gate (1 concurrent, FIFO)      ← coroutine wait, zero resources
        → global write-lane semaphore (M=8)         ← 〃
        → connection + advisory lock + transaction  ← resources only for the work span
        → git commit on a DEDICATED executor
        → PG writes → commit → release
```

Deadline (10s) exceeded → **429 + Retry-After** (REST) / **`code=write_busy`** envelope (MCP). Transaction boundary unchanged.

## Why

Two independent contagion paths let one hot vault take down the whole service (design: `docs/design/proposal/command-lane-write-path/rounds/round-05.md`):

1. **Pool poisoning** — waiters held a pool connection inside an open transaction while queueing for the per-vault git lock (documented incidents v0.4.1, and the proposal's own §1.2).
2. **Executor starvation** (new finding) — that queueing happened *inside* the shared `asyncio.to_thread` pool that git **reads** also use; on an 8-core node ~12 blocked waiters froze every read on every vault before the pool even drained.

## Hardening from review

- Cancellation absorption: executor threads can't be interrupted — cancellation is absorbed until the git op completes, so lane accounting stays truthful (`_dispatch_to_pool`, `must_complete`, `run_compensation`).
- ContextVar slot discipline: the commit executor only ever runs global-slot holders; ungated vault-lifecycle work can't crowd out admitted writers.
- create_vault rollback: per-name create lock, DB purge + RBAC cleanup, and a **never-destroy-foreign-data** guard (vaults-row `FOR UPDATE` + full-schema foreign checks incl. cross-vault `query_vault_names` references).
- `kill_after_timeout=30s` on every write-path git command.

## Review & verification

- **codex: 10 adversarial rounds → NO OBJECTIONS** (15 findings accepted, 1 rejected with rationale later upheld). Full trail: `docs/design/proposal/command-lane-write-path/feedback/2026-07-02-codex-round-{1..10}.md`.
- Unit: 23 new tests (`backend/tests/test_write_lane_unit.py`); full suite 456 passed; ruff/bandit/mypy clean on touched files.
- **Live scenario** (local stack, real HTTP surface): 180-writer hot-vault burst → 173 ok + 7×429 exactly at the deadline (~17 commits/s, matching the design estimate); cold-vault writes p50 **69ms** and `/livez` ≤ **7ms** throughout the burst; 429'd slugs left **no partial state**; MCP `write_busy` envelope captured live; delete→same-name recreate clean.

## Config

`write_lane_concurrency=8` · `write_lane_queue_timeout_secs=10` · `write_lane_max_waiters=512` · `git_write_timeout_secs=30`

## Follow-ups (out of scope, recorded in round-10 feedback)

- delete_vault lacks the same cross-vault `query_vault_names` dangling check (pre-existing).
- Staging hot-vault burst E2E (round-05 §6-3).
- Note for skillpack: MCP client timeouts should be ≥15s so clients see the 429 instead of cancelling first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149rWBRgj7ohUFCGF8Hbbed