### PR TITLE
feat(auth): identify legacy tokens for exact revocation

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -1,6 +1,7 @@
 """REST API routes for vault access management."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import SecretStr
 
 from app.api.deps import get_current_user
 from app.services.auth_service import (
@@ -14,6 +15,7 @@ from app.services.account_service import (
     ensure_service_user,
     get_user,
     get_user_by_external_identity,
+    identify_user_token,
     revoke_user_token,
     set_user_admin,
     suspend_user,
@@ -77,6 +79,10 @@ class EnsureServiceUserRequest(NFCModel):
 
 class SetUserRoleRequest(NFCModel):
     is_admin: bool
+
+
+class IdentifyTokenRequest(NFCModel):
+    token: SecretStr
 
 
 @router.get("/my/vaults", summary="List vaults accessible to me")
@@ -288,6 +294,27 @@ async def admin_revoke_user_token(
     return await revoke_user_token(
         user_id,
         token_id,
+        actor_id=user.user_id,
+    )
+
+
+@router.post(
+    "/admin/tokens/identify",
+    summary="[admin] Identify one presented token for exact migration revocation",
+)
+async def admin_identify_token(
+    req: IdentifyTokenRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Return only the owner and token IDs for an admin-presented raw token.
+
+    This migration endpoint deliberately ignores expiry and account status so
+    disabled legacy credentials can still be mapped to the exact owned revoke
+    route. The raw token and its fingerprint are never returned or audited.
+    """
+    _require_admin(user)
+    return await identify_user_token(
+        req.token.get_secret_value(),
         actor_id=user.user_id,
     )
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -17,6 +17,7 @@ from app.exceptions import (
 from app.repositories.events_repo import emit_event
 from app.services.auth_service import (
     REVOKE_REASON_ADMIN,
+    _hash_token,
     _revoke_sessions_in_conn,
     _unique_username,
 )
@@ -581,3 +582,35 @@ async def revoke_user_token(user_id: str, token_id: str, *, actor_id: str) -> di
     if needs_cleanup:
         await _cleanup_token_roles(pool, user_uuid, [token_uuid])
     return {"user_id": user_id, "token_id": token_id, "revoked": True}
+
+
+async def identify_user_token(raw_token: str, *, actor_id: str) -> dict:
+    """Map a presented token to exact ownership without authenticating it.
+
+    Legacy cleanup must also identify expired credentials and credentials owned
+    by suspended users. This path therefore performs a fingerprint lookup only;
+    it does not update last_used_at or apply the normal authentication filters.
+    """
+    token = _required(raw_token, "token")
+    if len(token) > 4096:
+        raise ValidationError("token is too long")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT id, user_id FROM tokens WHERE token_hash = $1",
+                _hash_token(token),
+            )
+            if row is None:
+                raise NotFoundError("Token", "presented credential")
+            result = {
+                "user_id": str(row["user_id"]),
+                "token_id": str(row["id"]),
+            }
+            await emit_event(
+                conn,
+                "auth.token_identified",
+                actor_id=actor_id,
+                payload=result,
+            )
+            return result

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -72,6 +72,32 @@ async def test_ensure_external_identity_forwards_verified_actor(monkeypatch):
     }
 
 
+async def test_token_identification_is_admin_only_and_never_returns_raw_token(monkeypatch):
+    from app.api.routes import access
+
+    raw_token = "akb_legacy-secret-material"
+    observed = {}
+
+    async def _identify(token, *, actor_id):
+        observed.update(token=token, actor_id=actor_id)
+        return {"user_id": "owner-id", "token_id": "token-id"}
+
+    monkeypatch.setattr(access, "identify_user_token", _identify)
+    request = access.IdentifyTokenRequest(token=raw_token)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_identify_token(request, _user(admin=False))
+    assert exc_info.value.status_code == 403
+    assert observed == {}
+
+    admin = _user(admin=True)
+    result = await access.admin_identify_token(request, admin)
+    assert result == {"user_id": "owner-id", "token_id": "token-id"}
+    assert raw_token not in repr(request)
+    assert raw_token not in repr(result)
+    assert observed == {"token": raw_token, "actor_id": admin.user_id}
+
+
 async def test_governance_routes_are_explicit_in_openapi():
     from app.main import app
 
@@ -85,6 +111,7 @@ async def test_governance_routes_are_explicit_in_openapi():
         "/api/v1/admin/users/{user_id}/suspend",
         "/api/v1/admin/users/{user_id}/activate",
         "/api/v1/admin/users/{user_id}/tokens/{token_id}",
+        "/api/v1/admin/tokens/identify",
     }
     assert expected <= set(paths)
     assert "/api/v1/admin/users/proxy" not in paths

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import uuid
 
@@ -530,3 +531,64 @@ async def test_exact_owned_token_revocation_is_strict_and_cross_user_safe(servic
     )
     assert revoked == {"user_id": owner["user_id"], "token_id": str(token_id), "revoked": True}
     assert token_id in role_sync.revoked_tokens
+
+
+async def test_admin_identifies_expired_suspended_legacy_token_without_secret_leak(services):
+    pool, _, service = services
+    owner = await service.ensure_service_user(
+        username=f"governance-token-identify-{uuid.uuid4().hex[:8]}",
+        email=f"governance-token-identify-{uuid.uuid4().hex[:8]}@service.akb.invalid",
+        display_name=None,
+        actor_id="platform-service",
+    )
+    owner_id = uuid.UUID(owner["user_id"])
+    raw_token = "akb_legacy-secret-material-" + uuid.uuid4().hex
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    async with pool.acquire() as conn:
+        token_id = await conn.fetchval(
+            """
+            INSERT INTO tokens (
+                user_id, name, token_hash, token_prefix, key_class, expires_at
+            ) VALUES ($1, 'legacy-platform-bridge', $2, 'akb_legacy', 'pat', NOW() - INTERVAL '1 day')
+            RETURNING id
+            """,
+            owner_id,
+            token_hash,
+        )
+        await conn.execute(
+            "UPDATE users SET account_status = 'suspended' WHERE id = $1",
+            owner_id,
+        )
+
+    identified = await service.identify_user_token(
+        raw_token,
+        actor_id="platform-service",
+    )
+    assert identified == {
+        "user_id": owner["user_id"],
+        "token_id": str(token_id),
+    }
+    async with pool.acquire() as conn:
+        event = await conn.fetchrow(
+            """
+            SELECT actor_id, payload::text
+              FROM events
+             WHERE kind = 'auth.token_identified'
+               AND payload->>'token_id' = $1
+             ORDER BY id DESC LIMIT 1
+            """,
+            str(token_id),
+        )
+    assert event["actor_id"] == "platform-service"
+    assert raw_token not in event["payload"]
+    assert token_hash not in event["payload"]
+
+    from app.exceptions import NotFoundError
+
+    with pytest.raises(NotFoundError) as exc_info:
+        await service.identify_user_token(
+            raw_token + "-unknown",
+            actor_id="platform-service",
+        )
+    assert raw_token not in str(exc_info.value)
+    assert token_hash not in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add an admin-only token identification endpoint for legacy credential migration
- identify expired or suspended-user tokens by fingerprint without authenticating them
- return and audit only exact user/token IDs, never raw token material

## Verification
- 30 account governance and auth-carrier tests passed on Python 3.14.6 with PostgreSQL
- ruff passed for all changed files

## Safety
- the endpoint does not alter token validity or last_used_at
- exact revocation remains the existing user_id + token_id strict path