### PR TITLE
feat(auth): adopt bootstrap admin as service principal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3005
+        "line_number": 3012
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-10T04:28:05Z"
+  "generated_at": "2026-07-10T12:20:49Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -25,6 +25,13 @@ Existing user IDs, JWT/PAT formats, Vault ownership, grants, and PG role names
 are unchanged. The pre-0.10 backend's register/login/PAT flow is verified
 against the expanded schema, and standalone local/open behavior remains covered.
 
+The managed operator can now adopt its exact local bootstrap administrator and
+current PAT in place as a non-interactive service principal. The operation keeps
+the raw credential stable across controller crashes, disables its password and
+JWT lifecycle, converts the current token to a service key, and strictly revokes
+all sibling tokens without granting first-user administration to ordinary
+service-user creation.
+
 ## 0.9.6 — 2026-07-09  *(fix — release /health pool slots before nested delete-outbox stats)*
 
 `GET /health` no longer holds the chunks stats pool connection while awaiting

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -11,6 +11,7 @@ from app.services.auth_service import (
 )
 from app.services.account_service import (
     activate_user,
+    adopt_current_admin_as_service,
     ensure_human_external_identity,
     ensure_service_user,
     get_user,
@@ -75,6 +76,11 @@ class EnsureServiceUserRequest(NFCModel):
     username: str
     email: str
     display_name: str | None = None
+
+
+class AdoptCurrentServiceUserRequest(NFCModel):
+    expected_username: str
+    expected_email: str
 
 
 class SetUserRoleRequest(NFCModel):
@@ -236,6 +242,32 @@ async def admin_ensure_service_user(
         username=req.username,
         email=req.email,
         display_name=req.display_name,
+        actor_id=user.user_id,
+    )
+
+
+@router.post(
+    "/admin/service-users/adopt-current",
+    summary="[admin] Adopt the current bootstrap administrator as a service identity",
+)
+async def admin_adopt_current_service_user(
+    req: AdoptCurrentServiceUserRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    if user.auth_method != "pat" or user.token_id is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Service identity adoption requires the current administrator PAT",
+                "code": "service_identity_adoption_requires_pat",
+            },
+        )
+    return await adopt_current_admin_as_service(
+        user_id=user.user_id,
+        token_id=user.token_id,
+        expected_username=req.expected_username,
+        expected_email=req.expected_email,
         actor_id=user.user_id,
     )
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -334,6 +334,7 @@ async def me(user: AuthenticatedUser = Depends(get_current_user)):
         "display_name": user.display_name,
         "is_admin": user.is_admin,
         "auth_method": user.auth_method,
+        "key_class": user.key_class,
     }
 
 

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -88,6 +88,17 @@ class ExternalIdentityConflictError(AKBError):
         )
 
 
+class ServiceIdentityAdoptionError(AKBError):
+    """A local bootstrap administrator cannot be safely adopted in place."""
+
+    def __init__(self):
+        super().__init__(
+            "Bootstrap administrator does not match the service identity adoption contract",
+            status_code=409,
+            code="service_identity_adoption_conflict",
+        )
+
+
 class ExternalAuthDisabledError(AKBError):
     """External authentication is disabled by deployment policy."""
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -361,7 +361,7 @@ async def adopt_current_admin_as_service(
         async with conn.transaction():
             current = await conn.fetchrow(
                 """
-                SELECT id, username, email, display_name, is_admin,
+                SELECT id, username, email, password_hash, display_name, is_admin,
                        auth_provider, account_status, account_kind,
                        EXISTS (
                            SELECT 1 FROM external_identities e
@@ -394,7 +394,7 @@ async def adopt_current_admin_as_service(
 
             token = await conn.fetchrow(
                 """
-                SELECT user_id, key_class, vault_scope, expires_at
+                SELECT user_id, key_class, scopes, vault_scope, expires_at
                   FROM tokens
                  WHERE id = $1
                    FOR UPDATE
@@ -410,32 +410,44 @@ async def adopt_current_admin_as_service(
             ):
                 raise ServiceIdentityAdoptionError()
 
-            await conn.execute(
-                """
-                UPDATE users
-                   SET account_kind = 'service',
-                       auth_provider = 'service',
-                       password_hash = $2,
-                       tokens_revoked_before = CASE
-                           WHEN account_kind = 'human' THEN NOW()
-                           ELSE tokens_revoked_before
-                       END,
-                       updated_at = NOW()
-                 WHERE id = $1
-                """,
-                user_uuid,
-                _SERVICE_SENTINEL_HASH,
+            user_changed = (
+                current["account_kind"] != "service"
+                or current["auth_provider"] != "service"
+                or current["password_hash"] != _SERVICE_SENTINEL_HASH
             )
-            await conn.execute(
-                """
-                UPDATE tokens
-                   SET key_class = 'service',
-                       scopes = ARRAY['read', 'write', 'admin']::text[]
-                 WHERE id = $1 AND user_id = $2
-                """,
-                token_uuid,
-                user_uuid,
+            wanted_scopes = ["read", "write", "admin"]
+            token_changed = (
+                token["key_class"] != "service"
+                or list(token["scopes"] or []) != wanted_scopes
             )
+            if user_changed:
+                await conn.execute(
+                    """
+                    UPDATE users
+                       SET account_kind = 'service',
+                           auth_provider = 'service',
+                           password_hash = $2,
+                           tokens_revoked_before = CASE
+                               WHEN account_kind = 'human' THEN NOW()
+                               ELSE tokens_revoked_before
+                           END,
+                           updated_at = NOW()
+                     WHERE id = $1
+                    """,
+                    user_uuid,
+                    _SERVICE_SENTINEL_HASH,
+                )
+            if token_changed:
+                await conn.execute(
+                    """
+                    UPDATE tokens
+                       SET key_class = 'service', scopes = $3::text[]
+                     WHERE id = $1 AND user_id = $2
+                    """,
+                    token_uuid,
+                    user_uuid,
+                    wanted_scopes,
+                )
             deleted = await conn.fetch(
                 """
                 DELETE FROM tokens
@@ -464,16 +476,17 @@ async def adopt_current_admin_as_service(
                 user_uuid,
             )
             pending_token_ids = [record["token_id"] for record in pending]
-            await emit_event(
-                conn,
-                "auth.bootstrap_service_adopted",
-                actor_id=actor_id,
-                payload={
-                    "user_id": user_id,
-                    "token_id": token_id,
-                    "revoked_token_ids": [str(value) for value in pending_token_ids],
-                },
-            )
+            if user_changed or token_changed or deleted:
+                await emit_event(
+                    conn,
+                    "auth.bootstrap_service_adopted",
+                    actor_id=actor_id,
+                    payload={
+                        "user_id": user_id,
+                        "token_id": token_id,
+                        "revoked_token_ids": [str(value) for value in pending_token_ids],
+                    },
+                )
             adopted = await _fetch_user(conn, user_uuid)
 
     await _cleanup_token_roles(pool, user_uuid, pending_token_ids)

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -12,6 +12,7 @@ from app.exceptions import (
     CredentialCleanupIncompleteError,
     ExternalIdentityConflictError,
     NotFoundError,
+    ServiceIdentityAdoptionError,
     ValidationError,
 )
 from app.repositories.events_repo import emit_event
@@ -333,6 +334,155 @@ async def ensure_service_user(
     if new_user_id is not None:
         await get_role_sync().on_user_create(new_user_id)
     return _user_result(row)
+
+
+async def adopt_current_admin_as_service(
+    *,
+    user_id: str,
+    token_id: str,
+    expected_username: str,
+    expected_email: str,
+    actor_id: str,
+) -> dict:
+    """Atomically adopt the current local bootstrap admin and its PAT.
+
+    The raw credential never changes, so a controller crash cannot strand the
+    workspace between AKB state and Secret delivery. Every other token is
+    denied in the transaction and its derived PG role is then cleaned strictly.
+    """
+
+    user_uuid = _uuid(user_id, "user_id")
+    token_uuid = _uuid(token_id, "token_id")
+    expected_username = _required(expected_username, "expected_username")
+    expected_email = _required(expected_email, "expected_email").lower()
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            current = await conn.fetchrow(
+                """
+                SELECT id, username, email, display_name, is_admin,
+                       auth_provider, account_status, account_kind,
+                       EXISTS (
+                           SELECT 1 FROM external_identities e
+                            WHERE e.user_id = users.id
+                       ) AS has_external_identity
+                  FROM users
+                 WHERE id = $1
+                   FOR UPDATE
+                """,
+                user_uuid,
+            )
+            if (
+                current is None
+                or current["username"] != expected_username
+                or current["email"].lower() != expected_email
+                or current["account_status"] != "active"
+                or not current["is_admin"]
+                or current["has_external_identity"]
+                or current["account_kind"] not in {"human", "service"}
+                or (
+                    current["account_kind"] == "human"
+                    and current["auth_provider"] != "local"
+                )
+                or (
+                    current["account_kind"] == "service"
+                    and current["auth_provider"] != "service"
+                )
+            ):
+                raise ServiceIdentityAdoptionError()
+
+            token = await conn.fetchrow(
+                """
+                SELECT user_id, key_class, vault_scope, expires_at
+                  FROM tokens
+                 WHERE id = $1
+                   FOR UPDATE
+                """,
+                token_uuid,
+            )
+            if (
+                token is None
+                or token["user_id"] != user_uuid
+                or token["key_class"] not in {"pat", "service"}
+                or token["vault_scope"] is not None
+                or token["expires_at"] is not None
+            ):
+                raise ServiceIdentityAdoptionError()
+
+            await conn.execute(
+                """
+                UPDATE users
+                   SET account_kind = 'service',
+                       auth_provider = 'service',
+                       password_hash = $2,
+                       tokens_revoked_before = CASE
+                           WHEN account_kind = 'human' THEN NOW()
+                           ELSE tokens_revoked_before
+                       END,
+                       updated_at = NOW()
+                 WHERE id = $1
+                """,
+                user_uuid,
+                _SERVICE_SENTINEL_HASH,
+            )
+            await conn.execute(
+                """
+                UPDATE tokens
+                   SET key_class = 'service',
+                       scopes = ARRAY['read', 'write', 'admin']::text[]
+                 WHERE id = $1 AND user_id = $2
+                """,
+                token_uuid,
+                user_uuid,
+            )
+            deleted = await conn.fetch(
+                """
+                DELETE FROM tokens
+                 WHERE user_id = $1 AND id <> $2
+             RETURNING id
+                """,
+                user_uuid,
+                token_uuid,
+            )
+            if deleted:
+                await conn.executemany(
+                    """
+                    INSERT INTO account_token_cleanup (token_id, user_id)
+                    VALUES ($1, $2)
+                    ON CONFLICT (token_id) DO NOTHING
+                    """,
+                    [(record["id"], user_uuid) for record in deleted],
+                )
+            pending = await conn.fetch(
+                """
+                SELECT token_id
+                  FROM account_token_cleanup
+                 WHERE user_id = $1 AND completed_at IS NULL
+                 ORDER BY requested_at, token_id
+                """,
+                user_uuid,
+            )
+            pending_token_ids = [record["token_id"] for record in pending]
+            await emit_event(
+                conn,
+                "auth.bootstrap_service_adopted",
+                actor_id=actor_id,
+                payload={
+                    "user_id": user_id,
+                    "token_id": token_id,
+                    "revoked_token_ids": [str(value) for value in pending_token_ids],
+                },
+            )
+            adopted = await _fetch_user(conn, user_uuid)
+
+    await _cleanup_token_roles(pool, user_uuid, pending_token_ids)
+    return {
+        **_user_result(adopted),
+        "token_id": token_id,
+        "key_class": "service",
+        "revoked_token_ids": [str(value) for value in pending_token_ids],
+    }
 
 
 async def get_user(user_id: str) -> dict:

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -25,6 +25,19 @@ def _user(*, admin: bool) -> AuthenticatedUser:
     )
 
 
+def _bootstrap_user(*, auth_method: str = "pat", token_id: str | None = None) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        username="platform-bot",
+        email="platform-bot@workspace.local",
+        display_name="Platform Bot",
+        is_admin=True,
+        auth_method=auth_method,
+        token_id=token_id,
+        key_class="pat",
+    )
+
+
 async def test_non_admin_is_rejected_before_account_service(monkeypatch):
     from app.api.routes import access
 
@@ -98,6 +111,42 @@ async def test_token_identification_is_admin_only_and_never_returns_raw_token(mo
     assert observed == {"token": raw_token, "actor_id": admin.user_id}
 
 
+async def test_adopt_current_service_requires_exact_admin_pat_and_forwards_ids(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _adopt(**kwargs):
+        observed.update(kwargs)
+        return {"account_kind": "service", "key_class": "service"}
+
+    monkeypatch.setattr(access, "adopt_current_admin_as_service", _adopt)
+    request = access.AdoptCurrentServiceUserRequest(
+        expected_username="platform-bot",
+        expected_email="platform-bot@workspace.local",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_adopt_current_service_user(
+            request,
+            _bootstrap_user(auth_method="jwt"),
+        )
+    assert exc_info.value.status_code == 409
+    assert observed == {}
+
+    token_id = str(uuid.uuid4())
+    actor = _bootstrap_user(token_id=token_id)
+    result = await access.admin_adopt_current_service_user(request, actor)
+    assert result == {"account_kind": "service", "key_class": "service"}
+    assert observed == {
+        "user_id": actor.user_id,
+        "token_id": token_id,
+        "expected_username": request.expected_username,
+        "expected_email": request.expected_email,
+        "actor_id": actor.user_id,
+    }
+
+
 async def test_governance_routes_are_explicit_in_openapi():
     from app.main import app
 
@@ -107,6 +156,7 @@ async def test_governance_routes_are_explicit_in_openapi():
         "/api/v1/admin/users/by-external-identity",
         "/api/v1/admin/users/{user_id}/governance",
         "/api/v1/admin/service-users/ensure",
+        "/api/v1/admin/service-users/adopt-current",
         "/api/v1/admin/users/{user_id}/role",
         "/api/v1/admin/users/{user_id}/suspend",
         "/api/v1/admin/users/{user_id}/activate",

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -147,6 +147,16 @@ async def test_adopt_current_service_requires_exact_admin_pat_and_forwards_ids(m
     }
 
 
+async def test_auth_me_exposes_additive_current_key_class():
+    from app.api.routes import auth
+
+    actor = _bootstrap_user(token_id=str(uuid.uuid4()))
+    actor.key_class = "service"
+    result = await auth.me(actor)
+    assert result["user_id"] == actor.user_id
+    assert result["key_class"] == "service"
+
+
 async def test_governance_routes_are_explicit_in_openapi():
     from app.main import app
 

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -360,6 +360,13 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     assert row["token_count"] == 1
     assert role_sync.revoked_tokens == [stale_token_id]
 
+    async with pool.acquire() as conn:
+        event_count = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE kind = 'auth.bootstrap_service_adopted' AND actor_id = $1",
+            str(user_id),
+        )
+    assert event_count == 1
+
     resolved = await auth_service.resolve_token(f"Bearer {raw_current}")
     assert resolved is not None
     assert resolved.user_id == str(user_id)
@@ -375,6 +382,12 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     )
     assert retried["revoked_token_ids"] == []
     assert role_sync.revoked_tokens == [stale_token_id]
+    async with pool.acquire() as conn:
+        retried_event_count = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE kind = 'auth.bootstrap_service_adopted' AND actor_id = $1",
+            str(user_id),
+        )
+    assert retried_event_count == event_count
 
 
 async def test_adopt_bootstrap_admin_rejects_identity_mismatch_atomically(services):

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -274,6 +274,260 @@ async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
     assert password_hash.startswith("!service-account:")
 
 
+async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
+    services,
+):
+    pool, role_sync, service = services
+    from app.services import auth_service
+
+    user_id = uuid.uuid4()
+    current_token_id = uuid.uuid4()
+    stale_token_id = uuid.uuid4()
+    username = f"governance-platform-bot-{uuid.uuid4().hex[:8]}"
+    email = f"{username}@workspace.local"
+    raw_current = "akb_" + uuid.uuid4().hex
+    raw_stale = "akb_" + uuid.uuid4().hex
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, display_name, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, $4, 'Platform Bot', true,
+                      'local', 'active', 'human')
+            """,
+            user_id,
+            username,
+            email,
+            auth_service.hash_password("legacy-password"),
+        )
+        await conn.executemany(
+            """
+            INSERT INTO tokens (
+                id, user_id, name, token_hash, token_prefix, key_class
+            ) VALUES ($1, $2, $3, $4, $5, 'pat')
+            """,
+            [
+                (
+                    current_token_id,
+                    user_id,
+                    "platform",
+                    auth_service._hash_token(raw_current),
+                    raw_current[:12],
+                ),
+                (
+                    stale_token_id,
+                    user_id,
+                    "stale",
+                    auth_service._hash_token(raw_stale),
+                    raw_stale[:12],
+                ),
+            ],
+        )
+
+    adopted = await service.adopt_current_admin_as_service(
+        user_id=str(user_id),
+        token_id=str(current_token_id),
+        expected_username=username,
+        expected_email=email,
+        actor_id=str(user_id),
+    )
+    assert adopted["user_id"] == str(user_id)
+    assert adopted["account_kind"] == "service"
+    assert adopted["auth_provider"] == "service"
+    assert adopted["is_admin"] is True
+    assert adopted["token_id"] == str(current_token_id)
+    assert adopted["key_class"] == "service"
+    assert adopted["revoked_token_ids"] == [str(stale_token_id)]
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT u.password_hash, u.tokens_revoked_before,
+                   t.key_class, t.scopes,
+                   (SELECT count(*) FROM tokens WHERE user_id = u.id) AS token_count
+              FROM users u
+              JOIN tokens t ON t.user_id = u.id AND t.id = $2
+             WHERE u.id = $1
+            """,
+            user_id,
+            current_token_id,
+        )
+    assert row["password_hash"].startswith("!service-account:")
+    assert row["tokens_revoked_before"] is not None
+    assert row["key_class"] == "service"
+    assert list(row["scopes"]) == ["read", "write", "admin"]
+    assert row["token_count"] == 1
+    assert role_sync.revoked_tokens == [stale_token_id]
+
+    resolved = await auth_service.resolve_token(f"Bearer {raw_current}")
+    assert resolved is not None
+    assert resolved.user_id == str(user_id)
+    assert resolved.key_class == "service"
+    assert resolved.is_admin is True
+
+    retried = await service.adopt_current_admin_as_service(
+        user_id=str(user_id),
+        token_id=str(current_token_id),
+        expected_username=username,
+        expected_email=email,
+        actor_id=str(user_id),
+    )
+    assert retried["revoked_token_ids"] == []
+    assert role_sync.revoked_tokens == [stale_token_id]
+
+
+async def test_adopt_bootstrap_admin_rejects_identity_mismatch_atomically(services):
+    pool, _, service = services
+    from app.services import auth_service
+    from app.exceptions import ServiceIdentityAdoptionError
+
+    user_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    username = f"governance-platform-bot-{uuid.uuid4().hex[:8]}"
+    email = f"{username}@workspace.local"
+    raw = "akb_" + uuid.uuid4().hex
+    password_hash = auth_service.hash_password("legacy-password")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, display_name, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, $4, 'Platform Bot', true,
+                      'local', 'active', 'human')
+            """,
+            user_id,
+            username,
+            email,
+            password_hash,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, key_class)
+            VALUES ($1, $2, 'platform', $3, $4, 'pat')
+            """,
+            token_id,
+            user_id,
+            auth_service._hash_token(raw),
+            raw[:12],
+        )
+
+    with pytest.raises(ServiceIdentityAdoptionError):
+        await service.adopt_current_admin_as_service(
+            user_id=str(user_id),
+            token_id=str(token_id),
+            expected_username=username,
+            expected_email="wrong@example.com",
+            actor_id=str(user_id),
+        )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT account_kind, auth_provider, password_hash,
+                   (SELECT key_class FROM tokens WHERE id = $2) AS key_class
+              FROM users WHERE id = $1
+            """,
+            user_id,
+            token_id,
+        )
+    assert dict(row) == {
+        "account_kind": "human",
+        "auth_provider": "local",
+        "password_hash": password_hash,
+        "key_class": "pat",
+    }
+
+
+async def test_adopt_bootstrap_admin_keeps_denial_and_retries_role_cleanup(services):
+    pool, role_sync, service = services
+    from app.exceptions import CredentialCleanupIncompleteError
+    from app.services import auth_service
+
+    user_id = uuid.uuid4()
+    current_token_id = uuid.uuid4()
+    stale_token_id = uuid.uuid4()
+    username = f"governance-platform-bot-{uuid.uuid4().hex[:8]}"
+    email = f"{username}@workspace.local"
+    current_raw = "akb_" + uuid.uuid4().hex
+    stale_raw = "akb_" + uuid.uuid4().hex
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, display_name, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, $4, 'Platform Bot', true,
+                      'local', 'active', 'human')
+            """,
+            user_id,
+            username,
+            email,
+            auth_service.hash_password("legacy-password"),
+        )
+        await conn.executemany(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, key_class)
+            VALUES ($1, $2, $3, $4, $5, 'pat')
+            """,
+            [
+                (current_token_id, user_id, "platform", auth_service._hash_token(current_raw), current_raw[:12]),
+                (stale_token_id, user_id, "stale", auth_service._hash_token(stale_raw), stale_raw[:12]),
+            ],
+        )
+
+    role_sync.fail_token = stale_token_id
+    with pytest.raises(CredentialCleanupIncompleteError):
+        await service.adopt_current_admin_as_service(
+            user_id=str(user_id),
+            token_id=str(current_token_id),
+            expected_username=username,
+            expected_email=email,
+            actor_id=str(user_id),
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            """
+            SELECT u.account_kind, u.auth_provider,
+                   EXISTS (SELECT 1 FROM tokens WHERE id = $2) AS current_exists,
+                   EXISTS (SELECT 1 FROM tokens WHERE id = $3) AS stale_exists,
+                   EXISTS (
+                       SELECT 1 FROM account_token_cleanup
+                        WHERE token_id = $3 AND completed_at IS NULL
+                   ) AS cleanup_pending
+              FROM users u WHERE u.id = $1
+            """,
+            user_id,
+            current_token_id,
+            stale_token_id,
+        )
+    assert dict(state) == {
+        "account_kind": "service",
+        "auth_provider": "service",
+        "current_exists": True,
+        "stale_exists": False,
+        "cleanup_pending": True,
+    }
+
+    role_sync.fail_token = None
+    retried = await service.adopt_current_admin_as_service(
+        user_id=str(user_id),
+        token_id=str(current_token_id),
+        expected_username=username,
+        expected_email=email,
+        actor_id=str(user_id),
+    )
+    assert retried["revoked_token_ids"] == [str(stale_token_id)]
+    async with pool.acquire() as conn:
+        completed = await conn.fetchval(
+            "SELECT completed_at IS NOT NULL FROM account_token_cleanup WHERE token_id = $1",
+            stale_token_id,
+        )
+    assert completed is True
+
+
 async def test_concurrent_service_user_ensure_converges_to_one_user(services):
     pool, _, service = services
     username = f"governance-concurrent-runtime-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary
- add an explicit admin-PAT-only route that adopts the current local bootstrap administrator in place as a service identity
- preserve the current raw credential while disabling local password/JWT use and converting the token to a service key
- revoke sibling tokens transactionally and retry strict PG-role cleanup durably

## Verification
- `scripts/check-workspace-account-governance.sh` (115 tests + old-image/new-schema compatibility)
- backend unit suite: 735 passed, 2 skipped
- ruff, mypy (198 files), bandit
