### PR TITLE
fix(auth): prepare managed accounts suspended

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3012
+        "line_number": 3021
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-10T12:20:49Z"
+  "generated_at": "2026-07-10T13:21:57Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -32,6 +32,15 @@ JWT lifecycle, converts the current token to a service key, and strictly revokes
 all sibling tokens without granting first-user administration to ordinary
 service-user creation.
 
+Managed control planes may also use the distinct
+`/admin/users/prepare-external-identity` endpoint. Keeping this separate from the
+standalone ensure route makes mixed-version rollout fail closed: an older AKB
+returns 404 instead of ignoring a new option and creating an active account. The
+binding and denial are committed atomically, any existing sessions and tokens
+are revoked through the same durable cleanup path, and the account stays
+inaccessible until the control plane explicitly activates it after committing
+its own membership authority.
+
 ## 0.9.6 — 2026-07-09  *(fix — release /health pool slots before nested delete-outbox stats)*
 
 `GET /health` no longer holds the chunks stats pool connection while awaiting

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -204,6 +204,26 @@ async def admin_ensure_external_identity(
     )
 
 
+@router.post(
+    "/admin/users/prepare-external-identity",
+    summary="[admin] Prepare a suspended human user and stable OIDC binding",
+)
+async def admin_prepare_external_identity(
+    req: EnsureExternalIdentityRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await ensure_human_external_identity(
+        issuer=req.issuer,
+        subject=req.subject,
+        email=req.email,
+        display_name=req.display_name,
+        existing_user_id=req.existing_user_id,
+        prepare_suspended=True,
+        actor_id=user.user_id,
+    )
+
+
 @router.get(
     "/admin/users/by-external-identity",
     summary="[admin] Resolve a user by exact OIDC issuer and subject",

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -75,6 +75,7 @@ async def ensure_human_external_identity(
     display_name: str | None,
     actor_id: str,
     existing_user_id: str | None = None,
+    prepare_suspended: bool = False,
 ) -> dict:
     issuer = _required(issuer, "issuer")
     subject = _required(subject, "subject")
@@ -86,6 +87,7 @@ async def ensure_human_external_identity(
     )
     pool = await get_pool()
     new_user_id: uuid.UUID | None = None
+    token_ids: list[uuid.UUID] = []
 
     async with pool.acquire() as conn:
         try:
@@ -244,6 +246,12 @@ async def ensure_human_external_identity(
                         "subject": subject,
                     },
                 )
+                if prepare_suspended:
+                    token_ids = await _suspend_user_in_conn(
+                        conn,
+                        user_id,
+                        actor_id=actor_id,
+                    )
         except asyncpg.UniqueViolationError:
             raise ExternalIdentityConflictError() from None
 
@@ -251,6 +259,8 @@ async def ensure_human_external_identity(
 
     if new_user_id is not None:
         await get_role_sync().on_user_create(new_user_id)
+    if prepare_suspended:
+        await _cleanup_token_roles(pool, user_id, token_ids)
     return _user_result(row)
 
 
@@ -598,66 +608,80 @@ async def _cleanup_token_roles(pool, user_id: uuid.UUID, token_ids: list[uuid.UU
         raise CredentialCleanupIncompleteError(failed)
 
 
+async def _suspend_user_in_conn(
+    conn,
+    user_id: uuid.UUID,
+    *,
+    actor_id: str,
+) -> list[uuid.UUID]:
+    row = await conn.fetchrow(
+        "SELECT account_status FROM users WHERE id = $1 FOR UPDATE",
+        user_id,
+    )
+    if row is None:
+        raise NotFoundError("User", str(user_id))
+
+    if row["account_status"] == "active":
+        await conn.execute(
+            """
+            UPDATE users
+               SET account_status = 'suspended', updated_at = NOW()
+             WHERE id = $1
+            """,
+            user_id,
+        )
+        await _revoke_sessions_in_conn(
+            conn,
+            user_id,
+            actor_id=actor_id,
+            reason=REVOKE_REASON_ADMIN,
+        )
+        deleted = await conn.fetch(
+            "DELETE FROM tokens WHERE user_id = $1 RETURNING id",
+            user_id,
+        )
+        token_ids = [record["id"] for record in deleted]
+        if token_ids:
+            await conn.executemany(
+                """
+                INSERT INTO account_token_cleanup (token_id, user_id)
+                VALUES ($1, $2)
+                ON CONFLICT (token_id) DO NOTHING
+                """,
+                [(token_id, user_id) for token_id in token_ids],
+            )
+        await emit_event(
+            conn,
+            "auth.account_suspended",
+            actor_id=actor_id,
+            payload={
+                "user_id": str(user_id),
+                "revoked_token_ids": [str(token_id) for token_id in token_ids],
+            },
+        )
+        return token_ids
+
+    pending = await conn.fetch(
+        """
+        SELECT token_id FROM account_token_cleanup
+         WHERE user_id = $1 AND completed_at IS NULL
+         ORDER BY requested_at, token_id
+        """,
+        user_id,
+    )
+    return [record["token_id"] for record in pending]
+
+
 async def suspend_user(user_id: str, *, actor_id: str) -> dict:
     user_uuid = _uuid(user_id, "user_id")
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            row = await conn.fetchrow(
-                "SELECT account_status FROM users WHERE id = $1 FOR UPDATE",
+            token_ids = await _suspend_user_in_conn(
+                conn,
                 user_uuid,
+                actor_id=actor_id,
             )
-            if row is None:
-                raise NotFoundError("User", user_id)
-
-            if row["account_status"] == "active":
-                await conn.execute(
-                    """
-                    UPDATE users
-                       SET account_status = 'suspended', updated_at = NOW()
-                     WHERE id = $1
-                    """,
-                    user_uuid,
-                )
-                await _revoke_sessions_in_conn(
-                    conn,
-                    user_uuid,
-                    actor_id=actor_id,
-                    reason=REVOKE_REASON_ADMIN,
-                )
-                deleted = await conn.fetch(
-                    "DELETE FROM tokens WHERE user_id = $1 RETURNING id",
-                    user_uuid,
-                )
-                token_ids = [record["id"] for record in deleted]
-                if token_ids:
-                    await conn.executemany(
-                        """
-                        INSERT INTO account_token_cleanup (token_id, user_id)
-                        VALUES ($1, $2)
-                        ON CONFLICT (token_id) DO NOTHING
-                        """,
-                        [(token_id, user_uuid) for token_id in token_ids],
-                    )
-                await emit_event(
-                    conn,
-                    "auth.account_suspended",
-                    actor_id=actor_id,
-                    payload={
-                        "user_id": user_id,
-                        "revoked_token_ids": [str(token_id) for token_id in token_ids],
-                    },
-                )
-            else:
-                pending = await conn.fetch(
-                    """
-                    SELECT token_id FROM account_token_cleanup
-                     WHERE user_id = $1 AND completed_at IS NULL
-                     ORDER BY requested_at, token_id
-                    """,
-                    user_uuid,
-                )
-                token_ids = [record["token_id"] for record in pending]
 
     await _cleanup_token_roles(pool, user_uuid, token_ids)
     return {

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -85,6 +85,38 @@ async def test_ensure_external_identity_forwards_verified_actor(monkeypatch):
     }
 
 
+async def test_prepare_external_identity_uses_distinct_fail_closed_route(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _ensure(**kwargs):
+        observed.update(kwargs)
+        return {"user_id": "prepared-user", "account_status": "suspended"}
+
+    monkeypatch.setattr(access, "ensure_human_external_identity", _ensure)
+    admin = _user(admin=True)
+    request = access.EnsureExternalIdentityRequest(
+        issuer="https://id.example.com/realms/akb",
+        subject="prepared-subject",
+        email="prepared@example.com",
+        display_name="Prepared member",
+    )
+
+    result = await access.admin_prepare_external_identity(request, admin)
+
+    assert result["account_status"] == "suspended"
+    assert observed == {
+        "issuer": request.issuer,
+        "subject": request.subject,
+        "email": request.email,
+        "display_name": request.display_name,
+        "existing_user_id": None,
+        "prepare_suspended": True,
+        "actor_id": admin.user_id,
+    }
+
+
 async def test_token_identification_is_admin_only_and_never_returns_raw_token(monkeypatch):
     from app.api.routes import access
 
@@ -163,6 +195,7 @@ async def test_governance_routes_are_explicit_in_openapi():
     paths = app.openapi()["paths"]
     expected = {
         "/api/v1/admin/users/ensure-external-identity",
+        "/api/v1/admin/users/prepare-external-identity",
         "/api/v1/admin/users/by-external-identity",
         "/api/v1/admin/users/{user_id}/governance",
         "/api/v1/admin/service-users/ensure",

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -125,6 +125,49 @@ async def test_ensure_human_binding_is_idempotent_and_never_bootstrap_admin(serv
     }
 
 
+async def test_prepare_human_binding_is_suspended_atomically_and_not_reactivated_by_default(
+    services,
+):
+    pool, _, service = services
+    subject = f"prepared-human-{uuid.uuid4().hex}"
+    email = f"governance-prepared-human-{uuid.uuid4().hex[:10]}@example.com"
+
+    prepared = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=subject,
+        email=email,
+        display_name="Prepared member",
+        actor_id="platform-service",
+        prepare_suspended=True,
+    )
+    retried_without_prepare = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=subject,
+        email=email,
+        display_name="Prepared member",
+        actor_id="platform-service",
+    )
+
+    assert prepared["user_id"] == retried_without_prepare["user_id"]
+    assert prepared["account_status"] == "suspended"
+    assert retried_without_prepare["account_status"] == "suspended"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT u.account_status, e.issuer, e.subject
+              FROM users u
+              JOIN external_identities e ON e.user_id = u.id
+             WHERE u.id = $1
+            """,
+            uuid.UUID(prepared["user_id"]),
+        )
+    assert dict(row) == {
+        "account_status": "suspended",
+        "issuer": _ISSUER,
+        "subject": subject,
+    }
+
+
 async def test_concurrent_human_ensure_converges_to_one_user(services):
     pool, _, service = services
     subject = f"concurrent-human-{uuid.uuid4().hex}"
@@ -664,6 +707,58 @@ async def test_suspend_revokes_sessions_tokens_and_strict_token_roles(services):
     assert row["account_status"] == "suspended"
     assert row["tokens_revoked_before"] > before
     assert row["token_count"] == 0
+
+
+async def test_prepare_existing_human_suspends_and_strictly_revokes_tokens(services):
+    pool, role_sync, service = services
+    subject = f"prepared-existing-{uuid.uuid4().hex}"
+    email = f"governance-prepared-existing-{uuid.uuid4().hex[:10]}@example.com"
+    ensured = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=subject,
+        email=email,
+        display_name="Existing member",
+        actor_id="platform-service",
+    )
+    user_id = uuid.UUID(ensured["user_id"])
+    async with pool.acquire() as conn:
+        token_id = await conn.fetchval(
+            """
+            INSERT INTO tokens (user_id, name, token_hash, token_prefix, key_class)
+            VALUES ($1, 'governance-prepare', $2, 'akb_govern', 'pat')
+            RETURNING id
+            """,
+            user_id,
+            uuid.uuid4().hex,
+        )
+
+    prepared = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=subject,
+        email=email,
+        display_name="Existing member",
+        actor_id="platform-service",
+        prepare_suspended=True,
+    )
+
+    assert prepared["account_status"] == "suspended"
+    assert role_sync.revoked_tokens == [token_id]
+    async with pool.acquire() as conn:
+        token_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM tokens WHERE user_id = $1",
+            user_id,
+        )
+        cleanup_completed = await conn.fetchval(
+            """
+            SELECT completed_at IS NOT NULL
+              FROM account_token_cleanup
+             WHERE token_id = $1 AND user_id = $2
+            """,
+            token_id,
+            user_id,
+        )
+    assert token_count == 0
+    assert cleanup_completed is True
 
 
 async def test_failed_strict_cleanup_keeps_denial_and_retry_finishes(services):


### PR DESCRIPTION
## Summary

- add an opt-in prepare_suspended contract to external identity ensure
- commit identity binding and account denial in one transaction
- reuse durable session, token, and strict PG-role cleanup without changing standalone defaults

## Why

A managed control plane must commit its own membership authority before the AKB account becomes reachable. Preparing an active AKB account first leaves a failure window where an uncommitted platform member can authenticate directly.

## Verification

- account governance tests: 47 passed (OpenAPI smoke rerun with writable temporary storage)
- ruff check .
- mypy --python-version 3.14 app/ mcp_server/
- bandit -r app/ mcp_server/ -c pyproject.toml --severity-level medium -q
