### PR TITLE
feat(auth): add recoverable managed token issuance

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3021
+        "line_number": 3028
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-10T13:21:57Z"
+  "generated_at": "2026-07-10T13:35:47Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -41,6 +41,13 @@ are revoked through the same durable cleanup path, and the account stays
 inaccessible until the control plane explicitly activates it after committing
 its own membership authority.
 
+Managed PAT issuance likewise has a distinct
+`/admin/users/{user_ref}/managed-tokens` endpoint that requires a
+caller-selected UUID. The UUID becomes the actual AKB token primary key, so a
+control plane can durably record it before the remote call and revoke that exact
+token after an ambiguous response. Older AKB images return 404 on this path
+instead of silently minting a token under an unrelated server-generated ID.
+
 ## 0.9.6 — 2026-07-09  *(fix — release /health pool slots before nested delete-outbox stats)*
 
 `GET /health` no longer holds the chunks stats pool connection while awaiting

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -447,6 +447,10 @@ class AdminMintTokenRequest(NFCModel):
     vault_scope: dict[str, list[str]] | None = None
 
 
+class AdminManagedMintTokenRequest(AdminMintTokenRequest):
+    token_id: str
+
+
 @router.post(
     "/admin/users/{user_ref}/tokens",
     summary="[admin] Mint a PAT for a user (by id or email)",
@@ -466,6 +470,28 @@ async def admin_mint_user_token(
     token once, same shape as ``/auth/tokens``.
     """
     _require_admin(user)
+    return await _mint_admin_user_token(user_ref, req)
+
+
+@router.post(
+    "/admin/users/{user_ref}/managed-tokens",
+    summary="[admin] Mint a PAT with a caller-selected durable token ID",
+)
+async def admin_mint_managed_user_token(
+    user_ref: str,
+    req: AdminManagedMintTokenRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await _mint_admin_user_token(user_ref, req, token_id=req.token_id)
+
+
+async def _mint_admin_user_token(
+    user_ref: str,
+    req: AdminMintTokenRequest,
+    *,
+    token_id: str | None = None,
+):
     import uuid as _uuid
     from app.db.postgres import get_pool
     from app.models.vault_scope import VaultScope
@@ -486,6 +512,7 @@ async def admin_mint_user_token(
     return await create_pat(
         str(row["id"]),
         req.name,
+        token_id=token_id,
         expires_days=req.expires_days,
         vault_scope=VaultScope.parse_input(req.vault_scope),
         scopes=req.scopes,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -790,6 +790,7 @@ async def create_pat(
     user_id: str,
     name: str,
     *,
+    token_id: str | None = None,
     expires_days: int | None = None,
     vault_scope: VaultScope | None = None,
     scopes: list[str] | None = None,
@@ -809,6 +810,13 @@ async def create_pat(
     key_class = _normalize_issuable_key_class(key_class)
     token_scopes = normalize_token_scopes(scopes)
     raw_token, token_hash, token_prefix = generate_pat(key_class)
+    if token_id is None:
+        resolved_token_id = uuid.uuid4()
+    else:
+        try:
+            resolved_token_id = uuid.UUID(token_id)
+        except (AttributeError, TypeError, ValueError):
+            raise ValidationError("token_id must be a UUID") from None
 
     expires_at = None
     if expires_days:
@@ -817,7 +825,6 @@ async def create_pat(
     vault_scope_json = json.dumps(vault_scope.to_db_json()) if vault_scope else None
 
     async with pool.acquire() as conn:
-        token_id = uuid.uuid4()
         async with conn.transaction():
             user_row = await conn.fetchrow(
                 "SELECT account_status FROM users WHERE id = $1 FOR UPDATE",
@@ -835,7 +842,7 @@ async def create_pat(
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 """,
-                token_id,
+                resolved_token_id,
                 uuid.UUID(user_id),
                 name,
                 token_hash,
@@ -853,12 +860,12 @@ async def create_pat(
     # never falls back to the full akb_user_<uid>). Unscoped PATs need none.
     if vault_scope is not None:
         await get_role_sync().on_token_create(
-            token_id, uuid.UUID(user_id), vault_scope,
+            resolved_token_id, uuid.UUID(user_id), vault_scope,
         )
 
     return {
         "token": raw_token,
-        "token_id": str(token_id),
+        "token_id": str(resolved_token_id),
         "name": name,
         "prefix": token_prefix,
         "scopes": token_scopes,

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -143,6 +143,54 @@ async def test_token_identification_is_admin_only_and_never_returns_raw_token(mo
     assert observed == {"token": raw_token, "actor_id": admin.user_id}
 
 
+async def test_admin_mint_forwards_caller_selected_token_id(monkeypatch):
+    from app.api.routes import access
+    from app.db import postgres
+    from app.services import auth_service
+
+    user_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    observed = {}
+
+    class _Connection:
+        async def fetchrow(self, _query, resolved_user_id):
+            assert resolved_user_id == user_id
+            return {"id": user_id}
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Connection()
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _get_pool():
+        return _Pool()
+
+    async def _create_pat(resolved_user_id, name, **kwargs):
+        observed.update(user_id=resolved_user_id, name=name, **kwargs)
+        return {"token_id": str(token_id), "token": "akb_once"}
+
+    monkeypatch.setattr(postgres, "get_pool", _get_pool)
+    monkeypatch.setattr(auth_service, "create_pat", _create_pat)
+    request = access.AdminManagedMintTokenRequest(
+        name="claude-code",
+        token_id=str(token_id),
+    )
+
+    result = await access.admin_mint_managed_user_token(
+        str(user_id), request, _user(admin=True)
+    )
+
+    assert result["token_id"] == str(token_id)
+    assert observed["token_id"] == str(token_id)
+    assert observed["user_id"] == str(user_id)
+
+
 async def test_adopt_current_service_requires_exact_admin_pat_and_forwards_ids(monkeypatch):
     from app.api.routes import access
 
@@ -204,6 +252,7 @@ async def test_governance_routes_are_explicit_in_openapi():
         "/api/v1/admin/users/{user_id}/suspend",
         "/api/v1/admin/users/{user_id}/activate",
         "/api/v1/admin/users/{user_id}/tokens/{token_id}",
+        "/api/v1/admin/users/{user_ref}/managed-tokens",
         "/api/v1/admin/tokens/identify",
     }
     assert expected <= set(paths)

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -317,6 +317,34 @@ async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
     assert password_hash.startswith("!service-account:")
 
 
+async def test_create_pat_uses_caller_selected_token_id(services):
+    pool, _, service = services
+    requested_token_id = uuid.uuid4()
+    ensured = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=f"selected-token-{uuid.uuid4().hex}",
+        email=f"governance-selected-token-{uuid.uuid4().hex[:10]}@example.com",
+        display_name="Selected token owner",
+        actor_id="platform-service",
+    )
+    from app.services.auth_service import create_pat
+
+    credential = await create_pat(
+        ensured["user_id"],
+        "platform-operation",
+        token_id=str(requested_token_id),
+    )
+
+    assert credential["token_id"] == str(requested_token_id)
+    async with pool.acquire() as conn:
+        stored = await conn.fetchval(
+            "SELECT id FROM tokens WHERE id = $1 AND user_id = $2",
+            requested_token_id,
+            uuid.UUID(ensured["user_id"]),
+        )
+    assert stored == requested_token_id
+
+
 async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     services,
 ):


### PR DESCRIPTION
## Summary

- add a distinct managed-token admin endpoint that requires a caller-selected UUID
- use that UUID as the actual AKB token primary key
- preserve the existing server-generated token ID behavior on all legacy endpoints

## Why

A control plane must know the exact remote token ID before the network call. It can then durably record the operation and revoke the precise token after a lost response or failed local metadata commit. A distinct endpoint makes old AKB images fail with 404 before minting anything.

## Verification

- 38 managed account and route tests passed
- OpenAPI route smoke passed with writable temporary storage
- ruff, mypy, and bandit passed
- detect-secrets baseline updated only for the shifted changelog line
