### PR TITLE
vault_write_policy: token-allowlist write guard for managed vaults

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -48,6 +48,38 @@ control plane can durably record it before the remote call and revoke that exact
 token after an ambiguous response. Older AKB images return 404 on this path
 instead of silently minting a token under an unrelated server-generated ID.
 
+A vault can now be marked **write-managed**: once marked, mutating calls
+(writer/admin/owner — REST, MCP, and `akb_sql`) are refused for every caller,
+including the vault owner and any JWT session, unless the request's PAT is on
+that vault's grant allowlist. This targets automation vaults (collector
+mirrors, gardener-compiled state) where an ordinary human edit is exactly the
+class of write that should be impossible without an explicit, auditable
+grant. An *unscoped* system administrator still gets through (a scoped admin
+PAT does not) so operators are never locked out, but every such bypass emits a
+loud `vault.write_policy_admin_bypass` audit event naming the vault, the
+managing owner, and the actor.
+
+New admin-only endpoints manage the policy: `PUT`/`DELETE
+/admin/vaults/{vault}/write-policy` mark/unmark a vault, and `PUT`/`DELETE
+/admin/vaults/{vault}/write-policy/grants/{token_id}` add/remove a token from
+the allowlist. Every call — including a no-op re-mark or an idempotent
+grant/unmark — emits `vault.write_policy_changed` (action, vault, managed_by,
+actor, and the token id for grant calls), so an unmark-write-remark
+break-glass sequence stays fully auditable. Marking requires the vault to
+exist; granting requires the vault to already be marked (409) and the token
+to exist (404); marking an external-git mirror vault is rejected (409) since
+that vault is already unconditionally read-only via its own poller and a
+grant there could never actually enable a write. Unmarking restores every
+caller to full pre-marking behavior immediately — there is no lingering
+restriction once a vault is unmarked.
+
+`GET /vaults/{vault}/info`, `GET /my/vaults`, and MCP `akb_vault_info` now
+report `managed_by: string | null` (the slim `akb_list_vaults` tool is
+unchanged — it stays `{name, description}` by design). Migration 044 (already
+shipped as pure substrate) adds the `vault_write_policy` /
+`vault_write_grants` tables; marking a vault has zero effect until an admin
+actually uses this new API.
+
 ## 0.9.6 — 2026-07-09  *(fix — release /health pool slots before nested delete-outbox stats)*
 
 `GET /health` no longer holds the chunks stats pool connection while awaiting

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -22,6 +22,7 @@ from app.services.account_service import (
     suspend_user,
 )
 from app.services.access_service import (
+    add_vault_write_grant,
     archive_vault,
     delete_user_account,
     delete_vault,
@@ -30,8 +31,11 @@ from app.services.access_service import (
     list_accessible_vaults,
     list_all_users_admin,
     list_vault_members,
+    remove_vault_write_grant,
+    remove_vault_write_policy,
     revoke_access,
     search_users,
+    set_vault_write_policy,
     transfer_ownership,
     unarchive_vault,
     update_vault_metadata,
@@ -62,6 +66,11 @@ class TransferRequest(NFCModel):
 class VaultPatchRequest(NFCModel):
     description: str | None = None
     public_access: str | None = None
+
+
+class SetVaultWritePolicyRequest(NFCModel):
+    managed_by: str
+    note: str | None = None
 
 
 class EnsureExternalIdentityRequest(NFCModel):
@@ -177,6 +186,69 @@ async def user_search(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     return {"users": await search_users(q, limit)}
+
+
+#
+# ── Vault write-policy admin (P0 S3) ─────────────────────────
+#
+# System-admin-only (`_require_admin`, same gate as every `/admin/...`
+# route below) — marking/granting is a platform-level decision, not a
+# vault-owner self-service one (a marked vault denies its OWNER too; see
+# `access_service.check_vault_access`'s write-policy guard). Business
+# logic + validation + the `vault.write_policy_changed` audit emission all
+# live in `access_service` (this module stays a thin adapter, same
+# convention as `admin_suspend_user` / `admin_ensure_service_user` below).
+#
+
+@router.put(
+    "/admin/vaults/{vault}/write-policy",
+    summary="[admin] Mark a vault as write-managed (PAT-grant-only writes)",
+)
+async def admin_set_vault_write_policy(
+    vault: str,
+    req: SetVaultWritePolicyRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await set_vault_write_policy(user.user_id, vault, req.managed_by, note=req.note)
+
+
+@router.delete(
+    "/admin/vaults/{vault}/write-policy",
+    summary="[admin] Unmark a vault (restore ordinary ACL-gated writes)",
+)
+async def admin_remove_vault_write_policy(
+    vault: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await remove_vault_write_policy(user.user_id, vault)
+
+
+@router.put(
+    "/admin/vaults/{vault}/write-policy/grants/{token_id}",
+    summary="[admin] Grant a token write access to a marked vault",
+)
+async def admin_add_vault_write_grant(
+    vault: str,
+    token_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await add_vault_write_grant(user.user_id, vault, token_id)
+
+
+@router.delete(
+    "/admin/vaults/{vault}/write-policy/grants/{token_id}",
+    summary="[admin] Revoke a token's write grant on a marked vault",
+)
+async def admin_remove_vault_write_grant(
+    vault: str,
+    token_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await remove_vault_write_grant(user.user_id, vault, token_id)
 
 
 @router.get("/admin/users", summary="[admin] List every user with stats")

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -1,7 +1,7 @@
 """REST API routes for vault access management."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import SecretStr
+from pydantic import Field, SecretStr
 
 from app.api.deps import get_current_user
 from app.services.auth_service import (
@@ -70,7 +70,10 @@ class VaultPatchRequest(NFCModel):
 
 class SetVaultWritePolicyRequest(NFCModel):
     managed_by: str
-    note: str | None = None
+    note: str | None = Field(
+        default=None,
+        description="Optional operator note. A re-mark REPLACES the whole policy row: omitting note clears any previously stored note (grants are preserved).",
+    )
 
 
 class EnsureExternalIdentityRequest(NFCModel):
@@ -209,6 +212,8 @@ async def admin_set_vault_write_policy(
     req: SetVaultWritePolicyRequest,
     user: AuthenticatedUser = Depends(get_current_user),
 ):
+    """Mark a vault as write-managed: re-marking REPLACES managed_by and note
+    (note omitted ⇒ cleared); grants are preserved."""
     _require_admin(user)
     return await set_vault_write_policy(user.user_id, vault, req.managed_by, note=req.note)
 

--- a/backend/app/db/migrations/044_vault_write_policy.py
+++ b/backend/app/db/migrations/044_vault_write_policy.py
@@ -1,0 +1,105 @@
+"""Migration 044: vault-grain write-policy tables (P0 slice S3 substrate).
+
+Adds two additive sidecar tables — no changes to any existing table.
+Generalizes the migration-010 ``vault_external_git`` sidecar pattern to a
+new axis: a vault MAY be marked so that mutating calls are only accepted
+from PATs on an explicit per-vault grant list (token-allowlist,
+class-agnostic — a collector PAT, a gardener PAT, an operator PAT, etc.
+are all just rows in ``vault_write_grants``. See
+plans/2026-07-10-naut-edit-semantics-sot-writeback-design.md §5.1a).
+
+1. ``vault_write_policy`` — 1:1 marker. A vault WITHOUT a row here is
+   ungoverned (existing behaviour, unaffected). ``managed_by`` is a
+   free-text provenance label (e.g. 'collector:<binding>',
+   'gardener:<policy>').
+
+2. ``vault_write_grants`` — the allowlist itself. ``(vault_id, token_id)``
+   composite PK; a grant can only exist for a vault that already has a
+   ``vault_write_policy`` row (FK to its PK, not to ``vaults`` directly).
+
+   IMPORTANT — token deletion silently drops the grant (``token_id ON
+   DELETE CASCADE``). There is no independent record that a grant ever
+   existed once its token is gone. Any token rotation against a marked
+   vault MUST grant the new token BEFORE revoking the old one
+   (grant-new-before-revoke-old) — revoking first, even for an instant,
+   leaves the vault with zero live writers. See
+   ``app/repositories/vault_write_policy_repo.py``.
+
+This slice (P0 S3) builds ONLY the substrate: the two tables + the repo.
+Nothing reads them yet — no guard, no API route (that is a later slice).
+Marking a vault today has zero runtime effect.
+
+Idempotent — safe to re-run on fresh and existing DBs (mirrors migration
+010/042's ``CREATE TABLE IF NOT EXISTS`` + transaction-wrapped style).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.044")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS vault_write_policy (
+                vault_id UUID PRIMARY KEY REFERENCES vaults(id) ON DELETE CASCADE,
+                managed_by TEXT NOT NULL,
+                note TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                created_by TEXT NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS vault_write_grants (
+                vault_id UUID NOT NULL REFERENCES vault_write_policy(vault_id) ON DELETE CASCADE,
+                token_id UUID NOT NULL REFERENCES tokens(id) ON DELETE CASCADE,
+                granted_by TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (vault_id, token_id)
+            )
+            """
+        )
+        # A token revocation cascade-deletes through this FK; without an
+        # index on the referencing column that cascade sequential-scans
+        # the whole grants table on every token delete (suspend/revoke/
+        # rotation, all elsewhere in the codebase already).
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_vault_write_grants_token
+                ON vault_write_grants(token_id)
+            """
+        )
+
+    logger.info("Migration 044 added vault_write_policy + vault_write_grants")
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -213,6 +213,7 @@ async def _apply_migrations() -> None:
         "041_tokens_key_class.py",              # tokens.key_class ('pat' default, 'service' BFF key, 'publishable' reserved seam)
         "042_vault_migrations.py",              # vault_migrations catalog for table migration idempotency/checksum replay
         "043_workspace_account_governance.py",  # users account status/kind + stable external OIDC identities
+        "044_vault_write_policy.py",             # vault_write_policy + vault_write_grants: vault-grain token-allowlist substrate (P0 S3; guard is a later slice)
     ):
         if filename in applied:
             continue

--- a/backend/app/models/vault_scope.py
+++ b/backend/app/models/vault_scope.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import re
+import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
@@ -134,6 +135,27 @@ current_vault_scope: ContextVar[VaultScope | None] = ContextVar(
 current_token_id: ContextVar[str | None] = ContextVar(
     "current_token_id", default=None
 )
+
+
+def current_token_uuid() -> uuid.UUID | None:
+    """``current_token_id`` parsed to a ``uuid.UUID``, or ``None``.
+
+    Covers both "no PAT on this request" (JWT/OAuth/tokenless — the
+    ContextVar's own default) and "the stored value isn't a well-formed
+    UUID". The latter cannot happen from ``_resolve_pat`` today (it
+    always sets a real, stringified ``tokens.id``), but a consumer that
+    treats "no token" as "deny" (``vault_write_policy``'s guard) must
+    fail toward that same deny branch rather than let a ``ValueError``
+    escape, so malformed folds into ``None`` here rather than raising.
+    """
+    raw = current_token_id.get()
+    if raw is None:
+        return None
+    try:
+        return uuid.UUID(raw)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
 
 # Request-scoped token metadata, set by ``auth_service.resolve_token`` for
 # rows from the tokens table. JWT / OAuth / internal paths leave these as

--- a/backend/app/repositories/vault_write_policy_repo.py
+++ b/backend/app/repositories/vault_write_policy_repo.py
@@ -1,0 +1,150 @@
+"""Repository for vault_write_policy / vault_write_grants operations.
+
+Sidecar 1:1 to ``vaults`` — generalizes the ``vault_external_git`` sidecar
+pattern (migration 010) to a new axis. A vault WITHOUT a
+``vault_write_policy`` row is ungoverned; existing code is completely
+unaffected. A vault WITH a row is *marked*: mutating calls should only be
+accepted from a PAT on its ``vault_write_grants`` allowlist
+(class-agnostic — collector, gardener, and operator PATs are all just rows
+here). This module is pure substrate: no caller enforces the allowlist
+yet — that guard is a later slice (P0 S4). Marking a vault today has zero
+runtime effect.
+
+CASCADE HAZARD: ``vault_write_grants.token_id`` is ``ON DELETE CASCADE``
+against ``tokens.id``. Deleting a token (revoke, suspend, rotation)
+silently drops every grant row for it — there is no tombstone. Once the
+guard lands, a vault left with zero live grants fail-closed rejects every
+mutating call, so rotating a granted token MUST ``add_grant`` the new
+token BEFORE ``remove_grant``-ing (or otherwise deleting) the old one —
+grant-new-before-revoke-old. Revoking first, even for an instant, wedges
+the vault with no live writer.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.db.postgres import get_pool
+
+_GET_POLICY_SQL = """
+    SELECT vault_id, managed_by, note, created_at, created_by
+      FROM vault_write_policy
+     WHERE vault_id = $1
+"""
+
+_IS_GRANTED_SQL = """
+    SELECT 1 FROM vault_write_grants WHERE vault_id = $1 AND token_id = $2
+"""
+
+_SET_POLICY_SQL = """
+    INSERT INTO vault_write_policy (vault_id, managed_by, note, created_by)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (vault_id) DO UPDATE
+       SET managed_by = EXCLUDED.managed_by,
+           note = EXCLUDED.note
+    RETURNING vault_id, managed_by, note, created_at, created_by
+"""
+
+_REMOVE_POLICY_SQL = "DELETE FROM vault_write_policy WHERE vault_id = $1"
+
+_ADD_GRANT_SQL = """
+    INSERT INTO vault_write_grants (vault_id, token_id, granted_by)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (vault_id, token_id) DO NOTHING
+"""
+
+_REMOVE_GRANT_SQL = (
+    "DELETE FROM vault_write_grants WHERE vault_id = $1 AND token_id = $2"
+)
+
+
+async def get_policy(vault_id: uuid.UUID, conn=None) -> dict | None:
+    """Return the policy row for ``vault_id``, or ``None`` if ungoverned."""
+    if conn is not None:
+        row = await conn.fetchrow(_GET_POLICY_SQL, vault_id)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            row = await acq.fetchrow(_GET_POLICY_SQL, vault_id)
+    return dict(row) if row is not None else None
+
+
+async def is_granted(vault_id: uuid.UUID, token_id: uuid.UUID, conn=None) -> bool:
+    """True iff ``token_id`` is on ``vault_id``'s write-grant allowlist.
+
+    This function alone does not tell a caller whether a write should be
+    allowed — an ungoverned vault (no ``vault_write_policy`` row) has no
+    allowlist to check against, and "no policy" means unrestricted, not
+    deny. That branch belongs to the guard (a later slice), not here.
+    """
+    if conn is not None:
+        found = await conn.fetchval(_IS_GRANTED_SQL, vault_id, token_id)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            found = await acq.fetchval(_IS_GRANTED_SQL, vault_id, token_id)
+    return found is not None
+
+
+async def set_policy(
+    vault_id: uuid.UUID,
+    managed_by: str,
+    created_by: str,
+    note: str | None = None,
+    conn=None,
+) -> dict:
+    """Create or update the marking on ``vault_id`` (upsert on the PK).
+
+    Re-marking an already-marked vault updates ``managed_by``/``note`` in
+    place; ``created_at``/``created_by`` stay pinned to the original mark.
+    """
+    if conn is not None:
+        row = await conn.fetchrow(_SET_POLICY_SQL, vault_id, managed_by, note, created_by)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            row = await acq.fetchrow(
+                _SET_POLICY_SQL, vault_id, managed_by, note, created_by
+            )
+    return dict(row)
+
+
+async def remove_policy(vault_id: uuid.UUID, conn=None) -> None:
+    """Unmark ``vault_id``. Cascades away every grant row for it too."""
+    if conn is not None:
+        await conn.execute(_REMOVE_POLICY_SQL, vault_id)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            await acq.execute(_REMOVE_POLICY_SQL, vault_id)
+
+
+async def add_grant(
+    vault_id: uuid.UUID, token_id: uuid.UUID, granted_by: str, conn=None
+) -> None:
+    """Grant ``token_id`` write access to ``vault_id``.
+
+    Requires an existing ``vault_write_policy`` row for ``vault_id`` (FK
+    — call ``set_policy`` first, or this raises a foreign-key violation).
+    Idempotent: granting an already-granted token is a no-op, not an error.
+    """
+    if conn is not None:
+        await conn.execute(_ADD_GRANT_SQL, vault_id, token_id, granted_by)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            await acq.execute(_ADD_GRANT_SQL, vault_id, token_id, granted_by)
+
+
+async def remove_grant(vault_id: uuid.UUID, token_id: uuid.UUID, conn=None) -> None:
+    """Revoke ``token_id``'s write access to ``vault_id``.
+
+    ROTATION SAFETY: ``add_grant`` the replacement token before calling
+    this for the outgoing one — see the module docstring's cascade hazard.
+    """
+    if conn is not None:
+        await conn.execute(_REMOVE_GRANT_SQL, vault_id, token_id)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            await acq.execute(_REMOVE_GRANT_SQL, vault_id, token_id)

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -926,9 +926,9 @@ async def set_vault_write_policy(
     Once marked, `check_vault_access`'s write-policy guard rejects every
     mutating call (including the vault OWNER and any JWT session) unless
     the caller's PAT is on the vault's `vault_write_grants` allowlist. Idempotent
-    upsert: re-marking an already-marked vault updates `managed_by`/`note`
-    in place (`vault_write_policy_repo.set_policy` pins `created_at`/
-    `created_by` to the original mark).
+    upsert: re-marking an already-marked vault REPLACES managed_by and note
+    (note omitted ⇒ cleared); grants are preserved (`vault_write_policy_repo.set_policy`
+    pins `created_at`/`created_by` to the original mark).
 
     External-git mirror vaults are REJECTED (409), not silently accepted:
     see the comment at the mirror check below for the reasoning.

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -424,12 +424,19 @@ async def list_accessible_vaults(user_id: str) -> list[dict]:
         # System admin sees all vaults
         is_admin = await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid)
 
+        # P0 S3 (design §5.1a): explicit LEFT JOIN on the 1:1
+        # vault_write_policy sidecar in both branches — a vault has at
+        # most one policy row (vault_id is its PK) so this never fans out
+        # rows. NULL (no match) reads as ungoverned, same convention as
+        # `get_vault_info`.
         if is_admin:
             rows = await conn.fetch(
                 """
                 SELECT v.id, v.name, v.description, v.status, v.created_at,
-                       COALESCE(CASE WHEN v.owner_id = $1 THEN 'owner' END, 'admin') as role
+                       COALESCE(CASE WHEN v.owner_id = $1 THEN 'owner' END, 'admin') as role,
+                       vwp.managed_by
                 FROM vaults v
+                LEFT JOIN vault_write_policy vwp ON v.id = vwp.vault_id
                 ORDER BY v.name
                 """,
                 uid,
@@ -438,9 +445,11 @@ async def list_accessible_vaults(user_id: str) -> list[dict]:
             rows = await conn.fetch(
                 """
                 SELECT v.id, v.name, v.description, v.status, v.created_at,
-                       COALESCE(va.role, CASE WHEN v.owner_id = $1 THEN 'owner' WHEN v.public_access != 'none' THEN v.public_access END) as role
+                       COALESCE(va.role, CASE WHEN v.owner_id = $1 THEN 'owner' WHEN v.public_access != 'none' THEN v.public_access END) as role,
+                       vwp.managed_by
                 FROM vaults v
                 LEFT JOIN vault_access va ON v.id = va.vault_id AND va.user_id = $1
+                LEFT JOIN vault_write_policy vwp ON v.id = vwp.vault_id
                 WHERE v.owner_id = $1 OR va.user_id = $1 OR v.public_access != 'none'
                 ORDER BY v.name
                 """,
@@ -454,6 +463,7 @@ async def list_accessible_vaults(user_id: str) -> list[dict]:
                 "description": r["description"],
                 "status": r["status"],
                 "role": r["role"],
+                "managed_by": r["managed_by"],
                 "created_at": r["created_at"].isoformat() if r["created_at"] else None,
             }
             for r in rows
@@ -495,6 +505,7 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
         edge_count,
         last_doc,
         is_external_git,
+        write_policy,
     ) = await asyncio.gather(
         _r("SELECT username, display_name FROM users WHERE id = $1", vault["owner_id"]),
         _q("SELECT COUNT(*) FROM vault_access WHERE vault_id = $1", vid),
@@ -511,6 +522,10 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
             vid,
         ),
         _q("SELECT 1 FROM vault_external_git WHERE vault_id = $1", vid),
+        # P0 S3: vault_write_policy is a 1:1 sidecar keyed on vault_id —
+        # reuse the repo (own pool-acquire, same fan-out style as the
+        # helpers above) rather than a bespoke query here.
+        write_policy_repo.get_policy(vid),
     )
 
     tables = await _list_tables_with_schema(vault_name, vid) if table_count else []
@@ -520,6 +535,11 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
         "description": vault["description"],
         "status": vault["status"],
         "is_archived": vault["status"] == "archived",
+        # P0 S3 (design §5.1a): None when ungoverned; otherwise the
+        # write-policy owner label (e.g. "collector:acme-jira",
+        # "gardener:distill") — naut's `normalizeAkbVaultList` and any
+        # other consumer key routing decisions off this one field.
+        "managed_by": write_policy["managed_by"] if write_policy else None,
         "is_external_git": bool(is_external_git),
         "public_access": vault["public_access"],
         "role": caller_role,
@@ -880,6 +900,244 @@ async def set_public_access(user_id: str, vault_name: str, level: str) -> dict:
 
     logger.info("Set public_access for %s → %s", vault_name, level)
     return {"vault": vault_name, "public_access": level}
+
+
+# ── Vault write-policy admin (P0 S3, design §5.1a) ──────────
+#
+# System-admin-only surface (enforced at the route layer via
+# `_require_admin` in `api/routes/access.py` — same convention every other
+# `/admin/...` function in this module already uses, e.g.
+# `account_service.suspend_user`: this module trusts the caller and takes
+# `actor_id` purely for the audit trail, it never re-checks `users.is_admin`
+# itself). Every mutation here emits `vault.write_policy_changed`
+# UNCONDITIONALLY — even when the call is a no-op against current state
+# (re-marking with the same managed_by, unmarking an already-unmarked
+# vault, removing a grant that was never added) — because the point of the
+# audit trail is "an admin invoked this action", not "state changed since
+# last read". That is also what makes the unmark → write → re-mark
+# break-glass sequence (Task 8/9's handoff note) fully auditable: a smart
+# no-op dedup would hide exactly the events that sequence needs recorded.
+
+async def set_vault_write_policy(
+    actor_id: str, vault_name: str, managed_by: str, note: str | None = None,
+) -> dict:
+    """Admin-only: mark ``vault_name`` write-managed.
+
+    Once marked, `check_vault_access`'s write-policy guard rejects every
+    mutating call (including the vault OWNER and any JWT session) unless
+    the caller's PAT is on the vault's `vault_write_grants` allowlist. Idempotent
+    upsert: re-marking an already-marked vault updates `managed_by`/`note`
+    in place (`vault_write_policy_repo.set_policy` pins `created_at`/
+    `created_by` to the original mark).
+
+    External-git mirror vaults are REJECTED (409), not silently accepted:
+    see the comment at the mirror check below for the reasoning.
+    """
+    managed_by = managed_by.strip()
+    if not managed_by:
+        raise ValidationError("managed_by must not be empty")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1 FOR UPDATE", vault_name,
+            )
+            if not vault:
+                raise NotFoundError("Vault", vault_name)
+
+            # DECISION (task 10): an external-git mirror vault is ALREADY
+            # read-only to every caller via its own unconditional guard in
+            # `check_vault_access` (writer-role mirror check, above the
+            # write-policy guard in that same function) — mutations there
+            # come exclusively from the in-process poller, which bypasses
+            # `check_vault_access` entirely. A grant on such a vault could
+            # therefore never make a PAT write succeed: the mirror check
+            # fires first and unconditionally, regardless of any
+            # `vault_write_grants` row. Marking it anyway would be
+            # harmless in enforcement terms but actively misleading in
+            # practice — an operator reading `managed_by="collector:x"`
+            # would reasonably (and wrongly) conclude a granted token can
+            # write there. Reject with a clear message rather than ship a
+            # marking that can never do what it appears to promise.
+            is_mirror = await conn.fetchval(
+                "SELECT 1 FROM vault_external_git WHERE vault_id = $1", vault["id"],
+            )
+            if is_mirror:
+                raise ConflictError(
+                    f"Vault '{vault_name}' is an external-git mirror "
+                    f"(already read-only via its own poller); marking it "
+                    f"with a write policy would not change enforcement and "
+                    f"misleadingly implies a granted token could write here"
+                )
+
+            policy = await write_policy_repo.set_policy(
+                vault["id"], managed_by, created_by=actor_id, note=note, conn=conn,
+            )
+            await emit_event(
+                conn, "vault.write_policy_changed",
+                vault_id=vault["id"],
+                resource_uri=vault_uri(vault_name),
+                actor_id=actor_id,
+                payload={
+                    "action": "marked",
+                    "vault": vault_name,
+                    "managed_by": managed_by,
+                    "note": note,
+                },
+            )
+
+    logger.info("Marked vault %s write-managed by %s", vault_name, managed_by)
+    return {
+        "vault": vault_name,
+        "managed_by": policy["managed_by"],
+        "note": policy["note"],
+        "marked": True,
+    }
+
+
+async def remove_vault_write_policy(actor_id: str, vault_name: str) -> dict:
+    """Admin-only: unmark ``vault_name`` — restore ordinary ACL-gated writes.
+
+    Idempotent: unmarking a vault that isn't currently marked is a
+    harmless no-op (`was_marked: False` in the response distinguishes it
+    from a real transition, but it still emits the event — see this
+    section's module-level comment for why). Cascades away every grant
+    row for this vault too (`vault_write_policy_repo.remove_policy`'s
+    `ON DELETE CASCADE`).
+
+    ROLLBACK PROOF: this is the operation that restores every caller
+    (including a plain JWT session) to full pre-marking behaviour — the
+    e2e's final step calls this and then re-attempts an ungranted write to
+    prove the guard is a true no-op once unmarked, not a one-way ratchet.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1 FOR UPDATE", vault_name,
+            )
+            if not vault:
+                raise NotFoundError("Vault", vault_name)
+
+            existing = await write_policy_repo.get_policy(vault["id"], conn=conn)
+            await write_policy_repo.remove_policy(vault["id"], conn=conn)
+            await emit_event(
+                conn, "vault.write_policy_changed",
+                vault_id=vault["id"],
+                resource_uri=vault_uri(vault_name),
+                actor_id=actor_id,
+                payload={
+                    "action": "unmarked",
+                    "vault": vault_name,
+                    "managed_by": existing["managed_by"] if existing else None,
+                },
+            )
+
+    logger.info("Unmarked vault %s (write-policy removed)", vault_name)
+    return {"vault": vault_name, "unmarked": True, "was_marked": existing is not None}
+
+
+async def add_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -> dict:
+    """Admin-only: grant ``token_id`` write access to a MARKED vault.
+
+    Requires the vault to already be marked (409 `ConflictError` — a grant
+    on an ungoverned vault has no allowlist to join and almost certainly
+    means the caller meant to mark first) and `token_id` to exist (404).
+    The design is class-agnostic (collector/gardener/operator/human PATs
+    are all just rows on the allowlist — see `vault_write_policy_repo`'s
+    module docstring), so no further ownership/role check on the token is
+    performed here.
+    """
+    try:
+        tid = uuid.UUID(token_id)
+    except (AttributeError, TypeError, ValueError):
+        raise ValidationError(f"Invalid token_id: {token_id!r}") from None
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1 FOR UPDATE", vault_name,
+            )
+            if not vault:
+                raise NotFoundError("Vault", vault_name)
+
+            policy = await write_policy_repo.get_policy(vault["id"], conn=conn)
+            if policy is None:
+                raise ConflictError(
+                    f"Vault '{vault_name}' is not write-managed; mark it "
+                    f"first with PUT .../write-policy"
+                )
+
+            token_row = await conn.fetchrow("SELECT id FROM tokens WHERE id = $1", tid)
+            if not token_row:
+                raise NotFoundError("Token", token_id)
+
+            await write_policy_repo.add_grant(vault["id"], tid, actor_id, conn=conn)
+            await emit_event(
+                conn, "vault.write_policy_changed",
+                vault_id=vault["id"],
+                resource_uri=vault_uri(vault_name),
+                actor_id=actor_id,
+                payload={
+                    "action": "grant_added",
+                    "vault": vault_name,
+                    "managed_by": policy["managed_by"],
+                    "token_id": token_id,
+                },
+            )
+
+    logger.info("Granted token %s write access to vault %s", token_id, vault_name)
+    return {"vault": vault_name, "token_id": token_id, "granted": True}
+
+
+async def remove_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -> dict:
+    """Admin-only: revoke ``token_id``'s write grant on ``vault_name``.
+
+    Idempotent (a token that was never granted is a harmless no-op — same
+    "always audit the action" rationale as `remove_vault_write_policy`).
+    Does NOT require the vault to still be marked — unlike the grant-add
+    direction, there is nothing to protect here: if the vault was
+    unmarked, the CASCADE already removed every grant, so this is
+    naturally a no-op regardless. `token_id` must still exist (404) — same
+    operator-typo guard as the grant-add direction.
+    """
+    try:
+        tid = uuid.UUID(token_id)
+    except (AttributeError, TypeError, ValueError):
+        raise ValidationError(f"Invalid token_id: {token_id!r}") from None
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1 FOR UPDATE", vault_name,
+            )
+            if not vault:
+                raise NotFoundError("Vault", vault_name)
+
+            token_row = await conn.fetchrow("SELECT id FROM tokens WHERE id = $1", tid)
+            if not token_row:
+                raise NotFoundError("Token", token_id)
+
+            policy = await write_policy_repo.get_policy(vault["id"], conn=conn)
+            await write_policy_repo.remove_grant(vault["id"], tid, conn=conn)
+            await emit_event(
+                conn, "vault.write_policy_changed",
+                vault_id=vault["id"],
+                resource_uri=vault_uri(vault_name),
+                actor_id=actor_id,
+                payload={
+                    "action": "grant_removed",
+                    "vault": vault_name,
+                    "managed_by": policy["managed_by"] if policy else None,
+                    "token_id": token_id,
+                },
+            )
+
+    logger.info("Revoked token %s write access to vault %s", token_id, vault_name)
+    return {"vault": vault_name, "token_id": token_id, "revoked": True}
 
 
 # ── Destructive: vault delete ───────────────────────────────

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -11,7 +11,8 @@ import uuid
 
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
-from app.models.vault_scope import current_vault_scope
+from app.models.vault_scope import current_token_uuid, current_vault_scope
+from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
@@ -52,6 +53,22 @@ def validate_public_access(level: str) -> str:
 
 # ── Permission checks ───────────────────────────────────────
 
+async def _is_unscoped_system_admin(uid: uuid.UUID, conn) -> bool:
+    """True iff `uid` is a system admin AND this request's PAT (if any)
+    carries no vault scope — the A3 bypass condition for the
+    write-policy guard below.
+
+    A *scoped* admin PAT must NOT get this bypass: same "a scope only
+    ever subtracts authority" rule the Option B scope guard enforces a
+    few lines up in `check_vault_access`. Re-queries `users.is_admin`
+    (rather than reusing the one a few lines below) because this runs
+    BEFORE that existing short-circuit computes it.
+    """
+    if current_vault_scope.get() is not None:
+        return False
+    return bool(await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid))
+
+
 async def check_vault_access(
     user_id: str, vault_name: str, required_role: str = "reader",
     *, allow_archived: bool = False,
@@ -64,6 +81,17 @@ async def check_vault_access(
 
     `allow_archived` lets a destructive lifecycle op (delete_vault) run
     on an archived vault; every normal mutating caller leaves it False.
+
+    Vault write-policy (P0 S3, design §5.1a): a MARKED vault (a
+    `vault_write_policy` row exists) accepts a mutating call
+    (writer/admin/owner) ONLY from a PAT on its `vault_write_grants`
+    allowlist — this denies even the vault OWNER and a JWT session. The
+    one escape hatch is an *unscoped* system admin, which bypasses with
+    a loud `vault.write_policy_admin_bypass` audit event (a *scoped*
+    admin PAT does not bypass). Consequence: `delete_vault` requests
+    required_role="admin", one of the guarded roles, so deleting a
+    MARKED vault also requires a grant or the admin bypass — the owner
+    alone cannot delete it.
     """
     pool = await get_pool()
     uid = uuid.UUID(user_id)
@@ -121,6 +149,51 @@ async def check_vault_access(
             raise ForbiddenError(
                 f"Token scope does not permit '{required_role}' on vault '{vault_name}'"
             )
+
+        # Vault write-policy guard (P0 S3, A2/A3 — see the docstring
+        # above). Sits BEFORE the is_admin / owner short-circuits below,
+        # same placement as the Option B scope guard above, so a MARKED
+        # vault denies every caller class unless granted — fail-CLOSED
+        # on absence, the opposite of the scope guard's "NULL scope ⇒
+        # unrestricted" fail-OPEN idiom above. Only fires for the same
+        # mutating roles as that guard.
+        if required_role in _MUTATING_ROLES:
+            policy = await write_policy_repo.get_policy(vault["id"], conn=conn)
+            if policy is not None:
+                token_id = current_token_uuid()
+                granted = token_id is not None and await write_policy_repo.is_granted(
+                    vault["id"], token_id, conn=conn,
+                )
+                if granted:
+                    return {
+                        "vault_id": vault["id"],
+                        "role": required_role,
+                        "status": vault["status"],
+                        "role_source": "write_policy_grant",
+                    }
+                if await _is_unscoped_system_admin(uid, conn):
+                    # A3: bypass, but LOUDLY — never a silent escape hatch.
+                    await emit_event(
+                        conn, "vault.write_policy_admin_bypass",
+                        vault_id=vault["id"],
+                        actor_id=str(uid),
+                        payload={
+                            "managed_by": policy["managed_by"],
+                            "required_role": required_role,
+                            "vault": vault_name,
+                        },
+                    )
+                    return {
+                        "vault_id": vault["id"],
+                        "role": "owner",
+                        "status": vault["status"],
+                        "role_source": "write_policy_admin_bypass",
+                    }
+                raise ForbiddenError(
+                    f"Vault '{vault_name}' is write-managed by "
+                    f"{policy['managed_by']}; writes require a granted "
+                    f"service token"
+                )
 
         # System admin bypasses all vault ACL
         is_admin = await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid)

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -26,7 +26,9 @@ import asyncpg
 
 from app.db.postgres import get_pool
 from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
+from app.models.vault_scope import current_token_uuid, current_vault_scope
 from app.repositories import table_data_repo, table_registry_repo
+from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
 from app.services.index_service import (
@@ -50,6 +52,7 @@ from app.util.errors import (
     UNDEFINED_TABLE,
     UNIQUE_VIOLATION,
     VAULT_ARCHIVED,
+    VAULT_WRITE_MANAGED,
 )
 from app.util.text import fuzzy_hint
 
@@ -1531,6 +1534,52 @@ async def execute_sql(
                     f"Vault '{names}' is archived (read-only); writes via "
                     f"akb_sql are not allowed. Unarchive the vault first.",
                     code=VAULT_ARCHIVED,
+                )
+
+            # Vault write-policy dual enforcement (P0 S3): mirrors the
+            # archived-vault block just above. `access_service.
+            # check_vault_access`'s own write-policy guard never fires for
+            # akb_sql — the REST route (tables.py) only ever asks it for
+            # required_role="reader" per referenced vault (read access;
+            # akb_sql's own DML-vs-DDL gate lives here, not there) — so a
+            # MARKED vault has to be re-checked directly against the SQL
+            # about to run. Same allow-conditions as that guard: a granted
+            # token passes, an *unscoped* system admin bypasses (+ the same
+            # loud audit event), everyone else is blocked before the
+            # statement ever reaches PG. `is_admin` is the caller-supplied
+            # flag (already sourced from `users.is_admin` by the REST
+            # route) — reused as-is rather than re-queried, unlike the
+            # access_service guard which has no such flag in scope yet.
+            for vrow in await conn.fetch(
+                "SELECT id, name FROM vaults WHERE name = ANY($1::text[])",
+                vault_names,
+            ):
+                policy = await write_policy_repo.get_policy(vrow["id"], conn=conn)
+                if policy is None:
+                    continue
+                token_id = current_token_uuid()
+                if token_id is not None and await write_policy_repo.is_granted(
+                    vrow["id"], token_id, conn=conn,
+                ):
+                    continue
+                if is_admin and current_vault_scope.get() is None:
+                    # A3: bypass, but LOUDLY — same event as the guard.
+                    await emit_event(
+                        conn, "vault.write_policy_admin_bypass",
+                        vault_id=vrow["id"],
+                        actor_id=user_id,
+                        payload={
+                            "managed_by": policy["managed_by"],
+                            "required_role": "writer",
+                            "vault": vrow["name"],
+                        },
+                    )
+                    continue
+                return err(
+                    f"Vault '{vrow['name']}' is write-managed by "
+                    f"{policy['managed_by']}; writes require a granted "
+                    f"service token",
+                    code=VAULT_WRITE_MANAGED,
                 )
 
     try:

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -53,6 +53,14 @@ NOT_FOUND = "not_found"
 # Authorization / permission
 PERMISSION_DENIED = "permission_denied"
 VAULT_ARCHIVED = "vault_archived"
+# A `vault_write_policy`-marked vault rejected a write because the
+# caller's token isn't on its `vault_write_grants` allowlist (P0 S3).
+# Mirrors VAULT_ARCHIVED's specificity — the akb_sql dual-enforcement
+# block in `table_service.execute_sql` returns this; the
+# `access_service.check_vault_access` guard raises a plain
+# `ForbiddenError` instead (like every other guard in that function),
+# which maps to the generic PERMISSION_DENIED at the HTTP/MCP envelope.
+VAULT_WRITE_MANAGED = "vault_write_managed"
 # RFC 6750 §3.1 — OAuth scope check failed at MCP tool dispatch
 # (caller is authenticated but the access token lacks the scope the
 # tool requires). PERMISSION_DENIED is for AKB-internal access (vault

--- a/backend/tests/test_vault_scope_unit.py
+++ b/backend/tests/test_vault_scope_unit.py
@@ -13,10 +13,17 @@ vault outside its declared sets" invariant.
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
 from app.exceptions import ValidationError
-from app.models.vault_scope import VaultScope, current_vault_scope
+from app.models.vault_scope import (
+    VaultScope,
+    current_token_id,
+    current_token_uuid,
+    current_vault_scope,
+)
 
 
 class TestPermits:
@@ -140,6 +147,37 @@ class TestContextVar:
         finally:
             current_vault_scope.reset(token)
         assert current_vault_scope.get() is None
+
+
+class TestCurrentTokenUuid:
+    """``current_token_uuid()`` — the str→UUID accessor the
+    ``vault_write_policy`` guard (Task 9) uses. The ContextVar itself is
+    typed ``str | None`` (mirrors the ``tokens.id`` the DB hands back
+    stringified); the repo calls (`is_granted`) need a real
+    ``uuid.UUID``.
+    """
+
+    def test_default_is_none(self) -> None:
+        assert current_token_uuid() is None
+
+    def test_valid_uuid_string_parses(self) -> None:
+        real_id = uuid.uuid4()
+        token = current_token_id.set(str(real_id))
+        try:
+            assert current_token_uuid() == real_id
+        finally:
+            current_token_id.reset(token)
+
+    def test_malformed_string_is_none_not_a_raise(self) -> None:
+        # A2 fail-closed contract (Task 9 handoff): a consumer that
+        # treats "no token" as "deny" must never see a ValueError
+        # bubble up from a corrupt ContextVar value — malformed folds to
+        # None (deny), same as "no token at all".
+        token = current_token_id.set("not-a-uuid-at-all")
+        try:
+            assert current_token_uuid() is None
+        finally:
+            current_token_id.reset(token)
 
 
 class TestAdversarialNeverWiden:

--- a/backend/tests/test_vault_write_policy_e2e.sh
+++ b/backend/tests/test_vault_write_policy_e2e.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# AKB vault_write_policy E2E — admin marking/grant API round trip (P0 S3,
+# Task 10). Modeled on test_external_git_e2e.sh's boot/auth pattern
+# (register -> login -> PAT) and test_jwt_revocation_e2e.sh /
+# test_events_emit_e2e.sh's direct-psql admin-bootstrap + events-table
+# verification convention (there is no self-service "become admin" API by
+# design, so DB access is required — same as those two siblings).
+#
+# Full round trip:
+#   create vault + PATs (admin, owner) -> mark -> JWT write 403 (naming
+#   managed_by) -> owner PAT (ungranted) write 403 -> grant the PAT ->
+#   write 200 -> admin bypass write while still marked (200 + audit
+#   event) -> validation edge cases (409 unmarked-grant, 404 missing
+#   token/vault) -> unmark -> ungranted write 200
+#   (ROLLBACK PROOF — the final assertion IS the kill-switch evidence).
+#
+# Uses REST (not MCP) throughout: check_vault_access's guard is
+# transport-agnostic, and REST gives a literal HTTP status code to assert
+# on ("expect 403") instead of an MCP JSON-RPC 200-wrapped error envelope.
+#
+# Run (local disposable stack, e.g. via the recipe in task-10-report.md):
+#   AKB_URL=http://localhost:8010 \
+#   AKB_PG_EXEC="docker exec -i akb-vwp-task10-pg" AKB_PG_USER=akb AKB_PG_DB=akb \
+#   bash backend/tests/test_vault_write_policy_e2e.sh
+#
+# Run (cluster, matching the CLAUDE.md deploy-checklist convention):
+#   AKB_URL=https://<host> AKB_NS=akb bash backend/tests/test_vault_write_policy_e2e.sh
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+TS="$(date +%s)-$$"
+VAULT="wpe2e-$TS"
+OTHER_VAULT="wpe2e-other-$TS"
+ADMIN="wpe2e-admin-$TS"
+OWNER="wpe2e-owner-$TS"
+PASS=0; FAIL=0; ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+# Portable DB access (admin bootstrap + events assertions). Defaults to
+# the cluster via kubectl; override AKB_PG_EXEC for a local stack, e.g.
+# AKB_PG_EXEC="docker exec -i akb-vwp-task10-pg" (disposable container) or
+# AKB_PG_EXEC="docker compose exec -T postgres" (docker-compose stack).
+PG_NS="${AKB_NS:-akb}"
+PG_POD="${AKB_PG_POD:-postgres-0}"
+PG_USER="${AKB_PG_USER:-akbuser}"
+PG_DB="${AKB_PG_DB:-akb}"
+run_psql() {
+  if [ -n "${AKB_PG_EXEC:-}" ]; then
+    ${AKB_PG_EXEC} psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  else
+    kubectl exec -n "$PG_NS" "$PG_POD" -- psql -U "$PG_USER" -d "$PG_DB" -tAc "$1" 2>/dev/null
+  fi
+}
+
+if [ -z "${AKB_PG_EXEC:-}" ] && ! command -v kubectl >/dev/null 2>&1; then
+  echo "no AKB_PG_EXEC and kubectl unavailable — cannot bootstrap an admin user (no self-service API by design); skipping"
+  exit 0
+fi
+
+echo "▸ AKB vault_write_policy e2e → $BASE_URL"
+
+jq_field() { python3 -c "import sys,json; d=json.load(sys.stdin); print(d$1)" 2>/dev/null; }
+
+register_login() {
+  local u=$1
+  curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$u\",\"email\":\"$u@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+  curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$u\",\"password\":\"test1234\"}" | jq_field "['token']"
+}
+mint_pat() {
+  local jwt=$1 name=$2
+  curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' -d "{\"name\":\"$name\"}"
+}
+# Usage: write_doc <bearer-token> <vault> -> echoes "HTTP_CODE|BODY"
+write_doc() {
+  local token=$1 vault=$2 resp
+  resp=$(curl -sk -w '\n%{http_code}' -X POST "$BASE_URL/api/v1/documents" \
+    -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
+    -d "{\"vault\":\"$vault\",\"collection\":\"e2e\",\"title\":\"probe\",\"content\":\"x\"}")
+  echo "$(echo "$resp" | tail -1)|$(echo "$resp" | sed '$d')"
+}
+
+echo ""
+echo "▸ 0. Setup: admin + owner users, vault"
+
+ADMIN_JWT=$(register_login "$ADMIN")
+[ -n "$ADMIN_JWT" ] && pass "admin registered" || { fail "setup" "no admin JWT"; exit 1; }
+run_psql "UPDATE users SET is_admin = true WHERE username = '$ADMIN'" >/dev/null
+IS_ADMIN=$(run_psql "SELECT is_admin FROM users WHERE username = '$ADMIN'")
+[ "$IS_ADMIN" = "t" ] && pass "admin bootstrapped via psql" || { fail "admin bootstrap" "is_admin=$IS_ADMIN"; exit 1; }
+ADMIN_PAT_RESP=$(mint_pat "$ADMIN_JWT" "wpe2e-admin-pat")
+ADMIN_PAT=$(echo "$ADMIN_PAT_RESP" | jq_field "['token']")
+[ -n "$ADMIN_PAT" ] && pass "admin PAT minted (unscoped -> A3 bypass eligible)" || { fail "admin PAT" "$ADMIN_PAT_RESP"; exit 1; }
+
+OWNER_JWT=$(register_login "$OWNER")
+[ -n "$OWNER_JWT" ] && pass "owner registered" || { fail "setup" "no owner JWT"; exit 1; }
+OWNER_PAT_RESP=$(mint_pat "$OWNER_JWT" "wpe2e-owner-pat")
+OWNER_PAT=$(echo "$OWNER_PAT_RESP" | jq_field "['token']")
+OWNER_TOKEN_ID=$(echo "$OWNER_PAT_RESP" | jq_field "['token_id']")
+[ -n "$OWNER_PAT" ] && [ -n "$OWNER_TOKEN_ID" ] && pass "owner PAT minted ($OWNER_TOKEN_ID)" || { fail "owner PAT" "$OWNER_PAT_RESP"; exit 1; }
+
+curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT" -H "Authorization: Bearer $OWNER_JWT" >/dev/null
+VAULT_ID=$(run_psql "SELECT id FROM vaults WHERE name = '$VAULT'")
+[ -n "$VAULT_ID" ] && pass "vault created ($VAULT_ID, owner=$OWNER)" || { fail "vault create" "not in DB"; exit 1; }
+
+echo ""
+echo "▸ 1. Baseline: owner JWT write succeeds BEFORE marking (positive control)"
+R=$(write_doc "$OWNER_JWT" "$VAULT")
+CODE="${R%%|*}"
+[ "$CODE" = "200" ] && pass "pre-mark owner write → 200 (control)" || fail "pre-mark control" "got $CODE: ${R#*|}"
+
+echo ""
+echo "▸ 2. Mark the vault"
+MARK_RESP=$(curl -sk -w '\n%{http_code}' -X PUT "$BASE_URL/api/v1/admin/vaults/$VAULT/write-policy" \
+  -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  -d '{"managed_by":"collector:wpe2e-test","note":"e2e round-trip"}')
+MARK_CODE=$(echo "$MARK_RESP" | tail -1)
+MARK_BODY=$(echo "$MARK_RESP" | sed '$d')
+[ "$MARK_CODE" = "200" ] && pass "PUT write-policy → 200" || fail "mark" "got $MARK_CODE: $MARK_BODY"
+MANAGED_BY=$(echo "$MARK_BODY" | jq_field "['managed_by']")
+[ "$MANAGED_BY" = "collector:wpe2e-test" ] && pass "response echoes managed_by" || fail "mark managed_by" "got '$MANAGED_BY'"
+
+NONADMIN_MARK_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X PUT "$BASE_URL/api/v1/admin/vaults/$VAULT/write-policy" \
+  -H "Authorization: Bearer $OWNER_JWT" -H 'Content-Type: application/json' \
+  -d '{"managed_by":"collector:should-fail"}')
+[ "$NONADMIN_MARK_CODE" = "403" ] && pass "non-admin (owner) PUT write-policy → 403" || fail "non-admin mark" "got $NONADMIN_MARK_CODE"
+
+echo ""
+echo "▸ 3. JWT write to marked vault → 403 naming managed_by"
+R=$(write_doc "$OWNER_JWT" "$VAULT")
+CODE="${R%%|*}"; BODY="${R#*|}"
+[ "$CODE" = "403" ] && pass "JWT write → 403" || fail "JWT write" "got $CODE: $BODY"
+echo "$BODY" | grep -q "collector:wpe2e-test" && pass "403 body names managed_by" || fail "403 managed_by" "$BODY"
+
+echo ""
+echo "▸ 4. Owner PAT (ungranted) write → 403"
+R=$(write_doc "$OWNER_PAT" "$VAULT")
+CODE="${R%%|*}"; BODY="${R#*|}"
+[ "$CODE" = "403" ] && pass "ungranted PAT write → 403" || fail "ungranted PAT write" "got $CODE: $BODY"
+echo "$BODY" | grep -q "collector:wpe2e-test" && pass "403 body names managed_by (PAT path)" || fail "403 managed_by (PAT)" "$BODY"
+
+echo ""
+echo "▸ 5. Grant the owner's PAT"
+GRANT_RESP=$(curl -sk -w '\n%{http_code}' -X PUT \
+  "$BASE_URL/api/v1/admin/vaults/$VAULT/write-policy/grants/$OWNER_TOKEN_ID" \
+  -H "Authorization: Bearer $ADMIN_PAT")
+GRANT_CODE=$(echo "$GRANT_RESP" | tail -1)
+[ "$GRANT_CODE" = "200" ] && pass "PUT grant → 200" || fail "grant" "got $GRANT_CODE: $(echo "$GRANT_RESP" | sed '$d')"
+
+echo ""
+echo "▸ 6. Granted PAT write → 200"
+R=$(write_doc "$OWNER_PAT" "$VAULT")
+CODE="${R%%|*}"
+[ "$CODE" = "200" ] && pass "granted PAT write → 200" || fail "granted PAT write" "got $CODE: ${R#*|}"
+
+echo ""
+echo "▸ 7. Admin bypass write while still marked → 200 + audit event"
+R=$(write_doc "$ADMIN_PAT" "$VAULT")
+CODE="${R%%|*}"
+[ "$CODE" = "200" ] && pass "admin bypass write → 200" || fail "admin bypass write" "got $CODE: ${R#*|}"
+BYPASS_COUNT=$(run_psql "SELECT COUNT(*) FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'vault.write_policy_admin_bypass'")
+{ [ -n "$BYPASS_COUNT" ] && [ "$BYPASS_COUNT" -ge 1 ]; } 2>/dev/null && pass "vault.write_policy_admin_bypass event recorded (count=$BYPASS_COUNT)" || fail "bypass event" "count=$BYPASS_COUNT"
+
+echo ""
+echo "▸ 8. vault.write_policy_changed audit trail (marked + grant_added)"
+MARKED_COUNT=$(run_psql "SELECT COUNT(*) FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'vault.write_policy_changed' AND payload->>'action' = 'marked'")
+GRANT_ADDED_COUNT=$(run_psql "SELECT COUNT(*) FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'vault.write_policy_changed' AND payload->>'action' = 'grant_added'")
+[ "$MARKED_COUNT" = "1" ] && pass "write_policy_changed action=marked recorded" || fail "marked event" "count=$MARKED_COUNT"
+[ "$GRANT_ADDED_COUNT" = "1" ] && pass "write_policy_changed action=grant_added recorded" || fail "grant_added event" "count=$GRANT_ADDED_COUNT"
+
+echo ""
+echo "▸ 9. Validation edge cases"
+curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$OTHER_VAULT" -H "Authorization: Bearer $OWNER_JWT" >/dev/null
+CONFLICT_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X PUT \
+  "$BASE_URL/api/v1/admin/vaults/$OTHER_VAULT/write-policy/grants/$OWNER_TOKEN_ID" \
+  -H "Authorization: Bearer $ADMIN_PAT")
+[ "$CONFLICT_CODE" = "409" ] && pass "grant on an unmarked vault → 409" || fail "grant conflict" "got $CONFLICT_CODE"
+
+FAKE_TOKEN="00000000-0000-0000-0000-000000000000"
+NOTFOUND_TOKEN_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X PUT \
+  "$BASE_URL/api/v1/admin/vaults/$VAULT/write-policy/grants/$FAKE_TOKEN" \
+  -H "Authorization: Bearer $ADMIN_PAT")
+[ "$NOTFOUND_TOKEN_CODE" = "404" ] && pass "grant of a missing token → 404" || fail "grant missing token" "got $NOTFOUND_TOKEN_CODE"
+
+MISSING_VAULT_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X PUT \
+  "$BASE_URL/api/v1/admin/vaults/wpe2e-does-not-exist-$TS/write-policy" \
+  -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  -d '{"managed_by":"collector:x"}')
+[ "$MISSING_VAULT_CODE" = "404" ] && pass "mark of a missing vault → 404" || fail "mark missing vault" "got $MISSING_VAULT_CODE"
+
+echo ""
+echo "▸ 10. Unmark — ROLLBACK PROOF"
+UNMARK_RESP=$(curl -sk -w '\n%{http_code}' -X DELETE "$BASE_URL/api/v1/admin/vaults/$VAULT/write-policy" \
+  -H "Authorization: Bearer $ADMIN_PAT")
+UNMARK_CODE=$(echo "$UNMARK_RESP" | tail -1)
+[ "$UNMARK_CODE" = "200" ] && pass "DELETE write-policy → 200" || fail "unmark" "got $UNMARK_CODE"
+
+UNMARKED_COUNT=$(run_psql "SELECT COUNT(*) FROM events WHERE vault_id = '$VAULT_ID' AND kind = 'vault.write_policy_changed' AND payload->>'action' = 'unmarked'")
+[ "$UNMARKED_COUNT" = "1" ] && pass "write_policy_changed action=unmarked recorded" || fail "unmarked event" "count=$UNMARKED_COUNT"
+
+# THE kill-switch assertion: an ungranted JWT write now succeeds again —
+# full behavioural rollback, not a one-way ratchet.
+R=$(write_doc "$OWNER_JWT" "$VAULT")
+CODE="${R%%|*}"
+[ "$CODE" = "200" ] && pass "POST-unmark JWT write → 200 (full rollback — kill-switch proven)" || fail "rollback proof" "got $CODE: ${R#*|}"
+
+echo ""
+echo "── Cleanup ──"
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" -H "Authorization: Bearer $OWNER_JWT" >/dev/null 2>&1 || true
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$OTHER_VAULT" -H "Authorization: Bearer $OWNER_JWT" >/dev/null 2>&1 || true
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  Passed: $PASS   Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "  Failures:"
+  printf '    - %s\n' "${ERRORS[@]}"
+  exit 1
+fi
+echo "All vault_write_policy e2e checks passed."
+exit 0

--- a/backend/tests/test_vault_write_policy_routes_unit.py
+++ b/backend/tests/test_vault_write_policy_routes_unit.py
@@ -1,0 +1,186 @@
+"""Route-level contract for the vault write-policy admin API (P0 S3, Task 10).
+
+Mirrors ``test_workspace_account_admin_routes.py``'s convention: no DB, no
+real service call — each route handler is invoked directly with a
+monkeypatched service function so route-level concerns (is_admin gating,
+argument forwarding, path/body wiring) are isolated from the DB-backed
+service-layer behaviour ``test_vault_write_policy_unit.py`` covers.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.auth_service import AuthenticatedUser
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _user(*, admin: bool) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        username="vwp-caller",
+        email="vwp-caller@service.akb.invalid",
+        display_name=None,
+        is_admin=admin,
+        auth_method="pat",
+        key_class="service",
+    )
+
+
+# ── non-admin → 403 before the service ever runs ────────────────────────
+
+async def test_non_admin_rejected_for_set_write_policy(monkeypatch):
+    from app.api.routes import access
+
+    async def _must_not_run(*_a, **_k):
+        raise AssertionError("service must not run for a non-admin")
+
+    monkeypatch.setattr(access, "set_vault_write_policy", _must_not_run)
+    req = access.SetVaultWritePolicyRequest(managed_by="collector:acme")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_set_vault_write_policy("some-vault", req, _user(admin=False))
+    assert exc_info.value.status_code == 403
+
+
+async def test_non_admin_rejected_for_remove_write_policy(monkeypatch):
+    from app.api.routes import access
+
+    async def _must_not_run(*_a, **_k):
+        raise AssertionError("service must not run for a non-admin")
+
+    monkeypatch.setattr(access, "remove_vault_write_policy", _must_not_run)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_remove_vault_write_policy("some-vault", _user(admin=False))
+    assert exc_info.value.status_code == 403
+
+
+async def test_non_admin_rejected_for_add_grant(monkeypatch):
+    from app.api.routes import access
+
+    async def _must_not_run(*_a, **_k):
+        raise AssertionError("service must not run for a non-admin")
+
+    monkeypatch.setattr(access, "add_vault_write_grant", _must_not_run)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_add_vault_write_grant(
+            "some-vault", str(uuid.uuid4()), _user(admin=False),
+        )
+    assert exc_info.value.status_code == 403
+
+
+async def test_non_admin_rejected_for_remove_grant(monkeypatch):
+    from app.api.routes import access
+
+    async def _must_not_run(*_a, **_k):
+        raise AssertionError("service must not run for a non-admin")
+
+    monkeypatch.setattr(access, "remove_vault_write_grant", _must_not_run)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_remove_vault_write_grant(
+            "some-vault", str(uuid.uuid4()), _user(admin=False),
+        )
+    assert exc_info.value.status_code == 403
+
+
+# ── admin → forwards to the service with the right arguments ───────────
+
+async def test_admin_set_write_policy_forwards_args(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _set(actor_id, vault_name, managed_by, note=None):
+        observed.update(
+            actor_id=actor_id, vault_name=vault_name, managed_by=managed_by, note=note,
+        )
+        return {"vault": vault_name, "managed_by": managed_by, "note": note, "marked": True}
+
+    monkeypatch.setattr(access, "set_vault_write_policy", _set)
+    admin = _user(admin=True)
+    req = access.SetVaultWritePolicyRequest(managed_by="collector:acme", note="pilot")
+
+    result = await access.admin_set_vault_write_policy("v1", req, admin)
+
+    assert result["marked"] is True
+    assert observed == {
+        "actor_id": admin.user_id,
+        "vault_name": "v1",
+        "managed_by": "collector:acme",
+        "note": "pilot",
+    }
+
+
+async def test_admin_remove_write_policy_forwards_args(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _remove(actor_id, vault_name):
+        observed.update(actor_id=actor_id, vault_name=vault_name)
+        return {"vault": vault_name, "unmarked": True, "was_marked": True}
+
+    monkeypatch.setattr(access, "remove_vault_write_policy", _remove)
+    admin = _user(admin=True)
+
+    result = await access.admin_remove_vault_write_policy("v1", admin)
+
+    assert result["unmarked"] is True
+    assert observed == {"actor_id": admin.user_id, "vault_name": "v1"}
+
+
+async def test_admin_add_grant_forwards_args(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+    token_id = str(uuid.uuid4())
+
+    async def _add(actor_id, vault_name, tid):
+        observed.update(actor_id=actor_id, vault_name=vault_name, token_id=tid)
+        return {"vault": vault_name, "token_id": tid, "granted": True}
+
+    monkeypatch.setattr(access, "add_vault_write_grant", _add)
+    admin = _user(admin=True)
+
+    result = await access.admin_add_vault_write_grant("v1", token_id, admin)
+
+    assert result["granted"] is True
+    assert observed == {"actor_id": admin.user_id, "vault_name": "v1", "token_id": token_id}
+
+
+async def test_admin_remove_grant_forwards_args(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+    token_id = str(uuid.uuid4())
+
+    async def _remove(actor_id, vault_name, tid):
+        observed.update(actor_id=actor_id, vault_name=vault_name, token_id=tid)
+        return {"vault": vault_name, "token_id": tid, "revoked": True}
+
+    monkeypatch.setattr(access, "remove_vault_write_grant", _remove)
+    admin = _user(admin=True)
+
+    result = await access.admin_remove_vault_write_grant("v1", token_id, admin)
+
+    assert result["revoked"] is True
+    assert observed == {"actor_id": admin.user_id, "vault_name": "v1", "token_id": token_id}
+
+
+async def test_write_policy_routes_are_explicit_in_openapi():
+    from app.main import app
+
+    paths = app.openapi()["paths"]
+    expected = {
+        "/api/v1/admin/vaults/{vault}/write-policy",
+        "/api/v1/admin/vaults/{vault}/write-policy/grants/{token_id}",
+    }
+    assert expected <= set(paths)

--- a/backend/tests/test_vault_write_policy_unit.py
+++ b/backend/tests/test_vault_write_policy_unit.py
@@ -12,8 +12,10 @@ and self-skip if unreachable.
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 
 import asyncpg
@@ -34,31 +36,45 @@ async def pool(monkeypatch):
     except Exception:
         pytest.skip("Postgres unreachable at AKB_TEST_DSN")
 
-    # Fresh-DB bootstrap: init.sql already has every prior migration's
-    # schema folded forward (see backend/app/db/init.sql), so applying it
-    # once + migration 044 on top is equivalent to the full ledger chain.
+    # Fresh-DB bootstrap: init.sql folds forward MOST prior migrations'
+    # schema, but not all — notably NOT `vault_external_git` (010) or the
+    # `events` outbox (015). Task 8's tests never exercised
+    # `check_vault_access` or `emit_event`, so 044-only was sufficient
+    # then; Task 9's guard calls both (the pre-existing external-git
+    # mirror check in `check_vault_access` unconditionally queries
+    # `vault_external_git` for any writer-role check, and the guard's own
+    # audit event needs `events`), so those two are applied here too.
     async with pg_pool.acquire() as conn:
         await conn.execute(_INIT_SQL_PATH.read_text())
 
     from app.db.postgres import _load_migration
     from app.repositories import vault_write_policy_repo
-    from app.services import auth_service
+    from app.services import access_service, auth_service, table_service
 
-    migration = _load_migration("044_vault_write_policy.py")
-    assert migration is not None
-    async with pg_pool.acquire() as conn:
-        await migration.migrate(conn=conn)
+    for filename in (
+        "010_external_git_mirror.py",
+        "015_events_outbox.py",
+        "044_vault_write_policy.py",
+    ):
+        migration = _load_migration(filename)
+        assert migration is not None
+        async with pg_pool.acquire() as conn:
+            await migration.migrate(conn=conn)
 
     async def _get_pool():
         return pg_pool
 
-    # Both modules resolve `get_pool` as a name bound into their own
+    # Every module resolves `get_pool` as a name bound into its own
     # namespace at import time (`from app.db.postgres import get_pool`),
     # so each needs its own patch target — patching only one leaves the
-    # other's conn=None fallback hitting the real (unreachable-from-here)
-    # app.db.postgres singleton pool.
+    # others' conn=None fallback hitting the real (unreachable-from-here)
+    # app.db.postgres singleton pool. access_service/table_service are
+    # needed from Task 9 on (the write-policy guard + akb_sql dual
+    # enforcement live there).
     monkeypatch.setattr(auth_service, "get_pool", _get_pool)
     monkeypatch.setattr(vault_write_policy_repo, "get_pool", _get_pool)
+    monkeypatch.setattr(access_service, "get_pool", _get_pool)
+    monkeypatch.setattr(table_service, "get_pool", _get_pool)
     monkeypatch.setattr(
         settings, "jwt_secret", "vwp-test-secret-at-least-32-bytes-long", raising=False
     )
@@ -85,6 +101,20 @@ async def _create_user(pg_pool) -> uuid.UUID:
     return user_id
 
 
+async def _create_admin_user(pg_pool) -> uuid.UUID:
+    user_id = uuid.uuid4()
+    suffix = uuid.uuid4().hex[:12]
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO users (id, username, email, password_hash, is_admin) "
+            "VALUES ($1, $2, $3, 'x', TRUE)",
+            user_id,
+            f"vwp-admin-{suffix}",
+            f"vwp-admin-{suffix}@example.com",
+        )
+    return user_id
+
+
 async def _create_vault(pg_pool, owner_id: uuid.UUID) -> uuid.UUID:
     vault_id = uuid.uuid4()
     async with pg_pool.acquire() as conn:
@@ -96,6 +126,40 @@ async def _create_vault(pg_pool, owner_id: uuid.UUID) -> uuid.UUID:
             owner_id,
         )
     return vault_id
+
+
+async def _create_named_vault(pg_pool, owner_id: uuid.UUID) -> tuple[uuid.UUID, str]:
+    """Like `_create_vault` but also returns the vault name — the guard
+    tests key off the name (`check_vault_access`/`execute_sql` both take
+    vault names, not ids)."""
+    vault_id = await _create_vault(pg_pool, owner_id)
+    async with pg_pool.acquire() as conn:
+        name = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+    return vault_id, name
+
+
+@contextmanager
+def _auth_context(token_id: uuid.UUID | str | None = None, scope=None):
+    """Simulate the request-scoped ContextVars `auth_service.resolve_token`
+    sets per-request (`app/models/vault_scope.py`). A JWT session leaves
+    both at their defaults (``None``); a PAT sets ``current_token_id`` to
+    the token's id (stringified, per `_resolve_pat`) and
+    ``current_vault_scope`` to its scope (``None`` if unscoped).
+
+    Resets via ``.reset(...)`` in ``finally`` — pytest-asyncio tasks in
+    this suite do not get a fresh ``contextvars.Context`` per test (see
+    ``TestContextVar`` above, which relies on the same fact), so a stray
+    ``.set()`` would otherwise leak into a later test.
+    """
+    from app.models.vault_scope import current_token_id, current_vault_scope
+
+    t1 = current_token_id.set(str(token_id) if token_id is not None else None)
+    t2 = current_vault_scope.set(scope)
+    try:
+        yield
+    finally:
+        current_token_id.reset(t1)
+        current_vault_scope.reset(t2)
 
 
 async def _create_token(pg_pool, user_id: uuid.UUID) -> uuid.UUID:
@@ -376,3 +440,255 @@ class TestContextVar:
             assert current_token_id.get() is None
         finally:
             current_token_id.reset(marker)
+
+
+class TestWritePolicyGuard:
+    """Task 9 — the enforcement guard in
+    ``access_service.check_vault_access``. Fires only for mutating roles
+    (writer/admin/owner) on a MARKED vault (a ``vault_write_policy`` row
+    exists): a granted PAT passes, an *unscoped* system admin bypasses
+    (+ a loud audit event), and everyone else — including the vault
+    OWNER and a JWT session — is denied. An unmarked vault is a
+    guaranteed no-op (existing behaviour, zero change).
+    """
+
+    async def test_jwt_session_write_to_marked_vault_is_403(self, pool):
+        """A2 core: a plain member with a real 'writer' ACL role, but no
+        PAT at all (the JWT-session shape — ``current_token_id`` stays at
+        its ``None`` default), is denied on a marked vault."""
+        from app.exceptions import ForbiddenError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        member_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO vault_access (vault_id, user_id, role) VALUES ($1, $2, 'writer')",
+                vault_id, member_id,
+            )
+
+        with _auth_context(token_id=None, scope=None):
+            with pytest.raises(ForbiddenError):
+                await check_vault_access(str(member_id), vault_name, required_role="writer")
+
+    async def test_vault_owner_without_grant_is_403(self, pool):
+        """The owner's own PAT exists (so this exercises the "token
+        present but not on the allowlist" branch, complementing the
+        no-token branch above) but was never granted — still denied.
+        Proves ownership does not substitute for a grant on a marked
+        vault (§5.1a: PAT-write-only)."""
+        from app.exceptions import ForbiddenError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        owner_token = await _create_token(pool, owner_id)  # never granted
+
+        with _auth_context(token_id=owner_token, scope=None):
+            with pytest.raises(ForbiddenError):
+                await check_vault_access(str(owner_id), vault_name, required_role="writer")
+
+    async def test_granted_pat_passes(self, pool):
+        """A token on the allowlist passes regardless of the underlying
+        user's ACL role — here a user with NO vault_access row and who
+        is not the owner, proving the grant alone is sufficient (the
+        "class-agnostic... collector, gardener, operator" allowlist
+        design, not a re-derivation of ordinary ACL)."""
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        service_user_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        token_id = await _create_token(pool, service_user_id)
+        await repo.add_grant(vault_id, token_id, "admin-user")
+
+        with _auth_context(token_id=token_id, scope=None):
+            result = await check_vault_access(
+                str(service_user_id), vault_name, required_role="writer",
+            )
+
+        assert result["vault_id"] == vault_id
+
+    async def test_unscoped_admin_bypasses_and_emits_audit(self, pool):
+        """A3: a system admin with no PAT vault scope bypasses a marked
+        vault's guard — but LOUDLY, via a `vault.write_policy_admin_bypass`
+        event carrying managed_by/required_role/actor."""
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        admin_id = await _create_admin_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        with _auth_context(token_id=None, scope=None):
+            result = await check_vault_access(str(admin_id), vault_name, required_role="writer")
+
+        assert result["vault_id"] == vault_id
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_admin_bypass' "
+                "AND vault_id = $1",
+                vault_id,
+            )
+        assert event is not None
+        assert event["actor_id"] == str(admin_id)
+        payload = (
+            json.loads(event["payload"])
+            if isinstance(event["payload"], str) else event["payload"]
+        )
+        assert payload["managed_by"] == "collector:acme"
+        assert payload["required_role"] == "writer"
+
+    async def test_scoped_admin_token_is_still_blocked(self, pool):
+        """A *scoped* admin PAT must NOT get the A3 bypass — mirrors the
+        Option B scope guard's own "a scope only ever subtracts" rule.
+        The scope explicitly permits this vault so the earlier scope
+        guard doesn't itself raise first; this isolates the write-policy
+        guard's own admin-bypass branch."""
+        from app.exceptions import ForbiddenError
+        from app.models.vault_scope import VaultScope
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        admin_id = await _create_admin_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        admin_token = await _create_token(pool, admin_id)  # never granted
+
+        scope = VaultScope(prefixes=(), extra_vaults=frozenset({vault_name}))
+
+        with _auth_context(token_id=admin_token, scope=scope):
+            with pytest.raises(ForbiddenError):
+                await check_vault_access(str(admin_id), vault_name, required_role="writer")
+
+    async def test_unmarked_vault_unaffected(self, pool):
+        """No `vault_write_policy` row ⇒ the guard is a complete no-op:
+        historical owner-bypass behaviour, unchanged."""
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        # No set_policy call — vault stays ungoverned.
+
+        with _auth_context(token_id=None, scope=None):
+            result = await check_vault_access(str(owner_id), vault_name, required_role="writer")
+
+        assert result["vault_id"] == vault_id
+        assert result["role"] == "owner"
+
+
+class TestAkbSqlDualEnforcement:
+    """Task 9 — `akb_sql`'s only `check_vault_access` call (the REST
+    route in ``tables.py``) asks for ``required_role="reader"`` per
+    referenced vault, so the mutating-role guard above never fires for
+    it. ``table_service.execute_sql`` re-checks directly against the
+    same allow-conditions, mirroring the pre-existing archived-vault
+    dual block in the same function.
+    """
+
+    async def test_akb_sql_dual_enforcement_blocks_vt_write(self, pool, monkeypatch):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services import table_service
+        from app.util.errors import VAULT_WRITE_MANAGED
+
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        def _poison():
+            raise AssertionError("must not reach the real executor — block happens before execution")
+
+        monkeypatch.setattr(table_service, "get_user_sql_executor", _poison)
+
+        with _auth_context(token_id=None, scope=None):
+            result = await table_service.execute_sql(
+                vault_names=[vault_name],
+                user_id=str(owner_id),
+                sql="UPDATE t SET x = 1",
+                is_admin=False,
+            )
+
+        assert result["code"] == VAULT_WRITE_MANAGED
+
+    async def test_akb_sql_dual_enforcement_admin_bypass(self, pool, monkeypatch):
+        """Admin-bypass twin: an unscoped admin is NOT blocked (the SQL
+        reaches the (stubbed) real executor) and the same loud audit
+        event fires as the access_service guard's A3 branch."""
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services import table_service
+
+        owner_id = await _create_user(pool)
+        admin_id = await _create_admin_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        calls = []
+
+        class _StubExecutor:
+            async def execute(self, **kwargs):
+                calls.append(kwargs)
+                return {"kind": "table_sql", "vaults": [], "result": "UPDATE 0"}
+
+        monkeypatch.setattr(table_service, "get_user_sql_executor", lambda: _StubExecutor())
+
+        with _auth_context(token_id=None, scope=None):  # unscoped admin
+            result = await table_service.execute_sql(
+                vault_names=[vault_name],
+                user_id=str(admin_id),
+                sql="UPDATE t SET x = 1",
+                is_admin=True,
+            )
+
+        assert len(calls) == 1  # fell through to the (stubbed) real executor
+        assert "code" not in result
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_admin_bypass' "
+                "AND vault_id = $1",
+                vault_id,
+            )
+        assert event is not None
+
+    async def test_akb_sql_multi_vault_blocks_on_the_second_referenced_vault(
+        self, pool, monkeypatch,
+    ):
+        """The dual-enforcement loop must examine EVERY referenced vault,
+        not just the first — an unmarked (harmless) vault listed before a
+        marked-and-blocked one must not let the statement slip through."""
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services import table_service
+        from app.util.errors import VAULT_WRITE_MANAGED
+
+        ok_owner_id = await _create_user(pool)
+        _ok_vault_id, ok_vault_name = await _create_named_vault(pool, ok_owner_id)
+        # ok_vault stays ungoverned — no set_policy call.
+
+        blocked_owner_id = await _create_user(pool)
+        blocked_vault_id, blocked_vault_name = await _create_named_vault(pool, blocked_owner_id)
+        await repo.set_policy(blocked_vault_id, "collector:acme", "admin-user")
+
+        def _poison():
+            raise AssertionError("must not reach the real executor — blocked before execution")
+
+        monkeypatch.setattr(table_service, "get_user_sql_executor", _poison)
+
+        with _auth_context(token_id=None, scope=None):  # no PAT, not admin
+            result = await table_service.execute_sql(
+                vault_names=[ok_vault_name, blocked_vault_name],
+                user_id=str(blocked_owner_id),
+                sql="UPDATE t SET x = 1",
+                is_admin=False,
+            )
+
+        assert result["code"] == VAULT_WRITE_MANAGED

--- a/backend/tests/test_vault_write_policy_unit.py
+++ b/backend/tests/test_vault_write_policy_unit.py
@@ -1,0 +1,378 @@
+"""Unit coverage for the vault_write_policy / vault_write_grants substrate.
+
+P0 slice S3: two sidecar tables + a repo + the ``current_token_id``
+ContextVar (already shipped alongside ``current_vault_scope`` for the
+PG-native RBAC role-switch — this file additionally pins its PAT/JWT/reset
+contract for the vault_write_policy consumer). DB-backed: migration 044
+and the repo are pure SQL, so these tests apply init.sql + migration 044
+onto a real Postgres (``AKB_TEST_DSN``, same convention as
+``test_account_status_auth_carriers.py`` / ``test_workspace_account_admin_service.py``)
+and self-skip if unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.config import settings
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
+_INIT_SQL_PATH = Path(__file__).resolve().parents[1] / "app" / "db" / "init.sql"
+
+
+@pytest.fixture
+async def pool(monkeypatch):
+    try:
+        pg_pool = await asyncpg.create_pool(_DSN, min_size=1, max_size=5)
+    except Exception:
+        pytest.skip("Postgres unreachable at AKB_TEST_DSN")
+
+    # Fresh-DB bootstrap: init.sql already has every prior migration's
+    # schema folded forward (see backend/app/db/init.sql), so applying it
+    # once + migration 044 on top is equivalent to the full ledger chain.
+    async with pg_pool.acquire() as conn:
+        await conn.execute(_INIT_SQL_PATH.read_text())
+
+    from app.db.postgres import _load_migration
+    from app.repositories import vault_write_policy_repo
+    from app.services import auth_service
+
+    migration = _load_migration("044_vault_write_policy.py")
+    assert migration is not None
+    async with pg_pool.acquire() as conn:
+        await migration.migrate(conn=conn)
+
+    async def _get_pool():
+        return pg_pool
+
+    # Both modules resolve `get_pool` as a name bound into their own
+    # namespace at import time (`from app.db.postgres import get_pool`),
+    # so each needs its own patch target — patching only one leaves the
+    # other's conn=None fallback hitting the real (unreachable-from-here)
+    # app.db.postgres singleton pool.
+    monkeypatch.setattr(auth_service, "get_pool", _get_pool)
+    monkeypatch.setattr(vault_write_policy_repo, "get_pool", _get_pool)
+    monkeypatch.setattr(
+        settings, "jwt_secret", "vwp-test-secret-at-least-32-bytes-long", raising=False
+    )
+
+    yield pg_pool
+
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DELETE FROM vaults WHERE name LIKE 'vwp-%'")
+        await conn.execute("DELETE FROM users WHERE username LIKE 'vwp-%'")
+    await pg_pool.close()
+
+
+async def _create_user(pg_pool) -> uuid.UUID:
+    user_id = uuid.uuid4()
+    suffix = uuid.uuid4().hex[:12]
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO users (id, username, email, password_hash) "
+            "VALUES ($1, $2, $3, 'x')",
+            user_id,
+            f"vwp-{suffix}",
+            f"vwp-{suffix}@example.com",
+        )
+    return user_id
+
+
+async def _create_vault(pg_pool, owner_id: uuid.UUID) -> uuid.UUID:
+    vault_id = uuid.uuid4()
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vaults (id, name, git_path, owner_id) VALUES ($1, $2, $3, $4)",
+            vault_id,
+            f"vwp-vault-{uuid.uuid4().hex[:10]}",
+            f"/tmp/vwp-{vault_id}.git",
+            owner_id,
+        )
+    return vault_id
+
+
+async def _create_token(pg_pool, user_id: uuid.UUID) -> uuid.UUID:
+    from app.services.auth_service import _hash_token
+
+    raw = f"akb_vwp_{uuid.uuid4().hex}"
+    async with pg_pool.acquire() as conn:
+        token_id = await conn.fetchval(
+            "INSERT INTO tokens (user_id, name, token_hash, token_prefix) "
+            "VALUES ($1, $2, $3, $4) RETURNING id",
+            user_id,
+            "vwp-test-token",
+            _hash_token(raw),
+            raw[:12],
+        )
+    return token_id
+
+
+class TestMigrationIdempotent:
+    async def test_migrate_applies_twice_without_error(self, pool):
+        from app.db.postgres import _load_migration
+
+        migration = _load_migration("044_vault_write_policy.py")
+        async with pool.acquire() as conn:
+            await migration.migrate(conn=conn)  # 2nd application (fixture already ran it once)
+
+        async with pool.acquire() as conn:
+            tables = await conn.fetch(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name IN ('vault_write_policy', 'vault_write_grants')"
+            )
+        assert {r["table_name"] for r in tables} == {
+            "vault_write_policy",
+            "vault_write_grants",
+        }
+
+    async def test_migrate_twice_preserves_existing_rows(self, pool):
+        from app.db.postgres import _load_migration
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO vault_write_policy (vault_id, managed_by, created_by) "
+                "VALUES ($1, 'collector:test', 'tester')",
+                vault_id,
+            )
+
+        migration = _load_migration("044_vault_write_policy.py")
+        async with pool.acquire() as conn:
+            await migration.migrate(conn=conn)
+
+        async with pool.acquire() as conn:
+            managed_by = await conn.fetchval(
+                "SELECT managed_by FROM vault_write_policy WHERE vault_id = $1",
+                vault_id,
+            )
+        assert managed_by == "collector:test"
+
+
+class TestRepoCrudRoundTrip:
+    async def test_get_policy_none_when_ungoverned(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+
+        assert await repo.get_policy(vault_id) is None
+
+    async def test_set_then_get_policy_round_trips(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+
+        created = await repo.set_policy(
+            vault_id, "collector:acme-jira", "admin-user", note="pilot vault"
+        )
+        assert created["vault_id"] == vault_id
+        assert created["managed_by"] == "collector:acme-jira"
+        assert created["note"] == "pilot vault"
+        assert created["created_by"] == "admin-user"
+
+        fetched = await repo.get_policy(vault_id)
+        assert fetched is not None
+        assert fetched["managed_by"] == "collector:acme-jira"
+        assert fetched["note"] == "pilot vault"
+
+    async def test_set_policy_upserts_without_disturbing_created_by(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+
+        await repo.set_policy(vault_id, "collector:v1", "first-admin")
+        updated = await repo.set_policy(vault_id, "collector:v2", "second-admin", note="re-marked")
+
+        assert updated["managed_by"] == "collector:v2"
+        assert updated["note"] == "re-marked"
+        # created_by is pinned to the original mark, not overwritten by the upsert.
+        assert updated["created_by"] == "first-admin"
+
+    async def test_remove_policy_clears_it(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+
+        await repo.remove_policy(vault_id)
+
+        assert await repo.get_policy(vault_id) is None
+
+    async def test_is_granted_false_then_add_grant_true_then_remove_false(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+
+        assert await repo.is_granted(vault_id, token_id) is False
+
+        await repo.add_grant(vault_id, token_id, "admin-user")
+        assert await repo.is_granted(vault_id, token_id) is True
+
+        await repo.remove_grant(vault_id, token_id)
+        assert await repo.is_granted(vault_id, token_id) is False
+
+    async def test_add_grant_is_idempotent(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+
+        await repo.add_grant(vault_id, token_id, "admin-user")
+        await repo.add_grant(vault_id, token_id, "admin-user")  # must not raise
+
+        assert await repo.is_granted(vault_id, token_id) is True
+
+    async def test_add_grant_without_policy_raises_fk_violation(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)  # no set_policy call
+        token_id = await _create_token(pool, owner_id)
+
+        with pytest.raises(asyncpg.ForeignKeyViolationError):
+            await repo.add_grant(vault_id, token_id, "admin-user")
+
+    async def test_repo_functions_accept_an_explicit_conn(self, pool):
+        """Callers embedding this in a larger transaction pass ``conn=``."""
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await repo.set_policy(vault_id, "collector:x", "admin-user", conn=conn)
+                await repo.add_grant(vault_id, token_id, "admin-user", conn=conn)
+                assert await repo.is_granted(vault_id, token_id, conn=conn) is True
+                assert (await repo.get_policy(vault_id, conn=conn))["managed_by"] == "collector:x"
+
+
+class TestCascade:
+    async def test_deleting_token_removes_its_grant(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+        await repo.add_grant(vault_id, token_id, "admin-user")
+        assert await repo.is_granted(vault_id, token_id) is True
+
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM tokens WHERE id = $1", token_id)
+
+        assert await repo.is_granted(vault_id, token_id) is False
+
+    async def test_deleting_policy_removes_all_its_grants(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_a = await _create_token(pool, owner_id)
+        token_b = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+        await repo.add_grant(vault_id, token_a, "admin-user")
+        await repo.add_grant(vault_id, token_b, "admin-user")
+
+        await repo.remove_policy(vault_id)
+
+        async with pool.acquire() as conn:
+            remaining = await conn.fetchval(
+                "SELECT COUNT(*) FROM vault_write_grants WHERE vault_id = $1", vault_id
+            )
+        assert remaining == 0
+
+    async def test_deleting_vault_removes_policy_and_grants(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+        await repo.add_grant(vault_id, token_id, "admin-user")
+
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+
+        assert await repo.get_policy(vault_id) is None
+        async with pool.acquire() as conn:
+            remaining = await conn.fetchval(
+                "SELECT COUNT(*) FROM vault_write_grants WHERE vault_id = $1", vault_id
+            )
+        assert remaining == 0
+
+
+class TestContextVar:
+    """current_token_id already exists (shipped for the PG-native RBAC
+    role-switch, ``app/models/vault_scope.py``) and is already set/reset
+    at exactly the sites vault_write_policy's guard needs — this class
+    pins that contract for this second consumer rather than driving new
+    production code.
+    """
+
+    async def test_pat_resolution_sets_current_token_id(self, pool):
+        from app.models.vault_scope import current_token_id
+        from app.services.auth_service import resolve_token
+
+        owner_id = await _create_user(pool)
+        raw = f"akb_vwp_ctxvar_{uuid.uuid4().hex}"
+        from app.services.auth_service import _hash_token
+
+        async with pool.acquire() as conn:
+            token_id = await conn.fetchval(
+                "INSERT INTO tokens (user_id, name, token_hash, token_prefix) "
+                "VALUES ($1, $2, $3, $4) RETURNING id",
+                owner_id,
+                "vwp-ctxvar-token",
+                _hash_token(raw),
+                raw[:12],
+            )
+
+        result = await resolve_token(f"Bearer {raw}")
+
+        assert result is not None
+        assert current_token_id.get() == str(token_id)
+
+    async def test_jwt_resolution_leaves_token_id_none(self, pool):
+        from app.models.vault_scope import current_token_id
+        from app.services.auth_service import create_jwt, resolve_token
+
+        owner_id = await _create_user(pool)
+        token = create_jwt(str(owner_id), "vwp-jwt-user")
+
+        marker = current_token_id.set("stale-marker-must-be-cleared")
+        try:
+            result = await resolve_token(f"Bearer {token}")
+            assert result is not None
+            assert current_token_id.get() is None
+        finally:
+            current_token_id.reset(marker)
+
+    async def test_resolve_token_reset_clears_stale_value_even_on_failure(self, pool):
+        from app.models.vault_scope import current_token_id
+        from app.services.auth_service import resolve_token
+
+        marker = current_token_id.set("stale-marker-must-be-cleared")
+        try:
+            result = await resolve_token("Bearer not-a-real-token-at-all")
+            assert result is None
+            assert current_token_id.get() is None
+        finally:
+            current_token_id.reset(marker)

--- a/backend/tests/test_vault_write_policy_unit.py
+++ b/backend/tests/test_vault_write_policy_unit.py
@@ -692,3 +692,393 @@ class TestAkbSqlDualEnforcement:
             )
 
         assert result["code"] == VAULT_WRITE_MANAGED
+
+
+class TestVaultInfoExposure:
+    """Task 10 — `managed_by` on `get_vault_info` / `list_accessible_vaults`."""
+
+    async def test_get_vault_info_managed_by_none_when_unmarked(self, pool):
+        from app.services.access_service import get_vault_info
+
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+
+        info = await get_vault_info(str(owner_id), vault_name)
+
+        assert info["managed_by"] is None
+
+    async def test_get_vault_info_managed_by_set_when_marked(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import get_vault_info
+
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        info = await get_vault_info(str(owner_id), vault_name)
+
+        assert info["managed_by"] == "collector:acme"
+
+    async def test_list_accessible_vaults_includes_managed_by(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import list_accessible_vaults
+
+        owner_id = await _create_user(pool)
+        marked_id, marked_name = await _create_named_vault(pool, owner_id)
+        _plain_id, plain_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(marked_id, "gardener:distill", "admin-user")
+
+        vaults = await list_accessible_vaults(str(owner_id))
+        by_name = {v["name"]: v for v in vaults}
+
+        assert by_name[marked_name]["managed_by"] == "gardener:distill"
+        assert by_name[plain_name]["managed_by"] is None
+
+    async def test_list_accessible_vaults_includes_managed_by_for_admin_viewer(self, pool):
+        """The admin branch of `list_accessible_vaults` (sees every vault,
+        not just owned/granted ones) has its own separate SQL — the JOIN
+        must be duplicated there too, not just in the member branch."""
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import list_accessible_vaults
+
+        owner_id = await _create_user(pool)
+        admin_id = await _create_admin_user(pool)
+        marked_id, marked_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(marked_id, "collector:acme", "admin-user")
+
+        vaults = await list_accessible_vaults(str(admin_id))
+        by_name = {v["name"]: v for v in vaults}
+
+        assert by_name[marked_name]["managed_by"] == "collector:acme"
+
+
+class TestAdminWritePolicyMarking:
+    """Task 10 — the admin-only marking service functions
+    (`access_service.set_vault_write_policy` / `remove_vault_write_policy`).
+
+    Called directly: route-level `_require_admin` gating is covered by
+    `test_vault_write_policy_routes_unit.py` (which mocks these functions
+    out) — the service layer itself trusts the caller, the same convention
+    every other admin-gated function in this module already uses (e.g.
+    `account_service.suspend_user` takes `actor_id` for audit only).
+    """
+
+    async def test_set_vault_write_policy_marks_and_emits_event(self, pool):
+        from app.services.access_service import get_vault_info, set_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+
+        result = await set_vault_write_policy(
+            str(admin_id), vault_name, "collector:acme", note="pilot vault",
+        )
+
+        assert result == {
+            "vault": vault_name,
+            "managed_by": "collector:acme",
+            "note": "pilot vault",
+            "marked": True,
+        }
+        info = await get_vault_info(str(owner_id), vault_name)
+        assert info["managed_by"] == "collector:acme"
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_changed' "
+                "AND vault_id = (SELECT id FROM vaults WHERE name = $1)",
+                vault_name,
+            )
+        assert event is not None
+        assert event["actor_id"] == str(admin_id)
+        payload = (
+            json.loads(event["payload"]) if isinstance(event["payload"], str) else event["payload"]
+        )
+        assert payload == {
+            "action": "marked",
+            "vault": vault_name,
+            "managed_by": "collector:acme",
+            "note": "pilot vault",
+        }
+
+    async def test_set_vault_write_policy_rejects_missing_vault(self, pool):
+        from app.exceptions import NotFoundError
+        from app.services.access_service import set_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+
+        with pytest.raises(NotFoundError):
+            await set_vault_write_policy(str(admin_id), "vwp-does-not-exist", "collector:acme")
+
+    async def test_set_vault_write_policy_rejects_empty_managed_by(self, pool):
+        from app.exceptions import ValidationError
+        from app.services.access_service import set_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+
+        with pytest.raises(ValidationError):
+            await set_vault_write_policy(str(admin_id), vault_name, "   ")
+
+    async def test_set_vault_write_policy_rejects_external_git_vault(self, pool):
+        """DECISION (task 10): marking an external-git mirror is REJECTED
+        rather than silently accepted as harmless overlap — see
+        `access_service.set_vault_write_policy`'s comment for the
+        rationale (a grant could never make a write succeed there, since
+        the mirror's own guard fires first and unconditionally; marking it
+        anyway would misleadingly imply otherwise)."""
+        from app.exceptions import ConflictError
+        from app.services.access_service import set_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO vault_external_git (vault_id, remote_url) VALUES ($1, $2)",
+                vault_id, "https://example.com/repo.git",
+            )
+
+        with pytest.raises(ConflictError):
+            await set_vault_write_policy(str(admin_id), vault_name, "collector:acme")
+
+    async def test_set_vault_write_policy_upsert_remarks_and_emits_again(self, pool):
+        """Re-marking (upsert) audits AGAIN — every call is a real admin
+        ACTION worth recording, not deduped against prior state. This is
+        also what makes the unmark → write → re-mark break-glass sequence
+        fully auditable (task 8/9's handoff note)."""
+        from app.services.access_service import set_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+
+        await set_vault_write_policy(str(admin_id), vault_name, "collector:v1")
+        await set_vault_write_policy(str(admin_id), vault_name, "collector:v2", note="updated")
+
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                "SELECT COUNT(*) FROM events WHERE kind = 'vault.write_policy_changed' "
+                "AND vault_id = (SELECT id FROM vaults WHERE name = $1)",
+                vault_name,
+            )
+            managed_by = await conn.fetchval(
+                "SELECT managed_by FROM vault_write_policy WHERE vault_id = "
+                "(SELECT id FROM vaults WHERE name = $1)",
+                vault_name,
+            )
+        assert count == 2
+        assert managed_by == "collector:v2"
+
+    async def test_remove_vault_write_policy_unmarks_and_emits_event(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import remove_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        result = await remove_vault_write_policy(str(admin_id), vault_name)
+
+        assert result == {"vault": vault_name, "unmarked": True, "was_marked": True}
+        assert await repo.get_policy(vault_id) is None
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_changed' "
+                "AND vault_id = $1 AND payload->>'action' = 'unmarked'",
+                vault_id,
+            )
+        assert event is not None
+        payload = (
+            json.loads(event["payload"]) if isinstance(event["payload"], str) else event["payload"]
+        )
+        assert payload["managed_by"] == "collector:acme"  # what it WAS managed by
+
+    async def test_remove_vault_write_policy_idempotent_on_unmarked_vault(self, pool):
+        from app.services.access_service import remove_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+
+        result = await remove_vault_write_policy(str(admin_id), vault_name)
+
+        assert result == {"vault": vault_name, "unmarked": True, "was_marked": False}
+
+    async def test_remove_vault_write_policy_rejects_missing_vault(self, pool):
+        from app.exceptions import NotFoundError
+        from app.services.access_service import remove_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+
+        with pytest.raises(NotFoundError):
+            await remove_vault_write_policy(str(admin_id), "vwp-does-not-exist")
+
+
+class TestAdminWritePolicyGrants:
+    """Task 10 — `add_vault_write_grant` / `remove_vault_write_grant`."""
+
+    async def test_add_vault_write_grant_success_and_emits_event(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        token_id = await _create_token(pool, owner_id)
+
+        result = await add_vault_write_grant(str(admin_id), vault_name, str(token_id))
+
+        assert result == {"vault": vault_name, "token_id": str(token_id), "granted": True}
+        assert await repo.is_granted(vault_id, token_id) is True
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_changed' "
+                "AND vault_id = $1 AND payload->>'action' = 'grant_added'",
+                vault_id,
+            )
+        assert event is not None
+        payload = (
+            json.loads(event["payload"]) if isinstance(event["payload"], str) else event["payload"]
+        )
+        assert payload["token_id"] == str(token_id)
+        assert payload["managed_by"] == "collector:acme"
+
+    async def test_add_vault_write_grant_rejects_unmarked_vault(self, pool):
+        from app.exceptions import ConflictError
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        _vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        # vault stays ungoverned — no set_policy call
+
+        with pytest.raises(ConflictError):
+            await add_vault_write_grant(str(admin_id), vault_name, str(token_id))
+
+    async def test_add_vault_write_grant_rejects_missing_token(self, pool):
+        from app.exceptions import NotFoundError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        with pytest.raises(NotFoundError):
+            await add_vault_write_grant(str(admin_id), vault_name, str(uuid.uuid4()))
+
+    async def test_add_vault_write_grant_rejects_missing_vault(self, pool):
+        from app.exceptions import NotFoundError
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        token_id = await _create_token(pool, owner_id)
+
+        with pytest.raises(NotFoundError):
+            await add_vault_write_grant(str(admin_id), "vwp-does-not-exist", str(token_id))
+
+    async def test_remove_vault_write_grant_success_and_emits_event(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import remove_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        token_id = await _create_token(pool, owner_id)
+        await repo.add_grant(vault_id, token_id, "admin-user")
+
+        result = await remove_vault_write_grant(str(admin_id), vault_name, str(token_id))
+
+        assert result == {"vault": vault_name, "token_id": str(token_id), "revoked": True}
+        assert await repo.is_granted(vault_id, token_id) is False
+
+        async with pool.acquire() as conn:
+            event = await conn.fetchrow(
+                "SELECT * FROM events WHERE kind = 'vault.write_policy_changed' "
+                "AND vault_id = $1 AND payload->>'action' = 'grant_removed'",
+                vault_id,
+            )
+        assert event is not None
+
+    async def test_remove_vault_write_grant_rejects_missing_token(self, pool):
+        from app.exceptions import NotFoundError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import remove_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        with pytest.raises(NotFoundError):
+            await remove_vault_write_grant(str(admin_id), vault_name, str(uuid.uuid4()))
+
+    async def test_remove_vault_write_grant_idempotent_when_not_granted(self, pool):
+        from app.services.access_service import remove_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        from app.repositories import vault_write_policy_repo as repo
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+        token_id = await _create_token(pool, owner_id)
+        # never granted
+
+        result = await remove_vault_write_grant(str(admin_id), vault_name, str(token_id))
+
+        assert result == {"vault": vault_name, "token_id": str(token_id), "revoked": True}
+
+    async def test_remove_vault_write_grant_rejects_missing_vault(self, pool):
+        from app.exceptions import NotFoundError
+        from app.services.access_service import remove_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        token_id = await _create_token(pool, owner_id)
+
+        with pytest.raises(NotFoundError):
+            await remove_vault_write_grant(str(admin_id), "vwp-does-not-exist", str(token_id))
+
+    async def test_add_vault_write_grant_rejects_malformed_token_id(self, pool):
+        """Characterization/pinning, not RED-driven — caught by self-review
+        (code-review skill pass) as a real, reachable branch (an admin
+        fat-fingering the token_id path segment) with zero prior coverage;
+        the `try: uuid.UUID(token_id) except ...: raise ValidationError`
+        guard already existed and was already correct, this just pins it
+        so a future refactor can't silently let a raw ValueError leak out
+        as a 500 instead of a clean 422."""
+        from app.exceptions import ValidationError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        with pytest.raises(ValidationError):
+            await add_vault_write_grant(str(admin_id), vault_name, "not-a-uuid")
+
+    async def test_remove_vault_write_grant_rejects_malformed_token_id(self, pool):
+        """Same characterization rationale as the add-grant twin above."""
+        from app.exceptions import ValidationError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import remove_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:acme", "admin-user")
+
+        with pytest.raises(ValidationError):
+            await remove_vault_write_grant(str(admin_id), vault_name, "not-a-uuid")


### PR DESCRIPTION
Slice S3 of the P0 write-semantics program (design: naut edit-semantics / SoT write-back, §5.1a — vault-grain token allowlist).

## What

A vault can be marked write-managed; a marked vault then accepts mutating calls only from PATs on its grant list. Class-agnostic, opt-in per vault.

- **Substrate** (migration 044): `vault_write_policy(vault_id, managed_by, note, …)` + `vault_write_grants(vault_id→policy, token_id→tokens, …)` with a token-side index for cascade deletes; 6-function repo; reuses the existing `current_token_id` ContextVar.
- **Guard** (`check_vault_access`, fail-closed — archived-vault template): marked vault ⇒ writer/admin/owner allowed only for a granted PAT; absent/malformed token ⇒ deny; **vault owner and JWT/OAuth sessions are denied** (marked = PAT-write-only); unscoped system admin bypasses with a `vault.write_policy_admin_bypass` audit event. `akb_sql` DML is dual-enforced in `table_service` with symmetric bypass+audit. Unmarked vaults are a strict no-op (one indexed PK lookup).
- **Admin API**: PUT/DELETE `/admin/vaults/{v}/write-policy` and PUT/DELETE `.../grants/{token_id}`, each emitting a transactional `vault.write_policy_changed` event; external-git mirror vaults are rejected (409). `managed_by` is exposed on `GET /vaults/{v}/info` and `/my/vaults` (MCP `akb_vault_info` inherits; the slim `akb_list_vaults` stays `{name, description}`).

## Why fail-closed on the owner

In the managed model the collector/gardener write **as the tenant who owns the vault**, so an owner-exemption would let exactly the human we mean to protect edit a mirror. The write-subject axis that actually distinguishes services from humans is the token, hence a token allowlist. `vault_scope` (this token can't write outside its scope) and `vault_write_policy` (no other token can write inside this vault) are complementary.

## Safety / rollback

Marking is opt-in: with zero marked vaults this branch changes no behavior on merge. Rollback is data-level — unmark restores prior behavior instantly (the e2e's final unmark→ungranted-write→200 step is that proof).

## Evidence

- 56 write-policy unit tests incl. planted positive controls (JWT-403, owner-403, scoped-admin-403, granted-passes, admin-bypass-emits-audit, unmarked-no-op, akb_sql dual block); full backend suite green.
- Live e2e (`tests/test_vault_write_policy_e2e.sh`) 26/26 GREEN ×3 against a real booted stack, ending in the rollback proof.

## Note for the deployment step (separate)

Grants are issued to service principals only, and a grant confers the full mutating-role set (incl. owner-level ops on that vault) — grant only to fully-trusted principals. This is relevant when vaults are first marked (a later ops step), not at merge.