### PR TITLE
feat(model): enforce managed gateway request identity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3028
+        "line_number": 3071
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-10T13:35:47Z"
+  "generated_at": "2026-07-11T01:20:31Z"
 }

--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ LLM is only used by the `metadata_worker` to auto-tag documents imported via
 external git mirroring. Core CRUD/search works without it. To enable, set
 `llm_base_url` / `llm_model` in `app.yaml` and `llm_api_key` in `secret.yaml`.
 
+Standalone deployments default to `model_api_governance_mode: external_metering`
+and may point embedding, chat, and rerank at any compatible provider. A managed
+control plane can instead set `platform_hard` plus an exact
+`platform_gateway_base_url`. In that mode AKB fails startup if an active model
+route points anywhere else or lacks a credential, and every model call carries
+a caller-generated `Idempotency-Key` for durable gateway reservation/settlement.
+Gateway policy or budget denials are never fanned out into per-item retries.
+
 ### Event fanout (optional)
 
 The PG `events` outbox is always written. Set `redis_url` in `app.yaml` to

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,17 @@ the `akb-mcp` stdio proxy. This changelog tracks the backend
 specifically; the proxy has its own log in
 `packages/akb-mcp-client/CHANGELOG.md` and a separate version stream.
 
+## Unreleased
+
+Standalone model routing remains unchanged under the default
+`external_metering` profile. Managed deployments can opt into
+`platform_hard`, which fails startup unless every active embedding, chat, and
+rerank route exactly matches the declared platform gateway and has a workload
+credential. Each model call supplies a caller-generated idempotency UUID, and
+gateway authentication, policy, route, and budget denials no longer trigger
+embedding batch fan-out. Daily-budget chat denials remain deferred rather than
+permanently abandoning work that can succeed after the cap resets.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AuditSettings(BaseModel):
@@ -117,6 +117,15 @@ class Settings(BaseModel):
     # using larger models (Qwen3-embed-8b = 4096) override in app.yaml.
     embed_dimensions: int = 1536
 
+    # Model API governance. Standalone deployments retain direct-provider
+    # behavior by default. Managed platform deployments opt into the hard
+    # profile and declare the exact gateway base URL that every active model
+    # route must use; startup rejects a direct-provider escape.
+    model_api_governance_mode: Literal[
+        "external_metering", "platform_hard"
+    ] = "external_metering"
+    platform_gateway_base_url: str = ""
+
     # LLM — optional. Only consumed by metadata_worker (auto-tagging
     # external_git imports). When unset, metadata_worker stays disabled
     # and core CRUD/search keeps working.
@@ -140,6 +149,44 @@ class Settings(BaseModel):
     # the legacy behavior (prefetch only when rerank is enabled). Raising this
     # lets rerank-off searches dedup over a wider dense+BM25 candidate set.
     search_prefetch: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_model_api_governance(self) -> "Settings":
+        if self.model_api_governance_mode != "platform_hard":
+            return self
+
+        gateway = self.platform_gateway_base_url.strip().rstrip("/")
+        if not gateway:
+            raise ValueError(
+                "platform_gateway_base_url is required in platform_hard mode"
+            )
+
+        routes = [
+            ("embed_base_url", self.embed_base_url, "embed_api_key", self.embed_api_key),
+        ]
+        if self.llm_base_url:
+            routes.append(
+                ("llm_base_url", self.llm_base_url, "llm_api_key", self.llm_api_key)
+            )
+        if self.rerank_enabled:
+            routes.append(
+                (
+                    "rerank_base_url",
+                    self.rerank_base_url or self.llm_base_url,
+                    "rerank_api_key",
+                    self.rerank_api_key or self.llm_api_key,
+                )
+            )
+
+        for url_name, url, key_name, key in routes:
+            if not url or url.strip().rstrip("/") != gateway:
+                raise ValueError(
+                    f"{url_name} must exactly match platform_gateway_base_url "
+                    "in platform_hard mode"
+                )
+            if not key.strip():
+                raise ValueError(f"{key_name} is required in platform_hard mode")
+        return self
 
     # Hard server-side ceiling on a search/grep `limit`. The MCP tool schema
     # advertises max 50 but that is client-side only — a direct REST call or a

--- a/backend/app/services/index_service.py
+++ b/backend/app/services/index_service.py
@@ -18,7 +18,7 @@ from typing import Literal
 import httpx
 
 from app.config import settings
-from app.services import http_pool
+from app.services import http_pool, model_gateway
 
 logger = logging.getLogger("akb.index")
 
@@ -342,16 +342,12 @@ async def _embed_call(
     Returns (status, embeddings, detail):
       - status='ok'        + embeddings filled
       - status='transient' + None: 5xx / network / timeout — retry later
-      - status='permanent' + None: 4xx — almost always one bad input in
-        the batch (oversize, wrong content type). Caller should fall
-        back to per-item to isolate the offender.
+      - status='permanent' + None: input-specific 4xx; caller may split.
+      - status='rejected'  + None: auth, policy, budget, or route denial;
+        caller must not fan the same denied batch out into per-item calls.
     `detail` is a short human-readable string suffix for logs/errors.
     """
-    headers = (
-        {"Authorization": f"Bearer {settings.embed_api_key}"}
-        if settings.embed_api_key
-        else {}
-    )
+    headers = model_gateway.request_headers(settings.embed_api_key)
     # Send `dimensions` so MRL-capable models (qwen3-embedding-8b native
     # 4096, text-embedding-3-* native 3072) truncate to the deployed
     # vector schema dim. Native-dim models (bge-m3@1024) accept it as a
@@ -371,10 +367,16 @@ async def _embed_call(
     except (httpx.ConnectError, httpx.TimeoutException, httpx.UnsupportedProtocol) as e:
         return "transient", None, f"{type(e).__name__}: {e}"
 
-    if resp.status_code >= 500:
+    hard_mode = settings.model_api_governance_mode == "platform_hard"
+    if resp.status_code >= 500 or (
+        hard_mode and resp.status_code in (408, 409, 425, 429)
+    ):
         return "transient", None, f"HTTP {resp.status_code}: {resp.text[:160]}"
     if resp.status_code >= 400:
-        return "permanent", None, f"HTTP {resp.status_code}: {resp.text[:160]}"
+        status = "permanent"
+        if hard_mode and resp.status_code not in (400, 413):
+            status = "rejected"
+        return status, None, f"HTTP {resp.status_code}: {resp.text[:160]}"
 
     try:
         data = resp.json()
@@ -419,10 +421,11 @@ async def generate_embeddings(
     indexing worker treats those as per-chunk failures and increments
     the per-row retry counter, instead of failing the whole batch.
 
-    On a 4xx batch failure the call falls back to per-item requests so
-    one oversize / malformed input can't poison its 31 batchmates. On a
-    transient (5xx / network / timeout) failure the whole batch is left
-    empty and the worker's normal retry/backoff handles it.
+    On an input-specific 400/413 batch failure (and legacy standalone 422)
+    the call falls back to per-item requests so one oversize / malformed input
+    can't poison its 31 batchmates. Managed authentication, policy, route,
+    price, and budget denials never fan out. On a transient failure the whole
+    batch is left empty and the worker's normal retry/backoff handles it.
     """
     if not texts:
         return []
@@ -439,15 +442,15 @@ async def generate_embeddings(
             out.extend(embs)
             continue
 
-        if status == "transient":
+        if status in ("transient", "rejected"):
             logger.warning(
-                "Embedding API transient failure on batch of %d: %s",
-                len(batch), detail,
+                "Embedding API %s failure on batch of %d: %s",
+                status, len(batch), detail,
             )
             out.extend([[] for _ in batch])
             continue
 
-        # Permanent (4xx) or shape mismatch — fall back to per-item so
+        # Input-specific permanent failure or shape mismatch — fall back so
         # only the truly bad input(s) get marked as failed.
         logger.warning(
             "Embedding API rejected batch of %d (%s); isolating per-item",
@@ -578,5 +581,3 @@ async def write_source_chunks(
             chunk.chunk_index, chunk.char_start, chunk.char_end,
         )
     return len(chunks)
-
-

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -14,7 +14,7 @@ from typing import Any
 
 
 from app.config import settings
-from app.services import http_pool
+from app.services import http_pool, model_gateway
 
 logger = logging.getLogger("akb.llm")
 
@@ -66,9 +66,7 @@ async def chat_json(
     }
     if disable_reasoning:
         payload["reasoning"] = {"enabled": False}
-    headers = {}
-    if settings.llm_api_key:
-        headers["Authorization"] = f"Bearer {settings.llm_api_key}"
+    headers = model_gateway.request_headers(settings.llm_api_key)
 
     client = http_pool.get_client()
     resp = await client.post(
@@ -77,6 +75,13 @@ async def chat_json(
         timeout=timeout,
     )
     if resp.status_code >= 400:
+        hard_mode = settings.model_api_governance_mode == "platform_hard"
+        if hard_mode and 400 <= resp.status_code < 500 and resp.status_code not in (
+            402, 408, 409, 425, 429,
+        ):
+            raise LLMPermanentError(
+                f"LLM HTTP {resp.status_code}: {resp.text[:200]}"
+            )
         raise LLMError(f"LLM HTTP {resp.status_code}: {resp.text[:200]}")
     data = resp.json()
 

--- a/backend/app/services/model_gateway.py
+++ b/backend/app/services/model_gateway.py
@@ -1,0 +1,21 @@
+"""Shared request identity for managed model API calls."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.config import settings
+
+
+def request_headers(api_key: str) -> dict[str, str]:
+    """Build provider headers without changing standalone compatibility.
+
+    The UUID is created once per logical SDK/HTTP call. A transport that retries
+    the same call reuses the header map, while a distinct call gets a new ID.
+    """
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if settings.model_api_governance_mode == "platform_hard":
+        headers["Idempotency-Key"] = str(uuid.uuid4())
+    return headers

--- a/backend/app/services/rerank_service.py
+++ b/backend/app/services/rerank_service.py
@@ -29,7 +29,7 @@ import httpx
 
 from app.config import settings
 from app.exceptions import AKBError
-from app.services import http_pool
+from app.services import http_pool, model_gateway
 
 logger = logging.getLogger("akb.rerank")
 
@@ -71,7 +71,7 @@ async def rerank(
         resp = await client.post(
             f"{base_url}/rerank",
             json=payload,
-            headers={"Authorization": f"Bearer {api_key}"},
+            headers=model_gateway.request_headers(api_key),
             timeout=settings.rerank_timeout_seconds,
         )
         resp.raise_for_status()

--- a/backend/tests/test_model_gateway_governance.py
+++ b/backend/tests/test_model_gateway_governance.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings, settings
+from app.services import http_pool, index_service, llm_service, rerank_service
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = "response"
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+
+            request = httpx.Request("POST", "https://gateway.example/v1")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("rejected", request=request, response=response)
+
+
+class _Client:
+    def __init__(self, responses: list[_Response]):
+        self.responses = responses
+        self.calls: list[dict] = []
+
+    async def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self.responses.pop(0)
+
+
+def _set_hard_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "model_api_governance_mode", "platform_hard")
+    monkeypatch.setattr(
+        settings, "platform_gateway_base_url", "https://gateway.example/v1"
+    )
+    monkeypatch.setattr(settings, "embed_base_url", "https://gateway.example/v1")
+    monkeypatch.setattr(settings, "embed_api_key", "gw_test")
+    monkeypatch.setattr(settings, "llm_base_url", "https://gateway.example/v1")
+    monkeypatch.setattr(settings, "llm_api_key", "gw_test")
+    monkeypatch.setattr(settings, "rerank_enabled", True)
+    monkeypatch.setattr(settings, "rerank_base_url", "")
+    monkeypatch.setattr(settings, "rerank_api_key", "")
+
+
+def _assert_managed_idempotency_key(call: dict) -> None:
+    value = call["headers"].get("Idempotency-Key")
+    assert value
+    assert str(uuid.UUID(value)) == value
+
+
+def test_platform_hard_config_rejects_direct_or_uncredentialed_model_routes():
+    with pytest.raises(ValidationError, match="embed_base_url"):
+        Settings(
+            model_api_governance_mode="platform_hard",
+            platform_gateway_base_url="https://gateway.example/v1",
+            embed_base_url="https://api.openai.com/v1",
+            embed_api_key="gw_test",
+        )
+
+    with pytest.raises(ValidationError, match="embed_api_key"):
+        Settings(
+            model_api_governance_mode="platform_hard",
+            platform_gateway_base_url="https://gateway.example/v1",
+            embed_base_url="https://gateway.example/v1/",
+        )
+
+    configured = Settings(
+        model_api_governance_mode="platform_hard",
+        platform_gateway_base_url="https://gateway.example/v1/",
+        embed_base_url="https://gateway.example/v1",
+        embed_api_key="gw_test",
+        llm_base_url="https://gateway.example/v1",
+        llm_api_key="gw_test",
+        rerank_enabled=True,
+    )
+    assert configured.model_api_governance_mode == "platform_hard"
+
+    standalone = Settings(
+        model_api_governance_mode="external_metering",
+        embed_base_url="https://api.openai.com/v1",
+    )
+    assert standalone.embed_base_url == "https://api.openai.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_platform_hard_model_calls_send_one_caller_generated_identity(monkeypatch):
+    _set_hard_mode(monkeypatch)
+
+    embed_client = _Client([_Response(200, {"data": [{"index": 0, "embedding": [1.0]}]})])
+    status, embeddings, _ = await index_service._embed_call(embed_client, ["text"], 5.0)
+    assert status == "ok" and embeddings == [[1.0]]
+    _assert_managed_idempotency_key(embed_client.calls[0])
+
+    chat_client = _Client([_Response(200, {
+        "choices": [{"message": {"content": "{\"ok\": true}"}, "finish_reason": "stop"}]
+    })])
+    monkeypatch.setattr(http_pool, "get_client", lambda: chat_client)
+    assert await llm_service.chat_json(system="system", user="user") == {"ok": True}
+    _assert_managed_idempotency_key(chat_client.calls[0])
+
+    rerank_client = _Client([_Response(200, {
+        "results": [{"index": 0, "relevance_score": 0.9}]
+    })])
+    monkeypatch.setattr(http_pool, "get_client", lambda: rerank_client)
+    assert await rerank_service.rerank("query", ["document"]) == [(0, 0.9)]
+    _assert_managed_idempotency_key(rerank_client.calls[0])
+
+
+@pytest.mark.asyncio
+async def test_external_metering_preserves_header_compatibility(monkeypatch):
+    monkeypatch.setattr(settings, "model_api_governance_mode", "external_metering")
+    client = _Client([_Response(200, {"data": [{"index": 0, "embedding": [1.0]}]})])
+
+    status, _, _ = await index_service._embed_call(client, ["text"], 5.0)
+
+    assert status == "ok"
+    assert "Idempotency-Key" not in client.calls[0]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_external_metering_preserves_legacy_4xx_classification(monkeypatch):
+    monkeypatch.setattr(settings, "model_api_governance_mode", "external_metering")
+    embed_client = _Client([_Response(401)])
+    status, _, _ = await index_service._embed_call(embed_client, ["text"], 5.0)
+    assert status == "permanent"
+
+    monkeypatch.setattr(settings, "llm_base_url", "https://api.openai.com/v1")
+    chat_client = _Client([_Response(403)])
+    monkeypatch.setattr(http_pool, "get_client", lambda: chat_client)
+    with pytest.raises(llm_service.LLMError) as caught:
+        await llm_service.chat_json(system="system", user="user")
+    assert not isinstance(caught.value, llm_service.LLMPermanentError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 402, 403, 404, 409, 422, 428])
+async def test_embedding_governance_rejection_does_not_fan_out_batch(
+    monkeypatch, status_code
+):
+    _set_hard_mode(monkeypatch)
+    client = _Client([_Response(status_code)])
+    monkeypatch.setattr(http_pool, "get_client", lambda: client)
+
+    embeddings = await index_service.generate_embeddings(["one", "two"])
+
+    assert embeddings == [[], []]
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_budget_denial_remains_deferred_instead_of_abandoned(monkeypatch):
+    _set_hard_mode(monkeypatch)
+    client = _Client([_Response(402)])
+    monkeypatch.setattr(http_pool, "get_client", lambda: client)
+
+    with pytest.raises(llm_service.LLMError, match="HTTP 402") as caught:
+        await llm_service.chat_json(system="system", user="user")
+
+    assert not isinstance(caught.value, llm_service.LLMPermanentError)
+    assert len(client.calls) == 1

--- a/backend/tests/test_model_gateway_governance.py
+++ b/backend/tests/test_model_gateway_governance.py
@@ -43,9 +43,9 @@ def _set_hard_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         settings, "platform_gateway_base_url", "https://gateway.example/v1"
     )
     monkeypatch.setattr(settings, "embed_base_url", "https://gateway.example/v1")
-    monkeypatch.setattr(settings, "embed_api_key", "gw_test")
+    monkeypatch.setattr(settings, "embed_api_key", "gw_test")  # pragma: allowlist secret
     monkeypatch.setattr(settings, "llm_base_url", "https://gateway.example/v1")
-    monkeypatch.setattr(settings, "llm_api_key", "gw_test")
+    monkeypatch.setattr(settings, "llm_api_key", "gw_test")  # pragma: allowlist secret
     monkeypatch.setattr(settings, "rerank_enabled", True)
     monkeypatch.setattr(settings, "rerank_base_url", "")
     monkeypatch.setattr(settings, "rerank_api_key", "")
@@ -63,7 +63,7 @@ def test_platform_hard_config_rejects_direct_or_uncredentialed_model_routes():
             model_api_governance_mode="platform_hard",
             platform_gateway_base_url="https://gateway.example/v1",
             embed_base_url="https://api.openai.com/v1",
-            embed_api_key="gw_test",
+            embed_api_key="gw_test",  # pragma: allowlist secret
         )
 
     with pytest.raises(ValidationError, match="embed_api_key"):
@@ -77,9 +77,9 @@ def test_platform_hard_config_rejects_direct_or_uncredentialed_model_routes():
         model_api_governance_mode="platform_hard",
         platform_gateway_base_url="https://gateway.example/v1/",
         embed_base_url="https://gateway.example/v1",
-        embed_api_key="gw_test",
+        embed_api_key="gw_test",  # pragma: allowlist secret
         llm_base_url="https://gateway.example/v1",
-        llm_api_key="gw_test",
+        llm_api_key="gw_test",  # pragma: allowlist secret
         rerank_enabled=True,
     )
     assert configured.model_api_governance_mode == "platform_hard"

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -31,6 +31,12 @@ embed_base_url: https://api.openai.com/v1
 embed_model: text-embedding-3-small
 embed_dimensions: 1536
 
+# Standalone default keeps direct-provider routing. A managed akb-platform
+# deployment sets platform_hard plus the exact gateway URL; startup then rejects
+# any active embed/LLM/rerank route that points elsewhere or lacks a credential.
+model_api_governance_mode: external_metering  # external_metering | platform_hard
+platform_gateway_base_url: ""
+
 # === LLM (optional) ===
 # Only used by metadata_worker to auto-tag external_git imports.
 # Leave empty to disable that worker; core CRUD/search keeps working.

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -18,11 +18,13 @@ jwt_secret: dev-only-change-me-before-deploying-anywhere-real
 keycloak_client_secret: ""
 
 # === Embedding API key (required) ===
-# Provider key for `embed_base_url` in app.yaml.
+# Provider key for `embed_base_url` in app.yaml. In platform_hard mode this is
+# the workload's platform gateway credential, not the upstream provider key.
 embed_api_key: ""
 
 # === LLM API key (optional) ===
-# Only needed if `llm_base_url` in app.yaml is set.
+# Only needed if `llm_base_url` in app.yaml is set. In platform_hard mode this
+# is the workload's platform gateway credential.
 llm_api_key: ""
 
 # === Reranker API key (optional) ===


### PR DESCRIPTION
## Summary\n- add standalone-safe external_metering and fail-closed platform_hard model routing profiles\n- require exact managed gateway URLs/credentials and send caller-generated Idempotency-Key on embedding, chat, and rerank calls\n- prevent managed gateway policy/budget errors from fanning embedding batches into duplicate calls while preserving standalone 4xx behavior\n\n## Verification\n- uv run pytest tests/test_model_gateway_governance.py -q (12 passed)\n- uv run pytest tests/test_search_rerank_fusion.py -q (14 passed)\n- uv run pytest tests/concurrency/test_invariants_unit.py -k embed_index_reorder -q (1 passed)\n- uv run pytest tests/test_auth_config_shape_unit.py -q (3 passed)\n- uv run ruff check .\n- uv run mypy --python-version 3.14 app/ mcp_server/\n- uv run bandit -r app/ mcp_server/ -c pyproject.toml --severity-level medium -q\n\n## Rollout\nDeploy this AKB backend before enabling downstream platform's managed hard gateway profile. Existing standalone configurations remain on external_metering by default.