### PR TITLE
fix(auth): return account errors to companion apps

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3071
+        "line_number": 3076
       }
     ],
     "backend/mcp_server/help.py": [

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -16,6 +16,11 @@ gateway authentication, policy, route, and budget denials no longer trigger
 embedding batch fan-out. Daily-budget chat denials remain deferred rather than
 permanently abandoning work that can succeed after the cap resets.
 
+Allowlisted companion applications now receive stable AKB account-denial and
+post-state SSO protocol codes on their original callback URL. The callback
+origin is revalidated before every error redirect; unlisted or stale targets
+still return only to AKB's own auth page.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -207,6 +207,19 @@ def _post_login_target(redirect: str | None, one_time_code: str) -> str:
     )
 
 
+def _post_login_error_target(redirect: str | None, reason: str) -> str:
+    """Return a failed post-login navigation to its trusted companion.
+
+    Only a flow whose stored redirect still matches the current companion
+    allowlist may leave AKB's own origin. The stable reason is appended while
+    preserving the companion's state-bearing completion query. Everything else
+    returns to AKB's local auth page.
+    """
+    if _allowed_companion_origin(redirect) is not None:
+        return _with_query_param(redirect, "sso_error", reason)  # type: ignore[arg-type]
+    return f"/auth?sso_error={urllib.parse.quote(reason, safe='')}"
+
+
 @router.get(
     "/auth/keycloak/login",
     response_class=RedirectResponse,
@@ -257,13 +270,13 @@ async def keycloak_callback(request: Request):
         tokens = await svc.exchange_code_for_tokens(code, flow.get("code_verifier"))
         id_token = tokens.get("id_token")
         if not id_token:
-            return _sso_error_redirect("no_id_token")
+            return _sso_error_redirect("no_id_token", flow.get("redirect_path"))
         claims = await svc.verify_id_token(id_token)
         login_response = await login_with_keycloak_claims(claims)
     except AKBError as e:
         # Don't leak detail into the URL; log server-side, show a code.
         logger.warning("Keycloak SSO callback failed: %s", e)
-        return _sso_error_redirect(_public_sso_error_reason(e))
+        return _sso_error_redirect(_public_sso_error_reason(e), flow.get("redirect_path"))
 
     # Hand the SPA a one-time code; the token is delivered via POST /exchange.
     # Stash the Keycloak id_token too so the SPA can pass it back as
@@ -310,11 +323,11 @@ async def keycloak_exchange(req: KeycloakExchangeRequest):
     return result
 
 
-def _sso_error_redirect(reason: str) -> RedirectResponse:
+def _sso_error_redirect(reason: str, redirect: str | None = None) -> RedirectResponse:
     """Bounce a failed SSO browser navigation back to the login page with a
     short reason code the SPA can surface (avoids dumping JSON at the user)."""
     return RedirectResponse(
-        f"/auth?sso_error={urllib.parse.quote(reason, safe='')}",
+        _post_login_error_target(redirect, reason),
         status_code=status.HTTP_302_FOUND,
     )
 

--- a/backend/tests/test_keycloak_redirect_unit.py
+++ b/backend/tests/test_keycloak_redirect_unit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import urllib.parse
 
 import pytest
+from starlette.requests import Request
 
 from app.api.routes import auth
 from app.config import settings
@@ -152,3 +153,117 @@ def test_target_unlisted_absolute_collapses_to_root(allow):
     assert target.startswith(settings.keycloak_post_login_path + "?")
     q = urllib.parse.parse_qs(urllib.parse.urlsplit(target).query)
     assert q["redirect"] == ["/"]
+
+
+# ── failed companion callback target ────────────────────────────────
+
+
+def test_error_target_companion_gets_stable_code_and_preserves_query(allow):
+    allow(["https://reef.example.com"])
+    target = auth._post_login_error_target(
+        "https://reef.example.com/api/auth/akb/sso/callback?redirect=%2Fdone",
+        "membership_required",
+    )
+    parts = urllib.parse.urlsplit(target)
+    assert f"{parts.scheme}://{parts.netloc}" == "https://reef.example.com"
+    assert parts.path == "/api/auth/akb/sso/callback"
+    assert urllib.parse.parse_qs(parts.query) == {
+        "redirect": ["/done"],
+        "sso_error": ["membership_required"],
+    }
+
+
+def test_error_target_unlisted_absolute_never_leaves_akb(allow):
+    allow(["https://reef.example.com"])
+    target = auth._post_login_error_target(
+        "https://evil.example.com/steal", "membership_required"
+    )
+    assert target == "/auth?sso_error=membership_required"
+
+
+@pytest.mark.asyncio
+async def test_callback_returns_account_error_to_allowed_companion(allow, monkeypatch):
+    from app.exceptions import MembershipRequiredError
+    from app.services import keycloak_oidc
+
+    companion = (
+        "https://reef.example.com/api/auth/akb/sso/callback"
+        "?redirect=%2Flogin%2Fsso-complete%3Fstate%3Dn-1%26next%3D%252Fissues"
+    )
+    allow(["https://reef.example.com"])
+    monkeypatch.setattr(auth, "_require_keycloak", lambda: None)
+
+    class FakeOIDC:
+        async def consume_state(self, state):
+            assert state == "state-1"
+            return {"code_verifier": "verifier", "redirect_path": companion}
+
+        async def exchange_code_for_tokens(self, code, verifier):
+            assert (code, verifier) == ("code-1", "verifier")
+            return {"id_token": "id-token"}
+
+        async def verify_id_token(self, token):
+            assert token == "id-token"
+            return {"sub": "subject-1"}
+
+    async def reject_membership(_claims):
+        raise MembershipRequiredError()
+
+    monkeypatch.setattr(keycloak_oidc, "get_keycloak_oidc", lambda: FakeOIDC())
+    monkeypatch.setattr(auth, "login_with_keycloak_claims", reject_membership)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "https",
+            "server": ("akb.example.com", 443),
+            "path": "/api/v1/auth/keycloak/callback",
+            "query_string": b"code=code-1&state=state-1",
+            "headers": [],
+        }
+    )
+
+    response = await auth.keycloak_callback(request)
+
+    location = response.headers["location"]
+    parts = urllib.parse.urlsplit(location)
+    assert f"{parts.scheme}://{parts.netloc}" == "https://reef.example.com"
+    assert urllib.parse.parse_qs(parts.query)["sso_error"] == ["membership_required"]
+
+
+@pytest.mark.asyncio
+async def test_callback_returns_post_state_protocol_error_to_allowed_companion(
+    allow, monkeypatch
+):
+    from app.services import keycloak_oidc
+
+    companion = "https://reef.example.com/cb?redirect=%2Fdone"
+    allow(["https://reef.example.com"])
+    monkeypatch.setattr(auth, "_require_keycloak", lambda: None)
+
+    class FakeOIDC:
+        async def consume_state(self, _state):
+            return {"code_verifier": "verifier", "redirect_path": companion}
+
+        async def exchange_code_for_tokens(self, _code, _verifier):
+            return {}
+
+    monkeypatch.setattr(keycloak_oidc, "get_keycloak_oidc", lambda: FakeOIDC())
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "https",
+            "server": ("akb.example.com", 443),
+            "path": "/api/v1/auth/keycloak/callback",
+            "query_string": b"code=code-1&state=state-1",
+            "headers": [],
+        }
+    )
+
+    response = await auth.keycloak_callback(request)
+
+    location = response.headers["location"]
+    parts = urllib.parse.urlsplit(location)
+    assert f"{parts.scheme}://{parts.netloc}" == "https://reef.example.com"
+    assert urllib.parse.parse_qs(parts.query)["sso_error"] == ["no_id_token"]

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -138,7 +138,8 @@ jwt_expire_hours: 24
 # keycloak_post_login_allowed_origins: []   # companion-app origins allowed to receive the SSO
 #                                           # one-time code, e.g. ["https://reef-acme.example.com"].
 #                                           # Lets a first-party app (reef) ride this akb's Keycloak
-#                                           # client and get the code back on ITS origin. Empty =
+#                                           # client and get the one-time code or a stable account
+#                                           # error back on ITS origin. Empty =
 #                                           # akb's own SPA only (open-redirect-safe default).
 # keycloak_exchange_code_ttl_secs: 60
 # keycloak_client_secret lives in secret.yaml (never commit it)


### PR DESCRIPTION
## Summary
- return stable account-denial codes to an allowlisted companion callback
- preserve the companion completion query while revalidating its origin
- keep untrusted and pre-state failures on AKB local auth

## Verification
- 26 Keycloak redirect unit tests
- backend unit suite: 799 passed, 19 skipped, 7 deselected
- ruff, mypy, and Bandit passed