### PR TITLE
fix(mcp): preserve vault access roles

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3076
+        "line_number": 3082
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-11T01:20:31Z"
+  "generated_at": "2026-07-12T07:21:25Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -21,6 +21,12 @@ post-state SSO protocol codes on their original callback URL. The callback
 origin is revalidated before every error redirect; unlisted or stale targets
 still return only to AKB's own auth page.
 
+The compact MCP `akb_list_vaults` response now preserves each vault's effective
+`role` alongside its name and description. This aligns the implementation with
+the documented MCP contract and lets managed runtimes distinguish an explicit
+writer grant from legacy role-less access without expanding to full REST vault
+metadata.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -63,6 +63,7 @@ from app.repositories.document_repo import DocumentRepository
 from mcp_server.tools import TOOLS
 from mcp_server.help import _resolve_help
 from mcp_server.instructions import INSTRUCTIONS
+from mcp_server.vault_contract import project_accessible_vault
 from app.services import audit_log
 
 
@@ -310,9 +311,9 @@ async def _handle_help(args: dict, uid: str, user: _MCPUser) -> dict:
 
 @_h("akb_list_vaults")
 async def _handle_list_vaults(args: dict, uid: str, user: _MCPUser) -> dict:
-    # Slim {name, description} only — full metadata bloats the payload
-    # past the agent client's truncate cap in large tenants. REST
-    # callers that need full rows use `GET /api/v1/vaults`.
+    # Keep the slim MCP shape so large tenants stay below the agent client's
+    # truncate cap, but preserve role because it is authorization metadata.
+    # REST callers that need full rows use `GET /api/v1/vaults`.
     vaults = await list_accessible_vaults(uid)
     include_archived = args.get("include_archived")
     needle = _filter_arg(args)
@@ -325,7 +326,7 @@ async def _handle_list_vaults(args: dict, uid: str, user: _MCPUser) -> dict:
         description = v.get("description") or ""
         if needle and needle not in name.lower() and needle not in description.lower():
             continue
-        slim.append({"name": name, "description": description})
+        slim.append(project_accessible_vault(v))
 
     return _paginate(slim, args, items_key="vaults")
 

--- a/backend/mcp_server/vault_contract.py
+++ b/backend/mcp_server/vault_contract.py
@@ -1,0 +1,15 @@
+"""Stable MCP projections for AKB vault access metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def project_accessible_vault(vault: dict[str, Any]) -> dict[str, str | None]:
+    """Keep the compact vault list shape without discarding access semantics."""
+    role = vault.get("role")
+    return {
+        "name": vault["name"],
+        "description": vault.get("description") or "",
+        "role": role if isinstance(role, str) else None,
+    }

--- a/backend/tests/test_mcp_vault_list_contract_unit.py
+++ b/backend/tests/test_mcp_vault_list_contract_unit.py
@@ -1,0 +1,42 @@
+"""Contract tests for the role-aware ``akb_list_vaults`` projection."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from mcp_server.vault_contract import project_accessible_vault
+
+
+def test_accessible_vault_projection_preserves_the_callers_effective_role():
+    result = project_accessible_vault(
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "gdn-state",
+            "description": "Managed gardener state",
+            "status": "active",
+            "role": "writer",
+            "created_at": "2026-07-12T00:00:00+00:00",
+        }
+    )
+
+    assert result == {
+        "name": "gdn-state",
+        "description": "Managed gardener state",
+        "role": "writer",
+    }
+
+
+def test_list_vaults_handler_uses_the_role_aware_projection():
+    server_py = Path(__file__).resolve().parents[1] / "mcp_server" / "server.py"
+    tree = ast.parse(server_py.read_text())
+    handler = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "_handle_list_vaults"
+    )
+
+    calls = {
+        node.func.id for node in ast.walk(handler) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "project_accessible_vault" in calls


### PR DESCRIPTION
## Summary
- preserve each caller-visible vault role in the compact `akb_list_vaults` response
- centralize the slim MCP projection so payload size stays bounded without discarding authorization semantics
- add a regression contract and document the additive response field

## Root cause
`list_accessible_vaults` and the MCP help contract exposed `role`, but `_handle_list_vaults` projected only `name` and `description`. Managed Pipeline runtimes therefore observed explicit writer grants as legacy role-less access and correctly failed closed.

## Verification
- `uv run --extra dev pytest -q` (`803 passed, 24 skipped`)
- `uv run --extra dev mypy mcp_server/vault_contract.py tests/test_mcp_vault_list_contract_unit.py`
- `uv run --extra dev ruff check mcp_server/server.py mcp_server/vault_contract.py tests/test_mcp_vault_list_contract_unit.py`
- `uv run --extra dev ruff format --check mcp_server/vault_contract.py tests/test_mcp_vault_list_contract_unit.py`