### PR TITLE
feat(auth): resolve legacy human by exact email

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3082
+        "line_number": 3089
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-12T07:21:25Z"
+  "generated_at": "2026-07-13T14:09:24Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -27,6 +27,13 @@ the documented MCP contract and lets managed runtimes distinguish an explicit
 writer grant from legacy role-less access without expanding to full REST vault
 metadata.
 
+Managed account migration can now resolve one existing human user by exact
+normalized email through an explicit administrator read endpoint. The endpoint
+does not create, bind, activate, or mutate an account, excludes service users,
+and reports whether the human already has an external identity so the control
+plane can reject unsafe legacy joins and offboard a local-only member without
+inventing an IdP account.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -15,6 +15,7 @@ from app.services.account_service import (
     ensure_human_external_identity,
     ensure_service_user,
     get_user,
+    get_human_user_by_email,
     get_user_by_external_identity,
     identify_user_token,
     revoke_user_token,
@@ -299,6 +300,18 @@ async def admin_prepare_external_identity(
         prepare_suspended=True,
         actor_id=user.user_id,
     )
+
+
+@router.get(
+    "/admin/users/by-email",
+    summary="[admin] Resolve one existing human user by exact email",
+)
+async def admin_get_human_user_by_email(
+    email: str = Query(...),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await get_human_user_by_email(email)
 
 
 @router.get(

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -518,6 +518,27 @@ async def get_user(user_id: str) -> dict:
     return _user_result(row)
 
 
+async def get_human_user_by_email(email: str) -> dict:
+    normalized_email = _required(email, "email").lower()
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT u.id, u.username, u.email, u.display_name, u.is_admin,
+                   u.auth_provider, u.account_status, u.account_kind,
+                   EXISTS (
+                       SELECT 1 FROM external_identities e WHERE e.user_id = u.id
+                   ) AS has_external_identity
+              FROM users u
+             WHERE u.email = $1 AND u.account_kind = 'human'
+            """,
+            normalized_email,
+        )
+    if row is None:
+        raise NotFoundError("Human user", normalized_email)
+    return {**_user_result(row), "has_external_identity": row["has_external_identity"]}
+
+
 async def get_user_by_external_identity(issuer: str, subject: str) -> dict:
     pool = await get_pool()
     async with pool.acquire() as conn:

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -85,6 +85,35 @@ async def test_ensure_external_identity_forwards_verified_actor(monkeypatch):
     }
 
 
+async def test_exact_human_email_lookup_is_admin_only(monkeypatch):
+    from app.api.routes import access
+
+    observed = []
+
+    async def _resolve(email):
+        observed.append(email)
+        return {
+            "user_id": "legacy-user",
+            "email": "legacy@example.com",
+            "account_kind": "human",
+            "has_external_identity": False,
+        }
+
+    monkeypatch.setattr(access, "get_human_user_by_email", _resolve)
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_get_human_user_by_email(
+            "legacy@example.com", _user(admin=False)
+        )
+    assert exc_info.value.status_code == 403
+    assert observed == []
+
+    result = await access.admin_get_human_user_by_email(
+        " Legacy@Example.com ", _user(admin=True)
+    )
+    assert result["user_id"] == "legacy-user"
+    assert observed == [" Legacy@Example.com "]
+
+
 async def test_prepare_external_identity_uses_distinct_fail_closed_route(monkeypatch):
     from app.api.routes import access
 
@@ -244,6 +273,7 @@ async def test_governance_routes_are_explicit_in_openapi():
     expected = {
         "/api/v1/admin/users/ensure-external-identity",
         "/api/v1/admin/users/prepare-external-identity",
+        "/api/v1/admin/users/by-email",
         "/api/v1/admin/users/by-external-identity",
         "/api/v1/admin/users/{user_id}/governance",
         "/api/v1/admin/service-users/ensure",

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -125,6 +125,79 @@ async def test_ensure_human_binding_is_idempotent_and_never_bootstrap_admin(serv
     }
 
 
+async def test_exact_email_lookup_returns_only_existing_human(services):
+    pool, _, service = services
+    user_id = uuid.uuid4()
+    email = f"governance-legacy-{uuid.uuid4().hex[:10]}@example.com"
+    username = f"governance-{uuid.uuid4().hex}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, display_name,
+                is_admin, auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, '!legacy!', 'Legacy member',
+                      false, 'local', 'active', 'human')
+            """,
+            user_id,
+            username,
+            email,
+        )
+
+    resolved = await service.get_human_user_by_email(f"  {email.upper()}  ")
+
+    assert resolved == {
+        "user_id": str(user_id),
+        "username": username,
+        "email": email,
+        "display_name": "Legacy member",
+        "is_admin": False,
+        "account_status": "active",
+        "account_kind": "human",
+        "auth_provider": "local",
+        "has_external_identity": False,
+    }
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO external_identities (user_id, issuer, subject, email_snapshot)
+            VALUES ($1, $2, $3, $4)
+            """,
+            user_id,
+            "https://id.example.com/realms/akb",
+            f"subject-{uuid.uuid4()}",
+            email,
+        )
+
+    bound = await service.get_human_user_by_email(email)
+    assert bound["user_id"] == str(user_id)
+    assert bound["has_external_identity"] is True
+
+
+async def test_exact_email_lookup_does_not_return_service_identity(services):
+    pool, _, service = services
+    email = f"governance-service-{uuid.uuid4().hex[:10]}@example.com"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, display_name,
+                is_admin, auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, '!service!', 'Service',
+                      false, 'service', 'active', 'service')
+            """,
+            uuid.uuid4(),
+            f"governance-{uuid.uuid4().hex}",
+            email,
+        )
+
+    from app.exceptions import NotFoundError
+
+    with pytest.raises(NotFoundError):
+        await service.get_human_user_by_email(email)
+
+
 async def test_prepare_human_binding_is_suspended_atomically_and_not_reactivated_by_default(
     services,
 ):


### PR DESCRIPTION
## Summary
- add an admin-only exact normalized-email lookup for existing human accounts
- return account governance fields plus the external-identity binding signal
- keep migration lookup read-only and exclude service identities

## Tests
- full backend pytest: 804 passed, 19 skipped
- repository static, type, frontend/client test, generated drift, and secret gates
- focused account route/service tests: 31 passed