### PR TITLE
feat(auth): expose managed account readiness state

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3089
+        "line_number": 3098
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T14:09:24Z"
+  "generated_at": "2026-07-13T19:48:03Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -34,6 +34,15 @@ and reports whether the human already has an external identity so the control
 plane can reject unsafe legacy joins and offboard a local-only member without
 inventing an IdP account.
 
+Managed orchestrators can now call the read-only administrator
+`/admin/managed-account-state` endpoint with their expected active AKB user IDs
+and configured-issuer subjects. AKB compares that intent with all active human
+accounts in one PostgreSQL snapshot and separately reports whether the running
+server has the complete invite-only/local-auth-disabled profile. The response
+contains only counts and stable issue codes; it never returns email, subject,
+password, token, or credential material. Standalone defaults and ordinary
+`/readyz` behavior are unchanged.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -16,6 +16,7 @@ from app.services.account_service import (
     ensure_service_user,
     get_user,
     get_human_user_by_email,
+    get_managed_account_state,
     get_user_by_external_identity,
     identify_user_token,
     revoke_user_token,
@@ -102,6 +103,16 @@ class SetUserRoleRequest(NFCModel):
 
 class IdentifyTokenRequest(NFCModel):
     token: SecretStr
+
+
+class ExpectedManagedHuman(NFCModel):
+    user_id: str
+    subject: str
+
+
+class ManagedAccountStateRequest(NFCModel):
+    issuer: str
+    expected_humans: list[ExpectedManagedHuman] = Field(min_length=1, max_length=10_000)
 
 
 @router.get("/my/vaults", summary="List vaults accessible to me")
@@ -261,6 +272,21 @@ async def admin_remove_vault_write_grant(
 async def admin_list_users(user: AuthenticatedUser = Depends(get_current_user)):
     _require_admin(user)
     return {"users": await list_all_users_admin()}
+
+
+@router.post(
+    "/admin/managed-account-state",
+    summary="[admin] Validate managed auth profile and exact active human inventory",
+)
+async def admin_managed_account_state(
+    req: ManagedAccountStateRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await get_managed_account_state(
+        issuer=req.issuer,
+        expected_humans=[item.model_dump() for item in req.expected_humans],
+    )
 
 
 @router.post(

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -6,6 +6,7 @@ import uuid
 
 import asyncpg
 
+from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import (
     AccountSuspendedError,
@@ -556,6 +557,112 @@ async def get_user_by_external_identity(issuer: str, subject: str) -> dict:
     if row is None:
         raise NotFoundError("External identity", f"{issuer}#{subject}")
     return _user_result(row)
+
+
+def _expected_managed_humans(
+    expected_humans: list[dict[str, str]],
+) -> dict[uuid.UUID, str]:
+    if not isinstance(expected_humans, list) or not expected_humans:
+        raise ValidationError("expected_humans must contain at least one account")
+    if len(expected_humans) > 10_000:
+        raise ValidationError("expected_humans exceeds the managed account limit")
+
+    expected: dict[uuid.UUID, str] = {}
+    subjects: set[str] = set()
+    for item in expected_humans:
+        if not isinstance(item, dict):
+            raise ValidationError("expected_humans entries must be objects")
+        raw_user_id = _required(item.get("user_id", ""), "user_id")
+        user_id = _uuid(raw_user_id, "user_id")
+        if str(user_id) != raw_user_id:
+            raise ValidationError("user_id must be a canonical UUID")
+        subject = _required(item.get("subject", ""), "subject")
+        if user_id in expected:
+            raise ValidationError("expected_humans contains a duplicate user_id")
+        if subject in subjects:
+            raise ValidationError("expected_humans contains a duplicate subject")
+        expected[user_id] = subject
+        subjects.add(subject)
+    return expected
+
+
+async def get_managed_account_state(
+    *,
+    issuer: str,
+    expected_humans: list[dict[str, str]],
+) -> dict:
+    """Compare the running AKB profile and active humans with platform intent.
+
+    The response deliberately contains only counts and stable issue codes. It
+    never returns email, subject, password, token, or credential material.
+    """
+
+    issuer = _required(issuer, "issuer")
+    if issuer != settings.keycloak_issuer:
+        raise ValidationError("issuer does not match the running AKB configuration")
+    expected = _expected_managed_humans(expected_humans)
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT u.id, u.auth_provider,
+                   COALESCE(
+                     array_agg(e.subject ORDER BY e.subject)
+                       FILTER (WHERE e.user_id IS NOT NULL),
+                     ARRAY[]::text[]
+                   ) AS subjects
+              FROM users u
+              LEFT JOIN external_identities e
+                ON e.user_id = u.id AND e.issuer = $1
+             WHERE u.account_kind = 'human'
+               AND u.account_status = 'active'
+             GROUP BY u.id, u.auth_provider
+             ORDER BY u.id
+            """,
+            issuer,
+        )
+
+    observed: dict[uuid.UUID, tuple[str, set[str]]] = {}
+    for row in rows:
+        user_id = uuid.UUID(str(row["id"]))
+        if user_id in observed:
+            raise RuntimeError("managed account query returned a duplicate user")
+        observed[user_id] = (
+            str(row["auth_provider"]),
+            {str(subject) for subject in row["subjects"]},
+        )
+
+    issues: set[str] = set()
+    if set(observed) != set(expected):
+        issues.add("active_human_set_mismatch")
+    if any(provider != "keycloak" for provider, _ in observed.values()):
+        issues.add("human_auth_provider_mismatch")
+    if any(
+        observed.get(user_id, ("", set()))[1] != {subject}
+        for user_id, subject in expected.items()
+    ):
+        issues.add("expected_identity_mismatch")
+
+    account_issues = set(issues)
+    profile_ready = (
+        settings.keycloak_enabled
+        and settings.keycloak_enrollment_mode == "invite_only"
+        and not settings.keycloak_link_by_email
+        and settings.keycloak_require_verified_email
+        and not settings.local_auth_enabled
+    )
+    if not profile_ready:
+        issues.add("managed_auth_profile_mismatch")
+
+    return {
+        "ready": not issues,
+        "account_inventory_ready": not account_issues,
+        "managed_auth_profile_ready": profile_ready,
+        "expected_active_humans": len(expected),
+        "observed_active_humans": len(observed),
+        "issues": sorted(issues),
+    }
 
 
 async def set_user_admin(user_id: str, *, is_admin: bool, actor_id: str) -> dict:

--- a/backend/tests/test_managed_account_readiness_postgres.py
+++ b/backend/tests/test_managed_account_readiness_postgres.py
@@ -1,0 +1,113 @@
+"""PostgreSQL proof for the managed active-human inventory query."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
+_ISSUER = "https://id.example.com/realms/akb-platform"
+
+
+async def test_managed_account_query_uses_one_exact_database_snapshot(monkeypatch):
+    try:
+        admin = await asyncpg.connect(_DSN)
+    except Exception:
+        pytest.skip("Postgres unreachable at AKB_TEST_DSN")
+
+    schema = "managed_readiness_" + uuid.uuid4().hex
+    await admin.execute(f'CREATE SCHEMA "{schema}"')
+    pool = None
+    try:
+        pool = await asyncpg.create_pool(
+            _DSN,
+            min_size=1,
+            max_size=2,
+            server_settings={"search_path": schema},
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE users (
+                    id UUID PRIMARY KEY,
+                    auth_provider TEXT NOT NULL,
+                    account_status TEXT NOT NULL,
+                    account_kind TEXT NOT NULL
+                );
+                CREATE TABLE external_identities (
+                    user_id UUID NOT NULL REFERENCES users(id),
+                    issuer TEXT NOT NULL,
+                    subject TEXT NOT NULL,
+                    UNIQUE (issuer, subject)
+                );
+                """
+            )
+            expected_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO users VALUES
+                  ($1, 'keycloak', 'active', 'human'),
+                  ($2, 'local', 'suspended', 'human'),
+                  ($3, 'service', 'active', 'service')
+                """,
+                expected_id,
+                uuid.uuid4(),
+                uuid.uuid4(),
+            )
+            await conn.execute(
+                "INSERT INTO external_identities VALUES ($1, $2, 'subject-1')",
+                expected_id,
+                _ISSUER,
+            )
+
+        from app.services import account_service
+
+        async def _get_pool():
+            return pool
+
+        monkeypatch.setattr(account_service, "get_pool", _get_pool)
+        settings = account_service.settings
+        for field, value in {
+            "keycloak_enabled": True,
+            "keycloak_enrollment_mode": "invite_only",
+            "keycloak_link_by_email": False,
+            "keycloak_require_verified_email": True,
+            "local_auth_enabled": False,
+            "keycloak_server_url": "https://id.example.com",
+            "keycloak_realm": "akb-platform",
+        }.items():
+            monkeypatch.setattr(settings, field, value, raising=False)
+
+        state = await account_service.get_managed_account_state(
+            issuer=_ISSUER,
+            expected_humans=[
+                {"user_id": str(expected_id), "subject": "subject-1"}
+            ],
+        )
+        assert state["ready"] is True
+        assert state["observed_active_humans"] == 1
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO users VALUES ($1, 'local', 'active', 'human')",
+                uuid.uuid4(),
+            )
+        drifted = await account_service.get_managed_account_state(
+            issuer=_ISSUER,
+            expected_humans=[
+                {"user_id": str(expected_id), "subject": "subject-1"}
+            ],
+        )
+        assert drifted["account_inventory_ready"] is False
+        assert "active_human_set_mismatch" in drifted["issues"]
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await admin.close()

--- a/backend/tests/test_managed_account_readiness_unit.py
+++ b/backend/tests/test_managed_account_readiness_unit.py
@@ -1,0 +1,214 @@
+"""Managed Pod readiness contract for exact platform-owned human accounts."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+ISSUER = "https://id.example.com/realms/akb-platform"
+USER_ID = "11111111-1111-4111-8111-111111111111"
+
+
+class _Acquire:
+    def __init__(self, rows):
+        self.connection = _Connection(rows)
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _Connection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.query = ""
+        self.args = ()
+
+    async def fetch(self, query, *args):
+        self.query = query
+        self.args = args
+        return self.rows
+
+
+class _Pool:
+    def __init__(self, rows):
+        self.acquire_context = _Acquire(rows)
+
+    def acquire(self):
+        return self.acquire_context
+
+
+def _managed_settings(monkeypatch, account_service, *, enabled: bool = True):
+    values = {
+        "keycloak_enabled": enabled,
+        "keycloak_enrollment_mode": "invite_only" if enabled else "open",
+        "keycloak_link_by_email": False if enabled else True,
+        "keycloak_require_verified_email": True,
+        "local_auth_enabled": False if enabled else True,
+        "keycloak_server_url": "https://id.example.com",
+        "keycloak_realm": "akb-platform",
+    }
+    for field, value in values.items():
+        monkeypatch.setattr(account_service.settings, field, value, raising=False)
+
+
+async def test_exact_managed_account_state_is_ready_without_sensitive_query_fields(monkeypatch):
+    from app.services import account_service
+
+    rows = [
+        {
+            "id": uuid.UUID(USER_ID),
+            "auth_provider": "keycloak",
+            "subjects": ["subject-1"],
+        }
+    ]
+    pool = _Pool(rows)
+
+    async def _get_pool():
+        return pool
+
+    monkeypatch.setattr(account_service, "get_pool", _get_pool)
+    _managed_settings(monkeypatch, account_service)
+
+    state = await account_service.get_managed_account_state(
+        issuer=ISSUER,
+        expected_humans=[{"user_id": USER_ID, "subject": "subject-1"}],
+    )
+
+    assert state == {
+        "ready": True,
+        "account_inventory_ready": True,
+        "managed_auth_profile_ready": True,
+        "expected_active_humans": 1,
+        "observed_active_humans": 1,
+        "issues": [],
+    }
+    query = pool.acquire_context.connection.query.lower()
+    assert "email" not in query
+    assert "password" not in query
+    assert "tokens" not in query
+    assert pool.acquire_context.connection.args == (ISSUER,)
+
+
+async def test_account_and_profile_divergence_are_independent_fail_closed_signals(monkeypatch):
+    from app.services import account_service
+
+    rows = [
+        {
+            "id": uuid.UUID(USER_ID),
+            "auth_provider": "local",
+            "subjects": ["different-subject"],
+        },
+        {
+            "id": uuid.UUID("22222222-2222-4222-8222-222222222222"),
+            "auth_provider": "local",
+            "subjects": [],
+        },
+    ]
+
+    async def _get_pool():
+        return _Pool(rows)
+
+    monkeypatch.setattr(account_service, "get_pool", _get_pool)
+    _managed_settings(monkeypatch, account_service, enabled=False)
+
+    state = await account_service.get_managed_account_state(
+        issuer=ISSUER,
+        expected_humans=[{"user_id": USER_ID, "subject": "subject-1"}],
+    )
+
+    assert state["ready"] is False
+    assert state["account_inventory_ready"] is False
+    assert state["managed_auth_profile_ready"] is False
+    assert state["expected_active_humans"] == 1
+    assert state["observed_active_humans"] == 2
+    assert state["issues"] == [
+        "active_human_set_mismatch",
+        "expected_identity_mismatch",
+        "human_auth_provider_mismatch",
+        "managed_auth_profile_mismatch",
+    ]
+
+
+async def test_exact_inventory_can_preflight_before_managed_profile_rollout(monkeypatch):
+    from app.services import account_service
+
+    rows = [
+        {
+            "id": uuid.UUID(USER_ID),
+            "auth_provider": "keycloak",
+            "subjects": ["subject-1"],
+        }
+    ]
+
+    async def _get_pool():
+        return _Pool(rows)
+
+    monkeypatch.setattr(account_service, "get_pool", _get_pool)
+    _managed_settings(monkeypatch, account_service, enabled=False)
+
+    state = await account_service.get_managed_account_state(
+        issuer=ISSUER,
+        expected_humans=[{"user_id": USER_ID, "subject": "subject-1"}],
+    )
+
+    assert state["account_inventory_ready"] is True
+    assert state["managed_auth_profile_ready"] is False
+    assert state["ready"] is False
+    assert state["issues"] == ["managed_auth_profile_mismatch"]
+
+
+async def test_invalid_or_ambiguous_expected_accounts_are_rejected_before_db(monkeypatch):
+    from app.exceptions import ValidationError
+    from app.services import account_service
+
+    async def _must_not_get_pool():
+        raise AssertionError("invalid expected accounts must fail before DB access")
+
+    monkeypatch.setattr(account_service, "get_pool", _must_not_get_pool)
+    _managed_settings(monkeypatch, account_service)
+
+    cases = [
+        [],
+        [
+            {"user_id": USER_ID, "subject": "subject-1"},
+            {"user_id": USER_ID, "subject": "subject-2"},
+        ],
+        [
+            {"user_id": USER_ID, "subject": "subject-1"},
+            {
+                "user_id": "22222222-2222-4222-8222-222222222222",
+                "subject": "subject-1",
+            },
+        ],
+        [{"user_id": "not-a-uuid", "subject": "subject-1"}],
+    ]
+    for expected in cases:
+        with pytest.raises(ValidationError):
+            await account_service.get_managed_account_state(
+                issuer=ISSUER,
+                expected_humans=expected,
+            )
+
+
+async def test_requested_issuer_must_equal_the_running_akb_issuer(monkeypatch):
+    from app.exceptions import ValidationError
+    from app.services import account_service
+
+    async def _must_not_get_pool():
+        raise AssertionError("issuer mismatch must fail before DB access")
+
+    monkeypatch.setattr(account_service, "get_pool", _must_not_get_pool)
+    _managed_settings(monkeypatch, account_service)
+
+    with pytest.raises(ValidationError):
+        await account_service.get_managed_account_state(
+            issuer="https://other.example.com/realms/akb-platform",
+            expected_humans=[{"user_id": USER_ID, "subject": "subject-1"}],
+        )

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -55,6 +55,51 @@ async def test_non_admin_is_rejected_before_account_service(monkeypatch):
     assert exc_info.value.status_code == 403
 
 
+async def test_managed_account_state_is_admin_only_and_forwards_exact_expectations(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _state(**kwargs):
+        observed.update(kwargs)
+        return {
+            "ready": True,
+            "account_inventory_ready": True,
+            "managed_auth_profile_ready": True,
+            "expected_active_humans": 1,
+            "observed_active_humans": 1,
+            "issues": [],
+        }
+
+    monkeypatch.setattr(access, "get_managed_account_state", _state)
+    request = access.ManagedAccountStateRequest(
+        issuer="https://id.example.com/realms/akb-platform",
+        expected_humans=[
+            access.ExpectedManagedHuman(
+                user_id="11111111-1111-4111-8111-111111111111",
+                subject="subject-1",
+            )
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_managed_account_state(request, _user(admin=False))
+    assert exc_info.value.status_code == 403
+    assert observed == {}
+
+    result = await access.admin_managed_account_state(request, _user(admin=True))
+    assert result["ready"] is True
+    assert observed == {
+        "issuer": request.issuer,
+        "expected_humans": [
+            {
+                "user_id": request.expected_humans[0].user_id,
+                "subject": request.expected_humans[0].subject,
+            }
+        ],
+    }
+
+
 async def test_ensure_external_identity_forwards_verified_actor(monkeypatch):
     from app.api.routes import access
 
@@ -266,7 +311,10 @@ async def test_auth_me_exposes_additive_current_key_class():
     assert result["key_class"] == "service"
 
 
-async def test_governance_routes_are_explicit_in_openapi():
+async def test_governance_routes_are_explicit_in_openapi(monkeypatch, tmp_path):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path))
     from app.main import app
 
     paths = app.openapi()["paths"]
@@ -283,6 +331,7 @@ async def test_governance_routes_are_explicit_in_openapi():
         "/api/v1/admin/users/{user_id}/activate",
         "/api/v1/admin/users/{user_id}/tokens/{token_id}",
         "/api/v1/admin/users/{user_ref}/managed-tokens",
+        "/api/v1/admin/managed-account-state",
         "/api/v1/admin/tokens/identify",
     }
     assert expected <= set(paths)


### PR DESCRIPTION
## Summary
- add an admin-only, read-only managed account state endpoint
- compare the expected active AKB user/subject set against one PostgreSQL snapshot
- report managed auth-profile readiness independently from account inventory readiness
- return only counts and stable issue codes; standalone defaults and /readyz are unchanged

## Verification
- RED-first managed inventory, profile, validation, and route tests
- real PostgreSQL exact-set and drift test
- 59 focused account/auth tests passed
- full backend suite: 813 passed, 24 skipped
- ruff and mypy passed
- git diff --check

## Rollout
Deploy this additive endpoint to compatibility tenants before the platform starts enforcing managed Pod readiness. No account or credential is mutated by this change.