### PR TITLE
test(auth): isolate old-image compatibility config

### DIFF
--- a/backend/tests/old_image_schema_compat.py
+++ b/backend/tests/old_image_schema_compat.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
+import shutil
 import sys
 import uuid
 from pathlib import Path
@@ -18,8 +20,28 @@ def _arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _activate_old_backend(backend: Path) -> None:
+    resolved = backend.resolve()
+    config_dir = resolved / "config"
+    archive_config = resolved.parent / "config"
+    for source_name, target_name in (
+        ("app.yaml.example", "app.yaml"),
+        ("secret.yaml.example", "secret.yaml"),
+    ):
+        target = config_dir / target_name
+        if target.exists():
+            continue
+        source = archive_config / source_name
+        if not source.is_file():
+            raise RuntimeError(f"archived compatibility config is missing: {source}")
+        config_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+    os.chdir(resolved)
+    sys.path.insert(0, str(resolved))
+
+
 def _configure_old_backend(backend: Path, dsn: str):
-    sys.path.insert(0, str(backend.resolve()))
+    _activate_old_backend(backend)
     from app.config import settings
 
     parsed = urlparse(dsn)

--- a/backend/tests/test_old_image_schema_compat_unit.py
+++ b/backend/tests/test_old_image_schema_compat_unit.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _compat_module():
+    path = Path(__file__).with_name("old_image_schema_compat.py")
+    spec = importlib.util.spec_from_file_location("old_image_schema_compat", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_old_backend_activation_isolates_relative_config(tmp_path, monkeypatch):
+    current = tmp_path / "current"
+    archived = tmp_path / "archived" / "backend"
+    (current / "config").mkdir(parents=True)
+    (archived / "config").mkdir(parents=True)
+    (current / "config" / "app.yaml").write_text("source: current\n")
+    (archived / "config" / "app.yaml").write_text("source: archived\n")
+    (archived / "config" / "secret.yaml").write_text("secret: archived\n")
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+
+    module = _compat_module()
+    module._activate_old_backend(archived)
+
+    assert Path.cwd() == archived.resolve()
+    assert Path("config/app.yaml").read_text() == "source: archived\n"
+
+
+def test_old_backend_activation_materializes_archive_examples(tmp_path, monkeypatch):
+    current = tmp_path / "current"
+    archived = tmp_path / "archive" / "backend"
+    examples = archived.parent / "config"
+    current.mkdir()
+    archived.mkdir(parents=True)
+    examples.mkdir()
+    (examples / "app.yaml.example").write_text("source: archived-example\n")
+    (examples / "secret.yaml.example").write_text("secret: test-only\n")
+    monkeypatch.chdir(current)
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+
+    module = _compat_module()
+    module._activate_old_backend(archived)
+
+    assert Path("config/app.yaml").read_text() == "source: archived-example\n"
+    assert Path("config/secret.yaml").read_text() == "secret: test-only\n"

--- a/scripts/check-workspace-account-governance.sh
+++ b/scripts/check-workspace-account-governance.sh
@@ -53,6 +53,7 @@ cd "$BACKEND"
   tests/test_workspace_account_admin_service.py \
   tests/test_workspace_account_admin_routes.py \
   tests/test_keycloak_redirect_unit.py \
+  tests/test_old_image_schema_compat_unit.py \
   tests/old_image_schema_compat.py
 "$PYTHON_BIN" -m mypy \
   app/services/account_service.py \
@@ -71,11 +72,13 @@ cd "$BACKEND"
   tests/test_auth_change_password.py \
   tests/test_password_service.py \
   tests/test_mcp_oauth_unit.py \
+  tests/test_old_image_schema_compat_unit.py \
   -q
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/akb-governance-compat.XXXXXX")"
 trap 'rm -rf "$tmp_dir"' EXIT
-git -C "$ROOT" archive --format=tar --output="$tmp_dir/old-backend.tar" "$BASE_REF" backend
+git -C "$ROOT" archive --format=tar --output="$tmp_dir/old-backend.tar" \
+  "$BASE_REF" backend config
 tar -xf "$tmp_dir/old-backend.tar" -C "$tmp_dir"
 "$PYTHON_BIN" tests/old_image_schema_compat.py \
   --backend "$tmp_dir/backend" \


### PR DESCRIPTION
## Summary
- run the archived backend from its own directory so relative config lookup cannot consume the current image config
- materialize temporary app/secret config from the same archived base-ref examples
- add unit coverage and include it in the workspace account governance gate

## Root cause
The compatibility process imported the archived backend while its CWD still pointed at the current backend. Once current config gained gateway-only keys, the old Settings model rejected them before the old-image/new-schema test could run.

## Verification
- RED: archive activation test failed before the helper existed; example materialization test failed before config preparation
- unit tests: 2 passed
- full workspace account governance gate: ruff/mypy, 131 tests, old-image/new-schema compatibility all passed
- `git diff --check`