### PR TITLE
feat(auth): add delegated file upload capability

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,5 +1,6 @@
 """Shared dependencies for API routes."""
 
+from dataclasses import dataclass
 from typing import NoReturn
 
 from fastapi import HTTPException, Request, Security
@@ -9,11 +10,24 @@ from app.models.vault_scope import (
     current_request_jwt_claims,
     parse_request_jwt_claims_header,
 )
-from app.services.auth_service import AuthenticatedUser, resolve_token, token_has_scope
+from app.services.auth_service import (
+    AuthenticatedUser,
+    resolve_akb_session_authorization,
+    resolve_token,
+    token_has_scope,
+)
 
 bearer_auth = HTTPBearer(auto_error=False, scheme_name="bearerAuth")
 
 _CLAIMS_HEADER = "x-akb-claims"
+_DELEGATED_AUTH_HEADER = "X-Akb-Delegated-Authorization"
+
+
+@dataclass(frozen=True)
+class DelegatedActor:
+    user: AuthenticatedUser
+    service_user_id: str
+    service_token_id: str
 
 
 def _required_scope_for_request(request: Request) -> str:
@@ -31,6 +45,45 @@ def _reject_claims(message: str, code: str) -> NoReturn:
             "message": message,
             "code": code,
         },
+    )
+
+
+def _reject_delegation(message: str, code: str) -> NoReturn:
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "message": message,
+            "code": code,
+        },
+    )
+
+
+async def require_delegated_actor(
+    request: Request,
+    service_user: AuthenticatedUser,
+) -> DelegatedActor:
+    """Resolve the human principal paired with an action-limited service key."""
+    if service_user.key_class != "service" or service_user.token_id is None:
+        _reject_delegation(
+            "Delegated authorization requires a service key",
+            "delegation_requires_service_key",
+        )
+    authorization = request.headers.get(_DELEGATED_AUTH_HEADER)
+    if authorization is None:
+        _reject_delegation(
+            f"{_DELEGATED_AUTH_HEADER} is required",
+            "delegated_authorization_required",
+        )
+    delegated = await resolve_akb_session_authorization(authorization)
+    if delegated is None or delegated.auth_method != "jwt":
+        _reject_delegation(
+            "Delegated authorization must be an active AKB user session",
+            "invalid_delegated_authorization",
+        )
+    return DelegatedActor(
+        user=delegated,
+        service_user_id=service_user.user_id,
+        service_token_id=service_user.token_id,
     )
 
 

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -26,6 +26,7 @@ from app.services.account_service import (
 from app.services.access_service import (
     add_vault_write_grant,
     archive_vault,
+    bootstrap_vault_write_policy,
     delete_user_account,
     delete_vault,
     get_vault_info,
@@ -82,6 +83,24 @@ class AddVaultWriteGrantRequest(NFCModel):
     actions: list[str] = Field(
         min_length=1,
         description="Managed write actions. Omit the body for the legacy wildcard grant.",
+    )
+
+
+class BootstrapVaultWriteGrantRequest(NFCModel):
+    token_id: str
+    actions: list[str] | None = Field(
+        default=None,
+        min_length=1,
+        description="Omit for a legacy wildcard grant.",
+    )
+
+
+class BootstrapVaultWritePolicyRequest(NFCModel):
+    managed_by: str
+    note: str | None = None
+    grants: list[BootstrapVaultWriteGrantRequest] = Field(
+        min_length=1,
+        description="Complete initial writer set committed with the policy.",
     )
 
 
@@ -235,6 +254,31 @@ async def admin_set_vault_write_policy(
     (note omitted ⇒ cleared); grants are preserved."""
     _require_admin(user)
     return await set_vault_write_policy(user.user_id, vault, req.managed_by, note=req.note)
+
+
+@router.put(
+    "/admin/vaults/{vault}/write-policy/bootstrap",
+    summary="[admin] Atomically mark a vault and install its initial write grants",
+)
+async def admin_bootstrap_vault_write_policy(
+    vault: str,
+    req: BootstrapVaultWritePolicyRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    return await bootstrap_vault_write_policy(
+        user.user_id,
+        vault,
+        req.managed_by,
+        [
+            {
+                "token_id": grant.token_id,
+                "write_actions": grant.actions,
+            }
+            for grant in req.grants
+        ],
+        note=req.note,
+    )
 
 
 @router.delete(

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -78,6 +78,13 @@ class SetVaultWritePolicyRequest(NFCModel):
     )
 
 
+class AddVaultWriteGrantRequest(NFCModel):
+    actions: list[str] = Field(
+        min_length=1,
+        description="Managed write actions. Omit the body for the legacy wildcard grant.",
+    )
+
+
 class EnsureExternalIdentityRequest(NFCModel):
     issuer: str
     subject: str
@@ -250,9 +257,17 @@ async def admin_add_vault_write_grant(
     vault: str,
     token_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
+    req: AddVaultWriteGrantRequest | None = None,
 ):
     _require_admin(user)
-    return await add_vault_write_grant(user.user_id, vault, token_id)
+    if req is None:
+        return await add_vault_write_grant(user.user_id, vault, token_id)
+    return await add_vault_write_grant(
+        user.user_id,
+        vault,
+        token_id,
+        write_actions=req.actions,
+    )
 
 
 @router.delete(

--- a/backend/app/api/routes/files.py
+++ b/backend/app/api/routes/files.py
@@ -1,9 +1,13 @@
 """REST API routes for vault file storage (S3-backed)."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
-from app.api.deps import get_current_user
-from app.services.access_service import check_vault_access
+from app.api.deps import get_current_user, require_delegated_actor
+from app.services.access_service import (
+    FILE_UPLOAD_WRITE_ACTION,
+    check_delegated_vault_writer,
+    check_vault_access,
+)
 from app.services.auth_service import AuthenticatedUser
 from app.services.file_service import FileService
 from app.util.text import to_nfc
@@ -12,8 +16,33 @@ router = APIRouter()
 file_service = FileService()
 
 
+async def _resolve_file_write_context(
+    request: Request,
+    vault: str,
+    user: AuthenticatedUser,
+) -> tuple[dict, str, dict[str, str] | None]:
+    access = await check_vault_access(
+        user.user_id,
+        vault,
+        required_role="writer",
+        write_action=FILE_UPLOAD_WRITE_ACTION,
+    )
+    actions = frozenset(access.get("write_grant_actions") or [])
+    if access.get("role_source") != "write_policy_grant" or "*" in actions:
+        return access, user.username, None
+
+    delegated_actor = await require_delegated_actor(request, user)
+    await check_delegated_vault_writer(delegated_actor.user.user_id, vault)
+    return access, delegated_actor.user.username, {
+        "delegated_user_id": delegated_actor.user.user_id,
+        "service_user_id": delegated_actor.service_user_id,
+        "service_token_id": delegated_actor.service_token_id,
+    }
+
+
 @router.post("/files/{vault}/upload", summary="Upload a file (presigned URL flow)")
 async def upload_file(
+    request: Request,
     vault: str,
     filename: str = Query(..., description="Original filename"),
     collection: str = Query("", description="Logical grouping"),
@@ -22,13 +51,15 @@ async def upload_file(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     """Returns a presigned PUT URL. Client uploads directly to S3."""
-    access = await check_vault_access(user.user_id, vault, required_role="writer")
+    access, actor_id, _delegated_actor = await _resolve_file_write_context(
+        request, vault, user,
+    )
     return await file_service.initiate_upload(
         vault_name=vault,
         vault_id=access["vault_id"],
         collection=to_nfc(collection),
         filename=to_nfc(filename),
-        actor_id=user.username,
+        actor_id=actor_id,
         mime_type=mime_type,
         description=to_nfc(description),
     )
@@ -36,6 +67,7 @@ async def upload_file(
 
 @router.post("/files/{vault}/{file_id}/confirm", summary="Confirm upload completion (recovery)")
 async def confirm_upload(
+    request: Request,
     vault: str,
     file_id: str,
     content_hash: str | None = Query(None, description="Optional client-computed sha256 of uploaded bytes"),
@@ -43,9 +75,12 @@ async def confirm_upload(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     """Called after presigned URL upload. Updates size and byte hash from S3."""
-    access = await check_vault_access(user.user_id, vault, required_role="writer")
+    access, actor_id, delegated_actor = await _resolve_file_write_context(
+        request, vault, user,
+    )
     return await file_service.confirm_upload(
-        access["vault_id"], file_id, actor_id=user.username,
+        access["vault_id"], file_id, actor_id=actor_id,
+        delegated_actor=delegated_actor,
         content_hash=content_hash, hash_algorithm=hash_algorithm,
     )
 

--- a/backend/app/db/migrations/044_vault_write_policy.py
+++ b/backend/app/db/migrations/044_vault_write_policy.py
@@ -25,9 +25,9 @@ plans/2026-07-10-naut-edit-semantics-sot-writeback-design.md §5.1a).
    leaves the vault with zero live writers. See
    ``app/repositories/vault_write_policy_repo.py``.
 
-This slice (P0 S3) builds ONLY the substrate: the two tables + the repo.
-Nothing reads them yet — no guard, no API route (that is a later slice).
-Marking a vault today has zero runtime effect.
+Migration 044 originally shipped as substrate only. The current access service
+and admin API enforce and manage these rows; migration 045 adds optional
+operation limits while preserving every 044 row as a wildcard grant.
 
 Idempotent — safe to re-run on fresh and existing DBs (mirrors migration
 010/042's ``CREATE TABLE IF NOT EXISTS`` + transaction-wrapped style).

--- a/backend/app/db/migrations/045_vault_write_grant_actions.py
+++ b/backend/app/db/migrations/045_vault_write_grant_actions.py
@@ -1,0 +1,74 @@
+"""Migration 045: operation limits for managed Vault write grants.
+
+Existing grants are intentionally broad and must retain their behavior. The
+new ``write_actions`` column therefore defaults every existing and future
+body-less grant to ``['*']``. New callers may replace that wildcard with one
+or more registered operation names, initially ``file_upload``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+
+logger = logging.getLogger("akb.migration.045")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE vault_write_grants
+                ADD COLUMN IF NOT EXISTS write_actions TEXT[]
+                NOT NULL DEFAULT ARRAY['*']::TEXT[]
+            """
+        )
+        await conn.execute(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                      FROM pg_constraint
+                     WHERE conname = 'vault_write_grants_actions_nonempty'
+                       AND conrelid = 'vault_write_grants'::regclass
+                ) THEN
+                    ALTER TABLE vault_write_grants
+                        ADD CONSTRAINT vault_write_grants_actions_nonempty
+                        CHECK (
+                            cardinality(write_actions) > 0
+                            AND NOT (write_actions @> ARRAY['']::TEXT[])
+                        );
+                END IF;
+            END
+            $$
+            """
+        )
+
+    logger.info("Migration 045 added operation limits to vault_write_grants")
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -213,7 +213,8 @@ async def _apply_migrations() -> None:
         "041_tokens_key_class.py",              # tokens.key_class ('pat' default, 'service' BFF key, 'publishable' reserved seam)
         "042_vault_migrations.py",              # vault_migrations catalog for table migration idempotency/checksum replay
         "043_workspace_account_governance.py",  # users account status/kind + stable external OIDC identities
-        "044_vault_write_policy.py",             # vault_write_policy + vault_write_grants: vault-grain token-allowlist substrate (P0 S3; guard is a later slice)
+        "044_vault_write_policy.py",             # vault_write_policy + vault_write_grants: vault-grain token-allowlist substrate
+        "045_vault_write_grant_actions.py",      # additive action limits; existing grants backfill to wildcard
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/vault_write_policy_repo.py
+++ b/backend/app/repositories/vault_write_policy_repo.py
@@ -4,11 +4,12 @@ Sidecar 1:1 to ``vaults`` — generalizes the ``vault_external_git`` sidecar
 pattern (migration 010) to a new axis. A vault WITHOUT a
 ``vault_write_policy`` row is ungoverned; existing code is completely
 unaffected. A vault WITH a row is *marked*: mutating calls should only be
-accepted from a PAT on its ``vault_write_grants`` allowlist
-(class-agnostic — collector, gardener, and operator PATs are all just rows
-here). This module is pure substrate: no caller enforces the allowlist
-yet — that guard is a later slice (P0 S4). Marking a vault today has zero
-runtime effect.
+accepted from a token on its ``vault_write_grants`` allowlist. The access
+service enforces that allowlist. Migration 045 adds an operation set to each
+row: ``['*']`` keeps the historical class-agnostic broad grant used by
+collector, gardener, and operator credentials, while an explicit action such
+as ``file_upload`` requires a narrowly scoped service key and fails closed for
+every other write.
 
 CASCADE HAZARD: ``vault_write_grants.token_id`` is ``ON DELETE CASCADE``
 against ``tokens.id``. Deleting a token (revoke, suspend, rotation)
@@ -32,8 +33,10 @@ _GET_POLICY_SQL = """
      WHERE vault_id = $1
 """
 
-_IS_GRANTED_SQL = """
-    SELECT 1 FROM vault_write_grants WHERE vault_id = $1 AND token_id = $2
+_GET_GRANT_ACTIONS_SQL = """
+    SELECT write_actions
+      FROM vault_write_grants
+     WHERE vault_id = $1 AND token_id = $2
 """
 
 _SET_POLICY_SQL = """
@@ -48,9 +51,11 @@ _SET_POLICY_SQL = """
 _REMOVE_POLICY_SQL = "DELETE FROM vault_write_policy WHERE vault_id = $1"
 
 _ADD_GRANT_SQL = """
-    INSERT INTO vault_write_grants (vault_id, token_id, granted_by)
-    VALUES ($1, $2, $3)
-    ON CONFLICT (vault_id, token_id) DO NOTHING
+    INSERT INTO vault_write_grants (vault_id, token_id, granted_by, write_actions)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (vault_id, token_id) DO UPDATE
+       SET write_actions = EXCLUDED.write_actions,
+           granted_by = EXCLUDED.granted_by
 """
 
 _REMOVE_GRANT_SQL = (
@@ -69,21 +74,40 @@ async def get_policy(vault_id: uuid.UUID, conn=None) -> dict | None:
     return dict(row) if row is not None else None
 
 
-async def is_granted(vault_id: uuid.UUID, token_id: uuid.UUID, conn=None) -> bool:
-    """True iff ``token_id`` is on ``vault_id``'s write-grant allowlist.
+async def get_grant_actions(
+    vault_id: uuid.UUID, token_id: uuid.UUID, conn=None,
+) -> frozenset[str] | None:
+    """Return the granted action set, or ``None`` when no grant exists."""
+    if conn is not None:
+        raw = await conn.fetchval(_GET_GRANT_ACTIONS_SQL, vault_id, token_id)
+    else:
+        pool = await get_pool()
+        async with pool.acquire() as acq:
+            raw = await acq.fetchval(_GET_GRANT_ACTIONS_SQL, vault_id, token_id)
+    if raw is None:
+        return None
+    return frozenset(str(action) for action in raw)
+
+
+async def is_granted(
+    vault_id: uuid.UUID,
+    token_id: uuid.UUID,
+    conn=None,
+    *,
+    action: str | None = None,
+) -> bool:
+    """True iff the grant permits ``action``.
 
     This function alone does not tell a caller whether a write should be
     allowed — an ungoverned vault (no ``vault_write_policy`` row) has no
     allowlist to check against, and "no policy" means unrestricted, not
-    deny. That branch belongs to the guard (a later slice), not here.
+    deny. A wildcard grant permits every action and preserves the pre-045
+    behavior. An action-limited grant never matches an omitted action.
     """
-    if conn is not None:
-        found = await conn.fetchval(_IS_GRANTED_SQL, vault_id, token_id)
-    else:
-        pool = await get_pool()
-        async with pool.acquire() as acq:
-            found = await acq.fetchval(_IS_GRANTED_SQL, vault_id, token_id)
-    return found is not None
+    actions = await get_grant_actions(vault_id, token_id, conn=conn)
+    if actions is None:
+        return False
+    return "*" in actions or (action is not None and action in actions)
 
 
 async def set_policy(
@@ -120,20 +144,30 @@ async def remove_policy(vault_id: uuid.UUID, conn=None) -> None:
 
 
 async def add_grant(
-    vault_id: uuid.UUID, token_id: uuid.UUID, granted_by: str, conn=None
+    vault_id: uuid.UUID,
+    token_id: uuid.UUID,
+    granted_by: str,
+    conn=None,
+    *,
+    write_actions: tuple[str, ...] = ("*",),
 ) -> None:
     """Grant ``token_id`` write access to ``vault_id``.
 
     Requires an existing ``vault_write_policy`` row for ``vault_id`` (FK
     — call ``set_policy`` first, or this raises a foreign-key violation).
-    Idempotent: granting an already-granted token is a no-op, not an error.
+    Idempotent for the same action set. Re-granting replaces the action set,
+    which gives operators a deterministic narrow/widen operation with one row.
     """
     if conn is not None:
-        await conn.execute(_ADD_GRANT_SQL, vault_id, token_id, granted_by)
+        await conn.execute(
+            _ADD_GRANT_SQL, vault_id, token_id, granted_by, list(write_actions),
+        )
     else:
         pool = await get_pool()
         async with pool.acquire() as acq:
-            await acq.execute(_ADD_GRANT_SQL, vault_id, token_id, granted_by)
+            await acq.execute(
+                _ADD_GRANT_SQL, vault_id, token_id, granted_by, list(write_actions),
+            )
 
 
 async def remove_grant(vault_id: uuid.UUID, token_id: uuid.UUID, conn=None) -> None:

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -1125,6 +1125,132 @@ async def set_vault_write_policy(
     }
 
 
+async def bootstrap_vault_write_policy(
+    actor_id: str,
+    vault_name: str,
+    managed_by: str,
+    grants: list[dict[str, object]],
+    note: str | None = None,
+) -> dict:
+    """Atomically mark a Vault and install its complete initial writer set.
+
+    The ordinary set-policy and add-grant endpoints remain useful for updates,
+    but cannot safely perform an initial cutover: committing the policy first
+    creates a visible fail-closed interval before the grants arrive. This path
+    validates every token, writes the policy and all grants, and emits its audit
+    event in one PostgreSQL transaction. Any failure leaves the Vault unmarked.
+    Re-running it is idempotent for the supplied grants and preserves unrelated
+    grants already present on an existing policy.
+    """
+    managed_by = managed_by.strip()
+    if not managed_by:
+        raise ValidationError("managed_by must not be empty")
+    if not grants:
+        raise ValidationError("bootstrap grants must not be empty")
+
+    normalized_grants: list[tuple[uuid.UUID, str, tuple[str, ...]]] = []
+    seen_token_ids: set[uuid.UUID] = set()
+    for grant in grants:
+        token_id = grant.get("token_id")
+        try:
+            tid = uuid.UUID(str(token_id))
+        except (AttributeError, TypeError, ValueError):
+            raise ValidationError(f"Invalid token_id: {token_id!r}") from None
+        if tid in seen_token_ids:
+            raise ValidationError(f"Duplicate bootstrap token_id: {tid}")
+        seen_token_ids.add(tid)
+        write_actions = grant.get("write_actions")
+        if write_actions is not None and not isinstance(write_actions, (list, tuple)):
+            raise ValidationError("write_actions must be a list of strings")
+        actions = normalize_write_actions(write_actions)
+        normalized_grants.append((tid, str(tid), actions))
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            vault = await conn.fetchrow(
+                "SELECT id FROM vaults WHERE name = $1 FOR UPDATE", vault_name,
+            )
+            if not vault:
+                raise NotFoundError("Vault", vault_name)
+
+            is_mirror = await conn.fetchval(
+                "SELECT 1 FROM vault_external_git WHERE vault_id = $1", vault["id"],
+            )
+            if is_mirror:
+                raise ConflictError(
+                    f"Vault '{vault_name}' is an external-git mirror "
+                    f"(already read-only via its own poller); marking it "
+                    f"with a write policy would not change enforcement and "
+                    f"misleadingly implies a granted token could write here"
+                )
+
+            for tid, token_id, actions in normalized_grants:
+                token_row = await conn.fetchrow(
+                    """
+                    SELECT t.id, t.scopes, t.vault_scope, t.key_class,
+                           (t.expires_at IS NULL OR t.expires_at > NOW()) AS is_unexpired,
+                           u.account_kind, u.account_status, u.is_admin
+                      FROM tokens t
+                      JOIN users u ON u.id = t.user_id
+                     WHERE t.id = $1
+                       FOR SHARE OF t, u
+                    """,
+                    tid,
+                )
+                if not token_row:
+                    raise NotFoundError("Token", token_id)
+                if actions != (WRITE_ACTION_WILDCARD,):
+                    _validate_action_limited_grant_token(
+                        dict(token_row), vault_name,
+                    )
+
+            policy = await write_policy_repo.set_policy(
+                vault["id"], managed_by, created_by=actor_id, note=note, conn=conn,
+            )
+            grant_results = []
+            for tid, token_id, actions in normalized_grants:
+                await write_policy_repo.add_grant(
+                    vault["id"],
+                    tid,
+                    actor_id,
+                    conn=conn,
+                    write_actions=actions,
+                )
+                grant_results.append(
+                    {"token_id": token_id, "write_actions": list(actions)}
+                )
+
+            await emit_event(
+                conn,
+                "vault.write_policy_changed",
+                vault_id=vault["id"],
+                resource_uri=vault_uri(vault_name),
+                actor_id=actor_id,
+                payload={
+                    "action": "bootstrapped",
+                    "vault": vault_name,
+                    "managed_by": managed_by,
+                    "note": note,
+                    "grants": grant_results,
+                },
+            )
+
+    logger.info(
+        "Atomically marked vault %s write-managed by %s with %d grants",
+        vault_name,
+        managed_by,
+        len(grant_results),
+    )
+    return {
+        "vault": vault_name,
+        "managed_by": policy["managed_by"],
+        "note": policy["note"],
+        "marked": True,
+        "grants": grant_results,
+    }
+
+
 async def remove_vault_write_policy(actor_id: str, vault_name: str) -> dict:
     """Admin-only: unmark ``vault_name`` — restore ordinary ACL-gated writes.
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -11,7 +11,7 @@ import uuid
 
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
-from app.models.vault_scope import current_token_uuid, current_vault_scope
+from app.models.vault_scope import VaultScope, current_token_uuid, current_vault_scope
 from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
 from app.services.role_sync import get_role_sync
@@ -29,6 +29,71 @@ VALID_PUBLIC_ACCESS = {"none", "reader", "writer"}
 # for these (reads are never scope-restricted: a scoped agent still reads
 # broadly, the scope bounds WRITES).
 _MUTATING_ROLES = frozenset({"writer", "admin", "owner"})
+
+WRITE_ACTION_WILDCARD = "*"
+FILE_UPLOAD_WRITE_ACTION = "file_upload"
+VALID_WRITE_ACTIONS = frozenset({WRITE_ACTION_WILDCARD, FILE_UPLOAD_WRITE_ACTION})
+
+
+def normalize_write_actions(actions: list[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    """Validate the small managed-write capability vocabulary.
+
+    ``None`` preserves the pre-045 broad-grant API. Mixing wildcard and named
+    actions is rejected rather than silently widening a grant.
+    """
+    if actions is None:
+        return (WRITE_ACTION_WILDCARD,)
+    if not actions:
+        raise ValidationError("write actions must not be empty")
+    if any(not isinstance(action, str) or not action.strip() for action in actions):
+        raise ValidationError("write actions must be non-empty strings")
+    normalized = tuple(sorted({action.strip() for action in actions}))
+    unknown = set(normalized) - VALID_WRITE_ACTIONS
+    if unknown:
+        raise ValidationError(
+            f"Unknown write action(s): {sorted(unknown)}. "
+            f"Use: {sorted(VALID_WRITE_ACTIONS)}"
+        )
+    if WRITE_ACTION_WILDCARD in normalized and len(normalized) > 1:
+        raise ValidationError("wildcard write action cannot be combined with named actions")
+    return normalized
+
+
+def _validate_action_limited_grant_token(token: dict, vault_name: str) -> None:
+    """Fail closed unless a limited grant targets an upload-only credential."""
+    if token["key_class"] != "service":
+        raise ValidationError("action-limited write grants require a service key")
+    if token["account_kind"] != "service" or token["is_admin"]:
+        raise ValidationError(
+            "action-limited write grants require a non-admin service account"
+        )
+    if token["account_status"] != "active":
+        raise ValidationError(
+            "action-limited write grants require an active service account"
+        )
+    if not token["is_unexpired"]:
+        raise ValidationError(
+            "action-limited write grants require an unexpired service key"
+        )
+
+    scopes = frozenset(str(scope) for scope in (token["scopes"] or ()))
+    if scopes != {"write"}:
+        raise ValidationError(
+            "action-limited write grants require exactly the coarse scope ['write']"
+        )
+
+    try:
+        vault_scope = VaultScope.from_db_json(token["vault_scope"])
+    except ValueError as exc:
+        raise ValidationError(f"invalid token Vault scope: {exc}") from exc
+    if (
+        vault_scope is None
+        or vault_scope.prefixes
+        or vault_scope.extra_vaults != {vault_name}
+    ):
+        raise ValidationError(
+            "action-limited write grants require a token scoped to exactly the target Vault"
+        )
 
 
 def _role_level(role: str) -> int:
@@ -71,7 +136,7 @@ async def _is_unscoped_system_admin(uid: uuid.UUID, conn) -> bool:
 
 async def check_vault_access(
     user_id: str, vault_name: str, required_role: str = "reader",
-    *, allow_archived: bool = False,
+    *, allow_archived: bool = False, write_action: str | None = None,
 ) -> dict:
     """Check if user has at least the required role on a vault.
 
@@ -161,15 +226,22 @@ async def check_vault_access(
             policy = await write_policy_repo.get_policy(vault["id"], conn=conn)
             if policy is not None:
                 token_id = current_token_uuid()
-                granted = token_id is not None and await write_policy_repo.is_granted(
-                    vault["id"], token_id, conn=conn,
+                grant_actions = (
+                    await write_policy_repo.get_grant_actions(
+                        vault["id"], token_id, conn=conn,
+                    )
+                    if token_id is not None else None
                 )
-                if granted:
+                if grant_actions is not None and (
+                    WRITE_ACTION_WILDCARD in grant_actions
+                    or (write_action is not None and write_action in grant_actions)
+                ):
                     return {
                         "vault_id": vault["id"],
                         "role": required_role,
                         "status": vault["status"],
                         "role_source": "write_policy_grant",
+                        "write_grant_actions": sorted(grant_actions),
                     }
                 if await _is_unscoped_system_admin(uid, conn):
                     # A3: bypass, but LOUDLY — never a silent escape hatch.
@@ -192,7 +264,7 @@ async def check_vault_access(
                 raise ForbiddenError(
                     f"Vault '{vault_name}' is write-managed by "
                     f"{policy['managed_by']}; writes require a granted "
-                    f"service token"
+                    f"service token with the required write action"
                 )
 
         # System admin bypasses all vault ACL
@@ -220,6 +292,63 @@ async def check_vault_access(
             raise ForbiddenError(f"Requires '{required_role}' role on vault '{vault_name}'")
 
         return {"vault_id": vault["id"], "role": user_role, "status": vault["status"], "role_source": "member"}
+
+
+async def check_delegated_vault_writer(user_id: str, vault_name: str) -> dict:
+    """Authorize the human half of a dual-principal managed file upload.
+
+    This check deliberately ignores ``vault_write_policy`` because the primary
+    action-limited service token already satisfies that boundary. It does not
+    inherit public access: a delegated writer must be an active AKB account
+    explicitly bound to this Vault (or the owner/system admin).
+    """
+    pool = await get_pool()
+    uid = uuid.UUID(user_id)
+    async with pool.acquire() as conn:
+        user = await conn.fetchrow(
+            "SELECT is_admin, account_status, account_kind FROM users WHERE id = $1",
+            uid,
+        )
+        if not user or user["account_status"] != "active":
+            raise ForbiddenError("Delegated AKB account is not active")
+        if user["account_kind"] != "human":
+            raise ForbiddenError("Delegated AKB account must be a human account")
+
+        vault = await conn.fetchrow(
+            "SELECT id, owner_id, status FROM vaults WHERE name = $1", vault_name,
+        )
+        if not vault:
+            raise NotFoundError("Vault", vault_name)
+        if vault["status"] == "archived":
+            raise ForbiddenError(f"Vault '{vault_name}' is archived (read-only)")
+        is_mirror = await conn.fetchval(
+            "SELECT 1 FROM vault_external_git WHERE vault_id = $1", vault["id"],
+        )
+        if is_mirror:
+            raise ForbiddenError(f"Vault '{vault_name}' is a read-only external git mirror")
+        if user["is_admin"] or vault["owner_id"] == uid:
+            return {
+                "vault_id": vault["id"],
+                "role": "owner",
+                "status": vault["status"],
+                "role_source": "member",
+            }
+
+        access = await conn.fetchrow(
+            "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            vault["id"], uid,
+        )
+        role = access["role"] if access else None
+        if role is None or _role_level(role) < _role_level("writer"):
+            raise ForbiddenError(
+                f"Delegated account requires explicit 'writer' role on vault '{vault_name}'"
+            )
+        return {
+            "vault_id": vault["id"],
+            "role": role,
+            "status": vault["status"],
+            "role_source": "member",
+        }
 
 
 async def get_user_role(user_id: str, vault_name: str) -> str | None:
@@ -1038,17 +1167,26 @@ async def remove_vault_write_policy(actor_id: str, vault_name: str) -> dict:
     return {"vault": vault_name, "unmarked": True, "was_marked": existing is not None}
 
 
-async def add_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -> dict:
+async def add_vault_write_grant(
+    actor_id: str,
+    vault_name: str,
+    token_id: str,
+    *,
+    write_actions: list[str] | tuple[str, ...] | None = None,
+) -> dict:
     """Admin-only: grant ``token_id`` write access to a MARKED vault.
 
     Requires the vault to already be marked (409 `ConflictError` — a grant
     on an ungoverned vault has no allowlist to join and almost certainly
     means the caller meant to mark first) and `token_id` to exist (404).
-    The design is class-agnostic (collector/gardener/operator/human PATs
-    are all just rows on the allowlist — see `vault_write_policy_repo`'s
-    module docstring), so no further ownership/role check on the token is
-    performed here.
+    Legacy wildcard grants remain class-agnostic. An explicit action-limited
+    grant is a stronger managed capability: it requires an active, unexpired,
+    non-admin service account token with exactly coarse ``write`` scope and an
+    exact one-Vault scope. This makes configuration errors fail at grant time
+    instead of on the first product request.
     """
+    actions_were_explicit = write_actions is not None
+    normalized_actions = normalize_write_actions(write_actions)
     try:
         tid = uuid.UUID(token_id)
     except (AttributeError, TypeError, ValueError):
@@ -1070,11 +1208,30 @@ async def add_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -
                     f"first with PUT .../write-policy"
                 )
 
-            token_row = await conn.fetchrow("SELECT id FROM tokens WHERE id = $1", tid)
+            token_row = await conn.fetchrow(
+                """
+                SELECT t.id, t.scopes, t.vault_scope, t.key_class,
+                       (t.expires_at IS NULL OR t.expires_at > NOW()) AS is_unexpired,
+                       u.account_kind, u.account_status, u.is_admin
+                  FROM tokens t
+                  JOIN users u ON u.id = t.user_id
+                 WHERE t.id = $1
+                   FOR SHARE OF t, u
+                """,
+                tid,
+            )
             if not token_row:
                 raise NotFoundError("Token", token_id)
+            if normalized_actions != (WRITE_ACTION_WILDCARD,):
+                _validate_action_limited_grant_token(dict(token_row), vault_name)
 
-            await write_policy_repo.add_grant(vault["id"], tid, actor_id, conn=conn)
+            await write_policy_repo.add_grant(
+                vault["id"],
+                tid,
+                actor_id,
+                conn=conn,
+                write_actions=normalized_actions,
+            )
             await emit_event(
                 conn, "vault.write_policy_changed",
                 vault_id=vault["id"],
@@ -1085,11 +1242,19 @@ async def add_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -
                     "vault": vault_name,
                     "managed_by": policy["managed_by"],
                     "token_id": token_id,
+                    "write_actions": list(normalized_actions),
                 },
             )
 
     logger.info("Granted token %s write access to vault %s", token_id, vault_name)
-    return {"vault": vault_name, "token_id": token_id, "granted": True}
+    result = {
+        "vault": vault_name,
+        "token_id": token_id,
+        "granted": True,
+    }
+    if actions_were_explicit:
+        result["write_actions"] = list(normalized_actions)
+    return result
 
 
 async def remove_vault_write_grant(actor_id: str, vault_name: str, token_id: str) -> dict:

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -994,6 +994,32 @@ async def revoke_all_sessions(
 
 # ── Token resolution (JWT or PAT) ───────────────────────────
 
+def _jwt_algorithm(token: str) -> str | None:
+    try:
+        header = jwt.get_unverified_header(token)
+    except Exception:
+        return None
+    alg = header.get("alg")
+    return alg if isinstance(alg, str) else None
+
+
+async def resolve_akb_session_authorization(
+    authorization: str,
+) -> AuthenticatedUser | None:
+    """Resolve only an AKB-issued user-session JWT, without ContextVar writes.
+
+    Dual-principal endpoints call this after the primary service PAT has already
+    populated request ContextVars. Accepting PAT or Keycloak token shapes here
+    would either blur the human/session contract or overwrite the primary
+    authorization state, so both are rejected.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    token = authorization[7:]
+    if token.startswith("akb_") or _jwt_algorithm(token) != "HS256":
+        return None
+    return await _resolve_akb_session_jwt(token)
+
 async def resolve_token(authorization: str) -> AuthenticatedUser | None:
     """Resolve an Authorization header to an authenticated user.
 
@@ -1036,11 +1062,7 @@ async def resolve_token(authorization: str) -> AuthenticatedUser | None:
     # Keycloak access tokens are RS256. We pick the verifier from the
     # token's own header so a single Bearer surface accepts both without
     # an O(2) verify attempt per request.
-    try:
-        unverified_header = jwt.get_unverified_header(token)
-    except (jwt.InvalidTokenError, Exception):
-        return None
-    alg = unverified_header.get("alg")
+    alg = _jwt_algorithm(token)
 
     if alg == "RS256":
         # Keycloak access token. Gated on mcp_oauth_enabled inside.
@@ -1052,7 +1074,11 @@ async def resolve_token(authorization: str) -> AuthenticatedUser | None:
         # token and (correctly) refuse but only after burning CPU.
         return None
 
-    # AKB-issued session JWT (existing path)
+    return await _resolve_akb_session_jwt(token)
+
+
+async def _resolve_akb_session_jwt(token: str) -> AuthenticatedUser | None:
+    """Validate one AKB HS256 session token and return its active account."""
     payload = decode_jwt(token)
     if not payload:
         return None

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -48,6 +48,24 @@ _PRESIGN_UPLOAD_TTL = 3600
 _PRESIGN_DOWNLOAD_TTL = 3600
 _S3_STREAM_CHUNK_SIZE = 64 * 1024
 
+_DELEGATED_ACTOR_EVENT_KEYS = (
+    "delegated_user_id",
+    "service_user_id",
+    "service_token_id",
+)
+
+
+def _delegated_actor_event_fields(
+    delegated_actor: dict[str, str] | None,
+) -> dict[str, str]:
+    """Return the exact non-secret delegation fields allowed in file events."""
+    if delegated_actor is None:
+        return {}
+    return {
+        key: delegated_actor[key]
+        for key in _DELEGATED_ACTOR_EVENT_KEYS
+    }
+
 
 # ── HTTP header helper (kept here — not S3-specific) ─────────────
 
@@ -208,6 +226,7 @@ class FileService:
         file_id: str,
         *,
         actor_id: str,
+        delegated_actor: dict[str, str] | None = None,
         content_hash: str | None = None,
         hash_algorithm: str = HASH_ALGORITHM,
     ) -> dict:
@@ -299,6 +318,7 @@ class FileService:
                         "hash_algorithm": HASH_ALGORITHM,
                         "etag": etag,
                         "storage_version": storage_version,
+                        **_delegated_actor_event_fields(delegated_actor),
                     },
                 )
 

--- a/backend/tests/test_delegated_file_upload_unit.py
+++ b/backend/tests/test_delegated_file_upload_unit.py
@@ -1,0 +1,311 @@
+"""Focused unit contract for action-limited delegated file uploads."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.services.auth_service import AuthenticatedUser
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request(delegated_authorization: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if delegated_authorization is not None:
+        headers.append(
+            (b"x-akb-delegated-authorization", delegated_authorization.encode())
+        )
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": headers})
+
+
+def _user(
+    *,
+    key_class: str | None,
+    auth_method: str = "pat",
+    token_id: str | None = None,
+    username: str = "naut-upload",
+) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        username=username,
+        email=f"{username}@example.test",
+        display_name=None,
+        is_admin=False,
+        auth_method=auth_method,
+        token_id=token_id,
+        key_class=key_class,
+        token_scopes=frozenset({"write"}) if key_class else None,
+    )
+
+
+async def test_write_action_normalization_is_small_deterministic_and_fail_closed():
+    from app.services.access_service import normalize_write_actions
+
+    assert normalize_write_actions(None) == ("*",)
+    assert normalize_write_actions(["file_upload", "file_upload"]) == ("file_upload",)
+    with pytest.raises(ValueError):
+        normalize_write_actions([])
+    with pytest.raises(ValueError):
+        normalize_write_actions(["*", "file_upload"])
+    with pytest.raises(ValueError):
+        normalize_write_actions(["document_write"])
+
+
+async def test_secondary_resolver_accepts_only_akb_session_jwt_without_mutating_primary_context(
+    monkeypatch,
+):
+    from app.models.vault_scope import current_key_class, current_token_id
+    from app.services import auth_service
+
+    delegated = _user(key_class=None, auth_method="jwt", username="alice")
+    observed: list[str] = []
+
+    async def _resolve_session(raw: str):
+        observed.append(raw)
+        return delegated
+
+    monkeypatch.setattr(auth_service, "_resolve_akb_session_jwt", _resolve_session)
+    raw = jwt.encode(
+        {"sub": delegated.user_id},
+        "unit-secret-at-least-32-bytes-long",
+        algorithm="HS256",
+    )
+    token_marker = current_token_id.set("primary-service-token-id")
+    class_marker = current_key_class.set("service")
+    try:
+        resolved = await auth_service.resolve_akb_session_authorization(f"Bearer {raw}")
+        assert resolved is delegated
+        assert observed == [raw]
+        assert current_token_id.get() == "primary-service-token-id"
+        assert current_key_class.get() == "service"
+        assert await auth_service.resolve_akb_session_authorization("Bearer akb_pat") is None
+    finally:
+        current_key_class.reset(class_marker)
+        current_token_id.reset(token_marker)
+
+
+async def test_delegated_actor_requires_service_key_and_active_session(monkeypatch):
+    from app.api import deps
+
+    service = _user(key_class="service", token_id=str(uuid.uuid4()))
+    delegated = _user(key_class=None, auth_method="jwt", username="alice")
+
+    async def _resolve(_authorization: str):
+        return delegated
+
+    monkeypatch.setattr(deps, "resolve_akb_session_authorization", _resolve)
+    actor = await deps.require_delegated_actor(
+        _request("Bearer user.jwt"), service,
+    )
+    assert actor.user is delegated
+    assert actor.service_user_id == service.user_id
+    assert actor.service_token_id == service.token_id
+
+    with pytest.raises(HTTPException) as missing:
+        await deps.require_delegated_actor(_request(), service)
+    assert missing.value.detail["code"] == "delegated_authorization_required"
+
+    with pytest.raises(HTTPException) as wrong_primary:
+        await deps.require_delegated_actor(
+            _request("Bearer user.jwt"),
+            _user(key_class="pat", token_id=str(uuid.uuid4())),
+        )
+    assert wrong_primary.value.detail["code"] == "delegation_requires_service_key"
+
+    async def _reject(_authorization: str):
+        return None
+
+    monkeypatch.setattr(deps, "resolve_akb_session_authorization", _reject)
+    with pytest.raises(HTTPException) as invalid:
+        await deps.require_delegated_actor(_request("Bearer stale.jwt"), service)
+    assert invalid.value.detail["code"] == "invalid_delegated_authorization"
+
+    async def _resolve_pat(_authorization: str):
+        return _user(
+            key_class="pat",
+            auth_method="pat",
+            token_id=str(uuid.uuid4()),
+            username="not-a-session",
+        )
+
+    monkeypatch.setattr(deps, "resolve_akb_session_authorization", _resolve_pat)
+    with pytest.raises(HTTPException) as delegated_pat:
+        await deps.require_delegated_actor(_request("Bearer akb_pat"), service)
+    assert delegated_pat.value.detail["code"] == "invalid_delegated_authorization"
+
+
+async def test_action_limited_upload_uses_human_actor_and_service_audit_metadata(
+    monkeypatch,
+):
+    from app.api.routes import files
+
+    service = _user(key_class="service", token_id=str(uuid.uuid4()))
+    human = _user(key_class=None, auth_method="jwt", username="alice")
+    observed: dict = {}
+
+    async def _check_service(user_id, vault, required_role, *, write_action=None):
+        observed["service_check"] = (user_id, vault, required_role, write_action)
+        return {
+            "vault_id": uuid.uuid4(),
+            "role": "writer",
+            "role_source": "write_policy_grant",
+            "write_grant_actions": ["file_upload"],
+        }
+
+    async def _delegated_actor(_request, primary):
+        assert primary is service
+        return SimpleNamespace(
+            user=human,
+            service_user_id=service.user_id,
+            service_token_id=service.token_id,
+        )
+
+    async def _check_human(user_id, vault):
+        observed["human_check"] = (user_id, vault)
+        return {"role": "writer"}
+
+    async def _initiate(**kwargs):
+        observed["initiate"] = kwargs
+        return {"uri": "akb://team/file/f-1"}
+
+    monkeypatch.setattr(files, "check_vault_access", _check_service)
+    monkeypatch.setattr(files, "require_delegated_actor", _delegated_actor)
+    monkeypatch.setattr(files, "check_delegated_vault_writer", _check_human)
+    monkeypatch.setattr(files.file_service, "initiate_upload", _initiate)
+
+    result = await files.upload_file(
+        request=_request("Bearer user.jwt"),
+        vault="team",
+        filename="diagram.png",
+        collection="notes",
+        description="diagram",
+        mime_type="image/png",
+        user=service,
+    )
+
+    assert result["uri"] == "akb://team/file/f-1"
+    assert observed["service_check"] == (
+        service.user_id,
+        "team",
+        "writer",
+        "file_upload",
+    )
+    assert observed["human_check"] == (human.user_id, "team")
+    assert observed["initiate"]["actor_id"] == human.username
+
+
+async def test_action_limited_confirm_emits_both_actor_ids(monkeypatch):
+    from app.api.routes import files
+
+    service = _user(key_class="service", token_id=str(uuid.uuid4()))
+    human = _user(key_class=None, auth_method="jwt", username="alice")
+    observed: dict = {}
+
+    async def _check_service(*_args, **_kwargs):
+        return {
+            "vault_id": uuid.uuid4(),
+            "role": "writer",
+            "role_source": "write_policy_grant",
+            "write_grant_actions": ["file_upload"],
+        }
+
+    async def _delegated_actor(*_args):
+        return SimpleNamespace(
+            user=human,
+            service_user_id=service.user_id,
+            service_token_id=service.token_id,
+        )
+
+    async def _check_human(*_args):
+        return {"role": "writer"}
+
+    async def _confirm(*args, **kwargs):
+        observed["args"] = args
+        observed["kwargs"] = kwargs
+        return {"uri": "akb://team/file/f-1"}
+
+    monkeypatch.setattr(files, "check_vault_access", _check_service)
+    monkeypatch.setattr(files, "require_delegated_actor", _delegated_actor)
+    monkeypatch.setattr(files, "check_delegated_vault_writer", _check_human)
+    monkeypatch.setattr(files.file_service, "confirm_upload", _confirm)
+
+    await files.confirm_upload(
+        request=_request("Bearer user.jwt"),
+        vault="team",
+        file_id="f-1",
+        content_hash=None,
+        hash_algorithm="sha256",
+        user=service,
+    )
+
+    assert observed["kwargs"]["actor_id"] == human.username
+    assert observed["kwargs"]["delegated_actor"] == {
+        "delegated_user_id": human.user_id,
+        "service_user_id": service.user_id,
+        "service_token_id": service.token_id,
+    }
+
+
+async def test_file_event_flattens_only_bounded_delegation_ids():
+    from app.services.file_service import _delegated_actor_event_fields
+
+    fields = _delegated_actor_event_fields(
+        {
+            "delegated_user_id": "human-id",
+            "service_user_id": "service-id",
+            "service_token_id": "token-id",
+            "authorization": "Bearer must-not-escape",
+        }
+    )
+
+    assert fields == {
+        "delegated_user_id": "human-id",
+        "service_user_id": "service-id",
+        "service_token_id": "token-id",
+    }
+    assert "delegated_actor" not in fields
+    assert "authorization" not in fields
+
+
+async def test_wildcard_grant_keeps_existing_non_delegated_file_behavior(monkeypatch):
+    from app.api.routes import files
+
+    service = _user(key_class="service", token_id=str(uuid.uuid4()))
+    observed: dict = {}
+
+    async def _check_service(*_args, **_kwargs):
+        return {
+            "vault_id": uuid.uuid4(),
+            "role": "writer",
+            "role_source": "write_policy_grant",
+            "write_grant_actions": ["*"],
+        }
+
+    async def _must_not_delegate(*_args):
+        raise AssertionError("wildcard compatibility path must not require delegation")
+
+    async def _initiate(**kwargs):
+        observed.update(kwargs)
+        return {"uri": "akb://team/file/f-2"}
+
+    monkeypatch.setattr(files, "check_vault_access", _check_service)
+    monkeypatch.setattr(files, "require_delegated_actor", _must_not_delegate)
+    monkeypatch.setattr(files.file_service, "initiate_upload", _initiate)
+
+    await files.upload_file(
+        request=_request(),
+        vault="team",
+        filename="collector.bin",
+        collection="",
+        description="",
+        mime_type="application/octet-stream",
+        user=service,
+    )
+    assert observed["actor_id"] == service.username

--- a/backend/tests/test_vault_write_policy_routes_unit.py
+++ b/backend/tests/test_vault_write_policy_routes_unit.py
@@ -156,6 +156,43 @@ async def test_admin_add_grant_forwards_args(monkeypatch):
     assert observed == {"actor_id": admin.user_id, "vault_name": "v1", "token_id": token_id}
 
 
+async def test_admin_add_grant_forwards_action_limit(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+    token_id = str(uuid.uuid4())
+
+    async def _add(actor_id, vault_name, tid, *, write_actions=None):
+        observed.update(
+            actor_id=actor_id,
+            vault_name=vault_name,
+            token_id=tid,
+            write_actions=write_actions,
+        )
+        return {
+            "vault": vault_name,
+            "token_id": tid,
+            "write_actions": write_actions,
+            "granted": True,
+        }
+
+    monkeypatch.setattr(access, "add_vault_write_grant", _add)
+    admin = _user(admin=True)
+    req = access.AddVaultWriteGrantRequest(actions=["file_upload"])
+
+    result = await access.admin_add_vault_write_grant(
+        "v1", token_id, admin, req=req,
+    )
+
+    assert result["write_actions"] == ["file_upload"]
+    assert observed == {
+        "actor_id": admin.user_id,
+        "vault_name": "v1",
+        "token_id": token_id,
+        "write_actions": ["file_upload"],
+    }
+
+
 async def test_admin_remove_grant_forwards_args(monkeypatch):
     from app.api.routes import access
 

--- a/backend/tests/test_vault_write_policy_routes_unit.py
+++ b/backend/tests/test_vault_write_policy_routes_unit.py
@@ -76,6 +76,27 @@ async def test_non_admin_rejected_for_add_grant(monkeypatch):
     assert exc_info.value.status_code == 403
 
 
+async def test_non_admin_rejected_for_atomic_bootstrap(monkeypatch):
+    from app.api.routes import access
+
+    async def _must_not_run(*_a, **_k):
+        raise AssertionError("service must not run for a non-admin")
+
+    monkeypatch.setattr(access, "bootstrap_vault_write_policy", _must_not_run)
+    req = access.BootstrapVaultWritePolicyRequest(
+        managed_by="akb-platform:workspace-a",
+        grants=[
+            access.BootstrapVaultWriteGrantRequest(token_id=str(uuid.uuid4()))
+        ],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_bootstrap_vault_write_policy(
+            "some-vault", req, _user(admin=False),
+        )
+    assert exc_info.value.status_code == 403
+
+
 async def test_non_admin_rejected_for_remove_grant(monkeypatch):
     from app.api.routes import access
 
@@ -193,6 +214,52 @@ async def test_admin_add_grant_forwards_action_limit(monkeypatch):
     }
 
 
+async def test_admin_atomic_bootstrap_forwards_complete_grant_set(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+    wildcard_id = str(uuid.uuid4())
+    upload_id = str(uuid.uuid4())
+
+    async def _bootstrap(actor_id, vault_name, managed_by, grants, note=None):
+        observed.update(
+            actor_id=actor_id,
+            vault_name=vault_name,
+            managed_by=managed_by,
+            grants=grants,
+            note=note,
+        )
+        return {"vault": vault_name, "marked": True, "grants": grants}
+
+    monkeypatch.setattr(access, "bootstrap_vault_write_policy", _bootstrap)
+    admin = _user(admin=True)
+    req = access.BootstrapVaultWritePolicyRequest(
+        managed_by="akb-platform:workspace-a",
+        note="initial managed cutover",
+        grants=[
+            access.BootstrapVaultWriteGrantRequest(token_id=wildcard_id),
+            access.BootstrapVaultWriteGrantRequest(
+                token_id=upload_id,
+                actions=["file_upload"],
+            ),
+        ],
+    )
+
+    result = await access.admin_bootstrap_vault_write_policy("v1", req, admin)
+
+    assert result["marked"] is True
+    assert observed == {
+        "actor_id": admin.user_id,
+        "vault_name": "v1",
+        "managed_by": "akb-platform:workspace-a",
+        "grants": [
+            {"token_id": wildcard_id, "write_actions": None},
+            {"token_id": upload_id, "write_actions": ["file_upload"]},
+        ],
+        "note": "initial managed cutover",
+    }
+
+
 async def test_admin_remove_grant_forwards_args(monkeypatch):
     from app.api.routes import access
 
@@ -218,6 +285,7 @@ async def test_write_policy_routes_are_explicit_in_openapi():
     paths = app.openapi()["paths"]
     expected = {
         "/api/v1/admin/vaults/{vault}/write-policy",
+        "/api/v1/admin/vaults/{vault}/write-policy/bootstrap",
         "/api/v1/admin/vaults/{vault}/write-policy/grants/{token_id}",
     }
     assert expected <= set(paths)

--- a/backend/tests/test_vault_write_policy_unit.py
+++ b/backend/tests/test_vault_write_policy_unit.py
@@ -55,6 +55,7 @@ async def pool(monkeypatch):
         "010_external_git_mirror.py",
         "015_events_outbox.py",
         "044_vault_write_policy.py",
+        "045_vault_write_grant_actions.py",
     ):
         migration = _load_migration(filename)
         assert migration is not None
@@ -178,6 +179,46 @@ async def _create_token(pg_pool, user_id: uuid.UUID) -> uuid.UUID:
     return token_id
 
 
+async def _create_upload_service_token(
+    pg_pool,
+    user_id: uuid.UUID,
+    vault_name: str,
+    *,
+    scopes: tuple[str, ...] = ("write",),
+    scoped_vault: str | None = None,
+    is_admin: bool = False,
+) -> uuid.UUID:
+    from app.services.auth_service import _hash_token
+
+    raw = f"akb_secret_vwp_{uuid.uuid4().hex}"
+    vault_scope = (
+        json.dumps({"prefixes": [], "extra_vaults": [scoped_vault or vault_name]})
+        if scoped_vault != ""
+        else None
+    )
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE users SET account_kind = 'service', is_admin = $2 WHERE id = $1",
+            user_id,
+            is_admin,
+        )
+        return await conn.fetchval(
+            """
+            INSERT INTO tokens (
+                user_id, name, token_hash, token_prefix,
+                scopes, vault_scope, key_class
+            )
+            VALUES ($1, 'vwp-upload-token', $2, $3, $4, $5::jsonb, 'service')
+            RETURNING id
+            """,
+            user_id,
+            _hash_token(raw),
+            raw[:12],
+            list(scopes),
+            vault_scope,
+        )
+
+
 class TestMigrationIdempotent:
     async def test_migrate_applies_twice_without_error(self, pool):
         from app.db.postgres import _load_migration
@@ -221,6 +262,61 @@ class TestMigrationIdempotent:
 
 
 class TestRepoCrudRoundTrip:
+    async def test_migration_045_backfills_preexisting_grants_to_wildcard(self, pool):
+        from app.db.postgres import _load_migration
+
+        migration = _load_migration("045_vault_write_grant_actions.py")
+        assert migration is not None
+        schema = f"vwp_m045_{uuid.uuid4().hex}"
+        vault_id = uuid.uuid4()
+        token_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            await conn.execute(f'CREATE SCHEMA "{schema}"')
+            await conn.execute(f'SET search_path TO "{schema}"')
+            try:
+                await conn.execute(
+                    """
+                    CREATE TABLE vault_write_grants (
+                        vault_id UUID NOT NULL,
+                        token_id UUID NOT NULL,
+                        granted_by TEXT NOT NULL,
+                        PRIMARY KEY (vault_id, token_id)
+                    )
+                    """
+                )
+                await conn.execute(
+                    "INSERT INTO vault_write_grants (vault_id, token_id, granted_by) "
+                    "VALUES ($1, $2, 'pre-045-admin')",
+                    vault_id,
+                    token_id,
+                )
+
+                await migration.migrate(conn=conn)
+
+                assert await conn.fetchval(
+                    "SELECT write_actions FROM vault_write_grants "
+                    "WHERE vault_id = $1 AND token_id = $2",
+                    vault_id,
+                    token_id,
+                ) == ["*"]
+                assert await conn.fetchval(
+                    "SELECT is_nullable = 'NO' FROM information_schema.columns "
+                    "WHERE table_schema = $1 "
+                    "AND table_name = 'vault_write_grants' "
+                    "AND column_name = 'write_actions'",
+                    schema,
+                ) is True
+                with pytest.raises(asyncpg.CheckViolationError):
+                    await conn.execute(
+                        "UPDATE vault_write_grants SET write_actions = ARRAY[]::TEXT[] "
+                        "WHERE vault_id = $1 AND token_id = $2",
+                        vault_id,
+                        token_id,
+                    )
+            finally:
+                await conn.execute("RESET search_path")
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+
     async def test_get_policy_none_when_ungoverned(self, pool):
         from app.repositories import vault_write_policy_repo as repo
 
@@ -301,6 +397,59 @@ class TestRepoCrudRoundTrip:
         await repo.add_grant(vault_id, token_id, "admin-user")  # must not raise
 
         assert await repo.is_granted(vault_id, token_id) is True
+
+    async def test_action_limited_grant_only_matches_declared_action(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "naut:upload", "admin-user")
+
+        await repo.add_grant(
+            vault_id,
+            token_id,
+            "admin-user",
+            write_actions=("file_upload",),
+        )
+
+        assert await repo.is_granted(vault_id, token_id, action="file_upload") is True
+        assert await repo.is_granted(vault_id, token_id, action="document_write") is False
+        assert await repo.is_granted(vault_id, token_id) is False
+        assert await repo.get_grant_actions(vault_id, token_id) == frozenset({"file_upload"})
+
+    async def test_regrant_replaces_wildcard_with_action_limit(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "naut:upload", "admin-user")
+
+        await repo.add_grant(vault_id, token_id, "admin-user")
+        await repo.add_grant(
+            vault_id,
+            token_id,
+            "admin-user",
+            write_actions=("file_upload",),
+        )
+
+        assert await repo.get_grant_actions(vault_id, token_id) == frozenset({"file_upload"})
+        assert await repo.is_granted(vault_id, token_id) is False
+
+    async def test_existing_default_grant_is_wildcard_compatible(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+
+        owner_id = await _create_user(pool)
+        vault_id = await _create_vault(pool, owner_id)
+        token_id = await _create_token(pool, owner_id)
+        await repo.set_policy(vault_id, "collector:x", "admin-user")
+        await repo.add_grant(vault_id, token_id, "admin-user")
+
+        assert await repo.get_grant_actions(vault_id, token_id) == frozenset({"*"})
+        assert await repo.is_granted(vault_id, token_id) is True
+        assert await repo.is_granted(vault_id, token_id, action="file_upload") is True
+        assert await repo.is_granted(vault_id, token_id, action="anything") is True
 
     async def test_add_grant_without_policy_raises_fk_violation(self, pool):
         from app.repositories import vault_write_policy_repo as repo
@@ -515,6 +664,91 @@ class TestWritePolicyGuard:
             )
 
         assert result["vault_id"] == vault_id
+
+    async def test_action_limited_grant_passes_only_when_guard_declares_matching_action(self, pool):
+        from app.exceptions import ForbiddenError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import check_vault_access
+
+        owner_id = await _create_user(pool)
+        service_user_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "naut:upload", "admin-user")
+        token_id = await _create_token(pool, service_user_id)
+        await repo.add_grant(
+            vault_id,
+            token_id,
+            "admin-user",
+            write_actions=("file_upload",),
+        )
+
+        with _auth_context(token_id=token_id, scope=None):
+            allowed = await check_vault_access(
+                str(service_user_id),
+                vault_name,
+                required_role="writer",
+                write_action="file_upload",
+            )
+            assert allowed["write_grant_actions"] == ["file_upload"]
+            with pytest.raises(ForbiddenError):
+                await check_vault_access(
+                    str(service_user_id), vault_name, required_role="writer",
+                )
+            with pytest.raises(ForbiddenError):
+                await check_vault_access(
+                    str(service_user_id),
+                    vault_name,
+                    required_role="writer",
+                    write_action="document_write",
+                )
+
+    async def test_delegated_human_requires_explicit_writer_membership(self, pool):
+        from app.exceptions import ForbiddenError
+        from app.services.access_service import check_delegated_vault_writer
+
+        owner_id = await _create_user(pool)
+        writer_id = await _create_user(pool)
+        reader_id = await _create_user(pool)
+        stranger_id = await _create_user(pool)
+        service_writer_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        _other_vault_id, other_vault_name = await _create_named_vault(pool, owner_id)
+        async with pool.acquire() as conn:
+            await conn.executemany(
+                "INSERT INTO vault_access (vault_id, user_id, role) VALUES ($1, $2, $3)",
+                [
+                    (vault_id, writer_id, "writer"),
+                    (vault_id, reader_id, "reader"),
+                    (vault_id, service_writer_id, "writer"),
+                ],
+            )
+            await conn.execute(
+                "UPDATE users SET account_kind = 'service' WHERE id = $1",
+                service_writer_id,
+            )
+            await conn.execute(
+                "INSERT INTO vault_access (vault_id, user_id, role) "
+                "SELECT id, $1, 'writer' FROM vaults WHERE name = $2",
+                stranger_id,
+                other_vault_name,
+            )
+
+        assert (await check_delegated_vault_writer(str(owner_id), vault_name))["role"] == "owner"
+        assert (await check_delegated_vault_writer(str(writer_id), vault_name))["role"] == "writer"
+        with pytest.raises(ForbiddenError):
+            await check_delegated_vault_writer(str(reader_id), vault_name)
+        with pytest.raises(ForbiddenError):
+            await check_delegated_vault_writer(str(stranger_id), vault_name)
+        with pytest.raises(ForbiddenError, match="human"):
+            await check_delegated_vault_writer(str(service_writer_id), vault_name)
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE users SET account_status = 'suspended' WHERE id = $1",
+                writer_id,
+            )
+        with pytest.raises(ForbiddenError):
+            await check_delegated_vault_writer(str(writer_id), vault_name)
 
     async def test_unscoped_admin_bypasses_and_emits_audit(self, pool):
         """A3: a system admin with no PAT vault scope bypasses a marked
@@ -948,6 +1182,110 @@ class TestAdminWritePolicyGrants:
         )
         assert payload["token_id"] == str(token_id)
         assert payload["managed_by"] == "collector:acme"
+
+    async def test_file_upload_grant_requires_exact_upload_service_profile(self, pool):
+        from app.exceptions import ValidationError
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import add_vault_write_grant
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        service_user_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        await repo.set_policy(vault_id, "naut:upload", "admin-user")
+        token_id = await _create_upload_service_token(
+            pool, service_user_id, vault_name,
+        )
+
+        result = await add_vault_write_grant(
+            str(admin_id),
+            vault_name,
+            str(token_id),
+            write_actions=["file_upload"],
+        )
+
+        assert result["write_actions"] == ["file_upload"]
+        assert await repo.get_grant_actions(vault_id, token_id) == frozenset({"file_upload"})
+
+        pat_id = await _create_token(pool, owner_id)
+        with pytest.raises(ValidationError, match="service key"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(pat_id),
+                write_actions=["file_upload"],
+            )
+
+        broad_user_id = await _create_user(pool)
+        broad_id = await _create_upload_service_token(
+            pool,
+            broad_user_id,
+            vault_name,
+            scopes=("read", "write"),
+        )
+        with pytest.raises(ValidationError, match="coarse scope"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(broad_id),
+                write_actions=["file_upload"],
+            )
+
+        unscoped_user_id = await _create_user(pool)
+        unscoped_id = await _create_upload_service_token(
+            pool,
+            unscoped_user_id,
+            vault_name,
+            scoped_vault="",
+        )
+        with pytest.raises(ValidationError, match="exactly the target Vault"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(unscoped_id),
+                write_actions=["file_upload"],
+            )
+
+        admin_service_user_id = await _create_user(pool)
+        admin_service_id = await _create_upload_service_token(
+            pool,
+            admin_service_user_id,
+            vault_name,
+            is_admin=True,
+        )
+        with pytest.raises(ValidationError, match="non-admin service account"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(admin_service_id),
+                write_actions=["file_upload"],
+            )
+
+        suspended_user_id = await _create_user(pool)
+        suspended_id = await _create_upload_service_token(
+            pool,
+            suspended_user_id,
+            vault_name,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE users SET account_status = 'suspended' WHERE id = $1",
+                suspended_user_id,
+            )
+        with pytest.raises(ValidationError, match="active service account"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(suspended_id),
+                write_actions=["file_upload"],
+            )
+
+        expired_user_id = await _create_user(pool)
+        expired_id = await _create_upload_service_token(
+            pool,
+            expired_user_id,
+            vault_name,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE tokens SET expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1",
+                expired_id,
+            )
+        with pytest.raises(ValidationError, match="unexpired service key"):
+            await add_vault_write_grant(
+                str(admin_id), vault_name, str(expired_id),
+                write_actions=["file_upload"],
+            )
 
     async def test_add_vault_write_grant_rejects_unmarked_vault(self, pool):
         from app.exceptions import ConflictError

--- a/backend/tests/test_vault_write_policy_unit.py
+++ b/backend/tests/test_vault_write_policy_unit.py
@@ -1183,6 +1183,112 @@ class TestAdminWritePolicyGrants:
         assert payload["token_id"] == str(token_id)
         assert payload["managed_by"] == "collector:acme"
 
+    async def test_atomic_bootstrap_commits_policy_and_complete_grant_set(self, pool):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import bootstrap_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        service_user_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        wildcard_id = await _create_token(pool, owner_id)
+        upload_id = await _create_upload_service_token(
+            pool, service_user_id, vault_name,
+        )
+
+        result = await bootstrap_vault_write_policy(
+            str(admin_id),
+            vault_name,
+            "akb-platform:workspace-a",
+            [
+                {"token_id": str(wildcard_id), "write_actions": None},
+                {
+                    "token_id": str(upload_id),
+                    "write_actions": ["file_upload"],
+                },
+            ],
+            note="initial managed cutover",
+        )
+
+        assert result == {
+            "vault": vault_name,
+            "managed_by": "akb-platform:workspace-a",
+            "note": "initial managed cutover",
+            "marked": True,
+            "grants": [
+                {"token_id": str(wildcard_id), "write_actions": ["*"]},
+                {"token_id": str(upload_id), "write_actions": ["file_upload"]},
+            ],
+        }
+        assert await repo.get_policy(vault_id) is not None
+        assert await repo.get_grant_actions(vault_id, wildcard_id) == frozenset({"*"})
+        assert await repo.get_grant_actions(vault_id, upload_id) == frozenset(
+            {"file_upload"}
+        )
+
+        async with pool.acquire() as conn:
+            events = await conn.fetch(
+                "SELECT payload FROM events "
+                "WHERE kind = 'vault.write_policy_changed' AND vault_id = $1",
+                vault_id,
+            )
+        assert len(events) == 1
+        payload = (
+            json.loads(events[0]["payload"])
+            if isinstance(events[0]["payload"], str)
+            else events[0]["payload"]
+        )
+        assert payload["action"] == "bootstrapped"
+        assert payload["grants"] == result["grants"]
+
+    async def test_atomic_bootstrap_rolls_back_policy_when_any_grant_fails(
+        self, pool, monkeypatch,
+    ):
+        from app.repositories import vault_write_policy_repo as repo
+        from app.services.access_service import bootstrap_vault_write_policy
+
+        admin_id = await _create_admin_user(pool)
+        owner_id = await _create_user(pool)
+        vault_id, vault_name = await _create_named_vault(pool, owner_id)
+        first_id = await _create_token(pool, owner_id)
+        second_id = await _create_token(pool, owner_id)
+        real_add_grant = repo.add_grant
+        calls = 0
+
+        async def _fail_second(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("injected second-grant failure")
+            await real_add_grant(*args, **kwargs)
+
+        monkeypatch.setattr(repo, "add_grant", _fail_second)
+
+        with pytest.raises(RuntimeError, match="second-grant failure"):
+            await bootstrap_vault_write_policy(
+                str(admin_id),
+                vault_name,
+                "akb-platform:workspace-a",
+                [
+                    {"token_id": str(first_id), "write_actions": None},
+                    {"token_id": str(second_id), "write_actions": None},
+                ],
+            )
+
+        assert await repo.get_policy(vault_id) is None
+        async with pool.acquire() as conn:
+            grant_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM vault_write_grants WHERE vault_id = $1",
+                vault_id,
+            )
+            event_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM events "
+                "WHERE kind = 'vault.write_policy_changed' AND vault_id = $1",
+                vault_id,
+            )
+        assert grant_count == 0
+        assert event_count == 0
+
     async def test_file_upload_grant_requires_exact_upload_service_profile(self, pool):
         from app.exceptions import ValidationError
         from app.repositories import vault_write_policy_repo as repo


### PR DESCRIPTION
## Summary
- add action-limited managed Vault write grants while preserving existing wildcard grants
- require an upload-only service key plus an active human AKB session for managed file upload and confirmation
- preserve both actor identities in bounded file audit fields
- add migration and regression coverage for compatibility, denial, and token-profile invariants

## Security boundaries
- `file_upload` grants require a non-admin service account, service key, exact `write` scope, and exactly one Vault
- delegated identities must be active human accounts with explicit writer-or-higher Vault membership
- limited grants do not authorize document, table, delete, SQL, or lifecycle writes

## Verification
- focused policy/delegation suite: 71 passed
- full backend suite: 830 passed, 24 skipped
- Ruff, mypy, and `uv build`: passed