### PR TITLE
test(auth): isolate write-policy OpenAPI route test

### DIFF
--- a/backend/tests/test_vault_write_policy_routes_unit.py
+++ b/backend/tests/test_vault_write_policy_routes_unit.py
@@ -279,7 +279,10 @@ async def test_admin_remove_grant_forwards_args(monkeypatch):
     assert observed == {"actor_id": admin.user_id, "vault_name": "v1", "token_id": token_id}
 
 
-async def test_write_policy_routes_are_explicit_in_openapi():
+async def test_write_policy_routes_are_explicit_in_openapi(monkeypatch, tmp_path):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
     from app.main import app
 
     paths = app.openapi()["paths"]


### PR DESCRIPTION
## Summary

- pin the OpenAPI route unit test Git storage to pytest temporary storage before importing the app
- remove the hidden dependency on a writable host /data path in clean checkouts

## Why

The merged-main cross-repo harness passed 74 tests and failed only when this route test imported GitService, whose production default is /data/vaults. Production behavior is unchanged; the test now owns its filesystem boundary.

## Verification

- uv run --locked --extra dev pytest -q: 834 passed, 24 skipped
- uv run --locked --extra dev ruff check app tests
- uv run --locked --extra dev mypy app
- uv build
- delegated upload cross-repo lane: 75 passed
