### PR TITLE
feat(auth): select OIDC client per trusted companion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3098
+        "line_number": 3105
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T19:48:03Z"
+  "generated_at": "2026-07-14T13:13:01Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -21,6 +21,13 @@ post-state SSO protocol codes on their original callback URL. The callback
 origin is revalidated before every error redirect; unlisted or stale targets
 still return only to AKB's own auth page.
 
+An already allowlisted companion origin may now select a dedicated Keycloak
+client through `keycloak_companion_client_ids_by_origin`. AKB stores that
+server-selected client in its single-use OIDC state and uses it consistently
+for authorization, code exchange, and ID-token audience verification. Empty
+configuration and every unlisted or malformed destination retain the existing
+global `keycloak_client_id` flow.
+
 The compact MCP `akb_list_vaults` response now preserves each vault's effective
 `role` alongside its name and description. This aligns the implementation with
 the documented MCP contract and lets managed runtimes distinguish an explicit

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -167,6 +167,31 @@ def _allowed_companion_origin(raw: str | None) -> str | None:
     return origin if origin in allowed else None
 
 
+def _keycloak_client_id_for_redirect(raw: str | None) -> str:
+    """Select a client only after ``raw`` passes the companion allowlist.
+
+    Client-specific Keycloak themes are useful for first-party products, but a
+    selector must not become a second, weaker trust boundary. We derive the
+    normalized origin with :func:`_allowed_companion_origin` first;
+    unlisted/relative/malformed URLs always retain the historical global
+    client. Mapping keys are normalized too so operator casing or a trailing
+    path cannot create surprising misses.
+    """
+    origin = _allowed_companion_origin(raw)
+    if origin is None:
+        return settings.keycloak_client_id
+    configured = {
+        normalized: client_id.strip()
+        for configured_origin, client_id in (
+            settings.keycloak_companion_client_ids_by_origin or {}
+        ).items()
+        if (normalized := _normalize_origin(configured_origin)) is not None
+        and isinstance(client_id, str)
+        and client_id.strip()
+    }
+    return configured.get(origin, settings.keycloak_client_id)
+
+
 def _with_query_param(url: str, key: str, value: str) -> str:
     """Append ``key=value`` to ``url``'s query, preserving existing query
     and fragment."""
@@ -237,7 +262,9 @@ async def keycloak_login(redirect: str = "/"):
         if _allowed_companion_origin(redirect) is not None
         else _safe_redirect_path(redirect)
     )
-    url = await get_keycloak_oidc().begin_login(dest)
+    url = await get_keycloak_oidc().begin_login(
+        dest, client_id=_keycloak_client_id_for_redirect(redirect)
+    )
     return RedirectResponse(url, status_code=status.HTTP_302_FOUND)
 
 
@@ -267,11 +294,14 @@ async def keycloak_callback(request: Request):
         return _sso_error_redirect("invalid_state")
 
     try:
-        tokens = await svc.exchange_code_for_tokens(code, flow.get("code_verifier"))
+        client_id = flow.get("client_id")
+        tokens = await svc.exchange_code_for_tokens(
+            code, flow.get("code_verifier"), client_id=client_id
+        )
         id_token = tokens.get("id_token")
         if not id_token:
             return _sso_error_redirect("no_id_token", flow.get("redirect_path"))
-        claims = await svc.verify_id_token(id_token)
+        claims = await svc.verify_id_token(id_token, client_id=client_id)
         login_response = await login_with_keycloak_claims(claims)
     except AKBError as e:
         # Don't leak detail into the URL; log server-side, show a code.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -330,6 +330,16 @@ class Settings(BaseModel):
     # full origin matched as scheme://host[:port], e.g.
     #   ["https://reef-acme.example.com"]
     keycloak_post_login_allowed_origins: list[str] = Field(default_factory=list)
+    # Optional per-companion OIDC client selection. Keys are companion origins
+    # (normalized as scheme://host[:port]); values are Keycloak client ids.
+    # The mapping is consulted only after the origin passes the allowlist above,
+    # so adding a mapping can never grant a new redirect destination. The AKB
+    # backend remains the sole OIDC client and uses its backend-only secret for
+    # the selected confidential client. Empty preserves the historical single
+    # `keycloak_client_id` flow.
+    keycloak_companion_client_ids_by_origin: dict[str, str] = Field(
+        default_factory=dict
+    )
     # One-time exchange-code TTL (seconds). The callback hands the SPA a
     # short-lived opaque code; the SPA trades it for the AKB JWT over a
     # POST so the token never rides in a URL. Keep this small.

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -130,7 +130,18 @@ class KeycloakOIDC:
         return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
     # ── Authorization request ────────────────────────────────────────
-    async def begin_login(self, redirect_path: str = "/") -> str:
+    @staticmethod
+    def _effective_client_id(client_id: str | None) -> str:
+        """Resolve an optional server-selected client to the legacy default."""
+        return (
+            client_id.strip()
+            if client_id and client_id.strip()
+            else settings.keycloak_client_id
+        )
+
+    async def begin_login(
+        self, redirect_path: str = "/", *, client_id: str | None = None
+    ) -> str:
         """Create CSRF state (+PKCE for public clients) and return the
         Keycloak authorization URL to redirect the browser to.
 
@@ -139,10 +150,14 @@ class KeycloakOIDC:
         be an allowlisted companion-app absolute URL (cross-origin SSO); the
         callback (`_post_login_target`) re-validates it before delivering the
         one-time code, so this layer just stores it verbatim."""
+        selected_client_id = self._effective_client_id(client_id)
         state = secrets.token_urlsafe(32)
-        payload: dict[str, str] = {"redirect_path": redirect_path}
+        payload: dict[str, str] = {
+            "redirect_path": redirect_path,
+            "client_id": selected_client_id,
+        }
         params: dict[str, str] = {
-            "client_id": settings.keycloak_client_id,
+            "client_id": selected_client_id,
             "redirect_uri": settings.keycloak_redirect_uri,
             "response_type": "code",
             "scope": _SCOPE,
@@ -166,13 +181,18 @@ class KeycloakOIDC:
 
     # ── Token exchange ───────────────────────────────────────────────
     async def exchange_code_for_tokens(
-        self, code: str, code_verifier: str | None
+        self,
+        code: str,
+        code_verifier: str | None,
+        *,
+        client_id: str | None = None,
     ) -> dict[str, Any]:
+        selected_client_id = self._effective_client_id(client_id)
         data: dict[str, str] = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": settings.keycloak_redirect_uri,
-            "client_id": settings.keycloak_client_id,
+            "client_id": selected_client_id,
         }
         if settings.keycloak_public_client:
             if code_verifier:
@@ -218,13 +238,16 @@ class KeycloakOIDC:
             (k for k in jwks.get("keys", []) if k.get("kid") == kid), None
         )
 
-    async def verify_id_token(self, id_token: str) -> dict[str, Any]:
+    async def verify_id_token(
+        self, id_token: str, *, client_id: str | None = None
+    ) -> dict[str, Any]:
         """Verify a Keycloak ID token locally and return its claims.
 
         Validates signature (RS256), audience (client_id), issuer (realm),
         and expiry. Refetches JWKS once if the token's ``kid`` is unknown
         (key rotation) before giving up.
         """
+        selected_client_id = self._effective_client_id(client_id)
         try:
             header = jwt.get_unverified_header(id_token)
         except jwt.InvalidTokenError as e:
@@ -249,7 +272,7 @@ class KeycloakOIDC:
                 id_token,
                 cast(Any, public_key),
                 algorithms=["RS256"],
-                audience=settings.keycloak_client_id,
+                audience=selected_client_id,
                 issuer=settings.keycloak_issuer,
                 options={"require": ["exp", "iat", "aud", "iss", "sub"]},
             )

--- a/backend/tests/test_keycloak_companion_client_unit.py
+++ b/backend/tests/test_keycloak_companion_client_unit.py
@@ -1,0 +1,111 @@
+"""Unit coverage for per-companion Keycloak OIDC client selection.
+
+The selected client is server-owned flow state.  It must be identical at the
+authorization endpoint, token exchange, and ID-token audience check; otherwise
+a themed companion login either leaks onto the shared client or fails midway.
+"""
+from __future__ import annotations
+
+import urllib.parse
+
+import pytest
+
+from app.config import settings
+from app.services import keycloak_oidc
+from app.services.keycloak_oidc import KeycloakOIDC
+
+
+@pytest.mark.asyncio
+async def test_begin_login_persists_and_authorizes_with_selected_client(monkeypatch):
+    issued: dict[str, object] = {}
+
+    async def capture_issue(key, kind, payload, ttl_secs):
+        issued.update(key=key, kind=kind, payload=payload, ttl_secs=ttl_secs)
+
+    monkeypatch.setattr(keycloak_oidc, "_store_issue", capture_issue)
+    monkeypatch.setattr(settings, "keycloak_public_client", False)
+
+    url = await KeycloakOIDC().begin_login(
+        "https://naut.example.com/api/auth/akb/sso/callback",
+        client_id="naut-web",
+    )
+
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+    assert query["client_id"] == ["naut-web"]
+    assert issued["kind"] == "state"
+    assert issued["payload"] == {
+        "redirect_path": "https://naut.example.com/api/auth/akb/sso/callback",
+        "client_id": "naut-web",
+    }
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_uses_selected_client_with_backend_secret(monkeypatch):
+    posted: dict[str, object] = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"id_token": "signed"}
+
+    class Client:
+        async def post(self, url, data):
+            posted.update(url=url, data=data)
+            return Response()
+
+    service = KeycloakOIDC()
+    monkeypatch.setattr(service, "_client", lambda: Client())
+    monkeypatch.setattr(settings, "keycloak_public_client", False)
+    monkeypatch.setattr(settings, "keycloak_client_secret", "backend-only-secret")
+
+    result = await service.exchange_code_for_tokens(
+        "code-1", None, client_id="naut-web"
+    )
+
+    assert result == {"id_token": "signed"}
+    assert posted["data"]["client_id"] == "naut-web"  # type: ignore[index]
+    assert posted["data"]["client_secret"] == "backend-only-secret"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_id_token_audience_uses_selected_client(monkeypatch):
+    decoded: dict[str, object] = {}
+    service = KeycloakOIDC()
+
+    async def fake_jwks(*, force=False):
+        return {"keys": [{"kid": "key-1", "kty": "RSA"}]}
+
+    def fake_decode(token, key, **kwargs):
+        decoded.update(token=token, key=key, **kwargs)
+        return {"sub": "user-1"}
+
+    monkeypatch.setattr(service, "_fetch_jwks", fake_jwks)
+    monkeypatch.setattr(keycloak_oidc.jwt, "get_unverified_header", lambda _: {"kid": "key-1"})
+    monkeypatch.setattr(keycloak_oidc.RSAAlgorithm, "from_jwk", lambda _: "public-key")
+    monkeypatch.setattr(keycloak_oidc.jwt, "decode", fake_decode)
+
+    claims = await service.verify_id_token("signed", client_id="naut-web")
+
+    assert claims == {"sub": "user-1"}
+    assert decoded["audience"] == "naut-web"
+
+
+@pytest.mark.asyncio
+async def test_default_client_remains_the_global_client(monkeypatch):
+    issued: dict[str, object] = {}
+
+    async def capture_issue(_key, _kind, payload, ttl_secs):
+        assert ttl_secs == 600
+        issued.update(payload)
+
+    monkeypatch.setattr(keycloak_oidc, "_store_issue", capture_issue)
+    monkeypatch.setattr(settings, "keycloak_public_client", False)
+    monkeypatch.setattr(settings, "keycloak_client_id", "akb-web")
+
+    url = await KeycloakOIDC().begin_login("/dashboard")
+
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+    assert query["client_id"] == ["akb-web"]
+    assert issued["client_id"] == "akb-web"

--- a/backend/tests/test_keycloak_redirect_unit.py
+++ b/backend/tests/test_keycloak_redirect_unit.py
@@ -43,6 +43,16 @@ def allow(monkeypatch):
     return _set
 
 
+@pytest.fixture
+def companion_clients(monkeypatch):
+    """Set the trusted companion-origin -> Keycloak client selector."""
+    def _set(mapping: dict[str, str]) -> None:
+        monkeypatch.setattr(
+            settings, "keycloak_companion_client_ids_by_origin", mapping, raising=False
+        )
+    return _set
+
+
 # ── _normalize_origin ────────────────────────────────────────────────
 
 @pytest.mark.parametrize(
@@ -103,6 +113,62 @@ def test_allowlist_entries_normalized(allow):
         auth._allowed_companion_origin("https://reef.example.com/cb")
         == "https://reef.example.com"
     )
+
+
+# ── _keycloak_client_id_for_redirect ───────────────────────────────
+
+
+def test_companion_client_selected_only_for_allowlisted_origin(
+    allow, companion_clients, monkeypatch
+):
+    monkeypatch.setattr(settings, "keycloak_client_id", "akb-web")
+    allow(["https://naut.example.com"])
+    companion_clients({"https://naut.example.com": "naut-web"})
+
+    assert auth._keycloak_client_id_for_redirect(
+        "https://naut.example.com/api/auth/akb/sso/callback"
+    ) == "naut-web"
+    assert auth._keycloak_client_id_for_redirect(
+        "https://evil.example.com/api/auth/akb/sso/callback"
+    ) == "akb-web"
+    assert auth._keycloak_client_id_for_redirect("/dashboard") == "akb-web"
+
+
+def test_companion_client_mapping_normalizes_origin(
+    allow, companion_clients, monkeypatch
+):
+    monkeypatch.setattr(settings, "keycloak_client_id", "akb-web")
+    allow(["https://Naut.Example.com/path"])
+    companion_clients({"https://NAUT.example.com/ignored": "naut-web"})
+
+    assert auth._keycloak_client_id_for_redirect(
+        "https://naut.example.com/callback"
+    ) == "naut-web"
+
+
+@pytest.mark.asyncio
+async def test_login_passes_selected_client_into_oidc_state(
+    allow, companion_clients, monkeypatch
+):
+    from app.services import keycloak_oidc
+
+    allow(["https://naut.example.com"])
+    companion_clients({"https://naut.example.com": "naut-web"})
+    monkeypatch.setattr(auth, "_require_keycloak", lambda: None)
+    captured: dict[str, str] = {}
+
+    class FakeOIDC:
+        async def begin_login(self, redirect_path, *, client_id=None):
+            captured.update(redirect_path=redirect_path, client_id=client_id)
+            return "https://auth.example.com/realms/akb/protocol/openid-connect/auth"
+
+    monkeypatch.setattr(keycloak_oidc, "get_keycloak_oidc", lambda: FakeOIDC())
+    companion = "https://naut.example.com/api/auth/akb/sso/callback"
+
+    response = await auth.keycloak_login(companion)
+
+    assert response.status_code == 302
+    assert captured == {"redirect_path": companion, "client_id": "naut-web"}
 
 
 # ── _post_login_target ───────────────────────────────────────────────
@@ -196,14 +262,20 @@ async def test_callback_returns_account_error_to_allowed_companion(allow, monkey
     class FakeOIDC:
         async def consume_state(self, state):
             assert state == "state-1"
-            return {"code_verifier": "verifier", "redirect_path": companion}
+            return {
+                "code_verifier": "verifier",
+                "redirect_path": companion,
+                "client_id": "naut-web",
+            }
 
-        async def exchange_code_for_tokens(self, code, verifier):
+        async def exchange_code_for_tokens(self, code, verifier, *, client_id=None):
             assert (code, verifier) == ("code-1", "verifier")
+            assert client_id == "naut-web"
             return {"id_token": "id-token"}
 
-        async def verify_id_token(self, token):
+        async def verify_id_token(self, token, *, client_id=None):
             assert token == "id-token"
+            assert client_id == "naut-web"
             return {"sub": "subject-1"}
 
     async def reject_membership(_claims):
@@ -239,13 +311,24 @@ async def test_callback_returns_post_state_protocol_error_to_allowed_companion(
 
     companion = "https://reef.example.com/cb?redirect=%2Fdone"
     allow(["https://reef.example.com"])
+    monkeypatch.setattr(
+        settings,
+        "keycloak_companion_client_ids_by_origin",
+        {"https://reef.example.com": "naut-web"},
+        raising=False,
+    )
     monkeypatch.setattr(auth, "_require_keycloak", lambda: None)
 
     class FakeOIDC:
         async def consume_state(self, _state):
-            return {"code_verifier": "verifier", "redirect_path": companion}
+            return {
+                "code_verifier": "verifier",
+                "redirect_path": companion,
+                "client_id": "naut-web",
+            }
 
-        async def exchange_code_for_tokens(self, _code, _verifier):
+        async def exchange_code_for_tokens(self, _code, _verifier, *, client_id=None):
+            assert client_id == "naut-web"
             return {}
 
     monkeypatch.setattr(keycloak_oidc, "get_keycloak_oidc", lambda: FakeOIDC())

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -141,6 +141,10 @@ jwt_expire_hours: 24
 #                                           # client and get the one-time code or a stable account
 #                                           # error back on ITS origin. Empty =
 #                                           # akb's own SPA only (open-redirect-safe default).
+# keycloak_companion_client_ids_by_origin: {} # optional client-specific theme selector;
+#                                             # keys must also be allowlisted origins, e.g.
+#                                             # {"https://naut.example.com": "naut-web"}.
+#                                             # Empty preserves the global akb-web client.
 # keycloak_exchange_code_ttl_secs: 60
 # keycloak_client_secret lives in secret.yaml (never commit it)
 

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -225,6 +225,8 @@ keycloak_public_client: false          # true → PKCE, no client_secret
 keycloak_verify_ssl: true
 keycloak_redirect_uri: https://akb.example.com/api/v1/auth/keycloak/callback
 keycloak_post_login_path: /auth/callback
+keycloak_post_login_allowed_origins: []
+keycloak_companion_client_ids_by_origin: {}
 keycloak_exchange_code_ttl_secs: 60
 # config/secret.yaml
 keycloak_client_secret: "<from Keycloak client credentials>"
@@ -233,6 +235,12 @@ keycloak_client_secret: "<from Keycloak client credentials>"
 - `keycloak_client_secret` lives only in `secret.yaml` (gitignored) —
   matches `feedback_oss_no_secrets`. (AKB reads no env vars, so the
   seahorse `client_secret_env` indirection is replaced by secret.yaml.)
+- `keycloak_companion_client_ids_by_origin` may select a dedicated Keycloak
+  client (and therefore a client-specific login theme) for an already
+  allowlisted first-party companion origin. The selected client id is stored
+  in server-side single-use OIDC state and reused for authorization, code
+  exchange, and ID-token audience verification. Empty mapping, relative paths,
+  and unlisted origins always use `keycloak_client_id`.
 - **Split-horizon** `keycloak_internal_url`: when set, the **backchannel**
   calls (token + JWKS) use it while the **issuer** and browser-facing
   authorization/logout endpoints stay on `keycloak_server_url`. Solves


### PR DESCRIPTION
## What changed

- Select a Keycloak OIDC client from a trusted companion-origin mapping after the existing origin allowlist succeeds.
- Persist the selected client in server-side OAuth state and reuse it for authorization, code exchange, and ID-token audience verification.
- Keep `akb-web` as the default and add unit coverage, example configuration, design documentation, and changelog notes.

## Why

Naut needs a client-specific Keycloak login theme while AKB remains the single backend callback and token owner. Previously every trusted companion was forced through the default `akb-web` client, so Keycloak could not select a Naut-only theme without changing other products.

## Impact and safety

The mapping is empty by default. Unmapped or relative origins retain the existing `akb-web` behavior, and client selection happens only after the origin allowlist check.

## Validation

- 79 relevant backend tests passed.
- Ruff and mypy passed.
- Naut isolated development environment live login completed through `naut-web`, callback, `/me`, and workspace loading.
