### PR TITLE
fix(access): truthful admin-bypass semantics for ownership surfaces

### DIFF
--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -267,10 +267,19 @@ async def check_vault_access(
                     f"service token with the required write action"
                 )
 
-        # System admin bypasses all vault ACL
+        # System admin bypasses all vault ACL. `role` stays "owner" so every
+        # required_role gate keeps passing, but `role_source` must tell the
+        # truth: labelling the bypass "member" made downstream callers
+        # (get_vault_info's role field, transfer_ownership's owner re-check)
+        # believe the admin literally owns the vault.
         is_admin = await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid)
         if is_admin:
-            return {"vault_id": vault["id"], "role": "owner", "status": vault["status"], "role_source": "member"}
+            return {
+                "vault_id": vault["id"],
+                "role": "owner",
+                "status": vault["status"],
+                "role_source": "system_admin",
+            }
 
         # Owner always has full access
         if vault["owner_id"] == uid:
@@ -624,6 +633,16 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
 
     vault = await _r("SELECT * FROM vaults WHERE name = $1", vault_name)
     vid = vault["id"]
+    if (
+        role_source in ("system_admin", "write_policy_admin_bypass")
+        and vault["owner_id"] != uuid.UUID(user_id)
+    ):
+        # An admin bypass is access, not ownership. Report the same "admin"
+        # label `list_accessible_vaults` uses for this caller/vault pair so
+        # consumers gating on role == "owner" (ownership transfer UIs, the
+        # pipeline's Pattern 35 target-vault gate) cannot mistake a
+        # superuser grant for ownership.
+        caller_role = "admin"
     (
         owner,
         member_count,
@@ -775,7 +794,7 @@ def _coerce_example(v):
 # ── Transfer ownership ──────────────────────────────────────
 
 async def transfer_ownership(owner_id: str, vault_name: str, new_owner_username: str) -> dict:
-    """Transfer vault ownership. Only current owner can do this.
+    """Transfer vault ownership. The current owner or a system admin can do this.
 
     All three mutations (owner update, old-owner-to-admin grant, new-owner
     vault_access cleanup) run in ONE transaction so a crash mid-transfer
@@ -783,7 +802,15 @@ async def transfer_ownership(owner_id: str, vault_name: str, new_owner_username:
     (06-F1). The vault row is selected ``FOR UPDATE`` so a concurrent
     transfer also serializes — only one of N parallel transfers wins.
     """
-    await check_vault_access(owner_id, vault_name, required_role="owner")
+    access = await check_vault_access(owner_id, vault_name, required_role="owner")
+    # An admin passes the gate above without literally owning the vault, so
+    # the owner-staleness re-check below must not treat that as a lost race
+    # (it used to raise a misleading "owner_id moved" conflict on EVERY
+    # admin-initiated transfer).
+    caller_is_system_admin = access["role_source"] in (
+        "system_admin",
+        "write_policy_admin_bypass",
+    )
 
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -796,8 +823,11 @@ async def transfer_ownership(owner_id: str, vault_name: str, new_owner_username:
                 raise NotFoundError("Vault", vault_name)
             current_owner_uid = uuid.UUID(owner_id)
             # Re-verify ownership under the row lock — a concurrent
-            # transfer might have already moved owner_id away from us.
-            if vault["owner_id"] != current_owner_uid:
+            # transfer might have already moved owner_id away from us. An
+            # admin's right to transfer does not depend on who currently
+            # owns the row (the FOR UPDATE lock still serializes), so the
+            # staleness check only applies to owner-initiated transfers.
+            if vault["owner_id"] != current_owner_uid and not caller_is_system_admin:
                 raise ConflictError(
                     "owner_id moved during transfer (another transfer won the race)"
                 )

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -1031,7 +1031,10 @@ TOOLS = [
     ),
     Tool(
         name="akb_transfer_ownership",
-        description="Transfer vault ownership to another user. Only the current owner can do this.",
+        description=(
+            "Transfer vault ownership to another user. The current owner or "
+            "a system admin can do this."
+        ),
         inputSchema={
             "type": "object",
             "properties": {

--- a/backend/tests/test_admin_ownership_semantics_unit.py
+++ b/backend/tests/test_admin_ownership_semantics_unit.py
@@ -1,0 +1,236 @@
+"""Admin-bypass ownership semantics: transfer + vault_info role truthfulness.
+
+Trigger case (2026-07-16, seahorse-pipeline console-e2e vault repair):
+
+- ``akb_transfer_ownership`` initiated by a system admin who is not the
+  literal owner always failed with the misleading conflict ``owner_id moved
+  during transfer`` — ``check_vault_access(required_role="owner")`` passes
+  via the admin bypass, but the row-lock staleness re-check assumed the
+  caller IS the owner.
+- ``get_vault_info`` reported ``role: "owner"`` to admins on vaults they do
+  not own (the bypass labelled itself ``role_source: "member"``), while
+  ``list_accessible_vaults`` reports ``"admin"`` for the same caller/vault —
+  consumers gating on ``role == "owner"`` (ownership-transfer UIs, the
+  pipeline's Pattern 35 target-vault gate) were lied to.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.services import access_service
+
+OWNER_ID = uuid.UUID("00000000-0000-0000-0000-00000000aaaa")
+ADMIN_ID = uuid.UUID("00000000-0000-0000-0000-00000000bbbb")
+NEW_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-00000000cccc")
+VAULT_ID = uuid.UUID("00000000-0000-0000-0000-00000000dddd")
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    """Answers the exact queries transfer_ownership runs, records writes."""
+
+    def __init__(self, *, vault_owner: uuid.UUID):
+        self.vault_owner = vault_owner
+        self.executed: list[tuple[str, tuple]] = []
+
+    def transaction(self):
+        return _FakeTransaction()
+
+    async def fetchrow(self, query: str, *args):
+        if "FROM vaults" in query:
+            return {"id": VAULT_ID, "owner_id": self.vault_owner}
+        if "FROM users" in query:
+            return {"id": NEW_OWNER_ID, "username": args[0]}
+        raise AssertionError(f"unexpected fetchrow: {query}")
+
+    async def execute(self, query: str, *args):
+        self.executed.append((" ".join(query.split()), args))
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self._conn)
+
+
+class _RoleSyncRecorder:
+    def __init__(self):
+        self.grants: list[tuple[uuid.UUID, uuid.UUID, str]] = []
+
+    async def on_grant(self, vault_id, user_id, role):
+        self.grants.append((vault_id, user_id, role))
+
+
+@pytest.fixture
+def transfer_env(monkeypatch):
+    conn = _FakeConn(vault_owner=OWNER_ID)
+    role_sync = _RoleSyncRecorder()
+    events: list[str] = []
+
+    async def _get_pool():
+        return _FakePool(conn)
+
+    async def _emit_event(_conn, event_type, **_kw):
+        events.append(event_type)
+
+    monkeypatch.setattr(access_service, "get_pool", _get_pool)
+    monkeypatch.setattr(access_service, "emit_event", _emit_event)
+    monkeypatch.setattr(access_service, "get_role_sync", lambda: role_sync)
+    return conn, role_sync, events
+
+
+def _grant_access(monkeypatch, *, role_source: str):
+    async def _check(_user_id, _vault_name, required_role="reader", **_kw):
+        assert required_role == "owner"
+        return {
+            "vault_id": VAULT_ID,
+            "role": "owner",
+            "status": "active",
+            "role_source": role_source,
+        }
+
+    monkeypatch.setattr(access_service, "check_vault_access", _check)
+
+
+async def test_admin_initiated_transfer_succeeds_for_unowned_vault(
+    monkeypatch, transfer_env
+):
+    """The exact live failure: admin caller, vault owned by someone else."""
+    conn, role_sync, events = transfer_env
+    _grant_access(monkeypatch, role_source="system_admin")
+
+    result = await access_service.transfer_ownership(
+        str(ADMIN_ID), "fixture-vault", "new-owner"
+    )
+
+    assert result["transferred"] is True
+    update = next(q for q, _ in conn.executed if q.startswith("UPDATE vaults"))
+    assert "SET owner_id" in update
+    # The previous literal owner (not the admin caller) is demoted to an
+    # admin grant, and role-sync mirrors both memberships.
+    assert (VAULT_ID, OWNER_ID, "admin") in role_sync.grants
+    assert (VAULT_ID, NEW_OWNER_ID, "admin") in role_sync.grants
+    assert events == ["access.transfer_ownership"]
+
+
+async def test_owner_initiated_transfer_still_detects_lost_race(
+    monkeypatch, transfer_env
+):
+    """A non-admin caller whose ownership moved mid-flight must still conflict."""
+    _grant_access(monkeypatch, role_source="member")
+
+    with pytest.raises(access_service.ConflictError, match="owner_id moved"):
+        await access_service.transfer_ownership(
+            str(ADMIN_ID),  # != vault owner in the locked row
+            "fixture-vault",
+            "new-owner",
+        )
+
+
+async def test_owner_initiated_transfer_succeeds_when_row_matches(
+    monkeypatch, transfer_env
+):
+    _grant_access(monkeypatch, role_source="member")
+
+    result = await access_service.transfer_ownership(
+        str(OWNER_ID), "fixture-vault", "new-owner"
+    )
+
+    assert result["transferred"] is True
+
+
+class _VaultInfoConn(_FakeConn):
+    """Extends the transfer fake with the vault_info fan-out queries."""
+
+    async def fetchrow(self, query: str, *args):
+        if "SELECT * FROM vaults" in query:
+            return {
+                "id": VAULT_ID,
+                "name": args[0],
+                "description": "",
+                "status": "active",
+                "public_access": "none",
+                "owner_id": self.vault_owner,
+                "created_at": __import__("datetime").datetime(2026, 5, 28),
+            }
+        if "FROM users" in query:
+            return {"username": "real-owner", "display_name": "Real Owner"}
+        if "FROM documents" in query:
+            return None
+        raise AssertionError(f"unexpected fetchrow: {query}")
+
+    async def fetchval(self, query: str, *args):
+        return 0
+
+
+@pytest.fixture
+def vault_info_env(monkeypatch):
+    conn = _VaultInfoConn(vault_owner=OWNER_ID)
+
+    async def _get_pool():
+        return _FakePool(conn)
+
+    async def _get_policy(_vault_id, conn=None):
+        return None
+
+    monkeypatch.setattr(access_service, "get_pool", _get_pool)
+    monkeypatch.setattr(access_service.write_policy_repo, "get_policy", _get_policy)
+    return conn
+
+
+def _grant_reader_access(monkeypatch, *, role: str, role_source: str):
+    async def _check(_user_id, _vault_name, required_role="reader", **_kw):
+        return {
+            "vault_id": VAULT_ID,
+            "role": role,
+            "status": "active",
+            "role_source": role_source,
+        }
+
+    monkeypatch.setattr(access_service, "check_vault_access", _check)
+
+
+async def test_vault_info_reports_admin_not_owner_for_unowned_vault(
+    monkeypatch, vault_info_env
+):
+    """Admin bypass on someone else's vault must read as access, not ownership."""
+    _grant_reader_access(monkeypatch, role="owner", role_source="system_admin")
+
+    info = await access_service.get_vault_info(str(ADMIN_ID), "fixture-vault")
+
+    assert info["role"] == "admin"
+    assert info["owner"] == "real-owner"
+
+
+async def test_vault_info_keeps_owner_role_for_the_literal_owner(
+    monkeypatch, vault_info_env
+):
+    """An admin who literally owns the vault still reads as owner."""
+    _grant_reader_access(monkeypatch, role="owner", role_source="system_admin")
+
+    info = await access_service.get_vault_info(str(OWNER_ID), "fixture-vault")
+
+    assert info["role"] == "owner"


### PR DESCRIPTION
## Summary

The system-admin bypass in `check_vault_access` returned `role=owner, role_source=member`, hiding the bypass from downstream ownership logic. Two user-visible defects followed (trigger case: 2026-07-16 downstream runtime repository console-e2e fixture-vault ownership repair):

1. **`akb_transfer_ownership` admin-initiated → deterministic false conflict.** An admin passes the `required_role=owner` gate without literally owning the vault, but the row-lock staleness re-check assumed caller == owner, so every admin-initiated transfer failed with the misleading `owner_id moved during transfer (another transfer won the race)`. Admin transfers now skip the staleness check (the `FOR UPDATE` lock still serializes concurrent transfers); owner-initiated transfers keep the race guard unchanged.
2. **`akb_vault_info` role inflation for admins.** `vault_info.role` reported `owner` to admins on vaults they do not own — contradicting `list_accessible_vaults` (which reports `admin` for the same caller/vault) and lying to consumers that gate on `role == owner` (ownership-transfer UIs, downstream runtime repository's Pattern 35 target-vault gate). `vault_info` now reports `admin` unless the caller literally owns the vault.

Root fix is shared: the bypass now labels itself `role_source=system_admin`. The only existing `role_source` consumer (delegated file upload's `write_policy_grant` check) is unaffected. `role` stays `owner` so every `required_role` gate keeps passing.

## Tests

- New `tests/test_admin_ownership_semantics_unit.py` (5 tests): admin-initiated transfer succeeds on an unowned vault (the exact live failure), owner race guard preserved, owner self-transfer path, vault_info `admin`-not-`owner` for unowned + `owner` for the literal owner.
- `pytest tests/ -k 'not _e2e'`: **659 passed, 167 skipped** (2 files excluded locally for a missing `hypothesis` dev dep, unrelated).
- `ruff` + `mypy --python-version 3.14` clean.