### PR TITLE
fix(auth): offload bcrypt off the event loop to prevent 503 stalls

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -8,6 +8,7 @@ Handles:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import secrets
@@ -89,6 +90,21 @@ def verify_password(password: str, password_hash: str) -> bool:
         return bcrypt.checkpw(password.encode(), password_hash.encode())
     except ValueError:
         return False
+
+
+# bcrypt (cost 12) costs ~hundreds of ms per call and — unlike Kiwi's
+# tokenizer — RELEASES the GIL while hashing, so a worker thread genuinely
+# runs it off the single event loop (and lets concurrent hashes overlap).
+# Calling it inline starved the loop under concurrent auth → /livez probe
+# timeouts → 503 / kubelet SIGKILL (2026-07-20 incident). Always await these
+# async wrappers from request paths; the sync forms remain the thread target.
+
+async def hash_password_async(password: str) -> str:
+    return await asyncio.to_thread(hash_password, password)
+
+
+async def verify_password_async(password: str, password_hash: str) -> bool:
+    return await asyncio.to_thread(verify_password, password, password_hash)
 
 
 # ── JWT ──────────────────────────────────────────────────────
@@ -206,7 +222,7 @@ def token_has_scope(granted: frozenset[str] | None, required: str) -> bool:
 async def register(username: str, email: str, password: str, display_name: str | None = None) -> dict:
     require_local_auth_enabled()
     pool = await get_pool()
-    pw_hash = hash_password(password)
+    pw_hash = await hash_password_async(password)
     user_id = uuid.uuid4()
 
     async with pool.acquire() as conn:
@@ -275,7 +291,7 @@ async def login(username: str, password: str) -> dict:
                 row["auth_provider"] != "local" or row["account_kind"] != "human"
             ):
                 raise AuthenticationError("Invalid credentials")
-            if not row or not verify_password(password, row["password_hash"]):
+            if not row or not await verify_password_async(password, row["password_hash"]):
                 raise AuthenticationError("Invalid credentials")
 
             # Push iat past the revocation cutoff so a login in the same
@@ -689,14 +705,14 @@ async def change_password(user_id: str, current: str, new: str) -> None:
                 raise AccountSuspendedError()
             if row["auth_provider"] != "local" or row["account_kind"] != "human":
                 raise PasswordLifecycleUnavailableError()
-            if not verify_password(current, row["password_hash"]):
+            if not await verify_password_async(current, row["password_hash"]):
                 raise AuthenticationError("Current password is incorrect")
-            if verify_password(new, row["password_hash"]):
+            if await verify_password_async(new, row["password_hash"]):
                 raise BadPasswordChange("New password must differ from current")
 
             await conn.execute(
                 "UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2",
-                hash_password(new),
+                await hash_password_async(new),
                 uuid.UUID(user_id),
             )
             # Otherwise a thief holding an old JWT would keep access

--- a/backend/app/services/password_service.py
+++ b/backend/app/services/password_service.py
@@ -25,7 +25,7 @@ from app.services.auth_policy import require_local_auth_enabled
 from app.services.auth_service import (
     REVOKE_REASON_PASSWORD_RESET,
     _revoke_sessions_in_conn,
-    hash_password,
+    hash_password_async,
 )
 
 
@@ -73,7 +73,7 @@ async def reset_password(
             temp = generate_temp_password()
             await conn.execute(
                 "UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2",
-                hash_password(temp),
+                await hash_password_async(temp),
                 row["id"],
             )
             # Otherwise the attacker who triggered the reset (or held

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import asyncio
 import re
 import secrets
 import uuid
@@ -121,6 +122,15 @@ def _generate_slug() -> str:
 
 def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+async def _hash_password_async(password: str) -> str:
+    # Offload bcrypt off the event loop — see auth_service.hash_password_async.
+    return await asyncio.to_thread(_hash_password, password)
+
+
+async def _verify_password_async(password: str, password_hash: str) -> bool:
+    return await asyncio.to_thread(_verify_password, password, password_hash)
 
 
 def _verify_password(password: str, password_hash: str) -> bool:
@@ -317,7 +327,7 @@ async def create_publication(
             )
 
     slug = _generate_slug()
-    pwd_hash = _hash_password(password) if password else None
+    pwd_hash = await _hash_password_async(password) if password else None
 
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -699,7 +709,7 @@ async def resolve_publication(
         if row["password_hash"] and not bypass_password:
             if not password:
                 raise PublicationPasswordRequired()
-            if not _verify_password(password, row["password_hash"]):
+            if not await _verify_password_async(password, row["password_hash"]):
                 raise PublicationPasswordInvalid()
 
         if increment_view:

--- a/backend/tests/test_bcrypt_offload_unit.py
+++ b/backend/tests/test_bcrypt_offload_unit.py
@@ -1,0 +1,73 @@
+"""Regression: bcrypt must run OFF the single event loop.
+
+2026-07-20 prod incident: concurrent auth (login/register/MCP-session)
+ran bcrypt (cost 12, ~hundreds of ms, on the event loop) which starved the
+single asyncio loop → `/livez` liveness probe timed out (`awaiting headers`)
+→ kubelet SIGKILL (exit 137) → whole service 503 (backend is replicas=1).
+
+`hash_password_async` / `verify_password_async` offload bcrypt to a worker
+thread (bcrypt releases the GIL, so a thread genuinely runs it off-loop and
+concurrent hashes overlap). These tests assert the loop stays responsive
+while many hashes run concurrently — i.e. re-inlining bcrypt regresses.
+
+No DB needed — pure event-loop behavior. Runs in `pytest -k 'not _e2e'`.
+"""
+
+import asyncio
+import time
+
+from app.services.auth_service import (
+    hash_password,
+    hash_password_async,
+    verify_password_async,
+)
+
+# Enough concurrent bcrypts that, if run ON the loop, they serialize into a
+# multi-second stall (N * ~0.2s). Offloaded, the loop barely notices.
+_N = 16
+# On-loop regression would push the heartbeat gap to ~3s+; offloaded it stays
+# well under 100ms. 1.5s cleanly separates the two on slow CI too.
+_MAX_LOOP_GAP_S = 1.5
+
+
+async def _max_heartbeat_gap(work: asyncio.Future) -> float:
+    """Tick every 10ms until ``work`` completes; return the worst gap between
+    ticks. A blocked loop can't service the ticks, so the gap balloons."""
+    max_gap = 0.0
+    last = time.perf_counter()
+    while not work.done():
+        await asyncio.sleep(0.01)
+        now = time.perf_counter()
+        max_gap = max(max_gap, now - last)
+        last = now
+    return max_gap
+
+
+async def test_verify_password_async_does_not_block_event_loop():
+    pw_hash = hash_password("correct-horse-battery-staple")
+    # Wrong password still runs the full bcrypt.checkpw — the hot path in the
+    # incident (concurrent failed logins).
+    work = asyncio.gather(
+        *(verify_password_async("wrong-guess", pw_hash) for _ in range(_N))
+    )
+    max_gap = await _max_heartbeat_gap(work)
+    results = await work
+    assert results == [False] * _N
+    assert max_gap < _MAX_LOOP_GAP_S, (
+        f"event loop stalled {max_gap:.3f}s under {_N} concurrent verifies — "
+        "bcrypt is running on the loop again"
+    )
+
+
+async def test_hash_password_async_roundtrips_without_blocking():
+    pw = "s3cret-Passw0rd!"
+    work = asyncio.gather(*(hash_password_async(pw) for _ in range(_N)))
+    max_gap = await _max_heartbeat_gap(work)
+    hashes = await work
+    assert all(h.startswith("$2") for h in hashes)  # bcrypt hash marker
+    verified = await asyncio.gather(*(verify_password_async(pw, h) for h in hashes))
+    assert all(verified)
+    assert max_gap < _MAX_LOOP_GAP_S, (
+        f"event loop stalled {max_gap:.3f}s under {_N} concurrent hashes — "
+        "bcrypt is running on the loop again"
+    )


### PR DESCRIPTION
## Problem

Concurrent auth (login/register/change-password/publication-password, MCP session auth) ran **bcrypt (cost 12, ~hundreds of ms) synchronously on the single asyncio event loop**. Under a burst of concurrent authenticated requests the loop starved: `/livez` timed out (`context deadline exceeded (awaiting headers)`) for >5s → kubelet SIGKILLed the pod (exit 137). Because backend runs `replicas=1`, the whole service **503**'d. This is the **2026-07-20 prod incident**, and the N1 finding from the production-readiness review.

## Fix

bcrypt **releases the GIL** while hashing, so a worker thread genuinely runs it off-loop (unlike Kiwi tokenize, which needed a ProcessPool — #244). Adds `hash_password_async` / `verify_password_async` (`asyncio.to_thread` wrappers) and routes every request-path bcrypt call through them:

- `auth_service`: register, login, change_password
- `publication_service`: create-with-password, verify-password
- `password_service`: admin reset

Sync `hash_password`/`verify_password` remain (thread target + tests). Behavior is identical — only the scheduling changes.

## Verification

Local docker compose (single uvicorn worker = prod `replicas=1`), same load harness before/after:

| /livez under 150 concurrent logins | before | after |
|---|---|---|
| worst latency | **20.006s** (curl timeout, `awaiting headers`) | **0.443s** |
| samples >5s (would fail prod liveness) | **2** | **0** |

Control (same concurrency of cheap GETs) never stalled either way → isolates bcrypt as the cause. Adds `test_bcrypt_offload_unit.py` — a no-DB regression asserting the loop stays responsive under concurrent hashing (heartbeat max-gap < 1.5s).

## Follow-up (separate PR)

Rate-limit `/auth` and `/mcp` for brute-force defense. Offload **alone** already stops the availability incident (the threadpool queues under flood but the loop stays responsive); rate-limiting is defense-in-depth and needs its own design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)