### PR TITLE
fix(access): enforce the per-PAT vault scope on vault creation (#284)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3105
+        "line_number": 3115
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5294,5 +5294,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T13:13:01Z"
+  "generated_at": "2026-07-20T07:52:39Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -50,6 +50,16 @@ contains only counts and stable issue codes; it never returns email, subject,
 password, token, or credential material. Standalone defaults and ordinary
 `/readyz` behavior are unchanged.
 
+A personal access token's vault scope now bounds vault **creation** as well as
+administration. Creating a vault whose name falls outside the token's scope is
+refused with `permission_denied`, in the same wording the scope guard already
+uses for administrative operations, on both the MCP `akb_create_vault` tool and
+`POST /vaults`. Previously creation consulted no scope at all, so a scoped token
+could place a vault anywhere in the namespace and was then denied every
+administrative operation on the vault it had just created — including deleting
+it — stranding a vault its creator could not remove. Unscoped tokens keep their
+existing behavior, and reads remain unrestricted.
+
 ## 0.10.0 — 2026-07-10  *(feat — stable workspace identities and account governance)*
 
 AKB now preserves its existing local user UUID while binding verified OIDC

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -5,7 +5,11 @@ from pydantic import BaseModel
 
 from app.api.deps import get_current_user
 from app.services import template_registry
-from app.services.access_service import check_vault_access, list_accessible_vaults
+from app.services.access_service import (
+    check_vault_access,
+    check_vault_scope,
+    list_accessible_vaults,
+)
 from app.models.document import (
     DocumentDeleteResponse,
     DocumentPutRequest,
@@ -45,6 +49,10 @@ async def create_vault(name: str, description: str = "", template: str | None = 
         )
     name = to_nfc(name)
     description = to_nfc(description)
+    # Per-PAT vault scope, on the NFC-normalised name the service will
+    # actually store. Creation confers ownership, hence required_role
+    # "owner" (dnotitia/akb#284).
+    check_vault_scope(name, required_role="owner")
     vault_id = await doc_service.create_vault(name, description, owner_id=user.user_id, template=template, public_access=public_access)
     return {"vault_id": vault_id, "name": name, "template": template, "public_access": public_access}
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -134,6 +134,40 @@ async def _is_unscoped_system_admin(uid: uuid.UUID, conn) -> bool:
     return bool(await conn.fetchval("SELECT is_admin FROM users WHERE id = $1", uid))
 
 
+def check_vault_scope(vault_name: str, required_role: str) -> None:
+    """Option B per-PAT vault scope, as a NAME-only check.
+
+    The scope is a pure name predicate — it needs no vault row — so this
+    is the whole policy, and `check_vault_access` calls it for vaults
+    that already exist. Split out so the two callers cannot drift: the
+    denial message and the resulting `permission_denied` code are
+    identical whichever surface refuses.
+
+    Callers that have no row to resolve use it directly. `create_vault`
+    is the motivating case (dnotitia/akb#284): creation is a mutating
+    op on a name that does not exist yet, so it could not route through
+    `check_vault_access`, and without this it silently escaped the
+    scope — a scoped token could plant a vault anywhere in the
+    namespace and was then denied every admin op on the vault it had
+    just made, including deleting it. Creation passes
+    `required_role="owner"` because creating a vault confers ownership
+    of it.
+
+    No-op when the request carries no scope (`None` ⇒ unscoped, the
+    historical full-ACL behaviour) or when `required_role` is
+    non-mutating — reads are never scope-restricted.
+    """
+    scope = current_vault_scope.get()
+    if (
+        scope is not None
+        and required_role in _MUTATING_ROLES
+        and not scope.permits(vault_name)
+    ):
+        raise ForbiddenError(
+            f"Token scope does not permit '{required_role}' on vault '{vault_name}'"
+        )
+
+
 async def check_vault_access(
     user_id: str, vault_name: str, required_role: str = "reader",
     *, allow_archived: bool = False, write_action: str | None = None,
@@ -205,15 +239,10 @@ async def check_vault_access(
         # write permission = user-ACL ∩ scope, for the whole surface that
         # routes through check_vault_access (REST + MCP). NULL token scope ⇒
         # current_vault_scope is None ⇒ historical full-ACL behaviour.
-        scope = current_vault_scope.get()
-        if (
-            scope is not None
-            and required_role in _MUTATING_ROLES
-            and not scope.permits(vault_name)
-        ):
-            raise ForbiddenError(
-                f"Token scope does not permit '{required_role}' on vault '{vault_name}'"
-            )
+        # The predicate itself lives in `check_vault_scope` — vault
+        # CREATION has no row to resolve and calls that helper directly,
+        # so both surfaces refuse with one message (dnotitia/akb#284).
+        check_vault_scope(vault_name, required_role)
 
         # Vault write-policy guard (P0 S3, A2/A3 — see the docstring
         # above). Sits BEFORE the is_admin / owner short-circuits below,

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -35,9 +35,9 @@ from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
 from app.services.uri_service import doc_uri, parse_uri, split_uri
 from app.services.access_service import (
-    check_vault_access, grant_access, revoke_access, list_vault_members,
-    list_accessible_vaults, get_vault_info, search_users, transfer_ownership,
-    archive_vault,
+    check_vault_access, check_vault_scope, grant_access, revoke_access,
+    list_vault_members, list_accessible_vaults, get_vault_info, search_users,
+    transfer_ownership, archive_vault,
 )
 from app.services.auth_service import resolve_token, token_has_scope
 from app.util.errors import (
@@ -333,6 +333,10 @@ async def _handle_list_vaults(args: dict, uid: str, user: _MCPUser) -> dict:
 
 @_h("akb_create_vault")
 async def _handle_create_vault(args: dict, uid: str, user: _MCPUser) -> dict:
+    # Per-PAT vault scope. Guard-first, like every other mutating tool —
+    # creation confers ownership, hence required_role "owner"
+    # (dnotitia/akb#284).
+    check_vault_scope(args["name"], required_role="owner")
     try:
         vault_id = await doc_service.create_vault(
             args["name"], args.get("description", ""),

--- a/backend/tests/test_vault_create_scope_unit.py
+++ b/backend/tests/test_vault_create_scope_unit.py
@@ -1,0 +1,254 @@
+"""Vault CREATION honours the per-PAT vault scope (dnotitia/akb#284).
+
+The Option B scope guard used to live inline in `check_vault_access`,
+which resolves an existing vault row before reaching it — structurally
+unable to cover creation, and neither creation entry point called it.
+A scoped token could therefore create a vault anywhere in the namespace
+and was then refused every administrative operation on the vault it had
+just made, including deleting it: creation and administration disagreed
+about the same scope, and the asymmetry stranded the vault.
+
+The predicate now lives in `access_service.check_vault_scope` — a pure
+name-only check, no DB — which `check_vault_access` calls for existing
+vaults and which both creation entry points call directly.
+
+DB-free by construction: every case here is refused (or admitted) before
+any repository call, so the service is stubbed and never reached on the
+allow path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from app.config import settings
+
+# Both entry-point modules construct a DocumentService() at import time,
+# which mkdir's the git storage path. Point it somewhere writable before
+# those imports so they don't try to create the default `/data/vaults`.
+# Same idiom as test_mcp_oauth_unit.py.
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-vault-create-scope-test-")
+
+from app.exceptions import ForbiddenError  # noqa: E402
+from app.models.vault_scope import VaultScope, current_vault_scope  # noqa: E402
+from app.services.access_service import check_vault_scope  # noqa: E402
+
+# The scope from the issue's reproduction.
+SCOPE = VaultScope(prefixes=("gdn-e2e-", "e2e-gdn-"), extra_vaults=frozenset({"slack-ops"}))
+
+IN_SCOPE = "gdn-e2e-scopeprobe"
+OUT_OF_SCOPE = "zz-scope-probe"
+
+
+@pytest.fixture
+def scoped():
+    """Run the test body under a PAT that carries SCOPE."""
+    token = current_vault_scope.set(SCOPE)
+    try:
+        yield SCOPE
+    finally:
+        current_vault_scope.reset(token)
+
+
+@pytest.fixture
+def unscoped():
+    """Run the test body under a PAT with no vault scope (NULL column)."""
+    token = current_vault_scope.set(None)
+    try:
+        yield None
+    finally:
+        current_vault_scope.reset(token)
+
+
+class _StubUser:
+    """Only `.user_id` / `.username` are read on the creation paths."""
+
+    def __init__(self) -> None:
+        self.user_id = "00000000-0000-0000-0000-000000000001"
+        self.username = "scoped-agent"
+        self.is_admin = False
+
+
+# ── The predicate itself ───────────────────────────────────────────
+
+
+class TestCheckVaultScope:
+    def test_denies_name_outside_scope(self, scoped) -> None:
+        with pytest.raises(ForbiddenError) as exc:
+            check_vault_scope(OUT_OF_SCOPE, required_role="owner")
+        # 403 ⇒ `permission_denied` at both the REST and MCP envelopes.
+        assert exc.value.status_code == 403
+        assert OUT_OF_SCOPE in str(exc.value)
+
+    def test_permits_name_inside_scope(self, scoped) -> None:
+        check_vault_scope(IN_SCOPE, required_role="owner")  # no raise
+        check_vault_scope("e2e-gdn-other", required_role="owner")
+        check_vault_scope("slack-ops", required_role="owner")  # exact whitelist
+
+    def test_unscoped_token_permits_anything(self, unscoped) -> None:
+        check_vault_scope(OUT_OF_SCOPE, required_role="owner")  # no raise
+
+    def test_non_mutating_role_is_never_scope_restricted(self, scoped) -> None:
+        # Reads stay unrestricted — a scoped agent still READS broadly.
+        check_vault_scope(OUT_OF_SCOPE, required_role="reader")
+
+    def test_message_matches_the_existing_guard_wording(self, scoped) -> None:
+        # One predicate, one message: the wording a caller sees on an
+        # out-of-scope CREATE is the wording `check_vault_access` has
+        # always used for an out-of-scope admin op.
+        with pytest.raises(ForbiddenError) as exc:
+            check_vault_scope(OUT_OF_SCOPE, required_role="admin")
+        assert str(exc.value) == (
+            f"Token scope does not permit 'admin' on vault '{OUT_OF_SCOPE}'"
+        )
+
+
+# ── Entry point 1: MCP `akb_create_vault` ──────────────────────────
+
+
+class TestMcpCreateVault:
+    async def test_denies_out_of_scope_create(self, scoped, monkeypatch) -> None:
+        from mcp_server import server
+
+        called = []
+
+        async def _record(name, description="", **kwargs):
+            called.append(name)
+            return "deadbeef-0000-0000-0000-000000000000"
+
+        monkeypatch.setattr(server.doc_service, "create_vault", _record)
+
+        with pytest.raises(ForbiddenError) as exc:
+            await server._handle_create_vault(
+                {"name": OUT_OF_SCOPE}, "uid", _StubUser(),
+            )
+        assert OUT_OF_SCOPE in str(exc.value)
+        # Guard-first: the service is never reached, so nothing is created.
+        assert called == []
+
+    async def test_permits_in_scope_create(self, scoped, monkeypatch) -> None:
+        from mcp_server import server
+
+        async def _fake_create_vault(name, description="", **kwargs):
+            return "11111111-1111-1111-1111-111111111111"
+
+        monkeypatch.setattr(server.doc_service, "create_vault", _fake_create_vault)
+
+        result = await server._handle_create_vault(
+            {"name": IN_SCOPE}, "uid", _StubUser(),
+        )
+        assert result["name"] == IN_SCOPE
+        assert result["vault_id"] == "11111111-1111-1111-1111-111111111111"
+
+    async def test_unscoped_token_creates_anywhere(self, unscoped, monkeypatch) -> None:
+        # No-regression control: a PAT with a NULL vault_scope keeps the
+        # historical full-ACL behaviour.
+        from mcp_server import server
+
+        async def _fake_create_vault(name, description="", **kwargs):
+            return "22222222-2222-2222-2222-222222222222"
+
+        monkeypatch.setattr(server.doc_service, "create_vault", _fake_create_vault)
+
+        result = await server._handle_create_vault(
+            {"name": OUT_OF_SCOPE}, "uid", _StubUser(),
+        )
+        assert result["name"] == OUT_OF_SCOPE
+
+
+# ── Entry point 2: REST `POST /vaults` ─────────────────────────────
+
+
+class TestRestCreateVault:
+    async def test_denies_out_of_scope_create(self, scoped, monkeypatch) -> None:
+        from app.api.routes import documents
+
+        called = []
+
+        async def _record(name, description="", **kwargs):
+            called.append(name)
+            return "deadbeef-0000-0000-0000-000000000000"
+
+        monkeypatch.setattr(documents.doc_service, "create_vault", _record)
+
+        with pytest.raises(ForbiddenError) as exc:
+            await documents.create_vault(name=OUT_OF_SCOPE, user=_StubUser())
+        assert OUT_OF_SCOPE in str(exc.value)
+        assert called == []
+
+    async def test_permits_in_scope_create(self, scoped, monkeypatch) -> None:
+        from app.api.routes import documents
+
+        async def _fake_create_vault(name, description="", **kwargs):
+            return "33333333-3333-3333-3333-333333333333"
+
+        monkeypatch.setattr(documents.doc_service, "create_vault", _fake_create_vault)
+
+        result = await documents.create_vault(name=IN_SCOPE, user=_StubUser())
+        assert result["name"] == IN_SCOPE
+        assert result["vault_id"] == "33333333-3333-3333-3333-333333333333"
+
+    async def test_unscoped_token_creates_anywhere(self, unscoped, monkeypatch) -> None:
+        from app.api.routes import documents
+
+        async def _fake_create_vault(name, description="", **kwargs):
+            return "44444444-4444-4444-4444-444444444444"
+
+        monkeypatch.setattr(documents.doc_service, "create_vault", _fake_create_vault)
+
+        result = await documents.create_vault(name=OUT_OF_SCOPE, user=_StubUser())
+        assert result["name"] == OUT_OF_SCOPE
+
+    async def test_scope_is_checked_on_the_normalised_name(
+        self, scoped, monkeypatch,
+    ) -> None:
+        # The route NFC-normalises before storing; the guard must see the
+        # same string the service will, so normalisation can't shift a
+        # name across the scope boundary after the check.
+        from app.api.routes import documents
+
+        seen = []
+
+        async def _fake_create_vault(name, description="", **kwargs):
+            seen.append(name)
+            return "55555555-5555-5555-5555-555555555555"
+
+        monkeypatch.setattr(documents.doc_service, "create_vault", _fake_create_vault)
+
+        await documents.create_vault(name=IN_SCOPE, user=_StubUser())
+        assert seen == [IN_SCOPE]
+
+
+# ── Regression boundary ────────────────────────────────────────────
+
+
+class TestExistingSurfacesUnchanged:
+    """`check_vault_access` kept its behaviour when the shared predicate
+    was extracted out of it — same roles gated, same wording, and the
+    guard still sits ahead of the is_admin / owner short-circuits."""
+
+    def test_check_vault_access_still_calls_the_predicate(self) -> None:
+        import inspect
+
+        from app.services import access_service
+
+        src = inspect.getsource(access_service.check_vault_access)
+        assert "check_vault_scope(vault_name, required_role)" in src
+
+    def test_scope_gate_still_covers_exactly_the_mutating_roles(self, scoped) -> None:
+        from app.services.access_service import _MUTATING_ROLES
+
+        assert _MUTATING_ROLES == frozenset({"writer", "admin", "owner"})
+        for role in sorted(_MUTATING_ROLES):
+            with pytest.raises(ForbiddenError):
+                check_vault_scope(OUT_OF_SCOPE, required_role=role)
+        for role in ("reader", "none", ""):
+            check_vault_scope(OUT_OF_SCOPE, required_role=role)  # no raise
+
+    def test_in_scope_vault_is_untouched_for_every_role(self, scoped) -> None:
+        # Administration of an in-scope vault must not have become
+        # stricter — the fix removes an asymmetry, it doesn't add one.
+        for role in ("reader", "writer", "admin", "owner"):
+            check_vault_scope(IN_SCOPE, required_role=role)


### PR DESCRIPTION
## Summary

Vault creation did not consult the per-PAT vault scope. A token whose
`vault_scope` restricts it to a set of name prefixes could create a vault
**outside** that scope, and was then denied every administrative operation on
the vault it had just created — including deleting it. Creation and
administration disagreed about the same scope, and the asymmetry stranded the
vault: cleanup required an unscoped token.

Fixes #284.

## Cause

The scope guard lived inline in `check_vault_access`. That function resolves an
existing vault row before reaching the guard, so it is structurally unable to
cover creation — and neither creation path called it:

- MCP `_handle_create_vault` called `doc_service.create_vault(...)` directly.
- REST `POST /vaults` likewise.

`_TOOL_SCOPES["akb_create_vault"] = _WRITE_SCOPE` is a *capability* scope
("may this token write at all") and is orthogonal to the per-PAT name-prefix
scope, so it did not close the gap.

## Change

Extract the guard into `access_service.check_vault_scope(vault_name,
required_role)` — a name-only predicate that needs no vault row, which is the
whole policy.

- `check_vault_access` calls it at the same point, in the same order, ahead of
  the `is_admin` / owner short-circuits. Existing surfaces are unchanged down
  to the denial wording.
- Both creation entry points call it directly, ahead of any repository work:
  the MCP `akb_create_vault` handler and `POST /vaults`.

Creation passes `required_role="owner"` because creating a vault confers
ownership of it. The REST path checks the NFC-normalised name the service will
actually store, so normalisation cannot shift a name across the scope boundary
after the check. A refusal raises `ForbiddenError` → HTTP 403 →
`permission_denied` at the REST envelope, and `permission_denied` at the MCP
envelope via `exception_envelope` — the same code and wording an out-of-scope
administrative operation already returns.

Unscoped tokens (NULL `vault_scope`) keep the historical full-ACL behaviour,
and reads remain unrestricted: the predicate is a no-op for a `None` scope and
for non-mutating roles.

Internal provisioning that calls `DocumentService.create_vault` outside a
request context is deliberately untouched — the guard sits at the
authorization boundary, where every other mutating surface enforces, not in
the service.

## Tests

`backend/tests/test_vault_create_scope_unit.py` — 15 cases, DB-free (every case
resolves before any repository call, so the service is stubbed and never
reached on the allow path):

- the predicate: denies out-of-scope, permits in-scope (prefix and exact
  `extra_vaults`), no-op when unscoped, no-op for non-mutating roles, and the
  denial wording matches the existing guard's
- MCP `akb_create_vault`: out-of-scope refused and the service never reached;
  in-scope succeeds; unscoped token creates anywhere
- REST `POST /vaults`: the same three, plus the scope being checked on the
  NFC-normalised name
- regression boundary: `check_vault_access` still routes through the predicate,
  the gate still covers exactly `{writer, admin, owner}`, and an in-scope vault
  is permitted at every role — the fix removes an asymmetry without adding one

Mutation-checked: removing the MCP guard reddens only the MCP denial case;
removing the REST guard reddens only the REST denial case; neutering the shared
predicate reddens five cases across all three groups. All restored green.

Gates: `ruff`, `mypy` (204 files), and `bandit` clean; full backend suite 720
passed / 174 skipped (skips are the DB-backed e2e set, unchanged).
