### PR TITLE
fix(sql): cap akb_sql result rows to bound event-loop stall

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -91,6 +91,14 @@ class Settings(BaseModel):
     pg_pool_min_size: int = 2
     pg_pool_max_size: int = 30
 
+    # Max rows a single `akb_sql` / REST SQL SELECT may return. The result is
+    # coerced + JSON-serialised on the single event loop, so an unbounded
+    # SELECT (e.g. `SELECT * FROM generate_series(1, 2e6)`) stalls /livez past
+    # the liveness probe → 503. Over-limit results are truncated and flagged
+    # (`truncated: true`) so callers paginate. Statement execution is
+    # unchanged — only the returned row count is capped.
+    akb_sql_max_rows: int = 10000
+
     # Git storage root (bare repos live here)
     git_storage_path: str = "/data/vaults"
 

--- a/backend/app/services/user_sql_executor.py
+++ b/backend/app/services/user_sql_executor.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 import asyncpg
 
+from app.config import settings
 from app.models.vault_scope import (
     current_request_jwt_claims,
     current_token_id,
@@ -184,12 +185,25 @@ class UserSqlExecutor:
 
                     if should_fetch:
                         rows = await conn.fetch(sql, *bind_params)
+                        # Cap the materialised result. `_coerce_row` + the
+                        # downstream JSON serialisation are pure-Python CPU on
+                        # the single event loop with no `await`, so an
+                        # unbounded SELECT stalls /livez (probe-timeout 503,
+                        # ~3s per 1M rows measured). Truncate to a configured
+                        # ceiling and flag it so callers paginate. The query
+                        # itself already ran identically — only the returned
+                        # rows are capped.
+                        max_rows = settings.akb_sql_max_rows
+                        truncated = len(rows) > max_rows
+                        if truncated:
+                            rows = rows[:max_rows]
                         return {
                             "kind": "table_query",
                             "vaults": vault_names or [],
                             "columns": list(dict(rows[0]).keys()) if rows else [],
                             "items": [_coerce_row(r) for r in rows],
                             "total": len(rows),
+                            "truncated": truncated,
                         }
                     result = await conn.execute(sql, *bind_params)
                     out = {

--- a/backend/tests/test_akb_sql_row_cap_unit.py
+++ b/backend/tests/test_akb_sql_row_cap_unit.py
@@ -1,0 +1,87 @@
+"""Regression: akb_sql caps the returned row count (event-loop stall).
+
+An unbounded SELECT result is `_coerce_row`d + JSON-serialised on the single
+event loop with NO await, so a huge result stalls /livez (~3s per 1M rows
+measured) → liveness-probe timeout → 503 (2026-07-20 event-loop audit).
+`UserSqlExecutor.execute` caps the returned rows to
+`settings.akb_sql_max_rows` and sets `truncated`. Statement execution is
+unchanged — only the returned rows are capped.
+
+DB-free: a fake pool/conn whose `fetch` returns N synthetic rows.
+"""
+
+import pytest
+
+from app.config import settings
+from app.services.user_sql_executor import UserSqlExecutor
+
+pytestmark = pytest.mark.asyncio
+
+
+class _ACtx:
+    def __init__(self, value=None):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, nrows: int):
+        self._nrows = nrows
+
+    def transaction(self):
+        return _ACtx()
+
+    async def execute(self, *a, **k):
+        return "SET"
+
+    async def fetch(self, sql, *a):
+        return [{"n": i} for i in range(self._nrows)]
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _ACtx(self._conn)
+
+
+async def _run(nrows: int) -> dict:
+    ex = UserSqlExecutor(_FakePool(_FakeConn(nrows)))
+    # is_admin=True skips the SET LOCAL ROLE role lookup; fetch=True forces the
+    # SELECT (row-returning) path regardless of the SQL text.
+    return await ex.execute(
+        user_id="00000000-0000-0000-0000-000000000000",
+        sql="SELECT n FROM t",
+        fetch=True,
+        is_admin=True,
+        vault_names=["v"],
+    )
+
+
+async def test_akb_sql_caps_oversized_result_and_flags_truncated(monkeypatch):
+    monkeypatch.setattr(settings, "akb_sql_max_rows", 100)
+    out = await _run(250)
+    assert out["truncated"] is True
+    assert out["total"] == 100
+    assert len(out["items"]) == 100
+
+
+async def test_akb_sql_under_cap_is_not_truncated(monkeypatch):
+    monkeypatch.setattr(settings, "akb_sql_max_rows", 100)
+    out = await _run(5)
+    assert out["truncated"] is False
+    assert out["total"] == 5
+    assert len(out["items"]) == 5
+
+
+async def test_akb_sql_exactly_at_cap_is_not_truncated(monkeypatch):
+    monkeypatch.setattr(settings, "akb_sql_max_rows", 100)
+    out = await _run(100)
+    assert out["truncated"] is False
+    assert out["total"] == 100


### PR DESCRIPTION
## Problem

`akb_sql` / REST `/tables/{vault}/sql` returned the **entire** SELECT result: `await conn.fetch(sql)` then `[_coerce_row(r) for r in rows]` + JSON serialisation — all **pure-Python CPU on the single event loop with no `await`**. A large SELECT (e.g. `SELECT * FROM generate_series(1, 2e6)`) stalls `/livez` past the liveness probe → **503**, from a **single request** (no concurrency needed).

Found by the 2026-07-20 event-loop-blocking audit. Measured stall scales linearly:

| rows | /livez stall | resp size |
|---|---|---|
| 250k | 0.88s | 55MB |
| 500k | 1.49s | 111MB |
| 1M | **3.07s** | 222MB |

→ ~1.7M rows crosses the 5s probe.

## Fix

Cap the **returned** rows at `settings.akb_sql_max_rows` (default 10000) and set `truncated: true` so callers paginate. The statement still executes identically — **data-modifying CTEs (`WITH ... UPDATE ... RETURNING`) are unaffected** — only the returned/serialised row count (what stalls the loop) is bounded.

## Verification

Local docker compose (single uvicorn worker = prod `replicas=1`), 1M-row SELECT:

| | before | after |
|---|---|---|
| /livez max stall | **3.07s** | **0.055s** |
| response | 222MB | 2.2MB |
| envelope | — | `total=10000, truncated=true` |
| 5-row control | — | `total=5, truncated=false` |

Adds `test_akb_sql_row_cap_unit.py` — DB-free (fake pool): over-cap → truncated, under/at cap → not truncated.

## Scope note (follow-up)

This bounds the **event-loop stall** (the 503) by capping coerce + serialize. **Peak fetch memory is still the full result set** — streaming with an asyncpg cursor to bound memory too is a follow-up, deferred because a cursor's interaction with data-modifying CTEs needs its own validation. Sibling companion PR #289 offloads the git-read blocking paths from the same audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)