### PR TITLE
fix(s3): bound every S3 call with connect/read timeouts + short retry

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -216,6 +216,20 @@ class Settings(BaseModel):
     s3_secret_key: str = ""
     s3_bucket: str = "akb-files"
     s3_region: str = ""
+    # boto3/botocore default to a 60 s connect AND 60 s read timeout with NO
+    # retries. A stalled MinIO/S3 (network blip, cold bucket, dead endpoint)
+    # then blocks the caller for up to 60 s — and several S3 primitives run on
+    # the single event loop (public raw-file read, snapshot put/read, HEAD
+    # confirm, bucket cold-start), so one stall starves /livez → probe timeout
+    # → 503. Bound every S3 call instead: connect ≤ 3 s, read ≤ 10 s, with a
+    # short retry for transient blips.
+    # NOTE: botocore's `max_attempts` is the RETRY count — total attempts =
+    # s3_max_attempts + 1. So the default 2 = 3 total attempts, i.e. a
+    # worst-case read hang of 3 × 10 s = 30 s (down from an unbounded 60 s,
+    # and now recoverable), and a connect failure bounded to 3 × 3 s = 9 s.
+    s3_connect_timeout_secs: float = 3.0
+    s3_read_timeout_secs: float = 10.0
+    s3_max_attempts: int = 2
 
     # Auth — jwt_secret must be set (validated at startup in lifecycle.init_storage)
     jwt_secret: str = ""

--- a/backend/app/services/adapters/s3_adapter.py
+++ b/backend/app/services/adapters/s3_adapter.py
@@ -77,7 +77,15 @@ def make_client(endpoint_url: str, access_key: str, secret_key: str, region: str
         endpoint_url=endpoint_url or None,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
-        config=BotoConfig(signature_version="s3v4"),
+        config=BotoConfig(
+            signature_version="s3v4",
+            # Bound every S3 op so a stalled endpoint can't block the caller
+            # (and, on the on-loop paths, the whole event loop) for the boto
+            # default of 60 s. See settings.s3_* for the rationale.
+            connect_timeout=settings.s3_connect_timeout_secs,
+            read_timeout=settings.s3_read_timeout_secs,
+            retries={"max_attempts": settings.s3_max_attempts, "mode": "standard"},
+        ),
         **({"region_name": region} if region else {}),
     )
 

--- a/backend/tests/test_s3_boto_timeouts_unit.py
+++ b/backend/tests/test_s3_boto_timeouts_unit.py
@@ -1,0 +1,50 @@
+"""Regression: every S3 client must carry bounded connect/read timeouts.
+
+boto3/botocore default to a 60 s connect AND 60 s read timeout with NO retries.
+Several S3 primitives run on the single event loop (public raw-file read,
+snapshot put/read, HEAD confirm, bucket cold-start), so a stalled MinIO/S3
+would block the loop for up to 60 s → /livez probe timeout → 503. `make_client`
+now stamps `settings.s3_*` timeouts + a short retry onto the boto config; this
+test pins that wiring so a future refactor can't silently drop back to 60 s.
+
+Network-free: `boto3.client(...)` resolves config offline (no call is made).
+DB-free. Runs in `pytest -k 'not _e2e'`.
+"""
+
+from app.config import settings
+from app.services.adapters import s3_adapter
+
+
+def test_make_client_applies_bounded_timeouts_from_settings():
+    c = s3_adapter.make_client("http://minio:9000", "ak", "sk", region="us-east-1")
+    cfg = c._client_config
+    assert cfg.connect_timeout == settings.s3_connect_timeout_secs
+    assert cfg.read_timeout == settings.s3_read_timeout_secs
+    # botocore's `max_attempts` is the retry count → total attempts = +1.
+    assert cfg.retries["mode"] == "standard"
+    assert cfg.retries["total_max_attempts"] == settings.s3_max_attempts + 1
+
+
+def test_make_client_timeouts_are_well_under_boto_default():
+    # The whole point is to escape the 60 s boto default. Guard the ceiling so a
+    # careless settings bump can't reintroduce a minute-long on-loop stall.
+    c = s3_adapter.make_client("http://minio:9000", "ak", "sk")
+    cfg = c._client_config
+    assert 0 < cfg.connect_timeout <= 10
+    assert 0 < cfg.read_timeout <= 30
+    # Worst-case read hang = total attempts × read_timeout must stay bounded.
+    total_attempts = cfg.retries["total_max_attempts"]
+    assert total_attempts * cfg.read_timeout <= 60
+
+
+def test_make_client_reads_settings_live(monkeypatch):
+    # Proves the timeouts come from settings (not a hardcode) — override and
+    # confirm a freshly built client reflects the new values.
+    monkeypatch.setattr(settings, "s3_connect_timeout_secs", 1.5)
+    monkeypatch.setattr(settings, "s3_read_timeout_secs", 4.0)
+    monkeypatch.setattr(settings, "s3_max_attempts", 1)
+    c = s3_adapter.make_client("http://minio:9000", "ak", "sk")
+    cfg = c._client_config
+    assert cfg.connect_timeout == 1.5
+    assert cfg.read_timeout == 4.0
+    assert cfg.retries["total_max_attempts"] == 2


### PR DESCRIPTION
## Problem

boto3/botocore default to a **60 s connect AND 60 s read timeout with NO retries**. A stalled MinIO/S3 (network blip, cold bucket, dead/mis-configured endpoint) then blocks the caller for up to 60 s.

Several S3 primitives run **on the single event loop** (public raw-file read, publication-snapshot put/read, upload HEAD-confirm, bucket cold-start `ensure_bucket`). On our single-worker/single-loop backend (`replicas=1`), one such stall starves `/livez` → liveness probe timeout → pod SIGKILL → **total outage**.

## Fix

`make_client()` now stamps `settings.s3_*` onto the boto config for **every** S3 client (primary + presign + audit store):

- `connect_timeout` ≤ 3 s
- `read_timeout` ≤ 10 s
- `retries={"max_attempts": 2, "mode": "standard"}` — a short retry for transient blips.

botocore's `max_attempts` is the **retry** count, so the default 2 = 3 total attempts → worst-case read hang **3 × 10 = 30 s** (down from an unbounded 60 s, and now recoverable); a connect failure is bounded to 3 × 3 = 9 s.

## Verification

Against a blackhole endpoint (`192.0.2.1`, TEST-NET-1 — SYN dropped), a `head_bucket` now raises `ConnectTimeoutError` in **~9.7 s**, not 60 s.

## Tests

- New `test_s3_boto_timeouts_unit.py` (network-free): `make_client` applies the settings timeouts + retry mode; guards the ceiling (`total_attempts × read_timeout ≤ 60`); proves the values come from `settings` (not a hardcode) via monkeypatch.
- Full `pytest -k 'not _e2e'`: **701 passed, 167 skipped, 0 failed** (against live PG/MinIO).

Complementary to offloading the specific on-loop S3 calls to `asyncio.to_thread` (follow-up); this PR bounds the *duration* of any S3 stall globally in one place. Part of the single-process event-loop hardening series.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>