### PR TITLE
fix(k8s): widen liveness tolerance so a transient loop stall can't SIGKILL the sole replica

### DIFF
--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -126,20 +126,31 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 60
+          # Readiness gates traffic and MUST stay honest — shed a stalled pod
+          # from Service endpoints quickly. Keep failureThreshold small; only
+          # widen timeout so a single slow (not dead) /readyz doesn't flap the
+          # endpoint. ~3×15s = 45s of sustained unreadiness before removal.
           readinessProbe:
             httpGet:
               path: /readyz
               port: 8000
             periodSeconds: 15
-            timeoutSeconds: 5
+            timeoutSeconds: 8
             failureThreshold: 3
+          # Liveness RESTARTS the pod (SIGKILL) — with replicas=1 that is a
+          # total outage, so it must fire ONLY on a genuinely dead loop, never
+          # on a transient multi-second stall (a big akb_sql, an indexing
+          # burst). The single event loop can be briefly unschedulable while
+          # still healthy, so tolerate ~6×30s = 3min before assuming deadlock.
+          # (Do NOT rely on a runtime `kubectl patch` — deploy-internal.sh
+          # re-applies this manifest and clobbers it; the value must live here.)
           livenessProbe:
             httpGet:
               path: /livez
               port: 8000
             periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            timeoutSeconds: 8
+            failureThreshold: 6
       volumes:
         - name: app-config
           configMap:


### PR DESCRIPTION
## Problem

The backend runs a **single event loop at `replicas=1`**, so a liveness SIGKILL is a **total outage**. But a healthy loop can be briefly unschedulable during a big `akb_sql`, an indexing burst, or a git-subprocess fan-out. The old liveness (`timeout 5s`, `failureThreshold 3`, `period 30s` → ~90s) restarted the only pod on such **transient** stalls — the exact mechanism behind the 2026-07-20 outage (loop stall → `/livez` `context deadline exceeded` → kubelet SIGKILL, exit 137).

## Change (`deploy/k8s/backend.yaml`)

| Probe | Before | After | Effect |
|---|---|---|---|
| liveness | timeout 5, failureThreshold 3, period 30 | timeout **8**, failureThreshold **6**, period 30 | ~**180s** sustained unresponsiveness before assuming a real deadlock |
| readiness | timeout 5, failureThreshold 3, period 15 | timeout **8**, failureThreshold 3, period 15 | stays honest — still sheds a stalled pod in ~45s, just doesn't flap on one slow `/readyz` |
| startup | (unchanged) | (unchanged) | 300s startup budget |

**Readiness intentionally stays tight** (traffic gate = honest), **liveness widens** (restart = last resort). This is the documented K8s/SRE pattern for single-worker async apps: liveness detects a *dead* loop, not a *busy* one.

## Why in the manifest, not `kubectl patch`

`deploy-internal.sh` re-applies this manifest and clobbers ad-hoc runtime patches (that's why the #244-era probe tuning never stuck). The internal overlay (`deploy/k8s/internal/`) does **not** override probes, so this base value is authoritative and survives the next deploy.

## Relationship to the other hardening PRs

Probe tolerance stops **pointless restarts on isolated transient stalls**; it does NOT fix sustained/concurrent blocking. The real cure is *not blocking the loop* — shipped separately: akb_sql streaming (#293), S3 timeouts (#294), bcrypt offload (#283, merged), git-read offload (#289). This PR is the safety-net layer.

No code paths changed; manifest-only. YAML validated (5 docs parse; liveness tolerance computes to 180s).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>