### PR TITLE
test(auth): pin the full published /auth/config contract

### DIFF
--- a/backend/tests/test_auth_config_shape_unit.py
+++ b/backend/tests/test_auth_config_shape_unit.py
@@ -60,3 +60,56 @@ def test_sso_only_default_false_in_hybrid_mode(monkeypatch):
     assert cfg["keycloak"]["enabled"] is True
     assert cfg["keycloak"]["sso_only"] is False
     assert cfg["local_auth"] == {"enabled": True}
+
+
+def test_payload_publishes_exactly_the_three_capability_groups(monkeypatch):
+    """The endpoint is UNAUTHENTICATED and documented as revealing no secrets,
+    so the published key set is itself the contract. Pinning it exactly means a
+    future field — a client secret, an internal URL, a tenant hint — cannot be
+    added to this payload without a test saying so out loud."""
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", False, raising=False)
+    monkeypatch.setattr(settings, "local_auth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+
+    cfg = _call()
+    assert set(cfg) == {"local_auth", "keycloak", "mcp_oauth"}
+    assert set(cfg["local_auth"]) == {"enabled"}
+    assert set(cfg["mcp_oauth"]) == {"enabled"}
+    assert set(cfg["keycloak"]) == {"enabled", "enrollment_mode", "login_url", "sso_only"}
+
+
+def test_mcp_oauth_group_tracks_its_setting_in_both_states(monkeypatch):
+    """Connector UIs choose between the OAuth snippet and the PAT one from this
+    group, so it is a published capability like the other two — pin both
+    states rather than only the disabled one the other tests happen to set."""
+    monkeypatch.setattr(settings, "keycloak_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", False, raising=False)
+    monkeypatch.setattr(settings, "local_auth_enabled", True, raising=False)
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    assert _call()["mcp_oauth"] == {"enabled": True}
+
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    assert _call()["mcp_oauth"] == {"enabled": False}
+
+
+def test_enrollment_mode_is_published_but_inert_while_keycloak_is_off(monkeypatch):
+    """`enrollment_mode` describes Keycloak enrollment, so it carries no policy
+    while Keycloak is disabled — yet the endpoint still publishes the configured
+    value rather than nulling it. That asymmetry is easy to misread: a consumer
+    can see `invite_only` on a deployment where nothing enrolls through Keycloak
+    at all. Pin the published-but-inert shape so the asymmetry is a stated
+    contract (consumers must gate on `enabled` first) instead of an accident one
+    refactor away from silently changing."""
+    monkeypatch.setattr(settings, "keycloak_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "keycloak_sso_only", False, raising=False)
+    monkeypatch.setattr(settings, "local_auth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    monkeypatch.setattr(settings, "keycloak_enrollment_mode", "invite_only", raising=False)
+
+    cfg = _call()
+    assert cfg["keycloak"]["enabled"] is False
+    assert cfg["keycloak"]["enrollment_mode"] == "invite_only"
+    assert cfg["keycloak"]["login_url"] is None
+    assert cfg["keycloak"]["sso_only"] is False


### PR DESCRIPTION
## What changed

Three tests-only pins on `GET /api/v1/auth/config`. No product code is touched and there is no behavior change.

| Pin | Why it matters |
| --- | --- |
| exact published key set | the endpoint is unauthenticated and documented as revealing no secrets, so the key set *is* the contract. A future client secret, internal URL, or tenant hint cannot reach this payload without a test saying so out loud. |
| `mcp_oauth` in both states | connector UIs choose between the OAuth snippet and the PAT one from this group, but it was only ever set to `false` incidentally by other tests and never asserted. |
| `enrollment_mode` while Keycloak is off | the field describes Keycloak enrollment, so it carries no policy in that state — yet the endpoint still publishes the configured value rather than nulling it. |

## The asymmetry worth stating

A deployment with Keycloak disabled still publishes whatever `enrollment_mode` is configured, so a consumer can observe `invite_only` on a deployment where nothing enrolls through Keycloak at all. Consumers must gate on `keycloak.enabled` before reading it. That was true but unstated; the new test makes it a contract rather than an accident one refactor away from silently changing.

The three compositions the existing tests already cover (SSO-only, local-only, hybrid) are unchanged.

## Validation

- `pytest backend/tests/test_auth_config_shape_unit.py backend/tests/test_local_auth_policy_unit.py` — 12 passed
- mutation-checked: adding a stray `internal_hint` field to the payload turns the key-set pin red (`test_payload_publishes_exactly_the_three_capability_groups`); removing it restores green

🤖 Generated with [Claude Code](https://claude.com/claude-code)