### PR TITLE
feat: harden activity history REST contracts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -157,6 +157,7 @@ jobs:
             test_pg_rbac_e2e.sh
             test_graph_replace_e2e.sh
             test_relations_rest_e2e.sh
+            test_history_rest_e2e.sh
             test_jwt_revocation_e2e.sh
             test_table_constraints_e2e.sh
             test_forbidden_permission_code_e2e.sh

--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -17,6 +17,12 @@ from app.services.document_service import DocumentService
 from app.services.git_service import GitService
 from app.services.user_directory import resolve_display_names
 from app.db.postgres import get_pool
+from app.models.activity import (
+    AkbActivityEnvelope,
+    AkbDocumentDiffEnvelope,
+    AkbDocumentHistoryEnvelope,
+    AkbRecentChangesEnvelope,
+)
 from app.repositories.document_repo import DocumentRepository
 
 router = APIRouter()
@@ -44,7 +50,14 @@ async def _resolve_activity_authors(entries: list[dict]) -> list[dict]:
     return entries
 
 
-@router.get("/activity/{vault}", summary="Get vault activity history (Git-based)")
+@router.get(
+    "/activity/{vault}",
+    summary="Get vault activity history (Git-based)",
+    operation_id="activityList",
+    tags=["activity"],
+    response_model=AkbActivityEnvelope,
+    response_model_exclude_unset=True,
+)
 async def vault_activity(
     vault: str,
     collection: str | None = Query(None),
@@ -66,10 +79,17 @@ async def vault_activity(
             or needle in (e.get("author_name") or "").lower()
         ]
 
-    return {"vault": vault, "total": len(entries), "activity": entries}
+    return {"kind": "activity", "vault": vault, "total": len(entries), "activity": entries}
 
 
-@router.get("/recent", summary="Recent document changes across vaults the user can access")
+@router.get(
+    "/recent",
+    summary="Recent document changes across vaults the user can access",
+    operation_id="activityRecent",
+    tags=["activity"],
+    response_model=AkbRecentChangesEnvelope,
+    response_model_exclude_unset=True,
+)
 async def recent_changes(
     vault: str | None = Query(None, description="Limit to a single vault"),
     limit: int = Query(20, ge=1, le=100),
@@ -137,10 +157,17 @@ async def recent_changes(
             "commit": r["current_commit"],
             "changed_at": r["updated_at"].isoformat() if r["updated_at"] else None,
         })
-    return {"changes": changes}
+    return {"kind": "recent_changes", "changes": changes}
 
 
-@router.get("/diff/{vault}/{doc_id:path}", summary="Get document diff at a specific commit")
+@router.get(
+    "/diff/{vault}/{doc_id:path}",
+    summary="Get document diff at a specific commit",
+    operation_id="documentsDiff",
+    tags=["documents"],
+    response_model=AkbDocumentDiffEnvelope,
+    response_model_exclude_unset=True,
+)
 async def document_diff(
     vault: str,
     doc_id: str,
@@ -157,10 +184,18 @@ async def document_diff(
         if not doc:
             raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
 
-    return git.file_diff(vault, doc["path"], commit)
+    result = git.file_diff(vault, doc["path"], commit)
+    return {"kind": "document_diff", **result}
 
 
-@router.get("/history/{vault}/{doc_id:path}", summary="Get document version history (Git-based)")
+@router.get(
+    "/history/{vault}/{doc_id:path}",
+    summary="Get document version history (Git-based)",
+    operation_id="documentsHistory",
+    tags=["documents"],
+    response_model=AkbDocumentHistoryEnvelope,
+    response_model_exclude_unset=True,
+)
 async def document_history(
     vault: str,
     doc_id: str,
@@ -177,4 +212,5 @@ async def document_history(
     which the global AKBError handler maps to 404.
     """
     await check_vault_access(user.user_id, vault, required_role="reader")
-    return await doc_service.history(vault, doc_id, limit=limit)
+    result = await doc_service.history(vault, doc_id, limit=limit)
+    return {"kind": "document_history", **result}

--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -1,0 +1,74 @@
+"""Typed REST contracts for git-backed activity and document history."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ActivityResponse(BaseModel):
+    """Preserve additive git/service fields while typing the public shape."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ActivityFileChange(ActivityResponse):
+    path: str
+    change: Literal["added", "deleted", "modified"]
+
+
+class ActivityEntry(ActivityResponse):
+    hash: str
+    subject: str
+    author: str
+    date: datetime
+    action: str
+    summary: str
+    agent: str
+    files: list[ActivityFileChange]
+    author_name: str | None = None
+
+
+class RecentDocumentChange(ActivityResponse):
+    doc_id: str
+    vault: str
+    path: str
+    title: str
+    type: str
+    commit: str | None
+    changed_at: datetime | None
+
+
+class DocumentHistoryEntry(ActivityResponse):
+    hash: str
+    message: str
+    author: str
+    date: datetime
+    author_name: str | None = None
+
+
+class AkbActivityEnvelope(ActivityResponse):
+    kind: Literal["activity"]
+    vault: str
+    total: int
+    activity: list[ActivityEntry]
+
+
+class AkbRecentChangesEnvelope(ActivityResponse):
+    kind: Literal["recent_changes"]
+    changes: list[RecentDocumentChange]
+
+
+class AkbDocumentHistoryEnvelope(ActivityResponse):
+    kind: Literal["document_history"]
+    uri: str
+    history: list[DocumentHistoryEntry]
+
+
+class AkbDocumentDiffEnvelope(ActivityResponse):
+    kind: Literal["document_diff"]
+    file: str
+    commit: str
+    type: Literal["added", "deleted", "modified", "unknown", "unchanged"]
+    diff: str
+    error: str | None = None

--- a/backend/app/openapi_contract.py
+++ b/backend/app/openapi_contract.py
@@ -71,6 +71,10 @@ ERROR_STATUSES = ("400", "401", "403", "404", "409", "422", "500")
 SUCCESS_STATUSES = ("200", "201", "202")
 HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
 KIND_SUCCESS_RESPONSE_REFS = {
+    ("get", "/api/v1/activity/{vault}"): "#/components/schemas/AkbActivityEnvelope",
+    ("get", "/api/v1/recent"): "#/components/schemas/AkbRecentChangesEnvelope",
+    ("get", "/api/v1/history/{vault}/{doc_id}"): "#/components/schemas/AkbDocumentHistoryEnvelope",
+    ("get", "/api/v1/diff/{vault}/{doc_id}"): "#/components/schemas/AkbDocumentDiffEnvelope",
     ("post", "/api/v1/documents"): "#/components/schemas/AkbDocumentWriteEnvelope",
     ("get", "/api/v1/documents/{vault}/{doc_id}"): "#/components/schemas/AkbDocumentEnvelope",
     ("patch", "/api/v1/documents/{vault}/{doc_id}"): "#/components/schemas/AkbDocumentWriteEnvelope",
@@ -122,6 +126,10 @@ KIND_ADDITIONAL_SUCCESS_RESPONSE_REFS: dict[tuple[str, str], dict[str, str | Non
 }
 OPERATION_TAG_OVERRIDES = {
     ("get", "/api/v1/browse/{vault}"): ["documents"],
+    ("get", "/api/v1/activity/{vault}"): ["activity"],
+    ("get", "/api/v1/recent"): ["activity"],
+    ("get", "/api/v1/history/{vault}/{doc_id}"): ["documents"],
+    ("get", "/api/v1/diff/{vault}/{doc_id}"): ["documents"],
 }
 
 
@@ -287,6 +295,10 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
                 {"$ref": "#/components/schemas/AkbRelationLinkEnvelope"},
                 {"$ref": "#/components/schemas/AkbRelationUnlinkEnvelope"},
                 {"$ref": "#/components/schemas/AkbProvenanceEnvelope"},
+                {"$ref": "#/components/schemas/AkbActivityEnvelope"},
+                {"$ref": "#/components/schemas/AkbRecentChangesEnvelope"},
+                {"$ref": "#/components/schemas/AkbDocumentHistoryEnvelope"},
+                {"$ref": "#/components/schemas/AkbDocumentDiffEnvelope"},
             ],
             "discriminator": {
                 "propertyName": "kind",
@@ -310,9 +322,123 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
                     "relation_link": "#/components/schemas/AkbRelationLinkEnvelope",
                     "relation_unlink": "#/components/schemas/AkbRelationUnlinkEnvelope",
                     "provenance": "#/components/schemas/AkbProvenanceEnvelope",
+                    "activity": "#/components/schemas/AkbActivityEnvelope",
+                    "recent_changes": "#/components/schemas/AkbRecentChangesEnvelope",
+                    "document_history": "#/components/schemas/AkbDocumentHistoryEnvelope",
+                    "document_diff": "#/components/schemas/AkbDocumentDiffEnvelope",
                 },
             },
         },
+        "ActivityFileChange": {
+            "type": "object",
+            "required": ["path", "change"],
+            "properties": {
+                "path": {"type": "string"},
+                "change": {"type": "string", "enum": ["added", "deleted", "modified"]},
+            },
+            "additionalProperties": {"$ref": "#/components/schemas/AkbJsonValue"},
+        },
+        "ActivityEntry": {
+            "type": "object",
+            "required": ["hash", "subject", "author", "date", "action", "summary", "agent", "files"],
+            "properties": {
+                "hash": {"type": "string"},
+                "subject": {"type": "string"},
+                "author": {"type": "string"},
+                "date": {"type": "string", "format": "date-time"},
+                "action": {"type": "string"},
+                "summary": {"type": "string"},
+                "agent": {"type": "string"},
+                "files": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/ActivityFileChange"},
+                },
+                "author_name": _nullable_string(),
+            },
+            "additionalProperties": {"$ref": "#/components/schemas/AkbJsonValue"},
+        },
+        "RecentDocumentChange": {
+            "type": "object",
+            "required": ["doc_id", "vault", "path", "title", "type", "commit", "changed_at"],
+            "properties": {
+                "doc_id": {"type": "string"},
+                "vault": {"type": "string"},
+                "path": {"type": "string"},
+                "title": {"type": "string"},
+                "type": {"type": "string"},
+                "commit": _nullable_string(),
+                "changed_at": {
+                    "anyOf": [
+                        {"type": "string", "format": "date-time"},
+                        {"type": "null"},
+                    ],
+                },
+            },
+            "additionalProperties": {"$ref": "#/components/schemas/AkbJsonValue"},
+        },
+        "DocumentHistoryEntry": {
+            "type": "object",
+            "required": ["hash", "message", "author", "date"],
+            "properties": {
+                "hash": {"type": "string"},
+                "message": {"type": "string"},
+                "author": {"type": "string"},
+                "date": {"type": "string", "format": "date-time"},
+                "author_name": _nullable_string(),
+            },
+            "additionalProperties": {"$ref": "#/components/schemas/AkbJsonValue"},
+        },
+        "AkbActivityEnvelope": _kind_schema(
+            "activity",
+            {
+                "vault": {"type": "string"},
+                "total": {"type": "integer"},
+                "activity": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/ActivityEntry"},
+                },
+            },
+            "Git-backed vault activity history.",
+            required=("kind", "vault", "total", "activity"),
+        ),
+        "AkbRecentChangesEnvelope": _kind_schema(
+            "recent_changes",
+            {
+                "changes": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/RecentDocumentChange"},
+                },
+            },
+            "Recent documents visible to the current user.",
+            required=("kind", "changes"),
+        ),
+        "AkbDocumentHistoryEnvelope": _kind_schema(
+            "document_history",
+            {
+                "uri": {"type": "string"},
+                "history": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/DocumentHistoryEntry"},
+                },
+            },
+            "Git-backed document version history.",
+            required=("kind", "uri", "history"),
+        ),
+        "AkbDocumentDiffEnvelope": _kind_schema(
+            "document_diff",
+            {
+                "file": {"type": "string"},
+                "commit": {"type": "string"},
+                "type": {
+                    "type": "string",
+                    "enum": ["added", "deleted", "modified", "unknown", "unchanged"],
+                },
+                "diff": {"type": "string"},
+                "error": _nullable_string(),
+            },
+            "Document diff at one commit.",
+            required=("kind", "file", "commit", "type", "diff"),
+        ),
         "AkbGraphNode": {
             "type": "object",
             "required": ["uri", "name", "resource_type"],

--- a/backend/tests/test_activity_routes_unit.py
+++ b/backend/tests/test_activity_routes_unit.py
@@ -6,13 +6,23 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.api.routes import activity as routes
 from app.models.activity import (
     AkbActivityEnvelope,
     AkbDocumentDiffEnvelope,
     AkbDocumentHistoryEnvelope,
     AkbRecentChangesEnvelope,
 )
+
+
+@pytest.fixture
+def routes(monkeypatch, tmp_path):
+    """Import the module only after redirecting its module-level GitService."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    from app.api.routes import activity
+
+    return activity
 
 
 def _pool_with(*, rows=(), vault_id="vault-id"):
@@ -30,7 +40,7 @@ def _pool_with(*, rows=(), vault_id="vault-id"):
 
 
 @pytest.mark.asyncio
-async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkeypatch):
+async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkeypatch, routes):
     entry = {
         "hash": "abc123",
         "subject": "[update] notes/a.md",
@@ -55,7 +65,7 @@ async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkey
 
 
 @pytest.mark.asyncio
-async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch):
+async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch, routes):
     rows = [{
         "id": "uuid-1",
         "title": "Nullable",
@@ -90,7 +100,9 @@ async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch):
         }, True),
     ],
 )
-async def test_diff_adds_kind_and_preserves_optional_error(monkeypatch, git_result, has_error):
+async def test_diff_adds_kind_and_preserves_optional_error(
+    monkeypatch, routes, git_result, has_error,
+):
     pool, _ = _pool_with()
     monkeypatch.setattr(routes, "get_pool", AsyncMock(return_value=pool))
     monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
@@ -110,7 +122,7 @@ async def test_diff_adds_kind_and_preserves_optional_error(monkeypatch, git_resu
 
 
 @pytest.mark.asyncio
-async def test_history_adds_kind_without_changing_entries(monkeypatch):
+async def test_history_adds_kind_without_changing_entries(monkeypatch, routes):
     entry = {
         "hash": "abc123",
         "message": "update",

--- a/backend/tests/test_activity_routes_unit.py
+++ b/backend/tests/test_activity_routes_unit.py
@@ -1,0 +1,134 @@
+"""Serialization contracts for activity, recent, history, and diff routes."""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.routes import activity as routes
+from app.models.activity import (
+    AkbActivityEnvelope,
+    AkbDocumentDiffEnvelope,
+    AkbDocumentHistoryEnvelope,
+    AkbRecentChangesEnvelope,
+)
+
+
+def _pool_with(*, rows=(), vault_id="vault-id"):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    conn.fetchrow = AsyncMock(return_value={"id": vault_id})
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    return pool, conn
+
+
+@pytest.mark.asyncio
+async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkeypatch):
+    entry = {
+        "hash": "abc123",
+        "subject": "[update] notes/a.md",
+        "author": "external-author",
+        "date": "2026-07-21T00:00:00+00:00",
+        "action": "update",
+        "summary": "changed",
+        "agent": "external-author",
+        "files": [{"path": "notes/a.md", "change": "modified"}],
+    }
+    monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
+    monkeypatch.setattr(routes.git, "vault_log", MagicMock(return_value=[entry]))
+    monkeypatch.setattr(routes, "_resolve_activity_authors", AsyncMock(return_value=[entry]))
+
+    out = await routes.vault_activity(
+        "v", collection=None, author=None, since=None, limit=20, user=MagicMock(),
+    )
+
+    assert out == {"kind": "activity", "vault": "v", "total": 1, "activity": [entry]}
+    dumped = AkbActivityEnvelope.model_validate(out).model_dump(exclude_unset=True)
+    assert "author_name" not in dumped["activity"][0]
+
+
+@pytest.mark.asyncio
+async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch):
+    rows = [{
+        "id": "uuid-1",
+        "title": "Nullable",
+        "path": "notes/nullable.md",
+        "doc_type": None,
+        "current_commit": None,
+        "updated_at": None,
+        "vault_name": "v",
+        "metadata": {"id": "d-nullable"},
+    }]
+    pool, _ = _pool_with(rows=rows)
+    monkeypatch.setattr(routes, "get_pool", AsyncMock(return_value=pool))
+
+    out = await routes.recent_changes(vault=None, limit=20, user=MagicMock(user_id="u"))
+
+    assert out["kind"] == "recent_changes"
+    assert out["changes"][0]["commit"] is None
+    assert out["changes"][0]["changed_at"] is None
+    dumped = AkbRecentChangesEnvelope.model_validate(out).model_dump(exclude_unset=True)
+    assert dumped["changes"][0]["commit"] is None
+    assert dumped["changes"][0]["changed_at"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("git_result", "has_error"),
+    [
+        ({"file": "a.md", "commit": "good", "type": "modified", "diff": "@@"}, False),
+        ({
+            "file": "a.md", "commit": "bad", "type": "unknown", "diff": "",
+            "error": "commit not found",
+        }, True),
+    ],
+)
+async def test_diff_adds_kind_and_preserves_optional_error(monkeypatch, git_result, has_error):
+    pool, _ = _pool_with()
+    monkeypatch.setattr(routes, "get_pool", AsyncMock(return_value=pool))
+    monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
+    monkeypatch.setattr(
+        routes.DocumentRepository,
+        "find_by_ref_with_conn",
+        AsyncMock(return_value={"path": "a.md"}),
+    )
+    monkeypatch.setattr(routes.git, "file_diff", MagicMock(return_value=git_result))
+
+    out = await routes.document_diff("v", "a.md", commit=git_result["commit"], user=MagicMock())
+
+    assert out["kind"] == "document_diff"
+    dumped = AkbDocumentDiffEnvelope.model_validate(out).model_dump(exclude_unset=True)
+    assert ("error" in dumped) is has_error
+    assert dumped["type"] == git_result["type"]
+
+
+@pytest.mark.asyncio
+async def test_history_adds_kind_without_changing_entries(monkeypatch):
+    entry = {
+        "hash": "abc123",
+        "message": "update",
+        "author": "writer",
+        "date": datetime(2026, 7, 21, tzinfo=timezone.utc),
+    }
+    monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
+    monkeypatch.setattr(
+        routes.doc_service,
+        "history",
+        AsyncMock(return_value={"uri": "akb://v/doc/a.md", "history": [entry]}),
+    )
+
+    out = await routes.document_history("v", "a.md", limit=20, user=MagicMock())
+
+    assert out == {
+        "kind": "document_history",
+        "uri": "akb://v/doc/a.md",
+        "history": [entry],
+    }
+    AkbDocumentHistoryEnvelope.model_validate(out)

--- a/backend/tests/test_history_rest_e2e.sh
+++ b/backend/tests/test_history_rest_e2e.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 #
-# AKB E2E: Document version history over HTTP REST.
+# AKB E2E: Activity, recent changes, document history, and diff over REST.
 #
-# Covers GET /api/v1/history/{vault}/{doc} — the REST twin of the
-# akb_history MCP tool. Both surfaces share DocumentService.history(), so
-# this asserts parity: the version list, the `limit` bound, the created_at
-# lineage boundary (recreate-at-same-path drops old commits), author_name
-# resolution (git author username → display_name), and the access matrix
-# (reader 200 / non-member 403 / unauth 401 / missing 404).
+# Pins the public OpenAPI contract and runtime envelopes for GET /activity,
+# /recent, /history, and /diff while retaining history lineage, author,
+# filtering, visibility, and access-boundary coverage.
 #
 # Docs are created via the REST write path (POST /documents) so the git
 # author is the actor's username — exercising the username branch of the
@@ -25,7 +22,7 @@ pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
 echo "╔══════════════════════════════════════════╗"
-echo "║   Document History REST E2E              ║"
+echo "║   Activity / History / Diff REST E2E     ║"
 echo "║   Target: $BASE_URL"
 echo "╚══════════════════════════════════════════╝"
 echo ""
@@ -84,6 +81,12 @@ rdeldoc() { curl -sk -X DELETE "$BASE_URL/api/v1/documents/$2" -H "Authorization
 # GET /history/{vault}/{doc}[?query]
 hget()      { curl -sk "$BASE_URL/api/v1/history/$2${3:-}" -H "Authorization: Bearer $1"; }
 hget_code() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/history/$2${3:-}" -H "Authorization: Bearer $1"; }
+aget()      { curl -sk "$BASE_URL/api/v1/activity/$2${3:-}" -H "Authorization: Bearer $1"; }
+aget_code() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/activity/$2${3:-}" -H "Authorization: Bearer $1"; }
+rget()      { curl -sk "$BASE_URL/api/v1/recent${2:-}" -H "Authorization: Bearer $1"; }
+rget_code() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/recent${2:-}" -H "Authorization: Bearer $1"; }
+dget()      { curl -sk "$BASE_URL/api/v1/diff/$2?commit=$3" -H "Authorization: Bearer $1"; }
+dget_code() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/diff/$2?commit=$3" -H "Authorization: Bearer $1"; }
 
 getpath()    { python3 -c "import sys,json; print(json.load(sys.stdin).get('path',''))" 2>/dev/null; }
 hist_count() { python3 -c "import sys,json
@@ -98,6 +101,8 @@ all_annotated() { python3 -c "import sys,json
 try:
   h=json.load(sys.stdin).get('history',[]); print(bool(h) and all('author_name' in e for e in h))
 except Exception: print(False)" 2>/dev/null; }
+json_field() { python3 -c "import sys,json; print(json.load(sys.stdin).get('$1',''))" 2>/dev/null; }
+contains_vault() { python3 -c "import sys,json; print(any(x.get('vault') == '$1' for x in json.load(sys.stdin).get('changes',[])))" 2>/dev/null; }
 
 USER1="hist-rest-u1-$(date +%s)"     # owner (writer) of the vault
 USER2="hist-rest-u2-$(date +%s)"     # reader on the vault
@@ -122,11 +127,49 @@ DOCPATH=$(rput "$PAT1" "{\"vault\":\"$VAULT\",\"collection\":\"history-test\",\"
 rpatch "$PAT1" "$VAULT/$DOCPATH" "{\"content\":\"## V2 updated\",\"message\":\"history rest e2e update\"}" >/dev/null
 pass "doc updated (v2)"
 
-# ── 1. GET /history — version list + entry shape ─────────────
+# ── 1. Public OpenAPI contract ───────────────────────────────
 echo ""
-echo "▸ 1. GET /history (version list)"
+echo "▸ 1. public OpenAPI contract"
+
+OPENAPI=$(curl -sk "$BASE_URL/openapi.json")
+OPENAPI_RESULT=$(echo "$OPENAPI" | python3 -c '
+import json, sys
+s = json.load(sys.stdin)
+expected = {
+  "/api/v1/activity/{vault}": ("activityList", "activity", "AkbActivityEnvelope", "activity"),
+  "/api/v1/recent": ("activityRecent", "activity", "AkbRecentChangesEnvelope", "recent_changes"),
+  "/api/v1/history/{vault}/{doc_id}": ("documentsHistory", "documents", "AkbDocumentHistoryEnvelope", "document_history"),
+  "/api/v1/diff/{vault}/{doc_id}": ("documentsDiff", "documents", "AkbDocumentDiffEnvelope", "document_diff"),
+}
+schemas = s["components"]["schemas"]
+union = schemas["AkbSuccessEnvelope"]
+ids = []
+for item in s["paths"].values():
+  ids.extend(op.get("operationId") for method, op in item.items() if method in {"get","post","put","patch","delete"})
+for path, (op_id, tag, model, kind) in expected.items():
+  op = s["paths"][path]["get"]
+  assert op["operationId"] == op_id and ids.count(op_id) == 1
+  assert op["tags"] == [tag]
+  assert op["responses"]["200"]["content"]["application/json"]["schema"] == {"$ref": f"#/components/schemas/{model}"}
+  for status in ("400","401","403","404","409","422","500"):
+    assert op["responses"][status]["content"]["application/json"]["schema"] == {"$ref": "#/components/schemas/AkbError"}
+  leaf = schemas[model]
+  assert "kind" in leaf["required"] and leaf["properties"]["kind"]["enum"] == [kind]
+  ref = f"#/components/schemas/{model}"
+  assert sum(x.get("$ref") == ref for x in union["oneOf"]) == 1
+  assert union["discriminator"]["mapping"][kind] == ref
+assert schemas["ActivityEntry"]["properties"]["files"]["items"]["$ref"].endswith("ActivityFileChange")
+assert schemas["DocumentHistoryEntry"]["properties"]["date"]["format"] == "date-time"
+assert schemas["AkbDocumentDiffEnvelope"]["properties"]["diff"]["type"] == "string"
+print("PASS")')
+[ "$OPENAPI_RESULT" = "PASS" ] && pass "four operations expose exact typed OpenAPI contracts" || fail "OpenAPI" "contract mismatch"
+
+# ── 2. GET /history — version list + entry shape ─────────────
+echo ""
+echo "▸ 2. GET /history (version list)"
 
 R=$(hget "$PAT1" "$VAULT/$DOCPATH")
+[ "$(echo "$R" | json_field kind)" = "document_history" ] && pass "history kind=document_history" || fail "history kind" "missing or wrong"
 CNT=$(echo "$R" | hist_count)
 [ "$CNT" -ge 2 ] 2>/dev/null && pass "lists >= 2 versions (count=$CNT)" || fail "history list" "expected >=2, got $CNT"
 
@@ -135,9 +178,9 @@ DATE=$(echo "$R" | first_field date)
 [ -n "$HASH" ] && pass "entry carries a commit hash ($HASH)" || fail "entry hash" "missing"
 [ -n "$DATE" ] && pass "entry carries a date" || fail "entry date" "missing"
 
-# ── 2. author_name resolution (the new annotation) ───────────
+# ── 3. author_name resolution ────────────────────────────────
 echo ""
-echo "▸ 2. author_name resolution"
+echo "▸ 3. author_name resolution"
 
 AUTHOR=$(echo "$R" | first_field author)
 AUTHORNAME=$(echo "$R" | first_field author_name)
@@ -148,9 +191,48 @@ AUTHORNAME=$(echo "$R" | first_field author_name)
 [ "$AUTHORNAME" = "$USER1" ] && pass "author_name resolved (username→display_name)" || fail "author_name" "expected $USER1, got '$AUTHORNAME'"
 [ "$(echo "$R" | all_annotated)" = "True" ] && pass "every entry annotated with author_name" || fail "annotate all" "some entries missing author_name"
 
-# ── 3. limit bound ───────────────────────────────────────────
+# ── 4. activity filters and envelope ─────────────────────────
 echo ""
-echo "▸ 3. limit query"
+echo "▸ 4. activity filters and envelope"
+
+A=$(aget "$PAT1" "$VAULT")
+[ "$(echo "$A" | json_field kind)" = "activity" ] && pass "activity kind=activity" || fail "activity kind" "missing or wrong"
+ACNT=$(echo "$A" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("activity",[])))' 2>/dev/null)
+[ "$ACNT" -ge 2 ] 2>/dev/null && pass "activity lists document commits" || fail "activity list" "expected >=2, got $ACNT"
+[ "$(aget "$PAT1" "$VAULT" "?limit=1" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("activity",[])))')" = "1" ] && pass "activity limit=1" || fail "activity limit" "not enforced"
+[ "$(aget "$PAT1" "$VAULT" "?collection=history-test" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("activity",[])))')" -ge 2 ] 2>/dev/null && pass "activity collection filter" || fail "activity collection" "expected matching commits"
+[ "$(aget "$PAT1" "$VAULT" "?author=$USER1" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("activity",[])))')" -ge 2 ] 2>/dev/null && pass "activity author filter" || fail "activity author" "expected matching commits"
+[ "$(aget "$PAT1" "$VAULT" "?since=2030-01-01T00:00:00Z" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("activity",[])))')" = "0" ] && pass "activity since filter" || fail "activity since" "future bound should be empty"
+
+# ── 5. recent visibility and envelope ────────────────────────
+echo ""
+echo "▸ 5. recent visibility and envelope"
+
+RECENT1=$(rget "$PAT1" "?vault=$VAULT")
+[ "$(echo "$RECENT1" | json_field kind)" = "recent_changes" ] && pass "recent kind=recent_changes" || fail "recent kind" "missing or wrong"
+[ "$(echo "$RECENT1" | contains_vault "$VAULT")" = "True" ] && pass "owner sees private vault recent changes" || fail "recent owner" "vault missing"
+[ "$(rget "$PAT2" "?vault=$VAULT" | contains_vault "$VAULT")" = "True" ] && pass "granted reader sees recent changes" || fail "recent reader" "vault missing"
+[ "$(rget "$PAT3" | contains_vault "$VAULT")" = "False" ] && pass "private vault does not leak via global recent" || fail "recent privacy" "private vault leaked"
+[ "$(rget_code "$PAT3" "?vault=$VAULT")" = "403" ] && pass "non-member private recent filter → 403" || fail "recent private access" "expected 403"
+m1 "akb_set_public" "{\"vault\":\"$VAULT\",\"level\":\"reader\"}" >/dev/null
+[ "$(rget "$PAT3" | contains_vault "$VAULT")" = "True" ] && pass "public reader sees vault in global recent" || fail "recent public" "public vault missing"
+m1 "akb_set_public" "{\"vault\":\"$VAULT\",\"level\":\"none\"}" >/dev/null
+
+# ── 6. diff normal/unknown compatibility ─────────────────────
+echo ""
+echo "▸ 6. document diff"
+
+DIFF=$(dget "$PAT1" "$VAULT/$DOCPATH" "$HASH")
+[ "$(echo "$DIFF" | json_field kind)" = "document_diff" ] && pass "diff kind=document_diff" || fail "diff kind" "missing or wrong"
+[ "$(echo "$DIFF" | json_field type)" = "modified" ] && pass "known update commit → modified" || fail "known diff" "unexpected type"
+UNKNOWN=$(dget "$PAT1" "$VAULT/$DOCPATH" "not-a-commit")
+[ "$(echo "$UNKNOWN" | json_field type)" = "unknown" ] && [ "$(echo "$UNKNOWN" | json_field error)" = "commit not found" ] && pass "unknown commit stays HTTP 200 unknown+error" || fail "unknown diff" "compatibility response changed"
+[ "$(dget_code "$PAT1" "$VAULT/$DOCPATH" "not-a-commit")" = "200" ] && pass "unknown commit status remains 200" || fail "unknown diff status" "expected 200"
+[ "$(echo "$DIFF" | python3 -c 'import sys,json; print("error" in json.load(sys.stdin))')" = "False" ] && pass "normal diff omits optional error" || fail "diff error absence" "error should be absent"
+
+# ── 7. query bounds ──────────────────────────────────────────
+echo ""
+echo "▸ 7. query bounds"
 
 ONE=$(hget "$PAT1" "$VAULT/$DOCPATH" "?limit=1" | hist_count)
 [ "$ONE" = "1" ] && pass "limit=1 returns exactly 1 entry" || fail "limit=1" "got $ONE"
@@ -159,9 +241,9 @@ CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH" "?limit=0")
 CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH" "?limit=500")
 [ "$CODE" = "422" ] && pass "limit=500 → 422 (above le=100)" || fail "limit=500" "got $CODE"
 
-# ── 4. access matrix ─────────────────────────────────────────
+# ── 8. access matrix ─────────────────────────────────────────
 echo ""
-echo "▸ 4. access matrix"
+echo "▸ 8. access matrix"
 
 CODE=$(hget_code "$PAT1" "$VAULT/$DOCPATH")
 [ "$CODE" = "200" ] && pass "owner → 200" || fail "owner" "got $CODE"
@@ -171,23 +253,31 @@ CODE=$(hget_code "$PAT3" "$VAULT/$DOCPATH")
 [ "$CODE" = "403" ] && pass "non-member → 403" || fail "non-member" "got $CODE"
 CODE=$(curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/history/$VAULT/$DOCPATH")
 [ "$CODE" = "401" ] && pass "unauthenticated → 401" || fail "no auth" "got $CODE"
+[ "$(aget_code "$PAT2" "$VAULT")" = "200" ] && pass "activity reader → 200" || fail "activity reader" "expected 200"
+[ "$(aget_code "$PAT3" "$VAULT")" = "403" ] && pass "activity non-member → 403" || fail "activity non-member" "expected 403"
+[ "$(curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/activity/$VAULT")" = "401" ] && pass "activity unauthenticated → 401" || fail "activity unauth" "expected 401"
+[ "$(dget_code "$PAT2" "$VAULT/$DOCPATH" "$HASH")" = "200" ] && pass "diff reader → 200" || fail "diff reader" "expected 200"
+[ "$(dget_code "$PAT3" "$VAULT/$DOCPATH" "$HASH")" = "403" ] && pass "diff non-member → 403" || fail "diff non-member" "expected 403"
+[ "$(curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/diff/$VAULT/$DOCPATH?commit=$HASH")" = "401" ] && pass "diff unauthenticated → 401" || fail "diff unauth" "expected 401"
 
-# ── 5. not found ─────────────────────────────────────────────
+# ── 9. not found ─────────────────────────────────────────────
 echo ""
-echo "▸ 5. not found"
+echo "▸ 9. not found"
 
 CODE=$(hget_code "$PAT1" "$VAULT/history-test/does-not-exist.md")
 [ "$CODE" = "404" ] && pass "missing document → 404" || fail "missing doc" "got $CODE"
 CODE=$(hget_code "$PAT1" "ghost-vault-$(date +%s)/history-test/hist-doc.md")
 [ "$CODE" = "404" ] && pass "missing vault → 404" || fail "missing vault" "got $CODE"
+[ "$(dget_code "$PAT1" "$VAULT/history-test/does-not-exist.md" "$HASH")" = "404" ] && pass "diff missing document → 404" || fail "diff missing doc" "expected 404"
+[ "$(aget_code "$PAT1" "ghost-vault-$(date +%s)")" = "404" ] && pass "activity missing vault → 404" || fail "activity missing vault" "expected 404"
 
-# ── 6. created_at lineage boundary (parity with MCP akb_history T6) ─
+# ── 10. created_at lineage boundary (parity with MCP akb_history T6) ─
 # Delete the doc and recreate it at the same path; the new document's
 # created_at trims the prior lineage so only the recreate commit shows.
 # sleep 1 keeps the delete commit strictly older than the new created_at
 # (the boundary is `committed_date >= created_at`, second-granular).
 echo ""
-echo "▸ 6. lineage boundary (recreate at same path)"
+echo "▸ 10. lineage boundary (recreate at same path)"
 
 rdeldoc "$PAT1" "$VAULT/$DOCPATH" >/dev/null
 sleep 1

--- a/backend/tests/test_rest_openapi_contract_unit.py
+++ b/backend/tests/test_rest_openapi_contract_unit.py
@@ -88,6 +88,113 @@ def test_api_error_responses_reference_single_akb_error_component():
             )
 
 
+def test_activity_history_diff_openapi_contract_is_codegen_typed():
+    schema = app.openapi()
+    paths = schema["paths"]
+    expected = {
+        "/api/v1/activity/{vault}": (
+            "activityList", "activity", "AkbActivityEnvelope",
+        ),
+        "/api/v1/recent": (
+            "activityRecent", "activity", "AkbRecentChangesEnvelope",
+        ),
+        "/api/v1/history/{vault}/{doc_id}": (
+            "documentsHistory", "documents", "AkbDocumentHistoryEnvelope",
+        ),
+        "/api/v1/diff/{vault}/{doc_id}": (
+            "documentsDiff", "documents", "AkbDocumentDiffEnvelope",
+        ),
+    }
+
+    operation_ids = [operation["operationId"] for _, _, operation in _api_operations()]
+    for path, (operation_id, tag, model) in expected.items():
+        operation = paths[path]["get"]
+        assert operation["operationId"] == operation_id
+        assert operation["tags"] == [tag]
+        assert operation_ids.count(operation_id) == 1
+        assert (
+            operation["responses"]["200"]["content"]["application/json"]["schema"]
+            == {"$ref": f"#/components/schemas/{model}"}
+        )
+        for status in ERROR_STATUSES:
+            assert (
+                operation["responses"][status]["content"]["application/json"]["schema"]
+                == {"$ref": "#/components/schemas/AkbError"}
+            )
+
+
+def test_activity_history_diff_schemas_have_literal_kinds_and_typed_fields():
+    schemas = app.openapi()["components"]["schemas"]
+    expected_kinds = {
+        "AkbActivityEnvelope": "activity",
+        "AkbRecentChangesEnvelope": "recent_changes",
+        "AkbDocumentHistoryEnvelope": "document_history",
+        "AkbDocumentDiffEnvelope": "document_diff",
+    }
+    for model, kind in expected_kinds.items():
+        leaf = schemas[model]
+        assert "kind" in leaf["required"]
+        assert leaf["properties"]["kind"] == {
+            "type": "string",
+            "enum": [kind],
+            "description": "Success envelope discriminator.",
+        }
+
+    activity_items = schemas["AkbActivityEnvelope"]["properties"]["activity"]
+    assert activity_items == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/ActivityEntry"},
+    }
+    assert schemas["ActivityEntry"]["properties"]["date"] == {
+        "type": "string", "format": "date-time",
+    }
+    assert schemas["ActivityEntry"]["properties"]["files"] == {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/ActivityFileChange"},
+    }
+    assert schemas["ActivityFileChange"]["properties"]["change"]["enum"] == [
+        "added", "deleted", "modified",
+    ]
+
+    recent_items = schemas["AkbRecentChangesEnvelope"]["properties"]["changes"]
+    assert recent_items["items"] == {"$ref": "#/components/schemas/RecentDocumentChange"}
+    recent = schemas["RecentDocumentChange"]["properties"]
+    assert recent["commit"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    assert recent["changed_at"] == {
+        "anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}],
+    }
+
+    history_items = schemas["AkbDocumentHistoryEnvelope"]["properties"]["history"]
+    assert history_items["items"] == {"$ref": "#/components/schemas/DocumentHistoryEntry"}
+    history = schemas["DocumentHistoryEntry"]["properties"]
+    assert history["hash"]["type"] == "string"
+    assert history["author"]["type"] == "string"
+    assert history["date"] == {"type": "string", "format": "date-time"}
+
+    diff = schemas["AkbDocumentDiffEnvelope"]
+    assert {"file", "commit", "type", "diff"}.issubset(diff["required"])
+    assert diff["properties"]["type"]["enum"] == [
+        "added", "deleted", "modified", "unknown", "unchanged",
+    ]
+    assert diff["properties"]["diff"]["type"] == "string"
+    assert "error" not in diff["required"]
+
+
+def test_activity_history_diff_are_registered_in_success_discriminator_once():
+    success = app.openapi()["components"]["schemas"]["AkbSuccessEnvelope"]
+    refs = [item["$ref"] for item in success["oneOf"]]
+    expected = {
+        "activity": "#/components/schemas/AkbActivityEnvelope",
+        "recent_changes": "#/components/schemas/AkbRecentChangesEnvelope",
+        "document_history": "#/components/schemas/AkbDocumentHistoryEnvelope",
+        "document_diff": "#/components/schemas/AkbDocumentDiffEnvelope",
+    }
+    mapping = success["discriminator"]["mapping"]
+    for kind, ref in expected.items():
+        assert refs.count(ref) == 1
+        assert mapping[kind] == ref
+
+
 def test_success_envelope_components_are_kind_discriminated():
     schemas = app.openapi()["components"]["schemas"]
     union = schemas["AkbSuccessEnvelope"]
@@ -113,6 +220,10 @@ def test_success_envelope_components_are_kind_discriminated():
             "relation_link": "#/components/schemas/AkbRelationLinkEnvelope",
             "relation_unlink": "#/components/schemas/AkbRelationUnlinkEnvelope",
             "provenance": "#/components/schemas/AkbProvenanceEnvelope",
+            "activity": "#/components/schemas/AkbActivityEnvelope",
+            "recent_changes": "#/components/schemas/AkbRecentChangesEnvelope",
+            "document_history": "#/components/schemas/AkbDocumentHistoryEnvelope",
+            "document_diff": "#/components/schemas/AkbDocumentDiffEnvelope",
         },
     }
     for name, kind in (
@@ -135,6 +246,10 @@ def test_success_envelope_components_are_kind_discriminated():
         ("AkbRelationLinkEnvelope", "relation_link"),
         ("AkbRelationUnlinkEnvelope", "relation_unlink"),
         ("AkbProvenanceEnvelope", "provenance"),
+        ("AkbActivityEnvelope", "activity"),
+        ("AkbRecentChangesEnvelope", "recent_changes"),
+        ("AkbDocumentHistoryEnvelope", "document_history"),
+        ("AkbDocumentDiffEnvelope", "document_diff"),
     ):
         schema = schemas[name]
         assert "kind" in schema["required"]


### PR DESCRIPTION
Harden the four git-backed REST read contracts.

### Changes

- add typed Pydantic activity/recent/history/diff envelopes with additive `kind` discriminators
- pin operation IDs, service tags, response models, unset-field serialization, 200 leaf refs, and global success-discriminator membership
- preserve flat payload keys, nullable recent fields, optional author/error fields, and invalid-commit HTTP 200 behavior
- expand the existing history REST E2E across all four routes and add it to the curated live-stack CI suite

### Verification

- Focused: `37 passed`
- Backend non-E2E: `750 passed, 168 skipped, 7 deselected`
- Repository gate: ruff, mypy, bandit, eslint/tsc, client build/typecheck/vitest/type drift, frontend vitest passed (existing eslint warnings; detect-secrets helper unavailable locally)
- Live REST: `48 passed, 0 failed`
- Source-blind behavior-validator: `satisfies_contract`, 6/6 clauses passed

### Proof — head `df18699e887736df9ff9b1c377c61e68e58bc585`

- [Redacted API transcript](https://gist.githubusercontent.com/younglokim-oss/f7cad4384840e7c6629f9ad48d7c0cc6/raw/56cdb1a7a59bbfe9411a6698a471ee4ec09ffedb/api-transcript.md) — public OpenAPI refs plus runtime method/path/status/kind/top-level-key, filter, error, and RBAC observations for this head.
- [Source-blind behavior-validator report](https://gist.githubusercontent.com/younglokim-oss/f7cad4384840e7c6629f9ad48d7c0cc6/raw/f55fabb0e8678251e42ef769fc79e10a94713261/behavior-validator-report.json) — contract-level PASS/FAIL evidence and anti-cheat probes for this head.
- [GitHub-hosted proof attachment](https://gist.github.com/younglokim-oss/f7cad4384840e7c6629f9ad48d7c0cc6) — rendered attachment container; contains no credentials, tokens, cookies, personal data, or desktop chrome.

### Residual risk

- PR #289 still independently changes the same route file to offload git reads. It is not merged as of this head; this PR leaves those existing synchronous lines untouched. If #289 lands first, the overlap should be mechanically rebased without reverting its `asyncio.to_thread` changes.
- No version, changelog, release, deployment, MCP, or generated client changes are included.
