### PR TITLE
feat(home): favorited vaults on home + align header gutter with content

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, useNavigate, Navigate, useLocation, useSearchParams, matchPath } from "react-router-dom";
+import { cn } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { Search as SearchIcon } from "lucide-react";
 import { getToken } from "@/lib/api";
@@ -92,7 +93,16 @@ export function Layout() {
       </a>
       {/* ── Glass app header ───────────────────────────────────────── */}
       <header className="app-header sticky top-0 z-40 shrink-0">
-        <div className="mx-auto grid grid-cols-[1fr_minmax(0,52rem)_1fr] max-w-[1600px] items-center gap-4 px-5 h-16">
+        {/* Header shares the content container on non-wide (app) routes so its
+            brand/nav line up with the page + footer (max-w-[1400px] px-6). Wide
+            vault-shell routes keep the wider gutter since their content is
+            full-bleed and has no 1400px column to align to. */}
+        <div
+          className={cn(
+            "mx-auto grid grid-cols-[1fr_minmax(0,52rem)_1fr] items-center gap-4 h-16",
+            wide ? "max-w-[1600px] px-5" : "max-w-[1400px] px-6",
+          )}
+        >
           {/* Brand */}
           <Link
             to="/"

--- a/frontend/src/components/vault-list.tsx
+++ b/frontend/src/components/vault-list.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { ArrowRight, File as FileIcon, FileText, Table as TableIcon } from "lucide-react";
+import { ArrowRight, File as FileIcon, FileText, Star, Table as TableIcon } from "lucide-react";
 import { getVaultInfo } from "@/lib/api";
 import { Panel } from "@/components/ui/panel";
 import { Badge } from "@/components/ui/badge";
@@ -24,6 +24,17 @@ interface VaultMetrics {
   last_activity?: string;
 }
 
+/**
+ * Optional favorite affordance. Capability-shaped (not a `showFavorite`
+ * boolean) so <VaultList> stays decoupled from where favorites live — the
+ * owner (Home) supplies the read + toggle, and a future server-synced
+ * `is_pinned` provider is invisible to this row UI.
+ */
+export interface VaultFavoriteControl {
+  isFavorite: (id: string) => boolean;
+  onToggle: (vault: VaultRow) => void;
+}
+
 // Cap concurrent /vaults/{v}/info calls — each one fans out into ~10 pooled
 // COUNT queries server-side, so an unbounded forEach risks pool exhaustion.
 const VAULT_INFO_CONCURRENCY = 5;
@@ -34,7 +45,13 @@ const VAULT_INFO_CONCURRENCY = 5;
  * per-vault /info enrichment (fetched once per name, skipped if already known),
  * so both the Home preview and the /vault index render an identical, live list.
  */
-export function VaultList({ vaults }: { vaults: VaultRow[] }) {
+export function VaultList({
+  vaults,
+  favoriteControl,
+}: {
+  vaults: VaultRow[];
+  favoriteControl?: VaultFavoriteControl;
+}) {
   const [metrics, setMetrics] = useState<Record<string, VaultMetrics>>({});
   const fetched = useRef<Set<string>>(new Set());
 
@@ -78,10 +95,13 @@ export function VaultList({ vaults }: { vaults: VaultRow[] }) {
           const m = metrics[v.name];
           const lastActivity = m?.last_activity;
           return (
-            <li key={v.id}>
+            <li
+              key={v.id}
+              className="group relative flex items-stretch bg-surface hover:bg-surface-muted transition-colors"
+            >
               <Link
                 to={`/vault/${v.name}`}
-                className="group grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 px-4 py-3 bg-surface hover:bg-surface-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 flex-1 min-w-0 px-4 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
               >
                 <VaultChip name={v.name} size="md" />
                 <div className="min-w-0 pr-4">
@@ -121,11 +141,48 @@ export function VaultList({ vaults }: { vaults: VaultRow[] }) {
                   />
                 </div>
               </Link>
+              {favoriteControl && (
+                <FavoriteStar
+                  name={v.name}
+                  favorite={favoriteControl.isFavorite(v.id)}
+                  onToggle={() => favoriteControl.onToggle(v)}
+                />
+              )}
             </li>
           );
         })}
       </ol>
     </Panel>
+  );
+}
+
+/**
+ * Favorite toggle — a sibling of the row's <Link> (never nested, so a click
+ * pins/unpins instead of navigating). Kept visible-but-muted rather than
+ * hover-only so it works on touch; the star fills + goes primary when pinned.
+ * 36×36px target meets the design-system icon-button floor.
+ */
+function FavoriteStar({
+  name,
+  favorite,
+  onToggle,
+}: {
+  name: string;
+  favorite: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={favorite}
+      aria-label={favorite ? `Remove ${name} from favorites` : `Add ${name} to favorites`}
+      className={`mr-2 grid h-9 w-9 shrink-0 self-center place-items-center rounded-[var(--radius-sm)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+        favorite ? "text-primary" : "text-foreground-muted hover:text-foreground"
+      }`}
+    >
+      <Star className={`h-4 w-4 ${favorite ? "fill-current" : ""}`} aria-hidden />
+    </button>
   );
 }
 

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -27,6 +27,7 @@ import { CodeSnippet } from "@/components/ui/code-snippet";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/empty-state";
 import { VaultList, type VaultRow } from "@/components/vault-list";
+import { useVaultFavorites } from "@/hooks/use-vault-favorites";
 import { VaultChip } from "@/components/ui/vault-chip";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { TooltipText } from "@/components/ui/tooltip-text";
@@ -85,6 +86,9 @@ export default function HomePage() {
   // "Show more" doubles it client-side (all vaults are already loaded, so no
   // refetch — unlike Recent activity, which grows its server-side limit).
   const [vaultLimit, setVaultLimit] = useState(VAULT_PREVIEW_LIMIT);
+  // Per-browser favorited vault IDs (localStorage) — same source the vault rail
+  // uses, so pinning here and in the rail stay in sync.
+  const { isFavorite, toggleFavorite, favOrder } = useVaultFavorites();
   const [recent, setRecent] = useState<RecentRow[]>([]);
   const [recentLoading, setRecentLoading] = useState(true);
   const [recentError, setRecentError] = useState(false);
@@ -155,12 +159,6 @@ export default function HomePage() {
   function loadMoreRecent() {
     // Grow by the current count ("this many again"), capped at the backend max.
     loadRecent(() => false, Math.min(recentLimit * 2, RECENT_MAX), { more: true });
-  }
-
-  function showMoreVaults() {
-    // Client-side only — reveal "this many again" of the already-loaded vaults,
-    // capped at the full count.
-    setVaultLimit((n) => Math.min(n * 2, vaults.length));
   }
 
   // Scroll to #vaults / #recent when a link lands here with that hash. Keyed on
@@ -249,13 +247,44 @@ export default function HomePage() {
   }, []);
 
   // Home shows a preview of the vault directory; the full list (with filter)
-  // lives on /vault. Memoized so <VaultList> doesn't re-fetch metrics on every
-  // unrelated render.
-  const previewVaults = useMemo(
-    () => vaults.slice(0, vaultLimit),
-    [vaults, vaultLimit],
+  // lives on /vault. Favorites float to the top (mirroring the vault rail) and
+  // are always visible: the preview cap is a FLOOR, not a hard slice — a
+  // favorite is never hidden behind "Show more". Memoized so <VaultList>
+  // doesn't re-fetch metrics on every unrelated render.
+  const orderedVaults = useMemo(() => {
+    // Filter to the LIVE list so a favorited-but-deleted/revoked vault id drops
+    // silently (same as the rail); newest-favorited first within the group.
+    const favs = vaults
+      .filter((v) => isFavorite(v.id))
+      .sort((a, b) => favOrder(a.id) - favOrder(b.id));
+    const rest = vaults.filter((v) => !isFavorite(v.id));
+    return [...favs, ...rest];
+  }, [vaults, isFavorite, favOrder]);
+  const liveFavCount = useMemo(
+    () => vaults.reduce((n, v) => (isFavorite(v.id) ? n + 1 : n), 0),
+    [vaults, isFavorite],
   );
-  const canShowMoreVaults = vaults.length > vaultLimit;
+  // Show at least `vaultLimit`, but never fewer than the live favorites.
+  const visibleVaultCount = Math.max(vaultLimit, liveFavCount);
+  const previewVaults = useMemo(
+    () => orderedVaults.slice(0, visibleVaultCount),
+    [orderedVaults, visibleVaultCount],
+  );
+  const canShowMoreVaults = orderedVaults.length > visibleVaultCount;
+
+  function showMoreVaults() {
+    // Grow from the ACTUAL rendered row count (not vaultLimit — favorites may
+    // have pushed it higher), "this many again", capped at the full list.
+    setVaultLimit(() => Math.min(visibleVaultCount * 2, orderedVaults.length));
+  }
+
+  function toggleVaultFavorite(v: VaultRow) {
+    // Lock in the current row count before toggling so unpinning a cap-exempt
+    // favorite can't make its own row vanish (row reorders in place; the keyed
+    // <li> keeps keyboard focus on the star). Per Codex design review.
+    setVaultLimit((n) => Math.max(n, visibleVaultCount));
+    toggleFavorite(v.id);
+  }
 
   // Main column — Recent + Vaults. Right rail — summary + connect.
   return (
@@ -444,7 +473,10 @@ export default function HomePage() {
             />
           ) : (
             <>
-              <VaultList vaults={previewVaults} />
+              <VaultList
+                vaults={previewVaults}
+                favoriteControl={{ isFavorite, onToggle: toggleVaultFavorite }}
+              />
               {canShowMoreVaults && (
                 <div className="mt-3 flex justify-center">
                   <Button

--- a/frontend/src/stories/components-akb-actions.stories.tsx
+++ b/frontend/src/stories/components-akb-actions.stories.tsx
@@ -212,3 +212,59 @@ export const VaultDirectory: Story = {
     </main>
   ),
 };
+
+/** VaultList with the optional favorite control — the star is a sibling of the
+ *  row link, so clicking it toggles the pin instead of navigating. */
+function VaultListFavDemo() {
+  const [favs, setFavs] = useState<Set<string>>(new Set());
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <VaultList
+        vaults={vaults}
+        favoriteControl={{
+          isFavorite: (id) => favs.has(id),
+          onToggle: (v) =>
+            setFavs((prev) => {
+              const next = new Set(prev);
+              if (next.has(v.id)) next.delete(v.id);
+              else next.add(v.id);
+              return next;
+            }),
+        }}
+      />
+    </main>
+  );
+}
+
+export const VaultDirectoryFavorites: Story = {
+  parameters: {
+    router: { initialEntries: ["/"] },
+    msw: {
+      handlers: [
+        http.get(`${API}/vaults/:vault/info`, ({ params }) =>
+          HttpResponse.json(infoByVault[String(params.vault)] || {}),
+        ),
+      ],
+    },
+  },
+  render: () => <VaultListFavDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const name = vaults[0].name;
+    // Starts unpinned: the accessible name says "Add …", aria-pressed=false.
+    const star = canvas.getByRole("button", { name: new RegExp(`Add ${name} to favorites`, "i") });
+    await expect(star).toHaveAttribute("aria-pressed", "false");
+    // Clicking the star toggles the pin in place (does not navigate — it is a
+    // sibling of the row link, not nested inside it).
+    await userEvent.click(star);
+    const unstar = await canvas.findByRole("button", {
+      name: new RegExp(`Remove ${name} from favorites`, "i"),
+    });
+    await expect(unstar).toHaveAttribute("aria-pressed", "true");
+    // Toggling back restores the original state.
+    await userEvent.click(unstar);
+    await expect(
+      canvas.getByRole("button", { name: new RegExp(`Add ${name} to favorites`, "i") }),
+    ).toHaveAttribute("aria-pressed", "false");
+  },
+};


### PR DESCRIPTION
Two home/layout polish items (bundled), each Codex design-reviewed.

## 1. Surface favorited vaults on Home (`f4bcf05`)
Per Codex review (Option A): *Your vaults* now orders favorites first (mirroring the vault rail) with an in-row star toggle. The preview cap is a **visibility floor** — favorites are always shown, never hidden behind "Show more". `VaultList` gains an optional capability-shaped `favoriteControl` ({ isFavorite, onToggle }); the star is a **sibling** of the row `<Link>` (click toggles, doesn't navigate). A11y: native button, `aria-pressed`, state-specific label, 36px target, visible-but-muted. Unpinning locks the current row count so a cap-exempt favorite can't vanish; keyed `<li>` keeps focus. Home + rail share the same `useVaultFavorites` (localStorage).

## 2. Align header gutter with page content (`fdc1afc`)
Per Codex review (approve-with-changes): the global header used `max-w-[1600px]/px-5` while content + footer use `max-w-[1400px]/px-6`, so brand/nav sat outside the content edges on Home. The header inner container now branches on the existing `wide` flag — non-wide (app) routes match the content container; wide vault-shell routes keep the wider gutter.

## Verification
- `tsc` + `eslint` clean
- Home render story 8/8; new VaultList favorite interaction story 5/5 (click toggles `aria-pressed` + Add/Remove label both ways)

🤖 Generated with [Claude Code](https://claude.com/claude-code)