### PR TITLE
fix(header): reserve a stable slot for the indexing badge (no search jitter)

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -168,7 +168,19 @@ export function Layout() {
               name="Vaults"
             />
             <div className="mx-1.5 h-6 w-px bg-border" aria-hidden />
-            <IndexingBadge pending={indexingPending} abandoned={indexingAbandoned} />
+            {/* Fixed-width slot so the indexing badge popping in/out (background
+                polling) can't resize the nav and shove the centered search
+                sideways. IndexingBadge still returns null when idle — the
+                always-mounted slot is the placeholder. Overflow is clipped
+                rather than pushed on the rare pending+abandoned two-chip case.
+                aria-live announces status changes politely (per Codex review). */}
+            <div
+              className="hidden sm:flex w-32 shrink-0 items-center justify-end gap-1 overflow-hidden whitespace-nowrap"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <IndexingBadge pending={indexingPending} abandoned={indexingAbandoned} />
+            </div>
             <ThemeToggle />
             <UserMenu />
           </nav>


### PR DESCRIPTION
The dynamic `IndexingBadge` popped in/out (background polling), resizing the right nav and shoving the centered search sideways — **measured 85px left + 25px narrower** each toggle.

Fix: wrap it in a fixed-width (`w-32`) right-aligned slot so the nav footprint is constant. Verified on live via DOM simulation: search jitter **85px → 0** when the badge toggles inside the slot. Badge still returns null when idle (mounted slot is the placeholder); rare two-chip case clips rather than pushes; `aria-live="polite"`; hidden below `sm` (matches the search breakpoint).

Approach agreed with Codex over two rounds (reserve a stable slot, plain pop-in, keep it out of header sizing). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)