### PR TITLE
fix(files): give uploaded files a stable identity so re-uploads are idempotent

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -93,10 +93,17 @@ jobs:
         # ASC/DESC physical order, migration 037 upgrade path, add-unique-key
         # concurrency race). They skip in the DB-free unit job above, so gate
         # them here where AKB_TEST_DSN is reachable.
+        #
+        # Idempotent-upload keying belongs here for the same reason and one
+        # more: the invariant it protects *is* the `UNIQUE(vault_id, s3_key)`
+        # constraint. Asserting that against a mock would only prove the mock
+        # agrees with itself, and leaving the file out of this list would let
+        # it skip in both jobs — a gate that never fires.
         run: >
           pytest
           tests/test_pgvector_ext_bootstrap_e2e.py
           tests/test_migration_037_upgrade_unit.py
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
+          tests/test_file_idempotent_upload_unit.py
           -v --tb=short

--- a/backend/app/api/routes/files.py
+++ b/backend/app/api/routes/files.py
@@ -48,6 +48,16 @@ async def upload_file(
     collection: str = Query("", description="Logical grouping"),
     description: str = Query("", description="File description"),
     mime_type: str = Query("application/octet-stream", description="MIME type"),
+    content_hash: str | None = Query(
+        None,
+        description=(
+            "Optional sha256 of the bytes about to be uploaded. Supplying it "
+            "makes the upload idempotent: the same bytes under the same "
+            "vault/collection/filename resolve to the existing file instead of "
+            "creating a duplicate. Omit for the original one-row-per-call "
+            "behaviour."
+        ),
+    ),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     """Returns a presigned PUT URL. Client uploads directly to S3."""
@@ -62,6 +72,7 @@ async def upload_file(
         actor_id=actor_id,
         mime_type=mime_type,
         description=to_nfc(description),
+        content_hash=content_hash,
     )
 
 

--- a/backend/app/repositories/vault_files_repo.py
+++ b/backend/app/repositories/vault_files_repo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import uuid
 
 
-async def insert(
+async def insert_or_adopt(
     conn,
     *,
     file_id: uuid.UUID,
@@ -26,17 +26,44 @@ async def insert(
     description: str,
     created_by: str,
     collection_id: uuid.UUID | None = None,
-) -> None:
-    await conn.execute(
+) -> uuid.UUID:
+    """Insert a file row, or adopt the row already holding `(vault_id, s3_key)`.
+
+    Returns the id of the row the caller should now use: `file_id` when a new
+    row was inserted, the pre-existing row's id when the key was already
+    taken. Callers tell the two apart by comparing against the `file_id` they
+    passed in.
+
+    Only reachable for a deterministic (content-addressed) key — a random key
+    cannot collide — so an adopted row is by construction the same bytes under
+    the same vault/collection/filename.
+
+    `ON CONFLICT ... DO UPDATE` rather than `DO NOTHING` on purpose. DO UPDATE
+    is the form PostgreSQL guarantees to be atomic insert-or-update: it always
+    returns a row, and against a *concurrent uncommitted* insert of the same
+    key it waits and then returns the winner. DO NOTHING returns no row on
+    conflict, forcing a follow-up SELECT that races the other transaction.
+
+    The re-`collection_id` is the only field touched on adopt: it re-attaches a
+    file whose collection row was dropped (`collections.id ON DELETE SET NULL`)
+    so the row agrees with the collection its key encodes. Descriptive fields
+    are left alone — first writer wins — so a repeat upload cannot silently
+    rewrite metadata that something else may already be reading.
+    """
+    row = await conn.fetchrow(
         """
         INSERT INTO vault_files
             (id, vault_id, collection_id, name, s3_key, mime_type,
              size_bytes, description, created_by)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        ON CONFLICT (vault_id, s3_key) DO UPDATE
+            SET collection_id = EXCLUDED.collection_id
+        RETURNING id
         """,
         file_id, vault_id, collection_id, name, s3_key,
         mime_type, size_bytes, description, created_by,
     )
+    return row["id"]
 
 
 async def find_by_id(

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -141,12 +141,69 @@ def put_object_bytes(
 # ── File-key naming convention ───────────────────────────────────
 
 
-def _s3_key(vault_name: str, collection: str, filename: str) -> str:
+# A key's leading path component is `{prefix}_{safe_filename}`. Two prefix
+# flavours exist and are told apart by `_CONTENT_KEY_MARKER`:
+#
+#   `{8 random hex}_name`        — opaque. The historical default, still used
+#                                  whenever the caller cannot state the bytes
+#                                  up front. Never collides, so re-uploading
+#                                  the same artifact always makes a new row.
+#   `sha256-{16 hex}_name`       — content-addressed. The digest is the leading
+#                                  16 hex chars of the sha256 of the object's
+#                                  bytes, so the key is a function of *what the
+#                                  object is* rather than of when it was
+#                                  uploaded. Re-uploading the same artifact
+#                                  lands on the same key and therefore on the
+#                                  existing `UNIQUE(vault_id, s3_key)` row.
+#
+# The digest is deliberately a plain prefix of the content hash and not a
+# derived value: an operator holding a `vault_files.content_hash` can pair it
+# to a key by eye, which is what makes an acquired artifact traceable.
+_CONTENT_KEY_MARKER = "sha256-"
+_CONTENT_KEY_DIGEST_LEN = 16
+
+
+def _content_key_prefix(content_hash: str) -> str:
+    """Key prefix that makes an object's key a function of its bytes."""
+    return f"{_CONTENT_KEY_MARKER}{content_hash[:_CONTENT_KEY_DIGEST_LEN]}"
+
+
+def _s3_key(
+    vault_name: str,
+    collection: str,
+    filename: str,
+    *,
+    content_hash: str | None = None,
+) -> str:
+    """Build the storage key for an uploaded file.
+
+    With `content_hash`, the key is deterministic: the same bytes under the
+    same vault/collection/filename always produce the same key. Without it,
+    the key carries a random prefix and is unique per call — the pre-existing
+    behaviour, preserved for callers that cannot hash before uploading.
+    """
     safe_name = filename.replace("/", "_")
-    uid = uuid.uuid4().hex[:8]
+    prefix = (
+        _content_key_prefix(content_hash) if content_hash
+        else uuid.uuid4().hex[:8]
+    )
     if collection:
-        return f"{vault_name}/{collection}/{uid}_{safe_name}"
-    return f"{vault_name}/{uid}_{safe_name}"
+        return f"{vault_name}/{collection}/{prefix}_{safe_name}"
+    return f"{vault_name}/{prefix}_{safe_name}"
+
+
+def _content_key_honors_hash(s3_key: str, content_hash: str) -> bool:
+    """Whether `s3_key`'s content claim is borne out by `content_hash`.
+
+    Only content-addressed keys make a claim about their bytes; a random
+    (legacy) key asserts nothing and therefore always passes. This is what
+    stops a caller from declaring one hash at `initiate_upload` — thereby
+    reserving that content's key — and then storing unrelated bytes under it.
+    """
+    last_segment = s3_key.rsplit("/", 1)[-1]
+    if not last_segment.startswith(_CONTENT_KEY_MARKER):
+        return True
+    return last_segment.startswith(f"{_content_key_prefix(content_hash)}_")
 
 
 from app.util.text import normalize_collection_path as _normalize_collection_path  # noqa: E402
@@ -169,6 +226,7 @@ class FileService:
         actor_id: str,
         mime_type: str = "application/octet-stream",
         description: str = "",
+        content_hash: str | None = None,
     ) -> dict:
         """Create a file record and return a presigned PUT URL.
 
@@ -177,10 +235,31 @@ class FileService:
         for vault root); a matching `collections` row is auto-created
         if needed so files share the same FK-normalized hierarchy as
         documents and tables.
+
+        `content_hash` is the caller's sha256 of the bytes it is about to
+        upload. Supplying it makes the upload **idempotent**: the storage key
+        becomes a function of the bytes, so re-uploading the same artifact to
+        the same vault/collection/filename resolves to the file that is
+        already there instead of creating a second row for the same content.
+        The returned envelope is unchanged in shape and still carries a usable
+        `upload_url` — an unaware client can re-PUT the identical bytes to the
+        identical key and confirm as usual; the net effect is one row, not two.
+        `deduplicated` says which happened, for clients that would rather skip
+        the redundant transfer.
+
+        The hash is a *claim* at this point — AKB certifies the real one in
+        `confirm_upload`, which rejects bytes that do not match the key they
+        were stored under. Omitting `content_hash` preserves the historical
+        behaviour exactly: a random key, and one new row per call.
         """
+        if content_hash is not None and not is_sha256_hex(content_hash):
+            raise AKBError("content_hash must be a lowercase sha256 hex digest", status_code=400)
+
         s3_adapter.ensure_bucket(self._bucket)
         collection_path = _normalize_collection_path(collection)
-        s3_key = _s3_key(vault_name, collection_path, filename)
+        s3_key = _s3_key(
+            vault_name, collection_path, filename, content_hash=content_hash,
+        )
         file_id = uuid.uuid4()
 
         presigned_url = s3_adapter.presign_put(
@@ -196,7 +275,7 @@ class FileService:
                     collection_id = await coll_repo.get_or_create(
                         vault_id, collection_path, conn=conn,
                     )
-                await vault_files_repo.insert(
+                stored_id = await vault_files_repo.insert_or_adopt(
                     conn,
                     file_id=file_id, vault_id=vault_id,
                     name=filename,
@@ -206,9 +285,12 @@ class FileService:
                     collection_id=collection_id,
                 )
 
+        deduplicated = stored_id != file_id
+        file_id = stored_id
+
         logger.info(
-            "Presigned upload URL for %s/%s (file_id=%s, collection=%s)",
-            vault_name, s3_key, file_id, collection_path or "<root>",
+            "Presigned upload URL for %s/%s (file_id=%s, collection=%s, deduplicated=%s)",
+            vault_name, s3_key, file_id, collection_path or "<root>", deduplicated,
         )
         return {
             "kind": "file",
@@ -218,6 +300,7 @@ class FileService:
             "upload_url": presigned_url,
             "s3_key": s3_key,
             "expires_in": _PRESIGN_UPLOAD_TTL,
+            "deduplicated": deduplicated,
         }
 
     async def confirm_upload(
@@ -269,7 +352,20 @@ class FileService:
             compute_stream_content_hash,
             s3_adapter.iter_chunks(row["s3_key"]),
         )
-        if content_hash and content_hash != server_content_hash:
+        # Two ways the stored bytes can fail to be what was declared: the
+        # caller's `content_hash` argument disagrees with them, or the key they
+        # were stored under is content-addressed and does not. The second check
+        # is what keeps a content-addressed key honest end to end — without it a
+        # caller could reserve some other content's key at `initiate_upload`,
+        # omit `content_hash` here, and leave unrelated bytes sitting where the
+        # next caller's idempotent upload would adopt them. Both are the same
+        # fault ("these are not the bytes you said") and take the same
+        # pre-existing 409 + cleanup path.
+        stored_bytes_disowned = (
+            (content_hash is not None and content_hash != server_content_hash)
+            or not _content_key_honors_hash(row["s3_key"], server_content_hash)
+        )
+        if stored_bytes_disowned:
             async with pool.acquire() as conn:
                 async with conn.transaction():
                     await vault_files_repo.delete(conn, fid)

--- a/backend/tests/test_file_idempotent_upload_unit.py
+++ b/backend/tests/test_file_idempotent_upload_unit.py
@@ -1,0 +1,482 @@
+"""Contract for content-addressed file keys and idempotent uploads.
+
+An uploaded file's identity used to be the moment it was uploaded: `_s3_key`
+prefixed every key with a fresh `uuid4`, so the one unique constraint the table
+has — `UNIQUE(vault_id, s3_key)` — could never fire and the same bytes uploaded
+twice produced two rows. `content_hash` is recorded but not unique, so nothing
+downstream could tell the copies apart either.
+
+These tests pin the fix: when the caller states the bytes up front, the key
+becomes a function of the bytes and the second upload of the same artifact
+resolves to the first one.
+
+The pure-unit half covers key construction. The DB half runs against a real
+Postgres (`AKB_TEST_DSN`, auto-skip otherwise) because the invariant under test
+*is* a database constraint — asserting it against a mock would prove only that
+the mock agrees with itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from starlette.requests import Request
+
+from app.exceptions import AKBError
+from app.repositories import vault_files_repo
+from app.repositories.vault_repo import VaultRepository
+from app.services.file_service import (
+    FileService,
+    _content_key_honors_hash,
+    _s3_key,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+_BYTES_A = b"the same page, fetched twice"
+_BYTES_B = b"a genuinely different page"
+_HASH_A = hashlib.sha256(_BYTES_A).hexdigest()
+_HASH_B = hashlib.sha256(_BYTES_B).hexdigest()
+
+
+# ── key construction ─────────────────────────────────────────────
+
+
+async def test_key_without_content_hash_keeps_the_random_legacy_shape():
+    """No hash stated ⇒ unchanged historical behaviour: a fresh key per call.
+
+    This is the backwards-compatibility guarantee. A caller that knows nothing
+    about content addressing must see exactly what it saw before.
+    """
+    first = _s3_key("vault", "confluence/IS", "page.html")
+    second = _s3_key("vault", "confluence/IS", "page.html")
+
+    assert first != second
+    assert first.startswith("vault/confluence/IS/")
+    assert first.endswith("_page.html")
+    prefix = first.rsplit("/", 1)[-1].removesuffix("_page.html")
+    assert len(prefix) == 8 and int(prefix, 16) >= 0  # 8 random hex chars
+
+
+async def test_same_bytes_same_name_produce_one_identical_key():
+    """The whole point: identity comes from the artifact, not the clock."""
+    first = _s3_key("vault", "confluence/IS", "page.html", content_hash=_HASH_A)
+    second = _s3_key("vault", "confluence/IS", "page.html", content_hash=_HASH_A)
+
+    assert first == second
+    assert first == f"vault/confluence/IS/sha256-{_HASH_A[:16]}_page.html"
+
+
+async def test_key_discriminates_content_name_and_collection():
+    """Only a genuinely identical artifact collapses onto one key."""
+    base = _s3_key("vault", "confluence/IS", "page.html", content_hash=_HASH_A)
+
+    assert _s3_key("vault", "confluence/IS", "page.html", content_hash=_HASH_B) != base
+    assert _s3_key("vault", "confluence/IS", "other.html", content_hash=_HASH_A) != base
+    assert _s3_key("vault", "confluence/OPS", "page.html", content_hash=_HASH_A) != base
+    assert _s3_key("other", "confluence/IS", "page.html", content_hash=_HASH_A) != base
+
+
+async def test_root_collection_key_is_addressable_too():
+    root = _s3_key("vault", "", "page.html", content_hash=_HASH_A)
+    assert root == f"vault/sha256-{_HASH_A[:16]}_page.html"
+    assert root == _s3_key("vault", "", "page.html", content_hash=_HASH_A)
+
+
+async def test_the_key_carries_the_content_hash_verbatim_for_operators():
+    """An operator holding a `vault_files.content_hash` can pair it to a key.
+
+    Not decoration: the reported defect included an orphan-retirement step that
+    was unsatisfiable precisely because no key said anything about its bytes.
+    """
+    key = _s3_key("vault", "coll", "page.html", content_hash=_HASH_A)
+    assert _HASH_A[:16] in key
+    assert _HASH_A.startswith(key.rsplit("sha256-", 1)[-1].split("_", 1)[0])
+
+
+# ── the key's claim is enforced, not trusted ─────────────────────
+
+
+async def test_content_key_honors_only_the_hash_it_was_built_from():
+    key = _s3_key("vault", "coll", "page.html", content_hash=_HASH_A)
+
+    assert _content_key_honors_hash(key, _HASH_A) is True
+    assert _content_key_honors_hash(key, _HASH_B) is False
+
+
+async def test_legacy_random_keys_make_no_claim_and_always_pass():
+    """Existing rows must keep confirming. A random key asserts nothing."""
+    legacy = _s3_key("vault", "coll", "page.html")
+
+    assert _content_key_honors_hash(legacy, _HASH_A) is True
+    assert _content_key_honors_hash(legacy, _HASH_B) is True
+
+
+async def test_a_filename_that_mimics_the_marker_cannot_forge_a_claim():
+    """The marker is positional — it is the key's prefix, not any substring."""
+    key = _s3_key("vault", "coll", f"sha256-{_HASH_B[:16]}_decoy.html")
+
+    assert key.rsplit("/", 1)[-1].startswith("sha256-") is False
+    assert _content_key_honors_hash(key, _HASH_A) is True
+
+
+async def test_initiate_upload_rejects_a_malformed_content_hash():
+    """Same 400 and same message `confirm_upload` already raises.
+
+    Unreachable for a caller that does not send the new parameter.
+    """
+    with pytest.raises(AKBError) as err:
+        await FileService().initiate_upload(
+            vault_name="vault",
+            vault_id=uuid.uuid4(),
+            collection="coll",
+            filename="page.html",
+            actor_id="tester",
+            content_hash="not-a-sha256",
+        )
+    assert err.value.status_code == 400
+
+
+# ── the constraint itself, against a real Postgres ───────────────
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect(_DSN):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=6)
+    backend_dir = Path(__file__).resolve().parents[1]
+    init_sql = (backend_dir / "app" / "db" / "init.sql").read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(init_sql)
+    # `events` (migration 015) and `s3_delete_outbox` (019) are not in
+    # init.sql but are part of the confirm/cleanup contract. Idempotent.
+    import importlib.util
+    for mig_name in ("015_events_outbox.py", "019_s3_delete_outbox.py"):
+        mig_path = backend_dir / "app" / "db" / "migrations" / mig_name
+        spec = importlib.util.spec_from_file_location(mig_name, str(mig_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        async with pool.acquire() as conn:
+            await module.migrate(conn=conn)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+@pytest_asyncio.fixture
+async def vault_id(pool):
+    vault_repo = VaultRepository(pool)
+    name = f"_test_idempotent_upload_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name,
+        description="ephemeral test vault",
+        git_path=f"/tmp/{name}.git",
+        owner_id=None,
+    )
+    try:
+        yield vid
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+
+
+async def _put(conn, vault_id, s3_key, *, name="page.html", collection_id=None,
+               description="", mime_type="text/html") -> uuid.UUID:
+    return await vault_files_repo.insert_or_adopt(
+        conn,
+        file_id=uuid.uuid4(), vault_id=vault_id, name=name,
+        s3_key=s3_key, mime_type=mime_type, size_bytes=0,
+        description=description, created_by="tester",
+        collection_id=collection_id,
+    )
+
+
+async def _row_count(conn, vault_id) -> int:
+    return await conn.fetchval(
+        "SELECT count(*) FROM vault_files WHERE vault_id = $1", vault_id,
+    )
+
+
+async def test_same_bytes_same_name_twice_is_one_row(pool, vault_id):
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+    async with pool.acquire() as conn:
+        first = await _put(conn, vault_id, key)
+        second = await _put(conn, vault_id, key)
+
+        assert second == first, "the second upload must adopt the first row"
+        assert await _row_count(conn, vault_id) == 1
+
+
+async def test_different_bytes_same_name_is_two_rows(pool, vault_id):
+    """The random prefix protected *this*: same name, genuinely different file.
+
+    Content addressing keeps that protection — nothing is overwritten in place
+    — which is why keying on `(vault, collection, name)` alone was rejected.
+    """
+    async with pool.acquire() as conn:
+        a = await _put(conn, vault_id, _s3_key("v", "IS", "page.html", content_hash=_HASH_A))
+        b = await _put(conn, vault_id, _s3_key("v", "IS", "page.html", content_hash=_HASH_B))
+
+        assert a != b
+        assert await _row_count(conn, vault_id) == 2
+
+
+async def test_different_bytes_different_name_is_two_rows(pool, vault_id):
+    async with pool.acquire() as conn:
+        await _put(conn, vault_id, _s3_key("v", "IS", "a.html", content_hash=_HASH_A), name="a.html")
+        await _put(conn, vault_id, _s3_key("v", "IS", "b.html", content_hash=_HASH_B), name="b.html")
+
+        assert await _row_count(conn, vault_id) == 2
+
+
+async def test_same_bytes_different_name_stay_separate_files(pool, vault_id):
+    """Each caller keeps the name it asked for; dedupe never renames a file."""
+    async with pool.acquire() as conn:
+        await _put(conn, vault_id, _s3_key("v", "IS", "a.html", content_hash=_HASH_A), name="a.html")
+        await _put(conn, vault_id, _s3_key("v", "IS", "b.html", content_hash=_HASH_A), name="b.html")
+
+        assert await _row_count(conn, vault_id) == 2
+        names = await conn.fetch(
+            "SELECT name FROM vault_files WHERE vault_id = $1 ORDER BY name", vault_id,
+        )
+        assert [r["name"] for r in names] == ["a.html", "b.html"]
+
+
+async def test_without_a_stated_hash_the_duplicate_still_happens(pool, vault_id):
+    """The defect, reproduced — and left alone for callers that do not opt in.
+
+    Two rows for one artifact is what the old path does, and this fix does not
+    change it for a caller that cannot state its bytes up front.
+    """
+    async with pool.acquire() as conn:
+        await _put(conn, vault_id, _s3_key("v", "IS", "page.html"))
+        await _put(conn, vault_id, _s3_key("v", "IS", "page.html"))
+
+        assert await _row_count(conn, vault_id) == 2
+
+
+async def test_adopt_leaves_first_writer_metadata_alone(pool, vault_id):
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+    async with pool.acquire() as conn:
+        first = await _put(conn, vault_id, key, description="original")
+        await _put(conn, vault_id, key, description="second attempt")
+
+        row = await conn.fetchrow(
+            "SELECT description FROM vault_files WHERE id = $1", first,
+        )
+        assert row["description"] == "original"
+
+
+async def test_adopt_reattaches_a_collection_that_was_dropped(pool, vault_id):
+    """`collections.id ON DELETE SET NULL` can strand a row at vault root.
+
+    Re-uploading to the collection the key encodes must put the row back where
+    it says it lives, rather than reporting a collection the row is not in.
+    """
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+    async with pool.acquire() as conn:
+        coll_id = await conn.fetchval(
+            "INSERT INTO collections (vault_id, path, name) VALUES ($1,$2,$3) RETURNING id",
+            vault_id, "IS", "IS",
+        )
+        file_id = await _put(conn, vault_id, key, collection_id=coll_id)
+        await conn.execute(
+            "UPDATE vault_files SET collection_id = NULL WHERE id = $1", file_id,
+        )
+
+        adopted = await _put(conn, vault_id, key, collection_id=coll_id)
+
+        assert adopted == file_id
+        assert await conn.fetchval(
+            "SELECT collection_id FROM vault_files WHERE id = $1", file_id,
+        ) == coll_id
+
+
+@pytest_asyncio.fixture
+async def confirmable(pool, monkeypatch):
+    """Wire `confirm_upload` to the test pool with a fake object store.
+
+    Returns a helper that stores `body` at `s3_key` and confirms `file_id`,
+    so each test states only the bytes actually sitting in storage.
+    """
+    from app.services import file_service as fs
+
+    async def _get_pool():
+        return pool
+
+    monkeypatch.setattr(fs, "get_pool", _get_pool)
+    monkeypatch.setattr(fs.s3_adapter, "ensure_bucket", lambda _b: None)
+
+    async def _noop_index(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(fs, "index_file_metadata", _noop_index)
+
+    async def confirm(vault_id, file_id, s3_key, body, **kwargs):
+        monkeypatch.setattr(
+            fs.s3_adapter, "head",
+            lambda key: {"ContentLength": len(body), "ETag": '"etag"'},
+        )
+        monkeypatch.setattr(
+            fs.s3_adapter, "iter_chunks",
+            lambda key, **_kw: iter([body]),
+        )
+        return await fs.FileService().confirm_upload(
+            vault_id, str(file_id), actor_id="tester", **kwargs,
+        )
+
+    return confirm
+
+
+async def test_confirm_certifies_bytes_that_match_the_key_they_are_under(
+    pool, vault_id, confirmable,
+):
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+    async with pool.acquire() as conn:
+        file_id = await _put(conn, vault_id, key)
+
+    result = await confirmable(vault_id, file_id, key, _BYTES_A)
+
+    assert result["content_hash"] == _HASH_A
+    async with pool.acquire() as conn:
+        assert await _row_count(conn, vault_id) == 1
+
+
+async def test_confirm_rejects_bytes_stored_under_another_content_key(
+    pool, vault_id, confirmable,
+):
+    """The key states a hash; storage holds something else ⇒ 409 + cleanup.
+
+    Without this the claim at `initiate_upload` would be unenforced whenever
+    the caller simply omits `content_hash` here: a writer could park arbitrary
+    bytes on some other content's key and the next caller's idempotent upload
+    would adopt them as its own.
+    """
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+    async with pool.acquire() as conn:
+        file_id = await _put(conn, vault_id, key)
+
+    with pytest.raises(AKBError) as err:
+        await confirmable(vault_id, file_id, key, _BYTES_B)  # no content_hash
+
+    assert err.value.status_code == 409
+    async with pool.acquire() as conn:
+        assert await _row_count(conn, vault_id) == 0, "the bad row must be cleaned up"
+        assert await conn.fetchval("SELECT count(*) FROM s3_delete_outbox") >= 1
+
+
+async def test_confirm_on_a_legacy_key_is_unchanged(pool, vault_id, confirmable):
+    """A random key claims nothing, so any bytes confirm — as they always did."""
+    key = _s3_key("v", "IS", "page.html")
+    async with pool.acquire() as conn:
+        file_id = await _put(conn, vault_id, key)
+
+    result = await confirmable(vault_id, file_id, key, _BYTES_B)
+
+    assert result["content_hash"] == _HASH_B
+
+
+async def test_confirm_still_rejects_a_mismatched_client_hash(
+    pool, vault_id, confirmable,
+):
+    """Pre-existing 409 path, untouched."""
+    key = _s3_key("v", "IS", "page.html")
+    async with pool.acquire() as conn:
+        file_id = await _put(conn, vault_id, key)
+
+    with pytest.raises(AKBError) as err:
+        await confirmable(vault_id, file_id, key, _BYTES_B, content_hash=_HASH_A)
+
+    assert err.value.status_code == 409
+
+
+async def test_upload_route_forwards_content_hash_and_defaults_it_off(monkeypatch):
+    """The parameter has to survive the HTTP boundary, and default to absent.
+
+    Without the default, every existing caller of `POST /files/{vault}/upload`
+    would change behaviour; without the forwarding, the feature is unreachable.
+    """
+    from app.api.routes import files
+
+    seen: list[dict] = []
+
+    async def _access(*_args, **_kwargs):
+        return {"vault_id": uuid.uuid4(), "role": "writer", "role_source": "member"}
+
+    async def _initiate(**kwargs):
+        seen.append(kwargs)
+        return {"uri": "akb://team/file/f-1"}
+
+    monkeypatch.setattr(files, "check_vault_access", _access)
+    monkeypatch.setattr(files.file_service, "initiate_upload", _initiate)
+
+    async def _call(**overrides):
+        await files.upload_file(
+            request=Request({"type": "http", "method": "POST", "path": "/", "headers": []}),
+            vault="team", filename="page.html", collection="IS",
+            description="", mime_type="text/html",
+            user=_service_user(), **overrides,
+        )
+
+    await _call(content_hash=_HASH_A)
+    await _call(content_hash=None)
+
+    assert seen[0]["content_hash"] == _HASH_A
+    assert seen[1]["content_hash"] is None
+
+
+def _service_user():
+    from app.services.auth_service import AuthenticatedUser
+
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()), username="tester", email="t@example.test",
+        display_name=None, is_admin=False, auth_method="pat",
+        token_id=None, key_class=None, token_scopes=None,
+    )
+
+
+async def test_concurrent_uploads_of_the_same_artifact_settle_on_one_row(pool, vault_id):
+    """Two writers, same artifact, overlapping transactions ⇒ still one row.
+
+    `insert_or_adopt` uses `ON CONFLICT ... DO UPDATE`, the form Postgres
+    guarantees to be an atomic insert-or-update: the loser waits on the
+    winner's uncommitted insert and is then handed the winner's id. `DO
+    NOTHING` would return no row here and force a SELECT that races.
+    """
+    key = _s3_key("v", "IS", "page.html", content_hash=_HASH_A)
+
+    async def writer(hold: float) -> uuid.UUID:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                stored = await _put(conn, vault_id, key)
+                await asyncio.sleep(hold)  # keep the transaction open
+                return stored
+
+    first, second = await asyncio.gather(writer(0.4), writer(0.0))
+
+    assert first == second
+    async with pool.acquire() as conn:
+        assert await _row_count(conn, vault_id) == 1

--- a/packages/akb-client/src/index.ts
+++ b/packages/akb-client/src/index.ts
@@ -334,11 +334,18 @@ export interface AkbStoragePresignUploadOptions extends AkbStorageVaultOptions {
   collection?: string | null;
   description?: string | null;
   mimeType?: string | null;
+  /**
+   * sha256 of the bytes being uploaded. Sent to `initiate_upload` as well as
+   * `confirm`, which makes the upload idempotent: re-uploading the same bytes
+   * to the same path resolves to the file that is already there rather than
+   * creating a duplicate. Omit to keep the original one-file-per-call
+   * behaviour.
+   */
+  contentHash?: string | null;
 }
 
 export interface AkbStorageUploadOptions extends AkbStoragePresignUploadOptions {
   confirm?: boolean;
-  contentHash?: string | null;
   hashAlgorithm?: string | null;
   headers?: HeadersInit;
 }
@@ -1010,6 +1017,7 @@ function makeStorageFacade(
     appendOptional(params, "collection", storagePath.collection);
     appendOptional(params, "description", options.description);
     appendOptional(params, "mime_type", options.mimeType ?? "application/octet-stream");
+    appendOptional(params, "content_hash", options.contentHash);
     return request<import("./core/schema.gen.js").AkbFileEnvelope>(
       `/files/${encodePathSegment(vault)}/upload?${params}`,
       { method: "POST" },

--- a/packages/akb-client/test/result.test.mjs
+++ b/packages/akb-client/test/result.test.mjs
@@ -1390,6 +1390,57 @@ test("graph relation and provenance facade preserves backend 4xx result behavior
   assert.throws(() => denied.throwOnError(), AkbError);
 });
 
+test("storage upload sends contentHash to presign so the same bytes are not stored twice", async () => {
+  const contentHash = "a".repeat(64);
+  const seen = [];
+  const client = createClient("https://akb.test/api/v1/", {
+    fetch: async (input, init) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.includes("/upload")) {
+        return responseJson({
+          kind: "file",
+          uri: "akb://eng/media/file/11111111-1111-4111-8111-111111111111",
+          upload_url: "https://s3.test/put",
+          deduplicated: true,
+        });
+      }
+      if (url === "https://s3.test/put") return new Response(null, { status: 200 });
+      return responseJson({ kind: "file", content_hash: contentHash });
+    },
+  });
+
+  await client.vault("eng").storage.upload("media/logo.txt", "hello", { contentHash });
+
+  const presign = new URL(seen.find((u) => u.includes("/upload")));
+  assert.equal(presign.searchParams.get("content_hash"), contentHash);
+  assert.equal(presign.searchParams.get("filename"), "logo.txt");
+});
+
+test("storage upload without contentHash sends no content_hash param", async () => {
+  const seen = [];
+  const client = createClient("https://akb.test/api/v1/", {
+    fetch: async (input) => {
+      const url = String(input);
+      seen.push(url);
+      if (url.includes("/upload")) {
+        return responseJson({
+          kind: "file",
+          uri: "akb://eng/media/file/11111111-1111-4111-8111-111111111111",
+          upload_url: "https://s3.test/put",
+        });
+      }
+      if (url === "https://s3.test/put") return new Response(null, { status: 200 });
+      return responseJson({ kind: "file" });
+    },
+  });
+
+  await client.vault("eng").storage.upload("media/logo.txt", "hello");
+
+  const presign = new URL(seen.find((u) => u.includes("/upload")));
+  assert.equal(presign.searchParams.has("content_hash"), false);
+});
+
 function responseJson(body, status = 200, statusText = "OK") {
   return new Response(JSON.stringify(body), { status, statusText, headers: { "content-type": "application/json" } });
 }


### PR DESCRIPTION
## The defect

`vault_files` has exactly one unique constraint — `UNIQUE(vault_id, s3_key)` — and `_s3_key` prefixed every key with a fresh `uuid4`. The constraint could therefore never fire. The same bytes uploaded twice under the same name produce two rows with an identical `content_hash` and a different `s3_key`:

```
06:39  vault/confluence/IS/90060be2_page.storage.html   16864  98eaf66d…
08:09  vault/confluence/IS/1f88a7a3_page.storage.html   16864  98eaf66d…
```

`content_hash` is indexed but not unique, and `confirm_upload` used a client-supplied hash only to *verify* bytes (mismatch ⇒ 409 + cleanup), never to deduplicate. So an uploaded file had no identity in the storage layer at all. Two consequences: a client that re-uploads a source on a schedule accumulates a permanent duplicate row per file with nothing to stop it, and an operator holding two such rows cannot tell from the keys that they are the same artifact.

## The constraint this had to be designed around

`initiate_upload` builds the key and presigns the URL **before any bytes exist** — the content hash is only known at `confirm_upload`. A content-addressed key is therefore not directly available on the presigned path.

## What this does

`initiate_upload` accepts an optional `content_hash` — the caller already holds the bytes it is about to send — and derives the key prefix from it:

```
{vault}/{collection}/sha256-{16 hex}_{filename}
```

Re-uploading the same artifact lands on the same key, collides on the constraint that already exists, and `insert_or_adopt` hands back the file that is already there. Putting the same file twice is an **idempotent success returning the same file**, which is what "put this file" already implies.

Identity is `(vault, collection, filename, content)`:

| | outcome |
|---|---|
| same bytes, same name | **one row** — second call returns the first file |
| different bytes, same name | two rows — nothing is overwritten in place |
| same bytes, different name | two rows — each keeps the name it was given |
| different bytes, different name | two rows |

The prefix is a plain prefix of the content hash rather than a derived value, so a `vault_files.content_hash` can be paired to a key by eye.

### The claim is enforced, not trusted

The hash is only a *claim* at initiate time. `confirm_upload` now also rejects bytes whose AKB-certified hash does not reproduce the content-addressed key they were stored under. Without that check a writer could reserve another artifact's key, omit `content_hash` at confirm, and leave unrelated bytes sitting where the next idempotent upload would adopt them. It reuses the existing 409-and-clean-up path rather than adding a failure mode.

### Concurrency

`insert_or_adopt` uses `ON CONFLICT … DO UPDATE`, the form Postgres guarantees to be an atomic insert-or-update: it always returns a row, and against a *concurrent uncommitted* insert of the same key it waits and returns the winner. `DO NOTHING` returns no row on conflict and would force a follow-up SELECT that races the other transaction. Covered by a test that holds one transaction open while a second writer inserts the same key.

## Backwards compatibility

Omitting `content_hash` preserves the previous behaviour **exactly** — a random key, one new row per call. Existing rows and existing keys are untouched and need no migration: a random key makes no claim about its bytes, so it confirms exactly as it did before. The new 400 (malformed hash, same message `confirm_upload` already raises) and the new 409 branch are both unreachable without sending the new parameter.

The initiate response gains an additive `deduplicated` boolean for clients that would rather skip a redundant transfer. An unaware client can ignore it, re-PUT the identical bytes to the identical key, and confirm as usual — the net effect is one row instead of two.

## Alternatives rejected

- **Key on `(vault, collection, name)` only.** Simpler and needs no client change, but re-uploading a *different* file under an existing name would overwrite it in place — silent data destruction, and precisely what the random prefix was protecting against. Content addressing keeps that protection.
- **Deduplicate at `confirm_upload`, once the hash is certified.** Works with no client change, but the caller would get back a `uri` different from the one `initiate_upload` handed it, so a caller that recorded the initiate `uri` and ignored the confirm response would later 404. That is a new failure mode for an unaware caller.

## Not addressed

- **Rows already duplicated before this change.** This stops new duplicates; it does not retire old ones.
- **Callers that cannot hash before uploading** necessarily keep the previous behaviour. There is no way to content-address a presigned key without the caller's help.
- **Two writers sharing one content-addressed row**: if one of them uploads bytes that fail the confirm check, the cleanup removes the row both were using. Only reachable between callers that opted in with the same claimed hash.
- A 64-bit key-digest collision would merge two different artifacts; it would also have to occur under the same vault, collection, and filename.

## Tests

22 new tests in `backend/tests/test_file_idempotent_upload_unit.py` (the DB half runs against a real Postgres via `AKB_TEST_DSN`, auto-skipping otherwise — the invariant under test *is* a database constraint) and 2 in `packages/akb-client/test/result.test.mjs`. `scripts/check.sh` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
