### PR TITLE
fix(tables): align REST alter permission with MCP admin gate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3128
+        "line_number": 3134
       }
     ],
     "backend/mcp_server/help.py": [

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,12 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+REST table schema alteration now requires the `admin` role, matching the MCP
+`akb_alter_table` authorization boundary. This closes the route-dependent
+permission gap that allowed a `writer` to perform destructive operations such
+as dropping a column through REST while the equivalent MCP call was denied.
+Operation-level writer/admin permission tiers remain a follow-up design change.
+
 Vault names now accept only single hyphens between lowercase alphanumeric
 segments (no leading, trailing, or consecutive hyphens). Hyphens map to
 underscores inside physical vault-table names and `__` separates the vault

--- a/backend/app/api/routes/tables.py
+++ b/backend/app/api/routes/tables.py
@@ -180,9 +180,9 @@ async def alter_table(
     req: AlterTableRequest,
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    # REST BaaS schema changes are a writer-level surface by AKB-034/067;
-    # the legacy MCP alter tool keeps its stricter admin gate.
-    access = await check_vault_access(user.user_id, vault, required_role="writer")
+    # Keep REST aligned with MCP's fail-closed policy until alter operations
+    # are classified into destructive and non-destructive permission tiers.
+    access = await check_vault_access(user.user_id, vault, required_role="admin")
     return await table_service.alter_table(
         access["vault_id"], table_name,
         actor_id=user.username,

--- a/backend/tests/test_table_crud_envelope_e2e.sh
+++ b/backend/tests/test_table_crud_envelope_e2e.sh
@@ -10,6 +10,7 @@ BASE_URL="${AKB_URL:-http://localhost:8000}"
 VAULT="tbl-envelope-$(date +%s)"
 USER="tbl-envelope-$(date +%s)"
 READER="tbl-envelope-reader-$(date +%s)"
+WRITER="tbl-envelope-writer-$(date +%s)"
 OUTSIDER="tbl-envelope-outsider-$(date +%s)"
 TABLE="cust"
 PASS=0
@@ -51,6 +52,19 @@ READER_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
 
 curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
   -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$WRITER\",\"email\":\"$WRITER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+WRITER_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$WRITER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+WRITER_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+  -H "Authorization: Bearer $WRITER_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"tbl-envelope-writer"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
   -d "{\"username\":\"$OUTSIDER\",\"email\":\"$OUTSIDER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
 
 OUTSIDER_JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
@@ -70,6 +84,11 @@ curl -sk -X POST "$BASE_URL/api/v1/vaults/$VAULT/grant" \
   -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
   -d "{\"user\":\"$READER\",\"role\":\"reader\"}" >/dev/null
+
+curl -sk -X POST "$BASE_URL/api/v1/vaults/$VAULT/grant" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d "{\"user\":\"$WRITER\",\"role\":\"writer\"}" >/dev/null
 
 # JSON-key assertion helper.
 assert_keys() {
@@ -119,6 +138,12 @@ ALTER_DENY=$(curl -sk -o /dev/null -w "%{http_code}" -X PATCH "$BASE_URL/api/v1/
   -H 'Content-Type: application/json' \
   -d '{"add_columns":[{"name":"status","type":"text"}]}')
 [ "$ALTER_DENY" = "403" ] && pass "alter.reader: HTTP 403" || fail "alter.reader" "expected 403, got $ALTER_DENY"
+
+ALTER_WRITER_DENY=$(curl -sk -o /dev/null -w "%{http_code}" -X PATCH "$BASE_URL/api/v1/tables/$VAULT/$TABLE" \
+  -H "Authorization: Bearer $WRITER_PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"drop_columns":["age"]}')
+[ "$ALTER_WRITER_DENY" = "403" ] && pass "alter.writer: HTTP 403" || fail "alter.writer" "expected 403, got $ALTER_WRITER_DENY"
 
 ALTER=$(curl -sk -X PATCH "$BASE_URL/api/v1/tables/$VAULT/$TABLE" \
   -H "Authorization: Bearer $PAT" \

--- a/backend/tests/test_tables_route_unit.py
+++ b/backend/tests/test_tables_route_unit.py
@@ -57,7 +57,7 @@ async def test_execute_sql_route_serialises_envelope_and_forwards_params(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_alter_table_route_forwards_schema_ops_with_writer_gate(monkeypatch) -> None:
+async def test_alter_table_route_forwards_schema_ops_with_admin_gate(monkeypatch) -> None:
     from app.api.routes import tables
 
     captured: dict[str, Any] = {}
@@ -96,7 +96,7 @@ async def test_alter_table_route_forwards_schema_ops_with_writer_gate(monkeypatc
     )
 
     assert result["kind"] == "table"
-    assert roles == ["writer"]
+    assert roles == ["admin"]
     assert captured == {
         "vault_id": "vault-1",
         "table_name": "incidents",


### PR DESCRIPTION
## Summary

- require the `admin` role for REST table schema alterations
- align `PATCH /tables/{vault}/{table}` with the MCP `akb_alter_table` authorization boundary
- add unit and REST E2E regression coverage for the writer denial
- document the temporary fail-closed policy and follow-up operation-level permission design

## Why

REST schema alteration was gated at `writer` while the equivalent MCP operation required `admin`. Because REST alteration includes destructive operations such as `drop_columns`, a writer could bypass the MCP boundary by switching interfaces and delete column data.

This change closes that route-dependent authorization gap conservatively. Splitting destructive and non-destructive operations into separate permission tiers remains follow-up work.

## Impact

Existing REST clients with only the `writer` role can no longer alter table schemas and will receive HTTP 403. Admins and owners retain access. Table creation and row-level writer operations are unchanged.

## Validation

- `uv run --project backend pytest -q backend/tests/test_tables_route_unit.py` — 11 passed
- `uv run --project backend ruff check backend/app/api/routes/tables.py backend/tests/test_tables_route_unit.py` — passed
- `bash -n backend/tests/test_table_crud_envelope_e2e.sh` — passed
- full deployed-server E2E not run
