### PR TITLE
Add typed table administration facade to the client SDK

### DIFF
--- a/packages/akb-client/README.md
+++ b/packages/akb-client/README.md
@@ -44,6 +44,29 @@ const result = await akb.request("/tables/reef");
 const { data } = result.throwOnError();
 ```
 
+Vault-scoped table administration is available through the immutable `.tables`
+facade. Request bodies use the generated public types, and migrations require
+an explicit idempotency key:
+
+```ts
+const tables = akb.vault("reef").tables;
+
+const created = await tables.create({
+  name: "incidents",
+  columns: [{ name: "state", type: "text" }],
+});
+
+const schema = await tables.schema("incidents");
+const migrated = await tables.migrate(
+  [{ op: "add_column", table: "incidents", name: "owner", type: "text" }],
+  { idempotencyKey: crypto.randomUUID() },
+);
+
+created.throwOnError();
+schema.throwOnError();
+migrated.throwOnError();
+```
+
 The backend and MCP surfaces are not rewrapped. `kind` remains the HTTP success discriminator and `{ data, error }` exists only at the SDK boundary.
 
 ## Runtime Table Types

--- a/packages/akb-client/src/index.ts
+++ b/packages/akb-client/src/index.ts
@@ -532,6 +532,30 @@ export interface AkbActivityFacade extends AkbNamespaceStub {
   ): Promise<AkbResult<import("./core/schema.gen.js").AkbRecentChangesEnvelope>>;
 }
 
+export interface AkbTableMigrationOptions {
+  idempotencyKey: string;
+}
+
+export interface AkbTablesFacade extends AkbNamespaceStub {
+  list(): Promise<AkbResult<import("./core/schema.gen.js").AkbTableEnvelope>>;
+  schema(): Promise<AkbResult<import("./core/schema.gen.js").AkbVaultTableSchemaEnvelope>>;
+  schema(table: string): Promise<AkbResult<import("./core/schema.gen.js").AkbTableSchemaEnvelope>>;
+  create(
+    input: import("./core/schema.gen.js").CreateTableRequest,
+  ): Promise<AkbResult<import("./core/schema.gen.js").AkbTableEnvelope>>;
+  alter(
+    table: string,
+    input: import("./core/schema.gen.js").AlterTableRequest,
+  ): Promise<AkbResult<import("./core/schema.gen.js").AkbTableEnvelope>>;
+  migrate(
+    operations: readonly import("./core/schema.gen.js").TableMigrationOperation[],
+    options: AkbTableMigrationOptions,
+  ): Promise<AkbResult<import("./core/schema.gen.js").AkbTableMigrationEnvelope>>;
+  drop(
+    table: string,
+  ): Promise<AkbResult<import("./core/schema.gen.js").AkbTableEnvelope>>;
+}
+
 export interface AkbStorageFacade extends AkbNamespaceStub {
   presignUpload(
     path: string,
@@ -653,6 +677,7 @@ export interface AkbClient<Schema = unknown> {
   readonly graph: AkbGraphFacade;
   readonly docs: AkbDocsFacade;
   readonly activity: AkbActivityFacade;
+  readonly tables: AkbTablesFacade;
   readonly storage: AkbStorageFacade;
 }
 
@@ -837,6 +862,7 @@ function makeClient(
     graph: makeGraphFacade(request, scope.defaultVault),
     docs: makeDocsFacade(request, scope.defaultVault),
     activity: makeActivityFacade(request, scope.defaultVault),
+    tables: makeTablesFacade(request, scope.defaultVault),
     storage: makeStorageFacade(request, scope.defaultVault, fetchImpl),
   };
   return Object.freeze(client) as unknown as AkbClient;
@@ -971,6 +997,77 @@ function makeGraphFacade(
       return request<import("./core/schema.gen.js").AkbProvenanceEnvelope>(`/provenance?${params}`);
     },
   } satisfies AkbGraphFacade;
+  return Object.freeze(facade);
+}
+
+function makeTablesFacade(
+  request: AkbClient["request"],
+  defaultVault: string | null,
+): AkbTablesFacade {
+  const rawRequest = <T = AkbSuccessEnvelope>(
+    path: string | URL = "",
+    init: RequestInit = {},
+  ) => request<T>(joinPath("/tables", path), init);
+  const scopedPath = (table?: string): string => {
+    const vault = resolveTablesVault(defaultVault);
+    const root = `/tables/${encodePathSegment(vault)}`;
+    return table === undefined ? root : `${root}/${encodePathSegment(table)}`;
+  };
+  function schema(): Promise<
+    AkbResult<import("./core/schema.gen.js").AkbVaultTableSchemaEnvelope>
+  >;
+  function schema(table: string): Promise<
+    AkbResult<import("./core/schema.gen.js").AkbTableSchemaEnvelope>
+  >;
+  function schema(
+    table?: string,
+  ): Promise<
+    AkbResult<
+      | import("./core/schema.gen.js").AkbVaultTableSchemaEnvelope
+      | import("./core/schema.gen.js").AkbTableSchemaEnvelope
+    >
+  > {
+    const path = table === undefined ? `${scopedPath()}/schema` : `${scopedPath(table)}/schema`;
+    return request(path);
+  }
+  const facade = {
+    name: "tables",
+    request: rawRequest,
+    list() {
+      return request<import("./core/schema.gen.js").AkbTableEnvelope>(scopedPath());
+    },
+    schema,
+    create(input: import("./core/schema.gen.js").CreateTableRequest) {
+      return request<import("./core/schema.gen.js").AkbTableEnvelope>(scopedPath(), {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+    },
+    alter(table: string, input: import("./core/schema.gen.js").AlterTableRequest) {
+      return request<import("./core/schema.gen.js").AkbTableEnvelope>(scopedPath(table), {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      });
+    },
+    migrate(
+      operations: readonly import("./core/schema.gen.js").TableMigrationOperation[],
+      options: AkbTableMigrationOptions,
+    ) {
+      return request<import("./core/schema.gen.js").AkbTableMigrationEnvelope>(
+        `${scopedPath()}/migrations`,
+        {
+          method: "POST",
+          headers: { "Idempotency-Key": options.idempotencyKey },
+          body: JSON.stringify(operations),
+        },
+      );
+    },
+    drop(table: string) {
+      return request<import("./core/schema.gen.js").AkbTableEnvelope>(scopedPath(table), {
+        method: "DELETE",
+      });
+    },
+  } satisfies AkbTablesFacade;
   return Object.freeze(facade);
 }
 
@@ -1347,6 +1444,13 @@ function resolveActivityVault(vault: string | null | undefined): string {
 function resolveGraphVault(vault: string | null | undefined, operation: "overview" | "health"): string {
   if (typeof vault === "string" && vault.length > 0) return vault;
   throw new TypeError(`Select a vault before using graph ${operation}: client.vault("...").graph.${operation}().`);
+}
+
+function resolveTablesVault(vault: string | null | undefined): string {
+  if (typeof vault === "string" && vault.length > 0) return vault;
+  throw new TypeError(
+    "Select a vault before using table administration: client.vault(\"...\").tables.",
+  );
 }
 
 function encodePathSegment(value: string): string {

--- a/packages/akb-client/src/lite.ts
+++ b/packages/akb-client/src/lite.ts
@@ -16,7 +16,9 @@ export type {
   AkbResult,
   AkbSqlTag,
   AkbSuccessEnvelope,
+  AkbTableMigrationOptions,
   AkbTableStub,
+  AkbTablesFacade,
   AkbThrowingResult,
   AkbVaultSqlResult,
 } from "./index.js";

--- a/packages/akb-client/test/tables-facade-consumer-proof.mjs
+++ b/packages/akb-client/test/tables-facade-consumer-proof.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+
+import { AkbError, createClient } from "@akb/client";
+
+const calls = [];
+const claims = {
+  sub: "artifact-user",
+  app_metadata: { org_id: "artifact-org", role: "admin" },
+};
+const root = createClient({
+  baseUrl: "https://public.example/api/v1",
+  token: () => ["artifact", "token"].join("-"),
+  fetch: async (input, init = {}) => {
+    const method = init.method ?? "GET";
+    const headers = Object.fromEntries(new Headers(init.headers));
+    const body = init.body === undefined ? undefined : JSON.parse(String(init.body));
+    calls.push({ url: String(input), method, headers, body });
+    if (String(input).endsWith("/denied")) {
+      return new Response(JSON.stringify({ message: "denied", code: "permission_denied" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    const pathname = new URL(String(input)).pathname;
+    const kind = pathname.endsWith("/migrations")
+      ? "table_migration"
+      : pathname.endsWith("/schema") && pathname.split("/").at(-3) !== "tables"
+        ? "table_schema"
+        : pathname.endsWith("/schema")
+          ? "vault_table_schema"
+          : "table";
+    return new Response(JSON.stringify({ kind, tables: [], total: 0 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  },
+}).actingAs(claims);
+
+const alpha = root.vault("vault one");
+const beta = root.vault("한글/둘");
+const createInput = {
+  name: "incidents",
+  description: null,
+  columns: [{ name: "state", type: "text" }],
+};
+const alterInput = {
+  add_columns: [{ name: "owner", type: "text" }],
+  drop_columns: ["legacy"],
+};
+const operations = [
+  { op: "add_column", table: "incidents", name: "priority", type: "text" },
+  { op: "drop_index", table: "incidents", name: "old_idx" },
+];
+
+assert.equal((await alpha.tables.list()).throwOnError().data.kind, "table");
+assert.equal((await alpha.tables.schema()).throwOnError().data.kind, "vault_table_schema");
+assert.equal((await alpha.tables.schema("incident/type")).throwOnError().data.kind, "table_schema");
+assert.equal((await alpha.tables.create(createInput)).throwOnError().data.kind, "table");
+assert.equal((await alpha.tables.alter("incident/type", alterInput)).throwOnError().data.kind, "table");
+assert.equal(
+  (
+    await alpha.tables.migrate(operations, {
+      idempotencyKey: "artifact-key-one",
+    })
+  ).throwOnError().data.kind,
+  "table_migration",
+);
+assert.equal((await alpha.tables.drop("incident/type")).throwOnError().data.kind, "table");
+await beta.tables.schema("테이블 name");
+await beta.tables.migrate([{ op: "drop_column", table: "events", name: "legacy" }], {
+  idempotencyKey: "artifact-key-two",
+});
+await alpha.tables.request("/denied");
+
+assert.deepEqual(
+  calls.slice(0, 9).map(({ url, method }) => ({ url, method })),
+  [
+    { url: "https://public.example/api/v1/tables/vault%20one", method: "GET" },
+    { url: "https://public.example/api/v1/tables/vault%20one/schema", method: "GET" },
+    {
+      url: "https://public.example/api/v1/tables/vault%20one/incident%2Ftype/schema",
+      method: "GET",
+    },
+    { url: "https://public.example/api/v1/tables/vault%20one", method: "POST" },
+    {
+      url: "https://public.example/api/v1/tables/vault%20one/incident%2Ftype",
+      method: "PATCH",
+    },
+    { url: "https://public.example/api/v1/tables/vault%20one/migrations", method: "POST" },
+    {
+      url: "https://public.example/api/v1/tables/vault%20one/incident%2Ftype",
+      method: "DELETE",
+    },
+    {
+      url: "https://public.example/api/v1/tables/%ED%95%9C%EA%B8%80%2F%EB%91%98/%ED%85%8C%EC%9D%B4%EB%B8%94%20name/schema",
+      method: "GET",
+    },
+    {
+      url: "https://public.example/api/v1/tables/%ED%95%9C%EA%B8%80%2F%EB%91%98/migrations",
+      method: "POST",
+    },
+  ],
+);
+assert.deepEqual(calls[3].body, createInput);
+assert.deepEqual(calls[4].body, alterInput);
+assert.deepEqual(calls[5].body, operations);
+assert.equal(calls[5].headers["idempotency-key"], "artifact-key-one");
+assert.equal(calls[8].headers["idempotency-key"], "artifact-key-two");
+for (const call of calls) {
+  assert.equal(call.headers.authorization, "Bearer artifact-token");
+  assert.deepEqual(JSON.parse(call.headers["x-akb-claims"]), claims);
+}
+
+const denied = await alpha.tables.request("/denied");
+assert.equal(denied.data, null);
+assert.ok(denied.error instanceof AkbError);
+assert.throws(() => denied.throwOnError(), AkbError);
+
+let missingVaultCalls = 0;
+const missingVault = createClient({
+  baseUrl: "https://public.example/api/v1",
+  fetch: async () => {
+    missingVaultCalls += 1;
+    return new Response("{}");
+  },
+});
+assert.throws(() => missingVault.tables.list(), /Select a vault before using table administration/);
+assert.equal(missingVaultCalls, 0);
+assert.equal(Object.isFrozen(alpha), true);
+assert.equal(Object.isFrozen(alpha.tables), true);
+
+console.log("tables facade packed runtime proof passed");

--- a/packages/akb-client/test/tables-facade-consumer-types.ts
+++ b/packages/akb-client/test/tables-facade-consumer-types.ts
@@ -1,0 +1,68 @@
+import {
+  createClient,
+  type AkbTableEnvelope,
+  type AkbTableMigrationEnvelope,
+  type AkbTableMigrationOptions,
+  type AkbTableSchemaEnvelope,
+  type AkbTablesFacade,
+  type AkbVaultTableSchemaEnvelope,
+  type AlterTableRequest,
+  type CreateTableRequest,
+  type TableMigrationOperation,
+} from "@akb/client";
+import type {
+  AkbTableMigrationOptions as LiteMigrationOptions,
+  AkbTablesFacade as LiteTablesFacade,
+} from "@akb/client/lite";
+
+const client = createClient({ baseUrl: "https://public.example/api/v1", defaultVault: "eng" });
+client.tables satisfies AkbTablesFacade;
+client.tables satisfies LiteTablesFacade;
+
+const createInput: CreateTableRequest = {
+  name: "incidents",
+  columns: [{ name: "state", type: "text" }],
+};
+const alterInput: AlterTableRequest = {
+  add_columns: [{ name: "owner", type: "text" }],
+};
+const operations = [
+  { op: "add_column", table: "incidents", name: "priority", type: "text" },
+  { op: "drop_index", table: "incidents", name: "old_idx" },
+] as const satisfies readonly TableMigrationOperation[];
+const options: AkbTableMigrationOptions = { idempotencyKey: "artifact-key" };
+options satisfies LiteMigrationOptions;
+
+const listed: AkbTableEnvelope = (await client.tables.list()).throwOnError().data;
+const vaultSchema: AkbVaultTableSchemaEnvelope = (
+  await client.tables.schema()
+).throwOnError().data;
+const tableSchema: AkbTableSchemaEnvelope = (
+  await client.tables.schema("incidents")
+).throwOnError().data;
+const created: AkbTableEnvelope = (
+  await client.tables.create(createInput)
+).throwOnError().data;
+const altered: AkbTableEnvelope = (
+  await client.tables.alter("incidents", alterInput)
+).throwOnError().data;
+const migrated: AkbTableMigrationEnvelope = (
+  await client.tables.migrate(operations, options)
+).throwOnError().data;
+const dropped: AkbTableEnvelope = (
+  await client.tables.drop("incidents")
+).throwOnError().data;
+listed.kind satisfies "table";
+vaultSchema.kind satisfies "vault_table_schema";
+tableSchema.kind satisfies "table_schema";
+created.kind satisfies "table";
+altered.kind satisfies "table";
+migrated.kind satisfies "table_migration";
+dropped.kind satisfies "table";
+
+// @ts-expect-error idempotencyKey is required.
+await client.tables.migrate(operations, {});
+// @ts-expect-error generated operations reject raw SQL.
+await client.tables.migrate([{ op: "raw_sql", sql: "SELECT 1" }], options);
+// @ts-expect-error generated create input requires column names.
+await client.tables.create({ name: "bad", columns: [{ type: "text" }] });

--- a/packages/akb-client/test/tables-facade-types.ts
+++ b/packages/akb-client/test/tables-facade-types.ts
@@ -1,0 +1,74 @@
+import {
+  createClient,
+  type AkbTableEnvelope,
+  type AkbTableMigrationEnvelope,
+  type AkbTableMigrationOptions,
+  type AkbTableSchemaEnvelope,
+  type AkbTablesFacade,
+  type AkbVaultTableSchemaEnvelope,
+  type AlterTableRequest,
+  type CreateTableRequest,
+  type TableMigrationOperation,
+} from "../src/index.js";
+import type {
+  AkbTableMigrationOptions as LiteMigrationOptions,
+  AkbTablesFacade as LiteTablesFacade,
+} from "../src/lite.js";
+
+const client = createClient({ baseUrl: "https://akb.test/api/v1", defaultVault: "eng" });
+client.tables satisfies AkbTablesFacade;
+client.tables satisfies LiteTablesFacade;
+
+const createInput: CreateTableRequest = {
+  name: "incidents",
+  columns: [{ name: "state", type: "text" }],
+};
+const alterInput: AlterTableRequest = {
+  alter_columns: [{ name: "state", set_default: "todo" }],
+};
+const operations = [
+  { op: "add_column", table: "incidents", name: "priority", type: "text" },
+  {
+    op: "add_index",
+    table_name: "incidents",
+    index: { columns: [{ name: "priority", order: "desc" }] },
+  },
+] as const satisfies readonly TableMigrationOperation[];
+const options: AkbTableMigrationOptions = { idempotencyKey: "migration-key" };
+options satisfies LiteMigrationOptions;
+
+const listed: AkbTableEnvelope = (await client.tables.list()).throwOnError().data;
+listed.kind satisfies "table";
+const vaultSchema: AkbVaultTableSchemaEnvelope = (
+  await client.tables.schema()
+).throwOnError().data;
+vaultSchema.kind satisfies "vault_table_schema";
+const tableSchema: AkbTableSchemaEnvelope = (
+  await client.tables.schema("incidents")
+).throwOnError().data;
+tableSchema.kind satisfies "table_schema";
+const created: AkbTableEnvelope = (
+  await client.tables.create(createInput)
+).throwOnError().data;
+const altered: AkbTableEnvelope = (
+  await client.tables.alter("incidents", alterInput)
+).throwOnError().data;
+const migrated: AkbTableMigrationEnvelope = (
+  await client.tables.migrate(operations, options)
+).throwOnError().data;
+const dropped: AkbTableEnvelope = (
+  await client.tables.drop("incidents")
+).throwOnError().data;
+created.kind satisfies "table";
+altered.kind satisfies "table";
+migrated.kind satisfies "table_migration";
+dropped.kind satisfies "table";
+
+// @ts-expect-error idempotencyKey is required.
+await client.tables.migrate(operations, {});
+// @ts-expect-error operations must be generated migration operations.
+await client.tables.migrate([{ op: "raw_sql", sql: "SELECT 1" }], options);
+// @ts-expect-error create input requires generated column definitions.
+await client.tables.create({ name: "bad", columns: [{ type: "text" }] });
+// @ts-expect-error alter input uses generated snake_case fields.
+await client.tables.alter("bad", { addColumns: [] });

--- a/packages/akb-client/test/tables-facade.test.mjs
+++ b/packages/akb-client/test/tables-facade.test.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { AkbError, createClient } from "../src/index.js";
+
+const fixtureToken = ["tables", "token"].join("-");
+const claims = {
+  sub: "tables-user",
+  app_metadata: { org_id: "tables-org", role: "admin" },
+};
+
+function responseFor(url, method) {
+  const pathname = new URL(url).pathname;
+  if (pathname.endsWith("/migrations")) {
+    return { kind: "table_migration", vault: "ignored", applied: [], total: 0 };
+  }
+  if (pathname.endsWith("/schema")) {
+    const segments = pathname.split("/");
+    return segments.at(-2) === "schema" || segments.at(-3) === "tables"
+      ? { kind: "vault_table_schema", vault: "ignored", tables: [], total: 0 }
+      : { kind: "table_schema", vault: "ignored", name: "ignored", columns: [] };
+  }
+  return { kind: "table", vault: "ignored", tables: method === "GET" ? [] : undefined };
+}
+
+test("tables facade maps every typed operation with exact encoded paths, bodies, and headers", async () => {
+  const calls = [];
+  const root = createClient({
+    baseUrl: "https://akb.test/api/v1",
+    token: fixtureToken,
+    fetch: async (input, init = {}) => {
+      const method = init.method ?? "GET";
+      calls.push({
+        url: String(input),
+        method,
+        headers: Object.fromEntries(new Headers(init.headers)),
+        body: init.body === undefined ? undefined : JSON.parse(String(init.body)),
+      });
+      return new Response(JSON.stringify(responseFor(String(input), method)), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  }).actingAs(claims);
+
+  const first = root.vault("vault one");
+  const second = root.vault("한글/공간");
+  const createInput = {
+    name: "incidents",
+    description: null,
+    columns: [{ name: "state", type: "text", nullable: false }],
+  };
+  const alterInput = {
+    add_columns: [{ name: "owner", type: "text" }],
+    rename_columns: { state: "status" },
+  };
+  const operations = [
+    { op: "add_column", table: "incidents", name: "priority", type: "text" },
+    { op: "drop_index", table: "incidents", name: "old_idx" },
+  ];
+
+  assert.equal((await first.tables.list()).throwOnError().data.kind, "table");
+  assert.equal((await first.tables.schema()).throwOnError().data.kind, "vault_table_schema");
+  assert.equal(
+    (await first.tables.schema("incident/type")).throwOnError().data.kind,
+    "table_schema",
+  );
+  assert.equal((await first.tables.create(createInput)).throwOnError().data.kind, "table");
+  assert.equal(
+    (await first.tables.alter("incident/type", alterInput)).throwOnError().data.kind,
+    "table",
+  );
+  assert.equal(
+    (
+      await first.tables.migrate(operations, {
+        idempotencyKey: "migration-key-one",
+      })
+    ).throwOnError().data.kind,
+    "table_migration",
+  );
+  assert.equal((await first.tables.drop("incident/type")).throwOnError().data.kind, "table");
+  await second.tables.schema("테이블 name");
+  await second.tables.migrate([{ op: "drop_column", table: "events", name: "legacy" }], {
+    idempotencyKey: "migration-key-two",
+  });
+
+  assert.deepEqual(
+    calls.map(({ url, method }) => ({ url, method })),
+    [
+      { url: "https://akb.test/api/v1/tables/vault%20one", method: "GET" },
+      { url: "https://akb.test/api/v1/tables/vault%20one/schema", method: "GET" },
+      {
+        url: "https://akb.test/api/v1/tables/vault%20one/incident%2Ftype/schema",
+        method: "GET",
+      },
+      { url: "https://akb.test/api/v1/tables/vault%20one", method: "POST" },
+      {
+        url: "https://akb.test/api/v1/tables/vault%20one/incident%2Ftype",
+        method: "PATCH",
+      },
+      { url: "https://akb.test/api/v1/tables/vault%20one/migrations", method: "POST" },
+      {
+        url: "https://akb.test/api/v1/tables/vault%20one/incident%2Ftype",
+        method: "DELETE",
+      },
+      {
+        url: "https://akb.test/api/v1/tables/%ED%95%9C%EA%B8%80%2F%EA%B3%B5%EA%B0%84/%ED%85%8C%EC%9D%B4%EB%B8%94%20name/schema",
+        method: "GET",
+      },
+      {
+        url: "https://akb.test/api/v1/tables/%ED%95%9C%EA%B8%80%2F%EA%B3%B5%EA%B0%84/migrations",
+        method: "POST",
+      },
+    ],
+  );
+  assert.deepEqual(calls[3].body, createInput);
+  assert.deepEqual(calls[4].body, alterInput);
+  assert.deepEqual(calls[5].body, operations);
+  assert.equal(calls[5].headers["idempotency-key"], "migration-key-one");
+  assert.equal(calls[8].headers["idempotency-key"], "migration-key-two");
+  for (const call of calls) {
+    assert.equal(call.headers.authorization, `Bearer ${fixtureToken}`);
+    assert.deepEqual(JSON.parse(call.headers["x-akb-claims"]), claims);
+  }
+  assert.equal(calls[6].body, undefined);
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(first.tables), true);
+});
+
+test("tables facade supports default vault and keeps the raw /tables request prefix", async () => {
+  const calls = [];
+  const client = createClient({
+    baseUrl: "https://akb.test/api/v1",
+    defaultVault: "default/vault",
+    fetch: async (input, init = {}) => {
+      calls.push({ url: String(input), method: init.method ?? "GET" });
+      return new Response(JSON.stringify({ kind: "table", tables: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  await client.tables.list();
+  await client.tables.request("/raw/path?fresh=true");
+
+  assert.deepEqual(calls, [
+    { url: "https://akb.test/api/v1/tables/default%2Fvault", method: "GET" },
+    { url: "https://akb.test/api/v1/tables/raw/path?fresh=true", method: "GET" },
+  ]);
+});
+
+test("tables facade rejects every typed method before fetch when no vault is selected", async () => {
+  let calls = 0;
+  const client = createClient({
+    baseUrl: "https://akb.test/api/v1",
+    fetch: async () => {
+      calls += 1;
+      return new Response("{}");
+    },
+  });
+  const attempts = [
+    () => client.tables.list(),
+    () => client.tables.schema(),
+    () => client.tables.schema("incidents"),
+    () => client.tables.create({ name: "incidents", columns: [] }),
+    () => client.tables.alter("incidents", {}),
+    () => client.tables.migrate([], { idempotencyKey: "key" }),
+    () => client.tables.drop("incidents"),
+  ];
+
+  for (const attempt of attempts) {
+    assert.throws(attempt, TypeError);
+    assert.throws(attempt, /Select a vault before using table administration/);
+  }
+  assert.equal(calls, 0);
+});
+
+test("tables facade preserves permission and validation errors plus throwOnError", async () => {
+  const statuses = [403, 403, 403, 422, 400];
+  const codes = [
+    "reader_required",
+    "writer_required",
+    "admin_required",
+    "validation_error",
+    "bad_migration",
+  ];
+  let call = 0;
+  const client = createClient({
+    baseUrl: "https://akb.test/api/v1",
+    fetch: async () => {
+      const index = call++;
+      return new Response(JSON.stringify({ message: codes[index], code: codes[index] }), {
+        status: statuses[index],
+        statusText: "Rejected",
+        headers: { "content-type": "application/json" },
+      });
+    },
+  }).vault("reef");
+
+  const results = [
+    await client.tables.list(),
+    await client.tables.create({ name: "incidents", columns: [] }),
+    await client.tables.drop("incidents"),
+    await client.tables.alter("incidents", {}),
+    await client.tables.migrate([], { idempotencyKey: "bad" }),
+  ];
+
+  for (const [index, result] of results.entries()) {
+    assert.equal(result.data, null);
+    assert.ok(result.error instanceof AkbError);
+    assert.equal(result.error.code, codes[index]);
+    assert.throws(() => result.throwOnError(), AkbError);
+  }
+});


### PR DESCRIPTION
## Summary

Adds an immutable, vault-scoped `.tables` facade to `@akb/client` for listing tables, reading vault or table schemas, creating and altering tables, applying idempotent migrations, and dropping tables.

The facade reuses the existing request boundary, generated request/response types, single-segment path encoding, authentication and acting-user claims propagation, `{ data, error }` results, and `.throwOnError()` behavior. It is also exported from the lite type surface and documented with a minimal example.

## Acceptance behavior

- `list`, both `schema` overloads, `create`, `alter`, `migrate`, and `drop` map to the exact REST method/path/body contract.
- Vault and table names are encoded as individual path segments.
- Migrations forward the operation array unchanged and send one exact `Idempotency-Key` header.
- Typed methods require a scoped/default vault and fail with a descriptive `TypeError` before any network request.
- Bearer auth and `X-Akb-Claims` flow through every typed method family.
- Reader, writer, admin, validation, and migration errors remain ordinary `AkbResult` errors and retain `.throwOnError()` behavior.
- Raw `.tables.request()` keeps the `/tables` namespace prefix.
- Client and facade objects remain frozen.
- Public main and lite exports provide generated input types, readonly migration operations, precise schema overloads, and leaf envelope narrowing.

## Validation

Evidence below applies to commit `ea09d478025c415c84e88842f19240b3037e780e`.

Focused package gates:

- `pnpm run build` — passed
- `pnpm run typecheck` — passed
- `pnpm exec vitest run test/result.test.mjs test/tables-facade.test.mjs` — 44 tests passed
- `pnpm run codegen:check` — passed
- `pnpm test` — 47 tests passed
- `git diff --check` — passed

Full repository gate:

- `PATH="<python-venv>/bin:$PATH" bash scripts/check.sh` — passed
- Backend ruff, mypy, and bandit passed.
- Frontend TypeScript passed; frontend unit suite passed with 55 files / 355 tests.
- SDK build, strict typecheck, 47-test suite, and generated-type drift check passed.
- Tracked-file secrets scan passed.

## Packed-artifact proof

A publishable tarball produced by `pnpm pack` was installed into a repository-external temporary consumer with only the packed `@akb/client` artifact and TypeScript 5.9.3.

- Runtime consumer: passed using two distinct vault/table/idempotency input sets.
- Observed both schema overloads and every mutation with exact encoded URLs, methods, unchanged JSON bodies, and migration headers.
- Observed bearer and acting-user claims propagation, permission error result and throw behavior, raw namespace prefix, frozen objects, and missing-vault zero-network preflight.
- Strict TypeScript consumer: passed using only public main/lite package exports.
- Negative compile cases rejected missing `idempotencyKey`, raw SQL migration operations, and invalid generated create shapes.
- No credentials, internal hostnames, private data, or local filesystem paths are included in this proof.
- Screenshot: N/A (non-visual SDK change).

## Residual risk

Server-side authorization and migration semantics remain owned and enforced by the existing REST contract. This facade intentionally does not duplicate UUID, permission, or DDL validation. Generated backend/OpenAPI surfaces were not changed; `codegen:check` confirms no drift.

## Checklist

- [x] Public facade and lite types
- [x] Exact request mapping and path encoding
- [x] Auth, claims, error, immutability, and raw escape-hatch regression coverage
- [x] Strict public type coverage and negative cases
- [x] Source-blind packed-artifact runtime/type proof
- [x] Focused and full local gates
- [x] Clean branch autoreview
- [x] Exact-head hosted CI complete
- [ ] Reviewer approval
