### PR TITLE
fix(mcp): akb_grep(replace=) required only read scope — promote to write

### DIFF
--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -63,12 +63,23 @@ _GENESIS = "0" * 64
 # new write-tool can never silently escape the audit trail. (File tools
 # `akb_get_file`/`akb_put_file` are proxy-only and never reach this
 # backend dispatch, so they're intentionally absent.)
+#
+# Membership here must agree with the read half of `_TOOL_SCOPES` in
+# mcp_server.server — a tool that needs `akb:vault:write` is by definition
+# state-changing. A test asserts the two agree; `akb_publication_snapshot`
+# was listed here while mapped write-grade, so with `log_reads` off it
+# wrote an S3 snapshot and flipped a publication's mode with no audit line.
+#
+# Tool-level membership is not sufficient on its own: `akb_grep` is a read
+# tool whose `replace` argument rewrites every matching document. The
+# caller therefore passes `is_write`, computed by the same
+# `_required_scope` that gates the call, so an argument-driven write is
+# recorded even though the tool name sits in this set.
 _READ_ONLY_TOOLS = frozenset({
     "akb_get", "akb_search", "akb_browse", "akb_drill_down", "akb_grep",
     "akb_graph", "akb_relations", "akb_history", "akb_diff", "akb_activity",
     "akb_provenance", "akb_list_vaults", "akb_vault_info", "akb_vault_members",
     "akb_whoami", "akb_help", "akb_search_users", "akb_publications",
-    "akb_publication_snapshot",
 })
 
 # Best-effort target-ref extraction from tool args (no bodies — Metadata
@@ -331,7 +342,7 @@ def _target_of(args: dict) -> str | None:
     return None
 
 
-def record_tool(name: str, args: dict, user, result) -> None:
+def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) -> None:
     """Audit one MCP tool call from the dispatch chokepoint. ``user`` is the
     resolved _MCPUser; ``result`` is the handler's return envelope (or the
     final error envelope) — outcome is derived from it.
@@ -349,8 +360,10 @@ def record_tool(name: str, args: dict, user, result) -> None:
     if not settings.audit.enabled:
         return
     # Skip reads only when the operator opted out of read logging; unknown
-    # (i.e. state-changing) tools are always kept.
-    if not settings.audit.log_reads and name in _READ_ONLY_TOOLS:
+    # (i.e. state-changing) tools are always kept. `is_write` overrides the
+    # tool-level classification for a read tool invoked with a mutating
+    # argument — see the note on `_READ_ONLY_TOOLS`.
+    if not settings.audit.log_reads and name in _READ_ONLY_TOOLS and not is_write:
         return
     outcome, code = "ok", None
     if isinstance(result, dict) and (result.get("error") is not None or result.get("code")):

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -256,12 +256,9 @@ def _required_scope(name: str, args: dict) -> str:
     `replace=""` IS a rewrite (it deletes every match), so emptiness must
     not be mistaken for absence.
     """
-    base = _TOOL_SCOPES.get(name, _WRITE_SCOPE)
-    if base == _WRITE_SCOPE:
-        return base
     if any(args.get(a) is not None for a in _ARG_WRITE_TRIGGERS.get(name, ())):
         return _WRITE_SCOPE
-    return base
+    return _TOOL_SCOPES.get(name, _WRITE_SCOPE)
 
 
 # Schema-derived: {tool_name: set(allowed_arg_names)}. Used by _dispatch

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -224,6 +224,46 @@ _TOOL_SCOPES: dict[str, str] = {
     "akb_import": _WRITE_SCOPE,
 }
 
+# Arguments that promote an otherwise read-grade tool to write-grade.
+#
+# `_TOOL_SCOPES` classifies a tool as a whole, which cannot express a
+# read tool that carries an optional mutating argument. `akb_grep` is
+# exactly that: a search tool whose `replace` rewrites EVERY matching
+# document across the scope (git commit + re-index per doc). Mapped flat
+# as read, a read-scoped token passed the gate and reached the rewrite.
+#
+# That was never privilege escalation — `_handle_grep` still requires
+# `check_vault_access(required_role="writer")` — but it defeated the
+# reason read-only tokens exist: handing an agent a read PAT is supposed
+# to mean it cannot change anything, and for a caller who *is* a vault
+# writer it did not.
+#
+# Declared here rather than branched inside `_dispatch` so the next tool
+# that grows a mutating argument has one obvious place to say so, and so
+# a test can assert every trigger names a real argument of that tool (a
+# typo would silently un-promote it — the exact failure this prevents).
+_ARG_WRITE_TRIGGERS: dict[str, tuple[str, ...]] = {
+    "akb_grep": ("replace",),
+}
+
+
+def _required_scope(name: str, args: dict) -> str:
+    """Scope a call needs: the tool's mapping, promoted to write when the
+    call carries a mutating argument.
+
+    Unmapped tools fail CLOSED to write (see `_dispatch`). A trigger
+    counts only when the argument is actually present and not None —
+    `replace=""` IS a rewrite (it deletes every match), so emptiness must
+    not be mistaken for absence.
+    """
+    base = _TOOL_SCOPES.get(name, _WRITE_SCOPE)
+    if base == _WRITE_SCOPE:
+        return base
+    if any(args.get(a) is not None for a in _ARG_WRITE_TRIGGERS.get(name, ())):
+        return _WRITE_SCOPE
+    return base
+
+
 # Schema-derived: {tool_name: set(allowed_arg_names)}. Used by _dispatch
 # to reject unknown arguments with a fuzzy hint. Built once at import
 # time from the same TOOLS list returned via list_tools, so the
@@ -1449,7 +1489,7 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
     # A test in `test_mcp_oauth_unit` asserts every registered handler
     # has an explicit mapping so CI catches the omission anyway.
     if user.oauth_scopes is not None:
-        required = _TOOL_SCOPES.get(name, _WRITE_SCOPE)
+        required = _required_scope(name, args)
         if required not in user.oauth_scopes:
             return err(
                 f"OAuth token is missing required scope '{required}' for tool '{name}'",
@@ -1458,7 +1498,7 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
                 granted_scopes=list(user.oauth_scopes),
             )
     if user.token_scopes is not None:
-        required = _TOOL_SCOPES.get(name, _WRITE_SCOPE)
+        required = _required_scope(name, args)
         required_token_scope = "write" if required == _WRITE_SCOPE else "read"
         if not token_has_scope(user.token_scopes, required_token_scope):
             return err(

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1432,7 +1432,10 @@ async def call_tool(name: str, arguments: dict):
         # thread (audit_log). No disk I/O or lock on the event loop, and it never
         # touches the shared to_thread pool — a stalled audit disk can't freeze
         # the loop or starve bcrypt / document reads.
-        audit_log.record_tool(name, arguments, user, result)
+        audit_log.record_tool(
+            name, arguments, user, result,
+            is_write=_required_scope(name, arguments) == _WRITE_SCOPE,
+        )
         # Serialise with json.dumps(default=str) — UNCHANGED from pre-hardening
         # so the MCP wire format stays byte-identical for every tool (datetime →
         # `str()` space form, Enum → `str()`, unknown → stringified). The
@@ -1458,7 +1461,10 @@ async def call_tool(name: str, arguments: dict):
         # Audit the failure too — a crashing tool call is exactly what a
         # security review wants to see. record_tool never raises and only
         # enqueues (non-blocking; see the success path).
-        audit_log.record_tool(name, arguments, user, envelope)
+        audit_log.record_tool(
+            name, arguments, user, envelope,
+            is_write=_required_scope(name, arguments) == _WRITE_SCOPE,
+        )
         return [TextContent(
             type="text",
             text=json.dumps(envelope, ensure_ascii=False, default=str),

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -115,6 +115,52 @@ def test_reads_skipped_when_disabled_but_writes_kept(audit_dir, monkeypatch):
     assert "akb_some_new_write" in actions
 
 
+def test_read_tool_invoked_as_a_write_is_still_audited(audit_dir, monkeypatch):
+    """`akb_grep` is in `_READ_ONLY_TOOLS`, but its `replace` argument
+    rewrites every matching document. With `log_reads` off, the tool-level
+    classification alone dropped that mass rewrite from the audit trail
+    entirely — contradicting this module's own "fail toward logging"
+    rule. The dispatcher passes `is_write`, which must override."""
+    monkeypatch.setattr(settings.audit, "log_reads", False)
+
+    class _U:
+        username, user_id = "bob", "u2"
+
+    audit_log.record_tool("akb_grep", {"vault": "v", "pattern": "x"}, _U(), {"ok": 1})
+    audit_log.record_tool(
+        "akb_grep", {"vault": "v", "pattern": "x", "replace": "y"}, _U(), {"ok": 1},
+        is_write=True,
+    )
+
+    lines = _read_lines(audit_dir / f"akb-audit-{_today()}.jsonl")
+    assert [json.loads(ln)["action"] for ln in lines] == ["akb_grep"], (
+        "the plain read must be skipped and the replace must be recorded"
+    )
+
+
+def test_read_only_set_agrees_with_the_mcp_scope_table(tmp_path, monkeypatch):
+    """The two classifications must not drift: a tool that needs
+    `akb:vault:write` to invoke is by definition state-changing, so it
+    cannot sit in the set that `log_reads=false` silently drops.
+
+    `akb_publication_snapshot` was in both — write-scoped, yet audited as
+    a read — so with read-logging off it wrote an S3 snapshot and flipped
+    a publication's mode leaving no audit line."""
+    from app.config import settings as _s
+
+    monkeypatch.setattr(_s, "git_storage_path", str(tmp_path / "vaults"))
+    from mcp_server.server import _READ_SCOPE, _TOOL_SCOPES
+
+    write_but_audited_as_read = sorted(
+        audit_log._READ_ONLY_TOOLS
+        - {n for n, scope in _TOOL_SCOPES.items() if scope == _READ_SCOPE}
+    )
+    assert write_but_audited_as_read == [], (
+        f"Tools audited as read-only but requiring the write scope: "
+        f"{write_but_audited_as_read}"
+    )
+
+
 def test_record_tool_marks_error_outcome(audit_dir):
     class _U:
         username, user_id = "bob", "u2"

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -560,6 +560,50 @@ def test_every_arg_write_trigger_names_a_real_tool_argument():
             )
 
 
+def _handler_can_write(handler) -> bool:
+    """True when the handler reaches a writer-gated access check.
+
+    AST rather than a substring scan: `'required_role="writer"' in source`
+    is defeated by single quotes, a module constant, or an enum — none of
+    which this repo lints against — so the guard below would have gone
+    green on exactly the regression it exists to catch. A non-literal
+    `required_role` is treated as a write (fail closed).
+
+    Still source-level, so a handler that delegates its access check to a
+    helper is a false negative. Tripwire, not proof.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(handler)))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        fname = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+        if fname != "check_vault_access":
+            continue
+        for kw in node.keywords:
+            if kw.arg != "required_role":
+                continue
+            if not isinstance(kw.value, ast.Constant):
+                return True  # non-literal role — cannot prove it is read-only
+            if kw.value.value != "reader":
+                return True
+    return False
+
+
+def test_the_omission_guard_itself_is_not_vacuous():
+    """`_handler_can_write` is the whole force of the guard below, and a
+    silently-broken predicate would make it pass forever. Pin it against
+    the one handler known to write."""
+    from mcp_server.server import _HANDLERS
+
+    assert _handler_can_write(_HANDLERS["akb_grep"]) is True
+    assert _handler_can_write(_HANDLERS["akb_search"]) is False
+
+
 def test_read_scoped_tools_that_can_write_declare_an_arg_trigger():
     """The omission guard — the failure mode that actually recurs.
 
@@ -568,14 +612,10 @@ def test_read_scoped_tools_that_can_write_declare_an_arg_trigger():
     tool that grows a mutating argument reproduces this bug silently.
 
     The invariant is checkable against code that already exists: a
-    handler that can reach `check_vault_access(required_role="writer")`
-    performs a write, so its tool cannot be read-grade unless some
-    argument promotes it. Source-level check, so it sees only a writer
-    check written directly in the handler — a handler that delegates to
-    a helper is a false negative. It is a tripwire, not a proof.
+    handler that can reach a writer-gated `check_vault_access` performs a
+    write, so its tool cannot be read-grade unless an argument promotes
+    it.
     """
-    import inspect
-
     from mcp_server.server import (
         _ARG_WRITE_TRIGGERS,
         _HANDLERS,
@@ -588,7 +628,7 @@ def test_read_scoped_tools_that_can_write_declare_an_arg_trigger():
         for name, handler in _HANDLERS.items()
         if _TOOL_SCOPES.get(name) == _READ_SCOPE
         and name not in _ARG_WRITE_TRIGGERS
-        and 'required_role="writer"' in inspect.getsource(handler)
+        and _handler_can_write(handler)
     )
     assert offenders == [], (
         f"Read-scoped tools whose handler performs a writer-gated write, with no "

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -466,6 +466,120 @@ async def test_dispatch_read_only_pat_scope_allows_read_tool():
             _HANDLERS.pop("akb_search", None)
 
 
+# ── akb_grep: scope depends on the arguments, not just the tool ────
+#
+# `akb_grep` is a search tool that ALSO accepts `replace`, which rewrites
+# every matching document across the scope (git commit + re-index per
+# doc). A flat read/write mapping cannot express that, so a read-scoped
+# token used to pass the gate and reach the rewrite. The handler's own
+# `check_vault_access(required_role="writer")` still applied, so this was
+# never privilege escalation — but it defeated the entire point of
+# issuing a read-only token to an agent that happens to be a vault
+# writer.
+
+
+@pytest.mark.asyncio
+async def test_grep_with_replace_is_refused_for_read_only_oauth_caller():
+    from mcp_server.server import _dispatch, _MCPUser
+
+    user = _MCPUser(user_id="u-1", oauth_scopes=["akb:vault:read"])
+    result = await _dispatch(
+        "akb_grep", {"vault": "v", "pattern": "x", "replace": "y"}, user
+    )
+    assert result.get("code") == "insufficient_scope"
+    assert result.get("details", {}).get("required_scope") == "akb:vault:write"
+
+
+@pytest.mark.asyncio
+async def test_grep_with_replace_is_refused_for_read_only_pat():
+    from mcp_server.server import _dispatch, _MCPUser
+
+    user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read"}))
+    result = await _dispatch(
+        "akb_grep", {"vault": "v", "pattern": "x", "replace": "y"}, user
+    )
+    assert result.get("code") == "insufficient_scope"
+    assert result.get("details", {}).get("required_scope") == "write"
+
+
+@pytest.mark.asyncio
+async def test_grep_without_replace_stays_readable_for_read_only_pat():
+    """Non-regression: plain grep must remain available to read-only
+    tokens — promoting the whole tool to write-grade would have been the
+    blunt fix and would take literal search away from every read agent."""
+    from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
+
+    called = []
+
+    async def _stub(args, uid, user):
+        called.append(args)
+        return {"ok": True}
+
+    original = _HANDLERS.get("akb_grep")
+    _HANDLERS["akb_grep"] = _stub
+    try:
+        user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read"}))
+        result = await _dispatch("akb_grep", {"vault": "v", "pattern": "x"}, user)
+        assert result == {"ok": True}
+        assert called == [{"vault": "v", "pattern": "x"}]
+    finally:
+        if original is not None:
+            _HANDLERS["akb_grep"] = original
+        else:
+            _HANDLERS.pop("akb_grep", None)
+
+
+@pytest.mark.asyncio
+async def test_grep_with_replace_passes_when_write_scope_present():
+    from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
+
+    called = []
+
+    async def _stub(args, uid, user):
+        called.append(args)
+        return {"ok": True}
+
+    original = _HANDLERS.get("akb_grep")
+    _HANDLERS["akb_grep"] = _stub
+    try:
+        user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read", "write"}))
+        args = {"vault": "v", "pattern": "x", "replace": "y"}
+        assert await _dispatch("akb_grep", args, user) == {"ok": True}
+        assert called == [args]
+    finally:
+        if original is not None:
+            _HANDLERS["akb_grep"] = original
+        else:
+            _HANDLERS.pop("akb_grep", None)
+
+
+def test_arg_sensitive_scope_rule_is_declared_not_hardcoded_in_dispatch():
+    """The rule must live in one reviewable place so the next tool that
+    grows a mutating argument has somewhere obvious to declare it."""
+    from mcp_server.server import _ARG_WRITE_TRIGGERS, _WRITE_SCOPE, _required_scope
+
+    assert _ARG_WRITE_TRIGGERS["akb_grep"] == ("replace",)
+    assert _required_scope("akb_grep", {"pattern": "x"}) != _WRITE_SCOPE
+    assert _required_scope("akb_grep", {"pattern": "x", "replace": ""}) == _WRITE_SCOPE
+
+
+def test_every_arg_write_trigger_names_a_real_tool_argument():
+    """A typo in a trigger name would silently disable the promotion —
+    the failure mode this whole block exists to prevent. Check each
+    trigger against the tool's published inputSchema."""
+    from mcp_server.server import _ARG_WRITE_TRIGGERS
+    from mcp_server.tools import TOOLS
+
+    schemas = {t.name: (t.inputSchema or {}).get("properties", {}) for t in TOOLS}
+    for tool, triggers in _ARG_WRITE_TRIGGERS.items():
+        assert tool in schemas, f"_ARG_WRITE_TRIGGERS names unknown tool {tool!r}"
+        for arg in triggers:
+            assert arg in schemas[tool], (
+                f"_ARG_WRITE_TRIGGERS[{tool!r}] names {arg!r}, "
+                f"which is not an argument of {tool}"
+            )
+
+
 # ── /.well-known/oauth-protected-resource ──────────────────────────
 
 

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -468,14 +468,7 @@ async def test_dispatch_read_only_pat_scope_allows_read_tool():
 
 # ── akb_grep: scope depends on the arguments, not just the tool ────
 #
-# `akb_grep` is a search tool that ALSO accepts `replace`, which rewrites
-# every matching document across the scope (git commit + re-index per
-# doc). A flat read/write mapping cannot express that, so a read-scoped
-# token used to pass the gate and reach the rewrite. The handler's own
-# `check_vault_access(required_role="writer")` still applied, so this was
-# never privilege escalation — but it defeated the entire point of
-# issuing a read-only token to an agent that happens to be a vault
-# writer.
+# Rationale lives with the rule, at `_ARG_WRITE_TRIGGERS` in server.py.
 
 
 @pytest.mark.asyncio
@@ -503,7 +496,7 @@ async def test_grep_with_replace_is_refused_for_read_only_pat():
 
 
 @pytest.mark.asyncio
-async def test_grep_without_replace_stays_readable_for_read_only_pat():
+async def test_grep_without_replace_stays_readable_for_read_only_pat(monkeypatch):
     """Non-regression: plain grep must remain available to read-only
     tokens — promoting the whole tool to write-grade would have been the
     blunt fix and would take literal search away from every read agent."""
@@ -515,22 +508,15 @@ async def test_grep_without_replace_stays_readable_for_read_only_pat():
         called.append(args)
         return {"ok": True}
 
-    original = _HANDLERS.get("akb_grep")
-    _HANDLERS["akb_grep"] = _stub
-    try:
-        user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read"}))
-        result = await _dispatch("akb_grep", {"vault": "v", "pattern": "x"}, user)
-        assert result == {"ok": True}
-        assert called == [{"vault": "v", "pattern": "x"}]
-    finally:
-        if original is not None:
-            _HANDLERS["akb_grep"] = original
-        else:
-            _HANDLERS.pop("akb_grep", None)
+    monkeypatch.setitem(_HANDLERS, "akb_grep", _stub)
+    user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read"}))
+    result = await _dispatch("akb_grep", {"vault": "v", "pattern": "x"}, user)
+    assert result == {"ok": True}
+    assert called == [{"vault": "v", "pattern": "x"}]
 
 
 @pytest.mark.asyncio
-async def test_grep_with_replace_passes_when_write_scope_present():
+async def test_grep_with_replace_passes_when_write_scope_present(monkeypatch):
     from mcp_server.server import _dispatch, _MCPUser, _HANDLERS
 
     called = []
@@ -539,45 +525,77 @@ async def test_grep_with_replace_passes_when_write_scope_present():
         called.append(args)
         return {"ok": True}
 
-    original = _HANDLERS.get("akb_grep")
-    _HANDLERS["akb_grep"] = _stub
-    try:
-        user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read", "write"}))
-        args = {"vault": "v", "pattern": "x", "replace": "y"}
-        assert await _dispatch("akb_grep", args, user) == {"ok": True}
-        assert called == [args]
-    finally:
-        if original is not None:
-            _HANDLERS["akb_grep"] = original
-        else:
-            _HANDLERS.pop("akb_grep", None)
+    monkeypatch.setitem(_HANDLERS, "akb_grep", _stub)
+    user = _MCPUser(user_id="u-1", token_scopes=frozenset({"read", "write"}))
+    args = {"vault": "v", "pattern": "x", "replace": "y"}
+    assert await _dispatch("akb_grep", args, user) == {"ok": True}
+    assert called == [args]
 
 
 def test_arg_sensitive_scope_rule_is_declared_not_hardcoded_in_dispatch():
     """The rule must live in one reviewable place so the next tool that
     grows a mutating argument has somewhere obvious to declare it."""
-    from mcp_server.server import _ARG_WRITE_TRIGGERS, _WRITE_SCOPE, _required_scope
+    from mcp_server.server import _WRITE_SCOPE, _required_scope
 
-    assert _ARG_WRITE_TRIGGERS["akb_grep"] == ("replace",)
     assert _required_scope("akb_grep", {"pattern": "x"}) != _WRITE_SCOPE
     assert _required_scope("akb_grep", {"pattern": "x", "replace": ""}) == _WRITE_SCOPE
 
 
 def test_every_arg_write_trigger_names_a_real_tool_argument():
     """A typo in a trigger name would silently disable the promotion —
-    the failure mode this whole block exists to prevent. Check each
-    trigger against the tool's published inputSchema."""
-    from mcp_server.server import _ARG_WRITE_TRIGGERS
-    from mcp_server.tools import TOOLS
+    the failure mode this whole block exists to prevent. Checked against
+    `_TOOL_ARG_NAMES`, which is the same schema-derived table `_dispatch`
+    rejects unknown arguments with, so a trigger can never name an
+    argument the dispatcher would refuse anyway."""
+    from mcp_server.server import _ARG_WRITE_TRIGGERS, _TOOL_ARG_NAMES
 
-    schemas = {t.name: (t.inputSchema or {}).get("properties", {}) for t in TOOLS}
     for tool, triggers in _ARG_WRITE_TRIGGERS.items():
-        assert tool in schemas, f"_ARG_WRITE_TRIGGERS names unknown tool {tool!r}"
+        assert tool in _TOOL_ARG_NAMES, (
+            f"_ARG_WRITE_TRIGGERS names unknown tool {tool!r}"
+        )
         for arg in triggers:
-            assert arg in schemas[tool], (
+            assert arg in _TOOL_ARG_NAMES[tool], (
                 f"_ARG_WRITE_TRIGGERS[{tool!r}] names {arg!r}, "
                 f"which is not an argument of {tool}"
             )
+
+
+def test_read_scoped_tools_that_can_write_declare_an_arg_trigger():
+    """The omission guard — the failure mode that actually recurs.
+
+    `_TOOL_SCOPES` has a completeness guard (a new tool must be mapped);
+    `_ARG_WRITE_TRIGGERS` needs the mirror of it, or the next read-mapped
+    tool that grows a mutating argument reproduces this bug silently.
+
+    The invariant is checkable against code that already exists: a
+    handler that can reach `check_vault_access(required_role="writer")`
+    performs a write, so its tool cannot be read-grade unless some
+    argument promotes it. Source-level check, so it sees only a writer
+    check written directly in the handler — a handler that delegates to
+    a helper is a false negative. It is a tripwire, not a proof.
+    """
+    import inspect
+
+    from mcp_server.server import (
+        _ARG_WRITE_TRIGGERS,
+        _HANDLERS,
+        _READ_SCOPE,
+        _TOOL_SCOPES,
+    )
+
+    offenders = sorted(
+        name
+        for name, handler in _HANDLERS.items()
+        if _TOOL_SCOPES.get(name) == _READ_SCOPE
+        and name not in _ARG_WRITE_TRIGGERS
+        and 'required_role="writer"' in inspect.getsource(handler)
+    )
+    assert offenders == [], (
+        f"Read-scoped tools whose handler performs a writer-gated write, with no "
+        f"_ARG_WRITE_TRIGGERS entry: {offenders}. Either the tool belongs in the "
+        f"write half of _TOOL_SCOPES, or the argument that makes it write must be "
+        f"declared in _ARG_WRITE_TRIGGERS."
+    )
 
 
 # ── /.well-known/oauth-protected-resource ──────────────────────────

--- a/docs/designs/mcp-oauth-dcr/00-overview.md
+++ b/docs/designs/mcp-oauth-dcr/00-overview.md
@@ -152,6 +152,12 @@ operation:
 | `akb_search`, `akb_get`, `akb_browse`, `akb_grep`, `akb_drill_down`, `akb_history`, `akb_relations`, `akb_graph` | `akb:vault:read` |
 | `akb_put`, `akb_update`, `akb_delete`, `akb_edit`, `akb_link`, `akb_unlink`, `akb_create_collection`, `akb_create_table`, `akb_alter_table`, `akb_publish`, `akb_unpublish`, file tools | `akb:vault:write` |
 
+The table is per-tool, but the requirement is per-**call**: `akb_grep` is
+read-grade only without its `replace` argument, which rewrites every
+matching document. `_ARG_WRITE_TRIGGERS` (`mcp_server/server.py`) declares
+such arguments and `_required_scope(name, args)` promotes the call to
+`akb:vault:write` when one is present.
+
 If neither scope is present, return `403 insufficient_scope`. The
 existing PG-RBAC layer still gates per-vault access; scopes are an
 additional coarse gate that the IdP can present at consent time.


### PR DESCRIPTION
## What

`akb_grep` was mapped to `akb:vault:read` in `_TOOL_SCOPES`, but it accepts an
optional argument that rewrites every matching document. That mapping is a real
enforcement gate — it is consulted for both OAuth access tokens and PAT scopes —
so a token deliberately scoped down to `read` passed the gate and reached the
mutating path.

## Severity

**Not privilege escalation.** The handler still requires the vault `writer`
role, so a vault *reader* cannot write.

What it defeated is the reason read-only tokens exist: handing an agent a read
PAT is supposed to mean it cannot change anything, and for a caller who *is* a
vault writer, it did not.

**Release impact — two different answers.** The scope bypass affects
unreleased `main` only: the gate it defeats was introduced after
`backend-v0.9.4`, so no tagged release carries it, and operators building from
`main` get the fix with the same `git pull`.

The audit-classification defect fixed alongside it **does** predate
`backend-v0.9.4`. There, `akb_grep` and `akb_publication_snapshot` sit in
`audit_log._READ_ONLY_TOOLS`, which is skipped entirely when `log_reads` is
false — while the shipped `app.yaml.example` states that writes are always
logged.

Auditing is off by default (`audit.enabled: false`) and `log_reads` defaults
to true, so this reaches only deployments that turned auditing **on** and read
logging **off**. **Those operators should assume mass replacements and
publication snapshots are absent from their audit stream on 0.9.4 and
earlier.** Everyone else is unaffected.

## Fix

`_required_scope(name, args)` promotes a read-grade tool to write when the call
carries a declared mutating argument; both gates use it.

The rule lives in `_ARG_WRITE_TRIGGERS` rather than a branch inside `_dispatch`,
so the next tool that grows such an argument has one obvious place to declare
it. The trigger tests for presence rather than truthiness, so a falsy-but-
supplied value is still classified as a write.

**Rejected:** mapping the whole tool write-grade. That would take literal and
regex search away from every read-only agent, and `akb_search` does not cover
it. A separate read/write tool split is the durable answer but changes the
published MCP `inputSchema`, so it belongs in the contract-convergence pass —
the same call `akb_sql`'s comment already records.

## Why CI was green

The existing guard asserted that every tool *has* a scope mapping, never that
the mapping is *correct*. `akb_grep` had one, so it passed.

Added two structural guards: the rule is declared rather than hardcoded, and
every declared trigger must name a real argument of that tool, checked against
the published `inputSchema` — a typo in a trigger name would silently
un-promote the tool, which is the exact failure this prevents.

## Tests

| | |
|---|---|
| `test_grep_with_replace_is_refused_for_read_only_oauth_caller` | OAuth path |
| `test_grep_with_replace_is_refused_for_read_only_pat` | PAT path |
| `test_grep_without_replace_stays_readable_for_read_only_pat` | non-regression |
| `test_grep_with_replace_passes_when_write_scope_present` | positive |

The same misclassification existed in the audit trail (`_READ_ONLY_TOOLS`), so
a mutating call could be dropped from the audit stream when read-logging was
off. `record_tool` now takes `is_write` from the dispatch chokepoint, and a
test pins the two classifications against each other.

Verified locally against the docker stack across the read/write × with/without
matrix, plus audit behaviour with read-logging disabled.


