### PR TITLE
feat(db): add app desired-state registry

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -106,4 +106,5 @@ jobs:
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
           tests/test_file_idempotent_upload_unit.py
+          tests/test_app_registry_migration_unit.py
           -v --tb=short

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3149
+        "line_number": 3209
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T05:02:52Z"
+  "generated_at": "2026-07-29T06:16:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3134
+        "line_number": 3144
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T07:43:05Z"
+  "generated_at": "2026-07-29T02:57:15Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3144
+        "line_number": 3149
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T02:57:15Z"
+  "generated_at": "2026-07-29T05:02:52Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,16 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+An additive app desired-state registry now stores stable app definitions,
+immutable versioned release manifests, one installation per app/Vault pair,
+monotonic capability grants, and explicit owned or retained resources. Database
+constraints reject cross-app release pointers, incoherent lifecycle/version
+states, duplicate installations, stale grant generations, and in-place release
+or grant mutation. A security-invoker installation view returns the current
+registry state in one query, while ordinary Vault SQL roles receive no access.
+Existing users, Vaults, tokens, Vault data, and standalone behavior are
+unchanged.
+
 REST table schema alteration now requires the `admin` role, matching the MCP
 `akb_alter_table` authorization boundary. This closes the route-dependent
 permission gap that allowed a `writer` to perform destructive operations such

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -12,10 +12,15 @@ immutable versioned release manifests, one installation per app/Vault pair,
 monotonic capability grants, and explicit owned or retained resources. Database
 constraints reject cross-app release pointers, incoherent lifecycle/version
 states, duplicate installations, stale grant generations, and in-place release
-or grant mutation. A security-invoker installation view returns the current
-registry state in one query, while ordinary Vault SQL roles receive no access.
-Existing users, Vaults, tokens, Vault data, and standalone behavior are
-unchanged.
+or grant mutation. App keys, installation app/Vault identity, and owned-resource
+identity are immutable, and one physical resource kind/key can belong to only
+one installation in a Vault. Uninstall remains a retained lifecycle state;
+direct registry deletion is rejected, while permanent Vault deletion removes
+only that Vault's installation, grant, and resource registry rows and preserves
+reusable app definitions and releases. A security-invoker installation view
+returns the current registry state in one query, while ordinary Vault SQL roles
+receive no access. Existing users, Vaults, tokens, Vault data, and standalone
+behavior are unchanged.
 
 REST table schema alteration now requires the `admin` role, matching the MCP
 `akb_alter_table` authorization boundary. This closes the route-dependent

--- a/backend/app/db/migrations/046_app_registry.py
+++ b/backend/app/db/migrations/046_app_registry.py
@@ -2,8 +2,8 @@
 
 The registry is control-plane state, not Vault data-plane state. It defines
 stable apps, immutable releases, one installation per app/Vault pair,
-monotonic grants, and explicit resource ownership without changing existing
-users, Vaults, tokens, or Vault content.
+monotonic grants, Vault-scoped resource ownership, and registry identity
+immutability without changing existing users, Vaults, tokens, or Vault content.
 """
 
 from __future__ import annotations
@@ -174,11 +174,19 @@ async def _run(conn):
                     SELECT 1 FROM pg_constraint
                      WHERE conname = 'vault_app_installations_vault_id_fkey'
                        AND conrelid = 'vault_app_installations'::regclass
+                ) OR EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_vault_id_fkey'
+                       AND conrelid = 'vault_app_installations'::regclass
+                       AND confdeltype <> 'c'
                 ) THEN
+                    ALTER TABLE vault_app_installations
+                        DROP CONSTRAINT IF EXISTS
+                        vault_app_installations_vault_id_fkey;
                     ALTER TABLE vault_app_installations
                         ADD CONSTRAINT vault_app_installations_vault_id_fkey
                         FOREIGN KEY (vault_id) REFERENCES vaults(id)
-                        ON DELETE RESTRICT;
+                        ON DELETE CASCADE;
                 END IF;
                 IF NOT EXISTS (
                     SELECT 1 FROM pg_constraint
@@ -188,6 +196,15 @@ async def _run(conn):
                     ALTER TABLE vault_app_installations
                         ADD CONSTRAINT vault_app_installations_app_vault_key
                         UNIQUE (app_id, vault_id);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_id_vault_key'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_id_vault_key
+                        UNIQUE (id, vault_id);
                 END IF;
                 IF NOT EXISTS (
                     SELECT 1 FROM pg_constraint
@@ -308,12 +325,20 @@ async def _run(conn):
                     SELECT 1 FROM pg_constraint
                      WHERE conname = 'installation_grants_installation_id_fkey'
                        AND conrelid = 'installation_grants'::regclass
+                ) OR EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_installation_id_fkey'
+                       AND conrelid = 'installation_grants'::regclass
+                       AND confdeltype <> 'c'
                 ) THEN
+                    ALTER TABLE installation_grants
+                        DROP CONSTRAINT IF EXISTS
+                        installation_grants_installation_id_fkey;
                     ALTER TABLE installation_grants
                         ADD CONSTRAINT installation_grants_installation_id_fkey
                         FOREIGN KEY (installation_id)
                         REFERENCES vault_app_installations(id)
-                        ON DELETE RESTRICT;
+                        ON DELETE CASCADE;
                 END IF;
                 IF NOT EXISTS (
                     SELECT 1 FROM pg_constraint
@@ -386,6 +411,7 @@ async def _run(conn):
             CREATE TABLE IF NOT EXISTS app_owned_resources (
                 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
                 installation_id UUID NOT NULL,
+                vault_id UUID,
                 resource_kind TEXT NOT NULL,
                 resource_key TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'owned',
@@ -394,18 +420,40 @@ async def _run(conn):
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             );
 
+            ALTER TABLE app_owned_resources
+                ADD COLUMN IF NOT EXISTS vault_id UUID;
+
+            UPDATE app_owned_resources AS resource
+               SET vault_id = installation.vault_id
+              FROM vault_app_installations AS installation
+             WHERE resource.installation_id = installation.id
+               AND resource.vault_id IS NULL;
+
+            ALTER TABLE app_owned_resources
+                ALTER COLUMN vault_id SET NOT NULL;
+
             DO $$
             BEGIN
-                IF NOT EXISTS (
+                IF EXISTS (
                     SELECT 1 FROM pg_constraint
                      WHERE conname = 'app_owned_resources_installation_id_fkey'
                        AND conrelid = 'app_owned_resources'::regclass
                 ) THEN
                     ALTER TABLE app_owned_resources
-                        ADD CONSTRAINT app_owned_resources_installation_id_fkey
-                        FOREIGN KEY (installation_id)
-                        REFERENCES vault_app_installations(id)
-                        ON DELETE RESTRICT;
+                        DROP CONSTRAINT
+                        app_owned_resources_installation_id_fkey;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_installation_vault_fkey'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT
+                        app_owned_resources_installation_vault_fkey
+                        FOREIGN KEY (installation_id, vault_id)
+                        REFERENCES vault_app_installations(id, vault_id)
+                        ON DELETE CASCADE;
                 END IF;
                 IF NOT EXISTS (
                     SELECT 1 FROM pg_constraint
@@ -415,6 +463,15 @@ async def _run(conn):
                     ALTER TABLE app_owned_resources
                         ADD CONSTRAINT app_owned_resources_identity_key
                         UNIQUE (installation_id, resource_kind, resource_key);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_vault_identity_key'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_vault_identity_key
+                        UNIQUE (vault_id, resource_kind, resource_key);
                 END IF;
                 IF NOT EXISTS (
                     SELECT 1 FROM pg_constraint
@@ -486,6 +543,136 @@ async def _run(conn):
             CREATE TRIGGER app_owned_resources_set_updated_at
                 BEFORE UPDATE ON app_owned_resources
                 FOR EACH ROW EXECUTE FUNCTION akb_registry_set_updated_at();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_guard_app_definition_identity()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.app_key IS DISTINCT FROM OLD.app_key THEN
+                    RAISE EXCEPTION
+                        'app identity is immutable; app_key cannot be changed'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_definitions_identity_immutable
+                ON app_definitions;
+            CREATE TRIGGER app_definitions_identity_immutable
+                BEFORE UPDATE ON app_definitions
+                FOR EACH ROW
+                EXECUTE FUNCTION akb_guard_app_definition_identity();
+
+            CREATE OR REPLACE FUNCTION akb_guard_installation_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    IF EXISTS (
+                        SELECT 1 FROM vaults WHERE id = OLD.vault_id
+                    ) THEN
+                        RAISE EXCEPTION
+                            'installation rows are retained; uninstall through lifecycle state'
+                            USING ERRCODE = '55000';
+                    END IF;
+                    RETURN OLD;
+                END IF;
+
+                IF NEW.app_id IS DISTINCT FROM OLD.app_id
+                   OR NEW.vault_id IS DISTINCT FROM OLD.vault_id
+                THEN
+                    RAISE EXCEPTION
+                        'installation app and vault identity are immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS vault_app_installations_identity_immutable
+                ON vault_app_installations;
+            CREATE TRIGGER vault_app_installations_identity_immutable
+                BEFORE UPDATE OR DELETE ON vault_app_installations
+                FOR EACH ROW
+                EXECUTE FUNCTION akb_guard_installation_mutation();
+
+            CREATE OR REPLACE FUNCTION akb_set_owned_resource_vault()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                installation_vault_id UUID;
+            BEGIN
+                SELECT vault_id
+                  INTO installation_vault_id
+                  FROM vault_app_installations
+                 WHERE id = NEW.installation_id;
+
+                IF installation_vault_id IS NULL THEN
+                    RAISE EXCEPTION 'installation does not exist'
+                        USING ERRCODE = '23503';
+                END IF;
+                IF NEW.vault_id IS NULL THEN
+                    NEW.vault_id = installation_vault_id;
+                ELSIF NEW.vault_id IS DISTINCT FROM installation_vault_id THEN
+                    RAISE EXCEPTION
+                        'owned resource vault must match its installation vault'
+                        USING ERRCODE = '23503';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_owned_resources_set_vault
+                ON app_owned_resources;
+            CREATE TRIGGER app_owned_resources_set_vault
+                BEFORE INSERT ON app_owned_resources
+                FOR EACH ROW EXECUTE FUNCTION akb_set_owned_resource_vault();
+
+            CREATE OR REPLACE FUNCTION akb_guard_owned_resource_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    IF EXISTS (
+                        SELECT 1
+                          FROM vault_app_installations
+                         WHERE id = OLD.installation_id
+                    ) THEN
+                        RAISE EXCEPTION
+                            'owned resource rows are retained; update ownership status instead'
+                            USING ERRCODE = '55000';
+                    END IF;
+                    RETURN OLD;
+                END IF;
+
+                IF NEW.installation_id IS DISTINCT FROM OLD.installation_id
+                   OR NEW.vault_id IS DISTINCT FROM OLD.vault_id
+                   OR NEW.resource_kind IS DISTINCT FROM OLD.resource_kind
+                   OR NEW.resource_key IS DISTINCT FROM OLD.resource_key
+                THEN
+                    RAISE EXCEPTION
+                        'owned resource installation, vault, kind, and key are immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_owned_resources_identity_immutable
+                ON app_owned_resources;
+            CREATE TRIGGER app_owned_resources_identity_immutable
+                BEFORE UPDATE OR DELETE ON app_owned_resources
+                FOR EACH ROW
+                EXECUTE FUNCTION akb_guard_owned_resource_mutation();
             """
         )
 
@@ -564,9 +751,16 @@ async def _run(conn):
             AS $$
             BEGIN
                 IF TG_OP = 'DELETE' THEN
-                    RAISE EXCEPTION
-                        'installation grants are retained as immutable generations'
-                        USING ERRCODE = '55000';
+                    IF EXISTS (
+                        SELECT 1
+                          FROM vault_app_installations
+                         WHERE id = OLD.installation_id
+                    ) THEN
+                        RAISE EXCEPTION
+                            'installation grants are retained as immutable generations'
+                            USING ERRCODE = '55000';
+                    END IF;
+                    RETURN OLD;
                 END IF;
 
                 IF OLD.status = 'active'
@@ -675,6 +869,14 @@ async def _run(conn):
             FROM PUBLIC;
 
             REVOKE EXECUTE ON FUNCTION akb_registry_set_updated_at()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_app_definition_identity()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_installation_mutation()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_set_owned_resource_vault()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_owned_resource_mutation()
                 FROM PUBLIC;
             REVOKE EXECUTE ON FUNCTION akb_reject_release_mutation()
                 FROM PUBLIC;

--- a/backend/app/db/migrations/046_app_registry.py
+++ b/backend/app/db/migrations/046_app_registry.py
@@ -1,0 +1,701 @@
+"""Migration 046: app desired-state registry.
+
+The registry is control-plane state, not Vault data-plane state. It defines
+stable apps, immutable releases, one installation per app/Vault pair,
+monotonic grants, and explicit resource ownership without changing existing
+users, Vaults, tokens, or Vault content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger("akb.migration.046")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS app_definitions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_key TEXT NOT NULL,
+                display_name TEXT,
+                description TEXT,
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            ALTER TABLE app_definitions
+                ADD COLUMN IF NOT EXISTS display_name TEXT,
+                ADD COLUMN IF NOT EXISTS description TEXT,
+                ADD COLUMN IF NOT EXISTS metadata JSONB
+                    NOT NULL DEFAULT '{}'::jsonb,
+                ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ
+                    NOT NULL DEFAULT NOW(),
+                ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ
+                    NOT NULL DEFAULT NOW();
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_definitions_app_key_key'
+                       AND conrelid = 'app_definitions'::regclass
+                ) THEN
+                    ALTER TABLE app_definitions
+                        ADD CONSTRAINT app_definitions_app_key_key
+                        UNIQUE (app_key);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_definitions_app_key_nonempty'
+                       AND conrelid = 'app_definitions'::regclass
+                ) THEN
+                    ALTER TABLE app_definitions
+                        ADD CONSTRAINT app_definitions_app_key_nonempty
+                        CHECK (btrim(app_key) <> '');
+                END IF;
+            END
+            $$;
+
+            CREATE TABLE IF NOT EXISTS app_releases (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_id UUID NOT NULL,
+                version TEXT NOT NULL,
+                manifest JSONB NOT NULL,
+                manifest_checksum TEXT NOT NULL,
+                registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_app_id_fkey'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_app_id_fkey
+                        FOREIGN KEY (app_id) REFERENCES app_definitions(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_app_id_version_key'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_app_id_version_key
+                        UNIQUE (app_id, version);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_app_id_id_key'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_app_id_id_key
+                        UNIQUE (app_id, id);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_version_nonempty'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_version_nonempty
+                        CHECK (btrim(version) <> '');
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_manifest_shape'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_manifest_shape
+                        CHECK (
+                            jsonb_typeof(manifest) = 'object'
+                            AND manifest ? 'steps'
+                            AND jsonb_typeof(manifest->'steps') = 'array'
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_releases_checksum_shape'
+                       AND conrelid = 'app_releases'::regclass
+                ) THEN
+                    ALTER TABLE app_releases
+                        ADD CONSTRAINT app_releases_checksum_shape
+                        CHECK (manifest_checksum ~ '^[0-9a-f]{64}$');
+                END IF;
+            END
+            $$;
+
+            CREATE TABLE IF NOT EXISTS vault_app_installations (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_id UUID NOT NULL,
+                vault_id UUID NOT NULL,
+                desired_release_id UUID,
+                current_release_id UUID,
+                lifecycle TEXT NOT NULL,
+                blocked_reason TEXT,
+                grant_generation BIGINT NOT NULL DEFAULT 0,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_app_id_fkey'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_app_id_fkey
+                        FOREIGN KEY (app_id) REFERENCES app_definitions(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_vault_id_fkey'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_vault_id_fkey
+                        FOREIGN KEY (vault_id) REFERENCES vaults(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_app_vault_key'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_app_vault_key
+                        UNIQUE (app_id, vault_id);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_desired_release_fkey'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_desired_release_fkey
+                        FOREIGN KEY (app_id, desired_release_id)
+                        REFERENCES app_releases(app_id, id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_current_release_fkey'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_current_release_fkey
+                        FOREIGN KEY (app_id, current_release_id)
+                        REFERENCES app_releases(app_id, id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_lifecycle_check'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_lifecycle_check
+                        CHECK (
+                            lifecycle IN (
+                                'installing',
+                                'active',
+                                'upgrading',
+                                'blocked',
+                                'uninstalled'
+                            )
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_release_coherence'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_release_coherence
+                        CHECK (
+                            (
+                                lifecycle = 'installing'
+                                AND desired_release_id IS NOT NULL
+                                AND current_release_id IS NULL
+                            )
+                            OR (
+                                lifecycle = 'active'
+                                AND desired_release_id IS NOT NULL
+                                AND current_release_id IS NOT NULL
+                                AND current_release_id = desired_release_id
+                            )
+                            OR (
+                                lifecycle = 'upgrading'
+                                AND desired_release_id IS NOT NULL
+                                AND current_release_id IS NOT NULL
+                                AND current_release_id <> desired_release_id
+                            )
+                            OR lifecycle = 'blocked'
+                            OR (
+                                lifecycle = 'uninstalled'
+                                AND desired_release_id IS NULL
+                            )
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_blocked_reason_check'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_blocked_reason_check
+                        CHECK (
+                            (
+                                lifecycle = 'blocked'
+                                AND NULLIF(btrim(blocked_reason), '') IS NOT NULL
+                            )
+                            OR (
+                                lifecycle <> 'blocked'
+                                AND blocked_reason IS NULL
+                            )
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'vault_app_installations_grant_generation_check'
+                       AND conrelid = 'vault_app_installations'::regclass
+                ) THEN
+                    ALTER TABLE vault_app_installations
+                        ADD CONSTRAINT vault_app_installations_grant_generation_check
+                        CHECK (grant_generation >= 0);
+                END IF;
+            END
+            $$;
+
+            CREATE TABLE IF NOT EXISTS installation_grants (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                installation_id UUID NOT NULL,
+                generation BIGINT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                capabilities TEXT[] NOT NULL,
+                issuer TEXT NOT NULL,
+                provenance JSONB NOT NULL DEFAULT '{}'::jsonb,
+                issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                revoked_at TIMESTAMPTZ
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_installation_id_fkey'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_installation_id_fkey
+                        FOREIGN KEY (installation_id)
+                        REFERENCES vault_app_installations(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_generation_key'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_generation_key
+                        UNIQUE (installation_id, generation);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_generation_check'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_generation_check
+                        CHECK (generation > 0);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_status_check'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_status_check
+                        CHECK (status IN ('active', 'revoked'));
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_capabilities_check'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_capabilities_check
+                        CHECK (
+                            cardinality(capabilities) > 0
+                            AND NOT capabilities @> ARRAY['']::text[]
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_issuer_nonempty'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_issuer_nonempty
+                        CHECK (btrim(issuer) <> '');
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'installation_grants_revocation_coherence'
+                       AND conrelid = 'installation_grants'::regclass
+                ) THEN
+                    ALTER TABLE installation_grants
+                        ADD CONSTRAINT installation_grants_revocation_coherence
+                        CHECK (
+                            (status = 'active' AND revoked_at IS NULL)
+                            OR (status = 'revoked' AND revoked_at IS NOT NULL)
+                        );
+                END IF;
+            END
+            $$;
+
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                installation_grants_one_active_idx
+                ON installation_grants(installation_id)
+                WHERE status = 'active';
+
+            CREATE TABLE IF NOT EXISTS app_owned_resources (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                installation_id UUID NOT NULL,
+                resource_kind TEXT NOT NULL,
+                resource_key TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'owned',
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_installation_id_fkey'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_installation_id_fkey
+                        FOREIGN KEY (installation_id)
+                        REFERENCES vault_app_installations(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_identity_key'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_identity_key
+                        UNIQUE (installation_id, resource_kind, resource_key);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_kind_nonempty'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_kind_nonempty
+                        CHECK (btrim(resource_kind) <> '');
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_key_nonempty'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_key_nonempty
+                        CHECK (btrim(resource_key) <> '');
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_owned_resources_status_check'
+                       AND conrelid = 'app_owned_resources'::regclass
+                ) THEN
+                    ALTER TABLE app_owned_resources
+                        ADD CONSTRAINT app_owned_resources_status_check
+                        CHECK (status IN ('owned', 'retained'));
+                END IF;
+            END
+            $$;
+
+            CREATE INDEX IF NOT EXISTS app_releases_app_registered_idx
+                ON app_releases(app_id, registered_at DESC);
+            CREATE INDEX IF NOT EXISTS vault_app_installations_vault_idx
+                ON vault_app_installations(vault_id, app_id);
+            CREATE INDEX IF NOT EXISTS installation_grants_latest_idx
+                ON installation_grants(installation_id, generation DESC);
+            CREATE INDEX IF NOT EXISTS app_owned_resources_installation_status_idx
+                ON app_owned_resources(installation_id, status, resource_kind);
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_registry_set_updated_at()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                NEW.updated_at = NOW();
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_definitions_set_updated_at
+                ON app_definitions;
+            CREATE TRIGGER app_definitions_set_updated_at
+                BEFORE UPDATE ON app_definitions
+                FOR EACH ROW EXECUTE FUNCTION akb_registry_set_updated_at();
+
+            DROP TRIGGER IF EXISTS vault_app_installations_set_updated_at
+                ON vault_app_installations;
+            CREATE TRIGGER vault_app_installations_set_updated_at
+                BEFORE UPDATE ON vault_app_installations
+                FOR EACH ROW EXECUTE FUNCTION akb_registry_set_updated_at();
+
+            DROP TRIGGER IF EXISTS app_owned_resources_set_updated_at
+                ON app_owned_resources;
+            CREATE TRIGGER app_owned_resources_set_updated_at
+                BEFORE UPDATE ON app_owned_resources
+                FOR EACH ROW EXECUTE FUNCTION akb_registry_set_updated_at();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_reject_release_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE EXCEPTION
+                    'registered app releases are immutable; register a new release'
+                    USING ERRCODE = '55000';
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_releases_immutable
+                ON app_releases;
+            CREATE TRIGGER app_releases_immutable
+                BEFORE UPDATE OR DELETE ON app_releases
+                FOR EACH ROW EXECUTE FUNCTION akb_reject_release_mutation();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_check_grant_generation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                advanced_id UUID;
+            BEGIN
+                IF NEW.status <> 'active' OR NEW.revoked_at IS NOT NULL THEN
+                    RAISE EXCEPTION
+                        'new installation grants must start active and not revoked'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                UPDATE vault_app_installations
+                   SET grant_generation = NEW.generation
+                 WHERE id = NEW.installation_id
+                   AND grant_generation + 1 = NEW.generation
+                RETURNING id INTO advanced_id;
+
+                IF advanced_id IS NULL THEN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM vault_app_installations
+                         WHERE id = NEW.installation_id
+                    ) THEN
+                        RAISE EXCEPTION 'installation does not exist'
+                            USING ERRCODE = '23503';
+                    END IF;
+                    RAISE EXCEPTION
+                        'grant generation must be the installation next generation'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS installation_grants_generation_guard
+                ON installation_grants;
+            CREATE TRIGGER installation_grants_generation_guard
+                BEFORE INSERT ON installation_grants
+                FOR EACH ROW EXECUTE FUNCTION akb_check_grant_generation();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_guard_grant_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION
+                        'installation grants are retained as immutable generations'
+                        USING ERRCODE = '55000';
+                END IF;
+
+                IF OLD.status = 'active'
+                   AND NEW.status = 'revoked'
+                   AND NEW.revoked_at IS NOT NULL
+                   AND NEW.installation_id = OLD.installation_id
+                   AND NEW.generation = OLD.generation
+                   AND NEW.capabilities = OLD.capabilities
+                   AND NEW.issuer = OLD.issuer
+                   AND NEW.provenance = OLD.provenance
+                   AND NEW.issued_at = OLD.issued_at
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                RAISE EXCEPTION
+                    'grant identity, capabilities, issuer, and provenance are immutable; only active to revoked is allowed'
+                    USING ERRCODE = '55000';
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS installation_grants_immutable
+                ON installation_grants;
+            CREATE TRIGGER installation_grants_immutable
+                BEFORE UPDATE OR DELETE ON installation_grants
+                FOR EACH ROW EXECUTE FUNCTION akb_guard_grant_mutation();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE VIEW app_installation_registry
+            WITH (security_invoker = true)
+            AS
+            SELECT
+                installation.id AS installation_id,
+                installation.app_id,
+                app.app_key,
+                installation.vault_id,
+                vault.name AS vault_name,
+                installation.lifecycle,
+                installation.blocked_reason,
+                installation.desired_release_id,
+                desired.version AS desired_version,
+                installation.current_release_id,
+                current_release.version AS current_version,
+                installation.grant_generation,
+                latest_grant.generation AS latest_grant_generation,
+                latest_grant.status AS latest_grant_status,
+                latest_grant.capabilities AS latest_grant_capabilities,
+                latest_grant.issuer AS latest_grant_issuer,
+                latest_grant.provenance AS latest_grant_provenance,
+                latest_grant.issued_at AS latest_grant_issued_at,
+                latest_grant.revoked_at AS latest_grant_revoked_at,
+                COALESCE(resources.items, '[]'::jsonb) AS resources,
+                installation.created_at,
+                installation.updated_at
+            FROM vault_app_installations AS installation
+            JOIN app_definitions AS app
+              ON app.id = installation.app_id
+            JOIN vaults AS vault
+              ON vault.id = installation.vault_id
+            LEFT JOIN app_releases AS desired
+              ON desired.id = installation.desired_release_id
+            LEFT JOIN app_releases AS current_release
+              ON current_release.id = installation.current_release_id
+            LEFT JOIN LATERAL (
+                SELECT
+                    grant_row.generation,
+                    grant_row.status,
+                    grant_row.capabilities,
+                    grant_row.issuer,
+                    grant_row.provenance,
+                    grant_row.issued_at,
+                    grant_row.revoked_at
+                FROM installation_grants AS grant_row
+                WHERE grant_row.installation_id = installation.id
+                ORDER BY grant_row.generation DESC
+                LIMIT 1
+            ) AS latest_grant ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'kind', resource.resource_kind,
+                        'key', resource.resource_key,
+                        'status', resource.status,
+                        'metadata', resource.metadata
+                    )
+                    ORDER BY resource.resource_kind, resource.resource_key
+                ) AS items
+                FROM app_owned_resources AS resource
+                WHERE resource.installation_id = installation.id
+            ) AS resources ON TRUE;
+            """
+        )
+
+        await conn.execute(
+            """
+            REVOKE ALL PRIVILEGES ON TABLE
+                app_definitions,
+                app_releases,
+                vault_app_installations,
+                installation_grants,
+                app_owned_resources,
+                app_installation_registry
+            FROM PUBLIC;
+
+            REVOKE EXECUTE ON FUNCTION akb_registry_set_updated_at()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_reject_release_mutation()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_check_grant_generation()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_grant_mutation()
+                FROM PUBLIC;
+            """
+        )
+
+    logger.info("Migration 046 added the app desired-state registry")
+
+
+async def _main():
+    from app.db.postgres import close_pool, init_db
+
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -215,6 +215,7 @@ async def _apply_migrations() -> None:
         "043_workspace_account_governance.py",  # users account status/kind + stable external OIDC identities
         "044_vault_write_policy.py",             # vault_write_policy + vault_write_grants: vault-grain token-allowlist substrate
         "045_vault_write_grant_actions.py",      # additive action limits; existing grants backfill to wildcard
+        "046_app_registry.py",                    # app definitions, immutable releases, installations, grants, and owned resources
     ):
         if filename in applied:
             continue

--- a/backend/tests/test_app_registry_migration_unit.py
+++ b/backend/tests/test_app_registry_migration_unit.py
@@ -1,0 +1,643 @@
+"""Live-PostgreSQL contract for the app desired-state registry migration."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import json
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATION = _BACKEND / "app" / "db" / "migrations" / "046_app_registry.py"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("app_registry_migration", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database(*, initialize: bool = True):
+    if not await _can_connect():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_registry_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    dsn = _database_dsn(name)
+    conn = await asyncpg.connect(dsn)
+    try:
+        if initialize:
+            await conn.execute(_INIT_SQL)
+        yield conn, dsn, name
+    finally:
+        await conn.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _apply(conn: asyncpg.Connection) -> None:
+    await _load_migration().migrate(conn=conn)
+
+
+async def _error_state(conn: asyncpg.Connection, sql: str, *args: object) -> str:
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await conn.execute(sql, *args)
+    assert exc.value.sqlstate is not None
+    return exc.value.sqlstate
+
+
+async def _app(conn: asyncpg.Connection, key: str) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO app_definitions (app_key, display_name) VALUES ($1, $2) RETURNING id",
+        key,
+        f"App {key}",
+    )
+
+
+async def _release(
+    conn: asyncpg.Connection,
+    app_id: uuid.UUID,
+    version: str,
+    *,
+    steps: list[dict[str, object]] | None = None,
+) -> uuid.UUID:
+    manifest = {"steps": steps or [{"id": "prepare"}, {"id": "apply"}]}
+    encoded = json.dumps(manifest, separators=(",", ":"))
+    checksum = hashlib.sha256(encoded.encode()).hexdigest()
+    return await conn.fetchval(
+        "INSERT INTO app_releases "
+        "(app_id, version, manifest, manifest_checksum) "
+        "VALUES ($1, $2, $3::jsonb, $4) RETURNING id",
+        app_id,
+        version,
+        encoded,
+        checksum,
+    )
+
+
+async def _vault(conn: asyncpg.Connection, name: str) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+        name,
+        f"/tmp/{name}.git",
+    )
+
+
+async def _installation(
+    conn: asyncpg.Connection,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    release_id: uuid.UUID,
+) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO vault_app_installations "
+        "(app_id, vault_id, desired_release_id, current_release_id, lifecycle) "
+        "VALUES ($1, $2, $3, $3, 'active') RETURNING id",
+        app_id,
+        vault_id,
+        release_id,
+    )
+
+
+async def test_fresh_apply_second_apply_and_compatible_partial_object():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_id = await _app(conn, f"idempotent-{uuid.uuid4().hex}")
+        before_objects = await conn.fetch(
+            """
+            SELECT relkind, count(*) AS count
+              FROM pg_class
+             WHERE relnamespace = 'public'::regnamespace
+               AND (
+                 relname LIKE 'app_%'
+                 OR relname LIKE 'vault_app_%'
+                 OR relname LIKE 'installation_%'
+               )
+             GROUP BY relkind
+             ORDER BY relkind
+            """
+        )
+        before_constraints = await conn.fetchval(
+            """
+            SELECT count(*)
+              FROM pg_constraint
+             WHERE conrelid IN (
+                 'app_definitions'::regclass,
+                 'app_releases'::regclass,
+                 'vault_app_installations'::regclass,
+                 'installation_grants'::regclass,
+                 'app_owned_resources'::regclass
+             )
+            """
+        )
+        before_row = await conn.fetchrow("SELECT * FROM app_definitions WHERE id = $1", app_id)
+
+        await _apply(conn)
+
+        assert (
+            await conn.fetch(
+                """
+            SELECT relkind, count(*) AS count
+              FROM pg_class
+             WHERE relnamespace = 'public'::regnamespace
+               AND (
+                 relname LIKE 'app_%'
+                 OR relname LIKE 'vault_app_%'
+                 OR relname LIKE 'installation_%'
+               )
+             GROUP BY relkind
+             ORDER BY relkind
+            """
+            )
+            == before_objects
+        )
+        assert (
+            await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM pg_constraint
+                 WHERE conrelid IN (
+                     'app_definitions'::regclass,
+                     'app_releases'::regclass,
+                     'vault_app_installations'::regclass,
+                     'installation_grants'::regclass,
+                     'app_owned_resources'::regclass
+                 )
+                """
+            )
+            == before_constraints
+        )
+        assert await conn.fetchrow("SELECT * FROM app_definitions WHERE id = $1", app_id) == before_row
+
+    async with _fresh_database() as (conn, _, _):
+        await conn.execute(
+            """
+            CREATE TABLE app_definitions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_key TEXT NOT NULL
+            )
+            """
+        )
+        preserved = await conn.fetchval(
+            "INSERT INTO app_definitions (app_key) VALUES ($1) RETURNING id",
+            f"partial-{uuid.uuid4().hex}",
+        )
+
+        await _apply(conn)
+
+        row = await conn.fetchrow("SELECT app_key, metadata FROM app_definitions WHERE id = $1", preserved)
+        assert row is not None
+        assert row["app_key"].startswith("partial-")
+        assert row["metadata"] == "{}"
+
+
+async def test_app_release_ownership_duplicate_installation_and_lifecycle_coherence():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_a = await _app(conn, f"app-a-{uuid.uuid4().hex}")
+        app_b = await _app(conn, f"app-b-{uuid.uuid4().hex}")
+        a1 = await _release(conn, app_a, "1.0.0")
+        a2 = await _release(conn, app_a, "2.0.0")
+        b1 = await _release(conn, app_b, "1.0.0")
+        vault_a = await _vault(conn, f"vault-a-{uuid.uuid4().hex[:10]}")
+        vault_b = await _vault(conn, f"vault-b-{uuid.uuid4().hex[:10]}")
+
+        assert (
+            await _error_state(
+                conn,
+                "INSERT INTO vault_app_installations "
+                "(app_id, vault_id, desired_release_id, current_release_id, lifecycle) "
+                "VALUES ($1, $2, $3, NULL, 'active')",
+                app_a,
+                vault_a,
+                a1,
+            )
+            == "23514"
+        )
+        installation_a = await _installation(conn, app_a, vault_a, a1)
+        assert (
+            await _error_state(
+                conn,
+                "INSERT INTO vault_app_installations "
+                "(app_id, vault_id, desired_release_id, current_release_id, lifecycle) "
+                "VALUES ($1, $2, $3, $3, 'active')",
+                app_a,
+                vault_a,
+                a1,
+            )
+            == "23505"
+        )
+
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE vault_app_installations "
+                "SET desired_release_id = $2, current_release_id = $2, lifecycle = 'active' "
+                "WHERE id = $1",
+                installation_a,
+                b1,
+            )
+            == "23503"
+        )
+        assert (
+            await _error_state(
+                conn,
+                "INSERT INTO vault_app_installations "
+                "(app_id, vault_id, desired_release_id, current_release_id, lifecycle) "
+                "VALUES ($1, $2, $3, $3, 'active')",
+                app_b,
+                vault_b,
+                a1,
+            )
+            == "23503"
+        )
+
+        await conn.execute(
+            "UPDATE vault_app_installations "
+            "SET desired_release_id = $2, current_release_id = $3, lifecycle = 'upgrading' "
+            "WHERE id = $1",
+            installation_a,
+            a2,
+            a1,
+        )
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE vault_app_installations "
+                "SET desired_release_id = current_release_id, lifecycle = 'upgrading' "
+                "WHERE id = $1",
+                installation_a,
+            )
+            == "23514"
+        )
+        await conn.execute(
+            "UPDATE vault_app_installations "
+            "SET desired_release_id = $2, current_release_id = $2, lifecycle = 'active' "
+            "WHERE id = $1",
+            installation_a,
+            a2,
+        )
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE vault_app_installations SET lifecycle = 'uninstalled' WHERE id = $1",
+                installation_a,
+            )
+            == "23514"
+        )
+        await conn.execute(
+            "UPDATE vault_app_installations SET desired_release_id = NULL, lifecycle = 'uninstalled' WHERE id = $1",
+            installation_a,
+        )
+
+
+async def test_release_rows_are_immutable_including_manifest_order_and_checksum():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_a = await _app(conn, f"release-a-{uuid.uuid4().hex}")
+        app_b = await _app(conn, f"release-b-{uuid.uuid4().hex}")
+        release_id = await _release(
+            conn,
+            app_a,
+            "1.2.3",
+            steps=[{"id": "first"}, {"id": "second"}],
+        )
+        before = await conn.fetchrow(
+            "SELECT app_id, version, manifest, manifest_checksum, registered_at FROM app_releases WHERE id = $1",
+            release_id,
+        )
+
+        mutations = (
+            ("UPDATE app_releases SET app_id = $2 WHERE id = $1", app_b),
+            ("UPDATE app_releases SET version = '9.9.9' WHERE id = $1", None),
+            (
+                'UPDATE app_releases SET manifest = \'{"steps":[{"id":"changed"}]}\'::jsonb WHERE id = $1',
+                None,
+            ),
+            (
+                "UPDATE app_releases "
+                'SET manifest = \'{"steps":[{"id":"second"},{"id":"first"}]}\'::jsonb '
+                "WHERE id = $1",
+                None,
+            ),
+            (
+                "UPDATE app_releases SET manifest_checksum = repeat('0', 64) WHERE id = $1",
+                None,
+            ),
+        )
+        for sql, extra in mutations:
+            args = (release_id, extra) if extra is not None else (release_id,)
+            assert await _error_state(conn, sql, *args) == "55000"
+        assert await _error_state(conn, "DELETE FROM app_releases WHERE id = $1", release_id) == "55000"
+        assert (
+            await conn.fetchrow(
+                "SELECT app_id, version, manifest, manifest_checksum, registered_at FROM app_releases WHERE id = $1",
+                release_id,
+            )
+            == before
+        )
+
+
+async def test_grant_generation_rejects_stale_skipped_duplicate_and_racing_writers():
+    async with _fresh_database() as (conn, dsn, _):
+        await _apply(conn)
+        app_id = await _app(conn, f"generation-{uuid.uuid4().hex}")
+        release_id = await _release(conn, app_id, "1.0.0")
+        vault_id = await _vault(conn, f"generation-{uuid.uuid4().hex[:10]}")
+        installation_id = await _installation(conn, app_id, vault_id, release_id)
+        insert_sql = (
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer, provenance) "
+            "VALUES ($1, $2, $3::text[], $4, $5::jsonb)"
+        )
+        await conn.execute(
+            insert_sql,
+            installation_id,
+            1,
+            ["schema.read"],
+            "operator",
+            '{"source":"test"}',
+        )
+        assert (
+            await _error_state(
+                conn,
+                insert_sql,
+                installation_id,
+                1,
+                ["schema.read"],
+                "operator",
+                '{"source":"test"}',
+            )
+            == "23514"
+        )
+        assert (
+            await _error_state(
+                conn,
+                insert_sql,
+                installation_id,
+                3,
+                ["schema.read"],
+                "operator",
+                '{"source":"test"}',
+            )
+            == "23514"
+        )
+
+        async def race(generation: int) -> list[str]:
+            async def attempt() -> str:
+                contender = await asyncpg.connect(dsn)
+                try:
+                    await contender.execute(
+                        insert_sql,
+                        installation_id,
+                        generation,
+                        ["schema.read"],
+                        "operator",
+                        '{"source":"race"}',
+                    )
+                    return "ok"
+                except asyncpg.PostgresError as exc:
+                    return exc.sqlstate or "unknown"
+                finally:
+                    await contender.close()
+
+            return await asyncio.gather(attempt(), attempt())
+
+        for next_generation in (2, 3):
+            await conn.execute(
+                "UPDATE installation_grants "
+                "SET status = 'revoked', revoked_at = NOW() "
+                "WHERE installation_id = $1 AND status = 'active'",
+                installation_id,
+            )
+            results = await race(next_generation)
+            assert results.count("ok") == 1
+            assert results.count("23514") == 1
+
+        rows = await conn.fetch(
+            "SELECT generation, status FROM installation_grants WHERE installation_id = $1 ORDER BY generation",
+            installation_id,
+        )
+        assert [row["generation"] for row in rows] == [1, 2, 3]
+        assert sum(row["status"] == "active" for row in rows) == 1
+
+
+async def test_grant_capability_and_issuer_are_immutable_and_revoke_is_one_way():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_id = await _app(conn, f"grant-{uuid.uuid4().hex}")
+        release_id = await _release(conn, app_id, "1.0.0")
+        vault_id = await _vault(conn, f"grant-{uuid.uuid4().hex[:10]}")
+        installation_id = await _installation(conn, app_id, vault_id, release_id)
+        grant_id = await conn.fetchval(
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer, provenance) "
+            "VALUES ($1, 1, ARRAY['schema.read'], 'operator', "
+            '\'{"source":"manual"}\'::jsonb) RETURNING id',
+            installation_id,
+        )
+        before = await conn.fetchrow(
+            "SELECT capabilities, issuer, provenance FROM installation_grants WHERE id = $1",
+            grant_id,
+        )
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE installation_grants SET capabilities = ARRAY['schema.write'] WHERE id = $1",
+                grant_id,
+            )
+            == "55000"
+        )
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE installation_grants SET issuer = 'platform' WHERE id = $1",
+                grant_id,
+            )
+            == "55000"
+        )
+        assert (
+            await _error_state(
+                conn,
+                'UPDATE installation_grants SET provenance = \'{"source":"other"}\'::jsonb WHERE id = $1',
+                grant_id,
+            )
+            == "55000"
+        )
+        assert (
+            await conn.fetchrow(
+                "SELECT capabilities, issuer, provenance FROM installation_grants WHERE id = $1",
+                grant_id,
+            )
+            == before
+        )
+
+        await conn.execute(
+            "UPDATE installation_grants SET status = 'revoked', revoked_at = NOW() WHERE id = $1",
+            grant_id,
+        )
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE installation_grants SET status = 'active', revoked_at = NULL WHERE id = $1",
+                grant_id,
+            )
+            == "55000"
+        )
+        await conn.execute(
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer, provenance) "
+            "VALUES ($1, 2, ARRAY['schema.write'], 'platform', "
+            '\'{"source":"restore"}\'::jsonb)',
+            installation_id,
+        )
+
+
+async def test_uninstall_retains_owned_resources_and_registry_view_is_complete():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_id = await _app(conn, f"resources-{uuid.uuid4().hex}")
+        release_id = await _release(conn, app_id, "1.0.0")
+        vault_id = await _vault(conn, f"resources-{uuid.uuid4().hex[:10]}")
+        other_vault_id = await _vault(conn, f"other-{uuid.uuid4().hex[:10]}")
+        installation_id = await _installation(conn, app_id, vault_id, release_id)
+        await _installation(conn, app_id, other_vault_id, release_id)
+        await conn.execute(
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer, provenance) "
+            "VALUES ($1, 1, ARRAY['schema.read','schema.write'], 'operator', "
+            '\'{"source":"install"}\'::jsonb)',
+            installation_id,
+        )
+        await conn.executemany(
+            "INSERT INTO app_owned_resources (installation_id, resource_kind, resource_key) VALUES ($1, $2, $3)",
+            [
+                (installation_id, "table", "orders"),
+                (installation_id, "index", "orders_created_at_idx"),
+            ],
+        )
+        await conn.execute(
+            "UPDATE vault_app_installations SET desired_release_id = NULL, lifecycle = 'uninstalled' WHERE id = $1",
+            installation_id,
+        )
+        await conn.execute(
+            "UPDATE app_owned_resources SET status = 'retained' WHERE installation_id = $1",
+            installation_id,
+        )
+
+        rows = await conn.fetch(
+            "SELECT * FROM app_installation_registry WHERE installation_id = $1",
+            installation_id,
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        resources = json.loads(row["resources"])
+        assert row["app_id"] == app_id
+        assert row["vault_id"] == vault_id
+        assert row["lifecycle"] == "uninstalled"
+        assert row["desired_release_id"] is None
+        assert row["current_release_id"] == release_id
+        assert row["latest_grant_generation"] == 1
+        assert row["latest_grant_status"] == "active"
+        assert row["latest_grant_capabilities"] == ["schema.read", "schema.write"]
+        assert {(r["kind"], r["key"], r["status"]) for r in resources} == {
+            ("table", "orders", "retained"),
+            ("index", "orders_created_at_idx", "retained"),
+        }
+
+
+async def test_existing_data_is_unchanged_and_ordinary_role_gets_no_registry_access():
+    async with _fresh_database() as (conn, _, name):
+        user_id = await conn.fetchval(
+            "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, 'sentinel-hash') RETURNING id",
+            f"user-{uuid.uuid4().hex}",
+            f"{uuid.uuid4().hex}@example.invalid",
+        )
+        vault_id = await _vault(conn, f"sentinel-{uuid.uuid4().hex[:10]}")
+        token_id = await conn.fetchval(
+            "INSERT INTO tokens "
+            "(user_id, name, token_hash, token_prefix) "
+            "VALUES ($1, 'sentinel', $2, 'akb_test') RETURNING id",
+            user_id,
+            uuid.uuid4().hex,
+        )
+        table_id = await conn.fetchval(
+            "INSERT INTO vault_tables (vault_id, name, columns) VALUES ($1, 'sentinel', '[]'::jsonb) RETURNING id",
+            vault_id,
+        )
+        row_id = await conn.fetchval(
+            "INSERT INTO vault_table_rows (table_id, data) VALUES ($1, '{\"preserved\":true}'::jsonb) RETURNING id",
+            table_id,
+        )
+        before = await conn.fetchrow(
+            """
+            SELECT
+              (SELECT row_to_json(u) FROM users u WHERE id = $1) AS user_row,
+              (SELECT row_to_json(v) FROM vaults v WHERE id = $2) AS vault_row,
+              (SELECT row_to_json(t) FROM tokens t WHERE id = $3) AS token_row,
+              (SELECT row_to_json(r) FROM vault_table_rows r WHERE id = $4) AS data_row
+            """,
+            user_id,
+            vault_id,
+            token_id,
+            row_id,
+        )
+
+        await _apply(conn)
+
+        after = await conn.fetchrow(
+            """
+            SELECT
+              (SELECT row_to_json(u) FROM users u WHERE id = $1) AS user_row,
+              (SELECT row_to_json(v) FROM vaults v WHERE id = $2) AS vault_row,
+              (SELECT row_to_json(t) FROM tokens t WHERE id = $3) AS token_row,
+              (SELECT row_to_json(r) FROM vault_table_rows r WHERE id = $4) AS data_row
+            """,
+            user_id,
+            vault_id,
+            token_id,
+            row_id,
+        )
+        assert after == before
+
+        role = f"akb_registry_probe_{uuid.uuid4().hex[:12]}"
+        await conn.execute(f'CREATE ROLE "{role}" NOLOGIN')
+        await conn.execute(f'GRANT CONNECT ON DATABASE "{name}" TO "{role}"')
+        await conn.execute(f'GRANT USAGE ON SCHEMA public TO "{role}"')
+        await conn.execute(f'SET ROLE "{role}"')
+        try:
+            assert await _error_state(conn, "SELECT count(*) FROM app_definitions") == "42501"
+            assert await _error_state(conn, "SELECT count(*) FROM app_installation_registry") == "42501"
+        finally:
+            await conn.execute("RESET ROLE")

--- a/backend/tests/test_app_registry_migration_unit.py
+++ b/backend/tests/test_app_registry_migration_unit.py
@@ -130,6 +130,24 @@ async def _installation(
     )
 
 
+async def _resource(
+    conn: asyncpg.Connection,
+    installation_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    kind: str,
+    key: str,
+) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO app_owned_resources "
+        "(installation_id, vault_id, resource_kind, resource_key) "
+        "VALUES ($1, $2, $3, $4) RETURNING id",
+        installation_id,
+        vault_id,
+        kind,
+        key,
+    )
+
+
 async def test_fresh_apply_second_apply_and_compatible_partial_object():
     async with _fresh_database() as (conn, _, _):
         await _apply(conn)
@@ -575,6 +593,372 @@ async def test_uninstall_retains_owned_resources_and_registry_view_is_complete()
             ("table", "orders", "retained"),
             ("index", "orders_created_at_idx", "retained"),
         }
+
+
+async def test_resource_identity_is_unique_within_a_vault_but_reusable_across_vaults():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_a = await _app(conn, f"owner-a-{uuid.uuid4().hex}")
+        app_b = await _app(conn, f"owner-b-{uuid.uuid4().hex}")
+        release_a = await _release(conn, app_a, "1.0.0")
+        release_b = await _release(conn, app_b, "1.0.0")
+        vault_a = await _vault(conn, f"owner-a-{uuid.uuid4().hex[:10]}")
+        vault_b = await _vault(conn, f"owner-b-{uuid.uuid4().hex[:10]}")
+        installation_a = await _installation(conn, app_a, vault_a, release_a)
+        installation_b = await _installation(conn, app_b, vault_a, release_b)
+        installation_other_vault = await _installation(conn, app_b, vault_b, release_b)
+
+        await _resource(conn, installation_a, vault_a, "table", "reef_issues")
+        assert (
+            await _error_state(
+                conn,
+                "INSERT INTO app_owned_resources "
+                "(installation_id, vault_id, resource_kind, resource_key) "
+                "VALUES ($1, $2, 'table', 'reef_issues')",
+                installation_b,
+                vault_a,
+            )
+            == "23505"
+        )
+        await _resource(
+            conn,
+            installation_other_vault,
+            vault_b,
+            "table",
+            "reef_issues",
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM app_owned_resources "
+                "WHERE resource_kind = 'table' AND resource_key = 'reef_issues'"
+            )
+            == 2
+        )
+
+
+async def test_upgrade_from_previous_registry_shape_preserves_registry_rows():
+    async with _fresh_database() as (conn, _, _):
+        await conn.execute(
+            """
+            CREATE TABLE app_definitions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_key TEXT NOT NULL,
+                display_name TEXT,
+                description TEXT,
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            CREATE TABLE app_releases (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_id UUID NOT NULL,
+                version TEXT NOT NULL,
+                manifest JSONB NOT NULL,
+                manifest_checksum TEXT NOT NULL,
+                registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            CREATE TABLE vault_app_installations (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_id UUID NOT NULL,
+                vault_id UUID NOT NULL,
+                desired_release_id UUID,
+                current_release_id UUID,
+                lifecycle TEXT NOT NULL,
+                blocked_reason TEXT,
+                grant_generation BIGINT NOT NULL DEFAULT 0,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            CREATE TABLE installation_grants (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                installation_id UUID NOT NULL,
+                generation BIGINT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                capabilities TEXT[] NOT NULL,
+                issuer TEXT NOT NULL,
+                provenance JSONB NOT NULL DEFAULT '{}'::jsonb,
+                issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                revoked_at TIMESTAMPTZ
+            );
+            CREATE TABLE app_owned_resources (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                installation_id UUID NOT NULL,
+                resource_kind TEXT NOT NULL,
+                resource_key TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'owned',
+                metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            """
+        )
+        app_id = await _app(conn, f"upgrade-{uuid.uuid4().hex}")
+        release_id = await _release(conn, app_id, "1.0.0")
+        vault_id = await _vault(conn, f"upgrade-{uuid.uuid4().hex[:10]}")
+        installation_id = await conn.fetchval(
+            "INSERT INTO vault_app_installations "
+            "(app_id, vault_id, desired_release_id, current_release_id, lifecycle, grant_generation) "
+            "VALUES ($1, $2, $3, $3, 'active', 1) RETURNING id",
+            app_id,
+            vault_id,
+            release_id,
+        )
+        grant_id = await conn.fetchval(
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer) "
+            "VALUES ($1, 1, ARRAY['schema.read'], 'operator') RETURNING id",
+            installation_id,
+        )
+        resource_id = await conn.fetchval(
+            "INSERT INTO app_owned_resources "
+            "(installation_id, resource_kind, resource_key, metadata) "
+            "VALUES ($1, 'table', 'reef_issues', '{\"source\":\"previous\"}'::jsonb) "
+            "RETURNING id",
+            installation_id,
+        )
+
+        await _apply(conn)
+        after_first = await conn.fetchrow(
+            """
+            SELECT
+              (SELECT row_to_json(a) FROM app_definitions a WHERE id = $1) AS app,
+              (SELECT row_to_json(r) FROM app_releases r WHERE id = $2) AS release,
+              (SELECT row_to_json(i) FROM vault_app_installations i WHERE id = $3) AS installation,
+              (SELECT row_to_json(g) FROM installation_grants g WHERE id = $4) AS grant,
+              (SELECT row_to_json(o) FROM app_owned_resources o WHERE id = $5) AS resource
+            """,
+            app_id,
+            release_id,
+            installation_id,
+            grant_id,
+            resource_id,
+        )
+        assert json.loads(after_first["resource"])["vault_id"] == str(vault_id)
+
+        await _apply(conn)
+        after_second = await conn.fetchrow(
+            """
+            SELECT
+              (SELECT row_to_json(a) FROM app_definitions a WHERE id = $1) AS app,
+              (SELECT row_to_json(r) FROM app_releases r WHERE id = $2) AS release,
+              (SELECT row_to_json(i) FROM vault_app_installations i WHERE id = $3) AS installation,
+              (SELECT row_to_json(g) FROM installation_grants g WHERE id = $4) AS grant,
+              (SELECT row_to_json(o) FROM app_owned_resources o WHERE id = $5) AS resource
+            """,
+            app_id,
+            release_id,
+            installation_id,
+            grant_id,
+            resource_id,
+        )
+        assert after_second == after_first
+
+
+async def test_registry_identities_are_immutable_but_mutable_fields_still_update():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_a_key = f"identity-a-{uuid.uuid4().hex}"
+        app_a = await _app(conn, app_a_key)
+        app_b = await _app(conn, f"identity-b-{uuid.uuid4().hex}")
+        release_a = await _release(conn, app_a, "1.0.0")
+        vault_a = await _vault(conn, f"identity-a-{uuid.uuid4().hex[:10]}")
+        vault_b = await _vault(conn, f"identity-b-{uuid.uuid4().hex[:10]}")
+        installation_id = await _installation(conn, app_a, vault_a, release_a)
+        resource_id = await _resource(
+            conn,
+            installation_id,
+            vault_a,
+            "table",
+            "reef_issues",
+        )
+
+        assert (
+            await _error_state(
+                conn,
+                "UPDATE app_definitions SET app_key = $2 WHERE id = $1",
+                app_a,
+                f"renamed-{uuid.uuid4().hex}",
+            )
+            == "55000"
+        )
+        await conn.execute(
+            "UPDATE app_definitions "
+            "SET display_name = 'Updated', metadata = '{\"reviewed\":true}'::jsonb "
+            "WHERE id = $1",
+            app_a,
+        )
+
+        for column, value in (("app_id", app_b), ("vault_id", vault_b)):
+            assert (
+                await _error_state(
+                    conn,
+                    f"UPDATE vault_app_installations SET {column} = $2 WHERE id = $1",
+                    installation_id,
+                    value,
+                )
+                == "55000"
+            )
+        await conn.execute(
+            "UPDATE vault_app_installations SET desired_release_id = NULL, lifecycle = 'uninstalled' WHERE id = $1",
+            installation_id,
+        )
+
+        identity_mutations = (
+            ("installation_id", uuid.uuid4()),
+            ("vault_id", vault_b),
+            ("resource_kind", "document"),
+            ("resource_key", "other"),
+        )
+        for column, value in identity_mutations:
+            assert (
+                await _error_state(
+                    conn,
+                    f"UPDATE app_owned_resources SET {column} = $2 WHERE id = $1",
+                    resource_id,
+                    value,
+                )
+                == "55000"
+            )
+        await conn.execute(
+            "UPDATE app_owned_resources "
+            "SET status = 'retained', metadata = '{\"reason\":\"uninstall\"}'::jsonb "
+            "WHERE id = $1",
+            resource_id,
+        )
+
+        app_row = await conn.fetchrow(
+            "SELECT app_key, display_name, metadata FROM app_definitions WHERE id = $1",
+            app_a,
+        )
+        assert app_row is not None
+        assert app_row["app_key"] == app_a_key
+        assert app_row["display_name"] == "Updated"
+        assert json.loads(app_row["metadata"]) == {"reviewed": True}
+        assert (
+            await conn.fetchval(
+                "SELECT lifecycle FROM vault_app_installations WHERE id = $1",
+                installation_id,
+            )
+            == "uninstalled"
+        )
+        resource = await conn.fetchrow(
+            "SELECT installation_id, vault_id, resource_kind, resource_key, status, metadata "
+            "FROM app_owned_resources WHERE id = $1",
+            resource_id,
+        )
+        assert resource is not None
+        assert (
+            resource["installation_id"],
+            resource["vault_id"],
+            resource["resource_kind"],
+            resource["resource_key"],
+        ) == (installation_id, vault_a, "table", "reef_issues")
+        assert resource["status"] == "retained"
+        assert json.loads(resource["metadata"]) == {"reason": "uninstall"}
+
+
+async def test_vault_delete_cascades_only_its_registry_state_and_direct_deletes_fail():
+    async with _fresh_database() as (conn, _, _):
+        await _apply(conn)
+        app_id = await _app(conn, f"delete-{uuid.uuid4().hex}")
+        release_id = await _release(conn, app_id, "1.0.0")
+        target_vault = await _vault(conn, f"delete-target-{uuid.uuid4().hex[:10]}")
+        other_vault = await _vault(conn, f"delete-other-{uuid.uuid4().hex[:10]}")
+        target_installation = await _installation(
+            conn,
+            app_id,
+            target_vault,
+            release_id,
+        )
+        other_installation = await _installation(
+            conn,
+            app_id,
+            other_vault,
+            release_id,
+        )
+        grant_id = await conn.fetchval(
+            "INSERT INTO installation_grants "
+            "(installation_id, generation, capabilities, issuer) "
+            "VALUES ($1, 1, ARRAY['schema.write'], 'operator') RETURNING id",
+            target_installation,
+        )
+        resource_id = await _resource(
+            conn,
+            target_installation,
+            target_vault,
+            "table",
+            "reef_issues",
+        )
+
+        assert (
+            await _error_state(
+                conn,
+                "DELETE FROM installation_grants WHERE id = $1",
+                grant_id,
+            )
+            == "55000"
+        )
+        assert (
+            await _error_state(
+                conn,
+                "DELETE FROM app_owned_resources WHERE id = $1",
+                resource_id,
+            )
+            == "55000"
+        )
+        assert (
+            await _error_state(
+                conn,
+                "DELETE FROM vault_app_installations WHERE id = $1",
+                target_installation,
+            )
+            == "55000"
+        )
+
+        await conn.execute("DELETE FROM vaults WHERE id = $1", target_vault)
+
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM vault_app_installations WHERE vault_id = $1",
+                target_vault,
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM installation_grants WHERE installation_id = $1",
+                target_installation,
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM app_owned_resources WHERE vault_id = $1",
+                target_vault,
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM vault_app_installations WHERE id = $1",
+                other_installation,
+            )
+            == 1
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM app_definitions WHERE id = $1",
+                app_id,
+            )
+            == 1
+        )
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM app_releases WHERE id = $1",
+                release_id,
+            )
+            == 1
+        )
 
 
 async def test_existing_data_is_unchanged_and_ordinary_role_gets_no_registry_access():


### PR DESCRIPTION
## Summary

- add the app desired-state registry for definitions, immutable releases, per-Vault installations, grants, and owned/retained resources
- enforce one owner per physical Vault resource, immutable registry identities, and Vault-delete-only registry cleanup
- preserve same-app release ownership, lifecycle/release coherence, immutable release/grant history, serialized grant generations, and ordinary Vault SQL isolation
- integrate after the tool-usage schema on current `main`, keeping both migrations and both live PostgreSQL test lanes active

## Persistence contract — review carefully

This additive migration does not rewrite existing users, Vaults, tokens, documents, or Vault table data. It does establish a durable control-plane persistence contract: app keys, app/Vault installation identity, release history, grant generations, physical-resource ownership, uninstall retention, and permanent Vault cleanup become database invariants. Once lifecycle and reconciliation writers depend on them, changing these rules requires a coordinated data migration rather than an ordinary application refactor.

### Corrected registry integrity

- A physical `(vault_id, resource_kind, resource_key)` has at most one installation owner. The same kind/key remains reusable in a different Vault.
- `app_key`, installation `app_id`/`vault_id`, and owned-resource installation/Vault/kind/key are immutable. Display fields, metadata, lifecycle state, and owned/retained status remain mutable within their existing checks.
- Direct installation, grant, and owned-resource deletion is rejected so uninstall remains an auditable lifecycle/retention transition. Permanently deleting a Vault cascades only that Vault's installation, grant, and resource registry rows; reusable app definitions and releases survive.
- Existing rows from the earlier proposed registry shape are upgraded in place: resource Vault identity is derived from its installation before the new uniqueness and foreign-key contract is installed.

### Representative workload fit

A representative managed app with versioned dynamic tables and fixed supporting documents can be expressed as a reusable app release manifest whose per-Vault installations own those physical resources. This PR supplies only the registry integrity needed for that model. Manifest and catalog authoring, lifecycle commands, observed inventory and checkpoints, brownfield adoption, reconciliation and rollout, credentials, and workload identity remain follow-up work outside this PR. Data-plane authorization continues to use the existing session and PAT boundaries.

### Security and migration boundary

Registry tables, the read view, and trigger functions revoke `PUBLIC` access. The view uses `security_invoker`, so ordinary per-user/per-Vault SQL roles gain no registry visibility. Migration 047 remains transaction-wrapped and idempotent on fresh databases and on the earlier proposed registry shape; current `main`'s tool-usage migration remains migration 046 and runs first.

The upgrade backfills `app_owned_resources.vault_id` and then installs uniqueness and cascade constraints. An already-populated pre-release registry containing conflicting same-Vault physical ownership would cause the migration to fail rather than silently reassign ownership; operators must resolve such invalid data before retrying. There is intentionally no destructive downgrade.

## Verification

Exact reviewed head: `83e79c429cae642f28eb2edf479cc7cdde694273`

- focused live PostgreSQL registry, migration-registration, and tool-usage suite — 23 passed
- full backend suite with PostgreSQL 16 — 1047 passed, 2 skipped, 18 deselected
- `PATH="$PWD/backend/.venv/bin:$PATH" bash scripts/check.sh` — passed
- branch-aware autoreview over `origin/main...HEAD` — clean, including TruffleHog

## Independent validation

Fresh independent PostgreSQL 16 validation passed at the exact reviewed head. It confirmed fresh, prepared, and compatible-partial application and reapplication of migration 047 without changing existing sentinel facts; same-app ownership and bidirectional cross-app rejection; duplicate-installation and lifecycle coherence; immutable releases, grants, and stable registry identities; serialized grant generations across two concurrency races; uninstall retention and complete registry reads; ordinary-role denial across registry tables, views, and functions; same-Vault resource ownership exclusion with cross-Vault reuse; Vault-scoped permanent-delete cleanup while reusable app and release state survives; and compatible partial-object upgrade preservation. No observable failures or blockers were found.

## Scope

This PR remains additive schema substrate only. It does not add REST/OpenAPI/SDK/frontend behavior, credential or token exchange, policy enforcement, lifecycle command APIs, inventory APIs, reconciliation/rollout, legacy adoption, or workload identity.