### PR TITLE
chore: refresh detect-secrets baseline after the 0.11.0 changelog entry

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3134
+        "line_number": 3194
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-24T07:43:05Z"
+  "generated_at": "2026-07-29T06:11:05Z"
 }


### PR DESCRIPTION
The static-analysis gate runs `detect-secrets-hook` over tracked files and exits non-zero when a recorded finding's `line_number` no longer matches the file. The 0.11.0 release section (#317) added 60 lines above the existing `backend/CHANGELOG.md` entry, shifting it from 3134 to 3194 and leaving `main` red.

No new or removed findings — the baseline still holds 653 entries, and the diff is the shifted line number plus `generated_at`:

```
-        "line_number": 3134
+        "line_number": 3194
-  "generated_at": "2026-07-24T07:43:05Z"
+  "generated_at": "2026-07-29T06:11:05Z"
```

Refreshed through the hook rather than `detect-secrets scan`, which would drop the pnpm-lock entries the check deliberately excludes from scanning.