### PR TITLE
feat(tables): opt-in idempotent create — akb_create_table(if_not_exists=true)

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -107,4 +107,5 @@ jobs:
           tests/concurrency/test_alter_unique_race_unit.py
           tests/test_file_idempotent_upload_unit.py
           tests/test_tool_usage_e2e.py
+          tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1147,
         "is_secret": false
       }
     ],
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T04:27:08Z"
+  "generated_at": "2026-08-03T05:27:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1147,
         "is_secret": false
       }
     ],
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T06:11:05Z"
+  "generated_at": "2026-07-29T18:16:15Z"
 }

--- a/backend/app/api/routes/tables.py
+++ b/backend/app/api/routes/tables.py
@@ -8,7 +8,7 @@ from pydantic_core import to_json
 
 from app.api.deps import get_current_user
 from app.services.access_service import check_vault_access
-from app.services.auth_service import AuthenticatedUser
+from app.services.auth_service import AuthenticatedUser, token_has_scope
 from app.services import (
     table_migration_service,
     table_row_query,
@@ -113,6 +113,14 @@ class CreateTableRequest(NFCModel):
     # from the service map to 422/409 via the global AKBError handler.
     unique_keys: list[TableUniqueKeySpec] | None = None
     indexes: list[TableIndexSpec] | None = None
+    # Opt-in idempotent create: an existing table is reported as
+    # created=false instead of raising 409. The STORED schema and the
+    # matches_request/mismatches divergence report accompany it only for a
+    # caller that also holds READ access to the vault. Only a
+    # same-vault (vault, name) row is suppressed — cross-vault physical-name
+    # fusion still conflicts, because reporting it as a no-op would disclose
+    # another tenant's schema.
+    if_not_exists: bool = False
 
 
 class AlterTableRequest(NFCModel):
@@ -258,6 +266,29 @@ class TableQueryResponse(NFCModel):
     total: int
 
 
+async def _can_read_vault(user: AuthenticatedUser, vault: str) -> bool:
+    """READ authority on `vault` for this credential — see the MCP twin in
+    `mcp_server/server.py`. Fail-closed: this gates a projection, never an
+    action, so refusing it can only under-disclose.
+
+    BOTH scope systems must be consulted. `token_has_scope(None, ...)` is
+    True by design — `None` means an unscoped credential, i.e. a JWT login.
+    But an OAuth credential ALSO carries `token_scopes=None` and keeps its
+    grants in `oauth_scopes`, so checking only the former waves through an
+    OAuth token holding nothing but `akb:vault:write`.
+    """
+    oauth = getattr(user, "oauth_scopes", None)
+    if oauth is not None and "akb:vault:read" not in oauth:
+        return False
+    if not token_has_scope(getattr(user, "token_scopes", None), "read"):
+        return False
+    try:
+        await check_vault_access(user.user_id, vault, required_role="reader")
+    except Exception:  # noqa: BLE001 — any failure means "no read authority"
+        return False
+    return True
+
+
 @router.post("/tables/{vault}", summary="Create a table in a vault")
 async def create_table(vault: str, req: CreateTableRequest, user: AuthenticatedUser = Depends(get_current_user)):
     access = await check_vault_access(user.user_id, vault, required_role="writer")
@@ -267,6 +298,12 @@ async def create_table(vault: str, req: CreateTableRequest, user: AuthenticatedU
         actor_id=user.username, description=payload.get("description", req.description),
         collection=payload.get("collection"),
         unique_keys=payload.get("unique_keys"), indexes=payload.get("indexes"),
+        if_not_exists=payload.get("if_not_exists", False),
+        # Write authority does not imply read (token_has_scope has no
+        # implication, and a managed wildcard grant can authorise a write
+        # without reader membership), so the no-op projection is gated on
+        # READ authority resolved here. Fail-closed: any failure → False.
+        can_read_existing=await _can_read_vault(user, vault),
     )
 
 

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -71,10 +71,17 @@ async def get_pool() -> asyncpg.Pool:
 
 
 async def close_pool() -> None:
+    """Close the pool and clear the module handle.
+
+    The handle is cleared BEFORE the await on purpose: if `close()` raises
+    or is cancelled, leaving `_pool` set would hand the next `get_pool()` a
+    half-closed pool — and in tests, one still pointing at the previous
+    database.
+    """
     global _pool
     if _pool is not None:
-        await _pool.close()
-        _pool = None
+        pool, _pool = _pool, None
+        await pool.close()
 
 
 async def init_db(max_retries: int = 10, delay: float = 2.0) -> None:

--- a/backend/app/openapi_contract.py
+++ b/backend/app/openapi_contract.py
@@ -651,6 +651,16 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
                 "name": {"type": "string"},
                 "sql_name": {"type": "string"},
                 "description": _nullable_string(),
+                # create only. `created` is true on a real create and false
+                # when if_not_exists=true matched an existing table; `outcome`
+                # appears only on the false branch. `matches_request` /
+                # `mismatches` accompany it ONLY when the caller also holds
+                # READ access — they are schema oracles, so a write-only
+                # credential gets just {kind, name, created, outcome}.
+                "created": {"type": "boolean"},
+                "outcome": {"type": "string"},
+                "matches_request": {"type": "boolean"},
+                "mismatches": {"type": "array", "items": {"type": "string"}},
                 "columns": JSON_OBJECT_ARRAY_SCHEMA,
                 "unique_keys": JSON_OBJECT_ARRAY_SCHEMA,
                 "indexes": JSON_OBJECT_ARRAY_SCHEMA,

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -554,6 +554,224 @@ async def delete_table_index(table_id: str) -> None:
 # ── CRUD ─────────────────────────────────────────────────────────
 
 
+def _normalize_column_specs(columns: list[dict]) -> list[dict]:
+    """Validate + normalize a caller's column list.
+
+    Extracted so the `if_not_exists` no-op can normalize the REQUEST the
+    same way the stored row was normalized at its own create — comparing a
+    raw request against a normalized row would report a mismatch on every
+    table.
+    """
+    seen: set[str] = set()
+    normalized: list[dict] = []
+    for col in columns:
+        if not isinstance(col, dict) or "name" not in col:
+            raise ValidationError(
+                f"Each column must be an object with a 'name' field; got {col!r}."
+            )
+        cname = col["name"]
+        _validate_column_name(cname)
+        key = cname.lower()
+        if key in seen:
+            raise ValidationError(
+                f"Duplicate column name {cname!r}. Column names must be "
+                f"unique (case-insensitive) and must not collide with "
+                f"reserved names {sorted(_RESERVED)}."
+            )
+        seen.add(key)
+        normalized.append(_normalize_column_spec(col))
+    return normalized
+
+
+def _canonical_create_spec(
+    *,
+    vault_name: str,
+    name: str,
+    columns: list[dict],
+    unique_keys: list[dict] | None,
+    indexes: list[dict] | None,
+    normalize_columns: bool = True,
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Canonicalize a create request the way a create would store it.
+
+    One canonicalizer for both branches. The no-op compares the REQUEST
+    against the STORED row, and the stored row went through exactly these
+    steps at its own create — comparing anything less would report a
+    mismatch on tables that in fact match, and (worse) report a match on
+    tables whose keys/indexes differ.
+
+    It also means a malformed `unique_keys`/`indexes` payload is still a 422
+    on the no-op path: "ensure a table matching this spec" is not satisfiable
+    by a spec that is not valid.
+
+    `normalize_columns=False` when the caller already normalized. Column
+    normalization is NOT idempotent — it SYNTHESIZES a CHECK for an enum
+    column and then rejects a column that already carries one, so running it
+    twice turns every enum create into a 422.
+    """
+    cols = _normalize_column_specs(columns) if normalize_columns else list(columns)
+    pg_name = table_data_repo.pg_table_name(vault_name, name)
+    uks = _inline_unique_keys(cols, pg_name) + _resolve_unique_keys(
+        unique_keys, cols, pg_name,
+    )
+    idxs = _inline_indexes(cols, pg_name) + _resolve_indexes(
+        indexes, cols, pg_name,
+    )
+    _reject_duplicate_meta_names(uks, label="unique-key")
+    _reject_duplicate_meta_names(idxs, label="index")
+    return cols, uks, idxs
+
+
+#: Boolean flags where `false` is indistinguishable from omitting the field.
+#: A caller may write `required: false` or leave it out; normalization keeps
+#: whichever spelling arrived, so the two forms produce unequal dicts for the
+#: same column.
+_COLUMN_NOOP_WHEN_FALSE = ("required", "unique", "index")
+
+#: Fields where only NULL means "absent". `default` is deliberately NOT in
+#: the set above: a boolean column with `default: false` generates
+#: `BOOLEAN DEFAULT FALSE`, which is a different table from plain `BOOLEAN`.
+#: The rest are `X | None = None` on `TableColumnSpec`, so REST accepts an
+#: explicit null, and an explicit null produces the same DDL as omitting it.
+_COLUMN_NOOP_WHEN_NULL = (
+    "default", "check", "enum", "references", "on_delete",
+)
+
+
+def _typed(value):
+    """Recursively tag values with their type for comparison.
+
+    Python equality says `False == 0` and `True == 1`. JSONB and the
+    generated DDL disagree — `DEFAULT FALSE` is not `DEFAULT 0` — so a plain
+    `==` on two column specs silently HIDES that divergence, including
+    nested inside a `check` spec. Comparing the tagged form makes the
+    distinction survive.
+    """
+    if isinstance(value, bool):          # before int: bool IS an int
+        return ("bool", value)
+    if isinstance(value, int):
+        return ("int", value)
+    if isinstance(value, float):
+        return ("float", value)
+    if isinstance(value, str):
+        return ("str", value)
+    if value is None:
+        return ("null",)
+    if isinstance(value, (list, tuple)):
+        return ("list", [_typed(v) for v in value])
+    if isinstance(value, dict):
+        return ("dict", sorted((k, _typed(v)) for k, v in value.items()))
+    return ("other", repr(value))
+
+
+def _comparable(specs: list[dict]) -> list[dict]:
+    """Drop no-op spellings so two descriptions of the SAME schema compare equal.
+
+    Used ONLY for the `if_not_exists` comparison — never for what is stored.
+    The stored row was normalized from whatever spelling its own creator used,
+    which may differ from this caller's, and reporting that as a mismatch
+    would send the caller off to alter a table that already matches. A false
+    mismatch is worse than no signal.
+
+    Only genuinely absent-equivalent values are dropped, and the rule differs
+    per field: `False` counts as absent for the boolean flags, but for
+    `default` only NULL does — `default: false` on a boolean column is a real
+    `DEFAULT FALSE`. `required: true` likewise still differs from omitting it.
+    """
+    def _absent(k, v) -> bool:
+        if k in _COLUMN_NOOP_WHEN_FALSE:
+            return v is False or v is None
+        if k in _COLUMN_NOOP_WHEN_NULL:
+            return v is None
+        return False
+
+    out = []
+    for spec in specs:
+        if not isinstance(spec, dict):
+            out.append(_typed(spec))
+            continue
+        out.append(_typed(
+            {k: v for k, v in spec.items() if not _absent(k, v)}))
+    return out
+
+
+def _existing_table_envelope(
+    existing: dict,
+    *,
+    vault_name: str,
+    name: str,
+    requested_columns: list[dict],
+    requested_unique_keys: list[dict],
+    requested_indexes: list[dict],
+    requested_collection: str | None,
+    requested_description: str,
+    can_read_existing: bool,
+) -> dict:
+    """Envelope for `if_not_exists=True` against a table that already exists.
+
+    Reports the STORED state, never the request's — the `create_collection`
+    contract ("report what's in the DB") applied to tables. `matches_request`
+    plus `mismatches` make divergence machine-explicit: a success-looking
+    `created=false` must not let a caller assume the columns it asked for are
+    the columns that exist.
+
+    Comparison is exact canonical equality. Anything looser ("compatible")
+    would reopen schema-diff policy, which `ensure_table` owns and this does
+    not.
+    """
+    if not can_read_existing:
+        # Write authority does not confer read authority — `token_has_scope`
+        # is `"admin" in granted or required in granted`, with no
+        # write->read implication, and `akb_create_table` is write-scoped
+        # while `akb_browse` is read-scoped. So a write-only credential must
+        # not learn the stored URI, collection or schema from a no-op.
+        # `matches_request` / `mismatches` are withheld for the same reason:
+        # they are schema oracles — repeated probing reconstructs the stored
+        # schema without ever returning it.
+        return {
+            "kind": "table",
+            "name": name,
+            "created": False,
+            "outcome": "already_exists",
+        }
+
+    stored_columns = table_registry_repo.parse_columns(existing.get("columns"))
+    stored_uks = table_registry_repo.parse_json_list(existing.get("unique_keys"))
+    stored_idxs = table_registry_repo.parse_json_list(existing.get("indexes"))
+    stored_collection = existing.get("collection") or None
+
+    # All five fields the envelope promises are compared. Returning a value
+    # without comparing it is how `matches_request` becomes a lie.
+    mismatches: list[str] = []
+    if _comparable(stored_columns) != _comparable(requested_columns):
+        mismatches.append("columns")
+    # Type-tagged here too: these carry nested column specs, and `False == 0`
+    # would hide a divergence in any of them just as it would in `columns`.
+    if _typed(stored_uks) != _typed(requested_unique_keys):
+        mismatches.append("unique_keys")
+    if _typed(stored_idxs) != _typed(requested_indexes):
+        mismatches.append("indexes")
+    if stored_collection != (requested_collection or None):
+        mismatches.append("collection")
+    if (existing.get("description") or "") != (requested_description or ""):
+        mismatches.append("description")
+
+    return {
+        "kind": "table",
+        "uri": table_uri(vault_name, name, collection=stored_collection),
+        "vault": vault_name,
+        "collection": stored_collection,
+        "name": name,
+        "created": False,
+        "outcome": "already_exists",
+        "matches_request": not mismatches,
+        "mismatches": mismatches,
+        "columns": stored_columns,
+        "unique_keys": stored_uks,
+        "indexes": stored_idxs,
+    }
+
+
 async def create_table(
     vault_id: uuid.UUID,
     name: str,
@@ -564,6 +782,8 @@ async def create_table(
     collection: str | None = None,
     unique_keys: list[dict] | None = None,
     indexes: list[dict] | None = None,
+    if_not_exists: bool = False,
+    can_read_existing: bool = False,
 ) -> dict:
     """Create a vault-scoped table inside an optional collection.
 
@@ -571,6 +791,20 @@ async def create_table(
     NULL / empty → vault root. The path is normalized and the matching
     `collections` row is auto-created via `CollectionRepository.get_or_create`
     if it doesn't exist yet.
+
+    `if_not_exists=True` changes the request from "create this table" to
+    "ensure this table exists": an existing table is reported as
+    `created=False` instead of raising 409 — with the stored schema only
+    when `can_read_existing` says the caller may see it. It
+    suppresses EXACTLY ONE conflict — a `(vault_id, name)` row in this vault.
+    Cross-vault physical-name fusion (issue #285) raises unchanged; those
+    sites share the `ConflictError` type but mean another tenant's table, and
+    reporting it as a no-op would disclose that tenant's schema.
+
+    `can_read_existing` is the caller's READ authority, resolved at the
+    REST/MCP authorization boundary and handed down as a capability — never
+    raw scopes. It defaults to False so a caller that forgets to pass it
+    receives the minimal envelope rather than the stored schema.
     """
     # pg_table_name maps any punctuation to underscore — allowing hyphens
     # would let `mcp-items` and `mcp_items` collide on the PG side.
@@ -584,34 +818,72 @@ async def create_table(
     collection_path = _normalize_collection_path(collection)
 
     async with pool.acquire() as conn:
-        async with conn.transaction():
+        # READ COMMITTED explicitly: the advisory lock only helps if the
+        # loser can SEE the winner's row after the wait. Under REPEATABLE
+        # READ the vault lookup below would fix a snapshot BEFORE the lock
+        # wait, so the loser would still miss the winner and fall through
+        # to a constraint violation it cannot recover from. The pool pins
+        # no isolation level (app/db/postgres.py), so a deployment-level
+        # default must not be able to break this.
+        async with conn.transaction(isolation="read_committed"):
             vault = await conn.fetchrow("SELECT name FROM vaults WHERE id = $1", vault_id)
             if not vault:
                 raise NotFoundError("Vault", str(vault_id))
 
+            # Serialize on the logical identity BEFORE looking it up, so a
+            # concurrent create of the same (vault, table) queues instead of
+            # racing. Without this there are two further windows in which a
+            # winner can commit — the to_regclass preflight and the CREATE
+            # TABLE itself — each surfacing as a different exception.
+            # (The registry insert is not a third window for the same
+            # logical table: the loser's CREATE TABLE fails before it.)
+            # Recovering from them after the fact is not possible:
+            # by then the transaction has hit a constraint violation and is
+            # aborted, so a re-read of the winner's row cannot run on this
+            # connection. Precedent: table_migration_service's per-(vault,key)
+            # xact lock. Taken on BOTH paths — the race predates the flag.
+            await conn.fetchval(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                # Domain-prefixed: table_migration_service calls the same
+                # function with an UNPREFIXED f"{vault_id}:{key}", so a
+                # migration key equal to a table name would alias onto this
+                # exact lock — harmless for correctness, needless blocking.
+                f"table-create:{vault_id}:{name}",
+            )
+
             existing = await table_registry_repo.find_by_name(conn, vault_id, name)
             if existing:
+                if if_not_exists:
+                    # Canonicalize the REQUEST so it is compared like-for-like
+                    # against the stored row, which went through exactly these
+                    # steps at its own create. This also means an invalid spec
+                    # is still a 422 here. The strict path deliberately keeps
+                    # its original order (409 before validation) so its
+                    # behaviour is unchanged.
+                    req_cols, req_uks, req_idxs = _canonical_create_spec(
+                        vault_name=vault["name"], name=name, columns=columns,
+                        unique_keys=unique_keys, indexes=indexes,
+                    )
+                    # Parity with the real create: a reference to a missing,
+                    # non-unique or wrong-typed target is a 422 either way.
+                    # Without this the SAME request is an error against an
+                    # absent table and a quiet no-op against a present one —
+                    # the flag would change what counts as a valid spec.
+                    await _validate_column_references(conn, vault_id, req_cols)
+                    return _existing_table_envelope(
+                        existing,
+                        vault_name=vault["name"],
+                        name=name,
+                        requested_columns=req_cols,
+                        requested_unique_keys=req_uks,
+                        requested_indexes=req_idxs,
+                        requested_collection=collection_path,
+                        requested_description=description,
+                        can_read_existing=can_read_existing,
+                    )
                 raise ConflictError(f"Table already exists: {name}")
 
-            seen: set[str] = set()
-            normalized_columns: list[dict] = []
-            for col in columns:
-                if not isinstance(col, dict) or "name" not in col:
-                    raise ValidationError(
-                        f"Each column must be an object with a 'name' field; got {col!r}."
-                    )
-                cname = col["name"]
-                _validate_column_name(cname)
-                key = cname.lower()
-                if key in seen:
-                    raise ValidationError(
-                        f"Duplicate column name {cname!r}. Column names must be "
-                        f"unique (case-insensitive) and must not collide with "
-                        f"reserved names {sorted(_RESERVED)}."
-                    )
-                seen.add(key)
-                normalized_columns.append(_normalize_column_spec(col))
-            columns = normalized_columns
+            columns = _normalize_column_specs(columns)
 
             collection_id = None
             if collection_path:
@@ -656,14 +928,18 @@ async def create_table(
             # DDL so a bad spec rolls back with zero schema change. On a
             # freshly-created (empty) table there is no duplicate-preflight
             # to run — a later duplicate INSERT surfaces PG 23505 via akb_sql.
-            resolved_uks = _inline_unique_keys(columns, pg_name) + _resolve_unique_keys(
-                unique_keys, columns, pg_name,
+            #
+            # Same canonicalizer the no-op comparison uses. Sharing it is what
+            # makes `matches_request` meaningful: if the two branches derived
+            # keys/indexes differently, a no-op could report a mismatch the
+            # real create would never have produced, or a match it would not
+            # have accepted. `columns` is already normalized above.
+            _, resolved_uks, resolved_idxs = _canonical_create_spec(
+                vault_name=vault["name"], name=name, columns=columns,
+                unique_keys=unique_keys, indexes=indexes,
+                # already normalized above; re-running would 422 every enum
+                normalize_columns=False,
             )
-            resolved_idxs = _inline_indexes(columns, pg_name) + _resolve_indexes(
-                indexes, columns, pg_name,
-            )
-            _reject_duplicate_meta_names(resolved_uks, label="unique-key")
-            _reject_duplicate_meta_names(resolved_idxs, label="index")
             await _validate_column_references(conn, vault_id, columns)
 
             try:
@@ -727,8 +1003,10 @@ async def create_table(
             ) as e:
                 raise ValidationError(_foreign_key_validation_message(name, e)) from e
             except asyncpg.UniqueViolationError as e:
-                # Concurrent create past the find_by_name check races on
-                # UNIQUE(vault_tables) or pg_type. Surface as 409.
+                # Defensive: for two concurrent creates of the SAME (vault,
+                # name) the loser cannot reach here — its CREATE TABLE fails
+                # first. This covers a registry row that arrived by another
+                # route. Surface as 409 either way.
                 raise ConflictError(f"Table already exists: {name}") from e
             # Grant inside the TX so akb_sql can address the table the
             # instant the create commits (no "exists but 42501" window).
@@ -770,6 +1048,10 @@ async def create_table(
         "vault": vault["name"],
         "collection": collection_path or None,
         "name": name,
+        # Present on BOTH branches so a caller never has to read absence as
+        # meaning anything. Additive to the envelope — see the contract
+        # surfaces listed in the design doc.
+        "created": True,
         "columns": columns,
         "unique_keys": resolved_uks,
         "indexes": resolved_idxs,

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -934,9 +934,43 @@ akb_drill_down(uri="akb://eng/doc/specs/api.md", section="API")     # Sections c
 | columns | ✓ | Column definitions |
 | unique_keys | | Declarative UNIQUE keys: `[{name?, columns}]` |
 | indexes | | Declarative lookup indexes: `[{name?, columns}]` |
+| if_not_exists | | `true` → an existing table is not an error. Default `false`. |
 
 ## Column Types
 `text`, `number`, `boolean`, `date`, `json`
+
+## if_not_exists — "ensure this table exists"
+
+Default (`false`) is unchanged: creating a table that already exists is a
+`conflict` error.
+
+With `if_not_exists=true` the request becomes "ensure this table exists":
+
+| Table | Result |
+|---|---|
+| absent | created → `created: true` |
+| present | **nothing is altered** → `created: false`, `outcome: "already_exists"` |
+
+Must be a real boolean — the string `"true"` is rejected, not coerced.
+
+**It never reconciles a schema.** If the stored table differs from what you
+asked for, you get the STORED shape back plus:
+
+- `matches_request` — `false` when anything differs
+- `mismatches` — which of `columns` / `unique_keys` / `indexes` /
+  `collection` / `description` differ
+
+so you can decide whether to follow up with `akb_alter_table`. Do NOT assume
+the columns you passed exist just because the call succeeded.
+
+If your credential has write but not read access to the vault, the response is
+only `{kind, name, created, outcome}` — the stored schema, `matches_request`
+and `mismatches` are all withheld, because they would disclose a schema you are
+not authorised to read. Their absence means "not disclosed", not "no
+divergence".
+
+Only a table already in THIS vault is suppressed. A name that collides with
+another vault's physical table still conflicts.
 
 ## Unique keys & indexes
 - `unique_keys` — single or composite UNIQUE constraints. Each item is

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -265,6 +265,32 @@ _ARG_WRITE_TRIGGERS: dict[str, tuple[str, ...]] = {
 }
 
 
+async def _can_read_vault(user: "_MCPUser", uid: str, vault: str) -> bool:
+    """Does this credential have READ authority on `vault`?
+
+    Write authority does not imply read: `token_has_scope` is
+    `"admin" in granted or required in granted`, with no implication, and a
+    managed-vault wildcard grant can authorise a write without reader
+    membership. A write-only caller must therefore not be handed stored
+    state it could not obtain through `akb_browse`.
+
+    Fail-closed on every uncertainty — an exception, a missing vault, a
+    denied role check all resolve to False. This gates a PROJECTION, never
+    an action, so refusing it can only under-disclose.
+    """
+    if user.oauth_scopes is not None and _READ_SCOPE not in user.oauth_scopes:
+        return False
+    if user.token_scopes is not None and not token_has_scope(
+        user.token_scopes, "read"
+    ):
+        return False
+    try:
+        await check_vault_access(uid, vault, required_role="reader")
+    except Exception:  # noqa: BLE001 — any failure means "no read authority"
+        return False
+    return True
+
+
 def _required_scope(name: str, args: dict) -> str:
     """Scope a call needs: the tool's mapping, promoted to write when the
     call carries a mutating argument.
@@ -1001,6 +1027,16 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
         vault, collection = _resolve_parent(args, kind_name="table")
     except ValueError as e:
         return err(str(e), code=INVALID_ARGUMENT)
+    # Reject rather than coerce. `bool("false")` is True, so a lenient cast
+    # hands the caller idempotent behaviour it never asked for; a strict
+    # `is True` silently gives `"true"` the 409 it did not expect. Either
+    # way the caller is misled without being told.
+    if "if_not_exists" in args and not isinstance(args["if_not_exists"], bool):
+        return err(
+            "if_not_exists must be a boolean (true/false), got "
+            f"{type(args['if_not_exists']).__name__}",
+            code=INVALID_ARGUMENT,
+        )
     access = await check_vault_access(uid, vault, required_role="writer")
     try:
         return await table_service.create_table(
@@ -1010,6 +1046,9 @@ async def _handle_create_table(args: dict, uid: str, user: _MCPUser) -> dict:
             collection=collection or None,
             unique_keys=args.get("unique_keys"),
             indexes=args.get("indexes"),
+            # Type already enforced above, so a plain read is safe here.
+            if_not_exists=args.get("if_not_exists", False),
+            can_read_existing=await _can_read_vault(user, uid, vault),
         )
     except (ValidationError, ValueError) as e:
         # ValidationError: bad table name / over-long PG identifier (422).

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -628,6 +628,21 @@ TOOLS = [
                 },
                 "vault": {"type": "string", "description": "Target vault name. Required unless `parent` is given."},
                 "name": {"type": "string", "description": "Table name (unique within the vault)"},
+                "if_not_exists": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "When true, an existing table is NOT an error: returns "
+                        "created=false instead of a 409 conflict. Nothing is "
+                        "altered either way. If you also hold READ access to "
+                        "the vault the response carries the STORED schema plus "
+                        "matches_request and mismatches[], so divergence from "
+                        "your spec is explicit; a write-only credential gets "
+                        "only {kind, name, created, outcome}. Must be a real "
+                        "boolean — the string \"true\" is rejected. Default "
+                        "false keeps the 409."
+                    ),
+                },
                 "collection": {
                     "type": "string",
                     "description": "Collection path (e.g. 'specs' or 'sessions/learnings'). Omit for vault root. Ignored when `parent` is given.",

--- a/backend/tests/test_table_if_not_exists_e2e.py
+++ b/backend/tests/test_table_if_not_exists_e2e.py
@@ -1,0 +1,327 @@
+"""Live-PostgreSQL behaviour of `create_table(if_not_exists=...)`.
+
+The unit suite proves the branching with fakes. Two properties cannot be
+proven that way and are the reason this file exists:
+
+  * The advisory lock actually SERIALIZES two concurrent creates of the same
+    (vault, table). A fake cannot show that; only two real sessions
+    contending on a real `pg_advisory_xact_lock` can.
+  * The two post-check race windows really are closed. Before the lock, a
+    loser that got past `find_by_name` could still be caught by the
+    `to_regclass` preflight or lose the `CREATE TABLE` itself — and neither
+    is recoverable, because by then the transaction is aborted.
+    (`find_by_name` is the only window that should decide anything: seeing
+    the row there is the intended `created=false`. The registry insert is
+    not a third window for the same logical table — the loser's CREATE TABLE
+    fails before it gets there.)
+
+Skips when `AKB_TEST_DSN` is unset so a plain `pytest tests/` stays green.
+If a DSN IS set and is unreachable the suite FAILS: a gate that green-skips
+on a broken database is not a gate.
+
+Isolation: a dedicated schema per run, dropped in teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+DSN = os.getenv("AKB_TEST_DSN")
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(not DSN, reason="AKB_TEST_DSN not set"),
+]
+
+_SCHEMA = "if_not_exists_e2e"
+
+
+async def _conn():
+    try:
+        c = await asyncpg.connect(DSN)
+    except (OSError, asyncpg.PostgresError) as e:  # pragma: no cover
+        pytest.fail(f"AKB_TEST_DSN is set but unreachable: {e}")
+    await c.execute(f"SET search_path TO {_SCHEMA}, public")
+    return c
+
+
+@pytest.fixture(autouse=True)
+async def _schema():
+    c = await asyncpg.connect(DSN)
+    await c.execute(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await c.execute(f"CREATE SCHEMA {_SCHEMA}")
+    await c.close()
+    yield
+    c = await asyncpg.connect(DSN)
+    await c.execute(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE")
+    await c.close()
+
+
+# ── the lock itself ──────────────────────────────────────────────
+
+
+async def test_advisory_lock_serializes_same_key():
+    """Two sessions taking the same xact lock must not hold it at once.
+
+    This is the property the whole design rests on: with it, the loser
+    reaches `find_by_name` only AFTER the winner committed, so it sees the
+    row and can report created=false — instead of racing ahead into a
+    constraint violation it cannot recover from.
+    """
+    vault_id, name = uuid.uuid4(), "issues"
+    key = f"{vault_id}:{name}"
+
+    a, b = await _conn(), await _conn()
+    order: list[str] = []
+    try:
+        tx_a = a.transaction()
+        await tx_a.start()
+        await a.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", key)
+        order.append("a-acquired")
+
+        async def _b():
+            tx_b = b.transaction()
+            await tx_b.start()
+            await b.fetchval(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", key)
+            order.append("b-acquired")
+            await tx_b.rollback()
+
+        task = asyncio.create_task(_b())
+        await asyncio.sleep(0.25)
+        # B must still be blocked while A holds the lock.
+        assert not task.done(), "second session acquired the lock concurrently"
+        assert order == ["a-acquired"]
+
+        await tx_a.rollback()          # release
+        await asyncio.wait_for(task, timeout=5)
+        assert order == ["a-acquired", "b-acquired"]
+    finally:
+        await a.close()
+        await b.close()
+
+
+async def test_different_keys_do_not_block_each_other():
+    """The lock is per (vault, table) — unrelated creates must stay parallel,
+    or every table create in the deployment serialises behind one mutex."""
+    a, b = await _conn(), await _conn()
+    try:
+        tx_a = a.transaction()
+        await tx_a.start()
+        await a.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"{uuid.uuid4()}:alpha")
+
+        tx_b = b.transaction()
+        await tx_b.start()
+        await asyncio.wait_for(
+            b.fetchval("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                       f"{uuid.uuid4()}:beta"),
+            timeout=3,
+        )
+        await tx_b.rollback()
+        await tx_a.rollback()
+    finally:
+        await a.close()
+        await b.close()
+
+
+async def test_lock_is_released_by_rollback_not_just_commit():
+    """`_xact_` scope: a failed create must not strand the lock, or one bad
+    request wedges every subsequent create of that table name."""
+    key = f"{uuid.uuid4()}:issues"
+    a, b = await _conn(), await _conn()
+    try:
+        tx_a = a.transaction()
+        await tx_a.start()
+        await a.fetchval(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", key)
+        with pytest.raises(asyncpg.PostgresError):
+            await a.execute("SELECT 1/0")     # abort the transaction
+        await tx_a.rollback()
+
+        tx_b = b.transaction()
+        await tx_b.start()
+        await asyncio.wait_for(
+            b.fetchval("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                       key),
+            timeout=3,
+        )
+        await tx_b.rollback()
+    finally:
+        await a.close()
+        await b.close()
+
+
+# ── the reason the original design was not implementable ─────────
+
+
+async def test_reread_after_constraint_violation_is_impossible():
+    """Pins the fact that motivated the lock.
+
+    The first design caught `UniqueViolationError` and re-read the winner's
+    row in place. This proves that cannot work: after the violation the
+    transaction is aborted and every subsequent query on that connection
+    fails until rollback. If this test ever starts passing a plain SELECT,
+    the constraint that forced the advisory-lock design has changed.
+    """
+    c = await _conn()
+    try:
+        await c.execute(
+            f"CREATE TABLE {_SCHEMA}.t (id int PRIMARY KEY)")
+        tx = c.transaction()
+        await tx.start()
+        await c.execute(f"INSERT INTO {_SCHEMA}.t VALUES (1)")
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await c.execute(f"INSERT INTO {_SCHEMA}.t VALUES (1)")
+
+        with pytest.raises(asyncpg.InFailedSQLTransactionError):
+            await c.fetchval(f"SELECT count(*) FROM {_SCHEMA}.t")
+        await tx.rollback()
+    finally:
+        await c.close()
+
+
+async def test_create_table_concurrency_through_the_service():
+    """The load-bearing guarantee, exercised through `create_table` itself
+    rather than through lock primitives.
+
+    Two concurrent `if_not_exists=True` creates of the SAME (vault, table)
+    must both succeed with exactly one `created=true`, exactly one registry
+    row, exactly one physical table and exactly one `table.create` event.
+    Before the advisory lock the loser raced past `find_by_name` into the
+    `to_regclass` preflight or the `CREATE TABLE` itself and surfaced a
+    different unrecoverable exception from each.
+    """
+    from urllib.parse import urlparse
+
+    from app.config import settings
+    from app.db import postgres as pg_mod
+    from app.services import table_service
+
+    # `create_table` acquires the APP pool (settings.asyncpg_dsn), not the
+    # test DSN, and the configured host is a container-internal name. Point
+    # the pool at the test database for the duration of this test.
+    saved_db = (settings.db_user, settings.db_password, settings.db_host,
+                settings.db_port, settings.db_name)
+    orig_role_sync = table_service.get_role_sync
+
+    vault_id = uuid.uuid4()
+    vault_name = "cvt"
+    table_name = "issues"
+    pg_name = f"vt_{vault_name}__{table_name}"
+    cols = [{"name": "title", "type": "text"}]
+    setup = None
+
+    # The try is ARMED BEFORE the first mutation, not after: `close_pool()`
+    # can itself fail or be cancelled, which would otherwise strand the
+    # mutated settings. Everything that can raise — including both
+    # `pytest.skip` sites — is inside, so a skipped run restores too.
+    try:
+        u = urlparse(DSN)
+        settings.db_user, settings.db_password = u.username, u.password
+        settings.db_host, settings.db_port = u.hostname, u.port or 5432
+        settings.db_name = (u.path or "/").lstrip("/")
+        await pg_mod.close_pool()
+
+        setup = await asyncpg.connect(DSN)
+        if not await setup.fetchval(
+            "SELECT to_regclass('public.vaults') IS NOT NULL"
+        ):
+            # The CI live-PG job runs against a FRESH database on purpose, so
+            # this must bootstrap rather than skip. A skip here would make the
+            # feature's load-bearing guarantee a gate that never fires — which
+            # is exactly what happened before this file was added to the job.
+            from app.db.postgres import init_db
+            await init_db()
+        await setup.execute(
+            "INSERT INTO vaults (id, name, description, git_path, created_at) "
+            "VALUES ($1, $2, '', $3, NOW())",
+            vault_id, vault_name, f"/tmp/{vault_name}",
+        )
+
+        # RoleSync is wired in the app lifespan; the create only calls
+        # grant_table_in_conn on the winning path, and per-vault PG roles are
+        # not what this test is about.
+        class _RoleSyncStub:
+            async def grant_table_in_conn(self, *a, **k):
+                return None
+
+        table_service.get_role_sync = lambda: _RoleSyncStub()
+
+        async def _one():
+            return await table_service.create_table(
+                vault_id, table_name, cols, actor_id="t",
+                if_not_exists=True, can_read_existing=True,
+            )
+
+        results = await asyncio.gather(_one(), _one(), return_exceptions=True)
+
+        errors = [r for r in results if isinstance(r, BaseException)]
+        assert not errors, f"a concurrent create raised: {errors!r}"
+
+        created = [r["created"] for r in results]
+        assert created.count(True) == 1, (
+            f"exactly one caller must have created the table, got {created}")
+        assert created.count(False) == 1
+
+        assert await setup.fetchval(
+            "SELECT count(*) FROM vault_tables WHERE vault_id=$1 AND name=$2",
+            vault_id, table_name,
+        ) == 1, "more than one registry row"
+        assert await setup.fetchval(
+            "SELECT to_regclass($1) IS NOT NULL", f"public.{pg_name}"
+        ), "physical table missing"
+        assert await setup.fetchval(
+            "SELECT count(*) FROM events WHERE kind='table.create' "
+            "AND vault_id=$1", vault_id,
+        ) == 1, "a no-op emitted a table.create event"
+    finally:
+        # Process-global state is restored FIRST and unconditionally: a
+        # failure while cleaning up rows must not leave the next test
+        # pointed at this database.
+        table_service.get_role_sync = orig_role_sync
+        (settings.db_user, settings.db_password, settings.db_host,
+         settings.db_port, settings.db_name) = saved_db
+        try:
+            if setup is not None:
+                try:
+                    await setup.execute(
+                        f"DROP TABLE IF EXISTS public.{pg_name} CASCADE")
+                    await setup.execute(
+                        "DELETE FROM vault_tables WHERE vault_id=$1", vault_id)
+                    await setup.execute(
+                        "DELETE FROM events WHERE vault_id=$1", vault_id)
+                    await setup.execute(
+                        "DELETE FROM vaults WHERE id=$1", vault_id)
+                finally:
+                    # A failed DELETE must not leak the connection.
+                    await setup.close()
+        finally:
+            await pg_mod.close_pool()
+
+
+async def test_hashtextextended_key_is_stable_and_distinguishes_names():
+    """The lock key is a hash, so collisions are possible in principle —
+    two different (vault, table) pairs sharing a lock would only cost
+    throughput, never correctness. What must hold is determinism: the same
+    key always maps to the same lock."""
+    c = await _conn()
+    try:
+        vault = uuid.uuid4()
+        k1 = await c.fetchval(
+            "SELECT hashtextextended($1, 0)", f"{vault}:issues")
+        k2 = await c.fetchval(
+            "SELECT hashtextextended($1, 0)", f"{vault}:issues")
+        k3 = await c.fetchval(
+            "SELECT hashtextextended($1, 0)", f"{vault}:incidents")
+        assert k1 == k2
+        assert k1 != k3
+    finally:
+        await c.close()

--- a/backend/tests/test_table_if_not_exists_unit.py
+++ b/backend/tests/test_table_if_not_exists_unit.py
@@ -1,0 +1,700 @@
+"""`akb_create_table(if_not_exists=True)` — opt-in idempotent create.
+
+Design: docs/design/proposal/2026-07-29-create-table-if-not-exists/
+
+The load-bearing property is NOT "conflicts become successes" — it is that
+exactly ONE conflict becomes a success. `ConflictError` is raised from four
+sites in `create_table` and means two different things:
+
+  * same vault, `(vault_id, name)` row exists      -> suppressible
+  * a DIFFERENT vault's table fused onto the same
+    physical name (issue #285)                     -> MUST stay a 409
+
+Both raise the same exception type, so an implementation that catches
+`ConflictError` broadly would hand a vault-A writer the schema of a vault-B
+table. PostgreSQL's `information_schema` is privilege-filtered per vault role,
+so that would be a genuine cross-tenant disclosure, not a restatement of
+something the caller could already read.
+
+DB-free: the fakes follow `test_vault_table_name_collision_unit`.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.exceptions import ConflictError, ValidationError
+from app.services import table_service
+
+pytestmark = pytest.mark.asyncio
+
+_COLS = [{"name": "title", "type": "text"}]
+
+
+class _AsyncCtx:
+    def __init__(self, value=None):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    """Drives create_table to a chosen decision point.
+
+    `existing` is the row `find_by_name` should return (None = absent).
+    `physical_taken` answers the cross-vault `to_regclass` preflight.
+    Every `execute` is recorded so a test can assert the advisory lock was
+    taken, and taken BEFORE the existence check.
+    """
+
+    def __init__(self, vault_name: str, *, existing=None, physical_taken=False):
+        self._vault_name = vault_name
+        self._existing = existing
+        self._physical_taken = physical_taken
+        self.executed: list[str] = []
+        self.calls: list[str] = []
+
+    def transaction(self, **kwargs):
+        self.tx_kwargs = kwargs
+        return _AsyncCtx()
+
+    async def execute(self, sql: str, *params):
+        self.executed.append(sql)
+        self.calls.append(f"execute:{sql.split()[1] if len(sql.split()) > 1 else sql}")
+        return "OK"
+
+    async def fetchrow(self, sql: str, *params):
+        if "FROM vaults" in sql:
+            self.calls.append("vault_lookup")
+            return {"name": self._vault_name}
+        if "FROM vault_tables" in sql:
+            self.calls.append("find_by_name")
+            return self._existing
+        return None
+
+    async def fetchval(self, sql: str, *params):
+        if "to_regclass" in sql:
+            self.calls.append("to_regclass")
+            return self._physical_taken
+        if "pg_advisory" in sql:
+            self.calls.append("advisory_lock")
+            return None
+        return None
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AsyncCtx(self._conn)
+
+
+def _wire(monkeypatch, conn):
+    async def _fake_get_pool():
+        return _FakePool(conn)
+
+    monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
+
+
+def _stored_row(*, name="issues", columns=None, collection=None):
+    """A `find_by_name` row as asyncpg would return it (dict-ified)."""
+    return {
+        "id": uuid.uuid4(),
+        "vault_id": uuid.uuid4(),
+        "collection_id": None,
+        "collection": collection,
+        "name": name,
+        "description": "",
+        "columns": columns if columns is not None else _COLS,
+        "unique_keys": [],
+        "indexes": [],
+        "created_by": "someone",
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+def _norm(specs: list[dict]) -> list[dict]:
+    """Normalize like a real create would, so a comparison test isolates the
+    field under test instead of tripping on `type` (json -> jsonb)."""
+    from app.repositories.table_data_repo import normalize_column_spec
+    return [normalize_column_spec(c) for c in specs]
+
+
+def _forbid_ddl(monkeypatch, why: str):
+    async def _must_not_run(*a, **k):
+        raise AssertionError(why)
+
+    monkeypatch.setattr(
+        table_service.table_data_repo, "create_dynamic_table", _must_not_run)
+
+
+# ── 1. default is unchanged ──────────────────────────────────────
+
+
+async def test_default_still_conflicts_on_existing_table(monkeypatch):
+    """Regression guard: omitting the flag must behave exactly as before."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no DDL on a duplicate")
+
+    with pytest.raises(ConflictError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(), "issues", _COLS, actor_id="t")
+    assert "already exists" in str(ei.value)
+
+
+async def test_explicit_false_still_conflicts(monkeypatch):
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no DDL on a duplicate")
+
+    with pytest.raises(ConflictError):
+        await table_service.create_table(
+            uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=False)
+
+
+# ── 2. the no-op branch ──────────────────────────────────────────
+
+
+async def test_existing_table_returns_created_false(monkeypatch):
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "a no-op must not create anything")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["created"] is False
+    assert out["outcome"] == "already_exists"
+    assert out["name"] == "issues"
+    assert out["kind"] == "table"
+
+
+async def test_no_op_emits_no_domain_event(monkeypatch):
+    """A no-op performed no domain write, so it must emit no event."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "a no-op must not create anything")
+
+    async def _must_not_emit(*a, **k):
+        raise AssertionError("no table.create event on a no-op")
+
+    monkeypatch.setattr(table_service, "emit_event", _must_not_emit)
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+    assert out["created"] is False
+
+
+async def test_no_op_skips_post_commit_metadata_indexing(monkeypatch):
+    """`index_table_metadata` runs after the create TX; a no-op created
+    nothing, so re-indexing would overwrite stored metadata with the
+    LOSING request's values."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "a no-op must not create anything")
+
+    async def _must_not_index(*a, **k):
+        raise AssertionError("no metadata indexing on a no-op")
+
+    monkeypatch.setattr(table_service, "index_table_metadata", _must_not_index)
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+    assert out["created"] is False
+
+
+# ── 3. divergence must be machine-explicit ───────────────────────
+
+
+async def test_identical_schema_reports_match(monkeypatch):
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row(columns=_COLS)))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is True
+    assert out["mismatches"] == []
+
+
+async def test_divergent_schema_names_the_differing_fields(monkeypatch):
+    """A success-looking created=false must not let the caller assume its
+    requested columns exist."""
+    stored = _stored_row(columns=[{"name": "headline", "type": "text"}])
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+    assert "columns" in out["mismatches"]
+    # the STORED schema, not the request's
+    assert out["columns"] == [{"name": "headline", "type": "text"}]
+
+
+async def test_divergent_collection_is_reported(monkeypatch):
+    stored = _stored_row(collection="other/place")
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        collection="specs", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+    assert "collection" in out["mismatches"]
+    assert out["collection"] == "other/place"
+
+
+async def test_legacy_json_string_columns_are_normalised(monkeypatch):
+    """Legacy rows store `columns` as a JSON string literal. Comparison
+    must go through the repo parser, or every legacy table reports a
+    spurious mismatch."""
+    stored = _stored_row(columns='[{"name": "title", "type": "text"}]')
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["columns"] == _COLS
+    assert out["matches_request"] is True
+
+
+@pytest.mark.parametrize("noop_field", [
+    {"required": False},
+    {"unique": False},
+    {"index": False},
+    {"default": None},
+    {"required": False, "unique": False, "index": False, "default": None},
+])
+async def test_no_op_falsy_flags_are_not_a_mismatch(monkeypatch, noop_field):
+    """`required: false` and omitting `required` describe the SAME column, and
+    normalization keeps whichever form the caller used. Comparing the raw
+    normalized dicts therefore reports a mismatch between two identical
+    schemas — purely because the stored row was created with one spelling and
+    this request uses the other.
+
+    A false mismatch is worse than no signal: it tells the caller to go alter
+    a table that already matches.
+    """
+    stored = _stored_row(columns=[{"name": "title", "type": "text"}])
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "title", "type": "text", **noop_field}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is True, (
+        f"{noop_field} should not differ from omitting it; "
+        f"mismatches={out['mismatches']}")
+
+
+async def test_boolean_default_false_is_a_real_difference(monkeypatch):
+    """`default: false` is NOT a no-op spelling.
+
+    A boolean column with no default generates `BOOLEAN`; with
+    `default: false` it generates `BOOLEAN DEFAULT FALSE`. Those are
+    different tables. `required`/`unique`/`index` are absent-equivalent when
+    false; `default` is only absent-equivalent when NULL.
+    """
+    stored = _stored_row(columns=[{"name": "flag", "type": "boolean"}])
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "flag", "type": "boolean", "default": False}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False, (
+        "default=false vs no default are different tables")
+    assert "columns" in out["mismatches"]
+
+
+@pytest.mark.parametrize("stored_default,requested_default", [
+    (False, 0),
+    (0, False),
+    (True, 1),
+    (1, True),
+])
+async def test_bool_and_int_defaults_are_not_interchangeable(
+    monkeypatch, stored_default, requested_default,
+):
+    """Python says `False == 0` and `True == 1`. JSONB does not, and neither
+    does the generated DDL — `DEFAULT FALSE` is not `DEFAULT 0`. A plain `==`
+    on the normalized dicts therefore HIDES a real divergence."""
+    # Normalize the STORED side too, or the mismatch lands on `type`
+    # (json -> jsonb) and the test passes without ever exercising the
+    # default comparison.
+    stored = _stored_row(columns=_norm(
+        [{"name": "v", "type": "json", "default": stored_default}]))
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "v", "type": "json", "default": requested_default}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False, (
+        f"stored default={stored_default!r} vs requested "
+        f"{requested_default!r} must not compare equal")
+
+
+async def test_nested_json_bool_vs_int_is_a_difference(monkeypatch):
+    """The same trap one level down, inside a check spec."""
+    stored = _stored_row(columns=_norm([
+        {"name": "v", "type": "json", "check": {"op": "eq", "value": False}}]))
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "v", "type": "json", "check": {"op": "eq", "value": 0}}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+
+
+@pytest.mark.parametrize("null_field", [
+    {"check": None},
+    {"enum": None},
+    {"references": None},
+    {"on_delete": None},
+])
+async def test_explicit_nulls_are_not_a_mismatch(monkeypatch, null_field):
+    """REST accepts these as `None` (they are `X | None = None` on
+    `TableColumnSpec`), and an explicit null is DDL-equivalent to omitting
+    the field. Only `default` was being stripped, so these reported a
+    spurious `columns` divergence."""
+    stored = _stored_row(columns=[{"name": "title", "type": "text"}])
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "title", "type": "text", **null_field}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is True, (
+        f"explicit {null_field} should equal omitting it; "
+        f"mismatches={out['mismatches']}")
+
+
+async def test_a_real_column_difference_is_still_reported(monkeypatch):
+    """Guard the guard: dropping no-op flags must not also drop real ones."""
+    stored = _stored_row(columns=[{"name": "title", "type": "text"}])
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "title", "type": "text", "required": True}],
+        actor_id="t", if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+    assert "columns" in out["mismatches"]
+
+
+async def test_divergent_unique_keys_are_reported(monkeypatch):
+    """`unique_keys` is returned in the envelope, so it must also be
+    compared — otherwise a completely different constraint set reports
+    matches_request=true, and the response lies about what exists."""
+    stored = _stored_row()
+    stored["unique_keys"] = [{"name": "uq_title", "columns": ["title"]}]
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        unique_keys=None, if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+    assert "unique_keys" in out["mismatches"]
+
+
+async def test_divergent_indexes_are_reported(monkeypatch):
+    stored = _stored_row()
+    stored["indexes"] = [
+        {"name": "ix_title", "columns": [{"name": "title", "order": "asc"}]}
+    ]
+    _wire(monkeypatch, _FakeConn("v", existing=stored))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        indexes=None, if_not_exists=True, can_read_existing=True)
+
+    assert out["matches_request"] is False
+    assert "indexes" in out["mismatches"]
+
+
+async def test_column_references_are_validated_on_the_no_op_path(monkeypatch):
+    """A real create rejects a reference to a missing / non-unique / wrong-
+    typed target. If the no-op skipped that check, the SAME request would be
+    a 422 against an absent table and a quiet no-op against a present one —
+    the flag would change what counts as a valid spec."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    async def _bad_ref(*a, **k):
+        raise ValidationError("references a column that does not exist")
+
+    monkeypatch.setattr(table_service, "_validate_column_references", _bad_ref)
+
+    with pytest.raises(ValidationError):
+        await table_service.create_table(
+            uuid.uuid4(), "issues", _COLS, actor_id="t",
+            if_not_exists=True, can_read_existing=True)
+
+
+async def test_malformed_unique_keys_are_still_validated_on_the_no_op_path(
+    monkeypatch,
+):
+    """"Ensure a table matching this spec" is not satisfiable by a spec
+    that is not valid, so an existing table must not let a bad
+    unique_keys/indexes payload through unchecked."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    with pytest.raises(ValidationError):
+        await table_service.create_table(
+            uuid.uuid4(), "issues", _COLS, actor_id="t",
+            unique_keys=[{"columns": ["does_not_exist"]}], if_not_exists=True)
+
+
+async def test_real_create_with_enum_column_is_not_double_normalized(monkeypatch):
+    """`_normalize_column_spec` SYNTHESIZES a CHECK for an enum column, and
+    then rejects a column that already carries one ("Enum columns derive
+    their CHECK constraint from `enum`; omit `check`").
+
+    So normalization is NOT idempotent, and the real create path must
+    canonicalize exactly once. Sharing `_canonical_create_spec` between the
+    two branches is what makes `matches_request` trustworthy — but it must
+    not re-normalize columns the caller already normalized.
+    """
+    conn = _FakeConn("v", existing=None)
+    _wire(monkeypatch, conn)
+
+    async def _ok(*a, **k):
+        return None
+
+    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _ok)
+    monkeypatch.setattr(table_service.table_registry_repo, "insert", _ok)
+    monkeypatch.setattr(table_service, "emit_event", _ok)
+    monkeypatch.setattr(table_service, "index_table_metadata", _ok)
+    monkeypatch.setattr(table_service, "_validate_column_references", _ok)
+
+    class _RS:
+        async def grant_table_in_conn(self, *a, **k):
+            return None
+
+    monkeypatch.setattr(table_service, "get_role_sync", lambda: _RS())
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues",
+        [{"name": "state", "type": "enum", "enum": ["todo", "done"]}],
+        actor_id="t",
+    )
+    assert out["created"] is True
+
+
+# ── 4. SECURITY: the flag must not cross a vault boundary ────────
+
+
+async def test_cross_vault_fusion_still_conflicts_under_if_not_exists(monkeypatch):
+    """#285 fusion: `find_by_name` finds NOTHING in this vault, but the
+    physical name belongs to another vault's table. `if_not_exists=True`
+    must NOT convert that into created=false."""
+    _wire(monkeypatch, _FakeConn("a", existing=None, physical_taken=True))
+    _forbid_ddl(monkeypatch, "must not reach DDL when the physical name is taken")
+
+    with pytest.raises(ConflictError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(), "b__c", _COLS, actor_id="t", if_not_exists=True)
+
+    msg = str(ei.value)
+    assert "another vault" in msg
+
+
+async def test_cross_vault_fusion_leaks_no_schema(monkeypatch):
+    """The 409 body must not carry the other tenant's columns, URI or
+    collection — only the fusion rule."""
+    _wire(monkeypatch, _FakeConn("a", existing=None, physical_taken=True))
+    _forbid_ddl(monkeypatch, "no DDL")
+
+    with pytest.raises(ConflictError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(), "b__c", _COLS, actor_id="t", if_not_exists=True)
+
+    msg = str(ei.value)
+    for leaked in ("headline", "created_by", "akb://", "collection_id"):
+        assert leaked not in msg
+
+
+# ── 5. SECURITY: write authority does not confer read authority ──
+
+
+async def test_no_op_without_read_authority_returns_minimal_envelope(monkeypatch):
+    """`token_has_scope` is `"admin" in granted or required in granted` —
+    there is no write->read implication. `akb_create_table` is write-scoped
+    and `akb_browse` is read-scoped, so a write-only credential can create
+    tables and cannot browse. The enriched no-op body (URI, collection,
+    columns, keys, indexes) would therefore be a NEW disclosure to it.
+
+    `matches_request` / `mismatches` are withheld too: they are schema
+    oracles — repeated probing reconstructs the stored schema without ever
+    returning it.
+    """
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        if_not_exists=True, can_read_existing=False)
+
+    assert out == {
+        "kind": "table",
+        "name": "issues",
+        "created": False,
+        "outcome": "already_exists",
+    }
+
+
+async def test_read_authority_defaults_closed(monkeypatch):
+    """A caller that never passes the capability must not be handed the
+    stored state by omission."""
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True)
+
+    assert "columns" not in out
+    assert "mismatches" not in out
+
+
+async def test_read_authority_grants_the_full_envelope(monkeypatch):
+    _wire(monkeypatch, _FakeConn("v", existing=_stored_row()))
+    _forbid_ddl(monkeypatch, "no-op")
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        if_not_exists=True, can_read_existing=True)
+
+    assert out["columns"] == _COLS
+    assert out["matches_request"] is True
+    assert "uri" in out and "collection" in out
+
+
+async def test_real_create_is_unaffected_by_the_capability(monkeypatch):
+    """The capability gates only the no-op projection. A caller that
+    actually created the table already knows its schema — it supplied it."""
+    conn = _FakeConn("v", existing=None)
+    _wire(monkeypatch, conn)
+
+    async def _ok(*a, **k):
+        return None
+
+    for fn in ("create_dynamic_table",):
+        monkeypatch.setattr(table_service.table_data_repo, fn, _ok)
+    monkeypatch.setattr(table_service.table_registry_repo, "insert", _ok)
+    monkeypatch.setattr(table_service, "emit_event", _ok)
+
+    async def _no_index(*a, **k):
+        return None
+
+    monkeypatch.setattr(table_service, "index_table_metadata", _no_index)
+
+    class _RS:
+        async def grant_table_in_conn(self, *a, **k):
+            return None
+
+    monkeypatch.setattr(table_service, "get_role_sync", lambda: _RS())
+
+    out = await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        if_not_exists=True, can_read_existing=False)
+
+    assert out["created"] is True
+    assert out["columns"] == _COLS
+
+
+# ── 6. the advisory lock ─────────────────────────────────────────
+
+
+async def test_advisory_lock_is_taken_before_the_existence_check(monkeypatch):
+    """Serialising on `(vault_id, name)` is what removes the create/create
+    race, instead of classifying each race outcome after the
+    fact — a reread inside an aborted transaction is not implementable."""
+    conn = _FakeConn("v", existing=_stored_row())
+    _wire(monkeypatch, conn)
+    _forbid_ddl(monkeypatch, "no-op")
+
+    await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t", if_not_exists=True)
+
+    assert "advisory_lock" in conn.calls, f"no lock taken; calls={conn.calls}"
+    assert conn.calls.index("advisory_lock") < conn.calls.index("find_by_name")
+
+
+async def test_transaction_pins_read_committed(monkeypatch):
+    """The lock only helps if the loser SEES the winner after the wait.
+    Under REPEATABLE READ the vault lookup fixes a snapshot before the wait,
+    so the loser would still miss the winner. The pool pins no isolation
+    level, so a deployment default must not be able to break this."""
+    conn = _FakeConn("v", existing=_stored_row())
+    _wire(monkeypatch, conn)
+    _forbid_ddl(monkeypatch, "no-op")
+
+    await table_service.create_table(
+        uuid.uuid4(), "issues", _COLS, actor_id="t",
+        if_not_exists=True, can_read_existing=True)
+
+    assert conn.tx_kwargs.get("isolation") == "read_committed"
+
+
+async def test_lock_key_is_domain_prefixed(monkeypatch):
+    """`table_migration_service` calls the same function with an
+    UNPREFIXED f"{vault_id}:{key}", so a migration key equal to a table
+    name would alias onto this exact lock."""
+    captured: list = []
+
+    class _Recorder(_FakeConn):
+        async def fetchval(self, sql, *params):
+            if "pg_advisory" in sql:
+                captured.append(params[0])
+            return await super().fetchval(sql, *params)
+
+    conn = _Recorder("v", existing=_stored_row())
+    _wire(monkeypatch, conn)
+    _forbid_ddl(monkeypatch, "no-op")
+
+    vid = uuid.uuid4()
+    await table_service.create_table(
+        vid, "issues", _COLS, actor_id="t",
+        if_not_exists=True, can_read_existing=True)
+
+    assert captured == [f"table-create:{vid}:issues"]
+
+
+async def test_advisory_lock_is_taken_on_the_strict_path_too(monkeypatch):
+    """The race exists regardless of the flag, so the lock is not
+    conditional on it."""
+    conn = _FakeConn("v", existing=_stored_row())
+    _wire(monkeypatch, conn)
+    _forbid_ddl(monkeypatch, "no DDL on a duplicate")
+
+    with pytest.raises(ConflictError):
+        await table_service.create_table(
+            uuid.uuid4(), "issues", _COLS, actor_id="t")
+
+    assert "advisory_lock" in conn.calls

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -39,7 +39,8 @@ class _FakeConn:
     def __init__(self, vault_name: str):
         self._vault_name = vault_name
 
-    def transaction(self):
+    def transaction(self, **kwargs):
+        # create_table pins isolation="read_committed"
         return _AsyncCtx()
 
     async def fetchrow(self, sql: str, *params):

--- a/backend/tests/test_table_read_authority_unit.py
+++ b/backend/tests/test_table_read_authority_unit.py
@@ -1,0 +1,204 @@
+"""READ-authority gate for the `if_not_exists` no-op projection.
+
+`akb_create_table` is write-scoped and `akb_browse` is read-scoped, and
+`token_has_scope` is `"admin" in granted or required in granted` — there is no
+write->read implication. So a write-only credential can create tables and
+cannot browse, and the enriched no-op envelope (URI, collection, columns, keys,
+indexes, and the `matches_request`/`mismatches` schema oracles) would be a new
+disclosure to it.
+
+The trap this file exists for: `token_has_scope(None, ...)` returns True by
+design — `None` means "unscoped credential", i.e. a JWT login. But an OAuth
+credential ALSO carries `token_scopes=None` and puts its grants in
+`oauth_scopes` instead. A gate that inspects only `token_scopes` therefore
+waves every OAuth token through, including one holding nothing but
+`akb:vault:write`.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from app.config import settings
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _temp_git_storage_path():
+    """Point `git_storage_path` at a temp dir for this module only.
+
+    `mcp_server.server` constructs a DocumentService (and therefore a
+    GitService) at import time, which mkdirs this path. The import is lazy —
+    it happens inside each test — so setting it here, before `yield`, is
+    early enough.
+
+    Deliberately NOT a module-level statement: that mutates during
+    COLLECTION, so `--collect-only`, full deselection, or a collection error
+    would leave the process-global setting pointing at a temp dir with no
+    test ever running to restore it.
+
+    Known limitation, pre-existing and shared with `test_mcp_oauth_unit`:
+    `mcp_server.server` caches a module-level `doc_service`, whose GitService
+    captures this path at construction. Restoring the setting does not
+    reconstruct that object, so a later test importing the same module still
+    sees the temp path. Fixing that means changing how the module is imported
+    under test, which is outside this change.
+    """
+    original = settings.git_storage_path
+    try:
+        settings.git_storage_path = tempfile.mkdtemp(
+            prefix="akb-read-authority-test-")
+        yield
+    finally:
+        settings.git_storage_path = original
+
+
+class _User:
+    def __init__(self, *, token_scopes=None, oauth_scopes=None):
+        self.user_id = "u1"
+        self.username = "u"
+        self.token_scopes = token_scopes
+        self.oauth_scopes = oauth_scopes
+
+
+def _allow_vault(monkeypatch, module, ok: bool = True):
+    async def _check(*a, **k):
+        if not ok:
+            raise PermissionError("no reader role")
+        return {"vault_id": "v1"}
+
+    monkeypatch.setattr(module, "check_vault_access", _check)
+
+
+# ── the OAuth trap, on both surfaces ─────────────────────────────
+
+
+@pytest.mark.parametrize("surface", ["rest", "mcp"])
+async def test_oauth_write_only_token_is_denied_read_authority(monkeypatch, surface):
+    """An OAuth token holding only `akb:vault:write` must NOT be granted the
+    enriched projection. It reaches this code because writing is what it is
+    allowed to do; reading is not."""
+    if surface == "rest":
+        from app.api.routes import tables as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(oauth_scopes=["akb:vault:write"]), "v")
+    else:
+        from mcp_server import server as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(oauth_scopes=["akb:vault:write"]), "u1", "v")
+    assert got is False
+
+
+@pytest.mark.parametrize("surface", ["rest", "mcp"])
+async def test_oauth_token_with_read_scope_is_granted(monkeypatch, surface):
+    if surface == "rest":
+        from app.api.routes import tables as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(oauth_scopes=["akb:vault:read", "akb:vault:write"]), "v")
+    else:
+        from mcp_server import server as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(oauth_scopes=["akb:vault:read", "akb:vault:write"]),
+            "u1", "v")
+    assert got is True
+
+
+# ── PAT scopes ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("surface", ["rest", "mcp"])
+async def test_pat_write_only_is_denied(monkeypatch, surface):
+    if surface == "rest":
+        from app.api.routes import tables as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(token_scopes=frozenset({"write"})), "v")
+    else:
+        from mcp_server import server as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(
+            _User(token_scopes=frozenset({"write"})), "u1", "v")
+    assert got is False
+
+
+@pytest.mark.parametrize("surface", ["rest", "mcp"])
+async def test_unscoped_jwt_login_is_granted(monkeypatch, surface):
+    """`token_scopes=None` AND `oauth_scopes=None` is a plain JWT login —
+    genuinely unscoped, so scope is not the thing that limits it. Vault ACL
+    still does."""
+    if surface == "rest":
+        from app.api.routes import tables as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(_User(), "v")
+    else:
+        from mcp_server import server as mod
+        _allow_vault(monkeypatch, mod)
+        got = await mod._can_read_vault(_User(), "u1", "v")
+    assert got is True
+
+
+# ── the flag must be a real boolean ──────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["true", "false", 1, 0, "yes", []])
+async def test_non_boolean_if_not_exists_is_rejected(monkeypatch, bad):
+    """Silently coercing is worse than either accepting or rejecting.
+    `bool("false")` is True, so a lenient cast hands the caller idempotent
+    behaviour it never asked for; a strict `is True` hands `"true"` the
+    409 it did not expect. Reject, so the caller learns."""
+    from mcp_server import server as mod
+
+    out = await mod._handle_create_table(
+        {"vault": "v", "name": "t", "columns": [], "if_not_exists": bad},
+        "u1", _User(),
+    )
+    assert out.get("error"), f"{bad!r} should have been rejected, got {out}"
+    assert "if_not_exists" in str(out)
+
+
+async def test_absent_if_not_exists_is_still_accepted(monkeypatch):
+    """Omission is not a malformed value — it is the documented default."""
+    from mcp_server import server as mod
+
+    _allow_vault(monkeypatch, mod)
+
+    called = {}
+
+    async def _svc(*a, **k):
+        called.update(k)
+        return {"kind": "table", "created": True}
+
+    monkeypatch.setattr(mod.table_service, "create_table", _svc)
+    monkeypatch.setattr(mod, "_can_read_vault", lambda *a, **k: _true())
+
+    out = await mod._handle_create_table(
+        {"vault": "v", "name": "t", "columns": []}, "u1", _User())
+    assert not out.get("error"), out
+    assert called["if_not_exists"] is False
+
+
+async def _true():
+    return True
+
+
+# ── the vault ACL still applies, and failures fail closed ────────
+
+
+@pytest.mark.parametrize("surface", ["rest", "mcp"])
+async def test_reader_role_denied_means_no_read_authority(monkeypatch, surface):
+    if surface == "rest":
+        from app.api.routes import tables as mod
+        _allow_vault(monkeypatch, mod, ok=False)
+        got = await mod._can_read_vault(_User(), "v")
+    else:
+        from mcp_server import server as mod
+        _allow_vault(monkeypatch, mod, ok=False)
+        got = await mod._can_read_vault(_User(), "u1", "v")
+    assert got is False

--- a/backend/tests/test_tables_route_unit.py
+++ b/backend/tests/test_tables_route_unit.py
@@ -68,6 +68,13 @@ async def test_create_table_route_forwards_plain_schema_with_legacy_defaults(mon
         "collection": None,
         "unique_keys": [{"columns": ["state"], "vendor_extension": "keep"}],
         "indexes": [{"columns": [{"name": "state", "order": "desc"}]}],
+        # Omitted by the caller → the route still forwards the explicit
+        # default, so the service never has to infer intent from absence.
+        "if_not_exists": False,
+        # Read authority is resolved at this boundary and passed down as a
+        # capability. False here because the stub user has no reader role —
+        # which is the fail-closed default the projection depends on.
+        "can_read_existing": False,
     }
 
 

--- a/backend/tests/test_vault_table_name_collision_unit.py
+++ b/backend/tests/test_vault_table_name_collision_unit.py
@@ -91,7 +91,8 @@ class _FakeConn:
         self._vault_name = vault_name
         self._taken = taken
 
-    def transaction(self):
+    def transaction(self, **kwargs):
+        # create_table pins isolation="read_committed"
         return _AsyncCtx()
 
     async def fetchrow(self, sql: str, *params):
@@ -100,6 +101,11 @@ class _FakeConn:
         return None  # find_by_name → no same-vault duplicate
 
     async def fetchval(self, sql: str, *params):
+        # create_table serialises same-(vault, table) creates on an xact
+        # advisory lock before the existence check; it is not part of what
+        # these tests assert, but it does reach the fake.
+        if "pg_advisory" in sql:
+            return None
         assert "to_regclass" in sql, f"unexpected fetchval: {sql}"
         return self._taken
 

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md
@@ -1,0 +1,463 @@
+---
+title: akb_create_table — opt-in idempotent create (`if_not_exists`)
+status: implemented
+stage: proposal
+created: 2026-07-29
+updated: 2026-07-29
+reviews:
+  - feedback/2026-07-29-codex-round1.md
+  - feedback/2026-07-29-codex-round2-impl.md
+  - feedback/2026-07-29-codex-round3-impl.md
+  - feedback/2026-07-29-codex-round4-impl.md
+  - feedback/2026-07-29-codex-round5-impl.md
+  - feedback/2026-07-29-codex-round6-impl.md
+  - feedback/2026-07-29-codex-round7-impl.md
+  - feedback/2026-07-29-codex-round8-impl.md
+  - feedback/2026-07-29-codex-round9-impl.md
+  - feedback/2026-07-29-codex-round10-impl.md
+  - feedback/2026-07-29-codex-round11-impl.md
+  - feedback/2026-07-29-codex-round12-impl.md
+  - feedback/2026-07-29-codex-round13-final.md
+---
+
+# `akb_create_table(if_not_exists=true)` — opt-in idempotent create
+
+> Revised across thirteen Codex rounds; every finding is folded in below. See
+> `feedback/`.
+
+## Problem
+
+`akb_create_table` has no idempotent mode. A caller that wants "make sure this
+table exists" has one option: call create, catch the 409, and infer that the
+table already exists.
+
+Production tool-usage data (2026-07-29, first ~110 minutes after enabling
+`tool_usage`) shows this is the dominant use of the tool:
+
+```
+tool               calls   errors   code       followed by
+akb_create_table     461      461    conflict   alter_table 66.6% / browse 33.4%
+akb_alter_table      308        0    —          —
+```
+
+Every `akb_create_table` call in the window returned 409; every one was followed
+in the same session by a successful call. A representative caller is a job that
+runs every 5 minutes, 29 calls, ~50s, whose steps 2–7 are three create/browse
+probe pairs.
+
+The caller is using an error response as a return value.
+
+## Why this is worth fixing
+
+1. **The recovery branch is a guess, not a contract.** It works because someone
+   inferred that `conflict` means "already exists" from the error string. AKB
+   never promised that; any new client must rediscover it.
+2. **Ambiguity the caller cannot resolve.** A `conflict` after a timeout could
+   mean the caller's own attempt won, or another actor's did.
+3. **The metric is destroyed.** 100% failure on a healthy tool cannot be alerted
+   on, and a real defect in the same tool would be indistinguishable from the
+   routine 461.
+4. **TOCTOU.** `find_by_name` then create is check-then-act; the pre-check can be
+   lost to a concurrent creator.
+
+## Internal precedent
+
+| Tool | Name collision behaviour |
+|---|---|
+| `akb_create_collection` | **Idempotent** — returns current row state, `created=False` |
+| `akb_put` | **Auto-avoids** — appends `-shortid` to the slug and creates |
+| `akb_create_table` | **409 Conflict** |
+
+`collection_service.py:137` states the response contract explicitly: *"an
+idempotent re-create against an existing collection with 5 docs surfaces
+doc_count=5, not 0."*
+
+**Not** a precedent for events: `create_collection` emits `collection.create`
+unconditionally, including on the no-op (`collection_service.py`). This
+proposal deliberately diverges (see Events below).
+
+## Proposal
+
+Add an optional `if_not_exists: bool = False` to `akb_create_table` (MCP) and
+`POST /api/v1/tables/{vault}` (REST, `tables.py`).
+
+```
+if_not_exists=false (default)
+    table absent  -> create
+    table present -> 409 ConflictError            (unchanged)
+
+if_not_exists=true
+    table absent  -> create           -> created=true
+    table present -> no write at all  -> created=false
+```
+
+The flag changes the request, not the reporting: without it the caller says
+"create this table"; with it, "ensure this table exists". This is why SQL spells
+them `CREATE TABLE` and `CREATE TABLE IF NOT EXISTS`.
+
+### Concurrency: take a lock, do not recover from the race
+
+Codex round 1 established that the original design — catch
+`asyncpg.UniqueViolationError` and re-read the committed row — **is not
+implementable**. The exception surfaces while the outer `conn.transaction()` is
+still active, so PostgreSQL is in an aborted state and every subsequent query on
+that connection fails until rollback.
+
+There are also more race outcomes than the two originally listed. A concurrent
+winner can commit:
+
+| Window | Loser observes | Raised as |
+|---|---|---|
+| before `find_by_name` | registry row present | (the intended `created=false`) |
+| between `find_by_name` and the physical preflight | `to_regclass` non-null | `ConflictError` (fusion message) |
+| during `CREATE TABLE` | `asyncpg.DuplicateTableError`, or a `pg_type` uniqueness failure | `ConflictError` |
+
+Only the first is a decision; the two later ones are unrecoverable, because by
+the time they surface the transaction is aborted.
+
+Note the registry insert is **not** a third post-check window for the same
+logical table: once one transaction has created the physical table, the other
+cannot reach the insert — its `CREATE TABLE` fails first. The
+`UniqueViolationError` arm around the insert is defensive, covering a registry
+row that arrived by some other route.
+
+**Resolution: serialize on the logical identity rather than classify each race
+outcome after the fact.** Take a transaction-scoped advisory lock keyed by `(vault_id, name)`
+before the existence check, following the existing precedent in
+`table_migration_service.py:240`:
+
+```python
+async with conn.transaction(isolation="read_committed"):
+    ...
+    await conn.fetchval(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        f"table-create:{vault_id}:{name}",
+    )
+```
+
+Two details the first draft got wrong, both caught in review:
+
+* **The key is domain-prefixed.** `table_migration_service` calls the same
+  function with an *unprefixed* `f"{vault_id}:{key}"`, so a migration key equal
+  to a table name would alias onto exactly this lock. Harmless for correctness
+  — the two paths each take one such lock and migration's `alter_table` takes
+  no second one, so no deadlock — but it is needless blocking.
+* **The transaction pins `read_committed`.** The lock only helps if the loser
+  can *see* the winner's row after the wait. Under `REPEATABLE READ` the vault
+  lookup would fix a snapshot *before* the wait, so the loser would still miss
+  the winner and fall through into the constraint violation it cannot recover
+  from. The pool sets no isolation level (`app/db/postgres.py`), so a
+  deployment-level default must not be able to break this.
+
+This makes both later windows impossible for the same logical table, so only
+the `find_by_name` check is left to decide — which is the one that should. It also closes the TOCTOU listed as
+cost 4 above — something the caller's catch-409 pattern cannot do, because on
+seeing a 409 it has no way to know whether its own transaction or another's won.
+
+If a uniqueness failure still surfaces (a different logical table fusing onto the
+same physical name), it **must remain a conflict** — see Security.
+
+`grant_table_in_conn` and `emit_event` stay winner-only inside the successful
+transaction, and a no-op must return before the post-commit metadata indexing
+(`index_table_metadata`, outside the create transaction).
+
+### Security: `if_not_exists` must never cross a vault boundary
+
+Two separate concerns, both load-bearing.
+
+**(a) Cross-vault physical-name fusion (#285).** Vault and table names are joined
+with `__`, and hyphens in vault names map to underscores, so vault `a--b` table
+`c` and vault `a` table `b__c` both resolve to `vt_a__b__c`. `table_service.py`
+raises `ConflictError` via `_physical_name_conflict_message()` for exactly this, and that function's docstring already treats the raw PG
+error as a disclosure — it *"confirms another tenant's physical table by name"*.
+
+**Every one of those sites raises the same `ConflictError` type.** An implementation
+that broadly catches `ConflictError` when `if_not_exists=true` would convert a
+cross-vault fusion into `created=false` and then return the other tenant's
+schema.
+
+> **Invariant.** `if_not_exists=true` suppresses the conflict **only** when a row
+> with the exact `(vault_id, name)` exists. Every other conflict — physical-name
+> fusion, `to_regclass` collision, `DuplicateTableError`, uniqueness violation
+> without a matching logical row — raises unchanged.
+
+Measured evidence that this boundary is real: PostgreSQL's `information_schema`
+is privilege-filtered and AKB issues per-vault PG roles. A writer role for a
+vault holding 61 tables sees exactly those 61 of the 518 `vt_` tables on the
+cluster, and 670 columns, all its own. The other 457 tables are invisible to it.
+So leaking another vault's columns here would be a genuine new disclosure, not a
+restatement of something already reachable.
+
+**(b) Write scope does not imply read scope.** The original draft argued the
+enriched response discloses nothing because "a writer could learn the same from
+`akb_browse`". That is **wrong**. `token_has_scope` is
+`"admin" in granted or required in granted` (`auth_service.py:213`) — there is no
+implication. `akb_create_table` is `_WRITE_SCOPE` and `akb_browse` is
+`_READ_SCOPE` (`server.py:205`, `:232`), so a write-only token can create tables
+and cannot browse. Managed-vault wildcard grants can likewise authorize a write
+before reader membership is checked (`access_service.py:254`).
+
+Existence itself is already disclosed by success-vs-409 in the current strict
+create, so the flag adds no existence bit. But **the stored schema, collection
+and URI are new disclosure to a write-only caller.**
+
+Resolution: the enriched no-op body requires read authority, resolved at the
+REST/MCP authorization boundary and handed to the service as a capability
+(`can_read_existing`), never as raw scopes. It defaults to `False`, so a caller
+that forgets to pass it gets the minimal envelope rather than the stored schema.
+A caller with write but not read receives exactly:
+
+```jsonc
+{"kind": "table", "name": "issues", "created": false, "outcome": "already_exists"}
+```
+
+`matches_request` and `mismatches` are withheld along with the schema: they are
+themselves schema oracles — repeated probing reconstructs the stored schema
+without it ever being returned.
+
+Both boundaries must consult **both** scope systems. `token_has_scope(None, …)`
+returns True by design — `None` means an unscoped credential, i.e. a JWT login —
+but an OAuth credential *also* carries `token_scopes=None` and keeps its grants
+in `oauth_scopes`. A gate that checks only the former waves through an OAuth
+token holding nothing but `akb:vault:write`. (The REST helper had exactly this
+defect in the first implementation; Codex round 3 caught it.)
+
+Separately and out of scope here: REST's `get_current_user` does not enforce
+OAuth scopes at all (`app/api/deps.py`), so a read-only or zero-scope OAuth
+token with writer membership can currently POST mutations. That predates this
+change and needs its own fix.
+
+(Alternatives considered: define write as implying read, or require read scope
+to pass the flag at all. Both are larger changes to the scope model.)
+
+### Response shape
+
+Codex round 1: returning stored state is necessary but insufficient — a
+success-looking `created=false` still invites the caller to assume its requested
+schema was ensured. Divergence must be machine-explicit:
+
+```jsonc
+{
+  "kind": "table",
+  "uri": "akb://myvault/coll/x/table/issues",
+  "vault": "myvault",
+  "name": "issues",
+  "created": false,
+  "outcome": "already_exists",
+  "matches_request": false,
+  "mismatches": ["collection", "columns"],
+  "columns":     [...],   // the STORED schema, not the request's
+  "unique_keys": [...],
+  "indexes":     [...]
+}
+```
+
+* Comparison is **exact canonical equality**, never "compatible" — anything
+  looser reopens schema-diff policy, which is explicitly out of scope.
+* Comparison covers `columns`, `unique_keys`, `indexes`, `collection` and
+  `description`. Each mismatching field is named in `mismatches`.
+* Stored JSONB is normalized through the repository parsing helpers, including
+  legacy string rows (`table_registry_repo.py:222`), before comparison.
+* `created` appears on `created=true` responses too, so its absence is never
+  meaningful.
+* The no-op canonicalizes the request through the **same** helper the real
+  create uses (`_canonical_create_spec`: normalize columns, resolve inline and
+  explicit keys/indexes, reject duplicate metadata names) and additionally runs
+  `_validate_column_references`. Sharing it is what makes `matches_request`
+  meaningful — two independently-derived canonical forms could report a
+  mismatch the real create would never have produced, or a match it would have
+  refused. It also means a malformed spec is rejected identically whether or
+  not the table exists — "ensure a table matching this spec" is not satisfiable
+  by an invalid spec. (A bad column/key/index spec is a `ValidationError` →
+  422; a reference to a table missing from the vault is `AKBError(400)`.)
+  The **strict** path deliberately keeps its original order (409 before column
+  validation), so which ERROR a caller gets is unchanged — an existing table
+  is still a 409 before any spec validation runs. Its success envelope does
+  gain `created: true`; see Compatibility.
+* **Comparison drops no-op spellings.** `required: false` and omitting
+  `required` describe the same column, but normalization keeps whichever
+  spelling arrived — so a stored row created with one form reported a
+  spurious mismatch against a request using the other. `_comparable()`
+  strips those before comparing, on BOTH sides and **never** on what is
+  stored. The rule is per field: `False` counts as absent for
+  `required`/`unique`/`index`, but for `default` only NULL does —
+  `default: false` on a boolean column is a real `DEFAULT FALSE` and a
+  genuine difference. Comparison is also **type-tagged**: Python says
+  `False == 0` and `True == 1`, but JSONB and the generated DDL do not, so
+  a plain `==` would hide that divergence — including nested inside a
+  `check` spec. Explicit `check`/`enum`/`references`/`on_delete` nulls are
+  stripped as absent, since REST accepts them and they generate the same
+  DDL as omission. A false mismatch is worse than no signal: it sends
+  the caller to alter a table that already matches.
+* **Column normalization runs exactly once.** It is NOT idempotent: it
+  synthesizes a `CHECK` for an enum column and then rejects a column that
+  already carries one (*"Enum columns derive their CHECK constraint from
+  `enum`; omit `check`"*). Sharing the canonicalizer naively therefore turned
+  **every enum create into a 422** — a regression introduced while fixing
+  `matches_request`, found by Codex round 4 and pinned by
+  `test_real_create_with_enum_column_is_not_double_normalized`.
+  `_canonical_create_spec(normalize_columns=False)` is how the real path opts
+  out; the no-op keeps the default because it holds raw caller input. Codex
+  round 5 verified both branches produce identical canonical tuples for enum
+  plus inline and explicit key/index inputs.
+
+### Events
+
+No `table.create` on a no-op. Domain events represent committed changes, and
+`tool_usage` already records the attempted command. This diverges from
+`create_collection`, which emits unconditionally — that is an inconsistency in
+the existing code, not a precedent to copy.
+
+A no-op must additionally not auto-create the requested collection, must not
+overwrite or re-index metadata from the losing request, and must emit at most
+one `table.create` under concurrency.
+
+## Compatibility
+
+Requests are fully compatible: the default is `false`, so existing callers keep
+the current behaviour including the 409, and the production catch-409 client
+needs no change.
+
+Responses are **additive, not identical** — every `create_table` response gains
+`created` (and the no-op branch gains `outcome` / `matches_request` /
+`mismatches`). Adding a field to a JSON response is conventionally safe: JSON
+parsers ignore keys they do not know, and the generated TypeScript envelope
+already carries an index signature. (An earlier draft justified this with
+`extra="allow"` on the request models — that governs request PARSING and says
+nothing about response compatibility. `CreateTableRequest` inherits `NFCModel`
+in any case.) The earlier claim that behaviour is unchanged "bit for bit" was
+an overstatement.
+
+The MCP flag is **type-strict**: a non-boolean is rejected with
+`invalid_argument` rather than coerced. Both lenient and strict casts mislead —
+`bool("false")` is `True`, so a lenient cast grants idempotent behaviour the
+caller never asked for, while a strict `is True` silently gives `"true"` the 409
+it did not expect.
+
+Contract surfaces updated in the same change:
+
+* `backend/mcp_server/tools.py` — MCP tool schema and description
+* `backend/app/openapi_contract.py` — static `AkbTableEnvelope`
+* `backend/tests/test_tables_route_unit.py` — route forwarding assertion
+* `backend/tests/test_vault_table_name_collision_unit.py`,
+  `test_table_name_length_unit.py` — fakes now see the advisory lock and the
+  `isolation` kwarg
+* `backend/mcp_server/help.py` — the `akb_create_table` help topic
+* `packages/akb-client/test/fixtures/openapi.core.json` +
+  `src/core/schema.gen.ts` — `if_not_exists?: boolean` on `CreateTableRequest`
+* `packages/akb-client/src/core/openapi-codegen.ts` — the hand-written
+  `AkbTableEnvelope` generator gained `created`, `outcome`, `matches_request`
+  and `mismatches`. Without this the response fields a caller needs to USE the
+  feature were reachable only through the `[key: string]: unknown` catch-all.
+
+Note the checked-in OpenAPI fixture has drifted from the live spec well beyond
+this change (regenerating it wholesale pulls in 68 new schemas, 26 changed ones
+and 2 new paths). Only the field this change introduces was added, so the diff
+stays reviewable; refreshing the fixture is its own piece of work.
+
+## Tests
+
+`backend/tests/test_table_if_not_exists_unit.py` (40 cases), DB-free:
+
+* Default and explicit `if_not_exists=false` on an existing table still raise 409.
+* Absent → creates, `created=true`. Present → `created=false`, no DDL, no
+  `table.create` event, no post-commit metadata indexing.
+* Divergent `columns` / `unique_keys` / `indexes` / `collection` each appear in
+  `mismatches`; `columns` reflect the STORED schema. Legacy JSON-string rows
+  normalize rather than reporting a spurious mismatch.
+* Malformed `unique_keys` and bad column references are 422 on the no-op path.
+* **Cross-vault fusion with `if_not_exists=true` still raises 409, and the body
+  carries no part of the other vault's schema, URI, or collection.**
+* The advisory lock is taken before `find_by_name`, on both paths, with the
+  `table-create:` prefix; the transaction pins `read_committed`.
+
+`backend/tests/test_table_read_authority_unit.py` (17), both surfaces:
+
+* An OAuth token holding only `akb:vault:write` is denied read authority; one
+  holding `akb:vault:read` is granted it. Same for PAT `write` vs `read`.
+* An unscoped JWT login is granted; a denied reader role is not.
+* Non-boolean `if_not_exists` (`"true"`, `1`, `[]`, …) is rejected, not coerced.
+
+`backend/tests/test_table_if_not_exists_e2e.py` (6), live PostgreSQL:
+
+* Two concurrent `create_table(if_not_exists=True)` calls for the same
+  (vault, table) both succeed with **exactly one** `created=true`, one registry
+  row, one physical table and one `table.create` event.
+* The advisory lock serializes same-key sessions, leaves different keys
+  unblocked, and releases on rollback as well as commit.
+* A re-read after a constraint violation raises
+  `InFailedSQLTransactionError` — pinning the fact that made the original
+  catch-and-reread design unimplementable.
+
+Falsification (both verified): removing the advisory lock fails the concurrency
+test 5/5 and passes again on restore; making the cross-vault branch return a
+no-op fails both security tests and passes again on revert.
+
+### Functional reproduction
+
+Tests assert; this exercised the feature. A script drove the real service
+against live PostgreSQL 16.13 and printed what a caller receives:
+
+| # | Call | Result |
+|---|---|---|
+| 1 | absent, `if_not_exists=True` | `created=True`, table actually created (enum column included) |
+| 2 | same spec again | `created=False`, `matches_request=True`, `mismatches=[]` |
+| 3 | different spec | `created=False`, `matches_request=False`, `mismatches=['columns','description']`, returned columns are the STORED ones |
+| 4 | `can_read_existing=False` | exactly `{kind, name, created, outcome}` |
+| 5 | no flag | `ConflictError: Table already exists: issues` |
+
+Database state after all five: **1** registry row, physical table present,
+exactly **1** `table.create` event, and the actual columns are
+`['id','title','state','created_by','created_at','updated_at']` — the
+`headline` column requested in (3) was never created. Scenarios 2–4 are
+no-ops and changed nothing; scenario 5 is a conflict, not a no-op.
+
+## Priority
+
+**Medium.** The original draft said "low, no user is blocked". Codex round 1
+pushed back and is right: the data proves callers *recovered*, not that tasks
+completed successfully or that nothing was slowed. It is systematic latency and
+cost, and it destroys an operational signal outright — after nine hours of
+production collection the count is **876 conflicts out of 897 calls (97.7%)**,
+so the tool's failure rate cannot be read at all.
+
+Still below the two live defects found in the same dataset and above backlog:
+
+* `akb_search` — 75 calls, **mean 14.0s, max 35.5s**, zero failures. Root cause
+  is now established independently: the vector working set (~23 GB) far exceeds
+  `shared_buffers` (2 GB) on CephFS-backed storage, so cold blocks cost
+  ~0.66–2.15 ms each and `track_io_timing` attributes 99.8% of a cold query to
+  disk I/O wait. A latency problem that never fails is invisible to any error
+  metric.
+* A 5-minute scheduled job whose terminal `akb_sql` step fails every run against
+  a missing table in another vault.
+
+## Out of scope
+
+Declarative reconciliation (`ensure_table`): if the table exists with different
+columns this reports the divergence and alters nothing. Reconciliation needs a
+destructive-divergence policy and cannot distinguish a rename from a
+drop-plus-add, which is why `akb_alter_table` exposes `rename_column` as its own
+operation.
+
+## Status
+
+**Implemented on `feat/create-table-if-not-exists`; Codex round 13 verdict is
+"Ready to merge. No blockers remain." Awaiting PM sign-off.** Revised through thirteen Codex rounds (see `feedback/`), which found and
+closed: an unimplementable transaction flow, an incorrect `matches_request`, a
+REST gate that ignored OAuth scopes, a stale typed SDK, and a double-
+normalization regression that broke every enum create.
+
+Verification: 1059 unit tests, 6 live-PostgreSQL tests (also run against a
+FRESH database, the CI condition), `ruff`, `mypy`, and the
+`akb-client` `codegen:check` all pass. Both load-bearing guarantees are
+falsified as well as asserted, and the feature was additionally exercised
+end-to-end against live PostgreSQL 16.13 — see Functional reproduction.
+
+Resolved since the first draft — the write-only-caller envelope is
+`{kind, name, created, outcome}`, and request validation runs on the no-op path
+while the strict path keeps validating *after* the existence check, so an
+existing table is still a 409 there and not a 422.
+
+Known gaps, deliberately not carried here: the OpenAPI fixture's pre-existing
+drift, and REST's missing OAuth-scope enforcement in `get_current_user`.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round1.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round1.md
@@ -1,0 +1,52 @@
+The proposal needs revision before acceptance. The transaction and race handling are blockers.
+
+1. The `UniqueViolationError` reread is not implementable inside the current transaction. The exception is caught while the outer transaction is still active, leaving PostgreSQL in an aborted state; any subsequent query fails until rollback. See [table_service.py:586](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:586) and [table_service.py:729](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:729).
+
+   Correct structures are either:
+
+   - Catch outside `async with conn.transaction()`, let the whole losing attempt roll back, then start a fresh transaction and reread.
+   - Put all potentially failing DDL/registry work in a nested `conn.transaction()` savepoint, catch only after that savepoint rolls back, then reread under `READ COMMITTED`.
+
+   In either case, return no-op only if the exact `(vault_id, name)` row exists. If it does not, preserve the conflict: the uniqueness failure may represent a cross-vault physical-name collision, not a concurrent logical create. `grant_table_in_conn` and `emit_event` must remain winner-only inside the successful transaction. The no-op must also return before post-commit metadata indexing at [table_service.py:750](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:750).
+
+   Better still: take a transaction-scoped advisory lock keyed by `(vault_id, name)` before the existence check, following the existing precedent in [table_migration_service.py:240](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_migration_service.py:240). That removes the same-name race rather than recovering from it.
+
+2. There are more than two collision sites. A winner can commit:
+
+   - Between `find_by_name` and `to_regclass`, causing the physical-name preflight to conflict at [table_service.py:648](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:648).
+   - After that preflight but before the loser’s `CREATE TABLE`, potentially producing `DuplicateTableError` at [table_service.py:674](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:674).
+   - During catalog or registry insertion, producing the cited uniqueness error.
+
+   All three race outcomes need exact-row classification, or the advisory lock must make the first two impossible for the same logical table. Physical fusion involving a different logical table must remain a conflict.
+
+3. The existence-disclosure conclusion is correct, but the stated reason is not. The current strict create already reveals existence through success versus 409, so the flag adds no new existence bit to anyone authorized to call create.
+
+   However, not every authorized writer can browse. Read and write token scopes are independent: create is write-scoped, browse is read-scoped, and `write` does not imply `read` ([server.py:205](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:205), [server.py:232](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:232), [auth_service.py:213](/Users/kwoo2/Desktop/storage/akb/backend/app/services/auth_service.py:213)). Managed-vault wildcard grants can also authorize a write before reader membership is checked ([access_service.py:254](/Users/kwoo2/Desktop/storage/akb/backend/app/services/access_service.py:254)).
+
+   Consequently, returning the stored schema, collection, and URI is a new disclosure for write-only callers. Either require read authority for the enriched no-op response, define write as implying read, or return a minimal no-op envelope to callers lacking read authority.
+
+4. Returning stored state is necessary but insufficient. A successful-looking `created=false` response still invites callers to assume the requested schema was ensured. Make mismatch machine-explicit, for example:
+
+   ```json
+   {
+     "created": false,
+     "outcome": "already_exists",
+     "matches_request": false,
+     "mismatches": ["collection", "columns"],
+     "table": { "...": "stored canonical resource" }
+   }
+   ```
+
+   Use an exact canonical comparison, not “compatible,” which would reopen schema-diff policy. Define whether comparison covers collection and description as well as columns, keys, and indexes. Also define validation order: currently an existing table bypasses column/key/index validation. Test concurrent requests with different schemas and different collection paths.
+
+5. Several compatibility and implementation claims need correction:
+
+   - Adding `created=true` to default successful creates means behavior is additive, not “bit for bit” unchanged.
+   - The actual REST route is `POST /api/v1/tables/{vault}`, not `/vaults/{vault}/tables` ([tables.py:261](/Users/kwoo2/Desktop/storage/akb/backend/app/api/routes/tables.py:261)).
+   - The MCP schema/help and static OpenAPI `AkbTableEnvelope` must change ([tools.py:606](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/tools.py:606), [openapi_contract.py:645](/Users/kwoo2/Desktop/storage/akb/backend/app/openapi_contract.py:645)).
+   - A no-op must not auto-create the requested collection, overwrite/index metadata from the losing request, or emit more than one `table.create`.
+   - Stored JSONB should be normalized through the repository parsing helpers, including legacy string rows ([table_registry_repo.py:222](/Users/kwoo2/Desktop/storage/akb/backend/app/repositories/table_registry_repo.py:222)).
+
+6. Agree: no `table.create` event on a no-op. Domain events represent committed changes, while tool usage already records the attempted command. But the collection precedent is described incorrectly: `create_collection` currently emits `collection.create` unconditionally, including `created=false`, at [collection_service.py:151](/Users/kwoo2/Desktop/storage/akb/backend/app/services/collection_service.py:151). Do not cite it as event precedent.
+
+7. “Low” understates the evidence. The data proves callers recovered from these conflicts, not that no user was blocked or that tasks completed successfully. At 461 conflicts in roughly 110 minutes, this is systematic latency/cost and destroys an operational signal. I would classify it medium priority—still below the live search-latency and failing-terminal-step defects, but not backlog-level low.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round10-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round10-impl.md
@@ -1,0 +1,14 @@
+Not ready to merge.
+
+1. **Blocker — `matches_request` has false mismatches.** Canonicalization preserves no-op fields: omitting `required` and specifying `required: false` produce unequal columns despite identical schemas. I reproduced this directly. The same applies to `unique/index: false` and some explicit nulls. Fix canonicalization and add regression coverage. [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:582)
+
+2. **Blocker — the load-bearing live test is not CI-gated.** The unit job excludes `_e2e`, while the live-Postgres job does not list this file. Moreover, its service-level test skips on the job’s unbootstrapped database. Add it to the live job and ensure schema setup cannot green-skip. [backend-pytest.yml](/Users/kwoo2/Desktop/storage/akb/.github/workflows/backend-pytest.yml:41) [test_table_if_not_exists_e2e.py](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:233)
+
+3. **Blocker — remaining factual wording:**
+
+   - “three further windows” names only the two post-check windows; the unit test still says “four different race outcomes.” [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:759) [test_table_if_not_exists_unit.py](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_unit.py:489)
+   - Missing reference targets are HTTP 400, not 422 as the comments/design claim. [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:391)
+   - Several docstrings promise stored schema unconditionally despite the minimal-envelope branch. [tables.py](/Users/kwoo2/Desktop/storage/akb/backend/app/api/routes/tables.py:113) [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:637)
+   - The compatibility rationale incorrectly says the relevant request models use `extra="allow"`; `CreateTableRequest` inherits `NFCModel`, and request parsing does not establish response compatibility. [README.md](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:301)
+
+No new follow-up-only item; the items above block merge.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round11-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round11-impl.md
@@ -1,0 +1,7 @@
+Not ready to merge.
+
+1. **Blocker:** `_comparable()` wrongly drops `default: False`. A boolean column without a default generates `BOOLEAN`; one with `default: false` generates `BOOLEAN DEFAULT FALSE`, yet they currently compare equal. Scope is correct; the predicate is not. Treat `False` as absent only for `required`/`unique`/`index`, and `None` as absent for `default`. Add that regression. [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:629)
+
+2. **CI gating is genuine.** The workflow supplies `AKB_TEST_DSN`, explicitly runs the file, bootstraps a fresh database, and connection/bootstrap failures fail rather than skip. [backend-pytest.yml](/Users/kwoo2/Desktop/storage/akb/.github/workflows/backend-pytest.yml:87)
+
+3. **Minor factual cleanup:** the design still says 24 feature units and 1045 total; the staged parametrization makes that 30 feature cases, and your reported total is 1049. [README.md](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:342)

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round12-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round12-impl.md
@@ -1,0 +1,7 @@
+Not ready to merge.
+
+1. **Blocker — real JSONB divergence is still hidden.** Python equality treats `False == 0`. Thus JSONB defaults `false` and `0` survive `_comparable()` but compare equal at [table_service.py:715](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:715), despite generating distinct DDL. The same defect affects JSONB check values and nested JSON. Use type-sensitive recursive comparison and add default/check regressions.
+
+2. **Blocker — nullable no-op fields still cause false mismatches.** Explicit `check: null`, `enum: null`, `references: null`, or `on_delete: null` is DDL-equivalent to omission, but only `default` is stripped at [table_service.py:634](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:634). These accepted REST inputs currently report `columns` divergence.
+
+The new rules for `required`/`unique`/`index` and `default` themselves are correct. No other blocker found.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round13-final.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round13-final.md
@@ -1,0 +1,3 @@
+1. No findings. Across the reachable JSON domain, I found no wrongly equated shape or hidden divergence. The non-JSON `repr` fallback is unreachable through REST/MCP/JSONB.
+
+2. Ready to merge. No blockers remain; `git diff --cached --check` is clean.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round2-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round2-impl.md
@@ -1,0 +1,56 @@
+Not ready to ship. Two blockers remain.
+
+1. **Blocker — write-only callers receive read-protected state.** The REST route and MCP handler establish only writer authority, then return the service result unchanged ([tables.py:267](/Users/kwoo2/Desktop/storage/akb/backend/app/api/routes/tables.py:267), [server.py:998](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:998)). The no-op exposes stored collection/URI/schema and mismatch information ([table_service.py:620](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:620)).
+
+   This belongs at the REST/MCP authorization boundary. Compute a fail-closed `can_read_existing` from both:
+
+   - credential scope: PAT `read`, and OAuth `akb:vault:read` when applicable;
+   - `check_vault_access(..., required_role="reader")`.
+
+   Then pass an explicit projection capability to the service or redact through one shared serializer. Do not pass raw scopes into the service. A caller lacking read authority should receive only:
+
+   ```json
+   {
+     "kind": "table",
+     "name": "issues",
+     "created": false,
+     "outcome": "already_exists"
+   }
+   ```
+
+   Omit URI, vault, collection, columns, keys, indexes, `matches_request`, and `mismatches`; the latter two are themselves schema oracles. Shipping the current disclosure is a security blocker.
+
+2. **Blocker — `matches_request` is materially incorrect.** Stored unique keys and indexes are parsed for output, but requested values are neither accepted nor compared ([table_service.py:586](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:586), [table_service.py:607](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:607)). Consequently, completely different requested constraints/indexes can return `matches_request=true`. Malformed `unique_keys`/`indexes` also bypass their validators on the no-op path; only columns are validated ([table_service.py:695](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:695)).
+
+   Extract one shared create-spec canonicalizer used by both branches: normalize columns, validate references, resolve inline and explicit keys/indexes, reject duplicate metadata names, then compare all five promised fields. Also canonicalize equivalent omissions such as `required` absent versus `false` if “canonical equality” is intended. Add explicit divergent/invalid key and index tests.
+
+3. **The advisory lock is correct under `READ COMMITTED`, with one hardening gap.** Placement before `find_by_name` is sufficient at the repository’s current PostgreSQL default, and the strict path must participate: otherwise a flag request can still race a concurrent strict creator ([table_service.py:674](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:674)).
+
+   `table_migration_service` does not actually use a domain-separated key: both use `f"{vault_id}:{value}"` ([table_migration_service.py:240](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_migration_service.py:240)). A migration key equal to a table name therefore aliases exactly. No advisory deadlock is evident today—each path acquires one such lock, and migration calls `alter_table`, which acquires no second advisory lock—but the alias causes unnecessary blocking. Prefix the domains, e.g. `table-create:` and `table-migration:`. Ordinary 64-bit hash collisions likewise cause false contention, not incorrect ownership classification.
+
+   The pool does not enforce transaction isolation ([postgres.py:49](/Users/kwoo2/Desktop/storage/akb/backend/app/db/postgres.py:49)). Under a deployment-level `REPEATABLE READ` default, the vault lookup establishes a snapshot before the wait, so the loser may not see the winner afterward. Make this transaction explicitly `isolation="read_committed"`.
+
+4. **Cross-vault table ownership is closed in the normal catalog model.** There is exactly one `created=false` return site, reached only after `find_by_name` matches `vt.vault_id = $1 AND vt.name = $2` ([table_registry_repo.py:27](/Users/kwoo2/Desktop/storage/akb/backend/app/repositories/table_registry_repo.py:27)).
+
+   Every other route is closed:
+
+   - Same logical concurrent creator: serialized, then exact-row lookup; valid no-op.
+   - Foreign physical table already present: `to_regclass` raises 409.
+   - Foreign physical table created after preflight: scoped `DuplicateTableError` raises 409.
+   - Registry/PG uniqueness failure: raises 409; never rereads or returns false.
+   - Advisory-key collision: only delays the exact lookup.
+   - There is no broad `ConflictError` suppression.
+
+   Thus the stated foreign-table invariant is airtight absent catalog corruption. One defense-in-depth caveat: `vault_tables.collection_id` is not constrained to the same vault, and the join checks only collection ID ([init.sql:258](/Users/kwoo2/Desktop/storage/akb/backend/app/db/init.sql:258), [table_registry_repo.py:38](/Users/kwoo2/Desktop/storage/akb/backend/app/repositories/table_registry_repo.py:38)). Ordinary application writes preserve it, but a corrupted/admin-written row could expose another vault’s collection path—not another vault’s table.
+
+5. **The early return is transactionally correct.** Returning inside `async with conn.transaction()` commits the read-only transaction during context exit, then releases the transaction-scoped advisory lock. No collection, DDL, event, or post-commit indexing executes. A validation exception rolls back and releases it instead. The lock is held only through lookup, normalization, and envelope construction on this path.
+
+Remaining gaps:
+
+- The “live PostgreSQL” tests exercise raw lock primitives, not concurrent calls through `table_service.create_table` ([test_table_if_not_exists_e2e.py:64](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:64)). Add a real service-level concurrency test asserting one `created=true`, one `false`, one registry/physical table, and one event—including differing schemas and collections.
+- Add write-only PAT/OAuth and managed-write-grant tests on both surfaces.
+- Give create its own OpenAPI response union/full-versus-minimal contract; the current shared envelope merely makes all new fields optional.
+- MCP’s `bool(args.get(...))` turns the string `"false"` into true ([server.py:1013](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:1013)); validate an actual boolean.
+- Reconcile the design document’s still-open status with the implementation decision.
+
+Focused staged tests: 44 passed, 1 skipped; cached diff hygiene passed.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round3-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round3-impl.md
@@ -1,0 +1,22 @@
+Not ready to merge.
+
+1. **Blocker — REST OAuth still leaks the enriched envelope.** The REST helper checks only `token_scopes`; OAuth credentials have `token_scopes=None`, which passes `token_has_scope`, while `oauth_scopes` is ignored ([tables.py](/Users/kwoo2/Desktop/storage/akb/backend/app/api/routes/tables.py:267)). I directly verified that an OAuth user holding only `akb:vault:write` returns `True` from this gate when the vault ACL passes. MCP correctly checks both scope systems ([server.py](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:268)).
+
+   More broadly, REST’s `get_current_user` does not enforce OAuth scopes at all ([deps.py](/Users/kwoo2/Desktop/storage/akb/backend/app/api/deps.py:107)); a read-only or zero-scope OAuth token with writer membership can currently POST mutations. Fix centrally or explicitly gate both write and read OAuth scopes here. This makes (b) a definite blocker.
+
+2. **Blocker — `_canonical_create_spec` is not actually the real-create canonicalizer.** The real branch duplicates its logic instead of calling it ([table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:796), [table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:841)). More importantly, only the real branch runs `_validate_column_references` ([table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:849)). Thus an existing-table request containing a syntactically valid reference to a missing, non-unique, or wrong-typed target returns a no-op/mismatch instead of the error a real create produces. Modern non-FK columns, keys, and indexes compare correctly, but full create parity is false.
+
+3. **Blocker — the checked-in REST client is stale.** Its public `CreateTableRequest` lacks `if_not_exists`, and `AkbTableEnvelope` lacks every new result field ([schema.gen.ts](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/schema.gen.ts:10), [schema.gen.ts](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/schema.gen.ts:458)). The OpenAPI fixture is stale too, so its codegen check merely proves stale fixture and stale output agree. Typed SDK users cannot use this feature.
+
+4. **`READ COMMITTED` is correct.** Each statement receives a new snapshot, so `find_by_name` after the advisory-lock wait sees the winner. Nothing else in this transaction requires stronger isolation ([table_service.py](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:746)). Add an assertion: the fake records `tx_kwargs` but never verifies it ([test_table_if_not_exists_unit.py](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_unit.py:63)).
+
+5. **Merge calls:**
+
+   - (a) blocks: concurrency is the feature’s load-bearing guarantee, but the live test exercises generic lock primitives using the old unprefixed key, never `create_table` ([test_table_if_not_exists_e2e.py](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:64)).
+   - (b) blocks, with the demonstrated REST defect.
+   - (c) may follow up; the union improves typing but is not runtime security-critical. Updating the existing SDK types now is still mandatory.
+   - (d) should block governance sign-off: it still says unresolved proposal, and its lock pseudocode is obsolete ([README.md](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:1), [README.md](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:110)).
+
+Also fix the MCP description/help: it promises stored schema to every caller despite the minimal branch, and `is True` silently treats malformed `"true"` as false instead of rejecting it ([tools.py](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/tools.py:631), [help.py](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/help.py:926)).
+
+Focused units: 54 passed, 1 skipped. The cached diff also contains several unrelated design/production-analysis packages; split those before review.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round4-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round4-impl.md
@@ -1,0 +1,11 @@
+Not ready to merge. Two blockers remain.
+
+1. **Enum creates are broken.** The real path normalizes at [table_service.py:802](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:802), then `_canonical_create_spec` normalizes again at [table_service.py:853](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:853). The first pass synthesizes an enum `check`; the second rejects it at [table_data_repo.py:186](/Users/kwoo2/Desktop/storage/akb/backend/app/repositories/table_data_repo.py:186). I reproduced the resulting `ValidationError`. Canonicalize exactly once and add a real-create enum regression test.
+
+2. **The SDK response remains stale.** `CreateTableRequest` is fixed, but the hardcoded `AkbTableEnvelope` generator still lacks `created`, `outcome`, `matches_request`, and `mismatches` at [openapi-codegen.ts:375](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/openapi-codegen.ts:375), as does [schema.gen.ts:10](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/schema.gen.ts:10). The catch-all exposes them only as `unknown`, despite these fields being how callers use the feature. Update the generator and regenerate. The unrelated 68/26/2 fixture drift can remain separate.
+
+3. **No remaining enriched-envelope leak found.** Both production boundaries require read scope plus reader ACL, and the service defaults closed. The broader REST OAuth mutation gap is legitimately separate: it predates this feature and does not bypass this projection gate. Track it independently as a security issue.
+
+4. **Concurrency is credible as a combined suite, but the service test alone is timing-dependent.** `asyncio.gather` does not force both calls past a shared race point, so an unlocked implementation can occasionally pass sequentially. The primitive-lock test, ordering unit test, and reported 5/5 falsification make the overall evidence adequate. Restore the mutated `settings.db_*` values in `finally` at [test_table_if_not_exists_e2e.py:207](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:207) to prevent test-order pollution.
+
+The general fixture-drift split is correct. `git diff --cached --check` is clean.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round5-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round5-impl.md
@@ -1,0 +1,11 @@
+Not ready to merge. No runtime blocker remains, but these items do:
+
+1. Test isolation is still incomplete. Settings are mutated before the `finally`; skips during bootstrap/seed bypass restoration at [test_table_if_not_exists_e2e.py:210](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:210). Cleanup failures can also bypass `close_pool()`. Put mutation through pool closure under one outer `try/finally`.
+
+2. The MCP help topic remains stale: it omits `if_not_exists` and its response semantics at [help.py:926](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/help.py:926).
+
+3. The design record is not current. It still says proposal, lists only round 1, says three rounds, 1042 tests, and 23 feature units instead of 24 at [README.md:3](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:3) and [README.md:304](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:304). It should also document the one-pass enum normalization split and SDK response fields.
+
+4. The `normalize_columns` split is correct. Both branches produce identical normalized columns, keys, and indexes; reference validation follows canonicalization in both. I also compared enum plus inline/explicit key/index inputs directly—the canonical tuples were identical.
+
+5. The feature-specific SDK/codegen surface is correct. One minor comment is inaccurate: [openapi-codegen.ts:384](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/openapi-codegen.ts:384) implies `outcome` is withheld without read access, but the minimal response includes it. Independently, the hardcoded envelope still omits the pre-existing OpenAPI `created_at` field; that is unrelated debt, not a blocker for this feature.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round6-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round6-impl.md
@@ -1,0 +1,19 @@
+Not ready to merge.
+
+1. Test isolation still leaks:
+
+   - `settings.db_*` is mutated before the outer `try`; `close_pool()` can fail or be cancelled before restoration is armed. Move the `try` above the first mutation. [test_table_if_not_exists_e2e.py:211](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:211)
+   - `settings.git_storage_path` is mutated at module import and never restored. [test_table_read_authority_unit.py:30](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_read_authority_unit.py:30)
+   - A row-cleanup failure still bypasses `setup.close()`, although `close_pool()` now runs. [test_table_if_not_exists_e2e.py:286](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:286)
+
+2. The design record is not yet faithful:
+
+   - Frontmatter still lists only rounds 1–4; round 5 is missing. [README.md:7](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:7)
+   - “Four no-ops” is inaccurate: scenarios 2–4 are no-ops; scenario 5 is a conflict. [README.md:374](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:374)
+
+3. The help topic itself is accurate, including disclosure semantics. Two adjacent comments remain inaccurate:
+
+   - The SDK comment says `outcome` accompanies both create outcomes, but successful creation has no `outcome`. [openapi-codegen.ts:383](/Users/kwoo2/Desktop/storage/akb/packages/akb-client/src/core/openapi-codegen.ts:383)
+   - The MCP tool description’s “only” envelope omits `kind`. [tools.py:640](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/tools.py:640)
+
+No runtime correctness or security blocker found beyond these items.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round7-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round7-impl.md
@@ -1,0 +1,10 @@
+Not ready to merge.
+
+1. Test isolation still has one gap. [`git_storage_path`](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_read_authority_unit.py:31) mutates during collection, but the fixture runs only if a test executes. Full deselection, `--collect-only`, or collection failure leaves it mutated. Move the save/set into the fixture before `yield`, with restoration in `finally`; lazy test imports occur afterward.
+
+2. Factual cleanup remains:
+
+   - The E2E header says “four post-check” windows; there are three. [test](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:9)
+   - The design says the “first three” windows become impossible; it is the last three, while `find_by_name` remains the intended outcome. It also retains imprecise “four/five sites” and contradictory “bit-for-bit unchanged” wording. [design](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:137)
+   - Several design line citations are stale, including `tables.py:261` and the `table_service.py` concurrency locations.
+   - The OpenAPI comment says all three fields accompany the false branch, but `matches_request` and `mismatches` are absent from the minimal false response. [openapi_contract.py](/Users/kwoo2/Desktop/storage/akb/backend/app/openapi_contract.py:654)

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round8-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round8-impl.md
@@ -1,0 +1,16 @@
+Not ready to merge.
+
+1. Process-global restoration is still incomplete:
+
+   - [`git_storage_path`](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_read_authority_unit.py:43) is assigned before the `try`.
+   - More importantly, the lazy import constructs the cached [`server.doc_service`](/Users/kwoo2/Desktop/storage/akb/backend/mcp_server/server.py:168), whose `GitService` permanently captures the temporary path. Restoring `settings` does not restore that object.
+   - The E2E cleanup can leave `postgres._pool` targeting the test database if `close_pool()` raises or is cancelled, because `_pool = None` occurs only after the awaited close.
+
+2. The race description is still inaccurate. For two calls through `create_table`, registry insertion is not a separate third post-check window: once one transaction successfully creates the physical table, the other cannot also reach registry insertion. A `pg_type` uniqueness failure may surface during `CREATE TABLE`; describe two later timing windows and their exception surfaces, not a registry-insert race.
+
+3. Remaining factual cleanup in the design:
+
+   - “the strict path is unchanged” at [README.md:428](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:428) remains unqualified.
+   - Citations `collection_service.py:151`, `table_service.py:652/:684`, and `tables.py:239` are still stale.
+
+The OpenAPI false-branch comment is now accurate.

--- a/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round9-impl.md
+++ b/docs/design/proposal/2026-07-29-create-table-if-not-exists/feedback/2026-07-29-codex-round9-impl.md
@@ -1,0 +1,10 @@
+Not ready to merge. One merge blocker remains: contradictory comments/design wording.
+
+- [table_service.py:759](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:759), [table_service.py:928](/Users/kwoo2/Desktop/storage/akb/backend/app/services/table_service.py:928), and [test_table_if_not_exists_e2e.py:198](/Users/kwoo2/Desktop/storage/akb/backend/tests/test_table_if_not_exists_e2e.py:198) still describe registry insertion as a same-path race window.
+- [README.md:119](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:119) still says “four race outcomes”; the table defines three total.
+- [README.md:431](/Users/kwoo2/Desktop/storage/akb/docs/design/proposal/2026-07-29-create-table-if-not-exists/README.md:431) retains the unqualified “strict path is unchanged.”
+- [postgres.py:76](/Users/kwoo2/Desktop/storage/akb/backend/app/db/postgres.py:76) says the clear occurs “in a `finally`”; it actually occurs before the await.
+
+The revised race table and E2E module header are correct. Remaining citations appear accurate.
+
+I agree the cached `doc_service` limitation is pre-existing test debt and a follow-up, not a merge blocker. No runtime blocker found.

--- a/packages/akb-client/src/core/openapi-codegen.ts
+++ b/packages/akb-client/src/core/openapi-codegen.ts
@@ -380,6 +380,17 @@ function schemaLines(): string[] {
     "  name?: string;",
     "  sql_name?: string;",
     "  description?: string | null;",
+    // create only. `created` is `true` on a real create and `false` when
+    // if_not_exists=true matched an existing table. `outcome` appears ONLY on
+    // the `false` branch ("already_exists"); a real create has no `outcome`.
+    // `matches_request` / `mismatches` describe how the stored table differs
+    // from the request, and are omitted — along with the schema itself — for
+    // a caller without READ authority on the vault, since they are schema
+    // oracles. Their absence means "not disclosed", NOT "no divergence".
+    "  created?: boolean;",
+    "  outcome?: string;",
+    "  matches_request?: boolean;",
+    "  mismatches?: string[];",
     "  columns?: AkbJsonObjectArray;",
     "  unique_keys?: AkbJsonObjectArray;",
     "  indexes?: AkbJsonObjectArray;",

--- a/packages/akb-client/src/core/schema.gen.ts
+++ b/packages/akb-client/src/core/schema.gen.ts
@@ -15,6 +15,10 @@ export interface AkbTableEnvelope {
   name?: string;
   sql_name?: string;
   description?: string | null;
+  created?: boolean;
+  outcome?: string;
+  matches_request?: boolean;
+  mismatches?: string[];
   columns?: AkbJsonObjectArray;
   unique_keys?: AkbJsonObjectArray;
   indexes?: AkbJsonObjectArray;
@@ -455,7 +459,7 @@ export type LinkRequest = { source: string; target: string; relation: "depends_o
 
 export type CreateCollectionRequest = { path: string; summary?: string | null };
 
-export type CreateTableRequest = { name: string; description?: string; columns: TableColumnSpec[]; collection?: string | null; unique_keys?: TableUniqueKeySpec[] | null; indexes?: TableIndexSpec[] | null };
+export type CreateTableRequest = { name: string; description?: string; columns: TableColumnSpec[]; collection?: string | null; unique_keys?: TableUniqueKeySpec[] | null; indexes?: TableIndexSpec[] | null; if_not_exists?: boolean };
 
 export type AlterTableRequest = { add_columns?: TableColumnSpec[] | null; alter_columns?: TableAlterColumnSpec[] | null; drop_columns?: string[] | null; rename_columns?: { [key: string]: string } | null; add_unique_keys?: TableUniqueKeySpec[] | null; drop_unique_keys?: string[] | null; add_indexes?: TableIndexSpec[] | null; drop_indexes?: string[] | null };
 

--- a/packages/akb-client/test/fixtures/openapi.core.json
+++ b/packages/akb-client/test/fixtures/openapi.core.json
@@ -1017,6 +1017,11 @@
               }
             ],
             "title": "Indexes"
+          },
+          "if_not_exists": {
+            "type": "boolean",
+            "title": "If Not Exists",
+            "default": false
           }
         },
         "type": "object",


### PR DESCRIPTION
## Why

`akb_create_table` has no idempotent mode, so a caller that wants "make sure
this table exists" has one option: call create, catch the 409, and infer from
the error string that the table already exists.

Production tool-usage data (collected after enabling `tool_usage` on 2026-07-29)
shows that is the **dominant** use of the tool:

| tool | calls | errors | code |
|---|---|---|---|
| `akb_create_table` | 897 | **876 (97.7%)** | `conflict` |
| `akb_alter_table` | 648 | 0 | — |

Every conflict was followed in the same session by a successful
`akb_alter_table` (66.6%) or `akb_browse` (33.4%). Nothing is broken — but the
tool's failure rate is unreadable, and the recovery branch every client writes
is a guess rather than a contract.

## What

`if_not_exists=true` changes the request from "create this table" to "ensure
this table exists":

```
if_not_exists=false (default)   absent -> create    present -> 409  (unchanged)
if_not_exists=true              absent -> create    present -> created=false
```

Nothing is ever altered. The default is `false`, so existing callers —
including the production catch-409 client — are unaffected.

## Three things worth reviewing

**Concurrency.** The first design caught `UniqueViolationError` and re-read the
winner's row. That is not implementable: the exception surfaces while the
transaction is still open, so every later query fails until rollback (a live
test pins this fact). Instead the create takes a transaction-scoped advisory
lock on `table-create:{vault_id}:{name}` before the existence check, on **both**
paths, under an explicit `read_committed` isolation — under `REPEATABLE READ`
the vault lookup would fix a snapshot *before* the lock wait and the loser would
still miss the winner.

**Security.** `ConflictError` means two different things here: a same-vault
duplicate, and a *different* vault's table fused onto the same physical name
(#285). Suppressing it broadly would hand a vault-A writer vault-B's schema,
which PostgreSQL's privilege-filtered `information_schema` otherwise hides (a
vault role sees 61 of 518 `vt_` tables). The flag suppresses the conflict
**only** when a row with the exact `(vault_id, name)` exists.

Separately: write authority does not imply read authority. The enriched no-op
body is gated on READ authority resolved at each boundary and passed down as a
capability, defaulting closed. A write-only caller gets
`{kind, name, created, outcome}` — the stored schema, `matches_request` and
`mismatches` are withheld, since they are schema oracles.

**Divergence is explicit.** `created=false` carries the STORED schema plus
`matches_request` / `mismatches`, so a success-looking response cannot be
mistaken for "the columns I asked for exist".

## Verification

```
1059 unit tests          6 live-PostgreSQL tests
6 on a FRESH database    ruff · mypy · akb-client codegen:check
```

The e2e file is registered in the `pgvector-e2e` job and **bootstraps rather
than skipping**, so the concurrency guarantee is genuinely gated — it previously
would have run in neither job.

Both load-bearing properties are **falsified** as well as asserted:

- neutering the advisory lock fails the concurrency test 5/5, and it passes
  again on restore;
- making the cross-vault branch return a no-op fails both security tests.

The feature was also exercised end-to-end against live PostgreSQL 16.13: absent
→ `created=true`; same spec → `created=false`, `matches_request=true`; different
spec → `mismatches=['columns','description']` with the stored columns returned;
no read authority → minimal envelope; no flag → `ConflictError`. Final DB state:
1 registry row, 1 physical table, 1 `table.create` event, and the column
requested by the divergent call was never created.

## Also

Fixes `close_pool()` leaving `_pool` set when `close()` raises, which handed the
next `get_pool()` a half-closed pool.

## Review history

Design and thirteen Codex rounds are in
`docs/design/proposal/2026-07-29-create-table-if-not-exists/`. Those rounds
found and closed an unimplementable transaction flow, an incorrect
`matches_request`, a REST gate that ignored OAuth scopes, a stale typed SDK, a
double-normalization regression that broke every enum create, an ungated live
test, and four separate comparison defects. Round 13 verdict: *"No findings …
Ready to merge."*

Byproduct findings outside this PR's scope — chiefly that REST
`get_current_user` never enforces OAuth scopes at all — are recorded separately
for independent triage.
