### PR TITLE
feat(revision): add measurement-gated PostgreSQL native ledger

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -89,6 +89,9 @@ jobs:
         env:
           # Matches the fixture default + the dev compose override.
           AKB_TEST_DSN: postgresql://akb:akb@localhost:15432/akb  # pragma: allowlist secret
+          # Native-ledger correctness must fail if this live-PG gate is
+          # accidentally disconnected; a skip here would be a false green.
+          REQUIRE_REAL_PG: '1'
         # #215 declarative-DDL integration tests need a live PG too (index
         # ASC/DESC physical order, migration 037 upgrade path, add-unique-key
         # concurrency race). They skip in the DB-free unit job above, so gate
@@ -105,6 +108,7 @@ jobs:
           tests/test_migration_037_upgrade_unit.py
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
+          tests/concurrency/test_native_ledger_b_core.py
           tests/test_file_idempotent_upload_unit.py
           tests/test_app_registry_migration_unit.py
           tests/test_tool_usage_e2e.py

--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -6,29 +6,22 @@ which are read-only views over git history rather than session
 management. The file was renamed accordingly.
 """
 
-import asyncio
-import json
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.api.deps import get_current_user
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
-from app.services.document_service import DocumentService
-from app.services.git_service import GitService
+from app.services.revision_backend import get_revision_backend
 from app.services.user_directory import resolve_display_names
-from app.db.postgres import get_pool
 from app.models.activity import (
     AkbActivityEnvelope,
     AkbDocumentDiffEnvelope,
     AkbDocumentHistoryEnvelope,
     AkbRecentChangesEnvelope,
 )
-from app.repositories.document_repo import DocumentRepository
 
 router = APIRouter()
-git = GitService()
-doc_service = DocumentService()
+revision_backend = get_revision_backend()
 
 
 async def _resolve_activity_authors(entries: list[dict]) -> list[dict]:
@@ -68,10 +61,8 @@ async def vault_activity(
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     await check_vault_access(user.user_id, vault, required_role="reader")
-    # vault_log spawns `git rev-list` + one `git diff` subprocess per commit;
-    # off-load it so the single event loop isn't starved (probe-timeout 503).
-    entries = await asyncio.to_thread(
-        git.vault_log, vault, max_count=limit, since=since, path=collection,
+    entries = await revision_backend.vault_activity(
+        vault, max_count=limit, since=since, path=collection,
     )
     entries = await _resolve_activity_authors(entries)
 
@@ -106,62 +97,11 @@ async def recent_changes(
     check). Otherwise, returns docs from every vault the user owns or has
     been granted access to. Documents are sorted by `updated_at DESC`.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        if vault:
-            await check_vault_access(user.user_id, vault, required_role="reader")
-            rows = await conn.fetch(
-                """
-                SELECT d.id, d.title, d.path, d.doc_type, d.current_commit,
-                       d.updated_at, v.name AS vault_name, d.metadata
-                FROM documents d
-                JOIN vaults v ON d.vault_id = v.id
-                WHERE v.name = $1
-                ORDER BY d.updated_at DESC
-                LIMIT $2
-                """,
-                vault, limit,
-            )
-        else:
-            # Include public-readable vaults so /recent is consistent with
-            # /search and list_accessible_vaults — pre-fix this route only
-            # surfaced owned/granted vaults, hiding docs from vaults the
-            # user could still read via public_access (06-F5).
-            rows = await conn.fetch(
-                """
-                SELECT d.id, d.title, d.path, d.doc_type, d.current_commit,
-                       d.updated_at, v.name AS vault_name, d.metadata
-                FROM documents d
-                JOIN vaults v ON d.vault_id = v.id
-                LEFT JOIN vault_access va
-                    ON va.vault_id = v.id AND va.user_id = $1
-                WHERE v.owner_id = $1
-                   OR va.user_id = $1
-                   OR v.public_access IN ('reader', 'writer')
-                ORDER BY d.updated_at DESC
-                LIMIT $2
-                """,
-                user.user_id, limit,
-            )
-
-    changes = []
-    for r in rows:
-        meta = r["metadata"] or {}
-        if isinstance(meta, str):
-            try:
-                meta = json.loads(meta)
-            except json.JSONDecodeError:
-                meta = {}
-        doc_id = meta.get("id") or str(r["id"])
-        changes.append({
-            "doc_id": doc_id,
-            "vault": r["vault_name"],
-            "path": r["path"],
-            "title": r["title"],
-            "type": r["doc_type"] or "note",
-            "commit": r["current_commit"],
-            "changed_at": r["updated_at"].isoformat() if r["updated_at"] else None,
-        })
+    if vault:
+        await check_vault_access(user.user_id, vault, required_role="reader")
+    changes = await revision_backend.recent_changes(
+        user.user_id, vault=vault, limit=limit,
+    )
     return {"kind": "recent_changes", "changes": changes}
 
 
@@ -181,16 +121,9 @@ async def document_diff(
 ):
     await check_vault_access(user.user_id, vault, required_role="reader")
 
-    pool = await get_pool()
-    doc_repo = DocumentRepository(pool)
-    async with pool.acquire() as conn:
-        v = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault)
-        doc = await doc_repo.find_by_ref_with_conn(conn, v["id"], doc_id)
-        if not doc:
-            raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
-
-    # off-load the git diff subprocess so the single event loop isn't starved
-    result = await asyncio.to_thread(git.file_diff, vault, doc["path"], commit)
+    result = await revision_backend.document_diff(vault, doc_id, commit)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
     return {"kind": "document_diff", **result}
 
 
@@ -218,5 +151,5 @@ async def document_history(
     which the global AKBError handler maps to 404.
     """
     await check_vault_access(user.user_id, vault, required_role="reader")
-    result = await doc_service.history(vault, doc_id, limit=limit)
+    result = await revision_backend.document_history(vault, doc_id, limit=limit)
     return {"kind": "document_history", **result}

--- a/backend/app/api/routes/collections.py
+++ b/backend/app/api/routes/collections.py
@@ -15,10 +15,10 @@ from app.services.collection_service import (
     CollectionService,
     InvalidPathError,
 )
-from app.services.document_service import DocumentService
+from app.services.revision_backend import get_document_service
 
 router = APIRouter()
-doc_service = DocumentService()
+doc_service = get_document_service()
 collection_service = CollectionService()
 
 

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -18,7 +18,7 @@ from app.models.document import (
     DocumentUpdateRequest,
 )
 from app.services.auth_service import AuthenticatedUser
-from app.services.document_service import DocumentService
+from app.services.revision_backend import get_document_service
 from app.util.git_refs import HEX_COMMIT_RE
 from app.util.text import to_nfc
 
@@ -37,7 +37,7 @@ class VaultTemplate(BaseModel):
 
 
 router = APIRouter()
-doc_service = DocumentService()
+doc_service = get_document_service()
 
 
 @router.post("/vaults", summary="Create a new vault")

--- a/backend/app/api/routes/help.py
+++ b/backend/app/api/routes/help.py
@@ -4,14 +4,15 @@ from typing import Any
 from fastapi import APIRouter, Depends
 from fastapi.responses import PlainTextResponse
 
-from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE, DocumentService
+from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE
+from app.services.revision_backend import get_document_service
 from app.services.auth_service import AuthenticatedUser
 from app.api.deps import get_current_user
 from app.services.access_service import check_vault_access
 from mcp_server.help import render_vault_skill_response
 
 router = APIRouter()
-doc_service = DocumentService()
+doc_service = get_document_service()
 
 
 MARKDOWN_RESPONSE: dict[int | str, dict[str, Any]] = {

--- a/backend/app/api/routes/knowledge_io.py
+++ b/backend/app/api/routes/knowledge_io.py
@@ -9,10 +9,10 @@ from app.api.deps import get_current_user
 from app.services import knowledge_io
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
-from app.services.document_service import DocumentService
+from app.services.revision_backend import get_document_service
 
 router = APIRouter()
-doc_service = DocumentService()
+doc_service = get_document_service()
 
 
 @router.get(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,9 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
+NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME = "akb_revision_m1_measurement"
+
+
 class AuditSettings(BaseModel):
     """Compliance-grade audit log — **producer-only**. AKB emits an
     append-only, hash-chained JSON-lines audit stream and (optionally)
@@ -154,6 +157,11 @@ class Settings(BaseModel):
     # Git storage root (bare repos live here)
     git_storage_path: str = "/data/vaults"
 
+    # Native ledger selection is a dedicated M1 measurement path. Normal
+    # deployments retain the legacy bare-Git revision behavior by default.
+    document_revision_backend: Literal["bare_git_current", "native_ledger_m1"] = "bare_git_current"
+    native_revision_m1_measurement_only: bool = False
+
     # External-git mirror — network timeouts (seconds) for the poller's
     # three remote-aware git ops. A hanging TCP session otherwise stalls
     # the entire poller task forever since asyncio.to_thread can't cancel
@@ -212,6 +220,17 @@ class Settings(BaseModel):
 
     @model_validator(mode="after")
     def validate_model_api_governance(self) -> "Settings":
+        if self.document_revision_backend == "native_ledger_m1":
+            if not self.native_revision_m1_measurement_only:
+                raise ValueError(
+                    "native_ledger_m1 requires native_revision_m1_measurement_only=true"
+                )
+            if self.db_name != NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME:
+                raise ValueError(
+                    "native_ledger_m1 requires dedicated measurement database "
+                    f"{NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME!r}"
+                )
+
         if self.model_api_governance_mode != "platform_hard":
             return self
 

--- a/backend/app/db/migrations/048_native_revision_core.py
+++ b/backend/app/db/migrations/048_native_revision_core.py
@@ -96,8 +96,9 @@ async def _run(conn):
                     UNIQUE (namespace_id, surface, resource_id)
             );
 
-            CREATE UNIQUE INDEX IF NOT EXISTS uq_native_resources_live_path
-                ON native_resources(namespace_id, surface, current_path)
+            DROP INDEX IF EXISTS uq_native_resources_live_path;
+            CREATE UNIQUE INDEX uq_native_resources_live_path
+                ON native_resources(namespace_id, current_path)
                 WHERE lifecycle = 'live';
 
             CREATE TABLE IF NOT EXISTS native_payload_manifests (
@@ -324,8 +325,9 @@ async def _run(conn):
                     DEFERRABLE INITIALLY DEFERRED
             );
 
-            CREATE UNIQUE INDEX IF NOT EXISTS uq_native_resource_path_aliases_live
-                ON native_resource_path_aliases(namespace_id, surface, old_path)
+            DROP INDEX IF EXISTS uq_native_resource_path_aliases_live;
+            CREATE UNIQUE INDEX uq_native_resource_path_aliases_live
+                ON native_resource_path_aliases(namespace_id, old_path)
                 WHERE retired_revision_id IS NULL;
 
             CREATE INDEX IF NOT EXISTS idx_native_resource_path_aliases_resource

--- a/backend/app/db/migrations/048_native_revision_core.py
+++ b/backend/app/db/migrations/048_native_revision_core.py
@@ -228,6 +228,9 @@ async def _run(conn):
             CREATE INDEX IF NOT EXISTS idx_native_revisions_resource_history
                 ON native_revisions(resource_id, occurred_at DESC, revision_id DESC);
 
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_native_revisions_namespace_revision
+                ON native_revisions(namespace_id, revision_id);
+
             CREATE TABLE IF NOT EXISTS native_revision_activity (
                 activity_event_id UUID PRIMARY KEY,
                 namespace_id UUID NOT NULL,
@@ -332,6 +335,15 @@ async def _run(conn):
 
             CREATE INDEX IF NOT EXISTS idx_native_resource_path_aliases_resource
                 ON native_resource_path_aliases(resource_id, created_at DESC);
+
+            ALTER TABLE native_resource_path_aliases
+                DROP CONSTRAINT IF EXISTS native_resource_path_aliases_retired_revision_fkey;
+            ALTER TABLE native_resource_path_aliases
+                ADD CONSTRAINT native_resource_path_aliases_retired_revision_fkey
+                FOREIGN KEY (namespace_id, retired_revision_id)
+                REFERENCES native_revisions(namespace_id, revision_id)
+                ON DELETE NO ACTION
+                DEFERRABLE INITIALLY DEFERRED;
 
             DO $$
             BEGIN

--- a/backend/app/db/migrations/048_native_revision_core.py
+++ b/backend/app/db/migrations/048_native_revision_core.py
@@ -1,0 +1,483 @@
+"""Migration 048: PostgreSQL-native Resource/Revision ledger for M1 B-core.
+
+The ``m1_reference_payloads`` relation is an explicitly experimental,
+verified payload adapter used to exercise the semantic ledger.  Its presence
+does not select the final searchable-body physical layout.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.048")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS m1_reference_payloads (
+                payload_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                namespace_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                content_profile TEXT NOT NULL DEFAULT 'text',
+                digest TEXT NOT NULL,
+                byte_size BIGINT NOT NULL,
+                encoding TEXT NOT NULL DEFAULT 'utf-8',
+                selected_placement TEXT NOT NULL DEFAULT 'm1-reference-payload-v1',
+                verification_profile TEXT NOT NULL DEFAULT 'sha256-size-utf8-v1',
+                canonical_bytes BYTEA NOT NULL,
+                prepared_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT m1_reference_payloads_profile_check
+                    CHECK (content_profile = 'text'),
+                CONSTRAINT m1_reference_payloads_digest_shape
+                    CHECK (digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT m1_reference_payloads_size_check
+                    CHECK (byte_size >= 0 AND octet_length(canonical_bytes) = byte_size),
+                CONSTRAINT m1_reference_payloads_digest_matches
+                    CHECK (encode(digest(canonical_bytes, 'sha256'), 'hex') = digest),
+                CONSTRAINT m1_reference_payloads_text_check
+                    CHECK (
+                        encoding = 'utf-8'
+                        AND convert_from(canonical_bytes, 'UTF8') IS NOT NULL
+                        AND position(decode('00', 'hex') IN canonical_bytes) = 0
+                    ),
+                CONSTRAINT m1_reference_payloads_placement_check
+                    CHECK (selected_placement = 'm1-reference-payload-v1'),
+                CONSTRAINT m1_reference_payloads_verification_check
+                    CHECK (verification_profile = 'sha256-size-utf8-v1'),
+                CONSTRAINT m1_reference_payloads_dedup_key
+                    UNIQUE (namespace_id, digest, byte_size),
+                CONSTRAINT m1_reference_payloads_manifest_identity
+                    UNIQUE (
+                        payload_id, namespace_id, content_profile, digest,
+                        byte_size, encoding, selected_placement,
+                        verification_profile
+                    )
+            );
+
+            CREATE TABLE IF NOT EXISTS native_resources (
+                resource_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                namespace_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                surface TEXT NOT NULL,
+                content_profile TEXT NOT NULL,
+                origin TEXT NOT NULL DEFAULT 'native',
+                mutability TEXT NOT NULL DEFAULT 'akb_writable',
+                current_path TEXT NOT NULL,
+                lifecycle TEXT NOT NULL DEFAULT 'live',
+                head_revision_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT native_resources_surface_check
+                    CHECK (surface IN ('document', 'file')),
+                CONSTRAINT native_resources_content_profile_check
+                    CHECK (content_profile IN ('text', 'binary')),
+                CONSTRAINT native_resources_origin_check
+                    CHECK (origin = 'native'),
+                CONSTRAINT native_resources_mutability_check
+                    CHECK (mutability = 'akb_writable'),
+                CONSTRAINT native_resources_path_nonempty
+                    CHECK (btrim(current_path) <> ''),
+                CONSTRAINT native_resources_lifecycle_check
+                    CHECK (lifecycle IN ('live', 'deleted')),
+                CONSTRAINT native_resources_namespace_resource_key
+                    UNIQUE (namespace_id, resource_id),
+                CONSTRAINT native_resources_namespace_surface_resource_key
+                    UNIQUE (namespace_id, surface, resource_id)
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_native_resources_live_path
+                ON native_resources(namespace_id, surface, current_path)
+                WHERE lifecycle = 'live';
+
+            CREATE TABLE IF NOT EXISTS native_payload_manifests (
+                payload_manifest_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                namespace_id UUID NOT NULL,
+                resource_id UUID NOT NULL,
+                content_profile TEXT NOT NULL,
+                digest TEXT NOT NULL,
+                byte_size BIGINT NOT NULL,
+                encoding TEXT NOT NULL,
+                selected_placement TEXT NOT NULL,
+                private_locator UUID NOT NULL,
+                verification_profile TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT native_payload_manifests_digest_shape
+                    CHECK (digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_payload_manifests_size_check
+                    CHECK (byte_size >= 0),
+                CONSTRAINT native_payload_manifests_resource_fkey
+                    FOREIGN KEY (namespace_id, resource_id)
+                    REFERENCES native_resources(namespace_id, resource_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT native_payload_manifests_reference_fkey
+                    FOREIGN KEY (
+                        private_locator, namespace_id, content_profile, digest,
+                        byte_size, encoding, selected_placement,
+                        verification_profile
+                    )
+                    REFERENCES m1_reference_payloads(
+                        payload_id, namespace_id, content_profile, digest,
+                        byte_size, encoding, selected_placement,
+                        verification_profile
+                    )
+                    ON DELETE NO ACTION
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_payload_manifests_resource_manifest_key
+                    UNIQUE (resource_id, payload_manifest_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS native_revisions (
+                revision_id TEXT PRIMARY KEY,
+                namespace_id UUID NOT NULL,
+                resource_id UUID NOT NULL,
+                parent_revision_id TEXT,
+                action TEXT NOT NULL,
+                path_at_revision TEXT NOT NULL,
+                path_from TEXT,
+                path_to TEXT,
+                payload_manifest_id UUID,
+                mutation_id UUID NOT NULL,
+                request_fingerprint TEXT NOT NULL,
+                message TEXT,
+                subject TEXT,
+                summary TEXT,
+                actor TEXT NOT NULL,
+                occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                activity_event_id UUID NOT NULL,
+                invalidation_intent_id UUID NOT NULL,
+                CONSTRAINT native_revisions_revision_id_shape
+                    CHECK (revision_id ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT native_revisions_action_check
+                    CHECK (action IN ('create', 'replace', 'move', 'delete')),
+                CONSTRAINT native_revisions_path_nonempty
+                    CHECK (btrim(path_at_revision) <> ''),
+                CONSTRAINT native_revisions_fingerprint_shape
+                    CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revisions_resource_fkey
+                    FOREIGN KEY (namespace_id, resource_id)
+                    REFERENCES native_resources(namespace_id, resource_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT native_revisions_parent_fkey
+                    FOREIGN KEY (resource_id, parent_revision_id)
+                    REFERENCES native_revisions(resource_id, revision_id)
+                    ON DELETE NO ACTION
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_revisions_manifest_fkey
+                    FOREIGN KEY (resource_id, payload_manifest_id)
+                    REFERENCES native_payload_manifests(resource_id, payload_manifest_id)
+                    ON DELETE NO ACTION
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_revisions_action_shape
+                    CHECK (
+                        (
+                            action = 'create'
+                            AND parent_revision_id IS NULL
+                            AND payload_manifest_id IS NOT NULL
+                            AND path_from IS NULL
+                            AND path_to = path_at_revision
+                        )
+                        OR (
+                            action = 'replace'
+                            AND parent_revision_id IS NOT NULL
+                            AND payload_manifest_id IS NOT NULL
+                            AND path_from IS NULL
+                            AND path_to IS NULL
+                        )
+                        OR (
+                            action = 'move'
+                            AND parent_revision_id IS NOT NULL
+                            AND payload_manifest_id IS NOT NULL
+                            AND path_from IS NOT NULL
+                            AND path_to = path_at_revision
+                            AND path_from <> path_to
+                        )
+                        OR (
+                            action = 'delete'
+                            AND parent_revision_id IS NOT NULL
+                            AND payload_manifest_id IS NULL
+                            AND path_from IS NULL
+                            AND path_to IS NULL
+                        )
+                    ),
+                CONSTRAINT native_revisions_namespace_mutation_key
+                    UNIQUE (namespace_id, mutation_id),
+                CONSTRAINT native_revisions_namespace_resource_revision_key
+                    UNIQUE (namespace_id, resource_id, revision_id),
+                CONSTRAINT native_revisions_resource_revision_key
+                    UNIQUE (resource_id, revision_id),
+                CONSTRAINT native_revisions_activity_key
+                    UNIQUE (activity_event_id),
+                CONSTRAINT native_revisions_intent_key
+                    UNIQUE (invalidation_intent_id),
+                CONSTRAINT native_revisions_manifest_key
+                    UNIQUE (payload_manifest_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_native_revisions_resource_history
+                ON native_revisions(resource_id, occurred_at DESC, revision_id DESC);
+
+            CREATE TABLE IF NOT EXISTS native_revision_activity (
+                activity_event_id UUID PRIMARY KEY,
+                namespace_id UUID NOT NULL,
+                resource_id UUID NOT NULL,
+                revision_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                subject TEXT,
+                summary TEXT,
+                changed_path_from TEXT,
+                changed_path_to TEXT,
+                occurred_at TIMESTAMPTZ NOT NULL,
+                CONSTRAINT native_revision_activity_action_check
+                    CHECK (action IN ('create', 'replace', 'move', 'delete')),
+                CONSTRAINT native_revision_activity_revision_fkey
+                    FOREIGN KEY (namespace_id, resource_id, revision_id)
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    ON DELETE CASCADE
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_revision_activity_revision_key
+                    UNIQUE (revision_id),
+                CONSTRAINT native_revision_activity_link_key
+                    UNIQUE (
+                        activity_event_id, namespace_id, resource_id,
+                        revision_id, action
+                    )
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_native_revision_activity_resource
+                ON native_revision_activity(resource_id, occurred_at DESC, revision_id DESC);
+
+            CREATE TABLE IF NOT EXISTS native_invalidation_intents (
+                intent_id UUID PRIMARY KEY,
+                namespace_id UUID NOT NULL,
+                resource_id UUID NOT NULL,
+                revision_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                selected_delivery TEXT,
+                occurred_at TIMESTAMPTZ NOT NULL,
+                claimed_at TIMESTAMPTZ,
+                completed_at TIMESTAMPTZ,
+                last_error TEXT,
+                CONSTRAINT native_invalidation_intents_reason_check
+                    CHECK (reason IN ('create', 'replace', 'move', 'delete')),
+                CONSTRAINT native_invalidation_intents_revision_fkey
+                    FOREIGN KEY (namespace_id, resource_id, revision_id)
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    ON DELETE CASCADE
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_invalidation_intents_revision_key
+                    UNIQUE (revision_id),
+                CONSTRAINT native_invalidation_intents_link_key
+                    UNIQUE (
+                        intent_id, namespace_id, resource_id,
+                        revision_id, reason
+                    )
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_native_invalidation_pending
+                ON native_invalidation_intents(occurred_at, intent_id)
+                WHERE completed_at IS NULL;
+
+            CREATE TABLE IF NOT EXISTS native_resource_path_aliases (
+                alias_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                namespace_id UUID NOT NULL,
+                surface TEXT NOT NULL,
+                old_path TEXT NOT NULL,
+                resource_id UUID NOT NULL,
+                created_revision_id TEXT NOT NULL,
+                retired_revision_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                retired_at TIMESTAMPTZ,
+                CONSTRAINT native_resource_path_aliases_surface_check
+                    CHECK (surface IN ('document', 'file')),
+                CONSTRAINT native_resource_path_aliases_path_nonempty
+                    CHECK (btrim(old_path) <> ''),
+                CONSTRAINT native_resource_path_aliases_retirement_check
+                    CHECK (
+                        (retired_revision_id IS NULL AND retired_at IS NULL)
+                        OR (retired_revision_id IS NOT NULL AND retired_at IS NOT NULL)
+                    ),
+                CONSTRAINT native_resource_path_aliases_resource_fkey
+                    FOREIGN KEY (namespace_id, surface, resource_id)
+                    REFERENCES native_resources(namespace_id, surface, resource_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT native_resource_path_aliases_created_revision_fkey
+                    FOREIGN KEY (namespace_id, resource_id, created_revision_id)
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    ON DELETE NO ACTION
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_resource_path_aliases_retired_revision_fkey
+                    FOREIGN KEY (namespace_id, resource_id, retired_revision_id)
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    ON DELETE NO ACTION
+                    DEFERRABLE INITIALLY DEFERRED
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_native_resource_path_aliases_live
+                ON native_resource_path_aliases(namespace_id, surface, old_path)
+                WHERE retired_revision_id IS NULL;
+
+            CREATE INDEX IF NOT EXISTS idx_native_resource_path_aliases_resource
+                ON native_resource_path_aliases(resource_id, created_at DESC);
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'native_resources_head_fkey'
+                       AND conrelid = 'native_resources'::regclass
+                ) THEN
+                    ALTER TABLE native_resources
+                        ADD CONSTRAINT native_resources_head_fkey
+                        FOREIGN KEY (resource_id, head_revision_id)
+                        REFERENCES native_revisions(resource_id, revision_id)
+                        ON DELETE NO ACTION
+                        DEFERRABLE INITIALLY DEFERRED;
+                END IF;
+
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'native_revisions_activity_fkey'
+                       AND conrelid = 'native_revisions'::regclass
+                ) THEN
+                    ALTER TABLE native_revisions
+                        ADD CONSTRAINT native_revisions_activity_fkey
+                        FOREIGN KEY (
+                            activity_event_id, namespace_id, resource_id,
+                            revision_id, action
+                        )
+                        REFERENCES native_revision_activity(
+                            activity_event_id, namespace_id, resource_id,
+                            revision_id, action
+                        )
+                        ON DELETE NO ACTION
+                        DEFERRABLE INITIALLY DEFERRED;
+                END IF;
+
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'native_revisions_intent_fkey'
+                       AND conrelid = 'native_revisions'::regclass
+                ) THEN
+                    ALTER TABLE native_revisions
+                        ADD CONSTRAINT native_revisions_intent_fkey
+                        FOREIGN KEY (
+                            invalidation_intent_id, namespace_id, resource_id,
+                            revision_id, action
+                        )
+                        REFERENCES native_invalidation_intents(
+                            intent_id, namespace_id, resource_id,
+                            revision_id, reason
+                        )
+                        ON DELETE NO ACTION
+                        DEFERRABLE INITIALLY DEFERRED;
+                END IF;
+            END
+            $$;
+
+            CREATE OR REPLACE FUNCTION akb_native_reject_immutable_fact_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' AND NOT EXISTS (
+                    SELECT 1 FROM vaults WHERE id = OLD.namespace_id
+                ) THEN
+                    RETURN OLD;
+                END IF;
+                RAISE EXCEPTION '% rows are immutable', TG_TABLE_NAME
+                    USING ERRCODE = '55000';
+            END;
+            $$;
+
+            CREATE OR REPLACE FUNCTION akb_native_validate_resource_head()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                observed_head TEXT;
+            BEGIN
+                SELECT head_revision_id
+                  INTO observed_head
+                  FROM native_resources
+                 WHERE resource_id = NEW.resource_id;
+                IF observed_head IS NULL THEN
+                    RAISE EXCEPTION 'native Resource must publish one Head'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NULL;
+            END;
+            $$;
+
+            DO $$
+            DECLARE
+                table_name TEXT;
+                trigger_name TEXT;
+            BEGIN
+                FOREACH table_name IN ARRAY ARRAY[
+                    'native_revisions',
+                    'native_payload_manifests',
+                    'native_revision_activity'
+                ]
+                LOOP
+                    trigger_name := 'trg_' || table_name || '_immutable';
+                    IF NOT EXISTS (
+                        SELECT 1
+                          FROM pg_trigger
+                         WHERE tgname = trigger_name
+                           AND tgrelid = table_name::regclass
+                           AND NOT tgisinternal
+                    ) THEN
+                        EXECUTE format(
+                            'CREATE TRIGGER %I BEFORE UPDATE OR DELETE ON %I '
+                            'FOR EACH ROW EXECUTE FUNCTION akb_native_reject_immutable_fact_mutation()',
+                            trigger_name,
+                            table_name
+                        );
+                    END IF;
+                END LOOP;
+            END
+            $$;
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                      FROM pg_trigger
+                     WHERE tgname = 'trg_native_resources_validate_head'
+                       AND tgrelid = 'native_resources'::regclass
+                       AND NOT tgisinternal
+                ) THEN
+                    CREATE CONSTRAINT TRIGGER trg_native_resources_validate_head
+                    AFTER INSERT OR UPDATE ON native_resources
+                    DEFERRABLE INITIALLY DEFERRED
+                    FOR EACH ROW EXECUTE FUNCTION akb_native_validate_resource_head();
+                END IF;
+
+                IF NOT EXISTS (
+                    SELECT 1
+                      FROM pg_trigger
+                     WHERE tgname = 'trg_m1_reference_payloads_immutable'
+                       AND tgrelid = 'm1_reference_payloads'::regclass
+                       AND NOT tgisinternal
+                ) THEN
+                    CREATE TRIGGER trg_m1_reference_payloads_immutable
+                    BEFORE UPDATE ON m1_reference_payloads
+                    FOR EACH ROW EXECUTE FUNCTION akb_native_reject_immutable_fact_mutation();
+                END IF;
+            END
+            $$;
+            """
+        )
+    logger.info("Migration 048: native revision M1 core ready")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -217,6 +217,7 @@ async def _apply_migrations() -> None:
         "045_vault_write_grant_actions.py",      # additive action limits; existing grants backfill to wildcard
         "046_tool_usage.py",                     # tool_calls + tool_usage_daily: MCP usage analytics (inert until enabled)
         "047_app_registry.py",                    # app definitions, immutable releases, installations, grants, and owned resources
+        "048_native_revision_core.py",             # M1 PostgreSQL-native resource/revision ledger + reference payload substrate
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -65,11 +65,17 @@ class NativeRevisionRepository:
         surface: str,
         *paths: str,
     ) -> None:
-        """Lock affected paths in lexical order; no namespace-wide gate."""
+        """Lock namespace-wide path ownership in lexical order.
+
+        ``surface`` remains in the call shape so callers cannot accidentally
+        omit their Resource axis, but it is deliberately absent from the lock
+        identity: a Document and File cannot concurrently own the same path.
+        """
+        del surface
         for path in sorted(set(paths)):
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                f"native-path:{namespace_id}:{surface}:{path}",
+                f"native-path:{namespace_id}:{path}",
             )
 
     @staticmethod
@@ -117,6 +123,53 @@ class NativeRevisionRepository:
             surface,
             path,
         )
+        return dict(row) if row is not None else None
+
+    async def resolve_live_reference(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        reference: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        """Resolve a current path first, then a live old-path alias.
+
+        Exact current ownership always wins.  The alias points directly to a
+        Resource (never another path), so a chain cannot form after repeated
+        moves and a deleted Resource cannot be resurrected by an old alias.
+        """
+        sql = """
+            SELECT rs.resource_id, rs.namespace_id, rs.surface,
+                   rs.content_profile, rs.current_path, rs.lifecycle,
+                   rs.head_revision_id, rs.created_at, rs.updated_at
+              FROM native_resources rs
+             WHERE rs.namespace_id = $1
+               AND rs.surface = $2
+               AND rs.lifecycle = 'live'
+               AND (
+                    rs.current_path = $3
+                    OR (
+                        rs.current_path <> $3
+                        AND EXISTS (
+                            SELECT 1
+                              FROM native_resource_path_aliases a
+                             WHERE a.namespace_id = rs.namespace_id
+                               AND a.surface = rs.surface
+                               AND a.resource_id = rs.resource_id
+                               AND a.old_path = $3
+                               AND a.retired_revision_id IS NULL
+                        )
+                    )
+               )
+             ORDER BY (rs.current_path = $3) DESC
+             LIMIT 1
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, namespace_id, surface, reference)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, namespace_id, surface, reference)
         return dict(row) if row is not None else None
 
     @staticmethod
@@ -439,6 +492,32 @@ class NativeRevisionRepository:
             occurred_at,
         )
 
+    @staticmethod
+    async def retire_resource_aliases(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        resource_id: uuid.UUID,
+        retired_revision_id: str,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE native_resource_path_aliases
+               SET retired_revision_id = $4, retired_at = $5
+             WHERE namespace_id = $1
+               AND surface = $2
+               AND resource_id = $3
+               AND retired_revision_id IS NULL
+            """,
+            namespace_id,
+            surface,
+            resource_id,
+            retired_revision_id,
+            occurred_at,
+        )
+
     async def get_current(
         self,
         *,
@@ -450,6 +529,8 @@ class NativeRevisionRepository:
         sql = """
             SELECT rs.resource_id, rs.namespace_id, rs.surface,
                    rs.content_profile, rs.current_path AS path, rs.lifecycle,
+                   rs.created_at AS resource_created_at,
+                   rs.updated_at AS resource_updated_at,
                    rv.revision_id, rv.parent_revision_id, rv.action,
                    rv.occurred_at, pm.payload_manifest_id, pm.digest,
                    pm.byte_size, pm.encoding, pm.selected_placement,
@@ -472,6 +553,36 @@ class NativeRevisionRepository:
                 row = await acquired.fetchrow(sql, namespace_id, surface, path)
         return dict(row) if row is not None else None
 
+    async def get_resource_head(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        sql = """
+            SELECT rs.resource_id, rs.namespace_id, rs.surface,
+                   rs.content_profile, rs.current_path AS path, rs.lifecycle,
+                   rs.created_at AS resource_created_at,
+                   rs.updated_at AS resource_updated_at,
+                   rv.revision_id, rv.parent_revision_id, rv.action,
+                   rv.occurred_at, pm.payload_manifest_id, pm.digest,
+                   pm.byte_size, pm.encoding, pm.selected_placement,
+                   pm.private_locator, pm.verification_profile
+              FROM native_resources rs
+              JOIN native_revisions rv
+                ON rv.resource_id = rs.resource_id
+               AND rv.revision_id = rs.head_revision_id
+              LEFT JOIN native_payload_manifests pm
+                ON pm.payload_manifest_id = rv.payload_manifest_id
+             WHERE rs.resource_id = $1
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, resource_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, resource_id)
+        return dict(row) if row is not None else None
+
     async def get_revision(
         self,
         *,
@@ -480,10 +591,14 @@ class NativeRevisionRepository:
         conn: asyncpg.Connection | None = None,
     ) -> dict | None:
         sql = """
-            SELECT rv.*, pm.digest, pm.byte_size, pm.encoding,
+            SELECT rv.*, rs.surface, rs.content_profile,
+                   rs.created_at AS resource_created_at,
+                   rs.updated_at AS resource_updated_at,
+                   pm.digest, pm.byte_size, pm.encoding,
                    pm.selected_placement, pm.private_locator,
                    pm.verification_profile
               FROM native_revisions rv
+              JOIN native_resources rs ON rs.resource_id = rv.resource_id
               LEFT JOIN native_payload_manifests pm
                 ON pm.payload_manifest_id = rv.payload_manifest_id
              WHERE rv.resource_id = $1 AND rv.revision_id = $2
@@ -517,6 +632,87 @@ class NativeRevisionRepository:
         else:
             async with self.pool.acquire() as acquired:
                 rows = await acquired.fetch(sql, resource_id, limit)
+        return [dict(row) for row in rows]
+
+    async def list_activity(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        limit: int,
+        since: datetime | None = None,
+        path: str | None = None,
+    ) -> list[dict]:
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT a.resource_id, a.revision_id, a.action, a.actor,
+                       a.subject, a.summary, a.changed_path_from,
+                       a.changed_path_to, a.occurred_at,
+                       r.path_at_revision
+                  FROM native_revision_activity a
+                  JOIN native_revisions r
+                    ON r.revision_id = a.revision_id
+                 WHERE a.namespace_id = $1
+                   AND ($2::timestamptz IS NULL OR a.occurred_at >= $2)
+                   AND (
+                        $3::text IS NULL
+                        OR r.path_at_revision = $3
+                        OR r.path_at_revision LIKE $3 || '/%'
+                        OR a.changed_path_from = $3
+                        OR a.changed_path_from LIKE $3 || '/%'
+                        OR a.changed_path_to = $3
+                        OR a.changed_path_to LIKE $3 || '/%'
+                   )
+                 ORDER BY a.occurred_at DESC, a.revision_id DESC
+                 LIMIT $4
+                """,
+                namespace_id,
+                since,
+                path,
+                limit,
+            )
+        return [dict(row) for row in rows]
+
+    async def list_recent_document_heads(
+        self,
+        *,
+        user_id: uuid.UUID | None,
+        vault: str | None,
+        limit: int,
+    ) -> list[dict]:
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT rs.resource_id, rs.current_path AS path,
+                       rs.head_revision_id AS revision_id, rs.updated_at,
+                       v.name AS vault_name, p.canonical_bytes
+                  FROM native_resources rs
+                  JOIN vaults v ON v.id = rs.namespace_id
+                  JOIN native_revisions rv
+                    ON rv.resource_id = rs.resource_id
+                   AND rv.revision_id = rs.head_revision_id
+                  JOIN native_payload_manifests pm
+                    ON pm.payload_manifest_id = rv.payload_manifest_id
+                  JOIN m1_reference_payloads p
+                    ON p.payload_id = pm.private_locator
+                  LEFT JOIN vault_access va
+                    ON va.vault_id = v.id AND va.user_id = $1
+                 WHERE rs.surface = 'document'
+                   AND rs.lifecycle = 'live'
+                   AND ($2::text IS NULL OR v.name = $2)
+                   AND (
+                        $2::text IS NOT NULL
+                        OR v.owner_id = $1
+                        OR va.user_id = $1
+                        OR v.public_access IN ('reader', 'writer')
+                   )
+                 ORDER BY rs.updated_at DESC, rs.resource_id DESC
+                 LIMIT $3
+                """,
+                user_id,
+                vault,
+                limit,
+            )
         return [dict(row) for row in rows]
 
     @staticmethod

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -1,0 +1,544 @@
+"""Low-level PostgreSQL primitives for the native Resource/Revision ledger."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Protocol
+
+import asyncpg
+
+from app.exceptions import ConflictError
+
+
+class NativeRevisionIdCollisionError(ConflictError):
+    """The server-generated opaque token collided with an existing Revision."""
+
+    def __init__(self):
+        super().__init__("Server-generated native Revision ID collision; retry the mutation")
+
+
+class PreparedPayload(Protocol):
+    @property
+    def payload_id(self) -> uuid.UUID: ...
+
+    @property
+    def content_profile(self) -> str: ...
+
+    @property
+    def digest(self) -> str: ...
+
+    @property
+    def byte_size(self) -> int: ...
+
+    @property
+    def encoding(self) -> str: ...
+
+    @property
+    def selected_placement(self) -> str: ...
+
+    @property
+    def verification_profile(self) -> str: ...
+
+
+class NativeRevisionRepository:
+    """Repository operations that compose inside one caller-owned transaction."""
+
+    def __init__(self, pool: asyncpg.Pool):
+        self.pool = pool
+
+    @staticmethod
+    async def lock_mutation(
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+        mutation_id: uuid.UUID,
+    ) -> None:
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            f"native-mutation:{namespace_id}:{mutation_id}",
+        )
+
+    @staticmethod
+    async def lock_paths(
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+        surface: str,
+        *paths: str,
+    ) -> None:
+        """Lock affected paths in lexical order; no namespace-wide gate."""
+        for path in sorted(set(paths)):
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"native-path:{namespace_id}:{surface}:{path}",
+            )
+
+    @staticmethod
+    async def find_mutation(
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+        mutation_id: uuid.UUID,
+    ) -> dict | None:
+        row = await conn.fetchrow(
+            """
+            SELECT r.revision_id, r.resource_id, r.parent_revision_id,
+                   r.action, r.path_at_revision AS path, r.request_fingerprint,
+                   r.payload_manifest_id, r.occurred_at
+              FROM native_revisions r
+             WHERE r.namespace_id = $1 AND r.mutation_id = $2
+            """,
+            namespace_id,
+            mutation_id,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def find_live_path(
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        *,
+        for_update: bool = False,
+    ) -> dict | None:
+        suffix = " FOR UPDATE" if for_update else ""
+        row = await conn.fetchrow(
+            """
+            SELECT resource_id, namespace_id, surface, content_profile,
+                   current_path, lifecycle, head_revision_id,
+                   created_at, updated_at
+              FROM native_resources
+             WHERE namespace_id = $1
+               AND surface = $2
+               AND current_path = $3
+               AND lifecycle = 'live'
+            """
+            + suffix,
+            namespace_id,
+            surface,
+            path,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def lock_resource(
+        conn: asyncpg.Connection,
+        resource_id: uuid.UUID,
+    ) -> dict | None:
+        row = await conn.fetchrow(
+            """
+            SELECT resource_id, namespace_id, surface, content_profile,
+                   current_path, lifecycle, head_revision_id,
+                   created_at, updated_at
+              FROM native_resources
+             WHERE resource_id = $1
+             FOR UPDATE
+            """,
+            resource_id,
+        )
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def insert_resource(
+        conn: asyncpg.Connection,
+        *,
+        resource_id: uuid.UUID,
+        namespace_id: uuid.UUID,
+        surface: str,
+        content_profile: str,
+        path: str,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO native_resources (
+                resource_id, namespace_id, surface, content_profile,
+                current_path, lifecycle, created_at, updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, 'live', $6, $6)
+            """,
+            resource_id,
+            namespace_id,
+            surface,
+            content_profile,
+            path,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def insert_manifest(
+        conn: asyncpg.Connection,
+        *,
+        payload_manifest_id: uuid.UUID,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        payload: PreparedPayload,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO native_payload_manifests (
+                payload_manifest_id, namespace_id, resource_id, content_profile,
+                digest, byte_size, encoding, selected_placement, private_locator,
+                verification_profile, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            """,
+            payload_manifest_id,
+            namespace_id,
+            resource_id,
+            payload.content_profile,
+            payload.digest,
+            payload.byte_size,
+            payload.encoding,
+            payload.selected_placement,
+            payload.payload_id,
+            payload.verification_profile,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def insert_revision(
+        conn: asyncpg.Connection,
+        *,
+        revision_id: str,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        parent_revision_id: str | None,
+        action: str,
+        path: str,
+        path_from: str | None,
+        path_to: str | None,
+        payload_manifest_id: uuid.UUID | None,
+        mutation_id: uuid.UUID,
+        request_fingerprint: str,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        actor: str,
+        occurred_at: datetime,
+        activity_event_id: uuid.UUID,
+        invalidation_intent_id: uuid.UUID,
+    ) -> None:
+        try:
+            await conn.execute(
+                """
+                INSERT INTO native_revisions (
+                    revision_id, namespace_id, resource_id, parent_revision_id,
+                    action, path_at_revision, path_from, path_to,
+                    payload_manifest_id, mutation_id, request_fingerprint,
+                    message, subject, summary, actor, occurred_at,
+                    activity_event_id, invalidation_intent_id
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9,
+                    $10, $11, $12, $13, $14, $15, $16, $17, $18
+                )
+                """,
+                revision_id,
+                namespace_id,
+                resource_id,
+                parent_revision_id,
+                action,
+                path,
+                path_from,
+                path_to,
+                payload_manifest_id,
+                mutation_id,
+                request_fingerprint,
+                message,
+                subject,
+                summary,
+                actor,
+                occurred_at,
+                activity_event_id,
+                invalidation_intent_id,
+            )
+        except asyncpg.UniqueViolationError as exc:
+            if exc.constraint_name in {
+                "native_revisions_pkey",
+                "native_revisions_resource_revision_key",
+                "native_revisions_namespace_resource_revision_key",
+            }:
+                raise NativeRevisionIdCollisionError() from exc
+            raise
+
+    @staticmethod
+    async def copy_manifest(
+        conn: asyncpg.Connection,
+        *,
+        source_manifest_id: uuid.UUID,
+        payload_manifest_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        occurred_at: datetime,
+    ) -> None:
+        """Pin the same verified payload facts in a new immutable manifest."""
+        status = await conn.execute(
+            """
+            INSERT INTO native_payload_manifests (
+                payload_manifest_id, namespace_id, resource_id, content_profile,
+                digest, byte_size, encoding, selected_placement, private_locator,
+                verification_profile, created_at
+            )
+            SELECT $2, namespace_id, $3, content_profile, digest, byte_size,
+                   encoding, selected_placement, private_locator,
+                   verification_profile, $4
+              FROM native_payload_manifests
+             WHERE payload_manifest_id = $1
+            """,
+            source_manifest_id,
+            payload_manifest_id,
+            resource_id,
+            occurred_at,
+        )
+        if status != "INSERT 0 1":
+            raise LookupError(f"Native payload manifest is missing: {source_manifest_id}")
+
+    @staticmethod
+    async def set_head(
+        conn: asyncpg.Connection,
+        *,
+        resource_id: uuid.UUID,
+        revision_id: str,
+        path: str,
+        lifecycle: str,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE native_resources
+               SET head_revision_id = $2,
+                   current_path = $3,
+                   lifecycle = $4,
+                   updated_at = $5
+             WHERE resource_id = $1
+            """,
+            resource_id,
+            revision_id,
+            path,
+            lifecycle,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def insert_activity(
+        conn: asyncpg.Connection,
+        *,
+        activity_event_id: uuid.UUID,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        revision_id: str,
+        action: str,
+        actor: str,
+        subject: str | None,
+        summary: str | None,
+        path_from: str | None,
+        path_to: str | None,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO native_revision_activity (
+                activity_event_id, namespace_id, resource_id, revision_id,
+                action, actor, subject, summary, changed_path_from,
+                changed_path_to, occurred_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            """,
+            activity_event_id,
+            namespace_id,
+            resource_id,
+            revision_id,
+            action,
+            actor,
+            subject,
+            summary,
+            path_from,
+            path_to,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def insert_invalidation_intent(
+        conn: asyncpg.Connection,
+        *,
+        intent_id: uuid.UUID,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        revision_id: str,
+        reason: str,
+        occurred_at: datetime,
+        selected_delivery: str | None = None,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO native_invalidation_intents (
+                intent_id, namespace_id, resource_id, revision_id,
+                reason, selected_delivery, occurred_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            """,
+            intent_id,
+            namespace_id,
+            resource_id,
+            revision_id,
+            reason,
+            selected_delivery,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def insert_path_alias(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        old_path: str,
+        resource_id: uuid.UUID,
+        created_revision_id: str,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            INSERT INTO native_resource_path_aliases (
+                namespace_id, surface, old_path, resource_id,
+                created_revision_id, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            namespace_id,
+            surface,
+            old_path,
+            resource_id,
+            created_revision_id,
+            occurred_at,
+        )
+
+    @staticmethod
+    async def retire_live_alias(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        old_path: str,
+        retired_revision_id: str,
+        occurred_at: datetime,
+    ) -> None:
+        await conn.execute(
+            """
+            UPDATE native_resource_path_aliases
+               SET retired_revision_id = $4, retired_at = $5
+             WHERE namespace_id = $1
+               AND surface = $2
+               AND old_path = $3
+               AND retired_revision_id IS NULL
+            """,
+            namespace_id,
+            surface,
+            old_path,
+            retired_revision_id,
+            occurred_at,
+        )
+
+    async def get_current(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        sql = """
+            SELECT rs.resource_id, rs.namespace_id, rs.surface,
+                   rs.content_profile, rs.current_path AS path, rs.lifecycle,
+                   rv.revision_id, rv.parent_revision_id, rv.action,
+                   rv.occurred_at, pm.payload_manifest_id, pm.digest,
+                   pm.byte_size, pm.encoding, pm.selected_placement,
+                   pm.private_locator, pm.verification_profile
+              FROM native_resources rs
+              JOIN native_revisions rv
+                ON rv.resource_id = rs.resource_id
+               AND rv.revision_id = rs.head_revision_id
+              LEFT JOIN native_payload_manifests pm
+                ON pm.payload_manifest_id = rv.payload_manifest_id
+             WHERE rs.namespace_id = $1
+               AND rs.surface = $2
+               AND rs.current_path = $3
+               AND rs.lifecycle = 'live'
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, namespace_id, surface, path)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, namespace_id, surface, path)
+        return dict(row) if row is not None else None
+
+    async def get_revision(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        revision_id: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        sql = """
+            SELECT rv.*, pm.digest, pm.byte_size, pm.encoding,
+                   pm.selected_placement, pm.private_locator,
+                   pm.verification_profile
+              FROM native_revisions rv
+              LEFT JOIN native_payload_manifests pm
+                ON pm.payload_manifest_id = rv.payload_manifest_id
+             WHERE rv.resource_id = $1 AND rv.revision_id = $2
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, resource_id, revision_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, resource_id, revision_id)
+        return dict(row) if row is not None else None
+
+    async def list_history(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        limit: int = 100,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[dict]:
+        sql = """
+            SELECT revision_id, resource_id, parent_revision_id, action,
+                   path_at_revision AS path, path_from, path_to,
+                   payload_manifest_id, message, subject, summary, actor,
+                   occurred_at
+              FROM native_revisions
+             WHERE resource_id = $1
+             ORDER BY occurred_at DESC, revision_id DESC
+             LIMIT $2
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, resource_id, limit)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, resource_id, limit)
+        return [dict(row) for row in rows]
+
+    @staticmethod
+    async def find_live_alias(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        old_path: str,
+    ) -> dict | None:
+        row = await conn.fetchrow(
+            """
+            SELECT alias_id, namespace_id, surface, old_path, resource_id,
+                   created_revision_id, created_at
+              FROM native_resource_path_aliases
+             WHERE namespace_id = $1
+               AND surface = $2
+               AND old_path = $3
+               AND retired_revision_id IS NULL
+            """,
+            namespace_id,
+            surface,
+            old_path,
+        )
+        return dict(row) if row is not None else None

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -106,21 +106,26 @@ class NativeRevisionRepository:
         *,
         for_update: bool = False,
     ) -> dict | None:
+        """Return the namespace-wide live owner of ``path``.
+
+        ``surface`` is retained in the call shape for symmetry with the
+        Resource APIs, but paths are one authority namespace across Document
+        and File Resources.
+        """
+        del surface
         suffix = " FOR UPDATE" if for_update else ""
         row = await conn.fetchrow(
             """
             SELECT resource_id, namespace_id, surface, content_profile,
                    current_path, lifecycle, head_revision_id,
                    created_at, updated_at
-              FROM native_resources
+             FROM native_resources
              WHERE namespace_id = $1
-               AND surface = $2
-               AND current_path = $3
+               AND current_path = $2
                AND lifecycle = 'live'
             """
             + suffix,
             namespace_id,
-            surface,
             path,
         )
         return dict(row) if row is not None else None
@@ -476,17 +481,16 @@ class NativeRevisionRepository:
         retired_revision_id: str,
         occurred_at: datetime,
     ) -> None:
+        del surface
         await conn.execute(
             """
             UPDATE native_resource_path_aliases
-               SET retired_revision_id = $4, retired_at = $5
+               SET retired_revision_id = $3, retired_at = $4
              WHERE namespace_id = $1
-               AND surface = $2
-               AND old_path = $3
+               AND old_path = $2
                AND retired_revision_id IS NULL
             """,
             namespace_id,
-            surface,
             old_path,
             retired_revision_id,
             occurred_at,
@@ -723,18 +727,18 @@ class NativeRevisionRepository:
         surface: str,
         old_path: str,
     ) -> dict | None:
+        """Return the namespace-wide live alias owner of ``old_path``."""
+        del surface
         row = await conn.fetchrow(
             """
             SELECT alias_id, namespace_id, surface, old_path, resource_id,
                    created_revision_id, created_at
-              FROM native_resource_path_aliases
+             FROM native_resource_path_aliases
              WHERE namespace_id = $1
-               AND surface = $2
-               AND old_path = $3
+               AND old_path = $2
                AND retired_revision_id IS NULL
             """,
             namespace_id,
-            surface,
             old_path,
         )
         return dict(row) if row is not None else None

--- a/backend/app/services/agent_memory_service.py
+++ b/backend/app/services/agent_memory_service.py
@@ -43,6 +43,7 @@ from app.db.postgres import get_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.models.document import DocumentPutRequest
 from app.services.document_service import DocumentService
+from app.services.revision_backend import get_document_service
 
 logger = logging.getLogger("akb.agent_memory")
 
@@ -310,7 +311,7 @@ class AgentMemoryService:
     """
 
     def __init__(self, doc_service: DocumentService | None = None):
-        self.doc_service = doc_service or DocumentService()
+        self.doc_service = doc_service or get_document_service()
 
     # ── Vault provisioning ─────────────────────────────────
 

--- a/backend/app/services/m1_reference_payload_store.py
+++ b/backend/app/services/m1_reference_payload_store.py
@@ -1,0 +1,167 @@
+"""Verified M1-only reference payload adapter for native-ledger experiments.
+
+This is not a final searchable-body placement decision.  It stores one
+canonical byte representation solely so B-core can pin, open, and verify a
+payload while transaction semantics are measured independently.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+
+import asyncpg
+
+from app.exceptions import ValidationError
+
+
+class ReferencePayloadIntegrityError(RuntimeError):
+    """A prepared reference payload no longer matches its verified facts."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedReferencePayload:
+    payload_id: uuid.UUID
+    namespace_id: uuid.UUID
+    content_profile: str
+    digest: str
+    byte_size: int
+    encoding: str
+    selected_placement: str
+    verification_profile: str
+
+
+class M1ReferencePayloadStore:
+    """Prepare and verify canonical UTF-8 bytes outside the authority TX."""
+
+    selected_placement = "m1-reference-payload-v1"
+    verification_profile = "sha256-size-utf8-v1"
+
+    def __init__(self, pool: asyncpg.Pool):
+        self.pool = pool
+
+    @staticmethod
+    def _verified_bytes(
+        payload: str | bytes,
+        *,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> tuple[bytes, str]:
+        if isinstance(payload, str):
+            canonical = payload.encode("utf-8")
+        elif isinstance(payload, bytes):
+            canonical = payload
+        else:
+            raise ValidationError("Reference payload must be str or bytes")
+        try:
+            canonical.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise ValidationError("Reference text payload must be valid UTF-8") from exc
+        if b"\x00" in canonical:
+            raise ValidationError("Reference text payload must not contain NUL bytes")
+
+        observed_digest = hashlib.sha256(canonical).hexdigest()
+        if expected_digest is not None and expected_digest != observed_digest:
+            raise ValidationError("Reference payload digest does not match expected digest")
+        if expected_size is not None and expected_size != len(canonical):
+            raise ValidationError("Reference payload size does not match expected size")
+        return canonical, observed_digest
+
+    async def prepare_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        payload: str | bytes,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> PreparedReferencePayload:
+        canonical, observed_digest = self._verified_bytes(
+            payload,
+            expected_digest=expected_digest,
+            expected_size=expected_size,
+        )
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO m1_reference_payloads (
+                    namespace_id, content_profile, digest, byte_size, encoding,
+                    selected_placement, verification_profile, canonical_bytes
+                )
+                VALUES ($1, 'text', $2, $3, 'utf-8', $4, $5, $6)
+                ON CONFLICT (namespace_id, digest, byte_size) DO NOTHING
+                RETURNING payload_id, namespace_id, content_profile, digest,
+                          byte_size, encoding, selected_placement,
+                          verification_profile, canonical_bytes
+                """,
+                namespace_id,
+                observed_digest,
+                len(canonical),
+                self.selected_placement,
+                self.verification_profile,
+                canonical,
+            )
+            if row is None:
+                row = await conn.fetchrow(
+                    """
+                    SELECT payload_id, namespace_id, content_profile, digest,
+                           byte_size, encoding, selected_placement,
+                           verification_profile, canonical_bytes
+                      FROM m1_reference_payloads
+                     WHERE namespace_id = $1 AND digest = $2 AND byte_size = $3
+                    """,
+                    namespace_id,
+                    observed_digest,
+                    len(canonical),
+                )
+        assert row is not None
+        self._verify_row(row, expected=canonical)
+        return PreparedReferencePayload(
+            payload_id=row["payload_id"],
+            namespace_id=row["namespace_id"],
+            content_profile=row["content_profile"],
+            digest=row["digest"],
+            byte_size=row["byte_size"],
+            encoding=row["encoding"],
+            selected_placement=row["selected_placement"],
+            verification_profile=row["verification_profile"],
+        )
+
+    @classmethod
+    def _verify_row(cls, row, *, expected: bytes | None = None) -> bytes:
+        canonical = bytes(row["canonical_bytes"])
+        if expected is not None and canonical != expected:
+            raise ReferencePayloadIntegrityError("Reference payload bytes changed after preparation")
+        if len(canonical) != row["byte_size"]:
+            raise ReferencePayloadIntegrityError("Reference payload byte size mismatch")
+        if hashlib.sha256(canonical).hexdigest() != row["digest"]:
+            raise ReferencePayloadIntegrityError("Reference payload digest mismatch")
+        if row["encoding"] != "utf-8":
+            raise ReferencePayloadIntegrityError("Reference payload encoding mismatch")
+        try:
+            canonical.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise ReferencePayloadIntegrityError("Reference payload is not valid UTF-8") from exc
+        if b"\x00" in canonical:
+            raise ReferencePayloadIntegrityError("Reference payload contains NUL bytes")
+        if row["selected_placement"] != cls.selected_placement:
+            raise ReferencePayloadIntegrityError("Reference payload placement mismatch")
+        if row["verification_profile"] != cls.verification_profile:
+            raise ReferencePayloadIntegrityError("Reference payload verification profile mismatch")
+        return canonical
+
+    async def open_verified(self, payload_id: uuid.UUID) -> bytes:
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT payload_id, namespace_id, content_profile, digest,
+                       byte_size, encoding, selected_placement,
+                       verification_profile, canonical_bytes
+                  FROM m1_reference_payloads
+                 WHERE payload_id = $1
+                """,
+                payload_id,
+            )
+        if row is None:
+            raise ReferencePayloadIntegrityError(f"Reference payload is missing: {payload_id}")
+        return self._verify_row(row)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -237,19 +237,35 @@ class NativeDocumentService(DocumentService):
             frontmatter["created_by"] = agent_id
         raw = _compose_markdown(frontmatter, req.content)
         actor = agent_id or "unknown"
-        message = f"[put] {final_path}\n\nagent: {actor}\naction: create\nsummary: {req.title}"
-        result = await (await self._native()).create_text(
-            namespace_id=vault_id,
-            surface="document",
-            path=final_path,
-            payload=raw,
-            actor=actor,
-            mutation_id=uuid.uuid4(),
-            resource_id=path_identity,
-            message=message,
-            subject=f"[put] {final_path}",
-            summary=req.title,
-        )
+        mutation_id = uuid.uuid4()
+        race_count = 0
+        while True:
+            message = f"[put] {final_path}\n\nagent: {actor}\naction: create\nsummary: {req.title}"
+            try:
+                result = await (await self._native()).create_text(
+                    namespace_id=vault_id,
+                    surface="document",
+                    path=final_path,
+                    payload=raw,
+                    actor=actor,
+                    mutation_id=mutation_id,
+                    resource_id=path_identity,
+                    message=message,
+                    subject=f"[put] {final_path}",
+                    summary=req.title,
+                )
+                break
+            except ConflictError as exc:
+                if req.slug or not str(exc).startswith("Native Resource already exists at path:"):
+                    raise
+                await self._yield_after_head_race(race_count)
+                race_count += 1
+                final_path = await self._resolve_native_free_path(
+                    vault_id,
+                    base_path,
+                    path_identity,
+                    aliases_own_path=False,
+                )
         content_hash = _certified_content_hash(raw)
         return DocumentPutResponse(
             uri=doc_uri(req.vault, final_path),
@@ -294,10 +310,29 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if req.status is not None and req.status not in DOC_STATUSES:
             raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
+        vault_id, current = await self._current(vault, doc_ref)
+        return await self._update_from_snapshot(
+            vault=vault,
+            vault_id=vault_id,
+            current=current,
+            req=req,
+            agent_id=agent_id,
+        )
+
+    async def _update_from_snapshot(
+        self,
+        *,
+        vault: str,
+        vault_id: uuid.UUID,
+        current: NativeRevisionSnapshot,
+        req: DocumentUpdateRequest,
+        agent_id: str | None,
+    ) -> DocumentPutResponse:
         exact_head_pinned = req.expected_commit is not None
+        resource_id = current.resource_id
+        native = await self._native()
         race_count = 0
         while True:
-            vault_id, current = await self._current(vault, doc_ref)
             if req.expected_commit and req.expected_commit != current.revision_id:
                 raise ConflictError(
                     f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
@@ -329,7 +364,7 @@ class NativeDocumentService(DocumentService):
             summary = req.message or f"Update {current.path}"
             message = f"[update] {current.path}\n\nagent: {actor}\naction: update\nsummary: {summary}"
             try:
-                result = await (await self._native()).replace_text(
+                result = await native.replace_text(
                     namespace_id=vault_id,
                     surface="document",
                     path=current.path,
@@ -340,15 +375,23 @@ class NativeDocumentService(DocumentService):
                     # attempt. Unpinned callers are transparently recomputed
                     # against the new Head; explicit predicates fail closed.
                     expected_revision_id=current.revision_id,
+                    expected_resource_id=resource_id,
                     message=message,
                     subject=f"[update] {current.path}",
                     summary=summary,
                 )
             except ConflictError as exc:
-                if exact_head_pinned or not str(exc).startswith("Native Revision conflict:"):
+                if exact_head_pinned or not str(exc).startswith(
+                    ("Native Revision conflict:", "Native Resource conflict:")
+                ):
                     raise
                 await self._yield_after_head_race(race_count)
                 race_count += 1
+                current = await native.get_current_resource(
+                    namespace_id=vault_id,
+                    surface="document",
+                    resource_id=resource_id,
+                )
                 continue
             return DocumentPutResponse(
                 uri=doc_uri(vault, result.path),
@@ -377,43 +420,78 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if collection is None and slug is None:
             raise ValidationError("move requires at least one of collection or slug")
-        vault_id, current = await self._current(vault, doc_ref)
-        current_collection, current_slug = split_doc_path(current.path)
-        next_collection = normalize_collection_path(collection) if collection is not None else current_collection
-        next_slug = (
-            slugify(slug)
-            if slug
-            else strip_own_suffix(
-                current_slug,
-                current.resource_id,
-            )
-        )
-        base_path = doc_path(next_collection, next_slug)
-        if base_path == current.path:
-            raise ValidationError("move is a no-op: the target path equals the current path")
-        next_path = await self._resolve_native_free_path(vault_id, base_path, current.resource_id)
-        if slug and next_path != base_path:
-            raise ConflictError(f"Document already exists at path: {base_path}")
+        requested_collection = normalize_collection_path(collection) if collection is not None else None
+        requested_slug = slugify(slug) if slug else None
         actor = agent_id or "unknown"
-        summary = message or f"{current.path} -> {next_path}"
-        history_message = f"[move] {current.path} -> {next_path}\n\nagent: {actor}\naction: move\nsummary: {summary}"
-        result = await (await self._native()).move_text(
-            namespace_id=vault_id,
-            surface="document",
-            path=current.path,
-            path_to=next_path,
-            actor=actor,
-            mutation_id=uuid.uuid4(),
-            expected_revision_id=None,
-            message=history_message,
-            subject=f"[move] {current.path} -> {next_path}",
-            summary=summary,
-        )
-        _, body = _parse_markdown(current.text)
+        vault_id, current = await self._current(vault, doc_ref)
+        resource_id = current.resource_id
+        native = await self._native()
+        race_count = 0
+        while True:
+            current_collection, current_slug = split_doc_path(current.path)
+            next_collection = requested_collection if requested_collection is not None else current_collection
+            next_slug = (
+                requested_slug
+                if requested_slug is not None
+                else strip_own_suffix(
+                    current_slug,
+                    current.resource_id,
+                )
+            )
+            base_path = doc_path(next_collection, next_slug)
+            if base_path == current.path:
+                raise ValidationError("move is a no-op: the target path equals the current path")
+            next_path = await self._resolve_native_free_path(vault_id, base_path, current.resource_id)
+            if requested_slug is not None and next_path != base_path:
+                raise ConflictError(f"Document already exists at path: {base_path}")
+            summary = message or f"{current.path} -> {next_path}"
+            history_message = (
+                f"[move] {current.path} -> {next_path}\n\n"
+                f"agent: {actor}\naction: move\nsummary: {summary}"
+            )
+            try:
+                result = await native.move_text(
+                    namespace_id=vault_id,
+                    surface="document",
+                    path=current.path,
+                    path_to=next_path,
+                    actor=actor,
+                    mutation_id=uuid.uuid4(),
+                    expected_revision_id=current.revision_id,
+                    expected_resource_id=resource_id,
+                    message=history_message,
+                    subject=f"[move] {current.path} -> {next_path}",
+                    summary=summary,
+                )
+            except ConflictError as exc:
+                retryable_authority_race = str(exc).startswith(
+                    ("Native Revision conflict:", "Native Resource conflict:")
+                )
+                retryable_allocation_race = requested_slug is None and str(exc).startswith(
+                    ("Native Resource already exists at path:", "Native Resource alias already owns path:")
+                )
+                if not (retryable_authority_race or retryable_allocation_race):
+                    raise
+                await self._yield_after_head_race(race_count)
+                race_count += 1
+                current = await native.get_current_resource(
+                    namespace_id=vault_id,
+                    surface="document",
+                    resource_id=resource_id,
+                )
+                continue
+            committed = await native.get_resource_revision(
+                namespace_id=vault_id,
+                surface="document",
+                resource_id=result.resource_id,
+                revision_id=result.revision_id,
+            )
+            _, body = _parse_markdown(committed.text)
+            break
         return DocumentPutResponse(
-            uri=doc_uri(vault, next_path),
+            uri=doc_uri(vault, result.path),
             vault=vault,
-            path=next_path,
+            path=result.path,
             commit_hash=result.revision_id,
             current_commit=result.revision_id,
             previous_commit=result.parent_revision_id,
@@ -437,9 +515,11 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if not old_string:
             raise EditError("old_string cannot be empty")
+        vault_id, current = await self._current(vault, doc_ref)
+        resource_id = current.resource_id
+        native = await self._native()
         race_count = 0
         while True:
-            _, current = await self._current(vault, doc_ref)
             if base_commit and base_commit != current.revision_id:
                 raise ConflictError(f"current_commit moved: expected {base_commit}, actual {current.revision_id}")
             _, body = _parse_markdown(current.text)
@@ -475,10 +555,11 @@ class NativeDocumentService(DocumentService):
                     entities_found=0,
                 )
             try:
-                return await self.update(
-                    vault,
-                    current.path,
-                    DocumentUpdateRequest(
+                return await self._update_from_snapshot(
+                    vault=vault,
+                    vault_id=vault_id,
+                    current=current,
+                    req=DocumentUpdateRequest(
                         content=new_body,
                         message=message,
                         # Pin each derived body to the snapshot it edited.
@@ -491,26 +572,48 @@ class NativeDocumentService(DocumentService):
                 if base_commit is not None:
                     raise
                 if not (
-                    str(exc).startswith("Native Revision conflict:") or str(exc).startswith("current_commit moved:")
+                    str(exc).startswith(("Native Revision conflict:", "Native Resource conflict:"))
+                    or str(exc).startswith("current_commit moved:")
                 ):
                     raise
                 await self._yield_after_head_race(race_count)
                 race_count += 1
+                current = await native.get_current_resource(
+                    namespace_id=vault_id,
+                    surface="document",
+                    resource_id=resource_id,
+                )
 
     async def delete(self, vault: str, doc_ref: str, agent_id: str | None = None) -> bool:
         vault_id, current = await self._current(vault, doc_ref)
+        resource_id = current.resource_id
+        native = await self._native()
         actor = agent_id or "unknown"
-        await (await self._native()).delete_resource(
-            namespace_id=vault_id,
-            surface="document",
-            path=current.path,
-            actor=actor,
-            mutation_id=uuid.uuid4(),
-            expected_revision_id=None,
-            message=f"[delete] {current.path}\n\nagent: {actor}\naction: delete",
-            subject=f"[delete] {current.path}",
-        )
-        return True
+        race_count = 0
+        while True:
+            try:
+                await native.delete_resource(
+                    namespace_id=vault_id,
+                    surface="document",
+                    path=current.path,
+                    actor=actor,
+                    mutation_id=uuid.uuid4(),
+                    expected_revision_id=current.revision_id,
+                    expected_resource_id=resource_id,
+                    message=f"[delete] {current.path}\n\nagent: {actor}\naction: delete",
+                    subject=f"[delete] {current.path}",
+                )
+                return True
+            except ConflictError as exc:
+                if not str(exc).startswith(("Native Revision conflict:", "Native Resource conflict:")):
+                    raise
+                await self._yield_after_head_race(race_count)
+                race_count += 1
+                current = await native.get_current_resource(
+                    namespace_id=vault_id,
+                    surface="document",
+                    resource_id=resource_id,
+                )
 
     async def history(self, vault: str, doc_ref: str, limit: int = 20) -> dict:
         vault_id = await self._vault_id(vault)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -230,11 +230,15 @@ class NativeDocumentService(DocumentService):
         path_identity = uuid.uuid4()
         if req.slug and await self._current_path_is_owned(vault_id, base_path):
             raise ConflictError(f"Document already exists at path: {base_path}")
-        final_path = await self._resolve_native_free_path(
-            vault_id,
-            base_path,
-            path_identity,
-            aliases_own_path=False,
+        final_path = (
+            base_path
+            if req.slug
+            else await self._resolve_native_free_path(
+                vault_id,
+                base_path,
+                path_identity,
+                aliases_own_path=False,
+            )
         )
 
         frontmatter = _build_frontmatter(req, now)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -7,6 +7,7 @@ constructs a Git service nor writes the legacy document projection.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime
 from typing import NoReturn
@@ -60,8 +61,6 @@ class NativeRevisionUnsupportedSurfaceError(AKBError):
 class NativeDocumentService(DocumentService):
     """Document lifecycle adapter preserving existing request/response models."""
 
-    _UNPINNED_RETRY_LIMIT = 4
-
     def __init__(self, *, pool: asyncpg.Pool | None = None):
         # Deliberately do not call DocumentService.__init__: that would create
         # the legacy Git adapter before a request is even served.
@@ -80,6 +79,16 @@ class NativeDocumentService(DocumentService):
 
     async def _native(self) -> NativeRevisionService:
         return NativeRevisionService(await self._pool())
+
+    @staticmethod
+    async def _yield_after_head_race(race_count: int) -> None:
+        """Cooperate under sustained writers without inventing a 409 limit.
+
+        ``asyncio.sleep`` is cancellation-safe: request cancellation interrupts
+        the retry instead of leaving a detached publication loop behind.
+        """
+        delay = min(0.001 * (2 ** min(race_count, 5)), 0.032)
+        await asyncio.sleep(delay)
 
     async def _current(
         self,
@@ -285,9 +294,9 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if req.status is not None and req.status not in DOC_STATUSES:
             raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
-        explicit_occ = req.expected_commit is not None or req.expected_content_hash is not None
-        last_conflict: ConflictError | None = None
-        for attempt in range(self._UNPINNED_RETRY_LIMIT):
+        exact_head_pinned = req.expected_commit is not None
+        race_count = 0
+        while True:
             vault_id, current = await self._current(vault, doc_ref)
             if req.expected_commit and req.expected_commit != current.revision_id:
                 raise ConflictError(
@@ -336,13 +345,10 @@ class NativeDocumentService(DocumentService):
                     summary=summary,
                 )
             except ConflictError as exc:
-                if (
-                    explicit_occ
-                    or not str(exc).startswith("Native Revision conflict:")
-                    or attempt + 1 == self._UNPINNED_RETRY_LIMIT
-                ):
+                if exact_head_pinned or not str(exc).startswith("Native Revision conflict:"):
                     raise
-                last_conflict = exc
+                await self._yield_after_head_race(race_count)
+                race_count += 1
                 continue
             return DocumentPutResponse(
                 uri=doc_uri(vault, result.path),
@@ -358,8 +364,6 @@ class NativeDocumentService(DocumentService):
                 chunks_indexed=0,
                 entities_found=0,
             )
-        assert last_conflict is not None
-        raise last_conflict
 
     async def move(
         self,
@@ -433,8 +437,8 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if not old_string:
             raise EditError("old_string cannot be empty")
-        last_conflict: ConflictError | None = None
-        for attempt in range(self._UNPINNED_RETRY_LIMIT):
+        race_count = 0
+        while True:
             _, current = await self._current(vault, doc_ref)
             if base_commit and base_commit != current.revision_id:
                 raise ConflictError(f"current_commit moved: expected {base_commit}, actual {current.revision_id}")
@@ -484,15 +488,14 @@ class NativeDocumentService(DocumentService):
                     agent_id=agent_id,
                 )
             except ConflictError as exc:
-                if base_commit is not None or attempt + 1 == self._UNPINNED_RETRY_LIMIT:
+                if base_commit is not None:
                     raise
                 if not (
                     str(exc).startswith("Native Revision conflict:") or str(exc).startswith("current_commit moved:")
                 ):
                     raise
-                last_conflict = exc
-        assert last_conflict is not None
-        raise last_conflict
+                await self._yield_after_head_race(race_count)
+                race_count += 1
 
     async def delete(self, vault: str, doc_ref: str, agent_id: str | None = None) -> bool:
         vault_id, current = await self._current(vault, doc_ref)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -144,7 +144,12 @@ class NativeDocumentService(DocumentService):
             candidate = f"{stem}-{path_identity.hex[:width]}.md"
             if not await path_is_owned(vault_id, candidate):
                 return candidate
-        return f"{stem}-{path_identity.hex}.md"
+        ordinal = 2
+        while True:
+            candidate = f"{stem}-{path_identity.hex}-{ordinal}.md"
+            if not await path_is_owned(vault_id, candidate):
+                return candidate
+            ordinal += 1
 
     async def _created_by_name(self, created_by: str | None) -> str | None:
         if not created_by:

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -1,0 +1,491 @@
+"""Measurement-only Document compatibility facade over the native ledger.
+
+The public Document models intentionally keep their historical commit-shaped
+field names.  Values are native opaque Revision tokens; this service neither
+constructs a Git service nor writes the legacy document projection.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import NoReturn
+
+import asyncpg
+
+from app.db.postgres import get_pool
+from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
+from app.models.document import (
+    DOC_STATUSES,
+    BrowseResponse,
+    DocumentPutRequest,
+    DocumentPutResponse,
+    DocumentResponse,
+    DocumentUpdateRequest,
+)
+from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.document_service import (
+    EditError,
+    DocumentService,
+    _body_content_hash,
+    _build_frontmatter,
+    _certified_content_hash,
+    _compose_markdown,
+    _parse_markdown,
+)
+from app.services.native_revision_service import NativeRevisionService, NativeRevisionSnapshot
+from app.services.resource_hash import HASH_ALGORITHM
+from app.services.uri_service import doc_uri
+from app.util.text import (
+    doc_path,
+    normalize_collection_path,
+    slugify,
+    split_doc_path,
+    strip_own_suffix,
+    to_nfc,
+)
+
+
+class NativeRevisionUnsupportedSurfaceError(AKBError):
+    """A non-revision surface was reached in the isolated measurement arm."""
+
+    def __init__(self, surface: str):
+        super().__init__(
+            f"{surface} is unavailable in the native-ledger M1 measurement arm",
+            status_code=501,
+            code="native_revision_surface_unsupported",
+        )
+
+
+class NativeDocumentService(DocumentService):
+    """Document lifecycle adapter preserving existing request/response models."""
+
+    def __init__(self, *, pool: asyncpg.Pool | None = None):
+        # Deliberately do not call DocumentService.__init__: that would create
+        # the legacy Git adapter before a request is even served.
+        self._injected_pool = pool
+
+    async def _pool(self) -> asyncpg.Pool:
+        return self._injected_pool or await get_pool()
+
+    async def _vault_id(self, vault: str) -> uuid.UUID:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            vault_id = await conn.fetchval("SELECT id FROM vaults WHERE name = $1", vault)
+        if vault_id is None:
+            raise NotFoundError("Vault", vault)
+        return vault_id
+
+    async def _native(self) -> NativeRevisionService:
+        return NativeRevisionService(await self._pool())
+
+    async def _current(
+        self,
+        vault: str,
+        reference: str,
+    ) -> tuple[uuid.UUID, NativeRevisionSnapshot]:
+        vault_id = await self._vault_id(vault)
+        snapshot = await (await self._native()).get_current_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference=to_nfc(reference),
+        )
+        return vault_id, snapshot
+
+    async def _path_is_owned(self, vault_id: uuid.UUID, path: str) -> bool:
+        repository = NativeRevisionRepository(await self._pool())
+        return await repository.resolve_live_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference=path,
+        ) is not None
+
+    async def _resolve_native_free_path(
+        self,
+        vault_id: uuid.UUID,
+        base_path: str,
+        path_identity: uuid.UUID,
+    ) -> str:
+        if not await self._path_is_owned(vault_id, base_path):
+            return base_path
+        stem = base_path[:-3] if base_path.endswith(".md") else base_path
+        for width in (8, 12, 16, len(path_identity.hex)):
+            candidate = f"{stem}-{path_identity.hex[:width]}.md"
+            if not await self._path_is_owned(vault_id, candidate):
+                return candidate
+        return f"{stem}-{path_identity.hex}.md"
+
+    async def _created_by_name(self, created_by: str | None) -> str | None:
+        if not created_by:
+            return None
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                SELECT COALESCE(display_name, username)
+                  FROM users
+                 WHERE id::text = $1 OR username = $1
+                 LIMIT 1
+                """,
+                created_by,
+            )
+
+    async def _public_slug(self, vault: str, path: str) -> str | None:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                SELECT slug
+                  FROM publications
+                 WHERE resource_uri = $1 AND resource_type = 'document'
+                 ORDER BY created_at DESC
+                 LIMIT 1
+                """,
+                doc_uri(vault, path),
+            )
+
+    async def _response(
+        self,
+        *,
+        vault: str,
+        current: NativeRevisionSnapshot,
+        selected: NativeRevisionSnapshot | None = None,
+    ) -> DocumentResponse:
+        selected = selected or current
+        current_fm, _ = _parse_markdown(current.text)
+        _, selected_body = _parse_markdown(selected.text)
+        created_by = current_fm.get("created_by")
+        public_slug = await self._public_slug(vault, current.path)
+        return DocumentResponse(
+            uri=doc_uri(vault, current.path),
+            vault=vault,
+            path=current.path,
+            title=current_fm.get("title") or current.path.rsplit("/", 1)[-1],
+            type=current_fm.get("type") or "note",
+            status=current_fm.get("status") or "draft",
+            summary=current_fm.get("summary"),
+            domain=current_fm.get("domain"),
+            created_by=created_by,
+            created_by_name=await self._created_by_name(created_by),
+            created_at=current_fm.get("created_at") or current.resource_created_at,
+            updated_at=current.resource_updated_at,
+            current_commit=selected.revision_id,
+            content_hash=_body_content_hash(selected_body),
+            hash_algorithm=HASH_ALGORITHM,
+            tags=list(current_fm.get("tags") or []),
+            content=selected_body,
+            is_public=public_slug is not None,
+            public_slug=public_slug,
+            metadata_is_current=selected.revision_id != current.revision_id,
+        )
+
+    async def put(
+        self,
+        req: DocumentPutRequest,
+        agent_id: str | None = None,
+    ) -> DocumentPutResponse:
+        if req.status not in DOC_STATUSES:
+            raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
+        vault_id = await self._vault_id(req.vault)
+        now = datetime.now(UTC)
+        base_slug = slugify(req.slug) if req.slug else slugify(req.title)
+        collection = normalize_collection_path(req.collection)
+        base_path = doc_path(collection, base_slug)
+        path_identity = uuid.uuid4()
+        if req.slug and await self._path_is_owned(vault_id, base_path):
+            raise ConflictError(f"Document already exists at path: {base_path}")
+        final_path = await self._resolve_native_free_path(vault_id, base_path, path_identity)
+
+        frontmatter = _build_frontmatter(req, now)
+        if agent_id:
+            frontmatter["created_by"] = agent_id
+        raw = _compose_markdown(frontmatter, req.content)
+        actor = agent_id or "unknown"
+        message = (
+            f"[put] {final_path}\n\nagent: {actor}\n"
+            f"action: create\nsummary: {req.title}"
+        )
+        result = await (await self._native()).create_text(
+            namespace_id=vault_id,
+            surface="document",
+            path=final_path,
+            payload=raw,
+            actor=actor,
+            mutation_id=uuid.uuid4(),
+            resource_id=path_identity,
+            message=message,
+            subject=f"[put] {final_path}",
+            summary=req.title,
+        )
+        content_hash = _certified_content_hash(raw)
+        return DocumentPutResponse(
+            uri=doc_uri(req.vault, final_path),
+            vault=req.vault,
+            path=final_path,
+            commit_hash=result.revision_id,
+            current_commit=result.revision_id,
+            content_hash=content_hash,
+            hash_algorithm=HASH_ALGORITHM,
+            action="created",
+            chunks_indexed=0,
+            entities_found=0,
+        )
+
+    async def get(self, vault: str, doc_ref: str) -> DocumentResponse:
+        _, current = await self._current(vault, doc_ref)
+        return await self._response(vault=vault, current=current)
+
+    async def get_at_commit(
+        self,
+        vault: str,
+        doc_ref: str,
+        version: str,
+    ) -> DocumentResponse:
+        vault_id, current = await self._current(vault, doc_ref)
+        if len(version) != 40 or any(ch not in "0123456789abcdef" for ch in version):
+            raise NotFoundError("Document version", f"{current.path}@{version[:8]}")
+        selected = await (await self._native()).get_revision(
+            namespace_id=vault_id,
+            surface="document",
+            reference=current.path,
+            revision_id=version,
+        )
+        return await self._response(vault=vault, current=current, selected=selected)
+
+    async def update(
+        self,
+        vault: str,
+        doc_ref: str,
+        req: DocumentUpdateRequest,
+        agent_id: str | None = None,
+    ) -> DocumentPutResponse:
+        if req.status is not None and req.status not in DOC_STATUSES:
+            raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
+        vault_id, current = await self._current(vault, doc_ref)
+        if req.expected_commit and req.expected_commit != current.revision_id:
+            raise ConflictError(
+                f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
+            )
+        frontmatter, current_body = _parse_markdown(current.text)
+        previous_hash = _body_content_hash(current_body)
+        if req.expected_content_hash and req.expected_content_hash != previous_hash:
+            raise ConflictError(
+                f"content_hash moved: expected {req.expected_content_hash}, actual {previous_hash}"
+            )
+        if req.title:
+            frontmatter["title"] = req.title
+        if req.type:
+            frontmatter["type"] = req.type
+        if req.status:
+            frontmatter["status"] = req.status
+        if req.tags is not None:
+            frontmatter["tags"] = req.tags
+        if req.domain is not None:
+            frontmatter["domain"] = req.domain
+        if req.summary is not None:
+            frontmatter["summary"] = req.summary
+        if req.depends_on is not None:
+            frontmatter["depends_on"] = req.depends_on
+        if req.related_to is not None:
+            frontmatter["related_to"] = req.related_to
+        frontmatter["updated_at"] = datetime.now(UTC).isoformat()
+        new_body = req.content if req.content is not None else current_body
+        raw = _compose_markdown(frontmatter, new_body)
+        actor = agent_id or "unknown"
+        summary = req.message or f"Update {current.path}"
+        message = (
+            f"[update] {current.path}\n\nagent: {actor}\n"
+            f"action: update\nsummary: {summary}"
+        )
+        result = await (await self._native()).replace_text(
+            namespace_id=vault_id,
+            surface="document",
+            path=current.path,
+            payload=raw,
+            actor=actor,
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=current.revision_id,
+            message=message,
+            subject=f"[update] {current.path}",
+            summary=summary,
+        )
+        return DocumentPutResponse(
+            uri=doc_uri(vault, current.path),
+            vault=vault,
+            path=current.path,
+            commit_hash=result.revision_id,
+            current_commit=result.revision_id,
+            previous_commit=current.revision_id,
+            previous_content_hash=previous_hash,
+            content_hash=_certified_content_hash(raw),
+            hash_algorithm=HASH_ALGORITHM,
+            action="updated",
+            chunks_indexed=0,
+            entities_found=0,
+        )
+
+    async def move(
+        self,
+        vault: str,
+        doc_ref: str,
+        *,
+        collection: str | None = None,
+        slug: str | None = None,
+        message: str | None = None,
+        agent_id: str | None = None,
+    ) -> DocumentPutResponse:
+        if collection is None and slug is None:
+            raise ValidationError("move requires at least one of collection or slug")
+        vault_id, current = await self._current(vault, doc_ref)
+        current_collection, current_slug = split_doc_path(current.path)
+        next_collection = (
+            normalize_collection_path(collection)
+            if collection is not None
+            else current_collection
+        )
+        next_slug = slugify(slug) if slug else strip_own_suffix(
+            current_slug,
+            current.resource_id,
+        )
+        base_path = doc_path(next_collection, next_slug)
+        if base_path == current.path:
+            raise ValidationError("move is a no-op: the target path equals the current path")
+        next_path = await self._resolve_native_free_path(vault_id, base_path, current.resource_id)
+        if slug and next_path != base_path:
+            raise ConflictError(f"Document already exists at path: {base_path}")
+        actor = agent_id or "unknown"
+        summary = message or f"{current.path} -> {next_path}"
+        history_message = (
+            f"[move] {current.path} -> {next_path}\n\nagent: {actor}\n"
+            f"action: move\nsummary: {summary}"
+        )
+        result = await (await self._native()).move_text(
+            namespace_id=vault_id,
+            surface="document",
+            path=current.path,
+            path_to=next_path,
+            actor=actor,
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=current.revision_id,
+            message=history_message,
+            subject=f"[move] {current.path} -> {next_path}",
+            summary=summary,
+        )
+        _, body = _parse_markdown(current.text)
+        return DocumentPutResponse(
+            uri=doc_uri(vault, next_path),
+            vault=vault,
+            path=next_path,
+            commit_hash=result.revision_id,
+            current_commit=result.revision_id,
+            previous_commit=current.revision_id,
+            content_hash=_body_content_hash(body),
+            hash_algorithm=HASH_ALGORITHM,
+            action="moved",
+            chunks_indexed=0,
+            entities_found=0,
+        )
+
+    async def edit(
+        self,
+        vault: str,
+        doc_ref: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+        message: str | None = None,
+        agent_id: str | None = None,
+        base_commit: str | None = None,
+    ) -> DocumentPutResponse:
+        _, current = await self._current(vault, doc_ref)
+        if base_commit and base_commit != current.revision_id:
+            raise ConflictError(
+                f"current_commit moved: expected {base_commit}, actual {current.revision_id}"
+            )
+        _, body = _parse_markdown(current.text)
+        if not old_string:
+            raise EditError("old_string cannot be empty")
+        occurrences = body.count(old_string)
+        if occurrences == 0:
+            raise EditError("old_string not found in document body. Use akb_get to verify current content.")
+        if occurrences > 1 and not replace_all:
+            raise EditError(
+                f"old_string appears {occurrences} times in document. "
+                "Add more surrounding context to make it unique, or set replace_all=true."
+            )
+        new_body = body.replace(old_string, new_string) if replace_all else body.replace(
+            old_string,
+            new_string,
+            1,
+        )
+        if new_body == body:
+            content_hash = _body_content_hash(body)
+            return DocumentPutResponse(
+                uri=doc_uri(vault, current.path),
+                vault=vault,
+                path=current.path,
+                commit_hash=current.revision_id,
+                current_commit=current.revision_id,
+                content_hash=content_hash,
+                hash_algorithm=HASH_ALGORITHM,
+                action="unchanged",
+                chunks_indexed=0,
+                entities_found=0,
+            )
+        return await self.update(
+            vault,
+            current.path,
+            DocumentUpdateRequest(
+                content=new_body,
+                message=message,
+                expected_commit=current.revision_id,
+            ),
+            agent_id=agent_id,
+        )
+
+    async def delete(self, vault: str, doc_ref: str, agent_id: str | None = None) -> bool:
+        vault_id, current = await self._current(vault, doc_ref)
+        actor = agent_id or "unknown"
+        await (await self._native()).delete_resource(
+            namespace_id=vault_id,
+            surface="document",
+            path=current.path,
+            actor=actor,
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=current.revision_id,
+            message=f"[delete] {current.path}\n\nagent: {actor}\naction: delete",
+            subject=f"[delete] {current.path}",
+        )
+        return True
+
+    async def history(self, vault: str, doc_ref: str, limit: int = 20) -> dict:
+        vault_id = await self._vault_id(vault)
+        resource, rows = await (await self._native()).list_history(
+            namespace_id=vault_id,
+            surface="document",
+            reference=to_nfc(doc_ref),
+            limit=limit,
+        )
+        history = [
+            {
+                "hash": row["revision_id"],
+                "message": row["message"] or row["subject"] or row["action"],
+                "author": row["actor"],
+                "date": row["occurred_at"].isoformat(),
+            }
+            for row in rows
+        ]
+        return {"uri": doc_uri(vault, resource["current_path"]), "history": history}
+
+    @staticmethod
+    def _unsupported(surface: str) -> NoReturn:
+        raise NativeRevisionUnsupportedSurfaceError(surface)
+
+    async def browse(self, *args, **kwargs) -> BrowseResponse:
+        self._unsupported("document browse")
+
+    async def create_vault(self, *args, **kwargs) -> str:
+        self._unsupported("vault creation")
+
+    async def list_vaults(self) -> list[dict]:
+        self._unsupported("vault listing")

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -60,6 +60,8 @@ class NativeRevisionUnsupportedSurfaceError(AKBError):
 class NativeDocumentService(DocumentService):
     """Document lifecycle adapter preserving existing request/response models."""
 
+    _UNPINNED_RETRY_LIMIT = 4
+
     def __init__(self, *, pool: asyncpg.Pool | None = None):
         # Deliberately do not call DocumentService.__init__: that would create
         # the legacy Git adapter before a request is even served.
@@ -94,24 +96,44 @@ class NativeDocumentService(DocumentService):
 
     async def _path_is_owned(self, vault_id: uuid.UUID, path: str) -> bool:
         repository = NativeRevisionRepository(await self._pool())
-        return await repository.resolve_live_reference(
-            namespace_id=vault_id,
-            surface="document",
-            reference=path,
-        ) is not None
+        return (
+            await repository.resolve_live_reference(
+                namespace_id=vault_id,
+                surface="document",
+                reference=path,
+            )
+            is not None
+        )
+
+    async def _current_path_is_owned(self, vault_id: uuid.UUID, path: str) -> bool:
+        repository = NativeRevisionRepository(await self._pool())
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            return (
+                await repository.find_live_path(
+                    conn,
+                    vault_id,
+                    "document",
+                    path,
+                )
+                is not None
+            )
 
     async def _resolve_native_free_path(
         self,
         vault_id: uuid.UUID,
         base_path: str,
         path_identity: uuid.UUID,
+        *,
+        aliases_own_path: bool = True,
     ) -> str:
-        if not await self._path_is_owned(vault_id, base_path):
+        path_is_owned = self._path_is_owned if aliases_own_path else self._current_path_is_owned
+        if not await path_is_owned(vault_id, base_path):
             return base_path
         stem = base_path[:-3] if base_path.endswith(".md") else base_path
         for width in (8, 12, 16, len(path_identity.hex)):
             candidate = f"{stem}-{path_identity.hex[:width]}.md"
-            if not await self._path_is_owned(vault_id, candidate):
+            if not await path_is_owned(vault_id, candidate):
                 return candidate
         return f"{stem}-{path_identity.hex}.md"
 
@@ -192,19 +214,21 @@ class NativeDocumentService(DocumentService):
         collection = normalize_collection_path(req.collection)
         base_path = doc_path(collection, base_slug)
         path_identity = uuid.uuid4()
-        if req.slug and await self._path_is_owned(vault_id, base_path):
+        if req.slug and await self._current_path_is_owned(vault_id, base_path):
             raise ConflictError(f"Document already exists at path: {base_path}")
-        final_path = await self._resolve_native_free_path(vault_id, base_path, path_identity)
+        final_path = await self._resolve_native_free_path(
+            vault_id,
+            base_path,
+            path_identity,
+            aliases_own_path=False,
+        )
 
         frontmatter = _build_frontmatter(req, now)
         if agent_id:
             frontmatter["created_by"] = agent_id
         raw = _compose_markdown(frontmatter, req.content)
         actor = agent_id or "unknown"
-        message = (
-            f"[put] {final_path}\n\nagent: {actor}\n"
-            f"action: create\nsummary: {req.title}"
-        )
+        message = f"[put] {final_path}\n\nagent: {actor}\naction: create\nsummary: {req.title}"
         result = await (await self._native()).create_text(
             namespace_id=vault_id,
             surface="document",
@@ -261,68 +285,81 @@ class NativeDocumentService(DocumentService):
     ) -> DocumentPutResponse:
         if req.status is not None and req.status not in DOC_STATUSES:
             raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
-        vault_id, current = await self._current(vault, doc_ref)
-        if req.expected_commit and req.expected_commit != current.revision_id:
-            raise ConflictError(
-                f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
+        explicit_occ = req.expected_commit is not None or req.expected_content_hash is not None
+        last_conflict: ConflictError | None = None
+        for attempt in range(self._UNPINNED_RETRY_LIMIT):
+            vault_id, current = await self._current(vault, doc_ref)
+            if req.expected_commit and req.expected_commit != current.revision_id:
+                raise ConflictError(
+                    f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
+                )
+            frontmatter, current_body = _parse_markdown(current.text)
+            previous_hash = _body_content_hash(current_body)
+            if req.expected_content_hash and req.expected_content_hash != previous_hash:
+                raise ConflictError(f"content_hash moved: expected {req.expected_content_hash}, actual {previous_hash}")
+            if req.title:
+                frontmatter["title"] = req.title
+            if req.type:
+                frontmatter["type"] = req.type
+            if req.status:
+                frontmatter["status"] = req.status
+            if req.tags is not None:
+                frontmatter["tags"] = req.tags
+            if req.domain is not None:
+                frontmatter["domain"] = req.domain
+            if req.summary is not None:
+                frontmatter["summary"] = req.summary
+            if req.depends_on is not None:
+                frontmatter["depends_on"] = req.depends_on
+            if req.related_to is not None:
+                frontmatter["related_to"] = req.related_to
+            frontmatter["updated_at"] = datetime.now(UTC).isoformat()
+            new_body = req.content if req.content is not None else current_body
+            raw = _compose_markdown(frontmatter, new_body)
+            actor = agent_id or "unknown"
+            summary = req.message or f"Update {current.path}"
+            message = f"[update] {current.path}\n\nagent: {actor}\naction: update\nsummary: {summary}"
+            try:
+                result = await (await self._native()).replace_text(
+                    namespace_id=vault_id,
+                    surface="document",
+                    path=current.path,
+                    payload=raw,
+                    actor=actor,
+                    mutation_id=uuid.uuid4(),
+                    # This internal compare protects the read/merge/write
+                    # attempt. Unpinned callers are transparently recomputed
+                    # against the new Head; explicit predicates fail closed.
+                    expected_revision_id=current.revision_id,
+                    message=message,
+                    subject=f"[update] {current.path}",
+                    summary=summary,
+                )
+            except ConflictError as exc:
+                if (
+                    explicit_occ
+                    or not str(exc).startswith("Native Revision conflict:")
+                    or attempt + 1 == self._UNPINNED_RETRY_LIMIT
+                ):
+                    raise
+                last_conflict = exc
+                continue
+            return DocumentPutResponse(
+                uri=doc_uri(vault, result.path),
+                vault=vault,
+                path=result.path,
+                commit_hash=result.revision_id,
+                current_commit=result.revision_id,
+                previous_commit=result.parent_revision_id,
+                previous_content_hash=previous_hash,
+                content_hash=_certified_content_hash(raw),
+                hash_algorithm=HASH_ALGORITHM,
+                action="updated",
+                chunks_indexed=0,
+                entities_found=0,
             )
-        frontmatter, current_body = _parse_markdown(current.text)
-        previous_hash = _body_content_hash(current_body)
-        if req.expected_content_hash and req.expected_content_hash != previous_hash:
-            raise ConflictError(
-                f"content_hash moved: expected {req.expected_content_hash}, actual {previous_hash}"
-            )
-        if req.title:
-            frontmatter["title"] = req.title
-        if req.type:
-            frontmatter["type"] = req.type
-        if req.status:
-            frontmatter["status"] = req.status
-        if req.tags is not None:
-            frontmatter["tags"] = req.tags
-        if req.domain is not None:
-            frontmatter["domain"] = req.domain
-        if req.summary is not None:
-            frontmatter["summary"] = req.summary
-        if req.depends_on is not None:
-            frontmatter["depends_on"] = req.depends_on
-        if req.related_to is not None:
-            frontmatter["related_to"] = req.related_to
-        frontmatter["updated_at"] = datetime.now(UTC).isoformat()
-        new_body = req.content if req.content is not None else current_body
-        raw = _compose_markdown(frontmatter, new_body)
-        actor = agent_id or "unknown"
-        summary = req.message or f"Update {current.path}"
-        message = (
-            f"[update] {current.path}\n\nagent: {actor}\n"
-            f"action: update\nsummary: {summary}"
-        )
-        result = await (await self._native()).replace_text(
-            namespace_id=vault_id,
-            surface="document",
-            path=current.path,
-            payload=raw,
-            actor=actor,
-            mutation_id=uuid.uuid4(),
-            expected_revision_id=current.revision_id,
-            message=message,
-            subject=f"[update] {current.path}",
-            summary=summary,
-        )
-        return DocumentPutResponse(
-            uri=doc_uri(vault, current.path),
-            vault=vault,
-            path=current.path,
-            commit_hash=result.revision_id,
-            current_commit=result.revision_id,
-            previous_commit=current.revision_id,
-            previous_content_hash=previous_hash,
-            content_hash=_certified_content_hash(raw),
-            hash_algorithm=HASH_ALGORITHM,
-            action="updated",
-            chunks_indexed=0,
-            entities_found=0,
-        )
+        assert last_conflict is not None
+        raise last_conflict
 
     async def move(
         self,
@@ -338,14 +375,14 @@ class NativeDocumentService(DocumentService):
             raise ValidationError("move requires at least one of collection or slug")
         vault_id, current = await self._current(vault, doc_ref)
         current_collection, current_slug = split_doc_path(current.path)
-        next_collection = (
-            normalize_collection_path(collection)
-            if collection is not None
-            else current_collection
-        )
-        next_slug = slugify(slug) if slug else strip_own_suffix(
-            current_slug,
-            current.resource_id,
+        next_collection = normalize_collection_path(collection) if collection is not None else current_collection
+        next_slug = (
+            slugify(slug)
+            if slug
+            else strip_own_suffix(
+                current_slug,
+                current.resource_id,
+            )
         )
         base_path = doc_path(next_collection, next_slug)
         if base_path == current.path:
@@ -355,10 +392,7 @@ class NativeDocumentService(DocumentService):
             raise ConflictError(f"Document already exists at path: {base_path}")
         actor = agent_id or "unknown"
         summary = message or f"{current.path} -> {next_path}"
-        history_message = (
-            f"[move] {current.path} -> {next_path}\n\nagent: {actor}\n"
-            f"action: move\nsummary: {summary}"
-        )
+        history_message = f"[move] {current.path} -> {next_path}\n\nagent: {actor}\naction: move\nsummary: {summary}"
         result = await (await self._native()).move_text(
             namespace_id=vault_id,
             surface="document",
@@ -366,7 +400,7 @@ class NativeDocumentService(DocumentService):
             path_to=next_path,
             actor=actor,
             mutation_id=uuid.uuid4(),
-            expected_revision_id=current.revision_id,
+            expected_revision_id=None,
             message=history_message,
             subject=f"[move] {current.path} -> {next_path}",
             summary=summary,
@@ -378,7 +412,7 @@ class NativeDocumentService(DocumentService):
             path=next_path,
             commit_hash=result.revision_id,
             current_commit=result.revision_id,
-            previous_commit=current.revision_id,
+            previous_commit=result.parent_revision_id,
             content_hash=_body_content_hash(body),
             hash_algorithm=HASH_ALGORITHM,
             action="moved",
@@ -397,51 +431,68 @@ class NativeDocumentService(DocumentService):
         agent_id: str | None = None,
         base_commit: str | None = None,
     ) -> DocumentPutResponse:
-        _, current = await self._current(vault, doc_ref)
-        if base_commit and base_commit != current.revision_id:
-            raise ConflictError(
-                f"current_commit moved: expected {base_commit}, actual {current.revision_id}"
-            )
-        _, body = _parse_markdown(current.text)
         if not old_string:
             raise EditError("old_string cannot be empty")
-        occurrences = body.count(old_string)
-        if occurrences == 0:
-            raise EditError("old_string not found in document body. Use akb_get to verify current content.")
-        if occurrences > 1 and not replace_all:
-            raise EditError(
-                f"old_string appears {occurrences} times in document. "
-                "Add more surrounding context to make it unique, or set replace_all=true."
+        last_conflict: ConflictError | None = None
+        for attempt in range(self._UNPINNED_RETRY_LIMIT):
+            _, current = await self._current(vault, doc_ref)
+            if base_commit and base_commit != current.revision_id:
+                raise ConflictError(f"current_commit moved: expected {base_commit}, actual {current.revision_id}")
+            _, body = _parse_markdown(current.text)
+            occurrences = body.count(old_string)
+            if occurrences == 0:
+                raise EditError("old_string not found in document body. Use akb_get to verify current content.")
+            if occurrences > 1 and not replace_all:
+                raise EditError(
+                    f"old_string appears {occurrences} times in document. "
+                    "Add more surrounding context to make it unique, or set replace_all=true."
+                )
+            new_body = (
+                body.replace(old_string, new_string)
+                if replace_all
+                else body.replace(
+                    old_string,
+                    new_string,
+                    1,
+                )
             )
-        new_body = body.replace(old_string, new_string) if replace_all else body.replace(
-            old_string,
-            new_string,
-            1,
-        )
-        if new_body == body:
-            content_hash = _body_content_hash(body)
-            return DocumentPutResponse(
-                uri=doc_uri(vault, current.path),
-                vault=vault,
-                path=current.path,
-                commit_hash=current.revision_id,
-                current_commit=current.revision_id,
-                content_hash=content_hash,
-                hash_algorithm=HASH_ALGORITHM,
-                action="unchanged",
-                chunks_indexed=0,
-                entities_found=0,
-            )
-        return await self.update(
-            vault,
-            current.path,
-            DocumentUpdateRequest(
-                content=new_body,
-                message=message,
-                expected_commit=current.revision_id,
-            ),
-            agent_id=agent_id,
-        )
+            if new_body == body:
+                content_hash = _body_content_hash(body)
+                return DocumentPutResponse(
+                    uri=doc_uri(vault, current.path),
+                    vault=vault,
+                    path=current.path,
+                    commit_hash=current.revision_id,
+                    current_commit=current.revision_id,
+                    content_hash=content_hash,
+                    hash_algorithm=HASH_ALGORITHM,
+                    action="unchanged",
+                    chunks_indexed=0,
+                    entities_found=0,
+                )
+            try:
+                return await self.update(
+                    vault,
+                    current.path,
+                    DocumentUpdateRequest(
+                        content=new_body,
+                        message=message,
+                        # Pin each derived body to the snapshot it edited.
+                        # An unpinned edit recomputes on a moved Head below.
+                        expected_commit=current.revision_id,
+                    ),
+                    agent_id=agent_id,
+                )
+            except ConflictError as exc:
+                if base_commit is not None or attempt + 1 == self._UNPINNED_RETRY_LIMIT:
+                    raise
+                if not (
+                    str(exc).startswith("Native Revision conflict:") or str(exc).startswith("current_commit moved:")
+                ):
+                    raise
+                last_conflict = exc
+        assert last_conflict is not None
+        raise last_conflict
 
     async def delete(self, vault: str, doc_ref: str, agent_id: str | None = None) -> bool:
         vault_id, current = await self._current(vault, doc_ref)
@@ -452,7 +503,7 @@ class NativeDocumentService(DocumentService):
             path=current.path,
             actor=actor,
             mutation_id=uuid.uuid4(),
-            expected_revision_id=current.revision_id,
+            expected_revision_id=None,
             message=f"[delete] {current.path}\n\nagent: {actor}\naction: delete",
             subject=f"[delete] {current.path}",
         )

--- a/backend/app/services/native_revision_backend.py
+++ b/backend/app/services/native_revision_backend.py
@@ -1,0 +1,258 @@
+"""Complete native RevisionBackend facade for the guarded M1 arm."""
+
+from __future__ import annotations
+
+import difflib
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+
+from app.db.postgres import get_pool
+from app.exceptions import NotFoundError
+from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.document_service import _parse_markdown
+from app.services.m1_reference_payload_store import M1ReferencePayloadStore
+from app.services.native_document_service import NativeDocumentService
+from app.services.native_revision_service import NativeRevisionService
+
+
+class NativeRevisionBackend:
+    """Native implementation of every revision method selected by A1."""
+
+    def __init__(
+        self,
+        *,
+        pool: asyncpg.Pool | None = None,
+        document_service: NativeDocumentService | None = None,
+    ):
+        self._injected_pool = pool
+        self.document_service = document_service or NativeDocumentService(pool=pool)
+
+    async def _pool(self) -> asyncpg.Pool:
+        return self._injected_pool or await get_pool()
+
+    async def _vault_id(self, vault: str) -> uuid.UUID | None:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            return await conn.fetchval("SELECT id FROM vaults WHERE name = $1", vault)
+
+    @staticmethod
+    def _public_action(action: str) -> str:
+        return "update" if action == "replace" else action
+
+    @staticmethod
+    def _activity_file(row: dict) -> dict[str, str]:
+        action = row["action"]
+        if action == "create":
+            change = "added"
+        elif action == "delete":
+            change = "deleted"
+        else:
+            change = "modified"
+        return {"path": row["path_at_revision"], "change": change}
+
+    @staticmethod
+    def _parse_since(since: str | None) -> datetime | None:
+        if not since:
+            return None
+        try:
+            parsed = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+    async def vault_activity(
+        self,
+        vault: str,
+        *,
+        max_count: int,
+        since: str | None,
+        path: str | None,
+    ) -> list[dict[str, Any]]:
+        vault_id = await self._vault_id(vault)
+        if vault_id is None:
+            return []
+        repository = NativeRevisionRepository(await self._pool())
+        rows = await repository.list_activity(
+            namespace_id=vault_id,
+            limit=max_count,
+            since=self._parse_since(since),
+            path=path,
+        )
+        return [
+            {
+                "hash": row["revision_id"],
+                "subject": row["subject"] or "",
+                "author": row["actor"],
+                "date": row["occurred_at"].isoformat(),
+                "action": self._public_action(row["action"]),
+                "summary": row["summary"] or "",
+                "agent": row["actor"],
+                "files": [self._activity_file(row)],
+            }
+            for row in rows
+        ]
+
+    async def recent_changes(
+        self,
+        user_id: str,
+        *,
+        vault: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        try:
+            principal = uuid.UUID(user_id)
+        except ValueError:
+            principal = None
+        repository = NativeRevisionRepository(await self._pool())
+        rows = await repository.list_recent_document_heads(
+            user_id=principal,
+            vault=vault,
+            limit=limit,
+        )
+        changes: list[dict[str, Any]] = []
+        for row in rows:
+            raw = bytes(row["canonical_bytes"]).decode("utf-8")
+            metadata, _ = _parse_markdown(raw)
+            changes.append(
+                {
+                    "doc_id": str(row["resource_id"]),
+                    "vault": row["vault_name"],
+                    "path": row["path"],
+                    "title": metadata.get("title") or row["path"].rsplit("/", 1)[-1],
+                    "type": metadata.get("type") or "note",
+                    "commit": row["revision_id"],
+                    "changed_at": row["updated_at"].isoformat(),
+                }
+            )
+        return changes
+
+    async def _resolve_resource(
+        self,
+        vault: str,
+        doc_ref: str,
+    ) -> tuple[uuid.UUID, dict] | None:
+        vault_id = await self._vault_id(vault)
+        if vault_id is None:
+            return None
+        repository = NativeRevisionRepository(await self._pool())
+        resource = await repository.resolve_live_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference=doc_ref,
+        )
+        if resource is None:
+            return None
+        return vault_id, resource
+
+    async def _revision_bytes(self, row: dict) -> bytes | None:
+        locator = row.get("private_locator")
+        if locator is None:
+            return None
+        return await M1ReferencePayloadStore(await self._pool()).open_verified(locator)
+
+    async def document_diff(
+        self,
+        vault: str,
+        doc_ref: str,
+        commit: str,
+    ) -> dict[str, Any] | None:
+        resolved = await self._resolve_resource(vault, doc_ref)
+        if resolved is None:
+            return None
+        _, resource = resolved
+        repository = NativeRevisionRepository(await self._pool())
+        selected = await repository.get_revision(
+            resource_id=resource["resource_id"],
+            revision_id=commit,
+        )
+        if selected is None:
+            return {
+                "file": resource["current_path"],
+                "commit": commit,
+                "type": "unknown",
+                "diff": "",
+                "error": "commit not found",
+            }
+        selected_bytes = await self._revision_bytes(selected)
+        parent_id = selected["parent_revision_id"]
+        parent = (
+            await repository.get_revision(
+                resource_id=resource["resource_id"],
+                revision_id=parent_id,
+            )
+            if parent_id
+            else None
+        )
+        parent_bytes = await self._revision_bytes(parent) if parent is not None else None
+        if selected["action"] == "create":
+            text = (selected_bytes or b"").decode("utf-8")
+            return {
+                "file": resource["current_path"],
+                "commit": commit,
+                "type": "added",
+                "diff": "\n".join(f"+{line}" for line in text.split("\n")),
+            }
+        if selected["action"] == "delete":
+            text = (parent_bytes or b"").decode("utf-8")
+            return {
+                "file": resource["current_path"],
+                "commit": commit,
+                "type": "deleted",
+                "diff": "\n".join(f"-{line}" for line in text.split("\n")),
+            }
+        before = (parent_bytes or b"").decode("utf-8").splitlines()
+        after = (selected_bytes or b"").decode("utf-8").splitlines()
+        patch = "\n".join(
+            difflib.unified_diff(
+                before,
+                after,
+                fromfile=f"a/{selected['path_at_revision']}",
+                tofile=f"b/{selected['path_at_revision']}",
+                lineterm="",
+            )
+        )
+        return {
+            "file": resource["current_path"],
+            "commit": commit,
+            "type": "modified" if patch else "unchanged",
+            "diff": patch,
+        }
+
+    async def document_version(
+        self,
+        vault: str,
+        doc_ref: str,
+        version: str,
+    ) -> tuple[dict[str, Any], str] | None:
+        current = await self.document_service.get(vault, doc_ref)
+        if len(version) != 40 or any(ch not in "0123456789abcdef" for ch in version):
+            return None
+        try:
+            vault_id = await self._vault_id(vault)
+            assert vault_id is not None
+            selected = await NativeRevisionService(await self._pool()).get_revision(
+                namespace_id=vault_id,
+                surface="document",
+                reference=current.path,
+                revision_id=version,
+            )
+        except NotFoundError:
+            return None
+        return current.model_dump(), selected.text
+
+    async def document_history(
+        self,
+        vault: str,
+        doc_ref: str,
+        *,
+        limit: int,
+    ) -> dict[str, Any]:
+        return await self.document_service.history(vault, doc_ref, limit=limit)
+
+
+def native_revision_backend_factory() -> NativeRevisionBackend:
+    """Synchronous process factory; the selected pool remains async/lazy."""
+    return NativeRevisionBackend()

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -1,0 +1,562 @@
+"""Internal M1 native-ledger transaction substrate.
+
+This module intentionally has no public route or compatibility composition.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import secrets
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import asyncpg
+
+from app.exceptions import ConflictError, NotFoundError, ValidationError
+from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.m1_reference_payload_store import (
+    M1ReferencePayloadStore,
+    PreparedReferencePayload,
+    ReferencePayloadIntegrityError,
+)
+
+
+Failpoint = Callable[[str], Awaitable[None] | None]
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMutationResult:
+    resource_id: uuid.UUID
+    revision_id: str
+    parent_revision_id: str | None
+    action: str
+    path: str
+    payload_manifest_id: uuid.UUID | None
+    occurred_at: datetime
+    idempotent_replay: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class NativeRevisionSnapshot:
+    resource_id: uuid.UUID
+    revision_id: str
+    parent_revision_id: str | None
+    surface: str
+    content_profile: str
+    path: str
+    action: str
+    occurred_at: datetime
+    payload_manifest_id: uuid.UUID
+    digest: str
+    byte_size: int
+    encoding: str
+    selected_placement: str
+    verification_profile: str
+    payload_bytes: bytes
+    text: str
+
+
+class NativeRevisionService:
+    """Publish one Resource mutation as one PostgreSQL authority transaction."""
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        repository: NativeRevisionRepository | None = None,
+        payload_store: M1ReferencePayloadStore | None = None,
+        failpoint: Failpoint | None = None,
+    ):
+        """Build the internal substrate.
+
+        ``failpoint`` is a deterministic test-only hook; production
+        composition must leave it unset.
+        """
+        self.pool = pool
+        self.repository = repository or NativeRevisionRepository(pool)
+        self.payload_store = payload_store or M1ReferencePayloadStore(pool)
+        self.failpoint = failpoint
+
+    async def _hit(self, name: str) -> None:
+        if self.failpoint is None:
+            return
+        value = self.failpoint(name)
+        if inspect.isawaitable(value):
+            await value
+
+    @staticmethod
+    def _validate_common(
+        *,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+    ) -> None:
+        if surface not in {"document", "file"}:
+            raise ValidationError("Native Resource surface must be document or file")
+        if not isinstance(path, str) or not path.strip():
+            raise ValidationError("Native Resource path must be non-empty")
+        if not isinstance(actor, str) or not actor.strip():
+            raise ValidationError("Native mutation actor must be non-empty")
+        if not isinstance(mutation_id, uuid.UUID):
+            raise ValidationError("Native mutation idempotency key must be a UUID")
+
+    @staticmethod
+    def _fingerprint(
+        *,
+        action: str,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        payload: PreparedReferencePayload,
+        expected_revision_id: str | None,
+        actor: str,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+    ) -> str:
+        canonical = json.dumps(
+            {
+                "action": action,
+                "namespace_id": str(namespace_id),
+                "surface": surface,
+                "path": path,
+                "payload_digest": payload.digest,
+                "payload_size": payload.byte_size,
+                "expected_revision_id": expected_revision_id,
+                "actor": actor,
+                "message": message,
+                "subject": subject,
+                "summary": summary,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    @staticmethod
+    def _from_row(row: dict, *, replay: bool) -> NativeMutationResult:
+        return NativeMutationResult(
+            resource_id=row["resource_id"],
+            revision_id=row["revision_id"],
+            parent_revision_id=row["parent_revision_id"],
+            action=row["action"],
+            path=row["path"],
+            payload_manifest_id=row["payload_manifest_id"],
+            occurred_at=row["occurred_at"],
+            idempotent_replay=replay,
+        )
+
+    @staticmethod
+    def _opaque_revision_id() -> str:
+        # P0 froze this at random 20 bytes rendered as 40 lowercase hex.
+        return secrets.token_hex(20)
+
+    async def _allocate_revision_id(self) -> str:
+        """Reject observed collisions and retry with a fresh server token."""
+        for _ in range(3):
+            candidate = self._opaque_revision_id()
+            async with self.pool.acquire() as conn:
+                exists = await conn.fetchval(
+                    "SELECT EXISTS(SELECT 1 FROM native_revisions WHERE revision_id = $1)",
+                    candidate,
+                )
+            if not exists:
+                return candidate
+        raise ConflictError("Unable to allocate a unique native Revision ID after collisions")
+
+    async def create_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        payload: str | bytes,
+        actor: str,
+        mutation_id: uuid.UUID,
+        message: str | None = None,
+        subject: str | None = None,
+        summary: str | None = None,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> NativeMutationResult:
+        self._validate_common(surface=surface, path=path, actor=actor, mutation_id=mutation_id)
+        await self._hit("payload.before_prepare")
+        prepared = await self.payload_store.prepare_text(
+            namespace_id=namespace_id,
+            payload=payload,
+            expected_digest=expected_digest,
+            expected_size=expected_size,
+        )
+        await self._hit("payload.after_verified")
+        fingerprint = self._fingerprint(
+            action="create",
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            payload=prepared,
+            expected_revision_id=None,
+            actor=actor,
+            message=message,
+            subject=subject,
+            summary=summary,
+        )
+        result = await self._publish_create(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            prepared=prepared,
+            fingerprint=fingerprint,
+        )
+        await self._hit("authority.after_commit_before_response")
+        return result
+
+    async def _publish_create(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        prepared: PreparedReferencePayload,
+        fingerprint: str,
+    ) -> NativeMutationResult:
+        resource_id = uuid.uuid4()
+        revision_id = await self._allocate_revision_id()
+        manifest_id = uuid.uuid4()
+        activity_id = uuid.uuid4()
+        intent_id = uuid.uuid4()
+        occurred_at = datetime.now(UTC)
+        try:
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    await self.repository.lock_mutation(conn, namespace_id, mutation_id)
+                    prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
+                    if prior is not None:
+                        if prior["request_fingerprint"] != fingerprint:
+                            raise ConflictError("Native idempotency key was reused with different input")
+                        return self._from_row(prior, replay=True)
+
+                    await self.repository.lock_paths(conn, namespace_id, surface, path)
+                    if await self.repository.find_live_path(conn, namespace_id, surface, path) is not None:
+                        raise ConflictError(f"Native Resource already exists at path: {path}")
+
+                    await self.repository.insert_resource(
+                        conn,
+                        resource_id=resource_id,
+                        namespace_id=namespace_id,
+                        surface=surface,
+                        content_profile="text",
+                        path=path,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_resource")
+                    await self.repository.insert_manifest(
+                        conn,
+                        payload_manifest_id=manifest_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        payload=prepared,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_manifest")
+                    await self.repository.insert_revision(
+                        conn,
+                        revision_id=revision_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        parent_revision_id=None,
+                        action="create",
+                        path=path,
+                        path_from=None,
+                        path_to=path,
+                        payload_manifest_id=manifest_id,
+                        mutation_id=mutation_id,
+                        request_fingerprint=fingerprint,
+                        message=message,
+                        subject=subject,
+                        summary=summary,
+                        actor=actor,
+                        occurred_at=occurred_at,
+                        activity_event_id=activity_id,
+                        invalidation_intent_id=intent_id,
+                    )
+                    await self._hit("authority.after_revision")
+                    await self.repository.set_head(
+                        conn,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        path=path,
+                        lifecycle="live",
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_head")
+                    await self.repository.insert_activity(
+                        conn,
+                        activity_event_id=activity_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        action="create",
+                        actor=actor,
+                        subject=subject,
+                        summary=summary,
+                        path_from=None,
+                        path_to=path,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_activity")
+                    await self.repository.insert_invalidation_intent(
+                        conn,
+                        intent_id=intent_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        reason="create",
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_invalidation")
+        except asyncpg.UniqueViolationError as exc:
+            if exc.constraint_name == "uq_native_resources_live_path":
+                raise ConflictError(f"Native Resource already exists at path: {path}") from exc
+            raise
+        return NativeMutationResult(
+            resource_id=resource_id,
+            revision_id=revision_id,
+            parent_revision_id=None,
+            action="create",
+            path=path,
+            payload_manifest_id=manifest_id,
+            occurred_at=occurred_at,
+        )
+
+    async def replace_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        payload: str | bytes,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None = None,
+        message: str | None = None,
+        subject: str | None = None,
+        summary: str | None = None,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> NativeMutationResult:
+        self._validate_common(surface=surface, path=path, actor=actor, mutation_id=mutation_id)
+        if expected_revision_id is not None and (
+            len(expected_revision_id) != 40
+            or any(ch not in "0123456789abcdef" for ch in expected_revision_id)
+        ):
+            raise ValidationError("Expected native Revision ID must be exactly 40 lowercase hex")
+        await self._hit("payload.before_prepare")
+        prepared = await self.payload_store.prepare_text(
+            namespace_id=namespace_id,
+            payload=payload,
+            expected_digest=expected_digest,
+            expected_size=expected_size,
+        )
+        await self._hit("payload.after_verified")
+        fingerprint = self._fingerprint(
+            action="replace",
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            payload=prepared,
+            expected_revision_id=expected_revision_id,
+            actor=actor,
+            message=message,
+            subject=subject,
+            summary=summary,
+        )
+        result = await self._publish_replace(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+            expected_revision_id=expected_revision_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            prepared=prepared,
+            fingerprint=fingerprint,
+        )
+        await self._hit("authority.after_commit_before_response")
+        return result
+
+    async def _publish_replace(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        prepared: PreparedReferencePayload,
+        fingerprint: str,
+    ) -> NativeMutationResult:
+        revision_id = await self._allocate_revision_id()
+        manifest_id = uuid.uuid4()
+        activity_id = uuid.uuid4()
+        intent_id = uuid.uuid4()
+        occurred_at = datetime.now(UTC)
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await self.repository.lock_mutation(conn, namespace_id, mutation_id)
+                prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
+                if prior is not None:
+                    if prior["request_fingerprint"] != fingerprint:
+                        raise ConflictError("Native idempotency key was reused with different input")
+                    return self._from_row(prior, replay=True)
+
+                await self.repository.lock_paths(conn, namespace_id, surface, path)
+                resource = await self.repository.find_live_path(
+                    conn, namespace_id, surface, path, for_update=True
+                )
+                if resource is None:
+                    raise NotFoundError("Native Resource", path)
+                parent_revision_id = resource["head_revision_id"]
+                if expected_revision_id is not None and expected_revision_id != parent_revision_id:
+                    raise ConflictError(
+                        "Native Revision conflict: expected "
+                        f"{expected_revision_id}, current Head is {parent_revision_id}"
+                    )
+                resource_id = resource["resource_id"]
+
+                await self.repository.insert_manifest(
+                    conn,
+                    payload_manifest_id=manifest_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    payload=prepared,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_manifest")
+                await self.repository.insert_revision(
+                    conn,
+                    revision_id=revision_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    parent_revision_id=parent_revision_id,
+                    action="replace",
+                    path=path,
+                    path_from=None,
+                    path_to=None,
+                    payload_manifest_id=manifest_id,
+                    mutation_id=mutation_id,
+                    request_fingerprint=fingerprint,
+                    message=message,
+                    subject=subject,
+                    summary=summary,
+                    actor=actor,
+                    occurred_at=occurred_at,
+                    activity_event_id=activity_id,
+                    invalidation_intent_id=intent_id,
+                )
+                await self._hit("authority.after_revision")
+                await self.repository.set_head(
+                    conn,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    path=path,
+                    lifecycle="live",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_head")
+                await self.repository.insert_activity(
+                    conn,
+                    activity_event_id=activity_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    action="replace",
+                    actor=actor,
+                    subject=subject,
+                    summary=summary,
+                    path_from=None,
+                    path_to=None,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_activity")
+                await self.repository.insert_invalidation_intent(
+                    conn,
+                    intent_id=intent_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    reason="replace",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_invalidation")
+        return NativeMutationResult(
+            resource_id=resource_id,
+            revision_id=revision_id,
+            parent_revision_id=parent_revision_id,
+            action="replace",
+            path=path,
+            payload_manifest_id=manifest_id,
+            occurred_at=occurred_at,
+        )
+
+    async def get_current(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+    ) -> NativeRevisionSnapshot:
+        row = await self.repository.get_current(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+        )
+        if row is None:
+            raise NotFoundError("Native Resource", path)
+        if row["payload_manifest_id"] is None or row["private_locator"] is None:
+            raise ReferencePayloadIntegrityError("Live native Head does not pin a payload manifest")
+        payload_bytes = await self.payload_store.open_verified(row["private_locator"])
+        if len(payload_bytes) != row["byte_size"]:
+            raise ReferencePayloadIntegrityError("Head manifest byte size mismatch")
+        if hashlib.sha256(payload_bytes).hexdigest() != row["digest"]:
+            raise ReferencePayloadIntegrityError("Head manifest digest mismatch")
+        text = payload_bytes.decode(row["encoding"], errors="strict")
+        return NativeRevisionSnapshot(
+            resource_id=row["resource_id"],
+            revision_id=row["revision_id"],
+            parent_revision_id=row["parent_revision_id"],
+            surface=row["surface"],
+            content_profile=row["content_profile"],
+            path=row["path"],
+            action=row["action"],
+            occurred_at=row["occurred_at"],
+            payload_manifest_id=row["payload_manifest_id"],
+            digest=row["digest"],
+            byte_size=row["byte_size"],
+            encoding=row["encoding"],
+            selected_placement=row["selected_placement"],
+            verification_profile=row["verification_profile"],
+            payload_bytes=payload_bytes,
+            text=text,
+        )

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -120,6 +120,8 @@ class NativeRevisionService:
         message: str | None,
         subject: str | None,
         summary: str | None,
+        requested_resource_id: uuid.UUID | None = None,
+        expected_resource_id: uuid.UUID | None = None,
     ) -> str:
         canonical = json.dumps(
             {
@@ -134,6 +136,10 @@ class NativeRevisionService:
                 "message": message,
                 "subject": subject,
                 "summary": summary,
+                "requested_resource_id": (
+                    str(requested_resource_id) if requested_resource_id is not None else None
+                ),
+                "expected_resource_id": str(expected_resource_id) if expected_resource_id is not None else None,
             },
             ensure_ascii=False,
             separators=(",", ":"),
@@ -154,6 +160,7 @@ class NativeRevisionService:
         message: str | None,
         subject: str | None,
         summary: str | None,
+        expected_resource_id: uuid.UUID | None = None,
     ) -> str:
         canonical = json.dumps(
             {
@@ -167,6 +174,7 @@ class NativeRevisionService:
                 "message": message,
                 "subject": subject,
                 "summary": summary,
+                "expected_resource_id": str(expected_resource_id) if expected_resource_id is not None else None,
             },
             ensure_ascii=False,
             separators=(",", ":"),
@@ -220,6 +228,7 @@ class NativeRevisionService:
         surface: str,
         reference: str,
         additional_paths: tuple[str, ...] = (),
+        expected_resource_id: uuid.UUID | None = None,
     ) -> dict:
         """Lock one live Resource before locking every path the mutation uses.
 
@@ -236,6 +245,11 @@ class NativeRevisionService:
         )
         if resolved is None:
             raise NotFoundError("Native Resource", reference)
+        if expected_resource_id is not None and resolved["resource_id"] != expected_resource_id:
+            raise ConflictError(
+                "Native Resource conflict: expected "
+                f"{expected_resource_id}, reference now resolves to {resolved['resource_id']}"
+            )
         resource = await self.repository.lock_resource(conn, resolved["resource_id"])
         if resource is None or resource["lifecycle"] != "live":
             raise NotFoundError("Native Resource", reference)
@@ -256,7 +270,7 @@ class NativeRevisionService:
         if confirmed is None:
             raise NotFoundError("Native Resource", reference)
         if confirmed["resource_id"] != resource["resource_id"]:
-            raise ConflictError(f"Native Resource reference changed while mutation waited: {reference}")
+            raise ConflictError(f"Native Resource conflict: reference changed while mutation waited: {reference}")
         return resource
 
     async def create_text(
@@ -297,6 +311,7 @@ class NativeRevisionService:
             message=message,
             subject=subject,
             summary=summary,
+            requested_resource_id=resource_id,
         )
         await self._hit("payload.after_prepare_before_tx")
         result = await self._publish_create(
@@ -467,6 +482,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None = None,
+        expected_resource_id: uuid.UUID | None = None,
         message: str | None = None,
         subject: str | None = None,
         summary: str | None = None,
@@ -494,6 +510,7 @@ class NativeRevisionService:
             message=message,
             subject=subject,
             summary=summary,
+            expected_resource_id=expected_resource_id,
         )
         await self._hit("payload.after_prepare_before_tx")
         result = await self._publish_replace(
@@ -503,6 +520,7 @@ class NativeRevisionService:
             actor=actor,
             mutation_id=mutation_id,
             expected_revision_id=expected_revision_id,
+            expected_resource_id=expected_resource_id,
             message=message,
             subject=subject,
             summary=summary,
@@ -521,6 +539,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None,
+        expected_resource_id: uuid.UUID | None,
         message: str | None,
         subject: str | None,
         summary: str | None,
@@ -545,6 +564,7 @@ class NativeRevisionService:
                     namespace_id=namespace_id,
                     surface=surface,
                     reference=path,
+                    expected_resource_id=expected_resource_id,
                 )
                 current_path = resource["current_path"]
                 parent_revision_id = resource["head_revision_id"]
@@ -643,6 +663,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None = None,
+        expected_resource_id: uuid.UUID | None = None,
         message: str | None = None,
         subject: str | None = None,
         summary: str | None = None,
@@ -669,6 +690,7 @@ class NativeRevisionService:
             message=message,
             subject=subject,
             summary=summary,
+            expected_resource_id=expected_resource_id,
         )
         result = await self._publish_move(
             namespace_id=namespace_id,
@@ -678,6 +700,7 @@ class NativeRevisionService:
             actor=actor,
             mutation_id=mutation_id,
             expected_revision_id=expected_revision_id,
+            expected_resource_id=expected_resource_id,
             message=message,
             subject=subject,
             summary=summary,
@@ -696,6 +719,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None,
+        expected_resource_id: uuid.UUID | None,
         message: str | None,
         subject: str | None,
         summary: str | None,
@@ -721,6 +745,7 @@ class NativeRevisionService:
                         surface=surface,
                         reference=path,
                         additional_paths=(path_to,),
+                        expected_resource_id=expected_resource_id,
                     )
                     resource_id = resource["resource_id"]
                     old_path = resource["current_path"]
@@ -867,6 +892,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None = None,
+        expected_resource_id: uuid.UUID | None = None,
         message: str | None = None,
         subject: str | None = None,
         summary: str | None = None,
@@ -889,6 +915,7 @@ class NativeRevisionService:
             message=message,
             subject=subject,
             summary=summary,
+            expected_resource_id=expected_resource_id,
         )
         result = await self._publish_delete(
             namespace_id=namespace_id,
@@ -897,6 +924,7 @@ class NativeRevisionService:
             actor=actor,
             mutation_id=mutation_id,
             expected_revision_id=expected_revision_id,
+            expected_resource_id=expected_resource_id,
             message=message,
             subject=subject,
             summary=summary,
@@ -914,6 +942,7 @@ class NativeRevisionService:
         actor: str,
         mutation_id: uuid.UUID,
         expected_revision_id: str | None,
+        expected_resource_id: uuid.UUID | None,
         message: str | None,
         subject: str | None,
         summary: str | None,
@@ -936,6 +965,7 @@ class NativeRevisionService:
                     namespace_id=namespace_id,
                     surface=surface,
                     reference=path,
+                    expected_resource_id=expected_resource_id,
                 )
                 resource_id = resource["resource_id"]
                 current_path = resource["current_path"]
@@ -1058,6 +1088,24 @@ class NativeRevisionService:
             raise NotFoundError("Native Resource", reference)
         return await self._snapshot_from_row(row)
 
+    async def get_current_resource(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        resource_id: uuid.UUID,
+    ) -> NativeRevisionSnapshot:
+        """Read the current Head while preserving Resource identity."""
+        row = await self.repository.get_resource_head(resource_id=resource_id)
+        if (
+            row is None
+            or row["namespace_id"] != namespace_id
+            or row["surface"] != surface
+            or row["lifecycle"] != "live"
+        ):
+            raise NotFoundError("Native Resource", str(resource_id))
+        return await self._snapshot_from_row(row)
+
     async def get_revision(
         self,
         *,
@@ -1076,6 +1124,27 @@ class NativeRevisionService:
             raise NotFoundError("Native Resource", reference)
         row = await self.repository.get_revision(
             resource_id=resource["resource_id"],
+            revision_id=revision_id,
+        )
+        if row is None or row["namespace_id"] != namespace_id or row["surface"] != surface:
+            raise NotFoundError("Native Revision", revision_id)
+        if row["payload_manifest_id"] is None:
+            raise NotFoundError("Native Revision payload", revision_id)
+        row["path"] = row["path_at_revision"]
+        return await self._snapshot_from_row(row)
+
+    async def get_resource_revision(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        resource_id: uuid.UUID,
+        revision_id: str,
+    ) -> NativeRevisionSnapshot:
+        """Read an exact committed Revision without relying on a mutable path."""
+        self._validate_expected_revision(revision_id)
+        row = await self.repository.get_revision(
+            resource_id=resource_id,
             revision_id=revision_id,
         )
         if row is None or row["namespace_id"] != namespace_id or row["surface"] != surface:

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -50,6 +50,8 @@ class NativeRevisionSnapshot:
     path: str
     action: str
     occurred_at: datetime
+    resource_created_at: datetime
+    resource_updated_at: datetime
     payload_manifest_id: uuid.UUID
     digest: str
     byte_size: int
@@ -140,6 +142,47 @@ class NativeRevisionService:
         return hashlib.sha256(canonical).hexdigest()
 
     @staticmethod
+    def _lifecycle_fingerprint(
+        *,
+        action: str,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        path_to: str | None,
+        expected_revision_id: str | None,
+        actor: str,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+    ) -> str:
+        canonical = json.dumps(
+            {
+                "action": action,
+                "namespace_id": str(namespace_id),
+                "surface": surface,
+                "path": path,
+                "path_to": path_to,
+                "expected_revision_id": expected_revision_id,
+                "actor": actor,
+                "message": message,
+                "subject": subject,
+                "summary": summary,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    @staticmethod
+    def _validate_expected_revision(expected_revision_id: str | None) -> None:
+        if expected_revision_id is not None and (
+            len(expected_revision_id) != 40
+            or any(ch not in "0123456789abcdef" for ch in expected_revision_id)
+        ):
+            raise ValidationError("Expected native Revision ID must be exactly 40 lowercase hex")
+
+    @staticmethod
     def _from_row(row: dict, *, replay: bool) -> NativeMutationResult:
         return NativeMutationResult(
             resource_id=row["resource_id"],
@@ -179,6 +222,7 @@ class NativeRevisionService:
         payload: str | bytes,
         actor: str,
         mutation_id: uuid.UUID,
+        resource_id: uuid.UUID | None = None,
         message: str | None = None,
         subject: str | None = None,
         summary: str | None = None,
@@ -186,6 +230,8 @@ class NativeRevisionService:
         expected_size: int | None = None,
     ) -> NativeMutationResult:
         self._validate_common(surface=surface, path=path, actor=actor, mutation_id=mutation_id)
+        if resource_id is not None and not isinstance(resource_id, uuid.UUID):
+            raise ValidationError("Native Resource ID must be a UUID")
         await self._hit("payload.before_prepare")
         prepared = await self.payload_store.prepare_text(
             namespace_id=namespace_id,
@@ -217,6 +263,7 @@ class NativeRevisionService:
             summary=summary,
             prepared=prepared,
             fingerprint=fingerprint,
+            resource_id=resource_id,
         )
         await self._hit("authority.after_commit_before_response")
         return result
@@ -234,13 +281,13 @@ class NativeRevisionService:
         summary: str | None,
         prepared: PreparedReferencePayload,
         fingerprint: str,
+        resource_id: uuid.UUID | None,
     ) -> NativeMutationResult:
-        resource_id = uuid.uuid4()
+        resource_id = resource_id or uuid.uuid4()
         revision_id = await self._allocate_revision_id()
         manifest_id = uuid.uuid4()
         activity_id = uuid.uuid4()
         intent_id = uuid.uuid4()
-        occurred_at = datetime.now(UTC)
         try:
             async with self.pool.acquire() as conn:
                 async with conn.transaction():
@@ -254,7 +301,15 @@ class NativeRevisionService:
                     await self.repository.lock_paths(conn, namespace_id, surface, path)
                     if await self.repository.find_live_path(conn, namespace_id, surface, path) is not None:
                         raise ConflictError(f"Native Resource already exists at path: {path}")
+                    if await self.repository.find_live_alias(
+                        conn,
+                        namespace_id=namespace_id,
+                        surface=surface,
+                        old_path=path,
+                    ) is not None:
+                        raise ConflictError(f"Native Resource alias already owns path: {path}")
 
+                    occurred_at = datetime.now(UTC)
                     await self.repository.insert_resource(
                         conn,
                         resource_id=resource_id,
@@ -305,6 +360,7 @@ class NativeRevisionService:
                         occurred_at=occurred_at,
                     )
                     await self._hit("authority.after_head")
+                    await self._hit("authority.after_path")
                     await self.repository.insert_activity(
                         conn,
                         activity_event_id=activity_id,
@@ -330,6 +386,7 @@ class NativeRevisionService:
                         occurred_at=occurred_at,
                     )
                     await self._hit("authority.after_invalidation")
+                    await self._hit("authority.before_commit")
         except asyncpg.UniqueViolationError as exc:
             if exc.constraint_name == "uq_native_resources_live_path":
                 raise ConflictError(f"Native Resource already exists at path: {path}") from exc
@@ -361,11 +418,7 @@ class NativeRevisionService:
         expected_size: int | None = None,
     ) -> NativeMutationResult:
         self._validate_common(surface=surface, path=path, actor=actor, mutation_id=mutation_id)
-        if expected_revision_id is not None and (
-            len(expected_revision_id) != 40
-            or any(ch not in "0123456789abcdef" for ch in expected_revision_id)
-        ):
-            raise ValidationError("Expected native Revision ID must be exactly 40 lowercase hex")
+        self._validate_expected_revision(expected_revision_id)
         await self._hit("payload.before_prepare")
         prepared = await self.payload_store.prepare_text(
             namespace_id=namespace_id,
@@ -421,7 +474,6 @@ class NativeRevisionService:
         manifest_id = uuid.uuid4()
         activity_id = uuid.uuid4()
         intent_id = uuid.uuid4()
-        occurred_at = datetime.now(UTC)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 await self.repository.lock_mutation(conn, namespace_id, mutation_id)
@@ -445,6 +497,7 @@ class NativeRevisionService:
                     )
                 resource_id = resource["resource_id"]
 
+                occurred_at = datetime.now(UTC)
                 await self.repository.insert_manifest(
                     conn,
                     payload_manifest_id=manifest_id,
@@ -485,6 +538,7 @@ class NativeRevisionService:
                     occurred_at=occurred_at,
                 )
                 await self._hit("authority.after_head")
+                await self._hit("authority.after_path")
                 await self.repository.insert_activity(
                     conn,
                     activity_event_id=activity_id,
@@ -510,6 +564,7 @@ class NativeRevisionService:
                     occurred_at=occurred_at,
                 )
                 await self._hit("authority.after_invalidation")
+                await self._hit("authority.before_commit")
         return NativeMutationResult(
             resource_id=resource_id,
             revision_id=revision_id,
@@ -517,6 +572,433 @@ class NativeRevisionService:
             action="replace",
             path=path,
             payload_manifest_id=manifest_id,
+            occurred_at=occurred_at,
+        )
+
+    async def move_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        path_to: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None = None,
+        message: str | None = None,
+        subject: str | None = None,
+        summary: str | None = None,
+    ) -> NativeMutationResult:
+        self._validate_common(
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+        )
+        if not isinstance(path_to, str) or not path_to.strip():
+            raise ValidationError("Native Resource destination path must be non-empty")
+        if path_to == path:
+            raise ValidationError("Native Resource move is a no-op")
+        self._validate_expected_revision(expected_revision_id)
+        fingerprint = self._lifecycle_fingerprint(
+            action="move",
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            path_to=path_to,
+            expected_revision_id=expected_revision_id,
+            actor=actor,
+            message=message,
+            subject=subject,
+            summary=summary,
+        )
+        result = await self._publish_move(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            path_to=path_to,
+            actor=actor,
+            mutation_id=mutation_id,
+            expected_revision_id=expected_revision_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            fingerprint=fingerprint,
+        )
+        await self._hit("authority.after_commit_before_response")
+        return result
+
+    async def _publish_move(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        path_to: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        fingerprint: str,
+    ) -> NativeMutationResult:
+        revision_id = await self._allocate_revision_id()
+        manifest_id = uuid.uuid4()
+        activity_id = uuid.uuid4()
+        intent_id = uuid.uuid4()
+        try:
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    await self.repository.lock_mutation(conn, namespace_id, mutation_id)
+                    prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
+                    if prior is not None:
+                        if prior["request_fingerprint"] != fingerprint:
+                            raise ConflictError("Native idempotency key was reused with different input")
+                        return self._from_row(prior, replay=True)
+
+                    await self.repository.lock_paths(
+                        conn,
+                        namespace_id,
+                        surface,
+                        path,
+                        path_to,
+                    )
+                    resolved = await self.repository.resolve_live_reference(
+                        namespace_id=namespace_id,
+                        surface=surface,
+                        reference=path,
+                        conn=conn,
+                    )
+                    if resolved is None:
+                        raise NotFoundError("Native Resource", path)
+                    resource = await self.repository.lock_resource(
+                        conn,
+                        resolved["resource_id"],
+                    )
+                    if resource is None or resource["lifecycle"] != "live":
+                        raise NotFoundError("Native Resource", path)
+                    resource_id = resource["resource_id"]
+                    old_path = resource["current_path"]
+                    parent_revision_id = resource["head_revision_id"]
+                    if expected_revision_id is not None and expected_revision_id != parent_revision_id:
+                        raise ConflictError(
+                            "Native Revision conflict: expected "
+                            f"{expected_revision_id}, current Head is {parent_revision_id}"
+                        )
+                    if path_to == old_path:
+                        raise ValidationError("Native Resource move is a no-op")
+                    await self.repository.lock_paths(
+                        conn,
+                        namespace_id,
+                        surface,
+                        old_path,
+                    )
+                    destination = await self.repository.find_live_path(
+                        conn,
+                        namespace_id,
+                        surface,
+                        path_to,
+                    )
+                    if destination is not None and destination["resource_id"] != resource_id:
+                        raise ConflictError(f"Native Resource already exists at path: {path_to}")
+                    destination_alias = await self.repository.find_live_alias(
+                        conn,
+                        namespace_id=namespace_id,
+                        surface=surface,
+                        old_path=path_to,
+                    )
+                    if (
+                        destination_alias is not None
+                        and destination_alias["resource_id"] != resource_id
+                    ):
+                        raise ConflictError(f"Native Resource alias already owns path: {path_to}")
+
+                    head = await self.repository.get_resource_head(
+                        resource_id=resource_id,
+                        conn=conn,
+                    )
+                    if head is None or head["payload_manifest_id"] is None:
+                        raise ReferencePayloadIntegrityError(
+                            "Live native Head does not pin a payload manifest"
+                        )
+                    occurred_at = datetime.now(UTC)
+                    await self.repository.copy_manifest(
+                        conn,
+                        source_manifest_id=head["payload_manifest_id"],
+                        payload_manifest_id=manifest_id,
+                        resource_id=resource_id,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_manifest")
+                    await self.repository.insert_revision(
+                        conn,
+                        revision_id=revision_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        parent_revision_id=parent_revision_id,
+                        action="move",
+                        path=path_to,
+                        path_from=old_path,
+                        path_to=path_to,
+                        payload_manifest_id=manifest_id,
+                        mutation_id=mutation_id,
+                        request_fingerprint=fingerprint,
+                        message=message,
+                        subject=subject,
+                        summary=summary,
+                        actor=actor,
+                        occurred_at=occurred_at,
+                        activity_event_id=activity_id,
+                        invalidation_intent_id=intent_id,
+                    )
+                    await self._hit("authority.after_revision")
+                    await self.repository.set_head(
+                        conn,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        path=path_to,
+                        lifecycle="live",
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_head")
+                    await self._hit("authority.after_path")
+                    if destination_alias is not None:
+                        await self.repository.retire_live_alias(
+                            conn,
+                            namespace_id=namespace_id,
+                            surface=surface,
+                            old_path=path_to,
+                            retired_revision_id=revision_id,
+                            occurred_at=occurred_at,
+                        )
+                    await self.repository.insert_path_alias(
+                        conn,
+                        namespace_id=namespace_id,
+                        surface=surface,
+                        old_path=old_path,
+                        resource_id=resource_id,
+                        created_revision_id=revision_id,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_alias")
+                    await self.repository.insert_activity(
+                        conn,
+                        activity_event_id=activity_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        action="move",
+                        actor=actor,
+                        subject=subject,
+                        summary=summary,
+                        path_from=old_path,
+                        path_to=path_to,
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_activity")
+                    await self.repository.insert_invalidation_intent(
+                        conn,
+                        intent_id=intent_id,
+                        namespace_id=namespace_id,
+                        resource_id=resource_id,
+                        revision_id=revision_id,
+                        reason="move",
+                        occurred_at=occurred_at,
+                    )
+                    await self._hit("authority.after_invalidation")
+                    await self._hit("authority.before_commit")
+        except asyncpg.UniqueViolationError as exc:
+            if exc.constraint_name in {
+                "uq_native_resources_live_path",
+                "uq_native_resource_path_aliases_live",
+            }:
+                raise ConflictError(f"Native Resource already exists at path: {path_to}") from exc
+            raise
+        return NativeMutationResult(
+            resource_id=resource_id,
+            revision_id=revision_id,
+            parent_revision_id=parent_revision_id,
+            action="move",
+            path=path_to,
+            payload_manifest_id=manifest_id,
+            occurred_at=occurred_at,
+        )
+
+    async def delete_resource(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None = None,
+        message: str | None = None,
+        subject: str | None = None,
+        summary: str | None = None,
+    ) -> NativeMutationResult:
+        self._validate_common(
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+        )
+        self._validate_expected_revision(expected_revision_id)
+        fingerprint = self._lifecycle_fingerprint(
+            action="delete",
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            path_to=None,
+            expected_revision_id=expected_revision_id,
+            actor=actor,
+            message=message,
+            subject=subject,
+            summary=summary,
+        )
+        result = await self._publish_delete(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+            expected_revision_id=expected_revision_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            fingerprint=fingerprint,
+        )
+        await self._hit("authority.after_commit_before_response")
+        return result
+
+    async def _publish_delete(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        expected_revision_id: str | None,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        fingerprint: str,
+    ) -> NativeMutationResult:
+        revision_id = await self._allocate_revision_id()
+        activity_id = uuid.uuid4()
+        intent_id = uuid.uuid4()
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await self.repository.lock_mutation(conn, namespace_id, mutation_id)
+                prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
+                if prior is not None:
+                    if prior["request_fingerprint"] != fingerprint:
+                        raise ConflictError("Native idempotency key was reused with different input")
+                    return self._from_row(prior, replay=True)
+
+                await self.repository.lock_paths(conn, namespace_id, surface, path)
+                resolved = await self.repository.resolve_live_reference(
+                    namespace_id=namespace_id,
+                    surface=surface,
+                    reference=path,
+                    conn=conn,
+                )
+                if resolved is None:
+                    raise NotFoundError("Native Resource", path)
+                resource = await self.repository.lock_resource(conn, resolved["resource_id"])
+                if resource is None or resource["lifecycle"] != "live":
+                    raise NotFoundError("Native Resource", path)
+                resource_id = resource["resource_id"]
+                current_path = resource["current_path"]
+                parent_revision_id = resource["head_revision_id"]
+                if expected_revision_id is not None and expected_revision_id != parent_revision_id:
+                    raise ConflictError(
+                        "Native Revision conflict: expected "
+                        f"{expected_revision_id}, current Head is {parent_revision_id}"
+                    )
+                await self.repository.lock_paths(
+                    conn,
+                    namespace_id,
+                    surface,
+                    current_path,
+                )
+                occurred_at = datetime.now(UTC)
+                await self.repository.insert_revision(
+                    conn,
+                    revision_id=revision_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    parent_revision_id=parent_revision_id,
+                    action="delete",
+                    path=current_path,
+                    path_from=None,
+                    path_to=None,
+                    payload_manifest_id=None,
+                    mutation_id=mutation_id,
+                    request_fingerprint=fingerprint,
+                    message=message,
+                    subject=subject,
+                    summary=summary,
+                    actor=actor,
+                    occurred_at=occurred_at,
+                    activity_event_id=activity_id,
+                    invalidation_intent_id=intent_id,
+                )
+                await self._hit("authority.after_revision")
+                await self.repository.set_head(
+                    conn,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    path=current_path,
+                    lifecycle="deleted",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_head")
+                await self._hit("authority.after_path")
+                await self.repository.retire_resource_aliases(
+                    conn,
+                    namespace_id=namespace_id,
+                    surface=surface,
+                    resource_id=resource_id,
+                    retired_revision_id=revision_id,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_alias")
+                await self.repository.insert_activity(
+                    conn,
+                    activity_event_id=activity_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    action="delete",
+                    actor=actor,
+                    subject=subject,
+                    summary=summary,
+                    path_from=None,
+                    path_to=None,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_activity")
+                await self.repository.insert_invalidation_intent(
+                    conn,
+                    intent_id=intent_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    reason="delete",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_invalidation")
+                await self._hit("authority.before_commit")
+        return NativeMutationResult(
+            resource_id=resource_id,
+            revision_id=revision_id,
+            parent_revision_id=parent_revision_id,
+            action="delete",
+            path=current_path,
+            payload_manifest_id=None,
             occurred_at=occurred_at,
         )
 
@@ -534,6 +1016,76 @@ class NativeRevisionService:
         )
         if row is None:
             raise NotFoundError("Native Resource", path)
+        return await self._snapshot_from_row(row)
+
+    async def get_current_reference(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        reference: str,
+    ) -> NativeRevisionSnapshot:
+        resource = await self.repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface=surface,
+            reference=reference,
+        )
+        if resource is None:
+            raise NotFoundError("Native Resource", reference)
+        row = await self.repository.get_resource_head(resource_id=resource["resource_id"])
+        if row is None or row["lifecycle"] != "live":
+            raise NotFoundError("Native Resource", reference)
+        return await self._snapshot_from_row(row)
+
+    async def get_revision(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        reference: str,
+        revision_id: str,
+    ) -> NativeRevisionSnapshot:
+        self._validate_expected_revision(revision_id)
+        resource = await self.repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface=surface,
+            reference=reference,
+        )
+        if resource is None:
+            raise NotFoundError("Native Resource", reference)
+        row = await self.repository.get_revision(
+            resource_id=resource["resource_id"],
+            revision_id=revision_id,
+        )
+        if row is None or row["namespace_id"] != namespace_id or row["surface"] != surface:
+            raise NotFoundError("Native Revision", revision_id)
+        if row["payload_manifest_id"] is None:
+            raise NotFoundError("Native Revision payload", revision_id)
+        row["path"] = row["path_at_revision"]
+        return await self._snapshot_from_row(row)
+
+    async def list_history(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        reference: str,
+        limit: int,
+    ) -> tuple[dict, list[dict]]:
+        resource = await self.repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface=surface,
+            reference=reference,
+        )
+        if resource is None:
+            raise NotFoundError("Native Resource", reference)
+        rows = await self.repository.list_history(
+            resource_id=resource["resource_id"],
+            limit=limit,
+        )
+        return resource, rows
+
+    async def _snapshot_from_row(self, row: dict) -> NativeRevisionSnapshot:
         if row["payload_manifest_id"] is None or row["private_locator"] is None:
             raise ReferencePayloadIntegrityError("Live native Head does not pin a payload manifest")
         payload_bytes = await self.payload_store.open_verified(row["private_locator"])
@@ -551,6 +1103,8 @@ class NativeRevisionService:
             path=row["path"],
             action=row["action"],
             occurred_at=row["occurred_at"],
+            resource_created_at=row["resource_created_at"],
+            resource_updated_at=row["resource_updated_at"],
             payload_manifest_id=row["payload_manifest_id"],
             digest=row["digest"],
             byte_size=row["byte_size"],

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -177,8 +177,7 @@ class NativeRevisionService:
     @staticmethod
     def _validate_expected_revision(expected_revision_id: str | None) -> None:
         if expected_revision_id is not None and (
-            len(expected_revision_id) != 40
-            or any(ch not in "0123456789abcdef" for ch in expected_revision_id)
+            len(expected_revision_id) != 40 or any(ch not in "0123456789abcdef" for ch in expected_revision_id)
         ):
             raise ValidationError("Expected native Revision ID must be exactly 40 lowercase hex")
 
@@ -212,6 +211,53 @@ class NativeRevisionService:
             if not exists:
                 return candidate
         raise ConflictError("Unable to allocate a unique native Revision ID after collisions")
+
+    async def _lock_live_reference(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        reference: str,
+        additional_paths: tuple[str, ...] = (),
+    ) -> dict:
+        """Lock one live Resource before locking every path the mutation uses.
+
+        Alias and current-path callers therefore share one global acquisition
+        order: resolve, Resource row, sorted path advisory locks, re-resolve.
+        The final resolution rejects a path that was reused while the caller
+        waited instead of mutating the Resource found by a stale pre-read.
+        """
+        resolved = await self.repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface=surface,
+            reference=reference,
+            conn=conn,
+        )
+        if resolved is None:
+            raise NotFoundError("Native Resource", reference)
+        resource = await self.repository.lock_resource(conn, resolved["resource_id"])
+        if resource is None or resource["lifecycle"] != "live":
+            raise NotFoundError("Native Resource", reference)
+        await self.repository.lock_paths(
+            conn,
+            namespace_id,
+            surface,
+            reference,
+            resource["current_path"],
+            *additional_paths,
+        )
+        confirmed = await self.repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface=surface,
+            reference=reference,
+            conn=conn,
+        )
+        if confirmed is None:
+            raise NotFoundError("Native Resource", reference)
+        if confirmed["resource_id"] != resource["resource_id"]:
+            raise ConflictError(f"Native Resource reference changed while mutation waited: {reference}")
+        return resource
 
     async def create_text(
         self,
@@ -252,6 +298,7 @@ class NativeRevisionService:
             subject=subject,
             summary=summary,
         )
+        await self._hit("payload.after_prepare_before_tx")
         result = await self._publish_create(
             namespace_id=namespace_id,
             surface=surface,
@@ -301,13 +348,12 @@ class NativeRevisionService:
                     await self.repository.lock_paths(conn, namespace_id, surface, path)
                     if await self.repository.find_live_path(conn, namespace_id, surface, path) is not None:
                         raise ConflictError(f"Native Resource already exists at path: {path}")
-                    if await self.repository.find_live_alias(
+                    reused_alias = await self.repository.find_live_alias(
                         conn,
                         namespace_id=namespace_id,
                         surface=surface,
                         old_path=path,
-                    ) is not None:
-                        raise ConflictError(f"Native Resource alias already owns path: {path}")
+                    )
 
                     occurred_at = datetime.now(UTC)
                     await self.repository.insert_resource(
@@ -361,6 +407,16 @@ class NativeRevisionService:
                     )
                     await self._hit("authority.after_head")
                     await self._hit("authority.after_path")
+                    if reused_alias is not None:
+                        await self.repository.retire_live_alias(
+                            conn,
+                            namespace_id=namespace_id,
+                            surface=surface,
+                            old_path=path,
+                            retired_revision_id=revision_id,
+                            occurred_at=occurred_at,
+                        )
+                    await self._hit("authority.after_alias")
                     await self.repository.insert_activity(
                         conn,
                         activity_event_id=activity_id,
@@ -439,6 +495,7 @@ class NativeRevisionService:
             subject=subject,
             summary=summary,
         )
+        await self._hit("payload.after_prepare_before_tx")
         result = await self._publish_replace(
             namespace_id=namespace_id,
             surface=surface,
@@ -483,12 +540,13 @@ class NativeRevisionService:
                         raise ConflictError("Native idempotency key was reused with different input")
                     return self._from_row(prior, replay=True)
 
-                await self.repository.lock_paths(conn, namespace_id, surface, path)
-                resource = await self.repository.find_live_path(
-                    conn, namespace_id, surface, path, for_update=True
+                resource = await self._lock_live_reference(
+                    conn,
+                    namespace_id=namespace_id,
+                    surface=surface,
+                    reference=path,
                 )
-                if resource is None:
-                    raise NotFoundError("Native Resource", path)
+                current_path = resource["current_path"]
                 parent_revision_id = resource["head_revision_id"]
                 if expected_revision_id is not None and expected_revision_id != parent_revision_id:
                     raise ConflictError(
@@ -514,7 +572,7 @@ class NativeRevisionService:
                     resource_id=resource_id,
                     parent_revision_id=parent_revision_id,
                     action="replace",
-                    path=path,
+                    path=current_path,
                     path_from=None,
                     path_to=None,
                     payload_manifest_id=manifest_id,
@@ -533,7 +591,7 @@ class NativeRevisionService:
                     conn,
                     resource_id=resource_id,
                     revision_id=revision_id,
-                    path=path,
+                    path=current_path,
                     lifecycle="live",
                     occurred_at=occurred_at,
                 )
@@ -570,7 +628,7 @@ class NativeRevisionService:
             revision_id=revision_id,
             parent_revision_id=parent_revision_id,
             action="replace",
-            path=path,
+            path=current_path,
             payload_manifest_id=manifest_id,
             occurred_at=occurred_at,
         )
@@ -657,27 +715,13 @@ class NativeRevisionService:
                             raise ConflictError("Native idempotency key was reused with different input")
                         return self._from_row(prior, replay=True)
 
-                    await self.repository.lock_paths(
+                    resource = await self._lock_live_reference(
                         conn,
-                        namespace_id,
-                        surface,
-                        path,
-                        path_to,
-                    )
-                    resolved = await self.repository.resolve_live_reference(
                         namespace_id=namespace_id,
                         surface=surface,
                         reference=path,
-                        conn=conn,
+                        additional_paths=(path_to,),
                     )
-                    if resolved is None:
-                        raise NotFoundError("Native Resource", path)
-                    resource = await self.repository.lock_resource(
-                        conn,
-                        resolved["resource_id"],
-                    )
-                    if resource is None or resource["lifecycle"] != "live":
-                        raise NotFoundError("Native Resource", path)
                     resource_id = resource["resource_id"]
                     old_path = resource["current_path"]
                     parent_revision_id = resource["head_revision_id"]
@@ -688,12 +732,6 @@ class NativeRevisionService:
                         )
                     if path_to == old_path:
                         raise ValidationError("Native Resource move is a no-op")
-                    await self.repository.lock_paths(
-                        conn,
-                        namespace_id,
-                        surface,
-                        old_path,
-                    )
                     destination = await self.repository.find_live_path(
                         conn,
                         namespace_id,
@@ -708,10 +746,7 @@ class NativeRevisionService:
                         surface=surface,
                         old_path=path_to,
                     )
-                    if (
-                        destination_alias is not None
-                        and destination_alias["resource_id"] != resource_id
-                    ):
+                    if destination_alias is not None and destination_alias["resource_id"] != resource_id:
                         raise ConflictError(f"Native Resource alias already owns path: {path_to}")
 
                     head = await self.repository.get_resource_head(
@@ -719,9 +754,7 @@ class NativeRevisionService:
                         conn=conn,
                     )
                     if head is None or head["payload_manifest_id"] is None:
-                        raise ReferencePayloadIntegrityError(
-                            "Live native Head does not pin a payload manifest"
-                        )
+                        raise ReferencePayloadIntegrityError("Live native Head does not pin a payload manifest")
                     occurred_at = datetime.now(UTC)
                     await self.repository.copy_manifest(
                         conn,
@@ -898,18 +931,12 @@ class NativeRevisionService:
                         raise ConflictError("Native idempotency key was reused with different input")
                     return self._from_row(prior, replay=True)
 
-                await self.repository.lock_paths(conn, namespace_id, surface, path)
-                resolved = await self.repository.resolve_live_reference(
+                resource = await self._lock_live_reference(
+                    conn,
                     namespace_id=namespace_id,
                     surface=surface,
                     reference=path,
-                    conn=conn,
                 )
-                if resolved is None:
-                    raise NotFoundError("Native Resource", path)
-                resource = await self.repository.lock_resource(conn, resolved["resource_id"])
-                if resource is None or resource["lifecycle"] != "live":
-                    raise NotFoundError("Native Resource", path)
                 resource_id = resource["resource_id"]
                 current_path = resource["current_path"]
                 parent_revision_id = resource["head_revision_id"]
@@ -918,12 +945,6 @@ class NativeRevisionService:
                         "Native Revision conflict: expected "
                         f"{expected_revision_id}, current Head is {parent_revision_id}"
                     )
-                await self.repository.lock_paths(
-                    conn,
-                    namespace_id,
-                    surface,
-                    current_path,
-                )
                 occurred_at = datetime.now(UTC)
                 await self.repository.insert_revision(
                     conn,

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -31,6 +31,7 @@ from app.exceptions import AKBError, NotFoundError
 from app.services import file_service, table_service
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
 from app.services.document_service import DocumentService
+from app.services.revision_backend import get_document_service
 from app.services.uri_service import parse_uri
 
 logger = logging.getLogger("akb.publications")
@@ -76,7 +77,7 @@ _doc_service: DocumentService | None = None
 def _get_doc_service() -> DocumentService:
     global _doc_service
     if _doc_service is None:
-        _doc_service = DocumentService()
+        _doc_service = get_document_service()
     return _doc_service
 
 

--- a/backend/app/services/revision_backend.py
+++ b/backend/app/services/revision_backend.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 from collections.abc import Callable
 from threading import Lock
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from app.config import NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME, settings
 from app.db.postgres import get_pool
@@ -133,7 +133,9 @@ class LegacyRevisionBackend:
     ) -> tuple[dict[str, Any], str] | None:
         document = await self._find_document(vault, doc_ref)
         if not document:
-            return None
+            from app.exceptions import NotFoundError
+
+            raise NotFoundError("Document", doc_ref)
         raw = await asyncio.to_thread(self._git.read_file, vault, document["path"], version)
         if raw is None:
             return None
@@ -194,22 +196,34 @@ def _assert_native_measurement_safety() -> None:
 
 def get_revision_backend() -> RevisionBackend:
     """Return the complete revision facade selected once for this process."""
-    global _revision_backend, _selected_backend
+    global _revision_backend, _selected_backend, _native_revision_backend_factory
     with _lock:
         if _revision_backend is not None:
             return _revision_backend
 
         backend = settings.document_revision_backend
+        revision_backend: RevisionBackend
         if backend == "bare_git_current":
             revision_backend = LegacyRevisionBackend()
         elif backend == "native_ledger_m1":
             _assert_native_measurement_safety()
             if _native_revision_backend_factory is None:
-                raise NativeRevisionBackendUnavailableError(
-                    "native_ledger_m1 was selected, but no native revision backend "
-                    "has been registered"
+                # Routes and the stdio MCP server select their facade from
+                # module globals during import.  Loading the native factory at
+                # this exact composition seam guarantees it is available
+                # before either caller receives a service, without importing
+                # any measurement-only code during default legacy startup.
+                from app.services.native_revision_backend import (
+                    native_revision_backend_factory,
                 )
-            revision_backend = _native_revision_backend_factory()
+
+                _native_revision_backend_factory = cast(
+                    RevisionBackendFactory,
+                    native_revision_backend_factory,
+                )
+            native_factory = _native_revision_backend_factory
+            assert native_factory is not None
+            revision_backend = native_factory()
         else:  # Settings validates this, but fail closed for in-process mutation.
             raise RuntimeError(f"unsupported document revision backend: {backend!r}")
 

--- a/backend/app/services/revision_backend.py
+++ b/backend/app/services/revision_backend.py
@@ -1,0 +1,237 @@
+"""Process-scoped selection of the document revision implementation.
+
+The legacy bare-Git document service remains the default. M1's native ledger
+path is measurement-only and must be registered by its implementation work.
+Selection happens once here, at a composition root, never from request or
+vault data.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from threading import Lock
+from typing import Any, Protocol
+
+from app.config import NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME, settings
+from app.db.postgres import get_pool
+from app.repositories.document_repo import DocumentRepository
+from app.services.document_service import DocumentService
+from app.services.git_service import GitService
+
+
+class NativeRevisionBackendUnavailableError(RuntimeError):
+    """A guarded native backend was selected but is not installed."""
+
+
+class RevisionBackend(Protocol):
+    """The complete revision surface consumed by document composition roots."""
+
+    document_service: DocumentService
+
+    async def vault_activity(
+        self, vault: str, *, max_count: int, since: str | None, path: str | None,
+    ) -> list[dict[str, Any]]: ...
+
+    async def recent_changes(
+        self, user_id: str, *, vault: str | None, limit: int,
+    ) -> list[dict[str, Any]]: ...
+
+    async def document_diff(
+        self, vault: str, doc_ref: str, commit: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def document_version(
+        self, vault: str, doc_ref: str, version: str,
+    ) -> tuple[dict[str, Any], str] | None: ...
+
+    async def document_history(
+        self, vault: str, doc_ref: str, *, limit: int,
+    ) -> dict[str, Any]: ...
+
+
+class LegacyRevisionBackend:
+    """Bare-Git revision adapter retaining the pre-M1 route behavior."""
+
+    def __init__(self) -> None:
+        self.document_service = DocumentService()
+        self._git = GitService()
+
+    async def vault_activity(
+        self, vault: str, *, max_count: int, since: str | None, path: str | None,
+    ) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(
+            self._git.vault_log, vault, max_count=max_count, since=since, path=path,
+        )
+
+    async def recent_changes(
+        self, user_id: str, *, vault: str | None, limit: int,
+    ) -> list[dict[str, Any]]:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            if vault:
+                rows = await conn.fetch(
+                    """
+                    SELECT d.id, d.title, d.path, d.doc_type, d.current_commit,
+                           d.updated_at, v.name AS vault_name, d.metadata
+                    FROM documents d
+                    JOIN vaults v ON d.vault_id = v.id
+                    WHERE v.name = $1
+                    ORDER BY d.updated_at DESC
+                    LIMIT $2
+                    """,
+                    vault, limit,
+                )
+            else:
+                rows = await conn.fetch(
+                    """
+                    SELECT d.id, d.title, d.path, d.doc_type, d.current_commit,
+                           d.updated_at, v.name AS vault_name, d.metadata
+                    FROM documents d
+                    JOIN vaults v ON d.vault_id = v.id
+                    LEFT JOIN vault_access va
+                        ON va.vault_id = v.id AND va.user_id = $1
+                    WHERE v.owner_id = $1
+                       OR va.user_id = $1
+                       OR v.public_access IN ('reader', 'writer')
+                    ORDER BY d.updated_at DESC
+                    LIMIT $2
+                    """,
+                    user_id, limit,
+                )
+
+        changes = []
+        for row in rows:
+            metadata = row["metadata"] or {}
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = {}
+            changes.append({
+                "doc_id": metadata.get("id") or str(row["id"]),
+                "vault": row["vault_name"],
+                "path": row["path"],
+                "title": row["title"],
+                "type": row["doc_type"] or "note",
+                "commit": row["current_commit"],
+                "changed_at": row["updated_at"].isoformat() if row["updated_at"] else None,
+            })
+        return changes
+
+    async def document_diff(
+        self, vault: str, doc_ref: str, commit: str,
+    ) -> dict[str, Any] | None:
+        document = await self._find_document(vault, doc_ref)
+        if not document:
+            return None
+        return await asyncio.to_thread(self._git.file_diff, vault, document["path"], commit)
+
+    async def document_version(
+        self, vault: str, doc_ref: str, version: str,
+    ) -> tuple[dict[str, Any], str] | None:
+        document = await self._find_document(vault, doc_ref)
+        if not document:
+            return None
+        raw = await asyncio.to_thread(self._git.read_file, vault, document["path"], version)
+        if raw is None:
+            return None
+        return document, raw
+
+    async def _find_document(self, vault: str, doc_ref: str) -> dict[str, Any] | None:
+        pool = await get_pool()
+        doc_repo = DocumentRepository(pool)
+        async with pool.acquire() as conn:
+            vault_row = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault)
+            if not vault_row:
+                return None
+            document = await doc_repo.find_by_ref_with_conn(conn, vault_row["id"], doc_ref)
+            if not document:
+                return None
+        return document
+
+    async def document_history(
+        self, vault: str, doc_ref: str, *, limit: int,
+    ) -> dict[str, Any]:
+        return await self.document_service.history(vault, doc_ref, limit=limit)
+
+
+RevisionBackendFactory = Callable[[], RevisionBackend]
+
+_lock = Lock()
+_revision_backend: RevisionBackend | None = None
+_selected_backend: str | None = None
+_native_revision_backend_factory: RevisionBackendFactory | None = None
+
+
+def register_native_revision_backend(factory: RevisionBackendFactory) -> None:
+    """Register the native facade before the process selects a backend.
+
+    A3 owns the native implementation and calls this while composing the
+    process. Replacing an already-selected backend is forbidden so a process
+    cannot switch revision semantics after serving requests.
+    """
+    global _native_revision_backend_factory
+    with _lock:
+        if _revision_backend is not None:
+            raise RuntimeError("document revision backend is already selected")
+        _native_revision_backend_factory = factory
+
+
+def _assert_native_measurement_safety() -> None:
+    """Defence in depth for callers that mutate settings in-process."""
+    if not settings.native_revision_m1_measurement_only:
+        raise RuntimeError(
+            "native_ledger_m1 requires native_revision_m1_measurement_only=true"
+        )
+    if settings.db_name != NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME:
+        raise RuntimeError(
+            "native_ledger_m1 requires dedicated measurement database "
+            f"{NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME!r}"
+        )
+
+
+def get_revision_backend() -> RevisionBackend:
+    """Return the complete revision facade selected once for this process."""
+    global _revision_backend, _selected_backend
+    with _lock:
+        if _revision_backend is not None:
+            return _revision_backend
+
+        backend = settings.document_revision_backend
+        if backend == "bare_git_current":
+            revision_backend = LegacyRevisionBackend()
+        elif backend == "native_ledger_m1":
+            _assert_native_measurement_safety()
+            if _native_revision_backend_factory is None:
+                raise NativeRevisionBackendUnavailableError(
+                    "native_ledger_m1 was selected, but no native revision backend "
+                    "has been registered"
+                )
+            revision_backend = _native_revision_backend_factory()
+        else:  # Settings validates this, but fail closed for in-process mutation.
+            raise RuntimeError(f"unsupported document revision backend: {backend!r}")
+
+        _revision_backend = revision_backend
+        _selected_backend = backend
+        return revision_backend
+
+
+def get_document_service() -> DocumentService:
+    """Return the document-service member of the selected revision facade."""
+    return get_revision_backend().document_service
+
+
+def selected_document_revision_backend() -> str | None:
+    """Return the process-selected backend, or ``None`` before composition."""
+    return _selected_backend
+
+
+def reset_document_service_for_tests() -> None:
+    """Clear process state for isolated unit tests only."""
+    global _revision_backend, _selected_backend, _native_revision_backend_factory
+    with _lock:
+        _revision_backend = None
+        _selected_backend = None
+        _native_revision_backend_factory = None

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -31,7 +31,8 @@ from mcp.types import TextContent
 
 from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError, WriteBusyError
-from app.services.document_service import DocumentService, EditError
+from app.services.document_service import EditError
+from app.services.revision_backend import get_revision_backend
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
 from app.services.uri_service import doc_uri, parse_uri, split_uri
@@ -165,7 +166,8 @@ def _session_id() -> str | None:
     except (LookupError, AttributeError):
         pass
     return None
-doc_service = DocumentService()
+revision_backend = get_revision_backend()
+doc_service = revision_backend.document_service
 search_service = SearchService()
 
 
@@ -495,16 +497,10 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
         # internal-id fields living in old frontmatter (legacy d-prefix)
         # must not leak out of the MCP boundary.
         import frontmatter as _fm
-        doc = await _find_doc(vault, doc_path)
-        if not doc:
-            return err("Document not found", code=NOT_FOUND)
-        from app.services.git_service import GitService
-        git = GitService()
-        # off-load the git blob read; the un-versioned path already offloads
-        # via doc_service.get, so keep the versioned MCP read off the loop too.
-        raw = await asyncio.to_thread(git.read_file, vault, doc["path"], commit=version)
-        if raw is None:
+        versioned = await revision_backend.document_version(vault, doc_path, version)
+        if versioned is None:
             return err(f"Version not found: {version}", code=NOT_FOUND)
+        doc, raw = versioned
         try:
             body = _fm.loads(raw).content
         except Exception:
@@ -853,8 +849,6 @@ def _sub_sections_of(section_paths: list[str], parent: str | None) -> list[str]:
 @_h("akb_activity")
 async def _handle_activity(args: dict, uid: str, user: _MCPUser) -> dict:
     await check_vault_access(uid, args["vault"], required_role="reader")
-    from app.services.git_service import GitService
-    git = GitService()
     limit = args.get("limit", 20)
     # Peek one past the limit so we can flag truncation without a
     # separate `git rev-list --count` walk (which would re-traverse the
@@ -863,8 +857,7 @@ async def _handle_activity(args: dict, uid: str, user: _MCPUser) -> dict:
     # post-fetch author filter below — i.e. when truncated=True the
     # caller knows commits exist past the window, but cannot tell
     # without paging whether they would survive the author filter.
-    entries = await asyncio.to_thread(
-        git.vault_log,
+    entries = await revision_backend.vault_activity(
         args["vault"],
         max_count=limit + 1,
         since=args.get("since"),
@@ -896,12 +889,10 @@ async def _handle_diff(args: dict, uid: str, user: _MCPUser) -> dict:
             "symbolic refs are not accepted",
             code=INVALID_ARGUMENT,
         )
-    doc = await _find_doc(vault, doc_path)
-    if not doc:
+    result = await revision_backend.document_diff(vault, doc_path, commit)
+    if result is None:
         return err(f"Document not found: {args['uri']}", code=NOT_FOUND)
-    from app.services.git_service import GitService
-    git = GitService()
-    return await asyncio.to_thread(git.file_diff, vault, doc["path"], commit)
+    return result
 
 
 @_h("akb_relations")
@@ -1372,7 +1363,9 @@ async def _handle_history(args: dict, uid: str, user: _MCPUser) -> dict:
     # annotation all live in DocumentService.history() so this tool and
     # GET /history stay byte-for-byte identical. A missing doc raises
     # NotFoundError, mapped to err(code=NOT_FOUND) by exception_envelope.
-    return await doc_service.history(vault, doc_path, limit=args.get("limit", 20))
+    return await revision_backend.document_history(
+        vault, doc_path, limit=args.get("limit", 20),
+    )
 
 
 @_h("akb_export")

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -497,7 +497,10 @@ async def _handle_get(args: dict, uid: str, user: _MCPUser) -> dict:
         # internal-id fields living in old frontmatter (legacy d-prefix)
         # must not leak out of the MCP boundary.
         import frontmatter as _fm
-        versioned = await revision_backend.document_version(vault, doc_path, version)
+        try:
+            versioned = await revision_backend.document_version(vault, doc_path, version)
+        except NotFoundError:
+            return err("Document not found", code=NOT_FOUND)
         if versioned is None:
             return err(f"Version not found: {version}", code=NOT_FOUND)
         doc, raw = versioned

--- a/backend/scripts/native_revision_m1_adapter.py
+++ b/backend/scripts/native_revision_m1_adapter.py
@@ -1,0 +1,839 @@
+#!/usr/bin/env python3
+"""First-party real-PostgreSQL adapter for the M1 native-ledger harness.
+
+This entrypoint is deliberately a measurement tool, not an AKB public API.  It
+only accepts an explicitly named measurement database, creates one fresh vault
+namespace per run, and drives :class:`NativeRevisionService` directly.  The
+workbench owns the receipt; this program writes only its concrete observation
+and the two SHA-256-bound artifacts required by that receipt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import difflib
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+
+BACKEND = Path(__file__).resolve().parents[1]
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from app.exceptions import ConflictError, NotFoundError  # noqa: E402
+from app.services.native_revision_service import NativeRevisionService  # noqa: E402
+
+
+PROTOCOL_VERSION = "akb-native-revision-m1-b-core/v1"
+MEASUREMENT_DATABASE_PREFIX = "akb_revision_m1_measurement"
+PRECOMMIT_BOUNDARIES = (
+    "payload_prepare",
+    "payload_verify",
+    "after_prepare_before_tx",
+    "manifest",
+    "revision",
+    "head",
+    "path",
+    "alias",
+    "activity",
+    "invalidation_intent",
+    "before_commit",
+)
+ACTUAL_FAILPOINTS = {
+    "payload_prepare": "payload.before_prepare",
+    "payload_verify": "payload.after_verified",
+    "after_prepare_before_tx": "payload.after_prepare_before_tx",
+    "manifest": "authority.after_manifest",
+    "revision": "authority.after_revision",
+    "head": "authority.after_head",
+    "path": "authority.after_path",
+    "alias": "authority.after_alias",
+    "activity": "authority.after_activity",
+    "invalidation_intent": "authority.after_invalidation",
+    "before_commit": "authority.before_commit",
+}
+
+
+class AdapterError(RuntimeError):
+    """A safe-to-report measurement setup or contract failure."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def write_bound_json(path: Path, value: Any) -> dict[str, str]:
+    """Exclusively publish an immutable JSON artifact and bind its digest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise AdapterError(f"measurement artifact already exists and will not be overwritten: {path}") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(encoded)
+            destination.flush()
+            os.fsync(destination.fileno())
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    return {"path": str(path.resolve()), "sha256": sha256_bytes(encoded)}
+
+
+def validate_measurement_database(name: str) -> None:
+    """Prevent an operator typo from making this harness mutate a normal DB."""
+    if name != MEASUREMENT_DATABASE_PREFIX and not name.startswith(f"{MEASUREMENT_DATABASE_PREFIX}_"):
+        raise AdapterError(
+            "AKB native M1 adapter requires a dedicated measurement database named "
+            f"{MEASUREMENT_DATABASE_PREFIX} or a suffixed isolated derivative; got {name!r}"
+        )
+
+
+def source_revision() -> str:
+    configured = os.environ.get("AKB_NATIVE_REVISION_ADAPTER_SOURCE_REVISION")
+    if configured is not None and (len(configured) != 40 or any(ch not in "0123456789abcdef" for ch in configured)):
+        raise AdapterError("AKB_NATIVE_REVISION_ADAPTER_SOURCE_REVISION must be exactly 40 lowercase hex")
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(BACKEND.parent), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except OSError, subprocess.CalledProcessError:
+        # Immutable production-style images normally contain no checkout.  The
+        # image build/deploy pipeline must inject its exact source commit rather
+        # than the adapter guessing a release version or using a mutable tag.
+        if configured is None:
+            raise AdapterError(
+                "cannot resolve AKB adapter source revision without .git; set "
+                "AKB_NATIVE_REVISION_ADAPTER_SOURCE_REVISION at image build/deploy time"
+            )
+        return configured
+    revision = result.stdout.strip()
+    if len(revision) != 40 or any(ch not in "0123456789abcdef" for ch in revision):
+        raise AdapterError("AKB adapter source revision must be a 40-lowercase-hex Git commit")
+    if configured is not None and configured != revision:
+        raise AdapterError("AKB_NATIVE_REVISION_ADAPTER_SOURCE_REVISION differs from the checked-out adapter source")
+    return revision
+
+
+def required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise AdapterError(f"{name} is required")
+    return value
+
+
+def bounded_json_object(name: str, *, required: bool) -> dict[str, Any]:
+    raw = os.environ.get(name)
+    if raw is None:
+        if required:
+            raise AdapterError(f"{name} is required for E1b measurements")
+        return {}
+    if len(raw.encode("utf-8")) > 16 * 1024:
+        raise AdapterError(f"{name} exceeds the 16 KiB provenance profile limit")
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AdapterError(f"{name} must be a JSON object") from exc
+    if not isinstance(value, dict):
+        raise AdapterError(f"{name} must be a JSON object")
+    return value
+
+
+def receipt_provenance(revision: str, database: str, namespace_id: uuid.UUID) -> tuple[dict[str, str], dict[str, Any]]:
+    """Read explicit runtime identity/profile inputs; never invent image facts."""
+    tier = os.environ.get("AKB_NATIVE_REVISION_MEASUREMENT_TIER", "E0")
+    if tier not in {"E0", "E1a", "E1b", "E2", "E3"}:
+        raise AdapterError("AKB_NATIVE_REVISION_MEASUREMENT_TIER must be E0, E1a, E1b, E2, or E3")
+    node_profile = bounded_json_object("AKB_NATIVE_REVISION_NODE_PROFILE_JSON", required=tier == "E1b")
+    supplied_storage = bounded_json_object("AKB_NATIVE_REVISION_STORAGE_PROFILE_JSON", required=tier == "E1b")
+    if tier == "E1b" and (not node_profile or not supplied_storage):
+        raise AdapterError("E1b measurements require non-empty node and storage provenance profiles")
+    configured_source = os.environ.get("AKB_NATIVE_REVISION_RUNTIME_SOURCE_REVISION")
+    if configured_source is not None and configured_source != revision:
+        raise AdapterError("AKB_NATIVE_REVISION_RUNTIME_SOURCE_REVISION must equal adapter source revision")
+    runtime = {
+        "image_digest": required_environment("AKB_NATIVE_REVISION_RUNTIME_IMAGE_DIGEST"),
+        "config_digest": required_environment("AKB_NATIVE_REVISION_RUNTIME_CONFIG_DIGEST"),
+        "source_revision": revision,
+    }
+    storage_profile = {
+        **supplied_storage,
+        "authority": "postgresql-native-ledger",
+        "database": database,
+        "isolation_scope": "dedicated-measurement-database/random-vault-namespace/no-global-truncate",
+        "namespace_id": str(namespace_id),
+    }
+    return runtime, {"tier": tier, "node_profile": node_profile, "storage_profile": storage_profile}
+
+
+def load_contract() -> dict[str, Any]:
+    path = Path(required_environment("AKB_NATIVE_REVISION_NATIVE_CONTRACT_PATH"))
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AdapterError(f"cannot read native contract: {path}") from exc
+    if value.get("protocol_version") != PROTOCOL_VERSION:
+        raise AdapterError("native contract protocol version differs from adapter protocol")
+    return value
+
+
+def run_artifact_path(name: str) -> Path:
+    root = Path(required_environment("AKB_NATIVE_REVISION_ARTIFACTS_DIR"))
+    run_id = required_environment("AKB_NATIVE_REVISION_RUN_ID")
+    if "/" in run_id or "\\" in run_id or run_id in {".", ".."}:
+        raise AdapterError("AKB_NATIVE_REVISION_RUN_ID must be a simple artifact name")
+    return root / f"{run_id}.{name}.json"
+
+
+def mutation_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+async def initialise_measurement_database(dsn: str) -> tuple[asyncpg.Pool, uuid.UUID, str]:
+    """Prepare schema on a dedicated DB and allocate a run-private namespace.
+
+    No cleanup or DDL is issued until ``current_database()`` passes the strict
+    measurement-name gate.  The namespace is random rather than global
+    truncation, so parallel harness runs can share a dedicated database safely.
+    """
+    conn = await asyncpg.connect(dsn, timeout=10)
+    try:
+        database = await conn.fetchval("SELECT current_database()")
+        validate_measurement_database(str(database))
+        init_sql = (BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+        await conn.execute(init_sql)
+        migration_path = BACKEND / "app" / "db" / "migrations" / "048_native_revision_core.py"
+        spec = importlib.util.spec_from_file_location("akb_native_revision_m1_migration", migration_path)
+        if spec is None or spec.loader is None:
+            raise AdapterError("cannot load native revision migration")
+        migration = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(migration)
+        await migration.migrate(conn=conn)
+        namespace = await conn.fetchval(
+            "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+            f"m1-native-{uuid.uuid4().hex}",
+            "/tmp/m1-native-measurement-unused.git",
+        )
+        return await asyncpg.create_pool(dsn, min_size=1, max_size=12), namespace, str(database)
+    finally:
+        await conn.close()
+
+
+async def authority_snapshot(pool: asyncpg.Pool, namespace_id: uuid.UUID) -> dict[str, Any]:
+    """Read authority facts from ledger tables, never from in-memory results."""
+    async with pool.acquire() as conn:
+        revisions = await conn.fetchval("SELECT count(*) FROM native_revisions WHERE namespace_id = $1", namespace_id)
+        activities = await conn.fetchval(
+            "SELECT count(*) FROM native_revision_activity WHERE namespace_id = $1", namespace_id
+        )
+        intents = await conn.fetchval(
+            "SELECT count(*) FROM native_invalidation_intents WHERE namespace_id = $1", namespace_id
+        )
+        head_rows = await conn.fetch(
+            """
+            SELECT resource_id, head_revision_id, current_path
+              FROM native_resources
+             WHERE namespace_id = $1 AND lifecycle = 'live'
+             ORDER BY current_path
+            """,
+            namespace_id,
+        )
+        alias_rows = await conn.fetch(
+            """
+            SELECT a.old_path, a.resource_id, r.head_revision_id, r.current_path
+              FROM native_resource_path_aliases a
+              JOIN native_resources r ON r.resource_id = a.resource_id
+             WHERE a.namespace_id = $1
+               AND a.retired_revision_id IS NULL
+               AND r.lifecycle = 'live'
+             ORDER BY a.old_path
+            """,
+            namespace_id,
+        )
+    heads = {str(row["resource_id"]): row["head_revision_id"] for row in head_rows}
+    paths = {row["current_path"]: str(row["resource_id"]) for row in head_rows}
+    aliases = {
+        row["old_path"]: {
+            "resource_id": str(row["resource_id"]),
+            "revision": row["head_revision_id"],
+            "resolves_to": row["current_path"],
+        }
+        for row in alias_rows
+    }
+    return {
+        "revisions": int(revisions),
+        # A native revision is the durable, atomically published head update.
+        "head_publications": int(revisions),
+        "heads": heads,
+        "paths": paths,
+        "aliases": aliases,
+        "activities": int(activities),
+        "invalidation_intents": int(intents),
+    }
+
+
+def request_record(operation: str, **facts: Any) -> dict[str, Any]:
+    return {"operation": operation, **facts}
+
+
+def lifecycle_result(result: Any) -> dict[str, Any]:
+    return {
+        "resource_id": str(result.resource_id),
+        "revision": result.revision_id,
+        "parent_revision": result.parent_revision_id,
+        "path": result.path,
+    }
+
+
+async def workload_lifecycle(
+    service: NativeRevisionService,
+    namespace_id: uuid.UUID,
+    contract: dict[str, Any],
+    requests: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    input_ = contract["workloads"]["W1-lifecycle"]["cases"]["C2"]["input"]
+    actor, path, moved_path = input_["actor"], input_["path"], input_["moved_path"]
+    create_key = mutation_id()
+    requests.append(request_record("create", path=path, mutation_id=str(create_key)))
+    created = await service.create_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path=path,
+        payload=input_["create_body"],
+        actor=actor,
+        mutation_id=create_key,
+    )
+    initial = await service.get_current(namespace_id=namespace_id, surface="document", path=path)
+    replace_key = mutation_id()
+    requests.append(
+        request_record("replace", path=path, mutation_id=str(replace_key), expected_revision=created.revision_id)
+    )
+    replaced = await service.replace_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path=path,
+        payload=input_["replace_body"],
+        actor=actor,
+        mutation_id=replace_key,
+        expected_revision_id=created.revision_id,
+    )
+    move_key = mutation_id()
+    requests.append(
+        request_record(
+            "move", path=path, path_to=moved_path, mutation_id=str(move_key), expected_revision=replaced.revision_id
+        )
+    )
+    moved = await service.move_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path=path,
+        path_to=moved_path,
+        actor=actor,
+        mutation_id=move_key,
+        expected_revision_id=replaced.revision_id,
+    )
+    current = await service.get_current(namespace_id=namespace_id, surface="document", path=moved_path)
+    moved_authority = await authority_snapshot(service.pool, namespace_id)
+    # The original name is an explicit live alias while the resource is live.
+    current_head = await service.get_current_reference(namespace_id=namespace_id, surface="document", reference=path)
+    pinned = await service.get_revision(
+        namespace_id=namespace_id,
+        surface="document",
+        reference=moved_path,
+        revision_id=replaced.revision_id,
+    )
+    deleted_key = mutation_id()
+    requests.append(
+        request_record("delete", path=moved_path, mutation_id=str(deleted_key), expected_revision=moved.revision_id)
+    )
+    deleted = await service.delete_resource(
+        namespace_id=namespace_id,
+        surface="document",
+        path=moved_path,
+        actor=actor,
+        mutation_id=deleted_key,
+        expected_revision_id=moved.revision_id,
+    )
+    try:
+        await service.get_current(namespace_id=namespace_id, surface="document", path=moved_path)
+        get_visible = True
+    except NotFoundError:
+        get_visible = False
+    deleted_authority = await authority_snapshot(service.pool, namespace_id)
+    # These native-ledger reads intentionally happen after delete but before
+    # recreate: C6 is the original resource's complete lifecycle, not the
+    # distinct same-path resource that follows it.
+    history_rows = await service.repository.list_history(resource_id=created.resource_id, limit=16)
+    activities = await service.repository.list_activity(namespace_id=namespace_id, limit=16)
+    recreate_key = mutation_id()
+    requests.append(request_record("recreate", path=path, mutation_id=str(recreate_key)))
+    recreated = await service.create_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path=path,
+        payload=input_["create_body"],
+        actor=actor,
+        mutation_id=recreate_key,
+    )
+    recreated_history = await service.repository.list_history(resource_id=recreated.resource_id, limit=16)
+    observed_diff = list(difflib.ndiff(initial.text.splitlines(), pinned.text.splitlines()))
+    removed_lines = [line[2:] for line in observed_diff if line.startswith("- ")]
+    added_lines = [line[2:] for line in observed_diff if line.startswith("+ ")]
+    cases = {
+        "C2": {
+            "create": {k: v for k, v in lifecycle_result(created).items() if k != "parent_revision"},
+            "initial_get": {
+                "resource_id": str(initial.resource_id),
+                "revision": initial.revision_id,
+                "path": initial.path,
+                "body": initial.text,
+            },
+            "replace": lifecycle_result(replaced),
+            "move": {k: v for k, v in lifecycle_result(moved).items() if k != "parent_revision"},
+            "current_get": {
+                "resource_id": str(current.resource_id),
+                "revision": current.revision_id,
+                "path": current.path,
+                "body": current.text,
+            },
+            "current_head": {"resource_id": str(current_head.resource_id), "revision": current_head.revision_id},
+            "live_paths": [
+                {"path": item_path, "resource_id": resource_id}
+                for item_path, resource_id in moved_authority["paths"].items()
+            ],
+            "old_path_aliases": [
+                {"path": item_path, **alias} for item_path, alias in moved_authority["aliases"].items()
+            ],
+            "delete": {
+                "resource_id": str(deleted.resource_id),
+                "revision": deleted.revision_id,
+                "visible": moved_path in deleted_authority["paths"],
+                "get_visible": get_visible,
+            },
+            "recreate": {
+                "resource_id": str(recreated.resource_id),
+                "revision": recreated.revision_id,
+                "path": path,
+                "history": [row["revision_id"] for row in recreated_history],
+                "lineage": {"ancestor_resource_ids": [], "parent_resource_id": None},
+            },
+        },
+        "C6": {
+            "pinned_get": {"revision": pinned.revision_id, "body": pinned.text},
+            "history": [row["revision_id"] for row in history_rows],
+            "diff": {
+                "from_revision": created.revision_id,
+                "to_revision": replaced.revision_id,
+                "removed_lines": removed_lines,
+                "added_lines": added_lines,
+            },
+            "activity": [
+                {"action": row["action"], "revision": row["revision_id"], "actor": row["actor"]} for row in activities
+            ],
+        },
+    }
+    return cases, requests
+
+
+async def workload_independent(
+    service: NativeRevisionService, namespace_id: uuid.UUID, requests: list[dict[str, Any]]
+) -> dict[str, Any]:
+    entered = 0
+    maximum = 0
+    ready = asyncio.Event()
+    lock = asyncio.Lock()
+
+    async def overlap(name: str) -> None:
+        nonlocal entered, maximum
+        if name != "authority.after_manifest":
+            return
+        async with lock:
+            entered += 1
+            maximum = max(maximum, entered)
+            if entered == 2:
+                ready.set()
+        await asyncio.wait_for(ready.wait(), timeout=5)
+        async with lock:
+            entered -= 1
+
+    concurrent = NativeRevisionService(service.pool, failpoint=overlap)
+
+    async def create(name: str) -> Any:
+        key = mutation_id()
+        requests.append(request_record("independent-create", path=name, mutation_id=str(key)))
+        return await concurrent.create_text(
+            namespace_id=namespace_id,
+            surface="document",
+            path=name,
+            payload=f"{name}\n",
+            actor="m1-actor",
+            mutation_id=key,
+        )
+
+    published = await asyncio.gather(create("independent-a"), create("independent-b"))
+    return {
+        "C4": {
+            "independent": {
+                "published": sorted(item.path for item in published),
+                "activity_delta": 2,
+                "overlap_observed": maximum >= 2,
+                "max_in_flight": maximum,
+            }
+        }
+    }
+
+
+async def workload_conflict(
+    service: NativeRevisionService, namespace_id: uuid.UUID, requests: list[dict[str, Any]]
+) -> dict[str, Any]:
+    seed = await service.create_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path="conflict.md",
+        payload="seed\n",
+        actor="m1-actor",
+        mutation_id=mutation_id(),
+    )
+    before_same_base = await authority_snapshot(service.pool, namespace_id)
+
+    async def replace(writer: str) -> tuple[str, Any]:
+        key = mutation_id()
+        requests.append(
+            request_record("same-base-replace", writer=writer, mutation_id=str(key), expected_revision=seed.revision_id)
+        )
+        try:
+            return writer, await service.replace_text(
+                namespace_id=namespace_id,
+                surface="document",
+                path="conflict.md",
+                payload=f"{writer}\n",
+                actor=writer,
+                mutation_id=key,
+                expected_revision_id=seed.revision_id,
+            )
+        except ConflictError:
+            return writer, "conflict"
+
+    one, two = await asyncio.gather(replace("writer-a"), replace("writer-b"))
+    winner_pair = next(pair for pair in (one, two) if pair[1] != "conflict")
+    loser_pair = next(pair for pair in (one, two) if pair[1] == "conflict")
+    after_race = await authority_snapshot(service.pool, namespace_id)
+    retry_key = mutation_id()
+    before_retry = await authority_snapshot(service.pool, namespace_id)
+    await service.replace_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path="conflict.md",
+        payload=f"{loser_pair[0]} retry\n",
+        actor=loser_pair[0],
+        mutation_id=retry_key,
+        expected_revision_id=winner_pair[1].revision_id,
+    )
+    after_retry = await authority_snapshot(service.pool, namespace_id)
+
+    left = await service.create_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path="move-a.md",
+        payload="a\n",
+        actor="m1-actor",
+        mutation_id=mutation_id(),
+    )
+    right = await service.create_text(
+        namespace_id=namespace_id,
+        surface="document",
+        path="move-b.md",
+        payload="b\n",
+        actor="m1-actor",
+        mutation_id=mutation_id(),
+    )
+    before_moves = await authority_snapshot(service.pool, namespace_id)
+
+    async def move(actor: str, path: str, revision: str) -> tuple[str, Any]:
+        key = mutation_id()
+        requests.append(
+            request_record(
+                "same-destination-move", mover=actor, path=path, path_to="destination.md", mutation_id=str(key)
+            )
+        )
+        try:
+            return actor, await service.move_text(
+                namespace_id=namespace_id,
+                surface="document",
+                path=path,
+                path_to="destination.md",
+                actor=actor,
+                mutation_id=key,
+                expected_revision_id=revision,
+            )
+        except ConflictError:
+            return actor, "conflict"
+
+    moved_left, moved_right = await asyncio.gather(
+        move("move-a", "move-a.md", left.revision_id), move("move-b", "move-b.md", right.revision_id)
+    )
+    move_winner = next(pair for pair in (moved_left, moved_right) if pair[1] != "conflict")
+    move_loser = next(pair for pair in (moved_left, moved_right) if pair[1] == "conflict")
+    after_moves = await authority_snapshot(service.pool, namespace_id)
+    return {
+        "C4": {
+            "same_base": {
+                "winner": winner_pair[0],
+                "loser": loser_pair[0],
+                "loser_outcome": "conflict",
+                "activity_delta": after_race["activities"] - before_same_base["activities"],
+                "head_revision": winner_pair[1].revision_id,
+                "retry": {
+                    "outcome": "published",
+                    "activity_delta": after_retry["activities"] - before_retry["activities"],
+                },
+            },
+            "same_destination": {
+                "winner": move_winner[0],
+                "loser": move_loser[0],
+                "loser_outcome": "conflict",
+                "destination_count": sum(path == "destination.md" for path in after_moves["paths"]),
+                "activity_delta": after_moves["activities"] - before_moves["activities"],
+            },
+        }
+    }
+
+
+def one_shot_failpoint(actual_name: str) -> Callable[[str], Awaitable[None]]:
+    triggered = False
+
+    async def failpoint(name: str) -> None:
+        nonlocal triggered
+        if name == actual_name and not triggered:
+            triggered = True
+            raise RuntimeError(f"injected native M1 boundary: {actual_name}")
+
+    return failpoint
+
+
+async def invoke_boundary(
+    service: NativeRevisionService,
+    namespace_id: uuid.UUID,
+    boundary: str,
+    key: uuid.UUID,
+    ordinal: int,
+    requests: list[dict[str, Any]],
+    alias_seeds: dict[int, tuple[str, str, str]],
+) -> Any:
+    if boundary == "alias":
+        source, target, seed_revision = alias_seeds[ordinal]
+        requests.append(
+            request_record("failpoint-move", boundary=boundary, mutation_id=str(key), path=source, path_to=target)
+        )
+        return await service.move_text(
+            namespace_id=namespace_id,
+            surface="document",
+            path=source,
+            path_to=target,
+            actor="m1-actor",
+            mutation_id=key,
+            expected_revision_id=seed_revision,
+        )
+    path = f"failpoint-{ordinal}-{boundary}.md"
+    requests.append(request_record("failpoint-create", boundary=boundary, mutation_id=str(key), path=path))
+    return await service.create_text(
+        namespace_id=namespace_id, surface="document", path=path, payload="payload\n", actor="m1-actor", mutation_id=key
+    )
+
+
+async def workload_failpoint(
+    service: NativeRevisionService, namespace_id: uuid.UUID, requests: list[dict[str, Any]]
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    alias_seeds: dict[int, tuple[str, str, str]] = {}
+    for ordinal, boundary in enumerate(PRECOMMIT_BOUNDARIES):
+        key = mutation_id()
+        if boundary == "alias":
+            source = f"failpoint-{ordinal}-old.md"
+            target = f"failpoint-{ordinal}-new.md"
+            seed = await NativeRevisionService(service.pool).create_text(
+                namespace_id=namespace_id,
+                surface="document",
+                path=source,
+                payload="seed\n",
+                actor="m1-actor",
+                mutation_id=mutation_id(),
+            )
+            alias_seeds[ordinal] = (source, target, seed.revision_id)
+            requests.append(request_record("failpoint-alias-seed", path=source, revision=seed.revision_id))
+        before = await authority_snapshot(service.pool, namespace_id)
+        injected = NativeRevisionService(service.pool, failpoint=one_shot_failpoint(ACTUAL_FAILPOINTS[boundary]))
+        try:
+            await invoke_boundary(injected, namespace_id, boundary, key, ordinal, requests, alias_seeds)
+        except RuntimeError as exc:
+            if "injected native M1 boundary" not in str(exc):
+                raise
+        else:
+            raise AdapterError(f"failpoint did not fire for {boundary}")
+        after = await authority_snapshot(service.pool, namespace_id)
+        before_retry = await authority_snapshot(service.pool, namespace_id)
+        published = await invoke_boundary(
+            NativeRevisionService(service.pool), namespace_id, boundary, key, ordinal, requests, alias_seeds
+        )
+        after_retry = await authority_snapshot(service.pool, namespace_id)
+        if published.idempotent_replay:
+            raise AdapterError(f"pre-commit retry unexpectedly replayed for {boundary}")
+        if (
+            after_retry["activities"] - before_retry["activities"] != 1
+            or after_retry["invalidation_intents"] - before_retry["invalidation_intents"] != 1
+        ):
+            raise AdapterError(f"retry failed to publish exactly once for {boundary}")
+        rows.append(
+            {
+                "boundary": boundary,
+                "failure_outcome": "injected",
+                "before": before,
+                "after": after,
+                "retry": {"outcome": "published", "activity_delta": 1, "invalidation_intent_delta": 1},
+            }
+        )
+
+    key = mutation_id()
+    before = await authority_snapshot(service.pool, namespace_id)
+    lost = NativeRevisionService(service.pool, failpoint=one_shot_failpoint("authority.after_commit_before_response"))
+    try:
+        await invoke_boundary(
+            lost, namespace_id, "committed_response_lost", key, len(PRECOMMIT_BOUNDARIES), requests, alias_seeds
+        )
+    except RuntimeError as exc:
+        if "injected native M1 boundary" not in str(exc):
+            raise
+    else:
+        raise AdapterError("committed response loss failpoint did not fire")
+    after = await authority_snapshot(service.pool, namespace_id)
+    recovered = await invoke_boundary(
+        NativeRevisionService(service.pool),
+        namespace_id,
+        "committed_response_lost",
+        key,
+        len(PRECOMMIT_BOUNDARIES),
+        requests,
+        alias_seeds,
+    )
+    final = await authority_snapshot(service.pool, namespace_id)
+    if not recovered.idempotent_replay or final != after:
+        raise AdapterError("committed response recovery was not an idempotent replay")
+    rows.append(
+        {
+            "boundary": "committed_response_lost",
+            "failure_outcome": "response_lost",
+            "before": before,
+            "after": after,
+            "retry": {
+                "outcome": "idempotent_recovery",
+                "revision_delta": 0,
+                "head_delta": 0,
+                "activity_delta": 0,
+                "invalidation_intent_delta": 0,
+                "publication_count": {
+                    "revisions": after["revisions"] - before["revisions"],
+                    "heads": after["head_publications"] - before["head_publications"],
+                    "activities": after["activities"] - before["activities"],
+                    "invalidation_intents": after["invalidation_intents"] - before["invalidation_intents"],
+                },
+            },
+        }
+    )
+    return {"C5": {"failpoints": rows}}
+
+
+async def run() -> dict[str, Any]:
+    contract = load_contract()
+    workload = required_environment("AKB_NATIVE_REVISION_WORKLOAD")
+    expected_cases = {"W1-lifecycle": "C2,C6", "W2-independent": "C4", "W2-conflict": "C4", "W2-failpoint": "C5"}
+    if workload not in expected_cases:
+        raise AdapterError(f"unsupported native M1 workload: {workload}")
+    if required_environment("AKB_NATIVE_REVISION_NATIVE_CASE_IDS") != expected_cases[workload]:
+        raise AdapterError("driver case binding differs from the requested workload")
+    dsn = required_environment("AKB_NATIVE_REVISION_MEASUREMENT_DSN")
+    pool, namespace_id, database = await initialise_measurement_database(dsn)
+    requests: list[dict[str, Any]] = []
+    started = time.perf_counter()
+    try:
+        service = NativeRevisionService(pool)
+        if workload == "W1-lifecycle":
+            cases, requests = await workload_lifecycle(service, namespace_id, contract, requests)
+        elif workload == "W2-independent":
+            cases = await workload_independent(service, namespace_id, requests)
+        elif workload == "W2-conflict":
+            cases = await workload_conflict(service, namespace_id, requests)
+        else:
+            cases = await workload_failpoint(service, namespace_id, requests)
+        authority = await authority_snapshot(pool, namespace_id)
+    finally:
+        await pool.close()
+    elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+    revision = source_revision()
+    runtime, environment = receipt_provenance(revision, database, namespace_id)
+    request_artifact = write_bound_json(
+        run_artifact_path("native-requests"),
+        {"workload": workload, "namespace_id": str(namespace_id), "requests": requests},
+    )
+    authority_artifact = write_bound_json(
+        run_artifact_path("native-authority"),
+        {"workload": workload, "namespace_id": str(namespace_id), "database": database, "final_authority": authority},
+    )
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "workload": workload,
+        "cases": cases,
+        "receipt": {
+            "inputs": {
+                "seed": required_environment("AKB_NATIVE_REVISION_RUN_ID"),
+                "corpus_id": str(namespace_id),
+                "request_trace_id": f"native-m1-{uuid.uuid4().hex}",
+            },
+            "runtime": runtime,
+            "environment": environment,
+            "latency": {"samples_or_artifact": [elapsed_ms], "unit": "ms"},
+            "resources": {
+                "snapshot": {"database": database, "namespace_id": str(namespace_id), "authority": authority}
+            },
+            "requests": {
+                "outcomes": [
+                    {"workload": workload, "operations": len(requests), "authority_revisions": authority["revisions"]}
+                ],
+                "artifact_digest": request_artifact["sha256"],
+            },
+        },
+        "provenance": {
+            "adapter": {"identity": "akb.backend.scripts.native_revision_m1_adapter", "source_revision": revision},
+            "request_artifact": request_artifact,
+            "authority_artifact": authority_artifact,
+        },
+    }
+
+
+def main() -> int:
+    observation_path = Path(required_environment("AKB_NATIVE_REVISION_NATIVE_OBSERVATION_PATH"))
+    observation = asyncio.run(run())
+    write_bound_json(observation_path, observation)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AdapterError as exc:
+        print(f"native revision M1 adapter: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -1145,6 +1145,62 @@ async def test_public_move_response_hash_is_derived_from_the_committed_head():
         assert moved.content_hash == current.content_hash
 
 
+async def test_explicit_slug_put_conflicts_when_base_is_claimed_after_precheck():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        base_path = "notes/explicit-race.md"
+
+        class ExplicitRaceDocumentService(NativeDocumentService):
+            raced = False
+            winner_resource_id: uuid.UUID | None = None
+
+            async def _current_path_is_owned(self, checked_vault_id, path):
+                owned = await super()._current_path_is_owned(checked_vault_id, path)
+                if path == base_path and not self.raced:
+                    self.raced = True
+                    winner = await NativeRevisionService(pool).create_text(
+                        namespace_id=checked_vault_id,
+                        surface="document",
+                        path=path,
+                        payload="competitor",
+                        actor="explicit-slug-racer",
+                        mutation_id=uuid.uuid4(),
+                    )
+                    self.winner_resource_id = winner.resource_id
+                return owned
+
+        service = ExplicitRaceDocumentService(pool=pool)
+        with pytest.raises(ConflictError, match=f"already exists at path: {base_path}"):
+            await service.put(
+                DocumentPutRequest(
+                    vault=vault,
+                    collection="notes",
+                    slug="explicit-race",
+                    title="Explicit race loser",
+                    content="must not be suffixed",
+                ),
+                agent_id="loser",
+            )
+
+        assert service.raced is True
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT resource_id, current_path
+                  FROM native_resources
+                 WHERE namespace_id = $1
+                   AND lifecycle = 'live'
+                   AND current_path LIKE 'notes/explicit-race%'
+                """,
+                vault_id,
+            )
+        assert [(row["resource_id"], row["current_path"]) for row in rows] == [
+            (service.winner_resource_id, base_path)
+        ]
+
+
 async def test_concurrent_title_derived_puts_allocate_distinct_paths():
     async with _fresh_database() as (pool, vault_id):
         async with pool.acquire() as conn:

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -1025,6 +1025,69 @@ async def test_collection_only_move_reallocates_after_destination_authority_race
             )
 
 
+async def test_collection_only_move_searches_beyond_all_uuid_path_candidates():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        document_service = NativeDocumentService(pool=pool)
+        created = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="exhausted-candidates",
+                title="Exhausted candidates",
+                content="original",
+            ),
+            agent_id="creator",
+        )
+        _, original = await document_service._current(vault, created.path)
+        stem = "archive/exhausted-candidates"
+        claimed_paths = [
+            f"{stem}.md",
+            *(f"{stem}-{original.resource_id.hex[:width]}.md" for width in (8, 12, 16, 32)),
+            f"{stem}-{original.resource_id.hex}-2.md",
+        ]
+        native = NativeRevisionService(pool)
+        for path in claimed_paths:
+            await native.create_text(
+                namespace_id=vault_id,
+                surface="document",
+                path=path,
+                payload=f"claimed: {path}",
+                actor="candidate-claimer",
+                mutation_id=uuid.uuid4(),
+            )
+
+        expected = f"{stem}-{original.resource_id.hex}-3.md"
+        assert (
+            await document_service._resolve_native_free_path(
+                vault_id,
+                f"{stem}.md",
+                original.resource_id,
+            )
+            == expected
+        )
+        moved = await asyncio.wait_for(
+            document_service.move(
+                vault,
+                created.path,
+                collection="archive",
+                agent_id="mover",
+            ),
+            timeout=3,
+        )
+
+        assert moved.path == expected
+        assert (
+            await native.get_current_resource(
+                namespace_id=vault_id,
+                surface="document",
+                resource_id=original.resource_id,
+            )
+        ).path == expected
+
+
 async def test_public_move_response_hash_is_derived_from_the_committed_head():
     async with _fresh_database() as (pool, vault_id):
         async with pool.acquire() as conn:

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -43,7 +43,7 @@ _DSN = os.environ.get(
 async def _can_connect() -> bool:
     try:
         conn = await asyncpg.connect(_DSN, timeout=2)
-    except (OSError, asyncpg.PostgresError):
+    except OSError, asyncpg.PostgresError:
         return False
     await conn.close()
     return True
@@ -181,9 +181,10 @@ async def test_create_get_replace_are_native_atomic_and_leave_legacy_projection_
         assert current.text == "beta\n"
 
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                "SELECT current_commit FROM documents WHERE id = $1", legacy_id
-            ) == "0123456789abcdef0123456789abcdef01234567"
+            assert (
+                await conn.fetchval("SELECT current_commit FROM documents WHERE id = $1", legacy_id)
+                == "0123456789abcdef0123456789abcdef01234567"
+            )
             rows = await conn.fetch(
                 """
                 SELECT r.revision_id, r.parent_revision_id, r.action,
@@ -277,14 +278,17 @@ async def test_document_and_file_cannot_own_the_same_namespace_path():
         assert len([item for item in outcomes if not isinstance(item, Exception)]) == 1
         assert len([item for item in outcomes if isinstance(item, ConflictError)]) == 1
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                """
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*) FROM native_resources
                  WHERE namespace_id = $1 AND current_path = 'notes/native.md'
                    AND lifecycle = 'live'
                 """,
-                vault_id,
-            ) == 1
+                    vault_id,
+                )
+                == 1
+            )
 
 
 async def test_waiting_unpinned_replacements_publish_monotonic_lineage_time():
@@ -334,9 +338,286 @@ async def test_waiting_unpinned_replacements_publish_monotonic_lineage_time():
             first.revision_id,
             second.revision_id,
         ]
-        assert [row["occurred_at"] for row in chronological] == sorted(
-            row["occurred_at"] for row in chronological
+        assert [row["occurred_at"] for row in chronological] == sorted(row["occurred_at"] for row in chronological)
+
+
+async def test_public_unpinned_metadata_and_body_updates_recompute_and_serialize():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        document_service = NativeDocumentService(pool=pool)
+        created = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="public-race",
+                title="Public race",
+                content="created",
+            ),
+            agent_id="creator",
         )
+
+        prepared_count = 0
+        both_prepared = asyncio.Event()
+
+        async def hold_after_prepare(name: str) -> None:
+            nonlocal prepared_count
+            if name != "payload.after_prepare_before_tx":
+                return
+            prepared_count += 1
+            if prepared_count == 2:
+                both_prepared.set()
+            await both_prepared.wait()
+
+        native = NativeRevisionService(pool, failpoint=hold_after_prepare)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        document_service._native = injected_native  # type: ignore[method-assign]
+        first, second = await asyncio.gather(
+            document_service.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(title="Updated title"),
+                agent_id="first",
+            ),
+            document_service.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(content="second"),
+                agent_id="second",
+            ),
+        )
+
+        rows = await NativeRevisionRepository(pool).list_history(
+            resource_id=(
+                await native.get_current(
+                    namespace_id=vault_id,
+                    surface="document",
+                    path=created.path,
+                )
+            ).resource_id,
+            limit=10,
+        )
+        chronological = list(reversed(rows))
+        assert chronological[0]["revision_id"] == created.commit_hash
+        assert {row["revision_id"] for row in chronological[1:]} == {
+            first.commit_hash,
+            second.commit_hash,
+        }
+        response_parents = {
+            first.commit_hash: first.previous_commit,
+            second.commit_hash: second.previous_commit,
+        }
+        assert response_parents == {row["revision_id"]: row["parent_revision_id"] for row in chronological[1:]}
+        current = await document_service.get(vault, created.path)
+        assert current.title == "Updated title"
+        assert current.content == "second"
+
+
+async def test_concurrent_unpinned_disjoint_edits_recompute_and_both_survive():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        document_service = NativeDocumentService(pool=pool)
+        created = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="edit-race",
+                title="Edit race",
+                content="alpha one\nbeta two",
+            ),
+            agent_id="creator",
+        )
+        prepared_count = 0
+        both_prepared = asyncio.Event()
+
+        async def hold_first_attempts(name: str) -> None:
+            nonlocal prepared_count
+            if name != "payload.after_prepare_before_tx":
+                return
+            prepared_count += 1
+            if prepared_count == 2:
+                both_prepared.set()
+            await both_prepared.wait()
+
+        native = NativeRevisionService(pool, failpoint=hold_first_attempts)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        document_service._native = injected_native  # type: ignore[method-assign]
+        await asyncio.gather(
+            document_service.edit(
+                vault,
+                created.path,
+                "alpha",
+                "ALPHA",
+                agent_id="alpha-editor",
+            ),
+            document_service.edit(
+                vault,
+                created.path,
+                "beta",
+                "BETA",
+                agent_id="beta-editor",
+            ),
+        )
+
+        current = await document_service.get(vault, created.path)
+        assert current.content == "ALPHA one\nBETA two"
+
+
+async def test_create_reuses_a_move_alias_and_atomically_retires_the_redirect():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        created = await service.create_text(**_create_args(vault_id))
+        moved = await service.move_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+            path_to="archive/native.md",
+            actor="mover",
+            mutation_id=uuid.uuid4(),
+        )
+
+        replacement_args = _create_args(vault_id)
+        replacement_args["payload"] = "fresh lineage"
+        replacement = await service.create_text(**replacement_args)
+
+        assert replacement.resource_id != created.resource_id
+        assert (
+            await service.get_current_reference(
+                namespace_id=vault_id,
+                surface="document",
+                reference="notes/native.md",
+            )
+        ).resource_id == replacement.resource_id
+        assert (
+            await service.get_current_reference(
+                namespace_id=vault_id,
+                surface="document",
+                reference="archive/native.md",
+            )
+        ).resource_id == moved.resource_id
+        async with pool.acquire() as conn:
+            retired = await conn.fetchrow(
+                """
+                SELECT retired_revision_id, retired_at
+                  FROM native_resource_path_aliases
+                 WHERE namespace_id = $1 AND old_path = 'notes/native.md'
+                """,
+                vault_id,
+            )
+        assert retired["retired_revision_id"] == replacement.revision_id
+        assert retired["retired_at"] is not None
+
+
+async def test_alias_delete_competing_with_current_path_update_has_no_raw_pg_deadlock():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        await service.create_text(**_create_args(vault_id))
+        await service.move_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+            path_to="archive/native.md",
+            actor="mover",
+            mutation_id=uuid.uuid4(),
+        )
+
+        alias_has_resource = asyncio.Event()
+        current_has_path = asyncio.Event()
+        current_attempted_resource = asyncio.Event()
+
+        class CoordinatedRepository(NativeRevisionRepository):
+            async def lock_resource(self, conn, resource_id):
+                task_name = asyncio.current_task().get_name()
+                if task_name == "current-update":
+                    current_attempted_resource.set()
+                    return await super().lock_resource(conn, resource_id)
+                resource = await super().lock_resource(conn, resource_id)
+                if task_name == "alias-delete":
+                    alias_has_resource.set()
+                    path_waiter = asyncio.create_task(current_has_path.wait())
+                    resource_waiter = asyncio.create_task(current_attempted_resource.wait())
+                    _, pending = await asyncio.wait(
+                        {path_waiter, resource_waiter},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for waiter in pending:
+                        waiter.cancel()
+                return resource
+
+            async def lock_paths(self, conn, namespace_id, surface, *paths):
+                if asyncio.current_task().get_name() == "current-update":
+                    await alias_has_resource.wait()
+                    await super().lock_paths(conn, namespace_id, surface, *paths)
+                    current_has_path.set()
+                    return
+                await super().lock_paths(conn, namespace_id, surface, *paths)
+
+        repository = CoordinatedRepository(pool)
+        alias_delete = asyncio.create_task(
+            NativeRevisionService(pool, repository=repository).delete_resource(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                actor="deleter",
+                mutation_id=uuid.uuid4(),
+            ),
+            name="alias-delete",
+        )
+        current_update = asyncio.create_task(
+            NativeRevisionService(pool, repository=repository).replace_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="archive/native.md",
+                payload="competing update",
+                actor="updater",
+                mutation_id=uuid.uuid4(),
+            ),
+            name="current-update",
+        )
+        outcomes = await asyncio.wait_for(
+            asyncio.gather(alias_delete, current_update, return_exceptions=True),
+            timeout=5,
+        )
+
+        assert not any(isinstance(item, asyncpg.DeadlockDetectedError) for item in outcomes)
+        assert all(
+            not isinstance(item, Exception) or isinstance(item, (ConflictError, NotFoundError)) for item in outcomes
+        )
+
+
+async def test_post_prepare_failpoint_is_distinct_and_precedes_authority_entry():
+    async with _fresh_database() as (pool, vault_id):
+        seen: list[str] = []
+
+        async def stop_before_authority(name: str) -> None:
+            seen.append(name)
+            if name == "payload.after_prepare_before_tx":
+                raise RuntimeError("stop before authority")
+
+        with pytest.raises(RuntimeError, match="stop before authority"):
+            await NativeRevisionService(pool, failpoint=stop_before_authority).create_text(**_create_args(vault_id))
+
+        assert seen == [
+            "payload.before_prepare",
+            "payload.after_verified",
+            "payload.after_prepare_before_tx",
+        ]
+        assert await _authority_counts(pool) == {
+            "native_resources": 0,
+            "native_revisions": 0,
+            "native_payload_manifests": 0,
+            "native_revision_activity": 0,
+            "native_invalidation_intents": 0,
+        }
 
 
 @pytest.mark.parametrize(
@@ -461,12 +742,15 @@ async def test_delete_failpoints_preserve_live_resource_and_alias(boundary: str)
         )
         assert current.revision_id == moved.revision_id
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                """
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*) FROM native_resource_path_aliases
                  WHERE retired_revision_id IS NULL
                 """
-            ) == 1
+                )
+                == 1
+            )
 
 
 async def test_committed_response_lost_retry_returns_same_revision_once():
@@ -753,9 +1037,7 @@ async def test_full_native_document_lifecycle_preserves_compatibility_without_gi
         )
         assert fresh_snapshot.resource_id != first_resource
         fresh_history = await backend.document_history(vault, recreated.path, limit=20)
-        assert [entry["hash"] for entry in fresh_history["history"]] == [
-            recreated.commit_hash
-        ]
+        assert [entry["hash"] for entry in fresh_history["history"]] == [recreated.commit_hash]
 
         async with pool.acquire() as conn:
             rows = await conn.fetch(
@@ -769,14 +1051,20 @@ async def test_full_native_document_lifecycle_preserves_compatibility_without_gi
                 recreated.path,
             )
             assert [row["lifecycle"] for row in rows] == ["deleted", "live"]
-            assert await conn.fetchval(
-                "SELECT action FROM native_revisions WHERE revision_id = $1",
-                rows[0]["head_revision_id"],
-            ) == "delete"
-            assert await conn.fetchval(
-                "SELECT count(*) FROM documents WHERE vault_id = $1",
-                vault_id,
-            ) == 0
+            assert (
+                await conn.fetchval(
+                    "SELECT action FROM native_revisions WHERE revision_id = $1",
+                    rows[0]["head_revision_id"],
+                )
+                == "delete"
+            )
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM documents WHERE vault_id = $1",
+                    vault_id,
+                )
+                == 0
+            )
 
         with pytest.raises(NativeRevisionUnsupportedSurfaceError):
             await document_service.browse(vault)

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -183,7 +183,7 @@ async def test_create_get_replace_are_native_atomic_and_leave_legacy_projection_
         async with pool.acquire() as conn:
             assert (
                 await conn.fetchval("SELECT current_commit FROM documents WHERE id = $1", legacy_id)
-                == "0123456789abcdef0123456789abcdef01234567"
+                == "0123456789abcdef0123456789abcdef01234567"  # pragma: allowlist secret
             )
             rows = await conn.fetch(
                 """

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -291,6 +291,95 @@ async def test_document_and_file_cannot_own_the_same_namespace_path():
             )
 
 
+async def test_create_retires_a_cross_surface_alias_before_claiming_its_path():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        file_args = _create_args(vault_id)
+        file_args["surface"] = "file"
+        file_resource = await service.create_text(**file_args)
+        file_move = await service.move_text(
+            namespace_id=vault_id,
+            surface="file",
+            path="notes/native.md",
+            path_to="archive/native.bin",
+            actor="file-mover",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=file_resource.revision_id,
+        )
+
+        document = await service.create_text(**_create_args(vault_id))
+
+        assert document.resource_id != file_resource.resource_id
+        assert (
+            await service.get_current_reference(
+                namespace_id=vault_id,
+                surface="document",
+                reference="notes/native.md",
+            )
+        ).resource_id == document.resource_id
+        assert (
+            await service.get_current_reference(
+                namespace_id=vault_id,
+                surface="file",
+                reference="archive/native.bin",
+            )
+        ).revision_id == file_move.revision_id
+        with pytest.raises(NotFoundError):
+            await service.get_current_reference(
+                namespace_id=vault_id,
+                surface="file",
+                reference="notes/native.md",
+            )
+        async with pool.acquire() as conn:
+            retired = await conn.fetchrow(
+                """
+                SELECT retired_revision_id
+                  FROM native_resource_path_aliases
+                 WHERE namespace_id = $1 AND old_path = 'notes/native.md'
+                """,
+                vault_id,
+            )
+        assert retired["retired_revision_id"] == document.revision_id
+
+
+async def test_move_rejects_a_destination_alias_owned_by_another_surface():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        file_args = _create_args(vault_id)
+        file_args["surface"] = "file"
+        file_resource = await service.create_text(**file_args)
+        await service.move_text(
+            namespace_id=vault_id,
+            surface="file",
+            path="notes/native.md",
+            path_to="archive/native.bin",
+            actor="file-mover",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=file_resource.revision_id,
+        )
+        document_args = _create_args(vault_id)
+        document_args["path"] = "notes/document.md"
+        document = await service.create_text(**document_args)
+
+        with pytest.raises(ConflictError, match="alias already owns path"):
+            await service.move_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/document.md",
+                path_to="notes/native.md",
+                actor="document-mover",
+                mutation_id=uuid.uuid4(),
+                expected_revision_id=document.revision_id,
+            )
+
+        current = await service.get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/document.md",
+        )
+        assert current.revision_id == document.revision_id
+
+
 async def test_waiting_unpinned_replacements_publish_monotonic_lineage_time():
     async with _fresh_database() as (pool, vault_id):
         created = await NativeRevisionService(pool).create_text(**_create_args(vault_id))
@@ -718,6 +807,328 @@ async def test_expected_commit_update_remains_single_attempt_across_head_race():
         assert current.title == "Original title"
 
 
+async def test_public_move_retries_a_concurrent_rename_and_preserves_unspecified_slug():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="original-name",
+                title="Move race",
+                content="stable body",
+            ),
+            agent_id="creator",
+        )
+
+        class RenameRaceNativeService(NativeRevisionService):
+            raced = False
+
+            async def move_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    await NativeRevisionService(pool).move_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=kwargs["path"],
+                        path_to="notes/concurrent-name.md",
+                        actor="rename-racer",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=kwargs["expected_revision_id"],
+                    )
+                return await super().move_text(**kwargs)
+
+        native = RenameRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        moved = await target.move(
+            vault,
+            created.path,
+            collection="archive",
+            agent_id="target",
+        )
+
+        assert native.raced is True
+        assert moved.path == "archive/concurrent-name.md"
+        current = await target.get(vault, created.path)
+        assert current.path == moved.path
+        assert moved.current_commit == current.current_commit
+
+
+async def test_public_move_retry_keeps_resource_identity_after_alias_shadowing_create():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="shadowed-name",
+                title="Alias shadow race",
+                content="original body",
+            ),
+            agent_id="creator",
+        )
+        _, original = await target._current(vault, created.path)
+
+        class AliasShadowRaceNativeService(NativeRevisionService):
+            raced = False
+            replacement_resource_id: uuid.UUID | None = None
+
+            async def move_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    competitor = NativeRevisionService(pool)
+                    await competitor.move_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=kwargs["path"],
+                        path_to="notes/concurrent-name.md",
+                        actor="rename-racer",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=kwargs["expected_revision_id"],
+                        expected_resource_id=kwargs["expected_resource_id"],
+                    )
+                    replacement = await competitor.create_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=kwargs["path"],
+                        payload=original.text.replace("original body", "replacement body"),
+                        actor="alias-shadow-racer",
+                        mutation_id=uuid.uuid4(),
+                    )
+                    self.replacement_resource_id = replacement.resource_id
+                return await super().move_text(**kwargs)
+
+        native = AliasShadowRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        moved = await target.move(
+            vault,
+            created.path,
+            collection="archive",
+            agent_id="target",
+        )
+
+        assert native.raced is True
+        assert moved.path == "archive/concurrent-name.md"
+        original_after = await native.get_current_resource(
+            namespace_id=vault_id,
+            surface="document",
+            resource_id=original.resource_id,
+        )
+        assert original_after.path == moved.path
+        replacement = await native.get_current_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference=created.path,
+        )
+        assert replacement.resource_id == native.replacement_resource_id
+        assert replacement.resource_id != original.resource_id
+        assert "replacement body" in replacement.text
+
+
+async def test_collection_only_move_reallocates_after_destination_authority_race():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="allocation-race",
+                title="Move allocation race",
+                content="original body",
+            ),
+            agent_id="creator",
+        )
+        _, original = await target._current(vault, created.path)
+
+        class DestinationRaceNativeService(NativeRevisionService):
+            raced = False
+            winner_resource_id: uuid.UUID | None = None
+
+            async def move_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    winner = await NativeRevisionService(pool).create_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=kwargs["path_to"],
+                        payload=original.text.replace("original body", "destination winner"),
+                        actor="destination-racer",
+                        mutation_id=uuid.uuid4(),
+                    )
+                    self.winner_resource_id = winner.resource_id
+                return await super().move_text(**kwargs)
+
+        native = DestinationRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        moved = await target.move(
+            vault,
+            created.path,
+            collection="archive",
+            agent_id="target",
+        )
+
+        assert native.raced is True
+        assert moved.path.startswith("archive/allocation-race-")
+        assert moved.path.endswith(".md")
+        assert (
+            await native.get_current_resource(
+                namespace_id=vault_id,
+                surface="document",
+                resource_id=original.resource_id,
+            )
+        ).path == moved.path
+        destination_winner = await native.get_current_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference="archive/allocation-race.md",
+        )
+        assert destination_winner.resource_id == native.winner_resource_id
+
+        another = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="explicit-source",
+                title="Explicit source",
+                content="body",
+            ),
+            agent_id="creator",
+        )
+        with pytest.raises(ConflictError, match="already exists at path"):
+            await target.move(
+                vault,
+                another.path,
+                collection="archive",
+                slug="allocation-race",
+                agent_id="explicit-mover",
+            )
+
+
+async def test_public_move_response_hash_is_derived_from_the_committed_head():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="content-race",
+                title="Content race",
+                content="original body",
+            ),
+            agent_id="creator",
+        )
+
+        class ContentRaceNativeService(NativeRevisionService):
+            raced = False
+
+            async def move_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    current = await self.get_current_reference(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        reference=kwargs["path"],
+                    )
+                    await NativeRevisionService(pool).replace_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=current.path,
+                        payload=current.text.replace("original body", "concurrent body"),
+                        actor="content-racer",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=current.revision_id,
+                    )
+                return await super().move_text(**kwargs)
+
+        native = ContentRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        moved = await target.move(
+            vault,
+            created.path,
+            collection="archive",
+            agent_id="target",
+        )
+
+        current = await target.get(vault, moved.path)
+        assert current.content == "concurrent body"
+        assert moved.content_hash == current.content_hash
+
+
+async def test_concurrent_title_derived_puts_allocate_distinct_paths():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        both_resolved = asyncio.Event()
+        resolved_count = 0
+
+        class CoordinatedDocumentService(NativeDocumentService):
+            async def _resolve_native_free_path(self, *args, **kwargs):
+                nonlocal resolved_count
+                path = await super()._resolve_native_free_path(*args, **kwargs)
+                resolved_count += 1
+                if resolved_count == 2:
+                    both_resolved.set()
+                await both_resolved.wait()
+                return path
+
+        service = CoordinatedDocumentService(pool=pool)
+        request = DocumentPutRequest(
+            vault=vault,
+            collection="notes",
+            title="Same implicit title",
+            content="body",
+        )
+        first, second = await asyncio.gather(
+            service.put(request, agent_id="first"),
+            service.put(request, agent_id="second"),
+        )
+
+        assert first.path != second.path
+        assert {first.path, second.path} & {"notes/same-implicit-title.md"}
+        assert all(path.startswith("notes/same-implicit-title") for path in (first.path, second.path))
+
+        with pytest.raises(ConflictError, match="already exists at path"):
+            await NativeDocumentService(pool=pool).put(
+                DocumentPutRequest(
+                    vault=vault,
+                    collection="notes",
+                    slug="same-implicit-title",
+                    title="Explicit slug remains exact",
+                    content="must not suffix",
+                ),
+                agent_id="explicit",
+            )
+
+
 async def test_create_reuses_a_move_alias_and_atomically_retires_the_redirect():
     async with _fresh_database() as (pool, vault_id):
         service = NativeRevisionService(pool)
@@ -1026,6 +1437,23 @@ async def test_committed_response_lost_retry_returns_same_revision_once():
         with pytest.raises(ConflictError, match="idempotency"):
             changed = _create_args(vault_id, mutation_id=mutation_id)
             changed["payload"] = "different retry"
+            await service.create_text(**changed)
+
+
+async def test_create_idempotency_fingerprint_includes_requested_resource_identity():
+    async with _fresh_database() as (pool, vault_id):
+        mutation_id = uuid.uuid4()
+        first_resource_id = uuid.uuid4()
+        second_resource_id = uuid.uuid4()
+        service = NativeRevisionService(pool)
+        args = _create_args(vault_id, mutation_id=mutation_id)
+        args["resource_id"] = first_resource_id
+        created = await service.create_text(**args)
+        assert created.resource_id == first_resource_id
+
+        changed = _create_args(vault_id, mutation_id=mutation_id)
+        changed["resource_id"] = second_resource_id
+        with pytest.raises(ConflictError, match="idempotency"):
             await service.create_text(**changed)
 
 

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -135,7 +135,7 @@ async def test_create_get_replace_are_native_atomic_and_leave_legacy_projection_
                 """,
                 vault_id,
                 "notes/native.md",
-                "0123456789abcdef0123456789abcdef01234567",
+                "0123456789abcdef0123456789abcdef01234567",  # pragma: allowlist secret
             )
 
         service = NativeRevisionService(pool)

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -472,6 +472,252 @@ async def test_concurrent_unpinned_disjoint_edits_recompute_and_both_survive():
         assert current.content == "ALPHA one\nBETA two"
 
 
+@pytest.mark.parametrize("operation", ["update", "edit"])
+async def test_unpinned_public_mutation_survives_more_than_four_successive_head_races(
+    operation: str,
+):
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        document_service = NativeDocumentService(pool=pool)
+        created = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug=f"many-races-{operation}",
+                title="Many races",
+                content="alpha body",
+            ),
+            agent_id="creator",
+        )
+
+        class SixRaceNativeService(NativeRevisionService):
+            forced_races = 0
+
+            async def replace_text(self, **kwargs):
+                if kwargs["actor"] == "target" and self.forced_races < 6:
+                    self.forced_races += 1
+                    current = await self.get_current_reference(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        reference=kwargs["path"],
+                    )
+                    await NativeRevisionService(pool).replace_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=current.path,
+                        payload=current.text,
+                        actor=f"forced-racer-{self.forced_races}",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=current.revision_id,
+                    )
+                return await super().replace_text(**kwargs)
+
+        native = SixRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        document_service._native = injected_native  # type: ignore[method-assign]
+        if operation == "update":
+            await document_service.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(title="Eventually published"),
+                agent_id="target",
+            )
+        else:
+            await document_service.edit(
+                vault,
+                created.path,
+                "alpha",
+                "omega",
+                agent_id="target",
+            )
+
+        assert native.forced_races == 6
+        current = await document_service.get(vault, created.path)
+        if operation == "update":
+            assert current.title == "Eventually published"
+            assert current.content == "alpha body"
+        else:
+            assert current.content == "omega body"
+
+
+async def test_content_hash_only_update_retries_across_metadata_head_change():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        competitor = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="hash-metadata-race",
+                title="Original title",
+                content="stable body",
+            ),
+            agent_id="creator",
+        )
+        original = await target.get(vault, created.path)
+
+        class MetadataRaceNativeService(NativeRevisionService):
+            raced = False
+
+            async def replace_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    await competitor.update(
+                        vault,
+                        created.path,
+                        DocumentUpdateRequest(title="Concurrent metadata"),
+                        agent_id="metadata-racer",
+                    )
+                return await super().replace_text(**kwargs)
+
+        native = MetadataRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        await target.update(
+            vault,
+            created.path,
+            DocumentUpdateRequest(
+                tags=["target"],
+                expected_content_hash=original.content_hash,
+            ),
+            agent_id="target",
+        )
+
+        current = await target.get(vault, created.path)
+        assert native.raced is True
+        assert current.title == "Concurrent metadata"
+        assert current.tags == ["target"]
+        assert current.content == "stable body"
+
+
+async def test_content_hash_only_update_conflicts_after_concurrent_body_change():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        competitor = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="hash-body-race",
+                title="Original title",
+                content="original body",
+            ),
+            agent_id="creator",
+        )
+        original = await target.get(vault, created.path)
+
+        class BodyRaceNativeService(NativeRevisionService):
+            raced = False
+
+            async def replace_text(self, **kwargs):
+                if kwargs["actor"] == "target" and not self.raced:
+                    self.raced = True
+                    await competitor.update(
+                        vault,
+                        created.path,
+                        DocumentUpdateRequest(content="changed body"),
+                        agent_id="body-racer",
+                    )
+                return await super().replace_text(**kwargs)
+
+        native = BodyRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        with pytest.raises(ConflictError, match="content_hash moved"):
+            await target.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(
+                    title="Must not publish",
+                    expected_content_hash=original.content_hash,
+                ),
+                agent_id="target",
+            )
+
+        current = await target.get(vault, created.path)
+        assert native.raced is True
+        assert current.title == "Original title"
+        assert current.content == "changed body"
+
+
+async def test_expected_commit_update_remains_single_attempt_across_head_race():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        target = NativeDocumentService(pool=pool)
+        created = await target.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="exact-head-race",
+                title="Original title",
+                content="stable body",
+            ),
+            agent_id="creator",
+        )
+
+        class ExactHeadRaceNativeService(NativeRevisionService):
+            race_count = 0
+
+            async def replace_text(self, **kwargs):
+                if kwargs["actor"] == "target" and self.race_count == 0:
+                    self.race_count += 1
+                    current = await self.get_current_reference(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        reference=kwargs["path"],
+                    )
+                    await NativeRevisionService(pool).replace_text(
+                        namespace_id=kwargs["namespace_id"],
+                        surface=kwargs["surface"],
+                        path=current.path,
+                        payload=current.text,
+                        actor="exact-head-racer",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=current.revision_id,
+                    )
+                return await super().replace_text(**kwargs)
+
+        native = ExactHeadRaceNativeService(pool)
+
+        async def injected_native() -> NativeRevisionService:
+            return native
+
+        target._native = injected_native  # type: ignore[method-assign]
+        with pytest.raises(ConflictError, match="Native Revision conflict"):
+            await target.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(
+                    title="Must not publish",
+                    expected_commit=created.commit_hash,
+                ),
+                agent_id="target",
+            )
+
+        assert native.race_count == 1
+        current = await target.get(vault, created.path)
+        assert current.title == "Original title"
+
+
 async def test_create_reuses_a_move_alias_and_atomically_retires_the_redirect():
     async with _fresh_database() as (pool, vault_id):
         service = NativeRevisionService(pool)

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -17,8 +17,15 @@ from pathlib import Path
 import asyncpg
 import pytest
 
-from app.exceptions import ConflictError, ValidationError
+from app.exceptions import ConflictError, NotFoundError, ValidationError
+from app.models.document import DocumentPutRequest, DocumentUpdateRequest
+from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.m1_reference_payload_store import M1ReferencePayloadStore
+from app.services.native_document_service import (
+    NativeDocumentService,
+    NativeRevisionUnsupportedSurfaceError,
+)
+from app.services.native_revision_backend import NativeRevisionBackend
 from app.services.native_revision_service import NativeRevisionService
 
 
@@ -58,6 +65,8 @@ def _load_migration():
 @asynccontextmanager
 async def _fresh_database():
     if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
         pytest.skip(f"Postgres not reachable at {_DSN}")
     admin = await asyncpg.connect(_DSN)
     name = f"akb_native_{uuid.uuid4().hex[:12]}"
@@ -252,6 +261,84 @@ async def test_same_path_create_has_one_winner_and_distinct_paths_do_not_share_a
         assert {item.path for item in extra} == {"notes/left.md", "notes/right.md"}
 
 
+async def test_document_and_file_cannot_own_the_same_namespace_path():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        document = _create_args(vault_id)
+        file = _create_args(vault_id)
+        file["surface"] = "file"
+
+        outcomes = await asyncio.gather(
+            service.create_text(**document),
+            service.create_text(**file),
+            return_exceptions=True,
+        )
+
+        assert len([item for item in outcomes if not isinstance(item, Exception)]) == 1
+        assert len([item for item in outcomes if isinstance(item, ConflictError)]) == 1
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                """
+                SELECT count(*) FROM native_resources
+                 WHERE namespace_id = $1 AND current_path = 'notes/native.md'
+                   AND lifecycle = 'live'
+                """,
+                vault_id,
+            ) == 1
+
+
+async def test_waiting_unpinned_replacements_publish_monotonic_lineage_time():
+    async with _fresh_database() as (pool, vault_id):
+        created = await NativeRevisionService(pool).create_text(**_create_args(vault_id))
+        first_holds_lock = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def first_failpoint(name: str) -> None:
+            if name == "authority.after_manifest":
+                first_holds_lock.set()
+                await release_first.wait()
+
+        first_service = NativeRevisionService(pool, failpoint=first_failpoint)
+        first_task = asyncio.create_task(
+            first_service.replace_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                payload="first waiter",
+                actor="first",
+                mutation_id=uuid.uuid4(),
+            )
+        )
+        await first_holds_lock.wait()
+        second_task = asyncio.create_task(
+            NativeRevisionService(pool).replace_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                payload="second waiter",
+                actor="second",
+                mutation_id=uuid.uuid4(),
+            )
+        )
+        await asyncio.sleep(0)
+        release_first.set()
+        first, second = await asyncio.gather(first_task, second_task)
+
+        rows = await NativeRevisionRepository(pool).list_history(
+            resource_id=created.resource_id,
+            limit=10,
+        )
+        chronological = list(reversed(rows))
+        assert [row["revision_id"] for row in chronological] == [
+            created.revision_id,
+            first.revision_id,
+            second.revision_id,
+        ]
+        assert [row["occurred_at"] for row in chronological] == sorted(
+            row["occurred_at"] for row in chronological
+        )
+
+
 @pytest.mark.parametrize(
     "boundary",
     [
@@ -259,8 +346,10 @@ async def test_same_path_create_has_one_winner_and_distinct_paths_do_not_share_a
         "authority.after_manifest",
         "authority.after_revision",
         "authority.after_head",
+        "authority.after_path",
         "authority.after_activity",
         "authority.after_invalidation",
+        "authority.before_commit",
     ],
 )
 async def test_authority_failpoints_rollback_every_published_fact(boundary: str):
@@ -289,6 +378,95 @@ async def test_authority_failpoints_rollback_every_published_fact(boundary: str)
         # unreferenced verified row is not a Revision and may be retried.
         async with pool.acquire() as conn:
             assert await conn.fetchval("SELECT count(*) FROM m1_reference_payloads") == 1
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "authority.after_path",
+        "authority.after_alias",
+        "authority.before_commit",
+    ],
+)
+async def test_move_failpoints_rollback_head_path_alias_and_activity(boundary: str):
+    async with _fresh_database() as (pool, vault_id):
+        created = await NativeRevisionService(pool).create_text(**_create_args(vault_id))
+
+        async def failpoint(name: str) -> None:
+            if name == boundary:
+                raise RuntimeError(f"injected:{name}")
+
+        service = NativeRevisionService(pool, failpoint=failpoint)
+        with pytest.raises(RuntimeError, match=f"injected:{boundary}"):
+            await service.move_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                path_to="archive/native.md",
+                actor="mover",
+                mutation_id=uuid.uuid4(),
+                expected_revision_id=created.revision_id,
+            )
+
+        current = await NativeRevisionService(pool).get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+        )
+        assert current.revision_id == created.revision_id
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT count(*) FROM native_resource_path_aliases") == 0
+        assert await _authority_counts(pool) == {
+            "native_resources": 1,
+            "native_revisions": 1,
+            "native_payload_manifests": 1,
+            "native_revision_activity": 1,
+            "native_invalidation_intents": 1,
+        }
+
+
+@pytest.mark.parametrize("boundary", ["authority.after_alias", "authority.before_commit"])
+async def test_delete_failpoints_preserve_live_resource_and_alias(boundary: str):
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        created = await service.create_text(**_create_args(vault_id))
+        moved = await service.move_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+            path_to="archive/native.md",
+            actor="mover",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=created.revision_id,
+        )
+
+        async def failpoint(name: str) -> None:
+            if name == boundary:
+                raise RuntimeError(f"injected:{name}")
+
+        with pytest.raises(RuntimeError, match=f"injected:{boundary}"):
+            await NativeRevisionService(pool, failpoint=failpoint).delete_resource(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                actor="deleter",
+                mutation_id=uuid.uuid4(),
+                expected_revision_id=moved.revision_id,
+            )
+
+        current = await service.get_current_reference(
+            namespace_id=vault_id,
+            surface="document",
+            reference="notes/native.md",
+        )
+        assert current.revision_id == moved.revision_id
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                """
+                SELECT count(*) FROM native_resource_path_aliases
+                 WHERE retired_revision_id IS NULL
+                """
+            ) == 1
 
 
 async def test_committed_response_lost_retry_returns_same_revision_once():
@@ -427,3 +605,178 @@ async def test_native_substrate_has_no_git_legacy_projection_or_write_lane_depen
     source = "\n".join(path.read_text(encoding="utf-8") for path in paths)
     for forbidden in ("GitService", "git_service", "current_commit", "write_lane", "documents"):
         assert forbidden not in source
+
+
+async def test_full_native_document_lifecycle_preserves_compatibility_without_git_or_legacy_projection():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        document_service = NativeDocumentService(pool=pool)
+        backend = NativeRevisionBackend(pool=pool, document_service=document_service)
+
+        created = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="native",
+                title="Native note",
+                content="Alpha body",
+                type="note",
+                status="draft",
+                tags=["native"],
+                summary="first revision",
+            ),
+            agent_id="m1-writer",
+        )
+        assert created.path == "notes/native.md"
+        assert created.commit_hash == created.current_commit
+        assert len(created.commit_hash) == 40
+        assert created.action == "created"
+
+        first = await document_service.get(vault, created.path)
+        assert first.content == "Alpha body"
+        assert first.title == "Native note"
+        assert first.current_commit == created.commit_hash
+        first_resource = (
+            await NativeRevisionService(pool).get_current(
+                namespace_id=vault_id,
+                surface="document",
+                path=created.path,
+            )
+        ).resource_id
+
+        replaced = await document_service.update(
+            vault,
+            created.path,
+            DocumentUpdateRequest(
+                content="Beta body",
+                title="Renamed note",
+                status="active",
+                message="replace native note",
+                expected_commit=created.commit_hash,
+            ),
+            agent_id="m1-writer",
+        )
+        assert replaced.previous_commit == created.commit_hash
+        assert replaced.commit_hash != created.commit_hash
+        assert replaced.current_commit == replaced.commit_hash
+        with pytest.raises(ConflictError, match="expected"):
+            await document_service.update(
+                vault,
+                created.path,
+                DocumentUpdateRequest(content="stale", expected_commit=created.commit_hash),
+                agent_id="stale-writer",
+            )
+
+        moved = await document_service.move(
+            vault,
+            created.path,
+            collection="archive",
+            slug="renamed",
+            message="move native note",
+            agent_id="m1-writer",
+        )
+        assert moved.path == "archive/renamed.md"
+        assert moved.previous_commit == replaced.commit_hash
+        assert (await document_service.get(vault, created.path)).path == moved.path
+
+        pinned = await document_service.get_at_commit(vault, created.path, created.commit_hash)
+        assert pinned.path == moved.path
+        assert pinned.title == "Renamed note"
+        assert pinned.content == "Alpha body"
+        assert pinned.current_commit == created.commit_hash
+        assert pinned.metadata_is_current is True
+
+        version = await backend.document_version(vault, created.path, created.commit_hash)
+        assert version is not None
+        version_doc, version_raw = version
+        assert version_doc["path"] == moved.path
+        assert "Alpha body" in version_raw
+
+        history = await backend.document_history(vault, created.path, limit=20)
+        assert history["uri"].endswith("/coll/archive/doc/renamed.md")
+        assert [entry["hash"] for entry in history["history"]] == [
+            moved.commit_hash,
+            replaced.commit_hash,
+            created.commit_hash,
+        ]
+        assert [entry["author"] for entry in history["history"]] == [
+            "m1-writer",
+            "m1-writer",
+            "m1-writer",
+        ]
+
+        diff = await backend.document_diff(vault, created.path, replaced.commit_hash)
+        assert diff is not None
+        assert diff["commit"] == replaced.commit_hash
+        assert diff["type"] == "modified"
+        assert "-Alpha body" in diff["diff"]
+        assert "+Beta body" in diff["diff"]
+
+        activity = await backend.vault_activity(
+            vault,
+            max_count=20,
+            since=None,
+            path=None,
+        )
+        assert [entry["hash"] for entry in activity] == [
+            moved.commit_hash,
+            replaced.commit_hash,
+            created.commit_hash,
+        ]
+        assert activity[0]["files"] == [{"path": moved.path, "change": "modified"}]
+        recent = await backend.recent_changes("unused-user", vault=vault, limit=20)
+        assert recent[0]["commit"] == moved.commit_hash
+        assert recent[0]["title"] == "Renamed note"
+
+        assert await document_service.delete(vault, created.path, agent_id="m1-writer") is True
+        with pytest.raises(NotFoundError):
+            await document_service.get(vault, created.path)
+        with pytest.raises(NotFoundError):
+            await document_service.get(vault, moved.path)
+
+        recreated = await document_service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="archive",
+                slug="renamed",
+                title="Fresh note",
+                content="Fresh lineage",
+            ),
+            agent_id="m1-writer",
+        )
+        fresh_snapshot = await NativeRevisionService(pool).get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path=recreated.path,
+        )
+        assert fresh_snapshot.resource_id != first_resource
+        fresh_history = await backend.document_history(vault, recreated.path, limit=20)
+        assert [entry["hash"] for entry in fresh_history["history"]] == [
+            recreated.commit_hash
+        ]
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT resource_id, lifecycle, head_revision_id
+                  FROM native_resources
+                 WHERE namespace_id = $1 AND current_path = $2
+                 ORDER BY created_at
+                """,
+                vault_id,
+                recreated.path,
+            )
+            assert [row["lifecycle"] for row in rows] == ["deleted", "live"]
+            assert await conn.fetchval(
+                "SELECT action FROM native_revisions WHERE revision_id = $1",
+                rows[0]["head_revision_id"],
+            ) == "delete"
+            assert await conn.fetchval(
+                "SELECT count(*) FROM documents WHERE vault_id = $1",
+                vault_id,
+            ) == 0
+
+        with pytest.raises(NativeRevisionUnsupportedSurfaceError):
+            await document_service.browse(vault)

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -1,0 +1,429 @@
+"""Focused real-PostgreSQL contract for the M1 B-core native ledger.
+
+The reference payload table exists only to exercise ledger publication in M1;
+these tests deliberately do not approve it as the final searchable-body store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.exceptions import ConflictError, ValidationError
+from app.services.m1_reference_payload_store import M1ReferencePayloadStore
+from app.services.native_revision_service import NativeRevisionService
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[2]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATION = _BACKEND / "app" / "db" / "migrations" / "048_native_revision_core.py"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("native_revision_migration", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_native_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    dsn = _database_dsn(name)
+    conn = await asyncpg.connect(dsn)
+    pool = None
+    try:
+        await conn.execute(_INIT_SQL)
+        migration = _load_migration()
+        await migration.migrate(conn=conn)
+        await migration.migrate(conn=conn)  # idempotent startup/retry
+        await conn.close()
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=8)
+        async with pool.acquire() as seeded:
+            vault_id = await seeded.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+                f"native-{uuid.uuid4().hex}",
+                "/tmp/legacy-unused.git",
+            )
+        yield pool, vault_id
+    finally:
+        if pool is not None:
+            await pool.close()
+        elif not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+def _create_args(vault_id: uuid.UUID, *, mutation_id: uuid.UUID | None = None) -> dict:
+    return {
+        "namespace_id": vault_id,
+        "surface": "document",
+        "path": "notes/native.md",
+        "payload": "alpha\n",
+        "actor": "m1-test",
+        "mutation_id": mutation_id or uuid.uuid4(),
+        "message": "create native note",
+        "subject": "native note",
+        "summary": "first revision",
+    }
+
+
+async def _authority_counts(pool: asyncpg.Pool) -> dict[str, int]:
+    tables = (
+        "native_resources",
+        "native_revisions",
+        "native_payload_manifests",
+        "native_revision_activity",
+        "native_invalidation_intents",
+    )
+    async with pool.acquire() as conn:
+        return {table: await conn.fetchval(f"SELECT count(*) FROM {table}") for table in tables}
+
+
+async def test_create_get_replace_are_native_atomic_and_leave_legacy_projection_untouched():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            legacy_id = await conn.fetchval(
+                """
+                INSERT INTO documents
+                    (vault_id, path, title, current_commit, created_by)
+                VALUES ($1, $2, 'legacy', $3, 'legacy-owner')
+                RETURNING id
+                """,
+                vault_id,
+                "notes/native.md",
+                "0123456789abcdef0123456789abcdef01234567",
+            )
+
+        service = NativeRevisionService(pool)
+        created = await service.create_text(**_create_args(vault_id))
+
+        assert len(created.revision_id) == 40
+        assert created.revision_id == created.revision_id.lower()
+        assert all(ch in "0123456789abcdef" for ch in created.revision_id)
+        assert created.parent_revision_id is None
+        assert created.action == "create"
+
+        current = await service.get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+        )
+        assert current.resource_id == created.resource_id
+        assert current.revision_id == created.revision_id
+        assert current.payload_bytes == b"alpha\n"
+        assert current.text == "alpha\n"
+        assert current.digest == hashlib.sha256(b"alpha\n").hexdigest()
+
+        replaced = await service.replace_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+            payload="beta\n",
+            actor="m1-test",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=created.revision_id,
+            message="replace native note",
+        )
+        assert replaced.resource_id == created.resource_id
+        assert replaced.parent_revision_id == created.revision_id
+        assert replaced.revision_id != created.revision_id
+
+        current = await service.get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+        )
+        assert current.revision_id == replaced.revision_id
+        assert current.text == "beta\n"
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT current_commit FROM documents WHERE id = $1", legacy_id
+            ) == "0123456789abcdef0123456789abcdef01234567"
+            rows = await conn.fetch(
+                """
+                SELECT r.revision_id, r.parent_revision_id, r.action,
+                       m.digest, m.byte_size, m.selected_placement,
+                       a.revision_id AS activity_revision,
+                       i.revision_id AS intent_revision
+                  FROM native_revisions r
+                  JOIN native_payload_manifests m ON m.payload_manifest_id = r.payload_manifest_id
+                  JOIN native_revision_activity a ON a.activity_event_id = r.activity_event_id
+                  JOIN native_invalidation_intents i ON i.intent_id = r.invalidation_intent_id
+                 WHERE r.resource_id = $1
+                 ORDER BY r.occurred_at, r.revision_id
+                """,
+                created.resource_id,
+            )
+        assert len(rows) == 2
+        assert {row["selected_placement"] for row in rows} == {"m1-reference-payload-v1"}
+        assert all(row["revision_id"] == row["activity_revision"] == row["intent_revision"] for row in rows)
+
+
+async def test_same_base_replace_has_one_winner_without_vault_write_lane():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        created = await service.create_text(**_create_args(vault_id))
+
+        async def replace(body: str):
+            return await service.replace_text(
+                namespace_id=vault_id,
+                surface="document",
+                path="notes/native.md",
+                payload=body,
+                actor="racer",
+                mutation_id=uuid.uuid4(),
+                expected_revision_id=created.revision_id,
+            )
+
+        outcomes = await asyncio.gather(replace("winner-a"), replace("winner-b"), return_exceptions=True)
+        successes = [item for item in outcomes if not isinstance(item, Exception)]
+        conflicts = [item for item in outcomes if isinstance(item, ConflictError)]
+        assert len(successes) == 1
+        assert len(conflicts) == 1
+
+        current = await service.get_current(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/native.md",
+        )
+        assert current.revision_id == successes[0].revision_id
+        assert await _authority_counts(pool) == {
+            "native_resources": 1,
+            "native_revisions": 2,
+            "native_payload_manifests": 2,
+            "native_revision_activity": 2,
+            "native_invalidation_intents": 2,
+        }
+
+
+async def test_same_path_create_has_one_winner_and_distinct_paths_do_not_share_a_vault_lock():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+
+        same_path = await asyncio.gather(
+            service.create_text(**_create_args(vault_id)),
+            service.create_text(**_create_args(vault_id)),
+            return_exceptions=True,
+        )
+        assert len([item for item in same_path if not isinstance(item, Exception)]) == 1
+        assert len([item for item in same_path if isinstance(item, ConflictError)]) == 1
+
+        left = _create_args(vault_id)
+        left["path"] = "notes/left.md"
+        right = _create_args(vault_id)
+        right["path"] = "notes/right.md"
+        extra = await asyncio.gather(service.create_text(**left), service.create_text(**right))
+        assert {item.path for item in extra} == {"notes/left.md", "notes/right.md"}
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "authority.after_resource",
+        "authority.after_manifest",
+        "authority.after_revision",
+        "authority.after_head",
+        "authority.after_activity",
+        "authority.after_invalidation",
+    ],
+)
+async def test_authority_failpoints_rollback_every_published_fact(boundary: str):
+    async with _fresh_database() as (pool, vault_id):
+        seen: list[str] = []
+
+        async def failpoint(name: str) -> None:
+            seen.append(name)
+            if name == boundary:
+                raise RuntimeError(f"injected:{name}")
+
+        service = NativeRevisionService(pool, failpoint=failpoint)
+        mutation_id = uuid.uuid4()
+        with pytest.raises(RuntimeError, match=f"injected:{boundary}"):
+            await service.create_text(**_create_args(vault_id, mutation_id=mutation_id))
+
+        assert boundary in seen
+        assert await _authority_counts(pool) == {
+            "native_resources": 0,
+            "native_revisions": 0,
+            "native_payload_manifests": 0,
+            "native_revision_activity": 0,
+            "native_invalidation_intents": 0,
+        }
+        # Preparation is deliberately outside the authority transaction. The
+        # unreferenced verified row is not a Revision and may be retried.
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT count(*) FROM m1_reference_payloads") == 1
+
+
+async def test_committed_response_lost_retry_returns_same_revision_once():
+    async with _fresh_database() as (pool, vault_id):
+        fired = False
+
+        async def failpoint(name: str) -> None:
+            nonlocal fired
+            if name == "authority.after_commit_before_response" and not fired:
+                fired = True
+                raise RuntimeError("response lost")
+
+        mutation_id = uuid.uuid4()
+        service = NativeRevisionService(pool, failpoint=failpoint)
+        with pytest.raises(RuntimeError, match="response lost"):
+            await service.create_text(**_create_args(vault_id, mutation_id=mutation_id))
+
+        retried = await service.create_text(**_create_args(vault_id, mutation_id=mutation_id))
+        assert retried.idempotent_replay is True
+        assert await _authority_counts(pool) == {
+            "native_resources": 1,
+            "native_revisions": 1,
+            "native_payload_manifests": 1,
+            "native_revision_activity": 1,
+            "native_invalidation_intents": 1,
+        }
+        with pytest.raises(ConflictError, match="idempotency"):
+            changed = _create_args(vault_id, mutation_id=mutation_id)
+            changed["payload"] = "different retry"
+            await service.create_text(**changed)
+
+
+async def test_reference_payload_verifies_digest_size_and_utf8_before_authority_tx():
+    async with _fresh_database() as (pool, vault_id):
+        store = M1ReferencePayloadStore(pool)
+        body = "한글 payload\n".encode()
+        digest = hashlib.sha256(body).hexdigest()
+        prepared = await store.prepare_text(
+            namespace_id=vault_id,
+            payload=body,
+            expected_digest=digest,
+            expected_size=len(body),
+        )
+        assert await store.open_verified(prepared.payload_id) == body
+
+        with pytest.raises(ValidationError, match="UTF-8"):
+            await store.prepare_text(namespace_id=vault_id, payload=b"\xff")
+        with pytest.raises(ValidationError, match="NUL"):
+            await store.prepare_text(namespace_id=vault_id, payload=b"a\x00b")
+        with pytest.raises(ValidationError, match="digest"):
+            await store.prepare_text(
+                namespace_id=vault_id,
+                payload=body,
+                expected_digest="0" * 64,
+            )
+        with pytest.raises(ValidationError, match="size"):
+            await store.prepare_text(namespace_id=vault_id, payload=body, expected_size=len(body) + 1)
+
+
+async def test_schema_enforces_revision_identity_head_ownership_and_immutable_facts():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        one = await service.create_text(**_create_args(vault_id))
+        other_args = _create_args(vault_id)
+        other_args["path"] = "notes/other.md"
+        other = await service.create_text(**other_args)
+
+        async with pool.acquire() as conn:
+            definition = await conn.fetchval(
+                """
+                SELECT pg_get_constraintdef(oid)
+                  FROM pg_constraint
+                 WHERE conname = 'native_revisions_revision_id_shape'
+                """
+            )
+            assert "{40}" in definition
+
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                async with conn.transaction():
+                    await conn.execute(
+                        "UPDATE native_resources SET head_revision_id = $2 WHERE resource_id = $1",
+                        one.resource_id,
+                        other.revision_id,
+                    )
+            with pytest.raises(asyncpg.ObjectNotInPrerequisiteStateError):
+                await conn.execute(
+                    "UPDATE native_revisions SET message = 'mutated' WHERE revision_id = $1",
+                    one.revision_id,
+                )
+            with pytest.raises(asyncpg.ObjectNotInPrerequisiteStateError):
+                await conn.execute(
+                    "DELETE FROM native_revision_activity WHERE revision_id = $1",
+                    one.revision_id,
+                )
+
+
+async def test_revision_id_collision_is_retried_as_identity_not_path_conflict(monkeypatch):
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        first = await service.create_text(**_create_args(vault_id))
+        allocated_after_retry = "f" * 40
+        candidates = iter((first.revision_id, allocated_after_retry))
+        monkeypatch.setattr(service, "_opaque_revision_id", lambda: next(candidates))
+
+        second_args = _create_args(vault_id)
+        second_args["path"] = "notes/collision-retried.md"
+        second = await service.create_text(**second_args)
+        assert second.revision_id == allocated_after_retry
+        assert second.resource_id != first.resource_id
+        assert (await _authority_counts(pool))["native_revisions"] == 2
+
+
+async def test_vault_delete_cascades_the_experimental_native_subtree():
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        await service.create_text(**_create_args(vault_id))
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+            for table in (
+                "native_resources",
+                "native_revisions",
+                "native_payload_manifests",
+                "native_revision_activity",
+                "native_invalidation_intents",
+                "m1_reference_payloads",
+            ):
+                assert await conn.fetchval(f"SELECT count(*) FROM {table}") == 0
+
+
+async def test_native_substrate_has_no_git_legacy_projection_or_write_lane_dependency():
+    paths = (
+        _BACKEND / "app" / "repositories" / "native_revision_repo.py",
+        _BACKEND / "app" / "services" / "m1_reference_payload_store.py",
+        _BACKEND / "app" / "services" / "native_revision_service.py",
+    )
+    source = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    for forbidden in ("GitService", "git_service", "current_commit", "write_lane", "documents"):
+        assert forbidden not in source

--- a/backend/tests/test_activity_git_offload_unit.py
+++ b/backend/tests/test_activity_git_offload_unit.py
@@ -16,13 +16,13 @@ thread to the loop thread and fails that test.
 No DB / no real git: the routes' and handlers' other deps are monkeypatched.
 Runs in ``pytest -k 'not _e2e'``.
 
-The module-level ``git = GitService()`` in activity.py (and ``GitService()`` in the
-MCP handlers) mkdir ``git_storage_path`` at construction — the prod default
-``/data/vaults`` is unwritable in CI — so the fixture redirects it to ``tmp_path``
-BEFORE importing the modules (the same pattern as test_activity_routes_unit.py).
+The process-selected legacy revision backend owns ``GitService()``. Its
+construction mkdirs ``git_storage_path`` — the prod default ``/data/vaults`` is
+unwritable in CI — so the fixture redirects it to ``tmp_path`` before import.
 """
 
 import threading
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -83,7 +83,7 @@ async def test_rest_vault_activity_offloads_vault_log(mods, monkeypatch):
     rec, assert_offloaded = _offload_probe([])
     monkeypatch.setattr(activity, "check_vault_access", _anoop)
     monkeypatch.setattr(activity, "_resolve_activity_authors", _aidentity)
-    monkeypatch.setattr(activity.git, "vault_log", rec)
+    monkeypatch.setattr(activity.revision_backend._git, "vault_log", rec)
 
     await activity.vault_activity(
         vault="v", collection=None, author=None, since=None,
@@ -97,35 +97,13 @@ async def test_rest_document_diff_offloads_file_diff_and_keeps_envelope(mods, mo
     activity, _server, _gs = mods
     rec, assert_offloaded = _offload_probe({"diff": "…", "type": "modified"})
 
-    class _Conn:
-        async def fetchrow(self, *a, **k):
-            return {"id": "vault-id"}
-
-    class _AcquireCtx:
-        async def __aenter__(self):
-            return _Conn()
-
-        async def __aexit__(self, *a):
-            return False
-
-    class _Pool:
-        def acquire(self):
-            return _AcquireCtx()
-
-    async def _get_pool():
-        return _Pool()
-
-    class _DocRepo:
-        def __init__(self, pool):
-            pass
-
-        async def find_by_ref_with_conn(self, conn, vid, doc_id):
-            return {"path": "docs/p.md"}
-
     monkeypatch.setattr(activity, "check_vault_access", _anoop)
-    monkeypatch.setattr(activity, "get_pool", _get_pool)
-    monkeypatch.setattr(activity, "DocumentRepository", _DocRepo)
-    monkeypatch.setattr(activity.git, "file_diff", rec)
+    monkeypatch.setattr(
+        activity.revision_backend,
+        "_find_document",
+        AsyncMock(return_value={"path": "docs/p.md"}),
+    )
+    monkeypatch.setattr(activity.revision_backend._git, "file_diff", rec)
 
     out = await activity.document_diff(
         vault="v", doc_id="docs/p.md", commit="abc1234", user=_User(),
@@ -141,10 +119,10 @@ async def test_rest_document_diff_offloads_file_diff_and_keeps_envelope(mods, mo
 
 
 async def test_mcp_activity_offloads_vault_log(mods, monkeypatch):
-    _activity, server, GitService = mods
+    _activity, server, _GitService = mods
     rec, assert_offloaded = _offload_probe([])
     monkeypatch.setattr(server, "check_vault_access", _anoop)
-    monkeypatch.setattr(GitService, "vault_log", rec)
+    monkeypatch.setattr(server.revision_backend._git, "vault_log", rec)
 
     await server._handle_activity({"vault": "v", "limit": 5}, "uid", _User())
 
@@ -152,16 +130,17 @@ async def test_mcp_activity_offloads_vault_log(mods, monkeypatch):
 
 
 async def test_mcp_diff_offloads_file_diff(mods, monkeypatch):
-    _activity, server, GitService = mods
+    _activity, server, _GitService = mods
     rec, assert_offloaded = _offload_probe({"diff": "…"})
-
-    async def _find(vault, path):
-        return {"path": "docs/p.md"}
 
     monkeypatch.setattr(server, "split_uri", lambda uri, expected_type=None: ("v", "docs/p.md"))
     monkeypatch.setattr(server, "check_vault_access", _anoop)
-    monkeypatch.setattr(server, "_find_doc", _find)
-    monkeypatch.setattr(GitService, "file_diff", rec)
+    monkeypatch.setattr(
+        server.revision_backend,
+        "_find_document",
+        AsyncMock(return_value={"path": "docs/p.md"}),
+    )
+    monkeypatch.setattr(server.revision_backend._git, "file_diff", rec)
 
     await server._handle_diff({"uri": "akb://v/doc/docs/p.md", "commit": "abc1234"}, "uid", _User())
 
@@ -169,16 +148,17 @@ async def test_mcp_diff_offloads_file_diff(mods, monkeypatch):
 
 
 async def test_mcp_versioned_get_offloads_read_file(mods, monkeypatch):
-    _activity, server, GitService = mods
+    _activity, server, _GitService = mods
     rec, assert_offloaded = _offload_probe("body content")
-
-    async def _find(vault, path):
-        return {"path": "docs/p.md", "title": "P"}
 
     monkeypatch.setattr(server, "split_uri", lambda uri, expected_type=None: ("v", "docs/p.md"))
     monkeypatch.setattr(server, "check_vault_access", _anoop)
-    monkeypatch.setattr(server, "_find_doc", _find)
-    monkeypatch.setattr(GitService, "read_file", rec)
+    monkeypatch.setattr(
+        server.revision_backend,
+        "_find_document",
+        AsyncMock(return_value={"path": "docs/p.md", "title": "P"}),
+    )
+    monkeypatch.setattr(server.revision_backend._git, "read_file", rec)
 
     await server._handle_get(
         {"uri": "akb://v/doc/docs/p.md", "version": "abc1234"}, "uid", _User(),

--- a/backend/tests/test_activity_git_offload_unit.py
+++ b/backend/tests/test_activity_git_offload_unit.py
@@ -165,3 +165,22 @@ async def test_mcp_versioned_get_offloads_read_file(mods, monkeypatch):
     )
 
     assert_offloaded("MCP versioned akb_get ran git.read_file ON the event loop (not offloaded)")
+
+
+async def test_mcp_versioned_get_preserves_missing_document_distinction(mods, monkeypatch):
+    _activity, server, _GitService = mods
+    monkeypatch.setattr(server, "split_uri", lambda uri, expected_type=None: ("v", "missing.md"))
+    monkeypatch.setattr(server, "check_vault_access", _anoop)
+    monkeypatch.setattr(
+        server.revision_backend,
+        "_find_document",
+        AsyncMock(return_value=None),
+    )
+
+    result = await server._handle_get(
+        {"uri": "akb://v/doc/missing.md", "version": "abc1234"},
+        "uid",
+        _User(),
+    )
+
+    assert result == {"error": "Document not found", "code": "not_found"}

--- a/backend/tests/test_activity_routes_unit.py
+++ b/backend/tests/test_activity_routes_unit.py
@@ -1,6 +1,5 @@
 """Serialization contracts for activity, recent, history, and diff routes."""
 
-from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -16,27 +15,13 @@ from app.models.activity import (
 
 @pytest.fixture
 def routes(monkeypatch, tmp_path):
-    """Import the module only after redirecting its module-level GitService."""
+    """Import after redirecting the selected legacy backend's Git storage."""
     from app.config import settings
 
     monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
     from app.api.routes import activity
 
     return activity
-
-
-def _pool_with(*, rows=(), vault_id="vault-id"):
-    conn = MagicMock()
-    conn.fetch = AsyncMock(return_value=rows)
-    conn.fetchrow = AsyncMock(return_value={"id": vault_id})
-
-    @asynccontextmanager
-    async def acquire():
-        yield conn
-
-    pool = MagicMock()
-    pool.acquire = acquire
-    return pool, conn
 
 
 @pytest.mark.asyncio
@@ -52,7 +37,9 @@ async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkey
         "files": [{"path": "notes/a.md", "change": "modified"}],
     }
     monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
-    monkeypatch.setattr(routes.git, "vault_log", MagicMock(return_value=[entry]))
+    monkeypatch.setattr(
+        routes.revision_backend, "vault_activity", AsyncMock(return_value=[entry]),
+    )
     monkeypatch.setattr(routes, "_resolve_activity_authors", AsyncMock(return_value=[entry]))
 
     out = await routes.vault_activity(
@@ -66,18 +53,18 @@ async def test_activity_adds_kind_and_preserves_unresolved_author_absence(monkey
 
 @pytest.mark.asyncio
 async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch, routes):
-    rows = [{
-        "id": "uuid-1",
-        "title": "Nullable",
+    changes = [{
+        "doc_id": "d-nullable",
+        "vault": "v",
         "path": "notes/nullable.md",
-        "doc_type": None,
-        "current_commit": None,
-        "updated_at": None,
-        "vault_name": "v",
-        "metadata": {"id": "d-nullable"},
+        "title": "Nullable",
+        "type": "note",
+        "commit": None,
+        "changed_at": None,
     }]
-    pool, _ = _pool_with(rows=rows)
-    monkeypatch.setattr(routes, "get_pool", AsyncMock(return_value=pool))
+    monkeypatch.setattr(
+        routes.revision_backend, "recent_changes", AsyncMock(return_value=changes),
+    )
 
     out = await routes.recent_changes(vault=None, limit=20, user=MagicMock(user_id="u"))
 
@@ -103,15 +90,12 @@ async def test_recent_adds_kind_and_preserves_explicit_nulls(monkeypatch, routes
 async def test_diff_adds_kind_and_preserves_optional_error(
     monkeypatch, routes, git_result, has_error,
 ):
-    pool, _ = _pool_with()
-    monkeypatch.setattr(routes, "get_pool", AsyncMock(return_value=pool))
     monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
     monkeypatch.setattr(
-        routes.DocumentRepository,
-        "find_by_ref_with_conn",
-        AsyncMock(return_value={"path": "a.md"}),
+        routes.revision_backend,
+        "document_diff",
+        AsyncMock(return_value=git_result),
     )
-    monkeypatch.setattr(routes.git, "file_diff", MagicMock(return_value=git_result))
 
     out = await routes.document_diff("v", "a.md", commit=git_result["commit"], user=MagicMock())
 
@@ -131,8 +115,8 @@ async def test_history_adds_kind_without_changing_entries(monkeypatch, routes):
     }
     monkeypatch.setattr(routes, "check_vault_access", AsyncMock())
     monkeypatch.setattr(
-        routes.doc_service,
-        "history",
+        routes.revision_backend,
+        "document_history",
         AsyncMock(return_value={"uri": "akb://v/doc/a.md", "history": [entry]}),
     )
 

--- a/backend/tests/test_mcp_oauth_unit.py
+++ b/backend/tests/test_mcp_oauth_unit.py
@@ -28,12 +28,10 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 from app.config import settings
 
-# server.py instantiates DocumentService() at module load, which creates
-# the git storage path via mkdir. Tests don't write any documents; we
-# just need somewhere writable so the import doesn't blow up on the
-# default `/data/vaults`. Override once at test-module load so every
-# lazy `from mcp_server.server import …` inside a test finds a working
-# path.
+# server.py selects the process-scoped DocumentService at module load, whose
+# legacy implementation creates the git storage path via mkdir. Tests don't
+# write documents; we just need somewhere writable so lazy imports do not
+# target the default `/data/vaults`.
 settings.git_storage_path = tempfile.mkdtemp(prefix="akb-mcp-oauth-test-vaults-")
 
 

--- a/backend/tests/test_native_revision_m1_adapter_unit.py
+++ b/backend/tests/test_native_revision_m1_adapter_unit.py
@@ -1,0 +1,70 @@
+"""Focused checks for the first-party M1 measurement adapter boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import uuid
+
+import pytest
+
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_SCRIPT = _BACKEND / "scripts" / "native_revision_m1_adapter.py"
+
+
+def _load_adapter():
+    spec = importlib.util.spec_from_file_location("native_revision_m1_adapter", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_measurement_database_guard_rejects_non_measurement_names():
+    adapter = _load_adapter()
+
+    with pytest.raises(adapter.AdapterError, match="dedicated measurement database"):
+        adapter.validate_measurement_database("akb")
+
+    adapter.validate_measurement_database("akb_revision_m1_measurement")
+    adapter.validate_measurement_database("akb_revision_m1_measurement_local")
+
+
+def test_bound_artifact_writes_recomputable_digest(tmp_path):
+    adapter = _load_adapter()
+    destination = tmp_path / "authority.json"
+
+    bound = adapter.write_bound_json(destination, {"safe": "fact"})
+
+    assert bound["path"] == str(destination.resolve())
+    assert len(bound["sha256"]) == 64
+    assert json.loads(destination.read_text()) == {"safe": "fact"}
+
+    with pytest.raises(adapter.AdapterError, match="will not be overwritten"):
+        adapter.write_bound_json(destination, {"safe": "different fact"})
+
+
+def test_source_revision_environment_must_be_a_git_oid(monkeypatch):
+    adapter = _load_adapter()
+    monkeypatch.setenv("AKB_NATIVE_REVISION_ADAPTER_SOURCE_REVISION", "not-a-git-oid")
+
+    with pytest.raises(adapter.AdapterError, match="exactly 40 lowercase hex"):
+        adapter.source_revision()
+
+
+def test_receipt_provenance_requires_explicit_runtime_identity(monkeypatch):
+    adapter = _load_adapter()
+    revision = "a" * 40
+    monkeypatch.setenv("AKB_NATIVE_REVISION_RUNTIME_IMAGE_DIGEST", "local-image@sha256:test")
+    monkeypatch.setenv("AKB_NATIVE_REVISION_RUNTIME_CONFIG_DIGEST", "sha256:config")
+    runtime, environment = adapter.receipt_provenance(revision, "akb_revision_m1_measurement", uuid.uuid4())
+
+    assert runtime == {
+        "image_digest": "local-image@sha256:test",
+        "config_digest": "sha256:config",
+        "source_revision": revision,
+    }
+    assert environment["tier"] == "E0"
+    assert environment["storage_profile"]["authority"] == "postgresql-native-ledger"

--- a/backend/tests/test_revision_backend_factory_unit.py
+++ b/backend/tests/test_revision_backend_factory_unit.py
@@ -24,11 +24,14 @@ def reset_revision_backend():
     revision_backend.reset_document_service_for_tests()
     yield
     revision_backend.reset_document_service_for_tests()
+    sys.modules.pop("app.main", None)
     sys.modules.pop("app.api.routes.activity", None)
+    sys.modules.pop("app.api.routes.documents", None)
     sys.modules.pop("mcp_server.server", None)
     routes_package = sys.modules.get("app.api.routes")
     if routes_package is not None:
         routes_package.__dict__.pop("activity", None)
+        routes_package.__dict__.pop("documents", None)
     mcp_package = sys.modules.get("mcp_server")
     if mcp_package is not None:
         mcp_package.__dict__.pop("server", None)
@@ -95,8 +98,9 @@ def test_native_backend_uses_registered_factory_once(monkeypatch, tmp_path):
     assert revision_backend.selected_document_revision_backend() == "native_ledger_m1"
 
 
-def test_native_backend_fails_closed_without_registered_implementation(monkeypatch, tmp_path):
+def test_native_backend_lazily_registers_real_facade_without_git(monkeypatch, tmp_path):
     from app.services import revision_backend
+    from app.services.native_document_service import NativeDocumentService
 
     monkeypatch.setattr(
         revision_backend,
@@ -109,8 +113,54 @@ def test_native_backend_fails_closed_without_registered_implementation(monkeypat
         ),
     )
 
-    with pytest.raises(revision_backend.NativeRevisionBackendUnavailableError):
-        revision_backend.get_document_service()
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("native composition must not construct GitService")
+
+    monkeypatch.setattr(revision_backend, "GitService", fail_if_constructed)
+    service = revision_backend.get_document_service()
+
+    assert isinstance(service, NativeDocumentService)
+    assert service is revision_backend.get_document_service()
+
+
+def test_app_and_stdio_imports_select_native_before_module_globals(monkeypatch, tmp_path):
+    from app.services import git_service, revision_backend
+
+    configured = _settings(
+        tmp_path,
+        db_name="akb_revision_m1_measurement",
+        document_revision_backend="native_ledger_m1",
+        native_revision_m1_measurement_only=True,
+    )
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    # app.main also imports the unrelated external-Git poller. Keep that
+    # legacy subsystem's import-time storage under the test directory; the
+    # assertion below guards the selected Document backend itself.
+    monkeypatch.setattr(git_service, "settings", configured)
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("native app import must not construct GitService")
+
+    monkeypatch.setattr(revision_backend, "GitService", fail_if_constructed)
+    monkeypatch.setattr(revision_backend, "LegacyRevisionBackend", fail_if_constructed)
+    sys.modules.pop("app.main", None)
+    sys.modules.pop("app.api.routes.documents", None)
+    sys.modules.pop("app.api.routes.activity", None)
+    sys.modules.pop("mcp_server.server", None)
+    routes_package = sys.modules.get("app.api.routes")
+    if routes_package is not None:
+        routes_package.__dict__.pop("documents", None)
+        routes_package.__dict__.pop("activity", None)
+
+    importlib.import_module("app.main")
+    documents = importlib.import_module("app.api.routes.documents")
+    activity = importlib.import_module("app.api.routes.activity")
+    server = importlib.import_module("mcp_server.server")
+
+    selected = revision_backend.get_revision_backend()
+    assert documents.doc_service is selected.document_service
+    assert activity.revision_backend is selected
+    assert server.revision_backend is selected
 
 
 class _NativeRevisionBackend:

--- a/backend/tests/test_revision_backend_factory_unit.py
+++ b/backend/tests/test_revision_backend_factory_unit.py
@@ -1,0 +1,187 @@
+"""Process-scoped document revision backend selection guards."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+
+from app.config import Settings
+from app.services.document_service import DocumentService
+
+
+def _settings(tmp_path, **overrides) -> Settings:
+    return Settings(git_storage_path=str(tmp_path), **overrides)
+
+
+@pytest.fixture(autouse=True)
+def reset_revision_backend():
+    from app.services import revision_backend
+
+    revision_backend.reset_document_service_for_tests()
+    yield
+    revision_backend.reset_document_service_for_tests()
+    sys.modules.pop("app.api.routes.activity", None)
+    sys.modules.pop("mcp_server.server", None)
+    routes_package = sys.modules.get("app.api.routes")
+    if routes_package is not None:
+        routes_package.__dict__.pop("activity", None)
+    mcp_package = sys.modules.get("mcp_server")
+    if mcp_package is not None:
+        mcp_package.__dict__.pop("server", None)
+
+
+def test_default_backend_is_legacy_document_service_once_per_process(monkeypatch, tmp_path):
+    from app.services import revision_backend
+    from app.services import git_service
+
+    configured = _settings(tmp_path)
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    monkeypatch.setattr(git_service, "settings", configured)
+
+    first = revision_backend.get_document_service()
+    second = revision_backend.get_document_service()
+
+    assert isinstance(first, DocumentService)
+    assert second is first
+    assert revision_backend.selected_document_revision_backend() == "bare_git_current"
+
+
+def test_native_backend_requires_explicit_measurement_opt_in(tmp_path):
+    with pytest.raises(ValueError, match="native_revision_m1_measurement_only"):
+        Settings(
+            git_storage_path=str(tmp_path),
+            document_revision_backend="native_ledger_m1",
+        )
+
+
+def test_native_backend_requires_dedicated_measurement_database(tmp_path):
+    with pytest.raises(ValueError, match="akb_revision_m1_measurement"):
+        Settings(
+            git_storage_path=str(tmp_path),
+            document_revision_backend="native_ledger_m1",
+            native_revision_m1_measurement_only=True,
+        )
+
+
+def test_native_backend_uses_registered_factory_once(monkeypatch, tmp_path):
+    from app.services import revision_backend
+
+    configured = _settings(
+        tmp_path,
+        db_name="akb_revision_m1_measurement",
+        document_revision_backend="native_ledger_m1",
+        native_revision_m1_measurement_only=True,
+    )
+    native_service = object()
+    native_backend = _NativeRevisionBackend(native_service)
+    factory_calls = 0
+
+    def make_native_backend():
+        nonlocal factory_calls
+        factory_calls += 1
+        return native_backend
+
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    revision_backend.register_native_revision_backend(make_native_backend)
+
+    assert revision_backend.get_document_service() is native_service
+    assert revision_backend.get_document_service() is native_service
+    assert revision_backend.get_revision_backend() is native_backend
+    assert factory_calls == 1
+    assert revision_backend.selected_document_revision_backend() == "native_ledger_m1"
+
+
+def test_native_backend_fails_closed_without_registered_implementation(monkeypatch, tmp_path):
+    from app.services import revision_backend
+
+    monkeypatch.setattr(
+        revision_backend,
+        "settings",
+        _settings(
+            tmp_path,
+            db_name="akb_revision_m1_measurement",
+            document_revision_backend="native_ledger_m1",
+            native_revision_m1_measurement_only=True,
+        ),
+    )
+
+    with pytest.raises(revision_backend.NativeRevisionBackendUnavailableError):
+        revision_backend.get_document_service()
+
+
+class _NativeRevisionBackend:
+    def __init__(self, document_service):
+        self.document_service = document_service
+
+    async def vault_activity(self, vault, *, max_count, since, path):
+        return []
+
+    async def recent_changes(self, user_id, *, vault, limit):
+        return []
+
+    async def document_diff(self, vault, doc_ref, commit):
+        return None
+
+    async def document_version(self, vault, doc_ref, version):
+        return None
+
+    async def document_history(self, vault, doc_ref, *, limit):
+        return {}
+
+
+def test_native_activity_route_import_has_no_git_or_current_commit_escape(monkeypatch, tmp_path):
+    from app.services import git_service, revision_backend
+
+    configured = _settings(
+        tmp_path,
+        db_name="akb_revision_m1_measurement",
+        document_revision_backend="native_ledger_m1",
+        native_revision_m1_measurement_only=True,
+    )
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    revision_backend.register_native_revision_backend(
+        lambda: _NativeRevisionBackend(object())
+    )
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("native activity route must not construct GitService")
+
+    monkeypatch.setattr(git_service, "GitService", fail_if_constructed)
+    sys.modules.pop("app.api.routes.activity", None)
+    activity = importlib.import_module("app.api.routes.activity")
+    server = importlib.import_module("mcp_server.server")
+
+    assert activity.revision_backend is revision_backend.get_revision_backend()
+    assert server.revision_backend is revision_backend.get_revision_backend()
+    source = Path(activity.__file__).read_text()
+    assert "GitService" not in source
+    assert "current_commit" not in source
+    assert "GitService" not in Path(server.__file__).read_text()
+
+
+def test_production_composition_roots_use_the_process_factory():
+    backend = Path(__file__).resolve().parents[1]
+    roots = {
+        "app/api/routes/activity.py": "get_revision_backend",
+        "app/api/routes/collections.py": "get_document_service",
+        "app/api/routes/documents.py": "get_document_service",
+        "app/api/routes/help.py": "get_document_service",
+        "app/api/routes/knowledge_io.py": "get_document_service",
+        "app/services/agent_memory_service.py": "get_document_service",
+        "app/services/publication_service.py": "get_document_service",
+        "mcp_server/server.py": "get_revision_backend",
+    }
+
+    for relative_path, factory_name in roots.items():
+        tree = ast.parse((backend / relative_path).read_text())
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        ]
+        assert any(call.func.id == factory_name for call in calls), relative_path
+        assert not any(call.func.id == "DocumentService" for call in calls), relative_path

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -17,6 +17,15 @@ db_user: akb
 # === Git storage (bare repos per vault live under this path) ===
 git_storage_path: /data/vaults
 
+# === Document revision backend ===
+# Default keeps the existing bare-Git implementation. native_ledger_m1 is
+# measurement-only: it requires native_revision_m1_measurement_only: true and
+# the exact dedicated database name below. Its native service must also be
+# registered before startup, so it cannot silently affect normal deployments.
+document_revision_backend: bare_git_current  # bare_git_current | native_ledger_m1
+native_revision_m1_measurement_only: false
+# Isolated M1 measurement runs must also set: db_name: akb_revision_m1_measurement
+
 # === External-git mirror — network timeouts (seconds) ===
 external_git_lsremote_timeout: 30
 external_git_fetch_timeout: 300


### PR DESCRIPTION
## Summary

- add an explicit, default-off `native_ledger_m1` backend selector for measurement
- add a dormant PostgreSQL Resource/Revision/Head ledger with namespace-wide path and alias authority
- preserve the current Document API through a native compatibility service with OCC, history, diff, activity, move, delete, and retry semantics
- add a first-party, exact-source-bound M1 measurement adapter and live-PostgreSQL concurrency/failpoint coverage

## Safety boundary

The default remains `bare_git_current`. The native arm activates only with the explicit measurement backend setting and the dedicated `akb_revision_m1_measurement` database name. It uses PostgreSQL as its sole authority and does not co-write Git.

This PR covers the M1 B-core measurement slice only. It does not select final body placement, add text-File/grep/binary/migration behavior, approve P1 conformance, or perform a cutover.

## Verification

- backend unit suite: 872 passed, 235 skipped, 18 deselected
- real PostgreSQL native ledger + adapter: 49 passed
- independent exact-head review at `0ed9ab2eae9fefac6b44a5cccd0c437f63b9893b`: 0 High / 0 Medium, mergeable for the M1 B-core measurement scope
- ruff, mypy, bandit, and tracked-file secret scan: passed
- canonical M1 E0 W1/W2 lifecycle, independent, conflict, and failpoint receipts: semantic pass; unpinned external adapter remains inconclusive

## Deferred

The next gate is an immutable-image, isolated comparative M1 run followed by a separate decision ADR. File, grep, binary storage, migration, and cutover remain out of scope.
