### PR TITLE
feat: add observed app inventory control plane

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -118,6 +118,7 @@ jobs:
           tests/test_file_idempotent_upload_unit.py
           tests/test_app_registry_migration_unit.py
           tests/test_app_identity_postgres.py
+          tests/test_app_inventory_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3308
+        "line_number": 3326
       }
     ],
     "backend/mcp_server/help.py": [

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -29,6 +29,24 @@ Credential lifecycle, exchange outcomes, and capability decisions emit bounded
 correlation-aware audit metadata without credential, token, cookie, or request
 body content. Existing user authentication and registry rows remain unchanged.
 
+### Added app installation inventory and rollout target snapshots
+
+System administrators and authorized app principals can read a bounded,
+stable-cursor installation inventory. Each item combines desired registry state
+with the latest sanitized worker observation, bounded checkpoint/error summary,
+live grant status, and independent release/schema/grant drift classifications;
+missing observations and absent expected schema fingerprints remain `unknown`.
+
+Workers can replace an observation only when its generation and timestamp are
+at least as new as the stored report. Rollout snapshot creation freezes every
+installation with a desired release in one transaction, seals membership and
+baseline release/grant values, and rechecks live installation, grant, and
+observed-state eligibility before marking a target `running`. Sealed snapshot
+membership and baselines are database-protected from mutation. The REST
+surface reuses the existing system-admin and app-principal boundaries, applies
+`no-store` to reads, and omits credentials, grant provenance, arbitrary Vault
+metadata, and worker payloads from responses and audit metadata.
+
 ## 0.13.0 — 2026-08-03  *(removes the `todos` stack; fixes account deletion)*
 
 ### Removed the `todos` stack — fixes permanently-failing account deletion

--- a/backend/app/api/routes/app_inventory.py
+++ b/backend/app/api/routes/app_inventory.py
@@ -1,0 +1,349 @@
+"""REST control-plane surface for app inventory and rollout snapshots."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import Field
+
+from app.api.deps import get_current_app, get_current_user, request_correlation_id
+from app.services.app_identity_service import (
+    AppPrincipal,
+    authorize_app_capability,
+    record_app_audit,
+)
+from app.services.auth_service import AuthenticatedUser
+from app.services.app_inventory_service import (
+    create_rollout_snapshot,
+    evaluate_rollout_target,
+    get_rollout_snapshot,
+    list_inventory,
+    report_observed_state,
+)
+from app.util.text import NFCModel
+
+router = APIRouter()
+
+
+class ObservedStateRequest(NFCModel):
+    installation_id: uuid.UUID
+    observed_generation: int = Field(ge=0)
+    observed_at: datetime | None = None
+    observed_release_id: uuid.UUID | None = None
+    observed_release_version: str | None = Field(default=None, max_length=256)
+    schema_fingerprint: str | None = Field(default=None, max_length=256)
+    observed_grant_generation: int | None = Field(default=None, ge=0)
+    checkpoint: dict[str, Any] = Field(default_factory=dict)
+    recent_error: dict[str, Any] | None = None
+
+
+class SnapshotRequest(NFCModel):
+    """Reserved empty request body for future snapshot labels."""
+
+
+def _mark_no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+def _require_system_admin(
+    request: Request,
+    user: AuthenticatedUser,
+    *,
+    app_id: uuid.UUID,
+    action: str,
+) -> None:
+    if user.is_admin:
+        return
+    record_app_audit(
+        action,
+        correlation_id=request_correlation_id(request),
+        outcome="error",
+        reason="system_admin_required",
+        actor=user.username,
+        actor_id=user.user_id,
+        app_id=app_id,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="System administrator permission required",
+    )
+
+
+async def _authorize_app(
+    principal: AppPrincipal,
+    request: Request,
+    capability: str,
+) -> str:
+    correlation_id = request_correlation_id(request)
+    await authorize_app_capability(
+        principal,
+        capability=capability,
+        correlation_id=correlation_id,
+    )
+    return correlation_id
+
+
+@router.get(
+    "/apps/{app_id}/inventory",
+    summary="Read an app installation inventory as a system administrator",
+)
+async def admin_inventory(
+    app_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None, max_length=4096),
+    lifecycle: str | None = Query(default=None, max_length=32),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_system_admin(
+        request,
+        user,
+        app_id=app_id,
+        action="app.inventory.read",
+    )
+    result = await list_inventory(
+        app_id,
+        limit=limit,
+        cursor=cursor,
+        lifecycle=lifecycle,
+        scope="admin",
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.get(
+    "/app/inventory",
+    summary="Read the caller app's installation inventory",
+)
+async def app_inventory(
+    request: Request,
+    response: Response,
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None, max_length=4096),
+    lifecycle: str | None = Query(default=None, max_length=32),
+    principal: AppPrincipal = Depends(get_current_app),
+):
+    await _authorize_app(principal, request, "inventory:read")
+    result = await list_inventory(
+        principal.app_id,
+        limit=limit,
+        cursor=cursor,
+        lifecycle=lifecycle,
+        scope="app",
+        capability="inventory:read",
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/apps/{app_id}/observed-state",
+    summary="Record an app installation worker observation as a system administrator",
+)
+async def admin_observed_state(
+    app_id: uuid.UUID,
+    req: ObservedStateRequest,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_system_admin(
+        request,
+        user,
+        app_id=app_id,
+        action="app.inventory.observed",
+    )
+    result = await report_observed_state(
+        req.installation_id,
+        observed_generation=req.observed_generation,
+        observed_at=req.observed_at,
+        observed_release_id=req.observed_release_id,
+        observed_release_version=req.observed_release_version,
+        schema_fingerprint=req.schema_fingerprint,
+        observed_grant_generation=req.observed_grant_generation,
+        checkpoint=req.checkpoint,
+        recent_error=req.recent_error,
+        app_id=app_id,
+        correlation_id=request_correlation_id(request),
+        actor=user.username,
+        actor_id=user.user_id,
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/app/observed-state",
+    summary="Record the caller app's installation worker observation",
+)
+async def app_observed_state(
+    req: ObservedStateRequest,
+    request: Request,
+    response: Response,
+    principal: AppPrincipal = Depends(get_current_app),
+):
+    result = await report_observed_state(
+        req.installation_id,
+        observed_generation=req.observed_generation,
+        observed_at=req.observed_at,
+        observed_release_id=req.observed_release_id,
+        observed_release_version=req.observed_release_version,
+        schema_fingerprint=req.schema_fingerprint,
+        observed_grant_generation=req.observed_grant_generation,
+        checkpoint=req.checkpoint,
+        recent_error=req.recent_error,
+        principal=principal,
+        correlation_id=request_correlation_id(request),
+        actor=f"app:{principal.app_id}",
+        actor_id=str(principal.app_id),
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/apps/{app_id}/rollout-snapshots",
+    summary="Create an immutable rollout target snapshot as a system administrator",
+)
+async def admin_create_snapshot(
+    app_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+    _req: SnapshotRequest | None = None,
+):
+    _require_system_admin(
+        request,
+        user,
+        app_id=app_id,
+        action="app.rollout.snapshot.create",
+    )
+    result = await create_rollout_snapshot(
+        app_id,
+        requested_by_kind="admin",
+        correlation_id=request_correlation_id(request),
+        actor=user.username,
+        actor_id=user.user_id,
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/app/rollout-snapshots",
+    summary="Create an immutable rollout target snapshot for the caller app",
+)
+async def app_create_snapshot(
+    request: Request,
+    response: Response,
+    principal: AppPrincipal = Depends(get_current_app),
+    _req: SnapshotRequest | None = None,
+):
+    correlation_id = await _authorize_app(principal, request, "rollout:request")
+    result = await create_rollout_snapshot(
+        principal.app_id,
+        requested_by_kind="app",
+        correlation_id=correlation_id,
+        actor=f"app:{principal.app_id}",
+        actor_id=str(principal.app_id),
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.get(
+    "/apps/{app_id}/rollout-snapshots/{snapshot_id}",
+    summary="Read an app rollout target snapshot as a system administrator",
+)
+async def admin_get_snapshot(
+    app_id: uuid.UUID,
+    snapshot_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_system_admin(
+        request,
+        user,
+        app_id=app_id,
+        action="app.rollout.snapshot.read",
+    )
+    result = await get_rollout_snapshot(app_id, snapshot_id)
+    _mark_no_store(response)
+    return result
+
+
+@router.get(
+    "/app/rollout-snapshots/{snapshot_id}",
+    summary="Read a caller-app rollout target snapshot",
+)
+async def app_get_snapshot(
+    snapshot_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    principal: AppPrincipal = Depends(get_current_app),
+):
+    await _authorize_app(principal, request, "rollout:read")
+    result = await get_rollout_snapshot(principal.app_id, snapshot_id)
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/apps/{app_id}/rollout-snapshots/{snapshot_id}/targets/{target_id}/eligibility",
+    summary="Recheck a rollout target before execution as a system administrator",
+)
+async def admin_evaluate_target(
+    app_id: uuid.UUID,
+    snapshot_id: uuid.UUID,
+    target_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_system_admin(
+        request,
+        user,
+        app_id=app_id,
+        action="app.rollout.target.eligibility",
+    )
+    result = await evaluate_rollout_target(
+        app_id,
+        snapshot_id,
+        target_id,
+        correlation_id=request_correlation_id(request),
+        actor=user.username,
+        actor_id=user.user_id,
+    )
+    _mark_no_store(response)
+    return result
+
+
+@router.post(
+    "/app/rollout-snapshots/{snapshot_id}/targets/{target_id}/eligibility",
+    summary="Recheck a caller-app rollout target before execution",
+)
+async def app_evaluate_target(
+    snapshot_id: uuid.UUID,
+    target_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    principal: AppPrincipal = Depends(get_current_app),
+):
+    correlation_id = await _authorize_app(principal, request, "rollout:request")
+    result = await evaluate_rollout_target(
+        principal.app_id,
+        snapshot_id,
+        target_id,
+        correlation_id=correlation_id,
+        actor=f"app:{principal.app_id}",
+        actor_id=str(principal.app_id),
+    )
+    _mark_no_store(response)
+    return result

--- a/backend/app/db/migrations/052_app_inventory.py
+++ b/backend/app/db/migrations/052_app_inventory.py
@@ -1,0 +1,511 @@
+"""Migration 052: app inventory, observed state, and rollout snapshots.
+
+The tables in this migration are control-plane state.  They deliberately keep
+worker reports and rollout membership separate from the desired-state registry:
+the registry remains the desired source of truth, while reports are monotonic
+observations and snapshots are sealed membership ledgers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger("akb.migration.052")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS app_installation_observed_states (
+                installation_id UUID PRIMARY KEY,
+                app_id UUID NOT NULL,
+                vault_id UUID NOT NULL,
+                observed_generation BIGINT NOT NULL,
+                observed_at TIMESTAMPTZ NOT NULL,
+                observed_release_id UUID,
+                observed_release_version TEXT,
+                schema_fingerprint TEXT,
+                observed_grant_generation BIGINT,
+                checkpoint JSONB NOT NULL DEFAULT '{}'::jsonb,
+                recent_error JSONB,
+                received_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_installation_fkey'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_installation_fkey
+                        FOREIGN KEY (installation_id)
+                        REFERENCES vault_app_installations(id)
+                        ON DELETE CASCADE;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_app_fkey'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_app_fkey
+                        FOREIGN KEY (app_id)
+                        REFERENCES app_definitions(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_vault_fkey'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_vault_fkey
+                        FOREIGN KEY (vault_id)
+                        REFERENCES vaults(id)
+                        ON DELETE CASCADE;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_release_fkey'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_release_fkey
+                        FOREIGN KEY (app_id, observed_release_id)
+                        REFERENCES app_releases(app_id, id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_generation_check'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_generation_check
+                        CHECK (observed_generation >= 0);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_grant_generation_check'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_grant_generation_check
+                        CHECK (
+                            observed_grant_generation IS NULL
+                            OR observed_grant_generation >= 0
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_checkpoint_shape'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_checkpoint_shape
+                        CHECK (jsonb_typeof(checkpoint) = 'object');
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_error_shape'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_error_shape
+                        CHECK (
+                            recent_error IS NULL
+                            OR jsonb_typeof(recent_error) = 'object'
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_release_version_length'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_release_version_length
+                        CHECK (observed_release_version IS NULL OR char_length(observed_release_version) <= 256);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_observed_states_schema_length'
+                       AND conrelid = 'app_installation_observed_states'::regclass
+                ) THEN
+                    ALTER TABLE app_installation_observed_states
+                        ADD CONSTRAINT app_observed_states_schema_length
+                        CHECK (schema_fingerprint IS NULL OR char_length(schema_fingerprint) <= 256);
+                END IF;
+            END
+            $$;
+
+            CREATE INDEX IF NOT EXISTS app_observed_states_app_idx
+                ON app_installation_observed_states(app_id, observed_at DESC);
+
+            CREATE OR REPLACE FUNCTION akb_guard_observed_state_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                installation_app_id UUID;
+                installation_vault_id UUID;
+            BEGIN
+                SELECT app_id, vault_id
+                  INTO installation_app_id, installation_vault_id
+                  FROM vault_app_installations
+                 WHERE id = NEW.installation_id;
+
+                IF installation_app_id IS NULL THEN
+                    RAISE EXCEPTION 'installation does not exist'
+                        USING ERRCODE = '23503';
+                END IF;
+                IF NEW.app_id IS DISTINCT FROM installation_app_id
+                   OR NEW.vault_id IS DISTINCT FROM installation_vault_id
+                THEN
+                    RAISE EXCEPTION
+                        'observed state identity must match its installation'
+                        USING ERRCODE = '23503';
+                END IF;
+
+                IF TG_OP = 'UPDATE' THEN
+                    IF NEW.installation_id IS DISTINCT FROM OLD.installation_id
+                       OR NEW.app_id IS DISTINCT FROM OLD.app_id
+                       OR NEW.vault_id IS DISTINCT FROM OLD.vault_id
+                    THEN
+                        RAISE EXCEPTION
+                            'observed state identity is immutable'
+                            USING ERRCODE = '55000';
+                    END IF;
+                    IF NEW.observed_generation < OLD.observed_generation
+                       OR NEW.observed_at < OLD.observed_at
+                    THEN
+                        RAISE EXCEPTION
+                            'older observed state cannot replace a newer report'
+                            USING ERRCODE = '55000';
+                    END IF;
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_observed_states_mutation_guard
+                ON app_installation_observed_states;
+            CREATE TRIGGER app_observed_states_mutation_guard
+                BEFORE INSERT OR UPDATE ON app_installation_observed_states
+                FOR EACH ROW EXECUTE FUNCTION akb_guard_observed_state_mutation();
+            """
+        )
+
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS app_rollout_snapshots (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                app_id UUID NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                sealed_at TIMESTAMPTZ,
+                requested_by_kind TEXT NOT NULL DEFAULT 'admin'
+            );
+
+            CREATE TABLE IF NOT EXISTS app_rollout_snapshot_targets (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                snapshot_id UUID NOT NULL,
+                app_id UUID NOT NULL,
+                installation_id UUID NOT NULL,
+                vault_id UUID NOT NULL,
+                desired_release_id UUID NOT NULL,
+                current_release_id UUID,
+                baseline_grant_generation BIGINT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'pending',
+                reason_code TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT app_rollout_snapshot_targets_snapshot_key
+                    UNIQUE (snapshot_id, installation_id)
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshots_app_fkey'
+                       AND conrelid = 'app_rollout_snapshots'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshots
+                        ADD CONSTRAINT app_rollout_snapshots_app_fkey
+                        FOREIGN KEY (app_id)
+                        REFERENCES app_definitions(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_snapshot_fkey'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_snapshot_fkey
+                        FOREIGN KEY (snapshot_id)
+                        REFERENCES app_rollout_snapshots(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_app_fkey'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_app_fkey
+                        FOREIGN KEY (app_id)
+                        REFERENCES app_definitions(id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_desired_release_fkey'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_desired_release_fkey
+                        FOREIGN KEY (app_id, desired_release_id)
+                        REFERENCES app_releases(app_id, id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_current_release_fkey'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_current_release_fkey
+                        FOREIGN KEY (app_id, current_release_id)
+                        REFERENCES app_releases(app_id, id)
+                        ON DELETE RESTRICT;
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshots_requester_kind_check'
+                       AND conrelid = 'app_rollout_snapshots'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshots
+                        ADD CONSTRAINT app_rollout_snapshots_requester_kind_check
+                        CHECK (requested_by_kind IN ('admin', 'app'));
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_generation_check'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_generation_check
+                        CHECK (baseline_grant_generation >= 0);
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_state_check'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_state_check
+                        CHECK (
+                            state IN (
+                                'pending', 'running', 'applied', 'replayed',
+                                'failed', 'skipped', 'denied'
+                            )
+                        );
+                END IF;
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                     WHERE conname = 'app_rollout_snapshot_targets_reason_check'
+                       AND conrelid = 'app_rollout_snapshot_targets'::regclass
+                ) THEN
+                    ALTER TABLE app_rollout_snapshot_targets
+                        ADD CONSTRAINT app_rollout_snapshot_targets_reason_check
+                        CHECK (
+                            reason_code IS NULL
+                            OR reason_code ~ '^[a-z][a-z0-9_.-]{0,63}$'
+                        );
+                END IF;
+            END
+            $$;
+
+            CREATE INDEX IF NOT EXISTS app_rollout_snapshots_app_idx
+                ON app_rollout_snapshots(app_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS app_rollout_snapshot_targets_snapshot_idx
+                ON app_rollout_snapshot_targets(snapshot_id, created_at, id);
+            CREATE INDEX IF NOT EXISTS app_rollout_snapshot_targets_app_idx
+                ON app_rollout_snapshot_targets(app_id, installation_id);
+
+            CREATE OR REPLACE FUNCTION akb_app_inventory_set_updated_at()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                NEW.updated_at = NOW();
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_rollout_snapshot_targets_set_updated_at
+                ON app_rollout_snapshot_targets;
+            CREATE TRIGGER app_rollout_snapshot_targets_set_updated_at
+                BEFORE UPDATE ON app_rollout_snapshot_targets
+                FOR EACH ROW EXECUTE FUNCTION akb_app_inventory_set_updated_at();
+
+            CREATE OR REPLACE FUNCTION akb_guard_rollout_snapshot_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION
+                        'sealed rollout snapshots are retained'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF NEW.id IS DISTINCT FROM OLD.id
+                   OR NEW.app_id IS DISTINCT FROM OLD.app_id
+                   OR NEW.created_at IS DISTINCT FROM OLD.created_at
+                   OR NEW.requested_by_kind IS DISTINCT FROM OLD.requested_by_kind
+                THEN
+                    RAISE EXCEPTION
+                        'rollout snapshot identity is immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF OLD.sealed_at IS NOT NULL THEN
+                    RAISE EXCEPTION
+                        'sealed rollout snapshots are immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF NEW.sealed_at IS NULL THEN
+                    RETURN NEW;
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_rollout_snapshots_immutable
+                ON app_rollout_snapshots;
+            CREATE TRIGGER app_rollout_snapshots_immutable
+                BEFORE UPDATE OR DELETE ON app_rollout_snapshots
+                FOR EACH ROW EXECUTE FUNCTION akb_guard_rollout_snapshot_mutation();
+
+            CREATE OR REPLACE FUNCTION akb_guard_rollout_snapshot_target_mutation()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                snapshot_app_id UUID;
+                snapshot_sealed_at TIMESTAMPTZ;
+                installation_app_id UUID;
+                installation_vault_id UUID;
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION
+                        'rollout snapshot membership is immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+
+                SELECT app_id, sealed_at
+                  INTO snapshot_app_id, snapshot_sealed_at
+                  FROM app_rollout_snapshots
+                 WHERE id = NEW.snapshot_id;
+                IF snapshot_app_id IS NULL THEN
+                    RAISE EXCEPTION 'rollout snapshot does not exist'
+                        USING ERRCODE = '23503';
+                END IF;
+                IF NEW.app_id IS DISTINCT FROM snapshot_app_id THEN
+                    RAISE EXCEPTION
+                        'rollout target app must match its snapshot'
+                        USING ERRCODE = '23503';
+                END IF;
+
+                IF TG_OP = 'INSERT' THEN
+                    IF snapshot_sealed_at IS NOT NULL THEN
+                        RAISE EXCEPTION
+                            'sealed rollout snapshot membership is immutable'
+                            USING ERRCODE = '55000';
+                    END IF;
+                    SELECT app_id, vault_id
+                      INTO installation_app_id, installation_vault_id
+                      FROM vault_app_installations
+                     WHERE id = NEW.installation_id;
+                    IF installation_app_id IS NULL THEN
+                        RAISE EXCEPTION 'installation does not exist'
+                            USING ERRCODE = '23503';
+                    END IF;
+                    IF NEW.app_id IS DISTINCT FROM installation_app_id
+                       OR NEW.vault_id IS DISTINCT FROM installation_vault_id
+                    THEN
+                        RAISE EXCEPTION
+                            'rollout target identity must match its installation'
+                            USING ERRCODE = '23503';
+                    END IF;
+                    RETURN NEW;
+                END IF;
+
+                IF NEW.id IS DISTINCT FROM OLD.id
+                   OR NEW.snapshot_id IS DISTINCT FROM OLD.snapshot_id
+                   OR NEW.app_id IS DISTINCT FROM OLD.app_id
+                   OR NEW.installation_id IS DISTINCT FROM OLD.installation_id
+                   OR NEW.vault_id IS DISTINCT FROM OLD.vault_id
+                   OR NEW.desired_release_id IS DISTINCT FROM OLD.desired_release_id
+                   OR NEW.current_release_id IS DISTINCT FROM OLD.current_release_id
+                   OR NEW.baseline_grant_generation IS DISTINCT FROM OLD.baseline_grant_generation
+                   OR NEW.created_at IS DISTINCT FROM OLD.created_at
+                THEN
+                    RAISE EXCEPTION
+                        'rollout target identity and baseline are immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS app_rollout_snapshot_targets_immutable
+                ON app_rollout_snapshot_targets;
+            CREATE TRIGGER app_rollout_snapshot_targets_immutable
+                BEFORE INSERT OR UPDATE OR DELETE ON app_rollout_snapshot_targets
+                FOR EACH ROW EXECUTE FUNCTION akb_guard_rollout_snapshot_target_mutation();
+
+            REVOKE ALL PRIVILEGES ON TABLE
+                app_installation_observed_states,
+                app_rollout_snapshots,
+                app_rollout_snapshot_targets
+            FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_observed_state_mutation()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_app_inventory_set_updated_at()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_rollout_snapshot_mutation()
+                FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION akb_guard_rollout_snapshot_target_mutation()
+                FROM PUBLIC;
+            """
+        )
+
+    logger.info("Migration 052 added app inventory and rollout snapshot state")
+
+
+async def _main():
+    from app.db.postgres import close_pool, init_db
+
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -228,6 +228,7 @@ async def _apply_migrations() -> None:
         "049_external_git_quarantine.py",        # external_git sync_state machine (pending_preflight/active/quarantined) + rollout fence for the pre-hardening poller
         "050_drop_todos.py",                     # archive todos → todos_archive, drop todos: entrypoint-less since PR #43 and the source of the NOT NULL account-deletion failure
         "051_app_credentials.py",                # exchange-only deployment credentials for app principals
+        "052_app_inventory.py",                  # observed installation state and sealed rollout snapshots
     ):
         if filename in applied:
             continue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.api.deps import get_current_user, get_optional_user
 from app.api.routes import (
     access,
     activity,
+    app_inventory,
     agent_sessions,
     app_identity,
     auth,
@@ -267,6 +268,7 @@ async def _no_store_public_surfaces(request: Request, call_next):
 
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(app_identity.router, prefix="/api/v1", tags=["app-identity"])
+app.include_router(app_inventory.router, prefix="/api/v1", tags=["app-inventory"])
 app.include_router(access.router, prefix="/api/v1", tags=["access"])
 app.include_router(documents.router, prefix="/api/v1", tags=["documents"])
 app.include_router(search.router, prefix="/api/v1", tags=["search"])

--- a/backend/app/services/app_identity_service.py
+++ b/backend/app/services/app_identity_service.py
@@ -739,3 +739,85 @@ async def authorize_app_request(
         vault_id=vault_id,
         generation=principal.credential_generation,
     )
+
+
+async def authorize_app_capability(
+    principal: AppPrincipal,
+    *,
+    capability: str,
+    correlation_id: str,
+    conn=None,
+) -> None:
+    """Authorize an app-scoped control-plane capability.
+
+    Inventory and rollout reads address an app as a whole rather than one
+    Vault, so the per-installation ``authorize_app_request`` helper cannot be
+    used as their boundary.  This check still binds authority to the live
+    registry: at least one active installation for the token's app must have
+    the current active grant with the requested capability.
+    """
+    if capability not in SUPPORTED_APP_CAPABILITIES:
+        record_app_audit(
+            "app.capability.denied",
+            correlation_id=correlation_id,
+            outcome="error",
+            reason="unsupported_capability",
+            actor=f"app:{principal.app_id}",
+            actor_id=str(principal.app_id),
+            app_id=principal.app_id,
+            deployment=principal.deployment,
+            generation=principal.credential_generation,
+        )
+        raise ForbiddenError("App request denied")
+
+    async def _check(active_conn):
+        return await active_conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                  FROM vault_app_installations AS installation
+                  JOIN installation_grants AS grant_row
+                    ON grant_row.installation_id = installation.id
+                   AND grant_row.generation = installation.grant_generation
+                   AND grant_row.status = 'active'
+                 WHERE installation.app_id = $1
+                   AND installation.lifecycle = 'active'
+                   AND $2 = ANY(grant_row.capabilities)
+            )
+            """,
+            principal.app_id,
+            capability,
+        )
+
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as acquired:
+            allowed = await _check(acquired)
+    else:
+        allowed = await _check(conn)
+
+    if not allowed:
+        record_app_audit(
+            "app.capability.denied",
+            correlation_id=correlation_id,
+            outcome="error",
+            reason="capability_not_granted",
+            actor=f"app:{principal.app_id}",
+            actor_id=str(principal.app_id),
+            app_id=principal.app_id,
+            deployment=principal.deployment,
+            generation=principal.credential_generation,
+        )
+        raise ForbiddenError("App request denied")
+
+    record_app_audit(
+        "app.capability.authorized",
+        correlation_id=correlation_id,
+        outcome="ok",
+        reason="authorized",
+        actor=f"app:{principal.app_id}",
+        actor_id=str(principal.app_id),
+        app_id=principal.app_id,
+        deployment=principal.deployment,
+        generation=principal.credential_generation,
+    )

--- a/backend/app/services/app_inventory_service.py
+++ b/backend/app/services/app_inventory_service.py
@@ -1,0 +1,1109 @@
+"""App control-plane inventory, observed state, and rollout snapshots.
+
+The desired registry remains the source of truth for what should exist.  This
+service only projects that state, stores the newest worker observation, and
+freezes rollout membership; it does not execute migrations or backfills.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.app_identity_service import (
+    AppPrincipal,
+    authorize_app_request,
+    record_app_audit,
+)
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
+INVENTORY_SCOPES = frozenset({"admin", "app"})
+INSTALLATION_LIFECYCLES = frozenset(
+    {"installing", "active", "upgrading", "blocked", "uninstalled"}
+)
+TARGET_STATES = frozenset(
+    {"pending", "running", "applied", "replayed", "failed", "skipped", "denied"}
+)
+
+_CURSOR_VERSION = 1
+_SAFE_CODE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+_SAFE_FINGERPRINT = re.compile(r"^[0-9A-Fa-f]{8,256}$")
+_SAFE_RELEASE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+-]{0,255}$")
+_SAFE_ISO = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def _cursor_secret() -> bytes:
+    configured = (settings.app_token_secret or settings.jwt_secret or "").encode()
+    # Unit-only configurations may intentionally leave auth secrets blank.  A
+    # deterministic fallback keeps cursors opaque and, more importantly,
+    # still binds them to their signed payload rather than exposing JSON.
+    return configured or b"akb-app-inventory-cursor-v1"
+
+
+def _as_uuid(value: uuid.UUID | str, *, field: str) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValidationError(f"{field} must be a UUID") from exc
+
+
+def _normalize_datetime(value: datetime | str | None, *, field: str) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValidationError(f"{field} must be an ISO-8601 timestamp") from exc
+    if value.tzinfo is None:
+        raise ValidationError(f"{field} must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def normalize_page_size(limit: int | None) -> int:
+    value = DEFAULT_PAGE_SIZE if limit is None else limit
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError("limit must be an integer")
+    if value < 1 or value > MAX_PAGE_SIZE:
+        raise ValidationError(f"limit must be between 1 and {MAX_PAGE_SIZE}")
+    return value
+
+
+def normalize_lifecycle(lifecycle: str | None) -> str | None:
+    if lifecycle is None:
+        return None
+    if lifecycle not in INSTALLATION_LIFECYCLES:
+        raise ValidationError("lifecycle filter is invalid")
+    return lifecycle
+
+
+def _cursor_payload_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+
+
+def encode_inventory_cursor(
+    *,
+    app_id: uuid.UUID,
+    scope: str,
+    limit: int,
+    lifecycle: str | None,
+    boundary: datetime,
+    last_created_at: datetime,
+    last_installation_id: uuid.UUID,
+) -> str:
+    """Create an opaque, signed cursor bound to one inventory traversal."""
+    if scope not in INVENTORY_SCOPES:
+        raise ValidationError("inventory cursor scope is invalid")
+    payload = {
+        "v": _CURSOR_VERSION,
+        "app": str(app_id),
+        "scope": scope,
+        "limit": normalize_page_size(limit),
+        "lifecycle": lifecycle,
+        "boundary": boundary.astimezone(timezone.utc).isoformat(),
+        "last": last_created_at.astimezone(timezone.utc).isoformat(),
+        "id": str(last_installation_id),
+    }
+    raw = _cursor_payload_bytes(payload)
+    signature = hmac.new(_cursor_secret(), raw, hashlib.sha256).digest()
+    encoded = base64.urlsafe_b64encode(raw + b"." + signature).rstrip(b"=")
+    return encoded.decode("ascii")
+
+
+def decode_inventory_cursor(
+    cursor: str,
+    *,
+    app_id: uuid.UUID,
+    scope: str,
+    limit: int,
+    lifecycle: str | None,
+) -> dict[str, Any]:
+    """Decode and validate a cursor without exposing its payload on failure."""
+    try:
+        if not isinstance(cursor, str) or not cursor or len(cursor) > 4096:
+            raise ValueError
+        padded = cursor + "=" * (-len(cursor) % 4)
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        raw, supplied_signature = decoded.rsplit(b".", 1)
+        expected_signature = hmac.new(_cursor_secret(), raw, hashlib.sha256).digest()
+        if not hmac.compare_digest(supplied_signature, expected_signature):
+            raise ValueError
+        payload = json.loads(raw.decode("ascii"))
+        if not isinstance(payload, dict):
+            raise ValueError
+        if (
+            payload.get("v") != _CURSOR_VERSION
+            or payload.get("app") != str(app_id)
+            or payload.get("scope") != scope
+            or payload.get("limit") != normalize_page_size(limit)
+            or payload.get("lifecycle") != lifecycle
+        ):
+            raise ValueError
+        boundary_value = payload.get("boundary")
+        last_created_at_value = payload.get("last")
+        if not isinstance(boundary_value, str) or not isinstance(last_created_at_value, str):
+            raise ValueError
+        boundary = _normalize_datetime(boundary_value, field="cursor")
+        last_created_at = _normalize_datetime(last_created_at_value, field="cursor")
+        last_id = _as_uuid(payload.get("id"), field="cursor")
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError, UnicodeError):
+        raise ValidationError("Invalid inventory cursor") from None
+    return {
+        "boundary": boundary,
+        "last_created_at": last_created_at,
+        "last_installation_id": last_id,
+    }
+
+
+def _safe_code(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_CODE.fullmatch(value) else None
+
+
+def _safe_iso(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        value = value.astimezone(timezone.utc).isoformat()
+    if not isinstance(value, str):
+        return None
+    return value if len(value) <= 64 and _SAFE_ISO.fullmatch(value) else None
+
+
+def _safe_fingerprint(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_FINGERPRINT.fullmatch(value) else None
+
+
+def _safe_release(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_RELEASE.fullmatch(value) else None
+
+
+def sanitize_checkpoint(value: Any) -> dict[str, Any]:
+    """Keep only bounded operational checkpoint fields.
+
+    Unknown keys are intentionally discarded.  This prevents worker request
+    bodies, credentials, and arbitrary provider metadata from becoming part of
+    the inventory read model.
+    """
+    value = _json_object(value)
+    result: dict[str, Any] = {}
+    for key in ("phase", "step", "code"):
+        safe = _safe_code(value.get(key))
+        if safe is not None:
+            result[key] = safe
+    for key in ("completed", "total", "attempt"):
+        item = value.get(key)
+        if isinstance(item, int) and not isinstance(item, bool) and 0 <= item <= 10**9:
+            result[key] = item
+    for key in ("at", "updated_at"):
+        safe = _safe_iso(value.get(key))
+        if safe is not None:
+            result[key] = safe
+    return result
+
+
+def sanitize_recent_error(value: Any) -> dict[str, Any] | None:
+    """Return a bounded error summary without free-form payload text."""
+    value = _json_object(value)
+    result: dict[str, Any] = {}
+    code = _safe_code(value.get("code"))
+    if code is not None:
+        result["code"] = code
+    phase = _safe_code(value.get("phase"))
+    if phase is not None:
+        result["phase"] = phase
+    at = _safe_iso(value.get("at") or value.get("occurred_at"))
+    if at is not None:
+        result["at"] = at
+    if isinstance(value.get("retryable"), bool):
+        result["retryable"] = value["retryable"]
+    return result or None
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def expected_schema_fingerprint(manifest: Any) -> str | None:
+    """Read the optional expected schema fingerprint from a release manifest."""
+    manifest = _json_object(manifest)
+    candidates = [
+        manifest.get("expected_schema_fingerprint"),
+        manifest.get("schema_fingerprint"),
+        _json_object(manifest.get("schema")).get("fingerprint"),
+        _json_object(manifest.get("schema")).get("expected_fingerprint"),
+    ]
+    for candidate in candidates:
+        value = _safe_fingerprint(candidate)
+        if value is not None:
+            return value
+    return None
+
+
+def classify_drift(row: Any) -> dict[str, Any]:
+    """Classify release, schema, and grant drift independently."""
+    observed_generation = row.get("observed_generation") if hasattr(row, "get") else row["observed_generation"]
+    observed_exists = observed_generation is not None
+    desired_release_id = row.get("desired_release_id") if hasattr(row, "get") else row["desired_release_id"]
+    observed_release_id = row.get("observed_release_id") if hasattr(row, "get") else row["observed_release_id"]
+    desired_version = row.get("desired_version") if hasattr(row, "get") else row["desired_version"]
+    observed_version = row.get("observed_release_version") if hasattr(row, "get") else row["observed_release_version"]
+    expected_schema = expected_schema_fingerprint(
+        row.get("desired_manifest") if hasattr(row, "get") else row["desired_manifest"]
+    )
+    observed_schema = _safe_fingerprint(
+        row.get("schema_fingerprint") if hasattr(row, "get") else row["schema_fingerprint"]
+    )
+    desired_grant_generation = row.get("grant_generation") if hasattr(row, "get") else row["grant_generation"]
+    observed_grant_generation = (
+        row.get("observed_grant_generation")
+        if hasattr(row, "get")
+        else row["observed_grant_generation"]
+    )
+
+    if not observed_exists:
+        release_status = schema_status = grant_status = "unknown"
+    else:
+        if desired_release_id is None:
+            release_status = "unknown"
+        elif observed_release_id is not None:
+            release_status = "match" if observed_release_id == desired_release_id else "mismatch"
+        elif observed_version is not None and desired_version is not None:
+            release_status = "match" if observed_version == desired_version else "mismatch"
+        else:
+            release_status = "unknown"
+
+        if expected_schema is None or observed_schema is None:
+            schema_status = "unknown"
+        else:
+            schema_status = "match" if expected_schema == observed_schema else "mismatch"
+
+        if observed_grant_generation is None or desired_grant_generation is None:
+            grant_status = "unknown"
+        else:
+            grant_status = (
+                "match"
+                if observed_grant_generation == desired_grant_generation
+                else "mismatch"
+            )
+
+    dimensions = {
+        "release": {
+            "status": release_status,
+            "desired": desired_version,
+            "observed": observed_version,
+        },
+        "schema": {
+            "status": schema_status,
+            "expected": expected_schema,
+            "observed": observed_schema,
+        },
+        "grant": {
+            "status": grant_status,
+            "desired_generation": desired_grant_generation,
+            "observed_generation": observed_grant_generation,
+        },
+    }
+    reasons = [
+        f"{dimension}_mismatch"
+        for dimension, data in dimensions.items()
+        if data["status"] == "mismatch"
+    ]
+    unknown = [
+        dimension
+        for dimension, data in dimensions.items()
+        if data["status"] == "unknown"
+    ]
+    overall = "drifted" if reasons else "unknown" if unknown else "in_sync"
+    dimensions["overall"] = overall
+    return {
+        "release": dimensions["release"],
+        "schema": dimensions["schema"],
+        "grant": dimensions["grant"],
+        "overall": overall,
+        "reasons": reasons,
+        "unknown_dimensions": unknown,
+    }
+
+
+def _release_payload(release_id: Any, version: Any) -> dict[str, Any] | None:
+    if release_id is None and version is None:
+        return None
+    return {
+        "id": str(release_id) if release_id is not None else None,
+        "version": version,
+    }
+
+
+def _observed_payload(row: Any) -> dict[str, Any] | None:
+    if row["observed_generation"] is None:
+        return None
+    return {
+        "generation": row["observed_generation"],
+        "observed_at": row["observed_at"].isoformat() if row["observed_at"] else None,
+        "release": _release_payload(
+            row["observed_release_id"],
+            row["observed_release_version"],
+        ),
+        "schema_fingerprint": _safe_fingerprint(row["schema_fingerprint"]),
+        "grant_generation": row["observed_grant_generation"],
+        "checkpoint": sanitize_checkpoint(row["checkpoint"]),
+        "recent_error": sanitize_recent_error(row["recent_error"]),
+    }
+
+
+def project_inventory_item(row: Any) -> dict[str, Any]:
+    """Project one DB row without issuer, provenance, resource metadata, or payloads."""
+    drift = classify_drift(row)
+    latest_grant = None
+    if row["latest_grant_generation"] is not None:
+        capabilities = row["latest_grant_capabilities"] or []
+        latest_grant = {
+            "generation": row["latest_grant_generation"],
+            "status": row["latest_grant_status"],
+            "capabilities": sorted(
+                capability for capability in capabilities if isinstance(capability, str)
+            ),
+        }
+    latest_active_grant = None
+    if row.get("latest_active_grant_generation") is not None:
+        active_capabilities = row["latest_active_grant_capabilities"] or []
+        latest_active_grant = {
+            "generation": row["latest_active_grant_generation"],
+            "status": row["latest_active_grant_status"],
+            "capabilities": sorted(
+                capability
+                for capability in active_capabilities
+                if isinstance(capability, str)
+            ),
+        }
+    return {
+        "installation_id": str(row["installation_id"]),
+        "app_id": str(row["app_id"]),
+        "vault_id": str(row["vault_id"]),
+        "vault_name": row["vault_name"],
+        "lifecycle": row["lifecycle"],
+        "desired_release": _release_payload(
+            row["desired_release_id"],
+            row["desired_version"],
+        ),
+        "current_release": _release_payload(
+            row["current_release_id"],
+            row["current_version"],
+        ),
+        "observed": _observed_payload(row),
+        "latest_grant": latest_grant,
+        "latest_active_grant": latest_active_grant,
+        "grant_generation": row["grant_generation"],
+        "checkpoint": (
+            sanitize_checkpoint(row["checkpoint"])
+            if row["observed_generation"] is not None
+            else {}
+        ),
+        "recent_error": (
+            sanitize_recent_error(row["recent_error"])
+            if row["observed_generation"] is not None
+            else None
+        ),
+        "drift": drift,
+        "drift_classification": drift,
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+
+
+_INVENTORY_SELECT = """
+    SELECT
+        installation.id AS installation_id,
+        installation.app_id,
+        installation.vault_id,
+        vault.name AS vault_name,
+        installation.lifecycle,
+        installation.desired_release_id,
+        desired.version AS desired_version,
+        desired.manifest AS desired_manifest,
+        installation.current_release_id,
+        current_release.version AS current_version,
+        installation.grant_generation,
+        latest_grant.generation AS latest_grant_generation,
+        latest_grant.status AS latest_grant_status,
+        latest_grant.capabilities AS latest_grant_capabilities,
+        latest_active_grant.generation AS latest_active_grant_generation,
+        latest_active_grant.status AS latest_active_grant_status,
+        latest_active_grant.capabilities AS latest_active_grant_capabilities,
+        observed.observed_generation,
+        observed.observed_at,
+        observed.observed_release_id,
+        observed.observed_release_version,
+        observed.schema_fingerprint,
+        observed.observed_grant_generation,
+        observed.checkpoint,
+        observed.recent_error,
+        installation.created_at,
+        installation.updated_at
+      FROM vault_app_installations AS installation
+      JOIN vaults AS vault ON vault.id = installation.vault_id
+      LEFT JOIN app_releases AS desired ON desired.id = installation.desired_release_id
+      LEFT JOIN app_releases AS current_release ON current_release.id = installation.current_release_id
+      LEFT JOIN app_installation_observed_states AS observed
+        ON observed.installation_id = installation.id
+      LEFT JOIN LATERAL (
+          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+            FROM installation_grants AS grant_row
+           WHERE grant_row.installation_id = installation.id
+           ORDER BY grant_row.generation DESC
+           LIMIT 1
+      ) AS latest_grant ON TRUE
+      LEFT JOIN LATERAL (
+          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+            FROM installation_grants AS grant_row
+           WHERE grant_row.installation_id = installation.id
+             AND grant_row.status = 'active'
+           ORDER BY grant_row.generation DESC
+           LIMIT 1
+      ) AS latest_active_grant ON TRUE
+"""
+
+
+async def list_inventory(
+    app_id: uuid.UUID | str,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+    lifecycle: str | None = None,
+    scope: str = "admin",
+    capability: str | None = None,
+) -> dict[str, Any]:
+    """List an app's inventory with a stable, bounded cursor traversal."""
+    app_id = _as_uuid(app_id, field="app_id")
+    if scope not in INVENTORY_SCOPES:
+        raise ValidationError("inventory scope is invalid")
+    limit = normalize_page_size(limit)
+    lifecycle = normalize_lifecycle(lifecycle)
+    if capability is not None and capability != "inventory:read":
+        raise ValidationError("inventory capability is invalid")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        if not await conn.fetchval("SELECT 1 FROM app_definitions WHERE id = $1", app_id):
+            raise NotFoundError("App", "not found")
+
+        if cursor is None:
+            boundary = await conn.fetchval("SELECT CURRENT_TIMESTAMP")
+            last_created_at = None
+            last_installation_id = None
+        else:
+            decoded = decode_inventory_cursor(
+                cursor,
+                app_id=app_id,
+                scope=scope,
+                limit=limit,
+                lifecycle=lifecycle,
+            )
+            boundary = decoded["boundary"]
+            last_created_at = decoded["last_created_at"]
+            last_installation_id = decoded["last_installation_id"]
+
+        rows = await conn.fetch(
+            _INVENTORY_SELECT
+            + """
+             WHERE installation.app_id = $1
+               AND installation.created_at <= $2
+               AND ($3::text IS NULL OR installation.lifecycle = $3)
+               AND (
+                   $4::timestamptz IS NULL
+                   OR installation.created_at > $4
+                   OR (
+                       installation.created_at = $4
+                       AND installation.id > $5
+                   )
+               )
+               AND (
+                   $6::text IS NULL
+                   OR EXISTS (
+                       SELECT 1
+                         FROM installation_grants AS visible_grant
+                        WHERE visible_grant.installation_id = installation.id
+                          AND visible_grant.generation = installation.grant_generation
+                          AND visible_grant.status = 'active'
+                          AND $6 = ANY(visible_grant.capabilities)
+                   )
+               )
+             ORDER BY installation.created_at ASC, installation.id ASC
+             LIMIT $7
+            """,
+            app_id,
+            boundary,
+            lifecycle,
+            last_created_at,
+            last_installation_id,
+            capability,
+            limit + 1,
+        )
+
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_cursor = None
+    if has_more and page:
+        tail = page[-1]
+        next_cursor = encode_inventory_cursor(
+            app_id=app_id,
+            scope=scope,
+            limit=limit,
+            lifecycle=lifecycle,
+            boundary=boundary,
+            last_created_at=tail["created_at"],
+            last_installation_id=tail["installation_id"],
+        )
+    return {
+        "items": [project_inventory_item(row) for row in page],
+        "next_cursor": next_cursor,
+    }
+
+
+async def report_observed_state(
+    installation_id: uuid.UUID | str,
+    *,
+    observed_generation: int,
+    observed_at: datetime | str | None = None,
+    observed_release_id: uuid.UUID | str | None = None,
+    observed_release_version: str | None = None,
+    schema_fingerprint: str | None = None,
+    observed_grant_generation: int | None = None,
+    checkpoint: Any = None,
+    recent_error: Any = None,
+    app_id: uuid.UUID | str | None = None,
+    principal: AppPrincipal | None = None,
+    correlation_id: str = "app-inventory",
+    actor: str | None = None,
+    actor_id: str | None = None,
+) -> dict[str, Any]:
+    """Persist the newest worker report for one installation."""
+    installation_id = _as_uuid(installation_id, field="installation_id")
+    if isinstance(observed_generation, bool) or not isinstance(observed_generation, int):
+        raise ValidationError("observed_generation must be an integer")
+    if observed_generation < 0:
+        raise ValidationError("observed_generation must not be negative")
+    if observed_grant_generation is not None and (
+        isinstance(observed_grant_generation, bool)
+        or not isinstance(observed_grant_generation, int)
+        or observed_grant_generation < 0
+    ):
+        raise ValidationError("observed_grant_generation must be a non-negative integer")
+    observed_at = _normalize_datetime(observed_at, field="observed_at")
+    app_uuid = _as_uuid(app_id, field="app_id") if app_id is not None else None
+    release_uuid = (
+        _as_uuid(observed_release_id, field="observed_release_id")
+        if observed_release_id is not None
+        else None
+    )
+    release_version = _safe_release(observed_release_version)
+    if observed_release_version is not None and release_version is None:
+        raise ValidationError("observed_release_version is invalid")
+    fingerprint = _safe_fingerprint(schema_fingerprint)
+    if schema_fingerprint is not None and fingerprint is None:
+        raise ValidationError("schema_fingerprint is invalid")
+    clean_checkpoint = sanitize_checkpoint(checkpoint)
+    clean_error = sanitize_recent_error(recent_error)
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            installation = await conn.fetchrow(
+                """
+                SELECT app_id, vault_id
+                  FROM vault_app_installations
+                 WHERE id = $1
+                """,
+                installation_id,
+            )
+            if installation is None or (
+                app_uuid is not None and installation["app_id"] != app_uuid
+            ):
+                raise NotFoundError("Installation", "not found")
+            if principal is not None and installation["app_id"] != principal.app_id:
+                raise NotFoundError("Installation", "not found")
+            if release_uuid is not None and not await conn.fetchval(
+                "SELECT 1 FROM app_releases WHERE app_id = $1 AND id = $2",
+                installation["app_id"],
+                release_uuid,
+            ):
+                raise ValidationError("observed_release_id is not registered for this app")
+            if principal is not None:
+                await authorize_app_request(
+                    principal,
+                    vault_id=installation["vault_id"],
+                    capability="inventory:read",
+                    correlation_id=correlation_id,
+                    conn=conn,
+                )
+
+            row = await conn.fetchrow(
+                """
+                INSERT INTO app_installation_observed_states (
+                    installation_id,
+                    app_id,
+                    vault_id,
+                    observed_generation,
+                    observed_at,
+                    observed_release_id,
+                    observed_release_version,
+                    schema_fingerprint,
+                    observed_grant_generation,
+                    checkpoint,
+                    recent_error
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb)
+                ON CONFLICT (installation_id) DO UPDATE
+                    SET observed_generation = EXCLUDED.observed_generation,
+                        observed_at = EXCLUDED.observed_at,
+                        observed_release_id = EXCLUDED.observed_release_id,
+                        observed_release_version = EXCLUDED.observed_release_version,
+                        schema_fingerprint = EXCLUDED.schema_fingerprint,
+                        observed_grant_generation = EXCLUDED.observed_grant_generation,
+                        checkpoint = EXCLUDED.checkpoint,
+                        recent_error = EXCLUDED.recent_error,
+                        received_at = NOW()
+                  WHERE EXCLUDED.observed_generation >= app_installation_observed_states.observed_generation
+                    AND EXCLUDED.observed_at >= app_installation_observed_states.observed_at
+                RETURNING *
+                """,
+                installation_id,
+                installation["app_id"],
+                installation["vault_id"],
+                observed_generation,
+                observed_at,
+                release_uuid,
+                release_version,
+                fingerprint,
+                observed_grant_generation,
+                json.dumps(clean_checkpoint),
+                json.dumps(clean_error) if clean_error is not None else None,
+            )
+            accepted = row is not None
+            if row is None:
+                row = await conn.fetchrow(
+                    "SELECT * FROM app_installation_observed_states WHERE installation_id = $1",
+                    installation_id,
+                )
+
+    if row is None:  # pragma: no cover - guarded by the installation lookup
+        raise ConflictError("Observed report was not stored")
+    return {
+        "accepted": accepted,
+        "installation_id": str(installation_id),
+        "observed_generation": row["observed_generation"],
+        "observed_at": row["observed_at"].isoformat(),
+    }
+
+
+async def create_rollout_snapshot(
+    app_id: uuid.UUID | str,
+    *,
+    requested_by_kind: str = "admin",
+    correlation_id: str = "app-inventory",
+    actor: str | None = None,
+    actor_id: str | None = None,
+) -> dict[str, Any]:
+    """Create and seal an immutable desired-release membership snapshot."""
+    app_id = _as_uuid(app_id, field="app_id")
+    if requested_by_kind not in {"admin", "app"}:
+        raise ValidationError("requested_by_kind is invalid")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            if not await conn.fetchval("SELECT 1 FROM app_definitions WHERE id = $1", app_id):
+                raise NotFoundError("App", "not found")
+            snapshot = await conn.fetchrow(
+                """
+                INSERT INTO app_rollout_snapshots (app_id, requested_by_kind)
+                VALUES ($1, $2)
+                RETURNING id, app_id, created_at
+                """,
+                app_id,
+                requested_by_kind,
+            )
+            await conn.execute(
+                """
+                INSERT INTO app_rollout_snapshot_targets (
+                    snapshot_id,
+                    app_id,
+                    installation_id,
+                    vault_id,
+                    desired_release_id,
+                    current_release_id,
+                    baseline_grant_generation
+                )
+                SELECT $1,
+                       installation.app_id,
+                       installation.id,
+                       installation.vault_id,
+                       installation.desired_release_id,
+                       installation.current_release_id,
+                       installation.grant_generation
+                  FROM vault_app_installations AS installation
+                 WHERE installation.app_id = $2
+                   AND installation.desired_release_id IS NOT NULL
+                """,
+                snapshot["id"],
+                app_id,
+            )
+            await conn.execute(
+                """
+                UPDATE app_rollout_snapshot_targets AS target
+                   SET state = CASE
+                       WHEN installation.lifecycle <> 'active'
+                           THEN 'denied'
+                       WHEN grant_row.generation IS NULL
+                            OR grant_row.status <> 'active'
+                            OR grant_row.generation <> installation.grant_generation
+                           THEN 'denied'
+                       WHEN observed.observed_generation IS NULL
+                           THEN 'skipped'
+                       WHEN observed.observed_grant_generation IS NULL
+                            OR observed.observed_grant_generation <> installation.grant_generation
+                           THEN 'skipped'
+                       WHEN installation.current_release_id IS NOT NULL
+                            AND (
+                                observed.observed_release_id IS NULL
+                                OR observed.observed_release_id <> installation.current_release_id
+                            )
+                           THEN 'skipped'
+                       ELSE 'pending'
+                   END,
+                       reason_code = CASE
+                       WHEN installation.lifecycle <> 'active'
+                           THEN 'installation_inactive'
+                       WHEN grant_row.generation IS NULL
+                            OR grant_row.status <> 'active'
+                            OR grant_row.generation <> installation.grant_generation
+                           THEN 'grant_revoked_or_missing'
+                       WHEN observed.observed_generation IS NULL
+                           THEN 'observed_state_missing'
+                       WHEN observed.observed_grant_generation IS NULL
+                            OR observed.observed_grant_generation <> installation.grant_generation
+                           THEN 'observed_grant_stale'
+                       WHEN installation.current_release_id IS NOT NULL
+                            AND (
+                                observed.observed_release_id IS NULL
+                                OR observed.observed_release_id <> installation.current_release_id
+                            )
+                           THEN 'observed_release_stale'
+                       ELSE NULL
+                   END
+                  FROM vault_app_installations AS installation
+                  LEFT JOIN LATERAL (
+                      SELECT grant_row.generation, grant_row.status
+                        FROM installation_grants AS grant_row
+                       WHERE grant_row.installation_id = installation.id
+                         AND grant_row.generation = installation.grant_generation
+                       LIMIT 1
+                  ) AS grant_row ON TRUE
+                  LEFT JOIN app_installation_observed_states AS observed
+                    ON observed.installation_id = installation.id
+                 WHERE target.snapshot_id = $1
+                   AND target.installation_id = installation.id
+                """,
+                snapshot["id"],
+            )
+            target_count = await conn.fetchval(
+                "SELECT count(*) FROM app_rollout_snapshot_targets WHERE snapshot_id = $1",
+                snapshot["id"],
+            )
+            sealed = await conn.fetchrow(
+                """
+                UPDATE app_rollout_snapshots
+                   SET sealed_at = NOW()
+                 WHERE id = $1 AND sealed_at IS NULL
+                RETURNING id, app_id, created_at, sealed_at, requested_by_kind
+                """,
+                snapshot["id"],
+            )
+
+    if sealed is None:  # pragma: no cover - the transaction owns the row
+        raise ConflictError("Rollout snapshot could not be sealed")
+    record_app_audit(
+        "app.rollout.snapshot.create",
+        correlation_id=correlation_id,
+        outcome="ok",
+        reason="sealed",
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_id,
+    )
+    return {
+        "snapshot_id": str(sealed["id"]),
+        "app_id": str(sealed["app_id"]),
+        "created_at": sealed["created_at"].isoformat(),
+        "sealed_at": sealed["sealed_at"].isoformat(),
+        "requested_by_kind": sealed["requested_by_kind"],
+        "target_count": int(target_count or 0),
+    }
+
+
+async def get_rollout_snapshot(
+    app_id: uuid.UUID | str,
+    snapshot_id: uuid.UUID | str,
+    *,
+    target_id: uuid.UUID | str | None = None,
+) -> dict[str, Any]:
+    """Read a snapshot and its frozen targets within one app scope."""
+    app_id = _as_uuid(app_id, field="app_id")
+    snapshot_id = _as_uuid(snapshot_id, field="snapshot_id")
+    target_uuid = _as_uuid(target_id, field="target_id") if target_id is not None else None
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        snapshot = await conn.fetchrow(
+            """
+            SELECT id, app_id, created_at, sealed_at, requested_by_kind
+              FROM app_rollout_snapshots
+             WHERE id = $1 AND app_id = $2
+            """,
+            snapshot_id,
+            app_id,
+        )
+        if snapshot is None:
+            raise NotFoundError("Rollout snapshot", "not found")
+        rows = await conn.fetch(
+            """
+            SELECT target.id,
+                   target.installation_id,
+                   target.vault_id,
+                   target.desired_release_id,
+                   desired.version AS desired_version,
+                   target.current_release_id,
+                   current_release.version AS current_version,
+                   target.baseline_grant_generation,
+                   target.state,
+                   target.reason_code,
+                   target.created_at,
+                   target.updated_at
+              FROM app_rollout_snapshot_targets AS target
+              LEFT JOIN app_releases AS desired
+                ON desired.id = target.desired_release_id
+              LEFT JOIN app_releases AS current_release
+                ON current_release.id = target.current_release_id
+             WHERE target.snapshot_id = $1
+               AND ($2::uuid IS NULL OR target.id = $2)
+             ORDER BY target.created_at ASC, target.id ASC
+            """,
+            snapshot_id,
+            target_uuid,
+        )
+
+    targets = [
+        {
+            "target_id": str(row["id"]),
+            "installation_id": str(row["installation_id"]),
+            "vault_id": str(row["vault_id"]),
+            "desired_release": _release_payload(
+                row["desired_release_id"],
+                row["desired_version"],
+            ),
+            "current_release": _release_payload(
+                row["current_release_id"],
+                row["current_version"],
+            ),
+            "baseline_grant_generation": row["baseline_grant_generation"],
+            "state": row["state"],
+            "reason_code": row["reason_code"],
+            "created_at": row["created_at"].isoformat(),
+            "updated_at": row["updated_at"].isoformat(),
+        }
+        for row in rows
+    ]
+    return {
+        "snapshot_id": str(snapshot["id"]),
+        "app_id": str(snapshot["app_id"]),
+        "created_at": snapshot["created_at"].isoformat(),
+        "sealed_at": snapshot["sealed_at"].isoformat() if snapshot["sealed_at"] else None,
+        "requested_by_kind": snapshot["requested_by_kind"],
+        "target_count": len(targets),
+        "targets": targets,
+    }
+
+
+async def evaluate_rollout_target(
+    app_id: uuid.UUID | str,
+    snapshot_id: uuid.UUID | str,
+    target_id: uuid.UUID | str,
+    *,
+    correlation_id: str = "app-inventory",
+    actor: str | None = None,
+    actor_id: str | None = None,
+) -> dict[str, Any]:
+    """Recheck live eligibility and mark a target running when safe.
+
+    This is the pre-execution seam only.  It never performs migration or
+    backfill work; an eligible target is merely moved to ``running`` for the
+    later AKB-126 executor.
+    """
+    app_id = _as_uuid(app_id, field="app_id")
+    snapshot_id = _as_uuid(snapshot_id, field="snapshot_id")
+    target_id = _as_uuid(target_id, field="target_id")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            target = await conn.fetchrow(
+                """
+                SELECT target.*, snapshot.created_at AS snapshot_created_at
+                  FROM app_rollout_snapshot_targets AS target
+                  JOIN app_rollout_snapshots AS snapshot
+                    ON snapshot.id = target.snapshot_id
+                 WHERE target.id = $1
+                   AND target.snapshot_id = $2
+                   AND target.app_id = $3
+                 FOR UPDATE
+                """,
+                target_id,
+                snapshot_id,
+                app_id,
+            )
+            if target is None:
+                raise NotFoundError("Rollout target", "not found")
+            if target["state"] != "pending":
+                return {
+                    "target_id": str(target["id"]),
+                    "eligible": target["state"] == "running",
+                    "executed": False,
+                    "state": target["state"],
+                    "reason_code": target["reason_code"],
+                }
+
+            installation = await conn.fetchrow(
+                """
+                SELECT id, app_id, vault_id, lifecycle,
+                       desired_release_id, current_release_id, grant_generation
+                  FROM vault_app_installations
+                 WHERE id = $1
+                """,
+                target["installation_id"],
+            )
+            state = "running"
+            reason = None
+            if installation is None:
+                state, reason = "denied", "installation_missing"
+            elif installation["app_id"] != app_id:
+                state, reason = "denied", "installation_scope_mismatch"
+            elif installation["lifecycle"] != "active":
+                state, reason = "denied", "installation_inactive"
+            elif (
+                installation["desired_release_id"] != target["desired_release_id"]
+                or installation["current_release_id"] != target["current_release_id"]
+            ):
+                state, reason = "skipped", "release_changed"
+            else:
+                latest_grant = await conn.fetchrow(
+                    """
+                    SELECT status, generation
+                      FROM installation_grants
+                     WHERE installation_id = $1
+                     ORDER BY generation DESC
+                     LIMIT 1
+                    """,
+                    installation["id"],
+                )
+                if (
+                    latest_grant is None
+                    or latest_grant["status"] != "active"
+                    or latest_grant["generation"] != installation["grant_generation"]
+                ):
+                    state, reason = "denied", "grant_revoked_or_missing"
+                elif installation["grant_generation"] != target["baseline_grant_generation"]:
+                    state, reason = "skipped", "grant_generation_stale"
+                else:
+                    observed = await conn.fetchrow(
+                        """
+                        SELECT observed_release_id, observed_grant_generation
+                          FROM app_installation_observed_states
+                         WHERE installation_id = $1
+                        """,
+                        installation["id"],
+                    )
+                    if observed is None:
+                        state, reason = "skipped", "observed_state_missing"
+                    elif (
+                        observed["observed_grant_generation"] is None
+                        or observed["observed_grant_generation"]
+                        != installation["grant_generation"]
+                    ):
+                        state, reason = "skipped", "observed_grant_stale"
+                    elif (
+                        installation["current_release_id"] is not None
+                        and (
+                            observed["observed_release_id"] is None
+                            or observed["observed_release_id"]
+                            != installation["current_release_id"]
+                        )
+                    ):
+                        state, reason = "skipped", "observed_release_stale"
+
+            await conn.execute(
+                """
+                UPDATE app_rollout_snapshot_targets
+                   SET state = $2, reason_code = $3
+                 WHERE id = $1
+                """,
+                target_id,
+                state,
+                reason,
+            )
+
+    record_app_audit(
+        "app.rollout.target.eligibility",
+        correlation_id=correlation_id,
+        outcome="ok" if state == "running" else "error",
+        reason=reason or "eligible",
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_id,
+    )
+    return {
+        "target_id": str(target_id),
+        "eligible": state == "running",
+        "executed": False,
+        "state": state,
+        "reason_code": reason,
+    }
+
+
+# Explicit aliases keep the service boundary discoverable to callers that use
+# the noun from the issue document rather than the shorter internal names.
+list_app_inventory = list_inventory
+upsert_observed_state = report_observed_state
+create_rollout_target_snapshot = create_rollout_snapshot
+get_rollout_target_snapshot = get_rollout_snapshot
+evaluate_target_eligibility = evaluate_rollout_target

--- a/backend/app/services/app_inventory_service.py
+++ b/backend/app/services/app_inventory_service.py
@@ -169,7 +169,10 @@ def decode_inventory_cursor(
             raise ValueError
         boundary = _normalize_datetime(boundary_value, field="cursor")
         last_created_at = _normalize_datetime(last_created_at_value, field="cursor")
-        last_id = _as_uuid(payload.get("id"), field="cursor")
+        cursor_id = payload.get("id")
+        if not isinstance(cursor_id, str):
+            raise ValueError
+        last_id = _as_uuid(cursor_id, field="cursor")
     except (ValueError, TypeError, KeyError, json.JSONDecodeError, UnicodeError):
         raise ValidationError("Invalid inventory cursor") from None
     return {
@@ -353,7 +356,6 @@ def classify_drift(row: Any) -> dict[str, Any]:
         if data["status"] == "unknown"
     ]
     overall = "drifted" if reasons else "unknown" if unknown else "in_sync"
-    dimensions["overall"] = overall
     return {
         "release": dimensions["release"],
         "schema": dimensions["schema"],

--- a/backend/app/services/app_inventory_service.py
+++ b/backend/app/services/app_inventory_service.py
@@ -143,7 +143,12 @@ def decode_inventory_cursor(
             raise ValueError
         padded = cursor + "=" * (-len(cursor) % 4)
         decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
-        raw, supplied_signature = decoded.rsplit(b".", 1)
+        signature_size = hashlib.sha256().digest_size
+        separator_index = len(decoded) - signature_size - 1
+        if separator_index < 1 or decoded[separator_index] != ord("."):
+            raise ValueError
+        raw = decoded[:separator_index]
+        supplied_signature = decoded[separator_index + 1 :]
         expected_signature = hmac.new(_cursor_secret(), raw, hashlib.sha256).digest()
         if not hmac.compare_digest(supplied_signature, expected_signature):
             raise ValueError

--- a/backend/tests/test_app_inventory_postgres.py
+++ b/backend/tests/test_app_inventory_postgres.py
@@ -261,3 +261,78 @@ async def test_snapshot_seal_membership_and_stale_target_eligibility(inventory_p
     )
     assert eligibility["state"] == "denied"
     assert eligibility["reason_code"] == "grant_revoked_or_missing"
+
+
+async def test_inventory_cursor_lineage_survives_late_insert_and_existing_update(
+    inventory_pool,
+):
+    app_id = await _app(inventory_pool, "cursor-lineage")
+    release_id = await _release(inventory_pool, app_id)
+    initial_ids = [
+        await _installation(
+            inventory_pool,
+            app_id,
+            await _vault(inventory_pool, f"cursor-{index}"),
+            release_id,
+        )
+        for index in range(65)
+    ]
+
+    first_page = await inventory.list_inventory(app_id, limit=20)
+    assert len(first_page["items"]) == 20
+    assert first_page["next_cursor"] is not None
+
+    late_id = await _installation(
+        inventory_pool,
+        app_id,
+        await _vault(inventory_pool, "cursor-late"),
+        release_id,
+    )
+    existing_id = uuid.UUID(first_page["items"][0]["installation_id"])
+    async with inventory_pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE vault_app_installations
+               SET lifecycle = 'blocked', blocked_reason = $2
+             WHERE id = $1
+            """,
+            existing_id,
+            "fixture_b1_updated",
+        )
+
+    original_pages = [first_page]
+    cursor = first_page["next_cursor"]
+    while cursor is not None:
+        page = await inventory.list_inventory(app_id, limit=20, cursor=cursor)
+        original_pages.append(page)
+        cursor = page["next_cursor"]
+
+    original_ids = [
+        item["installation_id"]
+        for page in original_pages
+        for item in page["items"]
+    ]
+    assert len(original_pages) >= 3
+    assert original_pages[-1]["next_cursor"] is None
+    assert len(original_ids) == len(initial_ids) == 65
+    assert len(set(original_ids)) == 65
+    assert str(late_id) not in original_ids
+
+    fresh_pages = []
+    cursor = None
+    while True:
+        page = await inventory.list_inventory(app_id, limit=20, cursor=cursor)
+        fresh_pages.append(page)
+        cursor = page["next_cursor"]
+        if cursor is None:
+            break
+
+    fresh_ids = [
+        item["installation_id"]
+        for page in fresh_pages
+        for item in page["items"]
+    ]
+    assert len(fresh_ids) == 66
+    assert len(set(fresh_ids)) == 66
+    assert fresh_ids.count(str(late_id)) == 1
+    assert [item_id for item_id in fresh_ids if item_id != str(late_id)] == original_ids

--- a/backend/tests/test_app_inventory_postgres.py
+++ b/backend/tests/test_app_inventory_postgres.py
@@ -1,0 +1,263 @@
+"""Live PostgreSQL proof for app inventory and sealed rollout snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.services import app_inventory_service as inventory
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATIONS = [
+    _BACKEND / "app" / "db" / "migrations" / "047_app_registry.py",
+    _BACKEND / "app" / "db" / "migrations" / "051_app_credentials.py",
+    _BACKEND / "app" / "db" / "migrations" / "052_app_inventory.py",
+]
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"Required PostgreSQL is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_app_inventory_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(_INIT_SQL)
+            for path in _MIGRATIONS:
+                await _load_migration(path).migrate(conn=conn)
+        yield pool
+    finally:
+        await pool.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _apply_all(pool):
+    async with pool.acquire() as conn:
+        for path in _MIGRATIONS:
+            await _load_migration(path).migrate(conn=conn)
+
+
+async def _app(pool, label: str) -> uuid.UUID:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "INSERT INTO app_definitions (app_key) VALUES ($1) RETURNING id",
+            f"{label}-{uuid.uuid4().hex}",
+        )
+
+
+async def _release(pool, app_id: uuid.UUID, version: str = "1.0.0") -> uuid.UUID:
+    manifest = {
+        "steps": [{"id": "prepare"}],
+        "expected_schema_fingerprint": "a" * 64,
+    }
+    encoded = json.dumps(manifest, separators=(",", ":"))
+    checksum = hashlib.sha256(encoded.encode()).hexdigest()
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            INSERT INTO app_releases (app_id, version, manifest, manifest_checksum)
+            VALUES ($1, $2, $3::jsonb, $4)
+            RETURNING id
+            """,
+            app_id,
+            version,
+            encoded,
+            checksum,
+        )
+
+
+async def _vault(pool, label: str) -> uuid.UUID:
+    name = f"{label}-{uuid.uuid4().hex[:10]}"
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+            name,
+            f"/tmp/{name}.git",
+        )
+
+
+async def _installation(
+    pool,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    release_id: uuid.UUID,
+) -> uuid.UUID:
+    async with pool.acquire() as conn:
+        installation_id = await conn.fetchval(
+            """
+            INSERT INTO vault_app_installations (
+                app_id, vault_id, desired_release_id, current_release_id, lifecycle
+            ) VALUES ($1, $2, $3, $3, 'active')
+            RETURNING id
+            """,
+            app_id,
+            vault_id,
+            release_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO installation_grants (installation_id, generation, capabilities, issuer)
+            VALUES ($1, 1, $2, 'fixture')
+            """,
+            installation_id,
+            ["inventory:read", "rollout:read", "rollout:request"],
+        )
+    return installation_id
+
+
+@pytest.fixture
+async def inventory_pool(monkeypatch):
+    async with _fresh_database() as pool:
+        monkeypatch.setattr(inventory, "get_pool", lambda: pool)
+        yield pool
+
+
+async def test_migration_reapply_and_observed_state_is_monotonic(inventory_pool):
+    await _apply_all(inventory_pool)
+    app_id = await _app(inventory_pool, "observed")
+    release_id = await _release(inventory_pool, app_id)
+    installation_id = await _installation(
+        inventory_pool,
+        app_id,
+        await _vault(inventory_pool, "observed"),
+        release_id,
+    )
+
+    initial = await inventory.list_inventory(app_id)
+    assert initial["items"][0]["drift"]["overall"] == "unknown"
+
+    observed_at = datetime.now(timezone.utc)
+    accepted = await inventory.report_observed_state(
+        installation_id,
+        observed_generation=2,
+        observed_at=observed_at,
+        observed_release_id=release_id,
+        schema_fingerprint="a" * 64,
+        observed_grant_generation=1,
+        checkpoint={"phase": "ready", "token": "secret-marker"},
+        recent_error={"code": "none", "message": "secret-marker"},
+    )
+    assert accepted["accepted"] is True
+
+    stale = await inventory.report_observed_state(
+        installation_id,
+        observed_generation=1,
+        observed_at=observed_at - timedelta(seconds=1),
+        observed_release_id=release_id,
+        schema_fingerprint="a" * 64,
+    )
+    assert stale["accepted"] is False
+
+    current = await inventory.list_inventory(app_id)
+    item = current["items"][0]
+    assert item["drift"]["overall"] == "in_sync"
+    assert "secret-marker" not in json.dumps(item)
+    assert item["recent_error"] == {"code": "none"}
+
+
+async def test_snapshot_seal_membership_and_stale_target_eligibility(inventory_pool):
+    app_id = await _app(inventory_pool, "snapshot")
+    release_id = await _release(inventory_pool, app_id)
+    vault_id = await _vault(inventory_pool, "snapshot")
+    installation_id = await _installation(inventory_pool, app_id, vault_id, release_id)
+    await inventory.report_observed_state(
+        installation_id,
+        observed_generation=1,
+        observed_release_id=release_id,
+        observed_grant_generation=1,
+    )
+    unobserved_installation_id = await _installation(
+        inventory_pool,
+        app_id,
+        await _vault(inventory_pool, "unobserved"),
+        release_id,
+    )
+
+    created = await inventory.create_rollout_snapshot(app_id)
+    snapshot = await inventory.get_rollout_snapshot(
+        app_id,
+        uuid.UUID(created["snapshot_id"]),
+    )
+    assert snapshot["sealed_at"] is not None
+    assert snapshot["target_count"] == 2
+    target_by_installation = {
+        target["installation_id"]: target for target in snapshot["targets"]
+    }
+    assert target_by_installation[str(installation_id)]["state"] == "pending"
+    assert target_by_installation[str(unobserved_installation_id)]["state"] == "skipped"
+    assert target_by_installation[str(unobserved_installation_id)]["reason_code"] == (
+        "observed_state_missing"
+    )
+    target_id = uuid.UUID(target_by_installation[str(installation_id)]["target_id"])
+
+    late_release = await _release(inventory_pool, app_id, "2.0.0")
+    await _installation(inventory_pool, app_id, await _vault(inventory_pool, "late"), late_release)
+    after_late_install = await inventory.get_rollout_snapshot(
+        app_id,
+        uuid.UUID(created["snapshot_id"]),
+    )
+    assert after_late_install["target_count"] == 2
+
+    async with inventory_pool.acquire() as conn:
+        with pytest.raises(asyncpg.PostgresError) as exc:
+            await conn.execute(
+                "UPDATE app_rollout_snapshot_targets SET baseline_grant_generation = 9 WHERE id = $1",
+                target_id,
+            )
+        assert exc.value.sqlstate == "55000"
+        await conn.execute(
+            "UPDATE installation_grants SET status = 'revoked', revoked_at = NOW() WHERE installation_id = $1",
+            installation_id,
+        )
+
+    eligibility = await inventory.evaluate_rollout_target(
+        app_id,
+        uuid.UUID(created["snapshot_id"]),
+        target_id,
+    )
+    assert eligibility["state"] == "denied"
+    assert eligibility["reason_code"] == "grant_revoked_or_missing"

--- a/backend/tests/test_app_inventory_routes_unit.py
+++ b/backend/tests/test_app_inventory_routes_unit.py
@@ -1,0 +1,135 @@
+"""HTTP ownership and cache contracts for the app inventory routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_app, get_current_user
+from app.api.routes import app_inventory
+from app.services.auth_service import AuthenticatedUser
+from app.services.app_identity_service import AppPrincipal
+
+
+def _user(*, is_admin: bool) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        username="operator",
+        email="operator@example.com",
+        display_name=None,
+        is_admin=is_admin,
+        auth_method="jwt",
+    )
+
+
+def _principal(app_id: uuid.UUID) -> AppPrincipal:
+    return AppPrincipal(
+        app_id=app_id,
+        credential_id=uuid.uuid4(),
+        credential_generation=1,
+        deployment="test",
+        token_id="token-id",
+        expires_at=None,  # type: ignore[arg-type]
+    )
+
+
+def _client(*, user: AuthenticatedUser | None = None, principal: AppPrincipal | None = None):
+    app = FastAPI()
+    app.include_router(app_inventory.router, prefix="/api/v1")
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    if principal is not None:
+        app.dependency_overrides[get_current_app] = lambda: principal
+    return TestClient(app)
+
+
+def test_non_admin_cannot_probe_inventory(monkeypatch):
+    called = False
+
+    async def forbidden(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return {"items": [], "next_cursor": None}
+
+    monkeypatch.setattr(app_inventory, "list_inventory", forbidden)
+    response = _client(user=_user(is_admin=False)).get(
+        f"/api/v1/apps/{uuid.uuid4()}/inventory"
+    )
+
+    assert response.status_code == 403
+    assert called is False
+    assert "inventory" not in response.json().get("message", "").lower()
+
+
+def test_admin_inventory_is_explicitly_scoped_and_no_store(monkeypatch):
+    app_id = uuid.uuid4()
+    calls = []
+
+    async def fake_list(requested_app_id, **kwargs):
+        calls.append((requested_app_id, kwargs))
+        return {"items": [], "next_cursor": None}
+
+    monkeypatch.setattr(app_inventory, "list_inventory", fake_list)
+    response = _client(user=_user(is_admin=True)).get(
+        f"/api/v1/apps/{app_id}/inventory?limit=7&lifecycle=active"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert calls == [
+        (
+            app_id,
+            {
+                "limit": 7,
+                "cursor": None,
+                "lifecycle": "active",
+                "scope": "admin",
+            },
+        )
+    ]
+
+
+def test_app_inventory_uses_token_app_id_and_cannot_select_another_app(monkeypatch):
+    app_id = uuid.uuid4()
+    principal = _principal(app_id)
+    auth_calls = []
+    list_calls = []
+
+    async def fake_authorize(requested, **kwargs):
+        auth_calls.append((requested.app_id, kwargs["capability"]))
+
+    async def fake_list(requested_app_id, **kwargs):
+        list_calls.append((requested_app_id, kwargs))
+        return {"items": [], "next_cursor": None}
+
+    monkeypatch.setattr(app_inventory, "authorize_app_capability", fake_authorize)
+    monkeypatch.setattr(app_inventory, "list_inventory", fake_list)
+    response = _client(principal=principal).get(
+        "/api/v1/app/inventory?app_id=" + str(uuid.uuid4())
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert auth_calls == [(app_id, "inventory:read")]
+    assert list_calls[0][0] == app_id
+    assert list_calls[0][1]["scope"] == "app"
+    assert list_calls[0][1]["capability"] == "inventory:read"
+
+
+def test_snapshot_create_accepts_empty_body(monkeypatch):
+    app_id = uuid.uuid4()
+
+    async def fake_create(requested_app_id, **kwargs):
+        assert requested_app_id == app_id
+        assert kwargs["requested_by_kind"] == "admin"
+        return {"snapshot_id": str(uuid.uuid4()), "target_count": 0}
+
+    monkeypatch.setattr(app_inventory, "create_rollout_snapshot", fake_create)
+    response = _client(user=_user(is_admin=True)).post(
+        f"/api/v1/apps/{app_id}/rollout-snapshots"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"

--- a/backend/tests/test_app_inventory_unit.py
+++ b/backend/tests/test_app_inventory_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import uuid
 from datetime import datetime, timezone
 
@@ -83,6 +84,41 @@ def test_cursor_is_opaque_and_bound_to_scope_and_filter():
                 limit=kwargs.get("limit", 50),
                 lifecycle=kwargs.get("lifecycle"),
             )
+
+
+def test_cursor_round_trip_when_signature_contains_separator_byte(monkeypatch):
+    app_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    installation_id = uuid.uuid4()
+    selected_cursor = None
+
+    for attempt in range(4096):
+        secret = f"cursor-separator-regression-{attempt}".encode()
+        monkeypatch.setattr(inventory, "_cursor_secret", lambda secret=secret: secret)
+        cursor = inventory.encode_inventory_cursor(
+            app_id=app_id,
+            scope="admin",
+            limit=20,
+            lifecycle=None,
+            boundary=now,
+            last_created_at=now,
+            last_installation_id=installation_id,
+        )
+        decoded = base64.urlsafe_b64decode(cursor + "=" * (-len(cursor) % 4))
+        _raw, signature = decoded.split(b".", 1)
+        if b"." in signature:
+            selected_cursor = cursor
+            break
+
+    assert selected_cursor is not None
+    decoded = inventory.decode_inventory_cursor(
+        selected_cursor,
+        app_id=app_id,
+        scope="admin",
+        limit=20,
+        lifecycle=None,
+    )
+    assert decoded["last_installation_id"] == installation_id
 
 
 def test_drift_keeps_missing_observations_and_expected_schema_unknown():

--- a/backend/tests/test_app_inventory_unit.py
+++ b/backend/tests/test_app_inventory_unit.py
@@ -1,0 +1,132 @@
+"""Pure contracts for app inventory projection and cursor safety."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services import app_inventory_service as inventory
+
+
+def _row(*, observed: bool = True, mismatch: bool = False) -> dict:
+    app_id = uuid.uuid4()
+    desired_release_id = uuid.uuid4()
+    observed_release_id = uuid.uuid4() if mismatch else desired_release_id
+    return {
+        "installation_id": uuid.uuid4(),
+        "app_id": app_id,
+        "vault_id": uuid.uuid4(),
+        "vault_name": "vault-a",
+        "lifecycle": "active",
+        "desired_release_id": desired_release_id,
+        "desired_version": "1.0.0",
+        "desired_manifest": {
+            "steps": [],
+            "expected_schema_fingerprint": "a" * 64,
+        },
+        "current_release_id": desired_release_id,
+        "current_version": "1.0.0",
+        "grant_generation": 4,
+        "latest_grant_generation": 4,
+        "latest_grant_status": "active",
+        "latest_grant_capabilities": ["inventory:read"],
+        "observed_generation": 3 if observed else None,
+        "observed_at": datetime.now(timezone.utc) if observed else None,
+        "observed_release_id": observed_release_id if observed else None,
+        "observed_release_version": "1.0.0" if observed else None,
+        "schema_fingerprint": "a" * 64 if observed else None,
+        "observed_grant_generation": 4 if observed else None,
+        "checkpoint": {"phase": "ready", "token": "secret-marker"},
+        "recent_error": {"code": "worker_timeout", "message": "secret-marker"},
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+
+def test_cursor_is_opaque_and_bound_to_scope_and_filter():
+    app_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    cursor = inventory.encode_inventory_cursor(
+        app_id=app_id,
+        scope="admin",
+        limit=50,
+        lifecycle=None,
+        boundary=now,
+        last_created_at=now,
+        last_installation_id=uuid.uuid4(),
+    )
+
+    assert str(app_id) not in cursor
+    decoded = inventory.decode_inventory_cursor(
+        cursor,
+        app_id=app_id,
+        scope="admin",
+        limit=50,
+        lifecycle=None,
+    )
+    assert decoded["boundary"] == now
+
+    for kwargs in (
+        {"app_id": uuid.uuid4()},
+        {"scope": "app"},
+        {"limit": 200},
+        {"lifecycle": "uninstalled"},
+    ):
+        with pytest.raises(ValidationError, match="Invalid inventory cursor"):
+            inventory.decode_inventory_cursor(
+                cursor,
+                app_id=kwargs.get("app_id", app_id),
+                scope=kwargs.get("scope", "admin"),
+                limit=kwargs.get("limit", 50),
+                lifecycle=kwargs.get("lifecycle"),
+            )
+
+
+def test_drift_keeps_missing_observations_and_expected_schema_unknown():
+    row = _row(observed=False)
+    drift = inventory.classify_drift(row)
+    assert drift["overall"] == "unknown"
+    assert drift["unknown_dimensions"] == ["release", "schema", "grant"]
+
+    row = _row(observed=True)
+    drift = inventory.classify_drift(row)
+    assert drift["overall"] == "in_sync"
+    assert not drift["reasons"]
+
+    row = _row(observed=True, mismatch=True)
+    drift = inventory.classify_drift(row)
+    assert drift["release"]["status"] == "mismatch"
+    assert drift["overall"] == "drifted"
+    assert "release_mismatch" in drift["reasons"]
+
+    row["desired_manifest"] = {"steps": []}
+    drift = inventory.classify_drift(row)
+    assert drift["schema"]["status"] == "unknown"
+    assert drift["overall"] == "drifted"
+
+
+def test_projection_redacts_unbounded_checkpoint_and_error_payloads():
+    item = inventory.project_inventory_item(_row())
+    serialized = str(item)
+    assert "secret-marker" not in serialized
+    assert "issuer" not in item["latest_grant"]
+    assert "provenance" not in serialized
+    assert item["recent_error"] == {"code": "worker_timeout"}
+    assert item["checkpoint"] == {"phase": "ready"}
+
+
+def test_target_state_set_is_contract_bounded():
+    assert inventory.TARGET_STATES == {
+        "pending",
+        "running",
+        "applied",
+        "replayed",
+        "failed",
+        "skipped",
+        "denied",
+    }
+    with pytest.raises(ValidationError):
+        inventory.normalize_page_size(201)


### PR DESCRIPTION
## Summary
- Add the control-plane service for app inventory, observed state, and immutable snapshots.
- Register the additive migration and main API router using the existing user/app-principal boundary.
- Refresh the detect-secrets line metadata for the new changelog entry.

## Acceptance mapping
- Paginated inventory preserves stable cursor lineage and app isolation.
- Observed drift reports release, schema, and grant differences honestly.
- Snapshot reads remain immutable and enforce installation eligibility.
- Existing user and app authentication boundaries remain enforced, with sensitive values redacted.

## Verification
- Focused inventory unit and route tests: passed.
- Migration, registry, and identity regression tests: passed.
- Live PostgreSQL inventory and identity tests: passed.
- Full backend test suite excluding E2E: passed.
- Repository check suite: passed.
- Independent API behavior coverage passed for pagination, isolation, drift, snapshots, authentication, and redaction.

Exact candidate HEAD: `83ad5ce93411afbd4ebe00c482192720adf1b1a9`

## Scope
No lifecycle command execution, reconciliation execution, UI, generated SDK facade, deployment, or release changes are included.
