### PR TITLE
fix(publications): one cleanup path for document deletes, and bind resolution to the vault

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -107,6 +107,37 @@ jobs:
         # state matrix and its fail-closed guard are pinned against a real PG
         # for the same reason — and so is the account-deletion regression it
         # exists to fix, which no other test exercises positively.
+        #
+        # The concurrency invariants file lands here because what it asserts
+        # is transactional: the publication cleanup helpers must delete inside
+        # the caller's TX, or a crash between the two commits orphans a
+        # publication row and a public slug then reaches a different
+        # document at the reused path. Rollback
+        # semantics are the thing under test, so a mock would prove nothing —
+        # and off this list the file skips in both jobs.
+        #
+        # The orphan-write guard belongs here for the same reason. What it
+        # asserts is that a write onto a path whose publication outlived its
+        # document is REFUSED — and the orphan has to be manufactured through
+        # the real publish path, because a publication whose `resource_uri`
+        # the test assembled by hand would agree with a guard that assembles
+        # it the same wrong way, and the pair would pass while production
+        # matched nothing. Only a real database can hold that state.
+        #
+        # The resolution vault-binding file needs a real PG for the same
+        # reason inverted: it manufactures a publication whose `vault_id`
+        # disagrees with the vault named in its `resource_uri` and asserts
+        # resolution refuses it. That state is two vaults, two documents at
+        # one path, and a row the product will not produce — nothing a mock
+        # can stand in for.
+        #
+        # The external-git cascade file needs a live PG *and* the real git
+        # binary: it drives a reconcile over the in-process smart-HTTP git
+        # fixture, publishes the mirrored document, then pushes an upstream
+        # commit deleting the path and asserts the publication went with it.
+        # The delete path it covers is a tree diff, a row lock and a cascade
+        # across three tables — mock any of it and the test stops covering the
+        # thing that would leak.
         run: >
           pytest
           tests/test_pgvector_ext_bootstrap_e2e.py
@@ -115,6 +146,10 @@ jobs:
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
           tests/concurrency/test_native_ledger_b_core.py
+          tests/concurrency/test_invariants_unit.py
+          tests/test_publication_resolution_vault_binding_unit.py
+          tests/test_publication_path_claim_guard_unit.py
+          tests/test_external_git_cascade_unit.py
           tests/test_file_idempotent_upload_unit.py
           tests/test_app_registry_migration_unit.py
           tests/test_tool_usage_e2e.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,9 +8,19 @@ name: e2e
 #
 # Scope: HTTP-only suites — the npm stdio proxy isn't installed so
 # file-tool suites (test_stdio_files_e2e.sh, test_put_file_param_e2e.sh)
-# stay out for now. S3 (MinIO) is intentionally NOT brought up either;
-# none of the suites picked here exercise the file backend. Add a
-# MinIO service container when wiring those tests in.
+# stay out for now. Those need the PROXY, not S3.
+#
+# S3: MinIO IS brought up (see "Start MinIO"), because
+# test_publications_e2e.sh exercises the file backend — file
+# publications, the /raw + /download proxies, and table-query
+# snapshots all round-trip through S3. It runs as a plain
+# `docker run` rather than a `services:` container: the minio image
+# needs the `server /data` ARGUMENT, and a service container can set
+# image/env/ports/options but has no way to pass a command argument.
+# The bucket is created explicitly in that step, mirroring
+# docker-compose.yaml's `minio-bootstrap` sidecar. The image tag is
+# pinned, like pgvector:pg16, so a MinIO release can't turn a green
+# branch red on its own.
 #
 # Embedding: stubbed by `backend/scripts/ci/embed_stub.py`. Suites
 # picked for CI either skip search assertions or tolerate "0 results"
@@ -79,13 +89,64 @@ jobs:
           llm_base_url: ""
           llm_model: ""
           rerank_enabled: false
-          s3_endpoint_url: ""
+          # Backend and curl both run ON the runner, so the internal
+          # endpoint is also reachable by the client following a
+          # presigned URL — s3_public_url can stay unset and fall back
+          # to this one.
+          s3_endpoint_url: http://localhost:9000
+          s3_bucket: akb-files
           YAML
           cat > config/secret.yaml <<'YAML'
           db_password: akb  # pragma: allowlist secret
           jwt_secret: ci-only-jwt-secret-not-for-prod-use  # pragma: allowlist secret
           embed_api_key: ci-stub-no-auth  # pragma: allowlist secret
+          s3_access_key: akb-ci  # pragma: allowlist secret
+          s3_secret_key: akb-ci-secret  # pragma: allowlist secret
           YAML
+
+      - name: Start MinIO (S3 for file publications)
+        # pragma: allowlist secret
+        run: |  # pragma: allowlist secret
+          docker run -d --name akb-minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=akb-ci \
+            -e MINIO_ROOT_PASSWORD=akb-ci-secret \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          # Poll the liveness probe rather than sleeping — MinIO is
+          # usually up in ~2s but the image pull dominates and varies.
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:9000/minio/health/live >/dev/null 2>&1; then
+              echo "minio ready"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:9000/minio/health/live >/dev/null \
+            || (echo "minio never came up"; docker logs akb-minio; exit 1)
+          # Create the bucket up front, mirroring docker-compose.yaml's
+          # `minio-bootstrap` sidecar. `s3_adapter.ensure_bucket` would
+          # also create it on first miss, but that path calls
+          # create_bucket from inside its own except-handler with no
+          # guard against a concurrent creator, so relying on it makes
+          # bucket setup a race rather than a precondition. boto3 is
+          # already installed by the backend step above, so this needs
+          # no extra image (compose uses minio/mc only because nothing
+          # python is available in that context).
+          python - <<'PY'
+          import boto3, botocore
+          s3 = boto3.client("s3", endpoint_url="http://localhost:9000",
+                            aws_access_key_id="akb-ci",
+                            aws_secret_access_key="akb-ci-secret")  # pragma: allowlist secret
+          try:
+              s3.create_bucket(Bucket="akb-files")
+              print("created bucket akb-files")
+          except botocore.exceptions.ClientError as e:
+              # Idempotent, like `mc mb -p`.
+              if e.response["Error"].get("Code") not in (
+                      "BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                  raise
+              print("bucket akb-files already present")
+          print("buckets:", [b["Name"] for b in s3.list_buckets()["Buckets"]])
+          PY
 
       - name: Start embedding stub (background)
         working-directory: backend
@@ -163,6 +224,20 @@ jobs:
             test_table_constraints_e2e.sh
             test_forbidden_permission_code_e2e.sh
             test_okf_export_import_e2e.sh
+            # Publication resolution regression. Its S3-dependent
+            # sections (T3 file-publication cleanup, T4 failed-confirm
+            # cleanup) now RUN rather than self-skip, alongside the two
+            # document resolution cases (recursive collection delete,
+            # move-onto-orphan). NOTE: CI sums pass/fail only — a suite
+            # that skips a section still reports 0 failed, so the skip
+            # branches there are a fallback, not an accepted outcome.
+            test_publication_resolution_e2e.sh
+            # The publication feature's own suite — 127 assertions over
+            # documents, table queries, snapshots and files. Needs S3
+            # (section 0 uploads a file, and sections 9/13 publish it),
+            # which is why MinIO is brought up above. Nothing else here
+            # is CI-hostile: no proxy, no psql, no embedding assertions.
+            test_publications_e2e.sh
           )
           TOTAL_PASS=0
           TOTAL_FAIL=0

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -186,7 +186,7 @@
         "filename": "backend/tests/concurrency/test_invariants_unit.py",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 24
       }
     ],
     "backend/tests/test_collection_repo.py": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T08:34:25Z"
+  "generated_at": "2026-08-04T04:08:17Z"
 }

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -1100,9 +1100,20 @@ async def oembed(url: str, format: str = "json"):
                     doc_row = await conn.fetchrow(
                         """
                         SELECT d.title FROM documents d JOIN vaults v ON v.id = d.vault_id
-                         WHERE v.name = $1 AND d.path = $2
+                         -- Bound to the publication's OWN vault_id, with the URI's
+                         -- vault name demoted to a cross-check — the same binding
+                         -- `resolve_document_publication` carries, and the one the
+                         -- file branch below has always had. Keyed on the URI's
+                         -- vault name alone, this returned the title of a document
+                         -- in whatever vault the URI named, which need not be this
+                         -- publication's vault. F1 above protects the publisher,
+                         -- who chose a password; nothing protected the third-party
+                         -- vault, which published nothing at all. No row leaves
+                         -- `title` None and the response falls through to the
+                         -- generic card below — fail closed.
+                         WHERE d.vault_id = $1 AND d.path = $2 AND v.name = $3
                         """,
-                        uri_vault, doc_path,
+                        to_uuid(publication["vault_id"]), doc_path, uri_vault,
                     )
                     if doc_row:
                         title = doc_row["title"]

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -101,13 +101,49 @@ class DocumentRepository:
         tags: list[str],
         metadata: dict,
         *,
+        vault_name: str,
         conn=None,
         doc_id: uuid.UUID | None = None,
     ) -> uuid.UUID:
+        """Insert one ``documents`` row. Raises ``ConflictError`` when the path
+        is taken — by a live document, or by a publication that outlived one.
+
+        ``vault_name`` is required because the second of those needs it: a
+        publication is bound to its document by a path-shaped ``akb://`` URI,
+        which cannot be built from ``vault_id``. Passing the name rather than
+        looking it up here keeps the guard to a single indexed probe, and the
+        one caller (``document_service._put_locked``) already holds it.
+
+        The caller runs the same check earlier, before its git write, so a
+        refusal normally happens with nothing committed anywhere. This copy
+        is the structural backstop: it sits at the one place every creation
+        goes through, so a future caller that forgets the early check is
+        still refused rather than silently allowed. Reaching this raise means
+        the early check was skipped or the row appeared between the two, and
+        a git commit with no ``documents`` row is left behind — invisible,
+        since every read resolves through PostgreSQL, and overwritten by the
+        next write to that path.
+        """
         # Caller may supply the id so a path can embed its short form; else mint one.
         doc_id = doc_id or uuid.uuid4()
 
+        # Imported here, not at module scope: publication_service imports the
+        # document services at import time, so a top-level import cycles.
+        from app.services.publication_service import (
+            assert_no_orphan_publication_for_document,
+        )
+
         async def _insert(c):
+            # Before the row lands, not after: if a publication already claims
+            # this path's canonical URI while no document occupies the path,
+            # refuse rather than let the new document inherit that slug. Runs on
+            # the connection the INSERT runs on, so when that is the caller's
+            # transaction (every production path) the check and the row commit
+            # or roll back together. The existing publication is left in place,
+            # not removed, so its state is preserved for the owner to resolve.
+            await assert_no_orphan_publication_for_document(
+                c, vault_name=vault_name, path=path,
+            )
             try:
                 await c.execute(
                     """
@@ -314,15 +350,111 @@ class DocumentRepository:
             async with self.pool.acquire() as own_conn:
                 await own_conn.execute(sql, *args)
 
-    async def delete(self, doc_id: uuid.UUID, *, conn=None) -> None:
-        """Delete the documents row. When `conn` is provided the DELETE
-        runs on the caller's connection (so it joins the same TX as the
-        cascade in `document_service.delete`)."""
-        if conn is None:
-            async with self.pool.acquire() as own_conn:
-                await own_conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
-        else:
-            await conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
+    async def delete_with_publications(
+        self,
+        conn,
+        *,
+        doc_id: uuid.UUID,
+        vault_id: uuid.UUID,
+    ) -> bool:
+        """Delete one ``documents`` row together with the publications bound
+        to it. Returns True when a row was actually removed.
+
+        **This is the only place an ordinary document row may be deleted.**
+        Publications lost their ``document_id`` FK in migration 022, so
+        nothing cascades: a delete that skips the publication cleanup leaves
+        a slug that still resolves *by path*, and because ``documents`` is
+        ``UNIQUE(vault_id, path)`` the next document created at that path
+        would then be reached through that old link. Of the three per-row
+        delete paths, two omitted the cleanup — and they omitted it because
+        the one path that had it kept it as an inline copy rather than
+        something callable. There was no single original to reach for, so
+        writing a new delete path correctly meant knowing to write the
+        second statement at all. Binding the two together in one method
+        means a new delete path can only be wrong by not deleting documents
+        at all.
+        ``tests/test_document_delete_chokepoint_unit.py`` allowlists the
+        remaining ``DELETE FROM documents`` sites so a sixth one fails review.
+
+        ``conn`` is REQUIRED and MUST already be inside a transaction. Both
+        statements have to commit together — on separate connections a crash
+        between them leaves exactly the orphan this exists to prevent — and
+        the row lock below is worthless outside a transaction (it would be
+        released the instant its autocommit statement returned).
+
+        **Lock ordering.** ``FOR UPDATE`` on the resource row comes FIRST,
+        before the publication cleanup, and closes a publish/delete TOCTOU:
+        ``publication_service.create_publication`` takes ``FOR SHARE`` on the
+        same row and then inserts, while the deleter's own serialization is
+        a ``pg_advisory_xact_lock`` over ``(vault_id, path)`` that the
+        publisher never acquires — two lock namespaces that do not serialize
+        against each other. With the cleanup running before any conflicting
+        row lock, a publisher could slip in between: cleanup finds nothing,
+        the publisher takes ``FOR SHARE`` and commits its INSERT, and the
+        deleter's ``DELETE FROM documents`` — which had been blocked on that
+        share lock — then proceeds over a publication that survives. Taking
+        ``FOR UPDATE`` first makes both orderings safe: either the deleter
+        wins and the publisher's ``FOR SHARE`` re-check finds no row and
+        aborts, or the publisher wins and this cleanup, now downstream of the
+        lock, sees the new row and removes it.
+
+        **The URI comes from the locked row, not from the caller.** The same
+        statement that takes the lock reads back the row's current ``path``
+        and its vault's name, and the cleanup URI is built from those. A
+        caller holding a stale path — a collection cascade iterating a
+        snapshot taken before a concurrent move, say — would otherwise delete
+        publications for a URI nothing matches, get a silent zero, and then
+        delete the document anyway: the orphan again, from the one method
+        that exists to prevent it. Identity is established under the lock or
+        not at all, so ``path`` and ``vault_name`` are deliberately NOT
+        parameters.
+
+        The cleanup is then passed that canonical **URI**, not the id, so it
+        never re-reads ``documents`` itself — which is also why running it
+        before the row delete is safe here. (The file helper does re-read
+        ``vault_files``; a caller that inverts that order gets a vault-root
+        URI, zero matches, and a silent no-op. See
+        ``publication_service.delete_publications_for_file``.)
+        """
+        if not conn.is_in_transaction():
+            raise RuntimeError(
+                "delete_with_publications requires a caller-managed transaction: "
+                "the row lock, the publication cleanup and the row delete must "
+                "commit as one unit"
+            )
+        # Imported here, not at module scope: publication_service imports the
+        # document services at import time, so a top-level import cycles.
+        from app.services.publication_service import delete_publications_by_doc_uri
+        from app.services.uri_service import doc_uri
+
+        # `FOR UPDATE OF d` locks the document row only — the joined `vaults`
+        # row is read, not locked, so this cannot contend with vault-level
+        # writers.
+        locked = await conn.fetchrow(
+            """
+            SELECT d.path AS path, v.name AS vault_name
+              FROM documents d JOIN vaults v ON v.id = d.vault_id
+             WHERE d.id = $1 AND d.vault_id = $2
+             FOR UPDATE OF d
+            """,
+            doc_id, vault_id,
+        )
+        if locked is None:
+            # Already gone (or not this vault's): nothing to delete, and no
+            # publication to clean up that a live document isn't backing.
+            return False
+        # The by-URI form, not the validating one: this URI was just built
+        # from the row we hold locked, so there is no caller-supplied string
+        # to guard against — and validating would reject a legitimate path
+        # containing braces, aborting the delete. See that function.
+        await delete_publications_by_doc_uri(
+            doc_uri(locked["vault_name"], locked["path"]),
+            expected_vault_id=vault_id, conn=conn,
+        )
+        deleted = await conn.fetchval(
+            "DELETE FROM documents WHERE id = $1 RETURNING id", doc_id,
+        )
+        return deleted is not None
 
     async def list_by_collection(self, vault_id: uuid.UUID, collection_path: str) -> list[dict]:
         async with self.pool.acquire() as conn:
@@ -466,6 +598,7 @@ class DocumentRepository:
         commit_hash: str | None,
         content_hash: str,
         hash_algorithm: str,
+        vault_name: str,
         created_by: str | None = None,
         conn=None,
     ) -> tuple[uuid.UUID, bool]:
@@ -482,6 +615,12 @@ class DocumentRepository:
         Accepts an optional `conn` so callers that already hold a
         connection (e.g. the reconcile loop doing upsert + chunks in
         one transaction) don't re-acquire.
+
+        `vault_name` is required for the same reason as in `create`: the
+        publication guard below is a URI lookup, and a URI needs the vault's
+        name. An upstream commit that re-adds a path a previous sync deleted
+        is an ordinary INSERT here, which is exactly the shape that re-points a
+        surviving publication.
         """
         sql = """
             INSERT INTO documents
@@ -523,11 +662,29 @@ class DocumentRepository:
             hash_algorithm, tags, dumps_jsonb(metadata),
             external_path, external_blob,
         )
+        from app.services.publication_service import (
+            assert_no_orphan_publication_for_document,
+        )
+
+        async def _upsert(c):
+            # Same guard as `create`, and correct for BOTH arms of the upsert
+            # without knowing in advance which one will run: the helper's
+            # "orphan" test is "a publication exists here AND no document
+            # resolves here", which is false by construction when this
+            # statement is about to take the ON CONFLICT (update) path. So a
+            # re-sync of an already-mirrored — and possibly published —
+            # document is never blocked; only a fresh INSERT onto a path whose
+            # publication outlived its document is.
+            await assert_no_orphan_publication_for_document(
+                c, vault_name=vault_name, path=path,
+            )
+            return await c.fetchrow(sql, *args)
+
         if conn is not None:
-            row = await conn.fetchrow(sql, *args)
+            row = await _upsert(conn)
         else:
             async with self.pool.acquire() as acq:
-                row = await acq.fetchrow(sql, *args)
+                row = await _upsert(acq)
         return row["id"], row["inserted"]
 
     async def mark_llm_metadata_filled(

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -17,7 +17,7 @@ import asyncpg
 from app.db.postgres import get_pool
 from app.exceptions import ConflictError, NotFoundError
 from app.repositories import table_data_repo, table_registry_repo, vault_files_repo
-from app.repositories.document_repo import CollectionRepository
+from app.repositories.document_repo import CollectionRepository, DocumentRepository
 from app.repositories.events_repo import emit_event
 from app.repositories.vault_repo import VaultRepository
 from app.services.git_service import GitService
@@ -25,6 +25,7 @@ from app.services.index_service import (
     delete_document_chunks, delete_file_chunks, delete_table_chunks,
 )
 from app.services.kg_service import delete_document_relations
+from app.services.publication_service import delete_publications_for_file
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
 from app.services.uri_service import file_uri, table_uri
 from app.services.write_lane import run_git_write, write_lane
@@ -224,6 +225,7 @@ class CollectionService:
             raise NotFoundError("Vault", vault)
 
         pool = await get_pool()
+        doc_repo = DocumentRepository(pool)
         docs_count = 0
         files_count = 0
         sub_count = 0
@@ -299,11 +301,26 @@ class CollectionService:
                 # blocks on multi-second worktree I/O. Under load
                 # that pins connection-pool slots and starves
                 # concurrent writers across the entire vault.
+
+                # The row delete goes through the repository chokepoint, which
+                # carries the publication cascade with it. `publications` lost
+                # its `document_id` FK in migration 022, so nothing cascades —
+                # and this loop, deleting the rows by hand, is where that was
+                # first forgotten: the orphaned publication's slug still
+                # resolved by path, and since `documents` is
+                # UNIQUE(vault_id, path), the next document created (or moved)
+                # onto that path would be reached through the old public
+                # link.
                 for d in docs:
                     await delete_document_chunks(conn, str(d["id"]))
                     await delete_document_relations(conn, vault, d["path"])
-                    await conn.execute(
-                        "DELETE FROM documents WHERE id = $1", d["id"],
+                    # The URI for the publication cleanup is derived from
+                    # the row under its lock, NOT from `d["path"]` — this
+                    # snapshot was taken without a document row lock
+                    # (`list_docs_under`), so a concurrent move could have
+                    # changed the path since. See the method's docstring.
+                    await doc_repo.delete_with_publications(
+                        conn, doc_id=d["id"], vault_id=vault_id,
                     )
 
                 # Per-file cost: edges + chunk outbox + s3 outbox +
@@ -323,6 +340,16 @@ class CollectionService:
                     await conn.execute(
                         "DELETE FROM edges WHERE source_uri = $1 OR target_uri = $1",
                         f_uri,
+                    )
+                    # Same cascade gap as the document loop above. A file
+                    # URI carries a UUID, so a stale row here cannot be reoccupied
+                    # onto a new resource — but it stays live in the
+                    # owner's publication list pointing at nothing. Must
+                    # run BEFORE `vault_files_repo.delete`: the helper
+                    # re-reads the file's collection to build the
+                    # canonical URI and sees no row once it is gone.
+                    await delete_publications_for_file(
+                        file_id, vault, expected_vault_id=vault_id, conn=conn,
                     )
                     try:
                         await delete_file_chunks(conn, file_id)

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -480,6 +480,25 @@ class DocumentService:
             )
         else:
             file_path = base_path
+        # Refuse a claimed path BEFORE the git write, not after. `doc_repo.create`
+        # runs this same check as the structural backstop — it is the chokepoint
+        # every creation goes through — but raising there would leave a commit in
+        # git while this transaction rolls back, and git and PG would then
+        # disagree about whether the document exists. `move` is placed the same
+        # way, for the same reason. `file_path` is final by this point, including
+        # the collision-suffixed form, so this checks the path actually claimed.
+        # `conn` is None only when a test drives this directly with fakes;
+        # every production path arrives holding the `_path_lock` connection.
+        # Skipping then costs nothing — the backstop in `doc_repo.create` is
+        # unconditional, so the write is still refused, just after the commit.
+        if conn is not None:
+            from app.services.publication_service import (
+                assert_no_orphan_publication_for_document,
+            )
+            await assert_no_orphan_publication_for_document(
+                conn, vault_name=req.vault, path=file_path,
+            )
+
         # A real doc now owns this path → clear any stale rename redirect that
         # pointed elsewhere (a reused path's history resets to the live doc).
         await drop_resource_alias(conn, vault_id, "document", file_path)
@@ -523,7 +542,7 @@ class DocumentService:
             summary=fm_dict.get("summary") or req.summary, domain=req.domain, created_by=agent_id,
             now=now, commit_hash=commit_hash, content_hash=content_hash,
             hash_algorithm=HASH_ALGORITHM, tags=req.tags, metadata={}, conn=conn,
-            doc_id=doc_id,
+            doc_id=doc_id, vault_name=req.vault,
         )
 
         # Index: write chunks into PG (truth) + best-effort vector-store upsert.
@@ -1003,6 +1022,26 @@ class DocumentService:
             if explicit_slug and new_path != base_new_path:
                 raise ConflictError(f"Document already exists at path: {base_new_path}")
 
+            # The destination has no document (resolved free above) — but it
+            # may still have a PUBLICATION, left behind by a document that was
+            # deleted without its cascade. Publications resolve by path, so
+            # landing here would hand this document the stale public slug —
+            # the same outcome as creating a new document at that path,
+            # reached without creating anything. `move` rewrites publications
+            # at the SOURCE uri further down (they follow the document); it has
+            # never looked at the destination.
+            #
+            # Before the git mv, deliberately. Raising after it would leave the
+            # commit in place while this transaction rolls back — git and PG
+            # would then disagree about where the document lives, which is a
+            # worse state than the write we are refusing.
+            from app.services.publication_service import (
+                assert_no_orphan_publication_for_document,
+            )
+            await assert_no_orphan_publication_for_document(
+                conn, vault_name=vault, path=new_path,
+            )
+
             new_collection_id = (
                 await coll_repo.get_or_create(vault_id, new_coll, conn=conn)
                 if new_coll else None
@@ -1345,15 +1384,6 @@ class DocumentService:
         # pool connection.
         await delete_document_chunks(conn, str(pg_doc_id))
         await delete_document_relations(conn, vault, file_path)
-        # App-level publication cascade. Previously this rode
-        # on `publications.document_id` ON DELETE CASCADE; that
-        # FK column is gone after migration 022, so we wipe
-        # publications by canonical URI before the doc row
-        # itself goes.
-        await conn.execute(
-            "DELETE FROM publications WHERE resource_uri = $1",
-            doc_uri(vault, file_path),
-        )
         # Drop any rename/move redirects that pointed at this doc so no alias
         # outlives the row it targets (a later doc reusing the old path then
         # resolves to itself, not a tombstone).
@@ -1369,7 +1399,18 @@ class DocumentService:
                 "path": file_path,
             },
         )
-        await doc_repo.delete(pg_doc_id, conn=conn)
+        # The row delete and the publication cascade are ONE call. That
+        # cascade used to be an inline DELETE here (publications lost their
+        # `document_id` FK in migration 022, so nothing cascades), and the
+        # two OTHER per-row delete paths — the collection cascade's doc loop
+        # and the external-git tombstone — never got a copy. With no single
+        # original to call, writing a new delete path correctly meant
+        # knowing to write the second statement at all. It now
+        # lives inside `delete_with_publications`, which also takes the row
+        # lock that closes the publish/delete race; see that docstring.
+        await doc_repo.delete_with_publications(
+            conn, doc_id=pg_doc_id, vault_id=vault_id,
+        )
 
         if collection_id:
             await coll_repo.decrement_count(collection_id, datetime.now(timezone.utc), conn=conn)

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -517,6 +517,7 @@ class ExternalGitService:
                     commit_hash=last_commit,
                     content_hash=compute_text_content_hash(body),
                     hash_algorithm=HASH_ALGORITHM,
+                    vault_name=vault_name,
                     created_by=created_by,
                     conn=conn,
                 )
@@ -587,6 +588,7 @@ class ExternalGitService:
         """
         pool = await get_pool()
         coll_repo = CollectionRepository(pool)
+        doc_repo = DocumentRepository(pool)
         from app.services.kg_service import delete_document_relations
         async with pool.acquire() as conn:
             async with conn.transaction():
@@ -612,10 +614,29 @@ class ExternalGitService:
                 # Remove implicit edges anchored on this doc — otherwise
                 # they survive the delete and dangle on the next BFS.
                 await delete_document_relations(conn, vault_name, path)
-                deleted = await conn.fetchrow(
-                    "DELETE FROM documents WHERE id = $1 RETURNING id", row["id"]
+                # The row delete and the publication cascade are one call
+                # through the repository chokepoint. `publications` lost its
+                # `document_id` FK in migration 022, so the tombstone has to
+                # drop the publication itself, on THIS connection: without it,
+                # an upstream commit that removes a mirrored path leaves a
+                # slug that still resolves by path — and a later upstream
+                # commit re-adding that path (a revert, a rename back)
+                # republishes whatever now lives there under the old public
+                # slug. The chokepoint derives that URI from `documents.path`
+                # under its own lock — `documents.path == external_path` for
+                # mirrored docs (see `upsert_external`), so it is the same URI
+                # `emit_event` reports below, but read from the row rather
+                # than from this function's `path` argument.
+                #
+                # The chokepoint re-takes `FOR UPDATE` on the row we already
+                # locked above; on the same transaction that is a no-op, and
+                # keeping it there rather than relying on this caller is the
+                # point — the lock is what closes the publish/delete race, and
+                # it must not depend on every caller remembering.
+                deleted = await doc_repo.delete_with_publications(
+                    conn, doc_id=row["id"], vault_id=vault_id,
                 )
-                if deleted is None:
+                if not deleted:
                     # Unreachable while we hold the row lock (no other tx can
                     # delete it first), but keep the count/event STRICTLY tied to
                     # a real row deletion rather than a stale pre-read. Nothing

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -205,6 +205,33 @@ def _content_key_honors_hash(s3_key: str, content_hash: str) -> bool:
 from app.util.text import normalize_collection_path as _normalize_collection_path  # noqa: E402
 
 
+async def _delete_file_publications(conn, vault_id: uuid.UUID, file_id: str) -> None:
+    """Drop this file's publications on the CALLER's connection, before its
+    `vault_files` row goes.
+
+    A file becomes publishable the moment `initiate_upload` writes its row —
+    `create_publication` only checks `SELECT 1 FROM vault_files WHERE id=$1
+    AND vault_id=$2`, with no confirmed/hash predicate. So a file can be
+    published while the upload is still outstanding, and the two
+    `confirm_upload` failure paths that clean up the row (S3 object missing,
+    declared-bytes mismatch) would otherwise leave the publication behind:
+    a live slug in the owner's list pointing at a resource that no longer
+    exists. A file URI carries a UUID, so this cannot be reoccupied the way
+    a document path can — the row is simply stale, not reachable as
+    something else.
+
+    Takes `vault_id` because `confirm_upload` never resolves the vault NAME,
+    which the shared helper needs to build the canonical URI.
+    """
+    from app.services.publication_service import delete_publications_for_file
+    vault_row = await conn.fetchrow("SELECT name FROM vaults WHERE id = $1", vault_id)
+    if not vault_row:
+        return
+    await delete_publications_for_file(
+        file_id, vault_row["name"], expected_vault_id=vault_id, conn=conn,
+    )
+
+
 # ── File domain service ──────────────────────────────────────────
 
 
@@ -337,7 +364,11 @@ class FileService:
             size_bytes = meta["ContentLength"]
         except NotFoundError:
             async with pool.acquire() as conn:
-                await vault_files_repo.delete(conn, fid)
+                # One transaction so the publication cannot outlive the row
+                # it points at — the same atomicity the delete paths need.
+                async with conn.transaction():
+                    await _delete_file_publications(conn, vault_id, file_id)
+                    await vault_files_repo.delete(conn, fid)
             logger.warning("Orphan file record deleted: %s (S3 object missing)", file_id)
             raise AKBError(
                 f"Upload not found in storage — file record cleaned up: {file_id}",
@@ -364,6 +395,7 @@ class FileService:
         if stored_bytes_disowned:
             async with pool.acquire() as conn:
                 async with conn.transaction():
+                    await _delete_file_publications(conn, vault_id, file_id)
                     await vault_files_repo.delete(conn, fid)
                     await _enqueue_s3_delete(conn, row["s3_key"])
             raise AKBError(
@@ -570,20 +602,31 @@ class FileService:
         # missing-blob row). The outbox row carries the s3_key.
         async with pool.acquire() as conn:
             async with conn.transaction():
-                await vault_files_repo.delete(conn, fid)
-
                 if vault_name:
                     f_uri = file_uri(vault_name, file_id, collection=row["collection"])
+                    # App-level publication cascade — `publications.
+                    # file_id` FK is gone after migration 022. Goes through
+                    # the shared helper instead of an inline DELETE (see
+                    # `delete_publications_for_document` for why there is
+                    # exactly one implementation), and runs BEFORE the
+                    # `vault_files` row is removed: the helper re-derives
+                    # the file's collection from `vault_files JOIN
+                    # collections`, and inside this transaction an
+                    # already-deleted row is invisible to it — it would
+                    # build a vault-root URI and match nothing.
+                    from app.services.publication_service import (
+                        delete_publications_for_file,
+                    )
+                    await delete_publications_for_file(
+                        file_id, vault_name,
+                        expected_vault_id=vault_id, conn=conn,
+                    )
                     await conn.execute(
                         "DELETE FROM edges WHERE source_uri = $1 OR target_uri = $1",
                         f_uri,
                     )
-                    # App-level publication cascade — `publications.
-                    # file_id` FK is gone after migration 022.
-                    await conn.execute(
-                        "DELETE FROM publications WHERE resource_uri = $1",
-                        f_uri,
-                    )
+
+                await vault_files_repo.delete(conn, fid)
 
                 # Drop the metadata chunk (outbox-driven vector-store delete).
                 # delete_file_chunks → _drop_source_chunks_with_outbox is

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -17,6 +17,7 @@ import math
 import re
 import secrets
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
@@ -27,7 +28,7 @@ import frontmatter
 
 from app.config import settings
 from app.db.postgres import get_pool
-from app.exceptions import AKBError, NotFoundError
+from app.exceptions import AKBError, ConflictError, NotFoundError
 from app.services import file_service, table_service
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
 from app.services.document_service import DocumentService
@@ -548,59 +549,275 @@ async def delete_publication(
     return deleted
 
 
+@asynccontextmanager
+async def _connection(conn):
+    """Yield the caller's connection when one is supplied, otherwise a
+    freshly acquired pool connection released on exit.
+
+    The cleanup helpers below run several statements, so the usual
+    ``if conn is None: … else: …`` shape (see ``DocumentRepository.create``)
+    would mean two copies of the body — and one copy silently drifting onto
+    the wrong connection is exactly the bug this parameter exists to
+    prevent. One body, one connection, no drift.
+    """
+    if conn is not None:
+        yield conn
+        return
+    pool = await get_pool()
+    async with pool.acquire() as own_conn:
+        yield own_conn
+
+
 async def delete_publications_for_document(
-    document_id: uuid.UUID | str,
+    resource_uri: str,
     *,
     expected_vault_id: uuid.UUID | None = None,
+    conn=None,
 ) -> int:
-    """Delete all publications for a given document, identified by either
-    its canonical URI (preferred — keeps the URI canonical story end-to-end)
-    or, for backwards compatibility with internal callers that still hold
-    the doc's UUID, the PG UUID. UUID inputs trigger a one-row join to
-    materialize the URI then drive the DELETE.
+    """Delete all publications for a document, identified by its canonical
+    ``akb://`` URI. Returns the number of publications deleted.
+
+    **URI only — deliberately.** This used to accept a PG UUID as well, and
+    the two forms carried *different ordering requirements* that nothing in
+    the signature revealed: the URI form touches no other table and is safe
+    to call at any point, while the UUID form joined ``documents`` to
+    materialize the URI. Called on the same connection after the row was
+    deleted, that join found nothing and the helper returned 0 — no rows
+    removed, no error raised, tests green, publication orphaned. Every
+    delete path was therefore correct only by accident of which argument it
+    happened to pass, and changing a call from a URI to ``row["id"]`` would
+    read as a tidy-up while silently restoring the defect at that path. The
+    ordering requirement is gone because the input form that had one is
+    gone. Callers that hold only an id resolve it themselves *before*
+    deleting — see ``DocumentRepository.delete_with_publications``, which
+    reads the path back from the row it has locked.
 
     ``expected_vault_id`` adds an explicit vault binding to the DELETE,
     matching what ``delete_publication(slug=…, expected_vault_id=…)`` does.
     The URI itself already encodes the vault, so this is belt-and-suspenders
     against any future code path that could fan a URI out across vaults.
 
-    Returns the number of publications deleted.
+    ``conn`` lets a caller that is already deleting the document inside its
+    own transaction run this cleanup on that same connection. That is a
+    correctness requirement, not a convenience: on a separate connection the
+    two deletes commit independently, and a crash in between leaves a
+    publication row pointing at a document that no longer exists. Because
+    ``documents`` is ``UNIQUE(vault_id, path)`` and publications resolve by
+    path, the next document created at that path would then be reached
+    through the old public link.
     """
-    from app.services.uri_service import doc_uri
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        if isinstance(document_id, str) and document_id.startswith("akb://"):
-            uri = document_id
-        else:
-            # Materialize the CANONICAL URI from the PG UUID. The old
-            # `'akb://' || v.name || '/doc/' || d.path` produced the
-            # pre-0.3.0 legacy shape (akb://V/doc/{coll}/{name}), which
-            # never matches the canonical publications.resource_uri
-            # (akb://V/coll/{coll}/doc/{name}) — so the cascade silently
-            # deleted nothing and left orphan publications. Build it via
-            # doc_uri so the DELETE actually matches.
-            row = await conn.fetchrow(
-                """
-                SELECT v.name AS vault_name, d.path AS path
-                  FROM documents d JOIN vaults v ON v.id = d.vault_id
-                 WHERE d.id = $1
-                """,
-                document_id if isinstance(document_id, uuid.UUID) else uuid.UUID(str(document_id)),
-            )
-            if not row:
-                return 0
-            uri = doc_uri(row["vault_name"], row["path"])
+    # Fail loudly rather than deleting nothing. A bare UUID (or any non-doc
+    # URI) matches no `resource_uri` and would otherwise return a perfectly
+    # calm 0 — the exact silent no-op this signature exists to prevent.
+    #
+    # This check is for a CALLER-SUPPLIED string. Internal callers that have
+    # just built the URI from a locked row go through
+    # `delete_publications_by_doc_uri` instead and skip it — see that function
+    # for why parsing there would be actively harmful.
+    parsed = parse_uri(resource_uri) if isinstance(resource_uri, str) else None
+    if parsed is None or parsed.kind != "doc":
+        raise ValueError(
+            "delete_publications_for_document requires a canonical document "
+            f"URI (akb://<vault>/…/doc/<name>), got {resource_uri!r}. "
+            "Resolve an id to its URI BEFORE deleting the row — resolving it "
+            "after leaves the publication behind."
+        )
+    return await delete_publications_by_doc_uri(
+        resource_uri, expected_vault_id=expected_vault_id, conn=conn,
+    )
+
+
+async def delete_publications_by_doc_uri(
+    resource_uri: str,
+    *,
+    expected_vault_id: uuid.UUID | None = None,
+    conn=None,
+) -> int:
+    """Delete by URI equality, without validating the URI.
+
+    For internal callers that just built ``resource_uri`` with ``doc_uri`` from
+    a row they hold a lock on. There is no caller-supplied string to guard
+    against, and the DELETE is an equality match that needs no parse.
+
+    **Do not add a parse here.** ``parse_uri`` rejects URIs containing braces
+    (template placeholders), and external-git accepts upstream paths like
+    ``templates/{{cookiecutter.project}}/README.md`` — so ``doc_uri`` can
+    legitimately produce a URI that ``parse_uri`` refuses. Raising on it would
+    abort the tombstone, roll the transaction back, and hold the external-git
+    sync cursor forever, since a per-file error there is retried and never
+    skipped: one templated file upstream would wedge the whole mirror. The
+    same reasoning is why ``assert_no_orphan_publication_for_document``
+    matches on equality rather than parsing.
+    """
+    async with _connection(conn) as conn:
         if expected_vault_id is not None:
             rows = await conn.fetch(
                 "DELETE FROM publications WHERE resource_uri = $1 AND vault_id = $2 RETURNING id",
-                uri, expected_vault_id,
+                resource_uri, expected_vault_id,
             )
         else:
             rows = await conn.fetch(
                 "DELETE FROM publications WHERE resource_uri = $1 RETURNING id",
-                uri,
+                resource_uri,
             )
     return len(rows)
+
+
+async def assert_no_orphan_publication_for_document(
+    conn,
+    *,
+    vault_name: str,
+    path: str,
+) -> None:
+    """Refuse a write that would land a document under a public slug it never
+    earned. Returns silently in the healthy case; raises ``ConflictError``
+    (409) when ``path``'s canonical URI already carries a publication and no
+    document occupies the path.
+
+    **Why a write has to care about publications at all.** A document
+    publication is bound to its document only by a path-shaped URI —
+    migration 022 dropped the ``document_id`` FK — and ``documents`` is
+    ``UNIQUE(vault_id, path)``, so paths are reusable. A publication that
+    outlives its document therefore still claims that path: the next
+    document to occupy it would be reached through the old link.
+    ``DocumentRepository.delete_with_publications`` keeps a delete from
+    leaving one behind. This guard covers the other direction — a write
+    arriving at a path some earlier state already left a claim on — so the
+    two together mean neither end of a path's lifecycle has to trust the
+    other to have been correct.
+
+    **The URI is built HERE, from (vault_name, path) — the caller never
+    assembles one.** Getting the URI right is the whole check: one that is
+    even slightly off-shape matches no publication, the guard silently never
+    fires, and the defect survives with green tests. That is not hypothetical —
+    the prior incident recorded in ``delete_publications_for_document`` was a
+    hand-built legacy URI that never matched what was stored. Its remedy there
+    was to accept *only* a URI and validate it; the remedy here is the mirror
+    image, and stronger: with the construction inside, there is no wrong URI a
+    caller could pass. (The two signatures therefore differ on purpose. Do not
+    "harmonize" them: that helper must not look anything up, because its
+    callers run it against a row they have already locked, while this one runs
+    before a write and has the intended path in hand.)
+
+    **The check is the resolver's own document lookup, inverted.**
+    ``resolve_document_publication`` finds the document behind a slug by
+    ``d.path = <path from the URI>`` under the vault the URI names, so
+    "orphan" here means "the resolver would find nothing" rather than an
+    approximation that could drift from it. Keying the anti-join on the vault
+    NAME also leaves this helper one vault identifier to be wrong about
+    instead of two a caller could pair inconsistently.
+
+    Everything else about the match is a deliberate SUPERSET of what the
+    resolver would serve, because a superset fails closed. Publications are
+    matched by ``resource_uri`` alone — no ``vault_id`` predicate, no
+    ``resource_type`` predicate — so a row stays caught however oddly it is
+    bound.
+
+    That makes this match set WIDER than what the cascade removes, in two
+    ways, and both are intentional. The cascade deletes one URI (the
+    canonical one) bound to one vault; this probes the legacy shape too and
+    ignores ``vault_id``. So a row the cascade cannot reach — a legacy-shape
+    URI, or one whose ``resource_uri`` and ``vault_id`` disagree — is not
+    silently reclaimed here; it blocks the path until someone revokes it.
+    A stuck path is the failure we want over a reused one, but it does mean
+    the two are not interchangeable: the guard is not a preview of what the
+    cascade would delete.
+
+    The resolver has since narrowed — it binds a publication to its own
+    ``vault_id`` (see ``resolve_document_publication``) — so this already
+    refuses a few writes for rows the resolver would no longer serve. Safe
+    direction, and those rows should not exist at all.
+
+    **Which stored URI shapes are matched.** Equality against an index, not a
+    parse of every row — so the shapes have to be enumerated. Two are:
+    the canonical form, and the pre-0.3.0 nested form
+    (``akb://V/doc/reports/q3.md``), which ``parse_uri`` still resolves to the
+    same document and which the resolver would therefore still serve.
+    Migration 026 rewrote every stored URI to the canonical form, so the
+    legacy shape should not exist — but "should not exist" is what left the
+    orphans in the incident this file already records, and the probe is one
+    index lookup either way. What is NOT matched is a hand-inserted URI with
+    trailing slashes (``parse_uri`` strips any number of them, so that family
+    is infinite and unindexable); no writer emits one.
+
+    **A path whose canonical URI is unparseable is not special-cased.**
+    ``parse_uri`` rejects URIs containing braces (they are template
+    placeholders), so a mirrored upstream path like
+    ``{{cookiecutter.project}}/README.md`` — which external-git accepts —
+    produces a URI nothing can parse. Equality needs no parse, so such a path
+    is treated like any other. Deliberately: raising on it instead would hold
+    the external-git sync cursor forever (a per-file error there is retried,
+    never skipped) over a publication that could not be served anyway, since
+    the resolver parses the stored URI too and 404s. The residue is that an
+    orphaned brace-path publication still blocks its path — a false conflict
+    in the strict sense, fail-closed, and resolved by revoking a dead row.
+
+    **Nothing is deleted.** The publication row carries the slug, its
+    creator, its creation time, restrictions and view count — the record an
+    owner needs to decide what to do with it. Silently reclaiming the path
+    would discard that, so the write loses and a human decides.
+
+    ``conn`` is REQUIRED and must be the connection the write runs on, inside
+    the caller's transaction: the check and the write then commit or roll back
+    as one unit. That is atomicity, not isolation — under READ COMMITTED each
+    statement takes its own snapshot, so a publication inserted between this
+    check and the write is not seen.
+
+    What closes that window differs by caller, and not every caller closes it
+    fully. ``put`` and ``move`` hold the ``(vault, path)`` advisory lock, but
+    on the BASE path — a collision-suffixed path from ``_resolve_free_path``
+    is covered by the final ``UNIQUE(vault_id, path)`` rather than the lock.
+    ``upsert_external`` holds neither; the external-git sync is single-poller,
+    so nothing races it today, but that is a property of the caller and not
+    something this helper enforces. The residual race is narrow (a publish
+    landing inside one transaction) and fails toward a stale claim rather
+    than a reused path.
+    """
+    from app.services.uri_service import doc_uri
+
+    candidates = [doc_uri(vault_name, path)]
+    if "/" in path:
+        # Pre-0.3.0 shape: the whole path in the identifier, no `/coll/`
+        # segment. `uri_service` deliberately has no builder for it (nothing
+        # may emit it), but `parse_uri` still accepts it, so a surviving row
+        # in this shape is still servable. Verified against `parse_uri` in
+        # tests/test_publication_path_claim_guard_unit.py rather than
+        # asserted here.
+        candidates.append(f"akb://{vault_name}/doc/{path}")
+    # Indexed probe: `idx_publications_resource_uri` (partial, WHERE
+    # resource_uri IS NOT NULL — non-null literals are passed, so it applies).
+    # The anti-join uses vaults' UNIQUE name and UNIQUE(vault_id, path), and
+    # is only reached for rows the outer probe returns — in a healthy database,
+    # none. That is the cost this pays on every document create.
+    row = await conn.fetchrow(
+        """
+        SELECT p.slug, p.created_at
+          FROM publications p
+         WHERE p.resource_uri = ANY($1::text[])
+           AND NOT EXISTS (
+                   SELECT 1
+                     FROM documents d
+                     JOIN vaults v ON v.id = d.vault_id
+                    WHERE v.name = $2 AND d.path = $3
+               )
+         ORDER BY p.created_at
+         LIMIT 1
+        """,
+        candidates, vault_name, path,
+    )
+    if row is None:
+        return
+    raise ConflictError(
+        f"Refusing to write {path!r} in vault {vault_name!r}: the path is "
+        f"claimed by a public link whose document no longer exists "
+        f"(publication slug {row['slug']}, created "
+        f"{row['created_at'].isoformat()}). A document written here would be "
+        f"reachable through that link. The publication is left in place "
+        f"rather than removed — review it, then "
+        f"revoke it (akb_unpublish slug={row['slug']}, or "
+        f"DELETE /api/v1/publications/{vault_name}/{row['slug']}) before "
+        f"reusing this path."
+    )
 
 
 async def delete_publications_for_file(
@@ -608,17 +825,32 @@ async def delete_publications_for_file(
     vault_name: str,
     *,
     expected_vault_id: uuid.UUID | None = None,
+    conn=None,
 ) -> int:
     """Delete all publications for a given file. Looks up the file's
     collection so the URI matches the canonical form stored in the
     ``publications.resource_uri`` column.
 
+    **CALL THIS BEFORE DELETING THE ``vault_files`` ROW.** The lookup below
+    reads ``vault_files``; run on the caller's connection after the row is
+    deleted, the row is already invisible inside that transaction, so the
+    helper builds a *vault-root* URI, matches nothing, and returns 0 — no
+    rows removed, no error, tests green. Note this is only wrong for files
+    that live in a collection: a vault-root file's root-form URI is correct
+    either way, so a call site with the ordering wrong still looks right
+    until someone puts a file in a folder. Every deleting caller today
+    passes ``conn`` and runs before its row delete; keep it that way.
+
     ``expected_vault_id`` adds an explicit vault binding to the DELETE
     (see ``delete_publications_for_document`` for rationale).
+
+    ``conn`` runs the lookup and the DELETE inside the caller's transaction
+    (same rationale as ``delete_publications_for_document``): on a separate
+    connection the two commit independently, and a crash between them leaves
+    the orphan the deleting caller is trying to avoid.
     """
     from app.services.uri_service import file_uri
-    pool = await get_pool()
-    async with pool.acquire() as conn:
+    async with _connection(conn) as conn:
         coll_row = await conn.fetchrow(
             """
             SELECT c.path AS collection
@@ -829,9 +1061,19 @@ async def resolve_document_publication(publication: dict) -> dict:
             -- user_directory.resolve_display_names.
             LEFT JOIN users u
                 ON u.id::text = d.created_by OR u.username = d.created_by
-            WHERE v.name = $1 AND d.path = $2
+            -- Bind to the publication's own vault_id (not the vault NAME
+            -- parsed out of resource_uri) so this can't be satisfied by a
+            -- same-path document in another vault (cross-vault IDOR) — the
+            -- same binding `resolve_file_publication` puts on vault_files.
+            -- `v.name = $3` is then the cross-check, not the lookup key: v is
+            -- joined on the pinned vault_id, so requiring it to equal the
+            -- URI's vault name means a row whose resource_uri disagrees with
+            -- its vault_id matches nothing and 404s. Fail closed — serving
+            -- the publication's own document at that path instead would be a
+            -- silent partial success on a row that is, either way, corrupt.
+            WHERE d.vault_id = $1 AND d.path = $2 AND v.name = $3
             """,
-            uri_vault, doc_path,
+            to_uuid(publication["vault_id"]), doc_path, uri_vault,
         )
         if doc_row is None:
             raise NotFoundError("Document", str(uri))

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -15,9 +15,19 @@ Covers:
 alongside the memory-feature removal — the underlying service no
 longer exists.)
 
+- The publication cleanup helpers' `conn=` contract — the DELETE must
+  run inside the caller's transaction, so a rollback resurrects the
+  publication row.
+
 Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable so
 the suite runs unattended on machines without a dev DB. The audit
 Docker stack default is `postgresql://akb:akb@localhost:5433/akb`.
+
+This file is listed in the DB-backed job of `backend-pytest.yml`, which
+sets `AKB_TEST_DSN` and `REQUIRE_REAL_PG=1` — under that flag an
+unreachable DB fails instead of skipping, so the gate cannot go quietly
+green. The `pool` fixture applies init.sql *and* the migrations, because
+CI hands it an empty database.
 """
 
 from __future__ import annotations
@@ -54,6 +64,11 @@ async def _can_connect(dsn: str) -> bool:
 @pytest_asyncio.fixture
 async def pool():
     if not await _can_connect(_DSN):
+        # This file is in the DB-backed CI job, where an unreachable
+        # Postgres means the gate silently stopped firing — fail loudly
+        # rather than skip into a false green. Locally it still skips.
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
         pytest.skip(f"Postgres not reachable at {_DSN}")
     pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=10)
     init_sql = (
@@ -67,6 +82,16 @@ async def pool():
     prev = pg_mod._pool
     pg_mod._pool = pool
     try:
+        # init.sql is only half the schema: `events` (migration 015),
+        # `s3_delete_outbox` (019), `chunks.vault_id` (014) and friends are
+        # created by migrations, and tests below need them. Against the
+        # empty database CI creates, init.sql alone leaves this file red.
+        # Drive the app's own runner rather than a hand-copied DDL list
+        # that would rot the first time someone adds a migration. This has
+        # to run AFTER the _pool wiring above — _apply_migrations resolves
+        # its connection through get_pool(). The schema_migrations ledger
+        # makes every run after the first a single SELECT.
+        await pg_mod._apply_migrations()
         yield pool
     finally:
         pg_mod._pool = prev
@@ -410,20 +435,26 @@ async def test_p1_2_file_delete_rolls_back_on_chunk_failure(pool, monkeypatch):
     assert still == 1, "file delete must roll back when chunk delete fails (was swallowed pre-fix)"
 
 
-# ── delete_publications_for_document UUID branch must match canonical URI ──
+# ── The cascade must delete under the CANONICAL URI ──
 
 
 @pytest.mark.asyncio
-async def test_delete_publications_for_document_uuid_canonical(pool):
-    """delete_publications_for_document(UUID) previously built a legacy
-    `akb://V/doc/{coll}/{name}` URI that never matched the canonical
-    `akb://V/coll/{coll}/doc/{name}` stored in publications.resource_uri,
-    so the cascade silently left orphan publications. The UUID branch now
-    builds the URI via doc_uri so the DELETE actually matches.
-    """
-    from app.services.publication_service import delete_publications_for_document
+async def test_chokepoint_materializes_the_canonical_uri(pool):
+    """A caller holding only a document id has to resolve it to the
+    CANONICAL URI — `akb://V/coll/{coll}/doc/{name}` — before the cascade can
+    match. An earlier incident built the pre-0.3.0 legacy shape
+    (`akb://V/doc/{coll}/{name}`), which never equals what
+    `publications.resource_uri` stores, so the cascade silently deleted
+    nothing and left orphans.
 
+    That resolution now lives in `DocumentRepository.delete_with_publications`,
+    which reads the path back from the row it locked and builds the URI with
+    `doc_uri`. (The helper itself no longer accepts ids at all — see
+    `test_delete_publications_for_document_rejects_a_bare_id`.) Driving the
+    chokepoint here tests the path that actually runs in production.
+    """
     vault_repo = VaultRepository(pool)
+    doc_repo = DocumentRepository(pool)
     name = f"_pubdel_{uuid.uuid4().hex[:8]}"
     vid = await vault_repo.create(
         name=name, description="pubdel", git_path=f"/tmp/{name}.git", owner_id=None,
@@ -444,16 +475,241 @@ async def test_delete_publications_for_document_uuid_canonical(pool):
             f"slug{uuid.uuid4().hex[:6]}", vid, canonical,
         )
 
-    deleted = await delete_publications_for_document(did)  # the UUID branch
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await doc_repo.delete_with_publications(conn, doc_id=did, vault_id=vid)
+        await tx.commit()
 
     async with pool.acquire() as conn:
         remaining = await conn.fetchval(
             "SELECT COUNT(*) FROM publications WHERE vault_id = $1", vid,
         )
+        docs_left = await conn.fetchval(
+            "SELECT COUNT(*) FROM documents WHERE id = $1", did,
+        )
         await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
 
-    assert deleted == 1, "UUID branch must materialize the canonical URI and match"
-    assert remaining == 0, "publication should be cascade-deleted, not orphaned"
+    assert deleted is True
+    assert docs_left == 0
+    assert remaining == 0, (
+        "publication should be cascade-deleted, not orphaned — a legacy-shape "
+        "URI would have matched nothing and left it behind"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_publications_for_document_rejects_a_bare_id(pool, vault):
+    """The helper takes a canonical URI and nothing else.
+
+    It used to accept a PG UUID too, resolving it through a join on
+    `documents`. The two input forms had different ordering requirements and
+    the signature said so nowhere: called after the row delete on the same
+    connection, the id form found no row and returned 0 — no error, nothing
+    deleted, publication orphaned. A delete path was correct only by accident
+    of which argument it happened to pass, and "tidying" a call from a URI to
+    `row["id"]` would have silently restored it. Rejecting ids outright
+    is what makes that unrepresentable.
+    """
+    from app.services.publication_service import delete_publications_for_document
+
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    uri = f"akb://{vname}/coll/incidents/doc/report.md"
+    slug = await _seed_publication(pool, vid, uri)
+
+    for bad in (did, str(did), f"akb://{vname}/file/{did}", "not-a-uri", ""):
+        with pytest.raises(ValueError, match="canonical document"):
+            await delete_publications_for_document(bad, expected_vault_id=vid)
+
+    # A rejected call must be a no-op, not a partial delete.
+    assert await _publication_exists(pool, slug)
+    assert await delete_publications_for_document(uri, expected_vault_id=vid) == 1
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_brace_path_document_is_not_blocked_by_uri_validation(
+    pool, vault,
+):
+    """A path `parse_uri` cannot parse must still be deletable.
+
+    `parse_uri` rejects URIs containing braces — they are template
+    placeholders — but external-git accepts upstream paths like
+    `templates/{{cookiecutter.project}}/README.md`, so `doc_uri` can
+    legitimately produce a URI nothing can parse. The delete path must match
+    on equality and never parse: raising instead aborts the tombstone, rolls
+    the transaction back, and holds the external-git sync cursor forever,
+    because a per-file error there is retried and never skipped. One
+    templated file upstream would wedge the entire mirror, and the document
+    it failed to delete stays live and searchable.
+
+    This is why the chokepoint calls `delete_publications_by_doc_uri` rather
+    than the validating entry point.
+    """
+    from app.services.publication_service import delete_publications_by_doc_uri
+    from app.services.uri_service import doc_uri, parse_uri
+
+    vid, vname = vault["id"], vault["name"]
+    path = "templates/{{cookiecutter.project_slug}}/README.md"
+    uri = doc_uri(vname, path)
+
+    # The premise: this URI is genuinely unparseable. If parse_uri ever starts
+    # accepting braces this test still passes, but it stops testing anything —
+    # so assert the premise rather than assuming it.
+    assert parse_uri(uri) is None, "premise broken: parse_uri now accepts braces"
+
+    slug = await _seed_publication(pool, vid, uri)
+    assert await delete_publications_by_doc_uri(uri, expected_vault_id=vid) == 1
+    assert not await _publication_exists(pool, slug)
+
+
+# ── The publication cleanup helpers must join the caller's transaction ──
+#
+# Callers that delete a document/file inside their own explicit TX have to
+# be able to run the publication cleanup on that same connection. If it
+# runs on a separate pool connection the two commits are independent, and
+# a crash between them leaves a publication row pointing at a deleted
+# document — the exact stale row that lets a public slug reach a
+# document at the reused path.
+
+
+async def _seed_publication(
+    pool, vault_id: uuid.UUID, uri: str, resource_type: str = "document",
+) -> str:
+    slug = f"slug{uuid.uuid4().hex[:6]}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO publications (id, slug, vault_id, resource_type, resource_uri, created_at) "
+            "VALUES (gen_random_uuid(), $1, $2, $3, $4, NOW())",
+            slug, vault_id, resource_type, uri,
+        )
+    return slug
+
+
+async def _publication_exists(pool, slug: str) -> bool:
+    async with pool.acquire() as conn:
+        return bool(await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE slug = $1", slug,
+        ))
+
+
+@pytest.mark.asyncio
+async def test_delete_publications_for_document_joins_caller_tx(pool, vault):
+    """`conn=` makes the DELETE part of the caller's transaction: rolling
+    the caller back must resurrect the publication row. Without it the
+    helper commits on its own connection and the rollback is a no-op.
+    """
+    from app.services.publication_service import delete_publications_for_document
+
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    uri = f"akb://{vname}/coll/incidents/doc/report.md"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, 'incidents/report.md', 'r', 'report', 'draft', NOW(), NOW(), "
+            "'cafef00d', '{}'::text[], '{}'::jsonb)",
+            did, vid,
+        )
+
+    # Rolled back → the row must come back.
+    slug = await _seed_publication(pool, vid, uri)
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await delete_publications_for_document(uri, conn=conn)
+        assert deleted == 1, "helper must still report the row it deleted"
+        await tx.rollback()
+    assert await _publication_exists(pool, slug), (
+        "publication survived only if the DELETE ran inside the caller's TX; "
+        "a separate connection would have committed it independently"
+    )
+
+    # Committed → the row is really gone (guards against a no-op 'fix').
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await delete_publications_for_document(uri, conn=conn)
+        await tx.commit()
+    assert deleted == 1
+    assert not await _publication_exists(pool, slug)
+
+    # expected_vault_id still binds the DELETE on the caller's connection.
+    slug = await _seed_publication(pool, vid, uri)
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await delete_publications_for_document(
+            uri, expected_vault_id=uuid.uuid4(), conn=conn,
+        )
+        await tx.commit()
+    assert deleted == 0, "wrong expected_vault_id must not delete"
+    assert await _publication_exists(pool, slug)
+
+
+@pytest.mark.asyncio
+async def test_delete_publications_for_file_joins_caller_tx(pool, vault):
+    """Same contract for the file helper. File publications carry a UUID
+    so they cannot be reoccupied, but a stale row is still wrong — and the
+    inline collection delete needs to clean them up inside its own TX.
+    """
+    from app.services.publication_service import delete_publications_for_file
+
+    vid, vname = vault["id"], vault["name"]
+    file_id = uuid.uuid4()
+    uri = f"akb://{vname}/file/{file_id}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_files (id, vault_id, name, s3_key, created_at, updated_at) "
+            "VALUES ($1, $2, 'diagram.png', $3, NOW(), NOW())",
+            file_id, vid, f"files/{file_id}",
+        )
+
+    slug = await _seed_publication(pool, vid, uri, resource_type="file")
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await delete_publications_for_file(file_id, vname, conn=conn)
+        assert deleted == 1
+        await tx.rollback()
+    assert await _publication_exists(pool, slug), (
+        "file publication must be deleted inside the caller's TX"
+    )
+
+    async with pool.acquire() as conn:
+        tx = conn.transaction()
+        await tx.start()
+        deleted = await delete_publications_for_file(file_id, vname, conn=conn)
+        await tx.commit()
+    assert deleted == 1
+    assert not await _publication_exists(pool, slug)
+
+
+@pytest.mark.asyncio
+async def test_delete_publications_for_file_without_conn(pool, vault):
+    """Omitting `conn` keeps the pre-existing self-acquiring behaviour —
+    the documents helper already has coverage above, this pins the file
+    one so the refactor can't regress it.
+    """
+    from app.services.publication_service import delete_publications_for_file
+
+    vid, vname = vault["id"], vault["name"]
+    file_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_files (id, vault_id, name, s3_key, created_at, updated_at) "
+            "VALUES ($1, $2, 'diagram.png', $3, NOW(), NOW())",
+            file_id, vid, f"files/{file_id}",
+        )
+    slug = await _seed_publication(
+        pool, vid, f"akb://{vname}/file/{file_id}", resource_type="file",
+    )
+
+    deleted = await delete_publications_for_file(file_id, vname, expected_vault_id=vid)
+
+    assert deleted == 1
+    assert not await _publication_exists(pool, slug)
 
 
 # ── P2: embedding response reordered by `index`, not array position ──
@@ -699,5 +955,261 @@ async def test_create_with_deleted_collection_raises_conflict(pool, vault):
             path="retire/lost-race.md", title="Doc", doc_type="note",
             status="draft", summary=None, domain=None, created_by=None, now=now,
             commit_hash="0" * 40, content_hash="h", hash_algorithm="sha256",
-            tags=[], metadata={},
+            tags=[], metadata={}, vault_name=vault["name"],
         )
+
+
+# ── The publish/delete TOCTOU: FOR UPDATE at the deletion chokepoint ──
+#
+# `create_publication` takes `FOR SHARE` on the documents row and then
+# INSERTs. The deleter's own serialization is `pg_advisory_xact_lock` over
+# (vault_id, path) — a namespace the publisher never touches, so the two do
+# NOT serialize against each other. With the publication cleanup running
+# before any conflicting row lock there is a window: cleanup finds nothing,
+# the publisher takes FOR SHARE and commits its INSERT, and the deleter's
+# `DELETE FROM documents` — which had been blocked on that share lock —
+# then proceeds over a publication that survives. The orphan resolves by
+# path, and `documents` is UNIQUE(vault_id, path), so the next document at
+# that path is reached through the old slug.
+#
+# `DocumentRepository.delete_with_publications` takes FOR UPDATE *before*
+# the cleanup, which makes both orderings safe.
+
+
+async def _blocked_queries(watch, *, contains: str | None = None) -> list[str]:
+    """Queries of every backend in this database currently waiting on a lock."""
+    rows = await watch.fetch(
+        "SELECT query FROM pg_stat_activity "
+        " WHERE datname = current_database() AND wait_event_type = 'Lock' "
+        "   AND pid <> pg_backend_pid()"
+    )
+    qs = [r["query"] for r in rows]
+    if contains is not None:
+        qs = [q for q in qs if contains.lower() in (q or "").lower()]
+    return qs
+
+
+async def _await_blocked(watch, *, count: int, contains: str | None = None,
+                         what: str, timeout: float = 20.0) -> list[str]:
+    """Block until `count` backends are waiting on a lock (optionally with
+    `contains` in their query text), or fail.
+
+    This is a wait-for-state, not a timing guess: the interleaving itself is
+    pinned by transaction control plus PostgreSQL's lock queue, and each side
+    is only released once the database itself reports it is parked on the
+    lock. A timeout here means the expected contention never happened, which
+    is a real failure, not flake — so it asserts rather than proceeding.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        qs = await _blocked_queries(watch, contains=contains)
+        if len(qs) >= count:
+            return qs
+        if loop.time() > deadline:
+            all_waiting = await _blocked_queries(watch)
+            raise AssertionError(
+                f"timed out waiting for {what}: expected >={count} blocked "
+                f"backend(s)"
+                + (f" matching {contains!r}" if contains else "")
+                + f", saw {len(qs)}. All waiters: {all_waiting}"
+            )
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_publish_delete_race_leaves_no_orphan_publication(pool, vault, monkeypatch):
+    """A publisher that commits *while a delete is in flight* must not leave
+    its publication behind.
+
+    The interleaving is forced, not hoped for. A third connection holds
+    FOR UPDATE on the document row, so both contenders park in PostgreSQL's
+    lock queue in a known order — publisher first, deleter second. Releasing
+    that lock hands the row to the publisher, which inserts and commits, and
+    only then to the deleter.
+
+    Pre-fix this is RED: the deleter's publication cleanup had already run
+    (against an empty table) before it ever queued for the row, so the
+    publication it never saw survived the document it pointed at. With
+    FOR UPDATE taken first, the deleter's cleanup runs downstream of the
+    lock, sees the freshly committed row, and removes it.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    path = "reports/q3.md"
+    uri = f"akb://{vname}/coll/reports/doc/q3.md"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, $3, 'Q3', 'report', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            did, vid, path,
+        )
+
+    doc_repo = DocumentRepository(pool)
+    blocker = await asyncpg.connect(_DSN)   # holds the row so we can order the queue
+    watch = await asyncpg.connect(_DSN)     # observes who is parked on it
+    pub_result: dict | None = None
+    pub_error: Exception | None = None
+    try:
+        btx = blocker.transaction()
+        await btx.start()
+        await blocker.fetchval(
+            "SELECT id FROM documents WHERE id = $1 FOR UPDATE", did,
+        )
+
+        # 1) Publisher queues FIRST. Its FOR SHARE conflicts with the
+        #    blocker's FOR UPDATE, so it parks before inserting anything.
+        pub_task = asyncio.create_task(create_publication(
+            vault_id=vid, resource_type="document", resource_uri=uri, title="Q3",
+        ))
+        await _await_blocked(
+            watch, count=1, contains="FOR SHARE",
+            what="create_publication to park on the document row",
+        )
+
+        # 2) Deleter queues SECOND, behind the publisher.
+        async def _delete() -> bool:
+            async with pool.acquire() as c:
+                tx = c.transaction()
+                await tx.start()
+                try:
+                    out = await doc_repo.delete_with_publications(
+                        c, doc_id=did, vault_id=vid,
+                    )
+                except BaseException:
+                    await tx.rollback()
+                    raise
+                await tx.commit()
+                return out
+
+        del_task = asyncio.create_task(_delete())
+        # Both contenders now park on the `documents` row: the publisher on
+        # its FOR SHARE, the deleter on the chokepoint's FOR UPDATE (or, in
+        # the pre-fix shape this test is built to catch, on its bare
+        # `DELETE FROM documents`). Matching on the table name covers both
+        # without letting an unrelated waiter satisfy the count.
+        await _await_blocked(
+            watch, count=2, contains="documents",
+            what="the delete to park behind the publisher",
+        )
+
+        # 3) Release. Publisher commits its INSERT, then the deleter runs.
+        await btx.commit()
+        try:
+            pub_result = await pub_task
+        except ValueError as e:          # the publisher may legitimately lose
+            pub_error = e
+        deleted = await del_task
+    finally:
+        if not blocker.is_closed():
+            await blocker.close()
+        await watch.close()
+
+    assert deleted is True, "the delete must have removed the document row"
+    # Pin the interleaving this test exists to exercise. The lock queue is
+    # FIFO, so the publisher — queued first — takes the row first, inserts,
+    # and commits BEFORE the deleter runs. If it ever lost instead, the
+    # orphan assertion below would pass for the wrong reason (that direction
+    # was already safe before this fix), so a losing publisher is a broken
+    # test, not a pass.
+    assert pub_result is not None, (
+        "the publisher was supposed to win the lock queue and commit its "
+        f"INSERT before the delete ran; it failed instead: {pub_error!r}. "
+        "The red interleaving was not exercised."
+    )
+
+    async with pool.acquire() as conn:
+        orphans = await conn.fetch(
+            "SELECT slug FROM publications WHERE resource_uri = $1", uri,
+        )
+        doc_rows = await conn.fetchval(
+            "SELECT COUNT(*) FROM documents WHERE id = $1", did,
+        )
+
+    assert doc_rows == 0, "the document row must be gone"
+    # Whichever side won the row, the invariant is the same: no publication
+    # may outlive the document it points at. Here the publisher wins the
+    # queue, so this is specifically asserting the deleter cleaned up a row
+    # that did not exist when its cleanup would have run pre-fix.
+    assert not orphans, (
+        "ORPHAN PUBLICATION SURVIVED the delete "
+        f"({[r['slug'] for r in orphans]}, publisher "
+        f"{'succeeded' if pub_result else f'failed: {pub_error}'}). "
+        "The next document created at this path would be reachable "
+        "under that slug, reopened by the race."
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeypatch):
+    """The other interleaving: the deleter wins the row, so the publisher's
+    FOR SHARE re-check finds nothing and `create_publication` fails closed
+    instead of inserting a publication for a document that is already gone.
+
+    This direction held before the chokepoint's FOR UPDATE too (the row
+    DELETE takes its own exclusive lock), so it is a contract pin rather
+    than a regression test — it is here so a future change to the publisher's
+    re-check cannot silently turn a hard abort into an orphan.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    path = "reports/q4.md"
+    uri = f"akb://{vname}/coll/reports/doc/q4.md"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, $3, 'Q4', 'report', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            did, vid, path,
+        )
+
+    doc_repo = DocumentRepository(pool)
+    watch = await asyncpg.connect(_DSN)
+    try:
+        async with pool.acquire() as c:
+            tx = c.transaction()
+            await tx.start()
+            deleted = await doc_repo.delete_with_publications(
+                c, doc_id=did, vault_id=vid,
+            )
+            assert deleted is True
+
+            # Publisher parks on the uncommitted delete.
+            pub_task = asyncio.create_task(create_publication(
+                vault_id=vid, resource_type="document", resource_uri=uri, title="Q4",
+            ))
+            await _await_blocked(
+                watch, count=1, contains="FOR SHARE",
+                what="create_publication to park on the in-flight delete",
+            )
+            await tx.commit()
+
+        with pytest.raises(ValueError, match="deleted concurrently"):
+            await pub_task
+    finally:
+        await watch.close()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE resource_uri = $1", uri,
+        )
+    assert rows == 0, "a publication must not be created for a deleted document"

--- a/backend/tests/extgit_http.py
+++ b/backend/tests/extgit_http.py
@@ -126,6 +126,26 @@ class GitHttpFixture:
         )
         return head
 
+    def remove_path(self, name: str, path: str, branch: str = "main") -> str:
+        """Delete ``path`` upstream and push. Returns the new upstream head SHA.
+
+        The counterpart of ``publish_change``: a reconcile against this head
+        takes the ``local.keys() - remote_tree.keys()`` branch, which is the
+        only way to reach ``_delete_external_path`` — and therefore the
+        publication cascade — with a real git transport.
+        """
+        work = self._works[name]
+        _git("rm", "-q", "--", path, cwd=work)
+        _git("commit", "-m", f"remove {path}", cwd=work)
+        head = _git("rev-parse", f"refs/heads/{branch}", cwd=work)
+        subprocess.run(
+            [GIT, "push", self.bare_path(name), f"{branch}:{branch}"],
+            cwd=work,
+            check=True,
+            capture_output=True,
+        )
+        return head
+
     def close(self) -> None:
         self._server.shutdown()
         self._server.server_close()

--- a/backend/tests/source_scan.py
+++ b/backend/tests/source_scan.py
@@ -1,0 +1,42 @@
+"""Shared AST helpers for the tests that scan production sources.
+
+Two guards enumerate call sites across the tree and compare them against an
+allowlist keyed by (file, function) — `test_document_delete_chokepoint_unit`
+for `DELETE FROM documents`, `test_external_git_cascade_unit` for
+`vault_external_git` creation. They need the same two primitives, so they
+live here rather than being maintained twice.
+
+`test_` is deliberately absent from the module name: pytest would otherwise
+collect it, and it holds no tests. Same convention as `extgit_http.py`.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+def python_files(roots: tuple[str, ...]) -> list[Path]:
+    """Every `.py` under each root, sorted so a failure names sites in a
+    stable order. Asserts the scan found something — a mistyped root would
+    otherwise make the guard pass by looking at nothing."""
+    files: list[Path] = []
+    for root in roots:
+        files.extend(sorted((BACKEND / root).rglob("*.py")))
+    assert files, f"no production sources found under {roots} — the scan root is wrong"
+    return files
+
+
+def enclosing_function(tree: ast.AST, lineno: int) -> str:
+    """The innermost def containing `lineno` — the unit an allowlist entry
+    should name, so a second site in an already-blessed file cannot ride in
+    on the entry that blessed the first. `<module>` when at module level."""
+    best, best_line = "<module>", -1
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = node.end_lineno or node.lineno
+            if node.lineno <= lineno <= end and node.lineno > best_line:
+                best, best_line = node.name, node.lineno
+    return best

--- a/backend/tests/test_document_delete_chokepoint_unit.py
+++ b/backend/tests/test_document_delete_chokepoint_unit.py
@@ -1,0 +1,301 @@
+"""One chokepoint for deleting a `documents` row — enforced statically.
+
+Publications lost their `document_id` FK in migration 022, so nothing
+cascades when a document row goes away. Resolution re-finds the document
+**by path**, and `documents` is `UNIQUE(vault_id, path)` — so a publication
+that outlives its document is reached by whatever document
+next occupies that path. Of the three per-row delete paths, two omitted the
+publication statement — the one that had it kept it as an inline copy, so
+there was no single original for the others to call.
+
+Convergence on a helper is a convention, and a convention is exactly what
+failed here. The structural version is
+`DocumentRepository.delete_with_publications`: the row delete and the
+publication cascade are one call, so a new delete path can only be wrong by
+not deleting documents at all. This file is the lock on that door — it
+enumerates every `DELETE FROM documents` in the production tree and fails on
+any site not on the allowlist, so a sixth one fails in review rather than in
+production.
+
+Comments are invisible to `ast`, and docstrings are filtered out, so only
+statements the database would actually execute are counted.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.source_scan import BACKEND as _BACKEND, enclosing_function, python_files
+
+
+_ROOTS = ("app", "mcp_server")
+
+# `public.documents`, `ONLY documents`, `"documents"` and TRUNCATE all remove
+# rows just as well as the plain form, so the scan covers them rather than
+# leaving four spellings of the same bypass.
+_DELETE_DOCUMENTS = re.compile(
+    r"""\b(?:
+          DELETE \s+ FROM \s+ (?:ONLY \s+)? (?:public\.)? "?documents"?
+        | TRUNCATE \s+ (?:TABLE \s+)? (?:ONLY \s+)? (?:public\.)? "?documents"?
+    )\b""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# A table name spliced in at runtime hides the phrase above from a literal
+# scan: `f"DELETE FROM {t}"`, `"DELETE FROM " + t`, `"DELETE FROM {}".format(t)`.
+# Any literal that ENDS mid-statement, right where the table name belongs, is
+# treated as a delete site — it may be innocent (some other table), but it is
+# indistinguishable from the bypass and so has to be looked at.
+# TRUNCATE only counts when an interpolation actually follows it — the bare
+# word is also a GRANT privilege name (`role_sync._EXPECTED_TABLE_PRIVS`) and
+# flagging that would be noise, not signal.
+_DANGLING_DELETE = re.compile(
+    r"""\b(?:
+          DELETE \s+ FROM \s* (?:\{[^}]*\})? \s*
+        | TRUNCATE (?:\s+TABLE)? \s* \{[^}]*\} \s*
+    )$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Interpolated-table deletes that provably never name `documents`. Same
+# contract as `_ALLOWLIST`: the sentence is the review.
+_DYNAMIC_TABLE_ALLOWLIST: dict[tuple[str, str], str] = {
+    ("app/db/migrations/026_uri_collection_prefix.py", "_run"): (
+        "`DELETE FROM {tmp}` where `tmp` is the TEMP TABLE created by the "
+        "CREATE TEMP TABLE two lines above, inside the same migration."
+    ),
+    ("app/services/table_row_write.py", "compile_delete_rows"): (
+        "User-table row delete. The name comes from "
+        "`table_data_repo.pg_table_name(vault, table)`, which only ever "
+        "produces a `vt_*` dynamic table — never a core table."
+    ),
+    ("app/services/table_row_write.py", "_compile_delete_ast"): (
+        "Same compiler, akb_sql's parsed-DELETE arm; same `vt_*`-only "
+        "table-name source."
+    ),
+}
+
+
+# Every production site allowed to delete `documents` rows, with the reason
+# it is allowed and how many such statements it is allowed to contain. The
+# count matters: keyed on (file, function) alone, an allowlist entry would
+# silently pre-approve a SECOND delete added to an already-blessed function.
+# Adding or growing an entry is a deliberate act with a reviewer attached.
+_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
+    ("app/repositories/document_repo.py", "delete_with_publications"): (1, (
+        "THE chokepoint. Takes FOR UPDATE on the row, runs the publication "
+        "cascade, then deletes — one call, one transaction. Every ordinary "
+        "document delete routes through here."
+    )),
+    ("app/services/document_service.py", "_rollback_vault_rows"): (1, (
+        "Vault lifecycle, not an ordinary delete: purges a half-created "
+        "vault, `DELETE FROM documents WHERE vault_id = $1` in bulk, and "
+        "drops the `vaults` row in the same transaction — so "
+        "`publications.vault_id ... ON DELETE CASCADE` (init.sql) removes "
+        "the publications, and no later document can occupy the reused "
+        "(vault_id, path) because the vault itself is gone. It also aborts "
+        "outright if any publication exists (the foreign-write guard), so "
+        "the branch that reaches the DELETE has none to clean. Routing it "
+        "through the per-row chokepoint would be N round-trips to redo work "
+        "one cascade already did."
+    )),
+    ("app/services/access_service.py", "delete_vault"): (1, (
+        "Vault lifecycle, same reasoning: the `vaults` row goes in the same "
+        "transaction and `publications.vault_id ... ON DELETE CASCADE` takes "
+        "the publications with it. The path cannot be reoccupied — there is no "
+        "vault left to hold it."
+    )),
+}
+
+
+def _python_files() -> list[Path]:
+    return python_files(_ROOTS)
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """ids of the Constant nodes that are docstrings, so prose describing a
+    DELETE is not mistaken for one."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = getattr(node, "body", None)
+            if not body:
+                continue
+            first = body[0]
+            if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) \
+                    and isinstance(first.value.value, str):
+                out.add(id(first.value))
+    return out
+
+
+
+
+def _delete_sites() -> dict[tuple[str, str], list[int]]:
+    """(relative path, enclosing function) → line numbers of executable
+    document-delete string literals."""
+    sites: dict[tuple[str, str], list[int]] = {}
+    for path in _python_files():
+        source = path.read_text()
+        if not _DELETE_DOCUMENTS.search(source):
+            continue  # cheap reject before paying for a parse
+        tree = ast.parse(source)
+        docstrings = _docstring_nodes(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in docstrings or not _DELETE_DOCUMENTS.search(node.value):
+                continue
+            key = (path.relative_to(_BACKEND).as_posix(), enclosing_function(tree, node.lineno))
+            sites.setdefault(key, []).append(node.lineno)
+    return sites
+
+
+def _dangling_delete_sites() -> list[tuple[str, str, int, str]]:
+    """Literals that stop right where a table name would be interpolated.
+
+    `f"DELETE FROM {table}"` renders as a JoinedStr whose literal part is
+    `"DELETE FROM "` — the table never appears in any single constant, so the
+    scan above cannot see it. Same for `+` concatenation and `.format()`.
+    Rather than try to evaluate the expression, flag the shape.
+    """
+    out: list[tuple[str, str, int, str]] = []
+    for path in _python_files():
+        source = path.read_text()
+        if not re.search(r"DELETE\s+FROM|TRUNCATE", source, re.IGNORECASE):
+            continue
+        tree = ast.parse(source)
+        docstrings = _docstring_nodes(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in docstrings:
+                continue
+            if _DANGLING_DELETE.search(node.value.rstrip()):
+                out.append((
+                    path.relative_to(_BACKEND).as_posix(),
+                    enclosing_function(tree, node.lineno),
+                    node.lineno,
+                    node.value.strip()[-60:],
+                ))
+    return out
+
+
+def test_every_document_delete_is_allowlisted():
+    """A new document delete anywhere in the production tree fails here. If
+    the new site is legitimate, add it to `_ALLOWLIST` *with the reason its
+    publications are handled* — that sentence is the review."""
+    found = _delete_sites()
+    unlisted = {k: v for k, v in found.items() if k not in _ALLOWLIST}
+    assert not unlisted, (
+        "unallowlisted document delete:\n"
+        + "\n".join(f"  {f}:{lines} in {fn}()" for (f, fn), lines in sorted(unlisted.items()))
+        + "\n\nDocument deletes must go through "
+        "`DocumentRepository.delete_with_publications`, which carries the "
+        "publication cascade. If this site genuinely cannot, add it to "
+        "_ALLOWLIST in this file with the reason its publications are handled."
+    )
+
+    # An extra delete inside an already-blessed function would otherwise ride
+    # in for free on the entry that blessed the first one.
+    grew = {
+        k: (len(v), _ALLOWLIST[k][0]) for k, v in found.items()
+        if k in _ALLOWLIST and len(v) != _ALLOWLIST[k][0]
+    }
+    assert not grew, (
+        "allowlisted function's delete count changed (found, allowed): "
+        f"{grew}. Each statement needs its own justification — update the "
+        "count in _ALLOWLIST only after reading the new one."
+    )
+
+
+def test_no_document_delete_hides_behind_an_interpolated_table_name():
+    """`f"DELETE FROM {table}"` renders the table name at runtime, so a
+    literal scan cannot see whether it says `documents`. Any literal that
+    stops exactly where the table belongs is flagged — an innocent one is
+    fine to allowlist, but it has to be read first."""
+    dangling = [
+        d for d in _dangling_delete_sites()
+        if (d[0], d[1]) not in _DYNAMIC_TABLE_ALLOWLIST
+    ]
+    assert not dangling, (
+        "delete statement with an interpolated table name — the static "
+        "chokepoint gate cannot see what it deletes:\n"
+        + "\n".join(f"  {f}:{ln} in {fn}(): ...{frag!r}" for f, fn, ln, frag in dangling)
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """The allowlist is not allowed to grow stale either: an entry whose
+    site was deleted or renamed must be removed, or it silently pre-approves
+    a site nobody has read."""
+    found = _delete_sites()
+    stale = sorted(set(_ALLOWLIST) - set(found))
+    assert not stale, f"_ALLOWLIST entries with no matching site: {stale}"
+
+
+def test_the_chokepoint_is_the_only_repository_delete():
+    """`DocumentRepository` must expose no plainer row-delete method. The
+    allowlist above stops a new inline SQL delete; this stops the other way
+    in — calling a repository method that skips the cascade."""
+    from app.repositories.document_repo import DocumentRepository
+
+    assert hasattr(DocumentRepository, "delete_with_publications")
+    assert not hasattr(DocumentRepository, "delete"), (
+        "DocumentRepository.delete deletes the row without the publication "
+        "cascade — that is the hole. Use delete_with_publications."
+    )
+
+
+def _chokepoint_body() -> str:
+    source = (_BACKEND / "app/repositories/document_repo.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "delete_with_publications":
+            body = node.body
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+                body = body[1:]  # drop the docstring — it describes the SQL too
+            return "\n".join(ast.unparse(stmt) for stmt in body)
+    pytest.fail("delete_with_publications not found in document_repo.py")
+
+
+def test_chokepoint_locks_before_it_cleans_up():
+    """Ordering is the whole fix for the publish/delete TOCTOU.
+    `create_publication` takes FOR SHARE on the documents row and then
+    inserts; the deleter's own serialization is a pg_advisory_xact_lock over
+    (vault_id, path) that the publisher never acquires, so the two lock
+    namespaces do not serialize. With the cleanup running before any
+    conflicting row lock, a publisher slips in between: the cleanup finds
+    nothing, the publisher commits its INSERT, and the row delete — which had
+    been blocked on that share lock — proceeds over a surviving publication.
+
+    FOR UPDATE first, then the cleanup, then the row delete. The live proof
+    is `tests/concurrency/test_invariants_unit.py`
+    ::test_publish_delete_race_leaves_no_orphan_publication; this pins the
+    ordering statically so a refactor cannot quietly invert it.
+    """
+    body = _chokepoint_body()
+    lock = body.find("FOR UPDATE")
+    # Either publication-cleanup entry point counts. The chokepoint uses the
+    # by-URI form (it builds the URI from the row it just locked, so there is
+    # no caller-supplied string to validate, and validating would reject a
+    # legitimate brace path) — but matching both keeps this assertion about
+    # the ORDER rather than about which helper name is in fashion.
+    cleanup = min(
+        (i for i in (
+            body.find("delete_publications_by_doc_uri("),
+            body.find("delete_publications_for_document("),
+        ) if i != -1),
+        default=-1,
+    )
+    row_delete = body.find("DELETE FROM documents")
+    assert lock != -1, "the chokepoint must take FOR UPDATE on the resource row"
+    assert cleanup != -1, "the chokepoint must run the publication cascade"
+    assert row_delete != -1, "the chokepoint must delete the row"
+    assert lock < cleanup < row_delete, (
+        "order must be FOR UPDATE → publication cleanup → DELETE FROM documents "
+        f"(got lock@{lock}, cleanup@{cleanup}, delete@{row_delete})"
+    )

--- a/backend/tests/test_external_git_cascade_unit.py
+++ b/backend/tests/test_external_git_cascade_unit.py
@@ -1,0 +1,767 @@
+"""The external-git publication cascade, and the two invariants that keep it
+out of reach.
+
+`external_git_service._delete_external_path` deletes a mirrored document
+through `DocumentRepository.delete_with_publications`, so an upstream commit
+that removes a path takes the document's publications with it. Without that,
+the surviving publication would resolve by path — and an upstream *revert*
+re-adding the path (or a rename back) would republish whatever landed there,
+through the old public slug.
+
+**That cascade cannot currently fire through the product**, because nothing can
+publish a mirrored document in the first place. Two invariants stand in the
+way, and neither is written down anywhere the code can enforce:
+
+  1. A mirror vault refuses `required_role="writer"` for every user including
+     the owner (`access_service.py:220-231`), and publishing asks for exactly
+     that role on both surfaces.
+  2. `vault_external_git` has exactly one INSERT path, inside `create_vault`'s
+     transaction (`document_service.py:1756`), so a vault is a mirror from
+     birth — and a mirror is empty at birth, so no document that predates the
+     mirror flag can carry a publication into it.
+
+This file is therefore NOT a red-then-green regression test: the cascade is
+already correct. It is a guard on all three facts at once. The day someone
+adds "attach an external-git remote to an existing vault", or relaxes the
+mirror guard, or moves publishing to a different role, invariant 1 or 2 fails
+in review — and the cascade test is what says the remaining protection still
+works.
+
+The cascade test drives the REAL git binary over `tests/extgit_http`'s
+in-process smart-HTTP server (a fake `mirror.test` host pinned to 127.0.0.1
+through the hermetic runner's DNS pin), against a REAL PostgreSQL. Nothing
+about the delete path is mocked: the upstream commit, the fetch, the tree
+diff, the row lock, the publication cleanup and the event are all the
+production code.
+
+Talks to Postgres via `AKB_TEST_DSN`; skips when unreachable, unless
+`REQUIRE_REAL_PG=1` (the DB-backed CI job), where an unreachable database
+fails rather than skips so the gate cannot go quietly green. The invariant
+tests at the bottom are static and run everywhere.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from tests.source_scan import BACKEND as _BACKEND, enclosing_function, python_files
+
+from app.exceptions import ForbiddenError
+from app.repositories.vault_external_git_repo import VaultExternalGitRepository
+from app.repositories.vault_repo import VaultRepository
+from app.services.external_git_service import ExternalGitService
+from app.services.git_service import GitService
+from app.services.uri_service import doc_uri
+from tests.extgit_http import build_runner
+
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+_MIRRORED_PATH = "reports/q3.md"
+_MIRRORED_BODY = "# Q3\n\nUpstream content that a public link points at.\n"
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=10)
+    async with pool.acquire() as conn:
+        await conn.execute((_BACKEND / "app" / "db" / "init.sql").read_text())
+    from app.db import postgres as pg_mod
+    prev = pg_mod._pool
+    pg_mod._pool = pool
+    try:
+        # `reconcile` writes events, chunks and the mirror sidecar's scheduler
+        # columns — all of which arrive by migration, not init.sql.
+        await pg_mod._apply_migrations()
+        yield pool
+    finally:
+        pg_mod._pool = prev
+        await pool.close()
+
+
+@pytest.fixture(autouse=True)
+def _public_base_url(monkeypatch):
+    """`create_publication` renders a share URL and refuses to build one
+    without a configured public base."""
+    from app.services import publication_service
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://cascade.test.local", raising=False,
+    )
+
+
+@pytest_asyncio.fixture
+async def created(pool):
+    """Rows to remove on teardown. Vaults go first: the vault-scoped tables
+    this file writes (`documents`, `publications`, `vault_external_git`,
+    `chunks`) are all `ON DELETE CASCADE` on `vaults.id`, but `vaults.owner_id`
+    references `users`, so a user cannot be removed while it still owns one.
+
+    `events` is deliberately left behind: its `vault_id` carries no foreign key
+    (`migrations/015_events_outbox.py:50`) because the outbox must survive the
+    vault it describes long enough to be published. A few rows per run in a
+    scratch database, and removing them would be this test asserting a
+    retention policy it does not own.
+    """
+    ids: dict[str, list] = {"vaults": [], "users": []}
+    try:
+        yield ids
+    finally:
+        async with pool.acquire() as conn:
+            for vault_id in ids["vaults"]:
+                await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+            for user_id in ids["users"]:
+                await conn.execute("DELETE FROM users WHERE id = $1", user_id)
+
+
+# ── 1. The cascade, end to end ───────────────────────────────────
+
+
+class _Mirror:
+    """A live mirror vault: upstream repo, DB rows, and the service wired to
+    the fixture's git transport."""
+
+    def __init__(self, *, vault_id, name, url, svc, git, fixture, repo_name):
+        self.vault_id = vault_id
+        self.name = name
+        self.url = url
+        self.svc = svc
+        self.git = git
+        self.fixture = fixture
+        self.repo_name = repo_name
+
+
+async def _make_mirror(pool, git_http, tmp_path, created, *, files: dict[str, str]) -> _Mirror:
+    """Create the upstream repo, the vault + sidecar rows, and activate the
+    sidecar so `mark_success` can advance the cursor.
+
+    The sidecar is born `sync_state='pending_preflight'` and the poller's
+    Layer-2 preflight is what promotes it; this calls the same repository
+    method that preflight does rather than writing `sync_state` by hand.
+    """
+    repo_name = f"cascade{uuid.uuid4().hex[:8]}"
+    url, _head = git_http.add_repo(repo_name, files)
+
+    git = GitService(
+        storage_path=str(tmp_path / "vaults"),
+        ext_runner=build_runner(git_http.port),
+    )
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+    vault_id = await VaultRepository(pool).create(
+        name=name,
+        description="external-git cascade fixture",
+        git_path=str(git._bare_path(name)),
+        owner_id=None,
+    )
+    created["vaults"].append(vault_id)
+    ext_repo = VaultExternalGitRepository(pool)
+    await ext_repo.create(
+        vault_id=vault_id, remote_url=url, remote_branch="main",
+        auth_token=None, poll_interval_secs=60,
+    )
+    assert await ext_repo.activate_from_preflight(vault_id, url, None, 60) is True
+
+    return _Mirror(
+        vault_id=vault_id, name=name, url=url,
+        svc=ExternalGitService(git=git), git=git,
+        fixture=git_http, repo_name=repo_name,
+    )
+
+
+async def _doc_row(pool, vault_id, path: str) -> dict | None:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id, path, source, external_path FROM documents "
+            " WHERE vault_id = $1 AND path = $2",
+            vault_id, path,
+        )
+    return dict(row) if row else None
+
+
+async def _publication_row(pool, slug: str) -> dict | None:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT slug, resource_uri, vault_id FROM publications WHERE slug = $1",
+            slug,
+        )
+    return dict(row) if row else None
+
+
+async def _publish_mirrored(mirror, path: str) -> str:
+    """Publish a mirrored document.
+
+    Deliberately `create_publication` and not the REST/MCP surface: publishing
+    asks for `required_role="writer"`, which a mirror vault refuses for every
+    user (invariant 1, pinned below). The service function has no mirror check,
+    which is exactly why the cascade has to be correct anyway — this is the one
+    seam through which a mirror publication could ever exist.
+    """
+    from app.services.publication_service import create_publication
+    pub = await create_publication(
+        vault_id=mirror.vault_id,
+        resource_type="document",
+        resource_uri=doc_uri(mirror.name, path),
+        title="Q3 (public)",
+    )
+    return pub["slug"]
+
+
+@pytest.fixture
+def mirror_doc_service(monkeypatch, tmp_path, git_http):
+    """Point the publication resolver's cached DocumentService at the fixture's
+    git storage, so resolving a mirror publication reads the real mirrored body
+    instead of falling back to 'content unavailable' against the default
+    storage root."""
+    from app.services import publication_service
+    from app.services.document_service import DocumentService
+    monkeypatch.setattr(
+        publication_service, "_doc_service",
+        DocumentService(git=GitService(
+            storage_path=str(tmp_path / "vaults"),
+            ext_runner=build_runner(git_http.port),
+        )),
+        raising=False,
+    )
+
+
+async def test_upstream_delete_takes_the_publication_with_the_document(
+    pool, git_http, tmp_path, created, mirror_doc_service,
+):
+    """An upstream commit that removes a mirrored path must remove that
+    document's publications in the same transaction.
+
+    Every step is real: `git rm` + push to the served bare, a fetch through the
+    hermetic runner over HTTP, the tree diff, and the tombstone's route through
+    `DocumentRepository.delete_with_publications`.
+    """
+    from app.services.publication_service import (
+        PublicationNotFound,
+        get_publication_by_slug,
+        resolve_document_publication,
+        resolve_publication,
+    )
+
+    mirror = await _make_mirror(
+        pool, git_http, tmp_path, created, files={_MIRRORED_PATH: _MIRRORED_BODY},
+    )
+
+    served_before = git_http.request_count
+    first = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+    assert first["status"] == "synced", first
+    assert first["added"] == 1, first
+    # The fixture counts every HTTP request it serves. Zero would mean the
+    # "mirror" was materialised without touching the transport — a local copy,
+    # a cached bare, a stubbed runner — and every assertion below would be
+    # about plumbing this test built rather than about the product.
+    assert git_http.request_count > served_before, (
+        "the reconcile performed no git traffic against the fixture server"
+    )
+    indexed = await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH)
+    assert indexed is not None
+    assert (indexed["source"], indexed["external_path"]) == ("external_git", _MIRRORED_PATH), (
+        f"the row at {_MIRRORED_PATH} did not come from the mirror import: {indexed}"
+    )
+
+    slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+
+    # The link is genuinely live before the delete — if it were not, the
+    # assertions after the delete would prove nothing.
+    live = await resolve_publication(slug=slug)
+    assert live["slug"] == slug
+    resolved = await resolve_document_publication(live)
+    assert resolved["content_unavailable"] is False, resolved
+    assert "Upstream content" in resolved["content"]
+
+    upstream_head = mirror.fixture.remove_path(mirror.repo_name, _MIRRORED_PATH)
+    served_before_delete = git_http.request_count
+    second = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+
+    assert second["status"] == "synced", second
+    # The delete leg is pinned to the transport and to the exact upstream
+    # commit — not merely to "some reconcile ran". A cached or short-circuited
+    # fetch would leave the count flat or the sha stale, and the deletion
+    # assertions below would be describing a tree nobody fetched.
+    assert git_http.request_count > served_before_delete, (
+        "the deleting reconcile performed no git traffic"
+    )
+    assert second["sha"] == upstream_head, (
+        f"reconciled against {second['sha']}, not the commit that removed the "
+        f"path ({upstream_head})"
+    )
+    assert second["deleted"] == 1, second
+    assert await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH) is None
+    assert await _publication_row(pool, slug) is None, (
+        "the publication outlived the document it pointed at — a slug that "
+        "still resolves by path, waiting for the next document at that path"
+    )
+    assert await get_publication_by_slug(slug) is None
+    with pytest.raises(PublicationNotFound):
+        await resolve_publication(slug=slug)
+
+
+async def test_an_upstream_revert_cannot_resurrect_the_old_slug(
+    pool, git_http, tmp_path, created,
+):
+    """The shape of the exposure the cascade exists to prevent.
+
+    Upstream removes a published path and then adds it back — an ordinary
+    revert, or a rename and a rename back. The re-added file is indexed as a
+    NEW document (fresh id) at the same path, and no slug is left pointing at
+    it.
+
+    What this does NOT do is demonstrate the anonymous read: with the cascade
+    broken, the re-import never lands at all, because
+    `DocumentRepository.upsert_external` now refuses to write onto a path a
+    publication still claims (the orphan-write guard). The two layers compose
+    — the cascade prevents the orphan, and the guard refuses to arm one that
+    exists anyway — so this test fails on the surviving publication row rather
+    than on a leaked body. That is the honest account of what it proves.
+    """
+    mirror = await _make_mirror(
+        pool, git_http, tmp_path, created, files={_MIRRORED_PATH: _MIRRORED_BODY},
+    )
+    first = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+    assert first["added"] == 1, first
+    before = await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH)
+    assert before is not None
+    slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+
+    mirror.fixture.remove_path(mirror.repo_name, _MIRRORED_PATH)
+    second = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+    assert second["deleted"] == 1, second
+    assert await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH) is None
+
+    mirror.fixture.publish_change(
+        mirror.repo_name, _MIRRORED_PATH,
+        "# Q3 INTERNAL\n\nDifferent content.\n",
+    )
+    third = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+    assert third["added"] == 1, third
+
+    after = await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH)
+    assert after is not None and after["id"] != before["id"], (
+        "premise: the revert must produce a NEW document row at the reused path"
+    )
+    assert await _publication_row(pool, slug) is None, (
+        f"slug {slug} survived and now points at a different document"
+    )
+
+
+async def test_an_untouched_publication_survives_an_unrelated_upstream_delete(
+    pool, git_http, tmp_path, created,
+):
+    """The cascade must be scoped to the path that disappeared. A guard that
+    cleaned too much would take live publications down with it, which is a
+    silent availability bug rather than a loud one."""
+    other = "reports/q2.md"
+    mirror = await _make_mirror(
+        pool, git_http, tmp_path, created,
+        files={_MIRRORED_PATH: _MIRRORED_BODY, other: "# Q2\n\nStill here.\n"},
+    )
+    await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+    keep_slug = await _publish_mirrored(mirror, other)
+    drop_slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+
+    mirror.fixture.remove_path(mirror.repo_name, _MIRRORED_PATH)
+    result = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
+
+    assert result["deleted"] == 1, result
+    assert await _publication_row(pool, drop_slug) is None
+    assert await _publication_row(pool, keep_slug) is not None, (
+        "an unrelated publication was collateral damage"
+    )
+    assert await _doc_row(pool, mirror.vault_id, other) is not None
+
+
+# ── 2. Invariant 1: a mirror vault is read-only to writers ───────
+
+
+async def _user(pool, created, *, is_admin: bool = False) -> uuid.UUID:
+    async with pool.acquire() as conn:
+        user_id = await conn.fetchval(
+            "INSERT INTO users (username, email, password_hash, is_admin) "
+            "VALUES ($1, $2, 'x', $3) RETURNING id",
+            f"u_{uuid.uuid4().hex[:10]}", f"{uuid.uuid4().hex[:10]}@test.local",
+            is_admin,
+        )
+    created["users"].append(user_id)
+    return user_id
+
+
+async def _plain_vault(pool, created, owner_id) -> str:
+    name = f"plain_{uuid.uuid4().hex[:8]}"
+    vault_id = await VaultRepository(pool).create(
+        name=name, description="control", git_path=f"/tmp/{name}.git",
+        owner_id=owner_id,
+    )
+    created["vaults"].append(vault_id)
+    return name
+
+
+async def _mirror_vault(pool, created, owner_id) -> str:
+    name = f"mirror_{uuid.uuid4().hex[:8]}"
+    vault_id = await VaultRepository(pool).create(
+        name=name, description="mirror", git_path=f"/tmp/{name}.git",
+        owner_id=owner_id,
+    )
+    created["vaults"].append(vault_id)
+    await VaultExternalGitRepository(pool).create(
+        vault_id=vault_id, remote_url="https://example.invalid/r.git",
+        remote_branch="main", auth_token=None, poll_interval_secs=60,
+    )
+    return name
+
+
+async def test_mirror_vault_refuses_writer_for_owner_and_for_system_admin(pool, created):
+    """Invariant 1. The mirror guard sits BEFORE the owner and system-admin
+    short-circuits, so neither can write — which is what stops any publication
+    from ever existing in a mirror vault, and therefore what keeps the delete
+    cascade unreachable through the product.
+
+    Scope note: the guard tests `required_role == "writer"` only. `"admin"`
+    (create_table / alter_table / drop_table) is NOT refused on a mirror —
+    a known gap tracked separately. This test deliberately does not assert
+    that gap's current behaviour in either direction; it pins the property
+    publishing depends on.
+    """
+    from app.services.access_service import check_vault_access
+
+    owner = await _user(pool, created)
+    admin = await _user(pool, created, is_admin=True)
+    vault = await _mirror_vault(pool, created, owner)
+
+    for actor, who in ((owner, "owner"), (admin, "system admin")):
+        with pytest.raises(ForbiddenError) as excinfo:
+            await check_vault_access(str(actor), vault, required_role="writer")
+        assert "read-only external git mirror" in str(excinfo.value), (
+            f"{who} was refused for the wrong reason: {excinfo.value}"
+        )
+
+
+async def test_mirror_vault_still_allows_readers(pool, created):
+    """The same guard must not break the point of a mirror. If reads were
+    refused too, the test above would pass for a reason that has nothing to do
+    with the invariant."""
+    from app.services.access_service import check_vault_access
+
+    owner = await _user(pool, created)
+    vault = await _mirror_vault(pool, created, owner)
+    access = await check_vault_access(str(owner), vault, required_role="reader")
+    assert access["role"] == "owner"
+
+
+async def test_the_same_vault_without_the_sidecar_allows_writer(pool, created):
+    """Control: the refusal above comes from the `vault_external_git` row and
+    nothing else."""
+    from app.services.access_service import check_vault_access
+
+    owner = await _user(pool, created)
+    vault = await _plain_vault(pool, created, owner)
+    access = await check_vault_access(str(owner), vault, required_role="writer")
+    assert access["role"] == "owner"
+
+
+_PUBLISH_SURFACES = {
+    "app/api/routes/public.py": "create_publication_route",
+    "mcp_server/server.py": "_handle_publish",
+}
+
+
+def test_publishing_has_exactly_the_two_entry_points_that_check_access():
+    """Invariant 1 covers publishing only as far as the callers it can see.
+
+    `create_publication` performs NO vault-access check of its own — the two
+    surfaces below do it before delegating (via `create_publication_for_vault`).
+    A third caller anywhere in the tree — an auto-publish feature, a seeder, a
+    background job — would create publications without ever consulting the
+    mirror guard, and every other test in this file would still pass while
+    mirrored documents became publishable.
+    """
+    callers: dict[tuple[str, str], list[int]] = {}
+    for path in _production_sources():
+        source = path.read_text()
+        if "create_publication" not in source:
+            continue
+        tree = ast.parse(source)
+        rel = path.relative_to(_BACKEND).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else (
+                node.func.id if isinstance(node.func, ast.Name) else None
+            )
+            if name in ("create_publication", "create_publication_for_vault"):
+                # Keyed by (file, ENCLOSING FUNCTION), not by file: a third
+                # route added to `public.py`, or a third handler added to
+                # `server.py`, would otherwise ride in on the entry that
+                # blessed the first one.
+                key = (rel, enclosing_function(tree, node.lineno))
+                callers.setdefault(key, []).append(node.lineno)
+
+    # `create_publication_for_vault` delegating to `create_publication` is the
+    # definition side, not a new surface.
+    expected = set(_PUBLISH_SURFACES.items()) | {
+        ("app/services/publication_service.py", "create_publication_for_vault"),
+    }
+    assert set(callers) == expected, (
+        f"publication creation callers changed: {sorted(callers)}. Read this "
+        "test's docstring — a new caller must do its own vault-access check "
+        "with required_role='writer', or mirror vaults become publishable."
+    )
+    grew = {k: v for k, v in callers.items() if len(v) != 1}
+    assert not grew, (
+        f"a blessed publish entry point gained a second publication call: {grew}"
+    )
+
+
+def test_publishing_asks_for_the_role_the_mirror_guard_refuses():
+    """The link in the chain nobody would think to check.
+
+    Invariant 1 protects publishing only because publishing asks for
+    `writer` — the one role the mirror guard refuses. Moving either publish
+    surface to `admin` (a role the guard does NOT cover) would silently make
+    mirror publications creatable through the product, and every test above
+    would still pass.
+
+    EVERY `check_vault_access` call in each surface is asserted, not merely
+    the presence of the string somewhere in the body. Both surfaces contain
+    two: the publication's own vault, and (for `table_query`) each vault the
+    query reads. A substring check would go green when only the FIRST was
+    relaxed — the one that actually gates publishing a mirrored document —
+    because the second would still spell 'writer'.
+    """
+    for relpath, func in _PUBLISH_SURFACES.items():
+        node = _function_node(relpath, func)
+        checks = [
+            call for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and (call.func.attr if isinstance(call.func, ast.Attribute)
+                 else getattr(call.func, "id", None)) == "check_vault_access"
+        ]
+        assert checks, f"{func} performs no vault access check"
+        for call in checks:
+            role = next(
+                (kw.value for kw in call.keywords if kw.arg == "required_role"), None,
+            )
+            assert isinstance(role, ast.Constant) and role.value == "writer", (
+                f"{relpath}:{call.lineno} in {func}() no longer requires "
+                f"'writer' (got {ast.unparse(role) if role else 'no required_role'}). "
+                "The external-git mirror guard in access_service refuses ONLY "
+                "required_role == 'writer', so this makes a mirrored document "
+                "publishable through the product — and its publication then "
+                "survives an upstream delete only by the cascade this file "
+                "also tests."
+            )
+
+
+# ── 3. Invariant 2: one INSERT path, inside create_vault's TX ────
+
+
+def _function_node(relpath: str, name: str):
+    tree = ast.parse((_BACKEND / relpath).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    pytest.fail(f"{name} not found in {relpath}")
+
+
+
+
+def _production_sources() -> list[Path]:
+    # `scripts` is in scope deliberately: a one-off "attach a mirror to an
+    # existing vault" helper is exactly the shape this guard exists to catch,
+    # and that is where one would be written.
+    return python_files(("app", "mcp_server", "scripts"))
+
+
+_INSERT_SIDECAR_RE = re.compile(
+    r"INSERT\s+INTO\s+(?:public\.)?\"?vault_external_git\"?", re.IGNORECASE
+)
+
+
+def _sidecar_write_sites() -> dict[tuple[str, str], list[int]]:
+    """Every production site that could create a `vault_external_git` row:
+    raw INSERT text (any casing/spacing), or a `.create(...)` on a receiver
+    that names the sidecar repository.
+
+    Migrations are excluded — they rewrite existing rows under review as a
+    schema change, not as a new product path.
+
+    This is a tripwire, not a proof. A scan over source text cannot see
+    dynamically composed SQL, a `COPY`, a renamed repository method, or raw
+    SQL submitted through `akb_sql` by an unscoped system admin (which
+    bypasses every application invariant by design). What it does catch is
+    the shape a new FEATURE would take, which is the case this invariant is
+    about.
+    """
+    sites: dict[tuple[str, str], list[int]] = {}
+    for path in _production_sources():
+        if "migrations/" in path.as_posix():
+            continue
+        source = path.read_text()
+        if "vault_external_git" not in source and "VaultExternalGitRepository" not in source:
+            continue
+        tree = ast.parse(source)
+        rel = path.relative_to(_BACKEND).as_posix()
+
+        def _add(lineno: int) -> None:
+            sites.setdefault((rel, enclosing_function(tree, lineno)), []).append(lineno)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if _INSERT_SIDECAR_RE.search(node.value):
+                    _add(node.lineno)
+            elif isinstance(node, ast.JoinedStr):
+                # An f-string splices the table name in at runtime; the
+                # literal parts are still visible.
+                literal = "".join(
+                    v.value for v in node.values
+                    if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                )
+                if _INSERT_SIDECAR_RE.search(literal):
+                    _add(node.lineno)
+            elif isinstance(node, ast.Call):
+                fn = node.func
+                if not isinstance(fn, ast.Attribute) or fn.attr != "create":
+                    continue
+                # `VaultExternalGitRepository(pool).create(...)`, or any
+                # receiver whose spelling names the sidecar (`ext_repo`,
+                # `external_git_repo`, `sidecar_repo` …).
+                target = ast.unparse(fn.value).lower()
+                if "vaultexternalgitrepository" in target or "ext" in target and "repo" in target:
+                    _add(node.lineno)
+    return sites
+
+
+# Keyed by (file, function) with the number of sites each may contain, so a
+# SECOND insert inside an already-blessed function fails review too.
+_SIDECAR_ALLOWLIST: dict[tuple[str, str], tuple[int, str]] = {
+    ("app/repositories/vault_external_git_repo.py", "create"): (1, (
+        "The repository itself — the INSERT statement's definition, not a "
+        "caller of it."
+    )),
+    ("app/services/document_service.py", "create_vault"): (1, (
+        "Inside the same transaction as the `vaults` row. This is the "
+        "invariant: a vault is a mirror from birth, so no document — and "
+        "therefore no publication — can predate the mirror flag."
+    )),
+}
+
+
+def test_vault_external_git_has_exactly_one_creation_path():
+    """Invariant 2. A second way to attach a mirror to a vault fails here.
+
+    It would not be a bug on its own — it would be a feature request
+    ("mirror an existing vault"). But it turns the external-git delete
+    cascade from unreachable into load-bearing: an existing vault can hold
+    published documents, and the moment it becomes a mirror, an upstream
+    delete-then-re-add re-points those slugs at different content. If
+    you are adding that feature, the cascade tests above are what you must
+    keep green, and this list is where you record the decision.
+    """
+    found = _sidecar_write_sites()
+    unlisted = sorted(set(found) - set(_SIDECAR_ALLOWLIST))
+    assert not unlisted, (
+        f"new `vault_external_git` creation path(s): {unlisted}. See this "
+        "test's docstring before adding one."
+    )
+    stale = sorted(set(_SIDECAR_ALLOWLIST) - set(found))
+    assert not stale, f"_SIDECAR_ALLOWLIST entries with no matching site: {stale}"
+
+    grew = {
+        k: (len(v), _SIDECAR_ALLOWLIST[k][0])
+        for k, v in found.items() if len(v) != _SIDECAR_ALLOWLIST[k][0]
+    }
+    assert not grew, (
+        f"allowlisted function's sidecar-write count changed (found, allowed): "
+        f"{grew}"
+    )
+
+
+def test_the_sidecar_row_is_created_in_create_vaults_transaction():
+    """The two rows must land together, on ONE connection.
+
+    Were the sidecar inserted outside the transaction that creates the `vaults`
+    row — or inside it but on a second connection, which is the same thing to
+    PostgreSQL — a crash between them would leave a vault that is writable and
+    publishable but about to become a mirror, or a mirror whose vault never
+    existed.
+
+    Both facts are asserted about the actual `.create(...)` CALL: that the call
+    node sits inside a `transaction()` block that also creates the vault, and
+    that it is handed the same `conn`. Matching the repository NAME anywhere in
+    the block would pass while the call itself had been moved out, leaving only
+    its constructor behind.
+    """
+    create_vault = _function_node("app/services/document_service.py", "create_vault")
+
+    tx_blocks = [
+        n for n in ast.walk(create_vault)
+        if isinstance(n, ast.AsyncWith)
+        and any("transaction()" in ast.unparse(item.context_expr) for item in n.items)
+    ]
+    assert tx_blocks, "create_vault opens no transaction"
+
+    def _sidecar_calls(node) -> list[ast.Call]:
+        out = []
+        for n in ast.walk(node):
+            if (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "create"
+                and "VaultExternalGitRepository" in ast.unparse(n.func.value)
+            ):
+                out.append(n)
+        return out
+
+    def _creates_vault_row(node) -> bool:
+        return any(
+            isinstance(n, ast.Call) and ast.unparse(n.func).endswith("vault_repo.create")
+            for n in ast.walk(node)
+        )
+
+    calls = _sidecar_calls(create_vault)
+    assert len(calls) == 1, f"expected one sidecar create in create_vault, got {len(calls)}"
+    sidecar = calls[0]
+
+    hosting = [
+        b for b in tx_blocks
+        if any(c is sidecar for c in _sidecar_calls(b)) and _creates_vault_row(b)
+    ]
+    assert hosting, (
+        "the `vault_external_git` create call and the `vaults` insert are not in "
+        "the same `async with conn.transaction()` block — a crash between them "
+        "leaves a half-created mirror"
+    )
+
+    conn_kwarg = next((kw for kw in sidecar.keywords if kw.arg == "conn"), None)
+    assert conn_kwarg is not None and ast.unparse(conn_kwarg.value) == "conn", (
+        "the sidecar create must run on the transaction's own connection "
+        "(`conn=conn`); on any other connection it commits independently and "
+        "the atomicity this test is about is gone"
+    )

--- a/backend/tests/test_external_git_delete_race_unit.py
+++ b/backend/tests/test_external_git_delete_race_unit.py
@@ -20,13 +20,21 @@ from app.services import external_git_service as egs
 
 
 class _FakeState:
-    def __init__(self, row):
+    def __init__(self, row, *, row_path="a.md", vault_name="v"):
         self.row = row  # current documents row dict, or None once deleted
+        # What the LOCKED row says its identity is. The chokepoint derives the
+        # publication URI from this, never from the caller's arguments, so the
+        # fake has to carry it separately to model that at all.
+        self.row_path = row_path
+        self.vault_name = vault_name
         self.select_sqls: list[str] = []
         self.chunk_deletes: list[str] = []
         self.relation_deletes: list[tuple[str, str]] = []
         self.decrements: list = []
         self.events: list[str] = []
+        # (resource_uri, vault_id) per publication DELETE, recorded only when
+        # it ran on THIS connection inside the transaction — see _FakeConn.fetch.
+        self.publication_deletes: list[tuple] = []
 
 
 class _FakeConn:
@@ -34,21 +42,53 @@ class _FakeConn:
         self.state = state
         self._in_tx = in_tx_flag  # single-element list → mutable "are we in a tx"
 
+    def is_in_transaction(self):
+        # `DocumentRepository.delete_with_publications` refuses to run outside
+        # one — the row lock it takes would be released the instant its
+        # autocommit statement returned.
+        return self._in_tx[0]
+
     async def fetchrow(self, sql, *args):
         s = " ".join(sql.split())
+        if s.startswith("SELECT d.path") and "FOR UPDATE OF d" in s:
+            # The repository chokepoint's lock. It reads the row's identity
+            # back under the lock and builds the publication URI from THAT,
+            # so the fake answers with its own stored path/vault rather than
+            # echoing whatever the caller asked to delete.
+            assert self._in_tx[0], "chokepoint FOR UPDATE ran OUTSIDE the transaction"
+            self.state.select_sqls.append(s)
+            if self.state.row is None:
+                return None
+            return {"path": self.state.row_path, "vault_name": self.state.vault_name}
         if "FOR UPDATE" in s:
             # The lock/read MUST happen inside the transaction, not before it.
             assert self._in_tx[0], "FOR UPDATE lookup ran OUTSIDE the transaction"
             self.state.select_sqls.append(s)
             return dict(self.state.row) if self.state.row else None
+        raise AssertionError(f"unexpected fetchrow SQL: {s}")
+
+    async def fetchval(self, sql, *args):
+        s = " ".join(sql.split())
         if s.startswith("DELETE FROM documents") and "RETURNING" in s:
             assert self._in_tx[0]
             row_id = args[0]
             if self.state.row is not None and self.state.row["id"] == row_id:
                 self.state.row = None  # the row dies here (RETURNING → 1 row)
-                return {"id": row_id}
+                return row_id
             return None  # already gone → RETURNING yields nothing
-        raise AssertionError(f"unexpected fetchrow SQL: {s}")
+        raise AssertionError(f"unexpected fetchval SQL: {s}")
+
+    async def fetch(self, sql, *args):
+        s = " ".join(sql.split())
+        if s.startswith("DELETE FROM publications") and "RETURNING" in s:
+            # The tombstone must drop the publication on the SAME connection,
+            # inside the SAME transaction as the documents DELETE. On a
+            # separate connection the two commit independently and a crash
+            # between them orphans a public slug onto a reusable path.
+            assert self._in_tx[0], "publication cleanup ran OUTSIDE the transaction"
+            self.state.publication_deletes.append(tuple(args))
+            return []
+        raise AssertionError(f"unexpected fetch SQL: {s}")
 
     async def execute(self, sql, *args):  # unused by the stubbed helpers
         return "OK"
@@ -145,8 +185,9 @@ async def test_delete_external_path_normal_single_delete(monkeypatch):
     with the lookup locked (FOR UPDATE) inside the transaction."""
     row = _row()
     state = _wire(monkeypatch, row)
+    vault_id = uuid.uuid4()
     outcome = await _svc()._delete_external_path(
-        vault_id=uuid.uuid4(), vault_name="v", path="a.md",
+        vault_id=vault_id, vault_name="v", path="a.md",
         expected_blob=row["external_blob"],
     )
     assert outcome == "deleted"  # explicit outcome for the caller
@@ -156,6 +197,11 @@ async def test_delete_external_path_normal_single_delete(monkeypatch):
     assert state.decrements == [row["collection_id"]]
     assert state.events == ["document.delete"]
     assert state.select_sqls and all("FOR UPDATE" in s for s in state.select_sqls)
+    # The publication cascade is app-level since migration 022 dropped
+    # `publications.document_id`: without it the mirrored path's slug outlives
+    # the doc, and a later upstream commit re-adding that path republishes
+    # whatever now lives there. Vault-bound, canonical URI, same TX.
+    assert state.publication_deletes == [("akb://v/doc/a.md", vault_id)]
 
 
 @pytest.mark.asyncio
@@ -179,6 +225,9 @@ async def test_overlapping_tombstone_decrements_and_emits_exactly_once(monkeypat
     assert state.decrements == [row["collection_id"]]  # exactly one
     assert state.events == ["document.delete"]  # no duplicate
     assert state.chunk_deletes == [str(row["id"])]  # second call bailed early
+    # Gated on a real row deletion, like the decrement and the event: the
+    # loser's DELETE must not re-run the publication cascade either.
+    assert len(state.publication_deletes) == 1
 
 
 @pytest.mark.asyncio
@@ -197,6 +246,9 @@ async def test_expected_blob_mismatch_skips_delete_and_side_effects(monkeypatch)
     assert state.chunk_deletes == []
     assert state.decrements == []
     assert state.events == []
+    # A surviving document keeps its publication — unpublishing a doc we
+    # deliberately did NOT delete would be its own bug.
+    assert state.publication_deletes == []
 
 
 @pytest.mark.asyncio
@@ -211,6 +263,7 @@ async def test_missing_row_is_a_noop(monkeypatch):
     assert state.chunk_deletes == []
     assert state.decrements == []
     assert state.events == []
+    assert state.publication_deletes == []
 
 
 @pytest.mark.asyncio
@@ -219,10 +272,41 @@ async def test_delete_without_expected_blob_still_deletes(monkeypatch):
     row is still tombstoned and the side effects fire once."""
     row = _row()
     state = _wire(monkeypatch, row)
+    vault_id = uuid.uuid4()
     outcome = await _svc()._delete_external_path(
-        vault_id=uuid.uuid4(), vault_name="v", path="a.md",
+        vault_id=vault_id, vault_name="v", path="a.md",
     )
     assert outcome == "deleted"
     assert state.row is None
     assert state.decrements == [row["collection_id"]]
     assert state.events == ["document.delete"]
+    assert state.publication_deletes == [("akb://v/doc/a.md", vault_id)]
+
+
+@pytest.mark.asyncio
+async def test_publication_uri_comes_from_the_locked_row_not_the_caller(monkeypatch):
+    """The chokepoint must build the publication URI from the row it just
+    locked, never from a caller-supplied path.
+
+    A caller can hold a stale path — a collection cascade iterating a
+    snapshot taken before a concurrent move, for instance. Building the URI
+    from that would delete publications for a URI nothing matches, return a
+    silent zero, and then delete the document anyway: the orphan again, out
+    of the one method that exists to prevent it. Here the locked row says it
+    lives at `renamed/b.md` while the caller is tombstoning `a.md`; the
+    cleanup must follow the row.
+    """
+    row = _row()
+    state = _wire(monkeypatch, row)
+    state.row_path = "renamed/b.md"
+    vault_id = uuid.uuid4()
+
+    outcome = await _svc()._delete_external_path(
+        vault_id=vault_id, vault_name="v", path="a.md",
+        expected_blob=row["external_blob"],
+    )
+
+    assert outcome == "deleted"
+    assert state.publication_deletes == [("akb://v/coll/renamed/doc/b.md", vault_id)], (
+        "the cleanup URI must come from the locked row, not the caller's path"
+    )

--- a/backend/tests/test_publication_path_claim_guard_unit.py
+++ b/backend/tests/test_publication_path_claim_guard_unit.py
@@ -1,0 +1,623 @@
+"""A write must refuse a path whose public link outlived its document.
+
+`DocumentRepository.delete_with_publications` closes the ways new orphan
+publications are *created*, but that is prospective only: it does nothing
+about an orphan already sitting in a live database. Such a row is still
+armed — publications resolve by path (migration 022 dropped the
+`document_id` FK) and `documents` is `UNIQUE(vault_id, path)` — so the next
+document to occupy that path is reached through the old public slug,
+having never been published.
+
+This file pins the other half of the fix: the three writes that can put a
+document on a path refuse when a publication already occupies its canonical
+URI, and refuse *nothing else*.
+
+  - ordinary create   → `DocumentRepository.create`     (every REST/MCP/OKF/
+                        agent-memory create funnels through `doc_service.put`)
+  - move              → `DocumentService.move`, on the DESTINATION path
+  - external-git sync → `DocumentRepository.upsert_external`, on the arm
+                        that inserts a fresh row
+
+**How the orphan is manufactured matters.** The product can no longer create
+one, so these tests build the state by hand — but NOT by inserting a
+hand-written `resource_uri`. A publication whose URI was assembled by the
+test would agree with a guard whose URI is assembled the same wrong way, and
+the pair would pass while production never matched anything. That is the
+exact failure mode that produced this defect (see the
+`delete_publications_for_document` docstring). So each test publishes a real
+document through `create_publication_for_vault` — the production path, which
+builds the URI from the resolved `documents.path` — and only then deletes the
+document row directly, bypassing the chokepoint the way the pre-fix code did.
+The URI under test is therefore genuinely the one production stores.
+
+Path shapes are parametrised for the same reason: a URI builder that is
+subtly wrong for vault-root documents, for nested collections, or for
+non-ASCII names would leave the guard silently never firing for those.
+
+Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable, unless
+`REQUIRE_REAL_PG=1` (set by the DB-backed CI job), where an unreachable
+database fails instead of skipping so the gate cannot go quietly green. The
+static tests at the bottom need no database and run everywhere.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.exceptions import ConflictError
+from app.repositories.document_repo import DocumentRepository
+from app.repositories.vault_repo import VaultRepository
+
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+_BACKEND = Path(__file__).resolve().parents[1]
+
+# Vault root, one collection deep, nested, and a non-ASCII name. Each has a
+# different `doc_uri` shape (`/doc/x` vs `/coll/…/doc/x`), and a builder that
+# is wrong for one of them fails silently rather than loudly.
+_PATH_SHAPES = [
+    pytest.param("release-notes.md", id="vault-root"),
+    pytest.param("reports/q3.md", id="one-collection-deep"),
+    pytest.param("reports/2026/internal/q3.md", id="nested-collections"),
+    pytest.param("보고서/한글-문서.md", id="unicode"),
+]
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=10)
+    init_sql = (_BACKEND / "app" / "db" / "init.sql").read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(init_sql)
+    # Services under test resolve their connection through the module-global
+    # `get_pool()`; wire it to this pool for the duration of the test.
+    from app.db import postgres as pg_mod
+    prev = pg_mod._pool
+    pg_mod._pool = pool
+    try:
+        # init.sql is only half the schema — `events`, `resource_aliases`,
+        # `chunks.vault_id` and friends arrive by migration, and the writes
+        # exercised here touch all of them. Drive the app's own runner rather
+        # than a hand-copied DDL list that would rot on the next migration.
+        await pg_mod._apply_migrations()
+        yield pool
+    finally:
+        pg_mod._pool = prev
+        await pool.close()
+
+
+@pytest_asyncio.fixture
+async def vault(pool):
+    vault_repo = VaultRepository(pool)
+    name = f"_orphan_guard_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name,
+        description="ephemeral unit-test vault",
+        git_path=f"/tmp/{name}.git",
+        owner_id=None,
+    )
+    try:
+        yield {"id": vid, "name": name}
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vid)
+
+
+@pytest.fixture(autouse=True)
+def _public_base_url(monkeypatch):
+    """`create_publication` renders a share URL, which refuses to build
+    without a configured public base. Irrelevant to what is under test, but
+    required to reach it."""
+    from app.services import publication_service
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://orphan-guard.test.local", raising=False,
+    )
+
+
+# ── Manufacturing an orphan ──────────────────────────────────────
+
+
+async def _create_doc(pool, vault, path: str, *, title: str = "Doc") -> uuid.UUID:
+    """Create a document row through the real repository (guard included)."""
+    doc_repo = DocumentRepository(pool)
+    return await doc_repo.create(
+        vault_id=vault["id"], collection_id=None, path=path, title=title,
+        doc_type="note", status="draft", summary=None, domain=None,
+        created_by=None, now=datetime.now(timezone.utc),
+        commit_hash="c" * 40, content_hash="h", hash_algorithm="sha256",
+        tags=[], metadata={}, vault_name=vault["name"],
+    )
+
+
+async def _publish(vault_name: str, doc_path: str) -> str:
+    """Publish through the production entry point, so `resource_uri` is
+    built exactly the way a real publication stores it."""
+    from app.services.publication_service import create_publication_for_vault
+    pub = await create_publication_for_vault(
+        vault_name=vault_name, resource_type="document", doc_id=doc_path,
+    )
+    return pub["slug"]
+
+
+async def _orphan_the_publication(pool, doc_id: uuid.UUID) -> None:
+    """Delete the document row and leave its publication behind.
+
+    Deliberately NOT `delete_with_publications` — this reproduces what the
+    pre-fix delete paths did, which is the only way to reach the state the
+    guard exists for now that the product refuses to produce it.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
+
+
+async def _armed_path(pool, vault, path: str) -> str:
+    """Publish a document at `path`, then orphan it. Returns the slug."""
+    doc_id = await _create_doc(pool, vault, path, title="Published original")
+    slug = await _publish(vault["name"], path)
+    await _orphan_the_publication(pool, doc_id)
+    return slug
+
+
+async def _doc_count(pool, vault, path: str) -> int:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT count(*) FROM documents WHERE vault_id = $1 AND path = $2",
+            vault["id"], path,
+        )
+
+
+async def _publication_exists(pool, slug: str) -> bool:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT count(*) FROM publications WHERE slug = $1", slug,
+        ) == 1
+
+
+# ── 1. Ordinary create ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_create_refuses_a_path_armed_by_an_orphan_publication(pool, vault, path):
+    """The core case: a slug outlived its document, and a new document at
+    that path would be reachable through it."""
+    slug = await _armed_path(pool, vault, path)
+
+    with pytest.raises(ConflictError) as excinfo:
+        await _create_doc(pool, vault, path, title="Replacement")
+
+    message = str(excinfo.value)
+    assert slug in message, (
+        "the error must name the publication to revoke — without the slug "
+        f"there is nothing actionable in it: {message!r}"
+    )
+    assert path in message
+    assert await _doc_count(pool, vault, path) == 0, "the write must not land"
+    assert await _publication_exists(pool, slug), (
+        "the stale row carries slug, creator and view count, which the owner "
+        "needs in order to decide what to do with it — the "
+        "guard must not clean it up"
+    )
+
+
+async def test_create_refuses_a_path_armed_by_a_pre_026_legacy_uri(pool, vault):
+    """The guard matches stored URIs by equality, so every shape the RESOLVER
+    still accepts has to be one of the strings it probes.
+
+    `parse_uri` accepts the pre-0.3.0 nested form — `akb://V/doc/reports/q3.md`,
+    the whole path in the identifier with no `/coll/` segment — and maps it to
+    exactly the same document as the canonical form. Migration 026 rewrote
+    every stored URI, so this shape should no longer exist; a row restored
+    from an older backup, or one the migration missed, would still be served.
+    The URI is hand-written here because nothing emits this shape any more —
+    and the first assertion is the check on that hand-writing: if it did not
+    resolve to (this vault, this path), the resolver could not serve it either
+    and the test would be proving nothing.
+    """
+    path = "reports/q3.md"
+    legacy_uri = f"akb://{vault['name']}/doc/{path}"
+    from app.services.uri_service import parse_uri
+    parsed = parse_uri(legacy_uri)
+    assert parsed is not None and parsed.kind == "doc"
+    assert (parsed.vault, parsed.identifier) == (vault["name"], path), (
+        "premise of this test: the legacy shape resolves to the same document"
+    )
+
+    doc_id = await _create_doc(pool, vault, path, title="Published original")
+    slug = await _publish(vault["name"], path)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE publications SET resource_uri = $1 WHERE slug = $2",
+            legacy_uri, slug,
+        )
+    await _orphan_the_publication(pool, doc_id)
+
+    with pytest.raises(ConflictError) as excinfo:
+        await _create_doc(pool, vault, path, title="Replacement")
+    assert slug in str(excinfo.value)
+    assert await _doc_count(pool, vault, path) == 0
+
+
+async def test_create_allows_a_path_with_no_publication(pool, vault):
+    """The overwhelmingly common case. A guard that rejects too much is
+    worse than none."""
+    doc_id = await _create_doc(pool, vault, "reports/q3.md")
+    assert doc_id is not None
+    assert await _doc_count(pool, vault, "reports/q3.md") == 1
+
+
+async def test_create_allows_a_path_whose_neighbour_is_published(pool, vault):
+    """A live publication elsewhere in the vault — even in the same
+    collection — says nothing about this path."""
+    live = await _create_doc(pool, vault, "reports/q2.md", title="Published")
+    slug = await _publish(vault["name"], "reports/q2.md")
+
+    await _create_doc(pool, vault, "reports/q3.md", title="Sibling")
+
+    assert await _doc_count(pool, vault, "reports/q3.md") == 1
+    assert await _publication_exists(pool, slug)
+    assert live is not None
+
+
+async def test_create_over_a_live_published_document_is_still_a_path_collision(pool, vault):
+    """A publication whose document is ALIVE is not an orphan, so the guard
+    must stay out of the way and let the ordinary `UNIQUE(vault_id, path)`
+    conflict surface with its own message. Getting this wrong would relabel
+    a routine 409 as a security incident."""
+    await _create_doc(pool, vault, "reports/q3.md", title="Published original")
+    slug = await _publish(vault["name"], "reports/q3.md")
+
+    with pytest.raises(ConflictError) as excinfo:
+        await _create_doc(pool, vault, "reports/q3.md", title="Second")
+
+    message = str(excinfo.value)
+    assert "Document already exists at path" in message, (
+        f"expected the plain path-collision error, got: {message!r}"
+    )
+    assert slug not in message
+    assert await _doc_count(pool, vault, "reports/q3.md") == 1
+
+
+async def test_create_allows_a_path_freed_by_a_proper_delete(pool, vault):
+    """Delete-then-recreate at the same path is an ordinary operation, and
+    a delete through the chokepoint takes the publication with it. Nothing
+    is left to refuse."""
+    doc_id = await _create_doc(pool, vault, "reports/q3.md", title="Published original")
+    slug = await _publish(vault["name"], "reports/q3.md")
+
+    doc_repo = DocumentRepository(pool)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            removed = await doc_repo.delete_with_publications(
+                conn, doc_id=doc_id, vault_id=vault["id"],
+            )
+    assert removed is True
+    assert not await _publication_exists(pool, slug)
+
+    await _create_doc(pool, vault, "reports/q3.md", title="Recreated")
+    assert await _doc_count(pool, vault, "reports/q3.md") == 1
+
+
+# ── 2. Move ──────────────────────────────────────────────────────
+
+
+class _StubGit:
+    """Enough GitService for a move: records what it was asked to do so a
+    refused write can be shown to have never reached git."""
+
+    def __init__(self, body: str = "---\ntitle: Mover\n---\n\nBody text\n"):
+        self.body = body
+        self.moves: list[tuple[str, str]] = []
+
+    def move_file(self, *, vault_name, old_path, new_path, message, author_name):
+        self.moves.append((old_path, new_path))
+        return "d" * 40
+
+    def read_file(self, vault_name, path, commit=None):
+        return self.body
+
+    def current_commit(self, vault_name):
+        return "d" * 40
+
+
+def _document_service(git: _StubGit):
+    from app.services.document_service import DocumentService
+    return DocumentService(git=git)
+
+
+async def test_move_refuses_a_destination_armed_by_an_orphan_publication(pool, vault):
+    """`move` rewrites publications at the SOURCE uri so they follow the
+    document; it has never looked at the destination. Moving an unpublished
+    document onto an orphaned path hands it the orphan's public slug — the
+    same outcome as a create, reached without creating anything."""
+    slug = await _armed_path(pool, vault, "reports/q3.md")
+    await _create_doc(pool, vault, "private/insider.md", title="Insider notes")
+
+    git = _StubGit()
+    with pytest.raises(ConflictError) as excinfo:
+        await _document_service(git).move(
+            vault["name"], "private/insider.md",
+            collection="reports", slug="q3", agent_id="mover",
+        )
+
+    assert slug in str(excinfo.value)
+    assert git.moves == [], (
+        "the guard must run BEFORE the git mv — raising after it leaves git "
+        "and PG disagreeing about where the document lives"
+    )
+    assert await _doc_count(pool, vault, "private/insider.md") == 1
+    assert await _doc_count(pool, vault, "reports/q3.md") == 0
+    assert await _publication_exists(pool, slug)
+
+
+async def test_move_allows_a_clean_destination_and_carries_its_publication(pool, vault):
+    """The ordinary move, including of a PUBLISHED document: it must still
+    work, and its own publication must follow it to the new path."""
+    await _create_doc(pool, vault, "drafts/plan.md", title="Plan")
+    slug = await _publish(vault["name"], "drafts/plan.md")
+
+    git = _StubGit()
+    moved = await _document_service(git).move(
+        vault["name"], "drafts/plan.md",
+        collection="reports", slug="plan-final", agent_id="mover",
+    )
+
+    assert moved.path == "reports/plan-final.md"
+    assert git.moves == [("drafts/plan.md", "reports/plan-final.md")]
+    async with pool.acquire() as conn:
+        uri = await conn.fetchval(
+            "SELECT resource_uri FROM publications WHERE slug = $1", slug,
+        )
+    assert uri == f"akb://{vault['name']}/coll/reports/doc/plan-final.md"
+
+
+async def test_move_to_a_path_freed_by_a_proper_delete_is_allowed(pool, vault):
+    """Same negative as for create: a destination whose publication was
+    cleaned up with its document is just an empty path."""
+    doc_id = await _create_doc(pool, vault, "reports/q3.md", title="Published original")
+    slug = await _publish(vault["name"], "reports/q3.md")
+    doc_repo = DocumentRepository(pool)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await doc_repo.delete_with_publications(
+                conn, doc_id=doc_id, vault_id=vault["id"],
+            )
+    assert not await _publication_exists(pool, slug)
+
+    await _create_doc(pool, vault, "private/insider.md", title="Insider notes")
+    git = _StubGit()
+    moved = await _document_service(git).move(
+        vault["name"], "private/insider.md",
+        collection="reports", slug="q3", agent_id="mover",
+    )
+    assert moved.path == "reports/q3.md"
+
+
+# ── 3. External-git import ───────────────────────────────────────
+
+
+async def _upsert_external(pool, vault, path: str, *, blob: str = "blob1"):
+    doc_repo = DocumentRepository(pool)
+    return await doc_repo.upsert_external(
+        vault_id=vault["id"], collection_id=None, path=path,
+        external_path=path, external_blob=blob, title="Mirrored",
+        doc_type="note", summary=None, domain=None, tags=[], metadata={},
+        now=datetime.now(timezone.utc), commit_hash="e" * 40,
+        content_hash="h", hash_algorithm="sha256", vault_name=vault["name"],
+    )
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_external_import_refuses_a_path_armed_by_an_orphan_publication(
+    pool, vault, path,
+):
+    """An upstream commit that re-adds a path a previous sync deleted lands
+    here as a fresh INSERT — the shape that re-points a surviving
+    publication."""
+    slug = await _armed_path(pool, vault, path)
+
+    with pytest.raises(ConflictError) as excinfo:
+        await _upsert_external(pool, vault, path)
+
+    assert slug in str(excinfo.value)
+    assert await _doc_count(pool, vault, path) == 0
+    assert await _publication_exists(pool, slug)
+
+
+async def test_external_import_of_a_free_path_is_allowed(pool, vault):
+    doc_id, inserted = await _upsert_external(pool, vault, "mirror/readme.md")
+    assert inserted is True
+    assert doc_id is not None
+
+
+async def test_a_path_with_no_parseable_uri_still_imports(pool, vault):
+    """`parse_uri` rejects braces — they are template placeholders — so a
+    mirrored upstream path like `{{cookiecutter.project}}/README.md` has no
+    parseable canonical URI at all.
+
+    A guard that insisted on parsing before checking would raise here, and in
+    external-git a raised error holds the sync cursor: the whole mirror would
+    stick permanently on a file that cannot be exposed anyway, since the
+    resolver parses the stored URI too and 404s on it. String equality needs
+    no parse, so both the create and the import go through.
+    """
+    weird = "{{cookiecutter.project}}/README.md"
+    from app.services.uri_service import doc_uri, parse_uri
+    assert parse_uri(doc_uri(vault["name"], weird)) is None, (
+        "premise of this test: braces make the canonical URI unparseable"
+    )
+
+    doc_id, inserted = await _upsert_external(pool, vault, weird)
+    assert inserted is True and doc_id is not None
+    await _create_doc(pool, vault, "{braces}.md")
+    assert await _doc_count(pool, vault, "{braces}.md") == 1
+
+
+async def test_external_resync_of_a_published_mirror_is_not_blocked(pool, vault):
+    """The ON CONFLICT arm: the document exists, so its publication is not an
+    orphan and re-syncing it must go through. This is the case a guard
+    written as 'is there a publication here?' would wrongly reject — every
+    mirrored document that is also published would stop syncing."""
+    doc_id, inserted = await _upsert_external(pool, vault, "mirror/readme.md")
+    assert inserted is True
+    slug = await _publish(vault["name"], "mirror/readme.md")
+
+    same_id, inserted_again = await _upsert_external(
+        pool, vault, "mirror/readme.md", blob="blob2",
+    )
+    assert inserted_again is False
+    assert same_id == doc_id
+    assert await _publication_exists(pool, slug)
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT external_blob FROM documents WHERE id = $1", doc_id,
+        ) == "blob2"
+
+
+# ── 4. Static gates (no database) ────────────────────────────────
+#
+# The guard is only as good as its coverage: a fourth way to put a row into
+# `documents` would leave it intact but useless, and `move` refusing only
+# after its `git mv` would leave git and PG disagreeing. Both are cheap to
+# pin statically. (`put` deliberately commits to git BEFORE the guarded
+# create — see `DocumentRepository.create` — so there is no such ordering to
+# pin there.)
+
+# Reuses the source enumeration from the delete-chokepoint gate rather than
+# growing a second copy of it — the two files enforce opposite halves of the
+# same invariant and must agree on what counts as production source.
+from tests.test_document_delete_chokepoint_unit import _python_files  # noqa: E402
+
+
+_GUARD = "assert_no_orphan_publication_for_document"
+
+# Every production site allowed to INSERT a `documents` row, and why it is
+# safe. Both are repository methods that call the guard first; anything else
+# would be a path-claiming write that skips it.
+_INSERT_ALLOWLIST = {
+    ("app/repositories/document_repo.py", "create"): (
+        "Ordinary create. Calls the guard on the same connection immediately "
+        "before the INSERT; every REST/MCP/OKF/agent-memory create reaches it "
+        "through document_service.put."
+    ),
+    ("app/repositories/document_repo.py", "upsert_external"): (
+        "External-git mirror upsert. Same guard, correct for both arms: the "
+        "orphan test is false by construction when the ON CONFLICT (update) "
+        "arm will run."
+    ),
+}
+
+
+def _outermost_function(tree: ast.AST, lineno: int) -> str:
+    """The top-level method containing `lineno`, not the innermost closure.
+
+    `create` issues its INSERT from a nested `_insert(c)` helper (so the same
+    body can run on the caller's connection or a freshly acquired one), and an
+    allowlist keyed on `_insert` would name an implementation detail that a
+    rename could silently retire.
+    """
+    best, best_line = "<module>", None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = node.end_lineno or node.lineno
+            if node.lineno <= lineno <= end and (best_line is None or node.lineno < best_line):
+                best, best_line = node.name, node.lineno
+    return best
+
+
+def _insert_sites() -> dict[tuple[str, str], list[int]]:
+    sites: dict[tuple[str, str], list[int]] = {}
+    for path in _python_files():
+        source = path.read_text()
+        if "INSERT INTO documents" not in source:
+            continue
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if "INSERT INTO documents" not in node.value:
+                continue
+            key = (
+                path.relative_to(_BACKEND).as_posix(),
+                _outermost_function(tree, node.lineno),
+            )
+            sites.setdefault(key, []).append(node.lineno)
+    return sites
+
+
+def _method_source(relpath: str, name: str) -> str:
+    tree = ast.parse((_BACKEND / relpath).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            body = node.body
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+                body = body[1:]  # docstrings describe the guard too
+            return "\n".join(ast.unparse(stmt) for stmt in body)
+    pytest.fail(f"{name} not found in {relpath}")
+
+
+def test_every_documents_insert_runs_the_orphan_guard():
+    """A new way to create a `documents` row fails here. Rows are claimed by
+    path, and an unguarded claim is what lets that happen.
+
+    That the guard runs BEFORE the row lands is asserted behaviourally
+    instead of lexically (the refused writes above leave no row): `create`
+    and `upsert_external` both issue their SQL from a nested runner defined
+    after the statement text, so source order says nothing useful about
+    execution order here.
+    """
+    found = _insert_sites()
+    unlisted = sorted(set(found) - set(_INSERT_ALLOWLIST))
+    assert not unlisted, (
+        f"unallowlisted document INSERT: {unlisted}. A write that claims a "
+        f"path must call {_GUARD}() on the same connection first, or a "
+        "publication that outlived its document re-points at it."
+    )
+    stale = sorted(set(_INSERT_ALLOWLIST) - set(found))
+    assert not stale, f"_INSERT_ALLOWLIST entries with no matching site: {stale}"
+
+    missing = [
+        func for _, func in sorted(_INSERT_ALLOWLIST)
+        if _GUARD not in _method_source("app/repositories/document_repo.py", func)
+    ]
+    assert not missing, f"allowlisted insert site no longer calls {_GUARD}(): {missing}"
+
+
+def test_move_runs_the_guard_before_it_touches_git():
+    """git is not transactional. A move that commits the `git mv` and then
+    rejects leaves git and PG disagreeing about where the document lives —
+    a worse state than the write being refused."""
+    body = _method_source("app/services/document_service.py", "move")
+    guard = body.find(_GUARD + "(")
+    git_write = body.find("self.git.move_file")
+    assert guard != -1, f"move() must call {_GUARD}()"
+    assert git_write != -1
+    assert guard < git_write, (
+        f"move() must run the guard before the git mv (guard@{guard}, "
+        f"git@{git_write})"
+    )

--- a/backend/tests/test_publication_resolution_e2e.sh
+++ b/backend/tests/test_publication_resolution_e2e.sh
@@ -1,0 +1,495 @@
+#!/bin/bash
+#
+# AKB Publication Resolution Regression E2E
+#
+# A publication stores `slug` + `resource_uri` and resolves its target
+# document by path (documents is UNIQUE(vault_id, path), so paths are
+# reusable). Publication cleanup on document delete therefore has to be
+# explicit and complete on every delete path, or a publication can outlive
+# its document and a later document at the same path inherits the slug.
+#
+# This suite asserts the corrected behaviour: after each delete path, the
+# slug must not resolve to a different document than the one it was
+# published for. See the design item at
+# docs/design/proposal/2026-08-04-publication-path-binding/ for background.
+#
+# Covered here:
+#   T1 — recursive collection delete
+#   T2 — move onto a path a publication still claims
+#   T3 — file publications under a recursively deleted collection
+#   T4 — publications when confirm_upload discards a file, both paths
+#   T5 — external-git delete: covered as a pytest test instead; see the
+#        note in section 5 below.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+TS=$(date +%s)
+VAULT="pubres-e2e-$TS"
+USER="pubres-user-$TS"
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+skip() { SKIP=$((SKIP+1)); echo "  ⊘ SKIP $1 — $2"; }
+info() { echo "    · $1"; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║   AKB Publication Resolution Regression  ║"
+echo "║   Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# ── 0. Setup: register user + login + vault ───────────────
+echo "▸ 0. Setup"
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+
+TOKEN=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])" 2>/dev/null)
+[ -n "$TOKEN" ] && pass "Login as $USER" || { fail "Login" "no token"; exit 1; }
+
+acurl() { curl -sk -H "Authorization: Bearer $TOKEN" "$@"; }
+
+R=$(acurl -X POST "$BASE_URL/api/v1/vaults?name=$VAULT&description=resolution%20regression")
+[ "$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("name",""))' 2>/dev/null)" = "$VAULT" ] \
+  && pass "Vault created ($VAULT)" || { fail "Vault create" "$R"; exit 1; }
+
+jfield() { python3 -c "import json,sys
+try: print(json.load(sys.stdin).get('$1',''))
+except Exception: print('')" 2>/dev/null; }
+
+# Create a document. Returns "<uri>|<path>" so callers get both without a
+# second round-trip; `slug` is passed explicitly so the resulting path is
+# deterministic and a later recreate lands on exactly the same path.
+mkdoc() {  # vault-collection, slug, title, content
+  acurl -X POST "$BASE_URL/api/v1/documents" -H "Content-Type: application/json" \
+    -d "{\"vault\":\"$VAULT\",\"collection\":\"$1\",\"slug\":\"$2\",\"title\":\"$3\",\"content\":\"$4\",\"type\":\"note\"}" \
+  | python3 -c "import json,sys
+try:
+    d = json.load(sys.stdin); print(d.get('uri',''), d.get('path',''), sep='|')
+except Exception: print('|')" 2>/dev/null
+}
+
+pubdoc() {  # doc uri -> slug
+  acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
+    -d "{\"resource_type\":\"document\",\"uri\":\"$1\"}" | jfield slug
+}
+
+code_of() { curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/api/v1/public/$1"; }
+
+# Recursive collection delete. The envelope is
+# {"kind":"collection_delete","ok":true,"deleted_docs":N,"deleted_files":N,...}
+delcoll() { acurl -X DELETE "$BASE_URL/api/v1/collections/$VAULT/$1?recursive=true"; }
+del_ok() { echo "$1" | grep -q '"ok":true'; }
+
+echo ""
+
+# ══════════════════════════════════════════════════════════
+# 1. Recursive collection delete
+# ══════════════════════════════════════════════════════════
+# A recursive collection delete removes each `documents` row. Its
+# publication cleanup has to run on that same path; the corrected code
+# routes every document delete through one method that cleans publications
+# under the row lock. This asserts a publication does not outlive its
+# document here, and that a document recreated at the same path does not
+# inherit the old slug.
+echo "▸ 1. Recursive collection delete"
+
+T1_COLL="t1-reports"
+T1_OPEN="T1-FIRST-BODY"
+T1_PRIVATE="T1-SECOND-BODY"
+
+OUT=$(mkdoc "$T1_COLL" "q3" "T1 first document" "$T1_OPEN")
+T1_URI="${OUT%%|*}"; T1_PATH="${OUT##*|}"
+[ -n "$T1_URI" ] && pass "T1 setup: original doc created ($T1_PATH)" \
+  || { fail "T1 setup" "doc create returned no uri"; }
+
+T1_SLUG=$(pubdoc "$T1_URI")
+[ -n "$T1_SLUG" ] && pass "T1 setup: published (slug=$T1_SLUG)" \
+  || fail "T1 setup" "publish returned no slug"
+
+# Sanity gate — if the slug does not serve the ORIGINAL here, every
+# assertion below is meaningless and the suite is lying to you.
+BEFORE=$(curl -sk "$BASE_URL/api/v1/public/$T1_SLUG")
+echo "$BEFORE" | grep -q "$T1_OPEN" \
+  && pass "T1 sanity: slug serves the original document" \
+  || fail "T1 sanity" "slug does not serve the original: $(echo "$BEFORE" | head -c 200)"
+
+D=$(delcoll "$T1_COLL")
+del_ok "$D" \
+  && pass "T1: collection deleted recursively" \
+  || fail "T1 collection delete" "$D"
+
+# Informational: this is the state that made the bug invisible for so
+# long. The slug 404s while the path is vacant, so a spot-check right
+# after the delete looks correct.
+info "GET /public/$T1_SLUG immediately after delete -> HTTP $(code_of "$T1_SLUG") (expected 404; the bug is not visible yet)"
+
+OUT=$(mkdoc "$T1_COLL" "q3" "T1 second document" "$T1_PRIVATE")
+T1_NEW_URI="${OUT%%|*}"; T1_NEW_PATH="${OUT##*|}"
+[ "$T1_NEW_PATH" = "$T1_PATH" ] \
+  && pass "T1: new doc occupies the same path ($T1_NEW_PATH)" \
+  || fail "T1 path reuse" "new path '$T1_NEW_PATH' != original '$T1_PATH' — collision suffix applied, test is not exercising the bug"
+
+# ── THE ASSERTION ────────────────────────────────────────
+AFTER=$(curl -sk "$BASE_URL/api/v1/public/$T1_SLUG")
+AFTER_CODE=$(code_of "$T1_SLUG")
+if echo "$AFTER" | grep -q "$T1_PRIVATE"; then
+  fail "T1 resolution" "slug $T1_SLUG resolved to the recreated document, not the one it was published for (HTTP $AFTER_CODE)"
+else
+  pass "T1: old slug does NOT serve the recreated document"
+fi
+[ "$AFTER_CODE" != "200" ] \
+  && pass "T1: old slug no longer resolves (HTTP $AFTER_CODE)" \
+  || fail "T1 resolves" "publication for a deleted document still returns HTTP 200"
+
+echo ""
+
+# ══════════════════════════════════════════════════════════
+# 2. Move onto a path a publication still claims
+# ══════════════════════════════════════════════════════════
+# A move rewrites publications at the source path but must not let an
+# unrelated document arrive at a destination path that a publication still
+# claims. This reaches the same resolution question as T1 without creating
+# anything new — the corrected code refuses the move at the destination.
+echo "▸ 2. Move onto a path a publication still claims"
+
+T2_COLL="t2-board"
+T2_OPEN="T2-FIRST-BODY"
+T2_PRIVATE="T2-SECOND-BODY"
+
+OUT=$(mkdoc "$T2_COLL" "minutes" "T2 first document" "$T2_OPEN")
+T2_URI="${OUT%%|*}"; T2_PATH="${OUT##*|}"
+[ -n "$T2_URI" ] && pass "T2 setup: original doc created ($T2_PATH)" || fail "T2 setup" "no uri"
+
+T2_SLUG=$(pubdoc "$T2_URI")
+[ -n "$T2_SLUG" ] && pass "T2 setup: published (slug=$T2_SLUG)" || fail "T2 setup" "no slug"
+
+curl -sk "$BASE_URL/api/v1/public/$T2_SLUG" | grep -q "$T2_OPEN" \
+  && pass "T2 sanity: slug serves the original document" \
+  || fail "T2 sanity" "slug does not serve the original"
+
+D=$(delcoll "$T2_COLL")
+del_ok "$D" \
+  && pass "T2: collection deleted recursively (publication now orphaned)" \
+  || fail "T2 collection delete" "$D"
+
+# The document that gets moved onto the claimed path. It lives somewhere
+# else entirely and carries different content.
+OUT=$(mkdoc "t2-other" "second" "T2 second document" "$T2_PRIVATE")
+T2_MOVER_URI="${OUT%%|*}"; T2_MOVER_PATH="${OUT##*|}"
+[ -n "$T2_MOVER_URI" ] && pass "T2 setup: unpublished doc created ($T2_MOVER_PATH)" || fail "T2 setup" "no mover uri"
+
+# There is no REST move endpoint — move is MCP-only (akb_move).
+SESS=$(curl -sk -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"pubres-e2e","version":"0.1"}}}' \
+  -i 2>&1 | grep -i "mcp-session-id:" | tr -d '\r' | awk '{print $2}')
+[ -n "$SESS" ] && pass "T2: MCP session initialized" || fail "T2 MCP init" "no session id"
+
+curl -sk -X POST "$BASE_URL/mcp/" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: $SESS" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+
+mcp() {
+  local id=$1; shift
+  local name=$1; shift
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Mcp-Session-Id: $SESS" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$1}}" 2>&1
+}
+mcp_text() {
+  python3 -c "
+import json, sys, re
+text = sys.stdin.read()
+m = re.search(r'(\{.*\})', text, re.DOTALL)
+if m:
+    data = json.loads(m.group(1))
+    if 'result' in data and 'content' in data['result']:
+        print(data['result']['content'][0]['text'])
+"
+}
+
+MV=$(mcp 20 akb_move "{\"uri\":\"$T2_MOVER_URI\",\"collection\":\"$T2_COLL\",\"slug\":\"minutes\"}" | mcp_text)
+T2_MOVED_PATH=$(echo "$MV" | jfield path)
+[ "$T2_MOVED_PATH" = "$T2_PATH" ] \
+  && pass "T2: unpublished doc moved onto the orphaned path ($T2_MOVED_PATH)" \
+  || fail "T2 move" "moved to '$T2_MOVED_PATH', expected '$T2_PATH' — response: $(echo "$MV" | head -c 240)"
+
+# ── THE ASSERTION ────────────────────────────────────────
+AFTER=$(curl -sk "$BASE_URL/api/v1/public/$T2_SLUG")
+AFTER_CODE=$(code_of "$T2_SLUG")
+if echo "$AFTER" | grep -q "$T2_PRIVATE"; then
+  fail "T2 resolution" "slug $T2_SLUG resolved to the moved document, not the one it was published for (HTTP $AFTER_CODE)"
+else
+  pass "T2: old slug does NOT serve the moved document"
+fi
+[ "$AFTER_CODE" != "200" ] \
+  && pass "T2: old slug no longer resolves (HTTP $AFTER_CODE)" \
+  || fail "T2 resolves" "publication for a deleted document still returns HTTP 200"
+
+echo ""
+
+# ══════════════════════════════════════════════════════════
+# 3. File publications under a recursively deleted collection
+# ══════════════════════════════════════════════════════════
+# collection_service.py:334 tears down each file's edges, chunks, S3
+# object and `vault_files` row — but not its publications. A file URI
+# carries a UUID (akb://V/coll/C/file/<uuid>), so unlike a document path
+# it CANNOT be reoccupied. The row just outlives its
+# resource. So the assertion here is that the row is GONE, not that it
+# fails to be reoccupied.
+#
+# Needs S3 (MinIO), which both docker-compose and the CI e2e workflow
+# now bring up — so this section RUNS in CI. The skip below is a
+# fallback for an S3-less stack, not the expected CI path.
+echo "▸ 3. File publication orphaned by recursive collection delete"
+
+T3_COLL="t3-assets"
+# --max-time: with no S3 configured the backend still round-trips boto
+# (bounded by settings.s3_*_timeout_secs) before erroring. Cap it here too
+# so a stalled endpoint degrades to a SKIP instead of hanging the suite.
+INIT=$(acurl --max-time 60 -X POST "$BASE_URL/api/v1/files/$VAULT/upload?filename=quarterly.json&collection=$T3_COLL&mime_type=application/json")
+T3_FILE_URI=$(echo "$INIT" | jfield uri)
+T3_UPLOAD_URL=$(echo "$INIT" | jfield upload_url)
+
+if [ -z "$T3_FILE_URI" ] || [ -z "$T3_UPLOAD_URL" ]; then
+  skip "T3 (file publication cleanup)" "no S3 backend reachable — upload init returned: $(echo "$INIT" | head -c 160)"
+else
+  T3_FID="${T3_FILE_URI##*/}"
+  printf '%s' '{"quarterly":"numbers"}' \
+    | curl -sk --max-time 60 -X PUT "$T3_UPLOAD_URL" -H "Content-Type: application/json" --data-binary @- >/dev/null
+  CONF=$(acurl -X POST "$BASE_URL/api/v1/files/$VAULT/$T3_FID/confirm")
+
+  T3_SLUG=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
+    -d "{\"resource_type\":\"file\",\"uri\":\"$T3_FILE_URI\"}" | jfield slug)
+
+  if [ -z "$T3_SLUG" ]; then
+    skip "T3 (file publication cleanup)" "could not publish the file — confirm: $(echo "$CONF" | head -c 160)"
+  else
+    pass "T3 setup: file uploaded + published (slug=$T3_SLUG)"
+
+    BEFORE_CODE=$(code_of "$T3_SLUG")
+    [ "$BEFORE_CODE" = "200" ] \
+      && pass "T3 sanity: file slug resolves before the delete (HTTP 200)" \
+      || fail "T3 sanity" "file slug returned HTTP $BEFORE_CODE before any delete"
+
+    D=$(delcoll "$T3_COLL")
+    del_ok "$D" \
+      && pass "T3: collection deleted recursively" \
+      || fail "T3 collection delete" "$D"
+
+    # ── THE ASSERTION ────────────────────────────────────
+    # The row must be gone, not merely unresolvable. A dangling row is
+    # still a live slug in the owner's publication list pointing at a
+    # resource that no longer exists.
+    LIST=$(acurl "$BASE_URL/api/v1/publications/$VAULT")
+    if echo "$LIST" | grep -q "\"$T3_SLUG\""; then
+      fail "T3 ORPHAN ROW" "publication $T3_SLUG survived the recursive delete of its file's collection"
+    else
+      pass "T3: publication row removed with the file"
+    fi
+
+    AFTER_CODE=$(code_of "$T3_SLUG")
+    [ "$AFTER_CODE" != "200" ] \
+      && pass "T3: file slug no longer resolves (HTTP $AFTER_CODE)" \
+      || fail "T3 resolves" "file publication still returns HTTP 200 after its file was deleted"
+  fi
+fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════
+# 4. Publications orphaned by a FAILED confirm_upload
+# ══════════════════════════════════════════════════════════
+# A file is publishable the moment `initiate_upload` writes its
+# `vault_files` row: `create_publication`'s existence check is
+# `SELECT 1 FROM vault_files WHERE id=$1 AND vault_id=$2` — no confirmed
+# state, no `hash_verified_at` predicate. `confirm_upload` then has TWO
+# paths that discard the row, and neither used to delete its publication:
+#
+#   file_service.py:338  S3 object missing  -> 404 (client abandoned the PUT)
+#   file_service.py:364  bytes disowned     -> 409 (declared hash mismatch)
+#
+# Like T3 this is a stale row, not a reoccupied path — a file URI carries a UUID, so
+# the row cannot be reoccupied. The assertion is that the row is GONE.
+#
+# The CONTROL at the end is what keeps this section honest: an
+# implementation that deleted publications unconditionally on every
+# confirm would pass both discard cases and fail the control.
+#
+# Needs S3 (MinIO), which CI now brings up — this RUNS in CI. The
+# skip below is a fallback for an S3-less stack, not the CI path.
+echo "▸ 4. Publications orphaned by a failed confirm_upload"
+
+# Publish a file that has NOT been confirmed yet. Echoes "<file_id>|<slug>",
+# or "" when S3 is unreachable so the caller can skip.
+mkunconfirmed() {  # collection, filename -> "<fid>|<slug>" (+ optional upload)
+  local init uri fid slug upload
+  init=$(acurl --max-time 60 -X POST \
+    "$BASE_URL/api/v1/files/$VAULT/upload?filename=$2&collection=$1&mime_type=application/json")
+  uri=$(echo "$init" | jfield uri)
+  upload=$(echo "$init" | jfield upload_url)
+  [ -z "$uri" ] && { echo ""; return; }
+  fid="${uri##*/}"
+  # Optionally park real bytes at the presigned URL (path B needs an object
+  # that EXISTS so the failure is the hash check, not a missing object).
+  if [ "${3:-}" = "upload" ]; then
+    printf '%s' '{"real":"bytes"}' \
+      | curl -sk --max-time 60 -X PUT "$upload" -H "Content-Type: application/json" --data-binary @- >/dev/null
+  fi
+  slug=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" \
+    -H "Content-Type: application/json" \
+    -d "{\"resource_type\":\"file\",\"uri\":\"$uri\"}" | jfield slug)
+  [ -z "$slug" ] && { echo ""; return; }
+  echo "$fid|$slug"
+}
+
+pub_listed() {  # slug -> 0 if the owner's publication list still carries it
+  acurl "$BASE_URL/api/v1/publications/$VAULT" | grep -q "\"$1\""
+}
+
+OUT=$(mkunconfirmed "t4-abandoned" "abandoned.json")
+if [ -z "$OUT" ]; then
+  skip "T4 (failed-confirm cleanup)" "no S3 backend reachable"
+else
+  # ── Path A: the client never completed the presigned PUT ──
+  T4A_FID="${OUT%%|*}"; T4A_SLUG="${OUT##*|}"
+  pass "T4a setup: unconfirmed file published (slug=$T4A_SLUG)"
+
+  # Sanity: the slug must genuinely serve the file BEFORE the failed
+  # confirm, or the "it's gone afterwards" assertion proves nothing.
+  [ "$(code_of "$T4A_SLUG")" = "200" ] \
+    && pass "T4a sanity: slug resolves before the failed confirm (HTTP 200)" \
+    || fail "T4a sanity" "slug returned HTTP $(code_of "$T4A_SLUG") before any confirm"
+
+  C=$(acurl -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/v1/files/$VAULT/$T4A_FID/confirm")
+  [ "$C" = "404" ] \
+    && pass "T4a: confirm rejected the abandoned upload (HTTP 404)" \
+    || fail "T4a confirm" "expected HTTP 404 for a missing S3 object, got $C"
+
+  pub_listed "$T4A_SLUG" \
+    && fail "T4a ORPHAN ROW" "publication $T4A_SLUG survived the discard of its unconfirmed file" \
+    || pass "T4a: publication row removed with the discarded file"
+
+  A=$(code_of "$T4A_SLUG")
+  [ "$A" != "200" ] \
+    && pass "T4a: slug no longer resolves (HTTP $A)" \
+    || fail "T4a resolves" "publication still returns HTTP 200 after its file was discarded"
+
+  # ── Path B: bytes present, but not the bytes that were declared ──
+  OUT=$(mkunconfirmed "t4-mismatch" "mismatch.json" upload)
+  if [ -z "$OUT" ]; then
+    skip "T4b (hash-mismatch cleanup)" "could not stage the uploaded file"
+  else
+    T4B_FID="${OUT%%|*}"; T4B_SLUG="${OUT##*|}"
+    pass "T4b setup: uploaded-but-unconfirmed file published (slug=$T4B_SLUG)"
+
+    [ "$(code_of "$T4B_SLUG")" = "200" ] \
+      && pass "T4b sanity: slug resolves before the failed confirm (HTTP 200)" \
+      || fail "T4b sanity" "slug returned HTTP $(code_of "$T4B_SLUG") before any confirm"
+
+    # `content_hash` is a QUERY parameter, not a body field — passing it in
+    # the body silently confirms SUCCESSFULLY and the test would prove nothing.
+    WRONG_HASH=$(printf 'a%.0s' $(seq 1 64))
+    C=$(acurl -o /dev/null -w '%{http_code}' -X POST \
+      "$BASE_URL/api/v1/files/$VAULT/$T4B_FID/confirm?content_hash=$WRONG_HASH")
+    [ "$C" = "409" ] \
+      && pass "T4b: confirm rejected the disowned bytes (HTTP 409)" \
+      || fail "T4b confirm" "expected HTTP 409 for a hash mismatch, got $C"
+
+    pub_listed "$T4B_SLUG" \
+      && fail "T4b ORPHAN ROW" "publication $T4B_SLUG survived the hash-mismatch discard" \
+      || pass "T4b: publication row removed with the discarded file"
+
+    B=$(code_of "$T4B_SLUG")
+    [ "$B" != "200" ] \
+      && pass "T4b: slug no longer resolves (HTTP $B)" \
+      || fail "T4b resolves" "publication still returns HTTP 200 after its file was discarded"
+  fi
+
+  # ── CONTROL: a SUCCESSFUL confirm must KEEP its publication ──
+  # Without this, "delete publications on every confirm" passes T4a+T4b.
+  OUT=$(mkunconfirmed "t4-control" "control.json" upload)
+  if [ -z "$OUT" ]; then
+    skip "T4 control" "could not stage the control file"
+  else
+    T4C_FID="${OUT%%|*}"; T4C_SLUG="${OUT##*|}"
+    C=$(acurl -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/v1/files/$VAULT/$T4C_FID/confirm")
+    [ "$C" = "200" ] \
+      && pass "T4 control: a normal confirm still succeeds (HTTP 200)" \
+      || fail "T4 control confirm" "expected HTTP 200 for a valid confirm, got $C"
+
+    pub_listed "$T4C_SLUG" \
+      && pass "T4 control: successful confirm KEEPS its publication" \
+      || fail "T4 control ORPHAN" "a successful confirm deleted the publication — cleanup is firing unconditionally"
+
+    C=$(code_of "$T4C_SLUG")
+    [ "$C" = "200" ] \
+      && pass "T4 control: slug still resolves after a successful confirm (HTTP 200)" \
+      || fail "T4 control resolves" "confirmed file's publication returned HTTP $C"
+  fi
+fi
+
+echo ""
+
+# ══════════════════════════════════════════════════════════
+# 5. External-git delete variant — INTENTIONALLY ABSENT
+# ══════════════════════════════════════════════════════════
+# external_git_service.py:616 deletes an external_git-sourced `documents`
+# row with no publication cascade either, so the same applies when
+# an upstream commit deletes a mirrored file and a later commit re-adds
+# one at the same path.
+#
+# It is NOT testable from a shell e2e and is deliberately not faked here:
+#
+#   * The delete only fires from the reconcile loop, driven by a real
+#     upstream commit that removes the path. That needs a repo we can
+#     push to — the existing shell suite (test_external_git_e2e.sh)
+#     mirrors a read-only public GitHub repo precisely because it cannot
+#     mutate an upstream.
+#   * A local bare repo is not a substitute: the mirror-URL validator is
+#     fail-closed on globally-routable unicast addresses, so a
+#     127.0.0.1 / file:// fixture is rejected outright by a live backend.
+#     The in-process fixture that gets around this
+#     (`backend/tests/extgit_http.py`) works by injecting a fake resolver
+#     plus a matching (host, CIDR, port) allowlist into `Settings` — it
+#     is a pytest fixture and cannot reach a backend over HTTP.
+#
+# Cover it as a pytest test built on `tests/extgit_http.py` instead.
+
+# ── 99. Cleanup ───────────────────────────────────────────
+echo "▸ 99. Cleanup"
+mcp 99 akb_delete_vault "{\"vault\":\"$VAULT\"}" >/dev/null 2>&1
+pass "Cleanup done"
+curl -sk -X DELETE "$BASE_URL/mcp/" -H "Authorization: Bearer $TOKEN" -H "Mcp-Session-Id: ${SESS:-}" >/dev/null 2>&1
+
+echo ""
+echo "╔══════════════════════════════════════════╗"
+printf "║   Results: %d passed, %d failed%s║\n" "$PASS" "$FAIL" "$(printf '%*s' $((22-${#PASS}-${#FAIL})) '')"
+echo "╚══════════════════════════════════════════╝"
+[ "$SKIP" -gt 0 ] && echo "   ($SKIP skipped)"
+
+if [ $FAIL -gt 0 ]; then
+  echo ""
+  echo "Errors:"
+  for e in "${ERRORS[@]}"; do
+    echo "  • $e"
+  done
+  exit 1
+fi
+exit 0

--- a/backend/tests/test_publication_resolution_vault_binding_unit.py
+++ b/backend/tests/test_publication_resolution_vault_binding_unit.py
@@ -1,0 +1,358 @@
+"""Document resolution must be bound to the publication's own vault_id.
+
+Two places used to derive a document entirely from one text column: they
+parse `resource_uri`, pull the vault NAME and the path out of it, and look
+the document up by that pair. Neither cross-checked the result against
+`publications.vault_id` — the column that actually says which vault the row
+belongs to. A publication whose URI names a vault other than its own would
+therefore reach that other vault's document under a slug issued against the
+first vault:
+
+  - `publication_service.resolve_document_publication` — the content path,
+    behind `GET /public/{slug}` and `/download`. Serves the document BODY.
+  - the oEmbed title lookup in `routes/public.py::oembed` — serves the
+    document title through an unfurl that needs no credentials.
+
+`resolve_file_publication` already bound the equivalent lookup
+(`WHERE f.id = $1 AND f.vault_id = $2`, with a comment naming cross-vault
+IDOR), as did oEmbed's own file branch — sitting a dozen lines below the
+document branch that did not. This file pins the binding for both document
+call sites.
+
+**The oEmbed branch is the one worth binding first.** It needs no
+credentials and runs with `increment_view=False`. A password-protected
+publication is already handled: `oembed` short-circuits to a generic
+"Protected AKB publication" card and skips every DB title lookup (labelled
+F1 in that function). But that check is about the publication's own
+password. Where there is none, the unbound lookup returned the title of a
+document in whatever vault the URI happened to name — which need not be the
+vault that owns the publication, and that vault made no choice about it.
+
+**This is narrower than the change it sits beside.** That one is about a
+publication outliving its document and a later document at the same path
+inheriting it. This is about the lookups trusting a text field against
+nothing. REST creation rejects a URI whose vault disagrees with the route
+vault (`create_publication_route`, the `uri_vault != vault` check), so no
+known path produces such a row today — which is the argument for binding it
+now, while it is cheap and the whole shape can go rather than one instance.
+
+**How the mismatch is manufactured matters.** The publication is created
+through the production entry point, so `resource_uri` is genuinely the string
+production stores; only then is `vault_id` moved to the other vault by direct
+UPDATE. A hand-written `resource_uri` would let a wrong-shaped URI agree with
+a wrong-shaped fix and pass while production matched nothing — the failure
+mode recorded in `delete_publications_for_document`.
+
+Both vaults hold a document at the SAME path, with different titles. That is
+what separates a fix from a near-miss. Binding to `vault_id` while DROPPING
+the URI-name cross-check would also stop the cross-vault serve — by silently
+returning the publication's OWN vault's document at that path. That is a
+different answer to a corrupt row, not a refusal, and an assertion that only
+checked "not the far vault's title" would pass on it. Demanding a refusal
+catches both shapes, and the failure message names the title that came back,
+so which near-miss is in play is readable off the red run.
+
+Talks to a real Postgres via `AKB_TEST_DSN`; skips when unreachable, unless
+`REQUIRE_REAL_PG=1` (set by the DB-backed CI job), where an unreachable
+database fails instead of skipping so the gate cannot go quietly green.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.exceptions import NotFoundError
+from app.repositories.document_repo import DocumentRepository
+from app.repositories.vault_repo import VaultRepository
+
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+_BACKEND = Path(__file__).resolve().parents[1]
+
+# The document lives at the same path in both vaults, so "which vault" is the
+# only thing that distinguishes the two rows. Shapes vary because `doc_uri`
+# renders a vault-root document differently from one inside a collection, and
+# a binding that is right for one shape and wrong for the other would pass a
+# single-shape test.
+_PATH_SHAPES = [
+    pytest.param("handbook.md", id="vault-root"),
+    pytest.param("reports/q3.md", id="one-collection-deep"),
+]
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=2, max_size=10)
+    init_sql = (_BACKEND / "app" / "db" / "init.sql").read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(init_sql)
+    # The service under test resolves its connection through the module-global
+    # `get_pool()`; wire it to this pool for the duration of the test.
+    from app.db import postgres as pg_mod
+    prev = pg_mod._pool
+    pg_mod._pool = pool
+    try:
+        await pg_mod._apply_migrations()
+        yield pool
+    finally:
+        pg_mod._pool = prev
+        await pool.close()
+
+
+async def _make_vault(pool, label: str) -> dict:
+    vault_repo = VaultRepository(pool)
+    name = f"_vaultbind_{label}_{uuid.uuid4().hex[:8]}"
+    vid = await vault_repo.create(
+        name=name,
+        description="ephemeral unit-test vault",
+        git_path=f"/tmp/{name}.git",
+        owner_id=None,
+    )
+    return {"id": vid, "name": name}
+
+
+@pytest_asyncio.fixture
+async def vaults(pool):
+    """Two vaults: `home` owns the publication row, `far` is named by its URI."""
+    home = await _make_vault(pool, "home")
+    far = await _make_vault(pool, "far")
+    try:
+        yield {"home": home, "far": far}
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM vaults WHERE id = ANY($1::uuid[])",
+                [home["id"], far["id"]],
+            )
+
+
+@pytest.fixture(autouse=True)
+def _public_base_url(monkeypatch):
+    """`create_publication` renders a share URL, which refuses to build
+    without a configured public base. Irrelevant to what is under test, but
+    required to reach it."""
+    from app.services import publication_service
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://vault-binding.test.local", raising=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _git_content(monkeypatch):
+    """Serve document bodies from memory.
+
+    Resolution reads the body off the Git worktree; these vaults have no
+    repository on disk, and the resolver would fall into its
+    `content_unavailable` branch and still return a row. That branch would
+    mask a positive assertion on content, so return a body keyed by
+    (vault, path) instead — which also makes "whose document came back"
+    checkable from the content itself, not just the title.
+    """
+    from app.services import publication_service
+
+    class _Git:
+        @staticmethod
+        def read_file(vault_name: str, path: str) -> str:
+            return f"# body\n\nvault={vault_name} path={path}\n"
+
+    class _DocService:
+        git = _Git()
+
+    monkeypatch.setattr(publication_service, "_get_doc_service", lambda: _DocService())
+
+
+async def _create_doc(pool, vault: dict, path: str, *, title: str) -> uuid.UUID:
+    doc_repo = DocumentRepository(pool)
+    return await doc_repo.create(
+        vault_id=vault["id"], collection_id=None, path=path, title=title,
+        doc_type="note", status="draft", summary=None, domain=None,
+        created_by=None, now=datetime.now(timezone.utc),
+        commit_hash="c" * 40, content_hash="h", hash_algorithm="sha256",
+        tags=[], metadata={}, vault_name=vault["name"],
+    )
+
+
+async def _publish(vault_name: str, doc_path: str) -> str:
+    """Publish through the production entry point, so `resource_uri` is
+    built exactly the way a real publication stores it."""
+    from app.services.publication_service import create_publication_for_vault
+    pub = await create_publication_for_vault(
+        vault_name=vault_name, resource_type="document", doc_id=doc_path,
+    )
+    return pub["slug"]
+
+
+async def _internal(slug: str) -> dict:
+    """The internal publication dict, the shape the resolver is handed."""
+    from app.services.publication_service import get_publication_by_slug
+    pub = await get_publication_by_slug(slug)
+    assert pub is not None, f"publication {slug} vanished"
+    return pub
+
+
+async def _mismatch(pool, vaults, path: str) -> tuple[str, str]:
+    """Build a publication whose `vault_id` disagrees with its `resource_uri`.
+
+    A document at `path` exists in BOTH vaults. The publication is created
+    against `far` — so its URI names `far` — and then reassigned to `home`.
+    Returns (slug, far_title).
+    """
+    far_title = "Far vault original"
+    await _create_doc(pool, vaults["far"], path, title=far_title)
+    await _create_doc(pool, vaults["home"], path, title="Home vault document")
+    slug = await _publish(vaults["far"]["name"], path)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE publications SET vault_id = $1 WHERE slug = $2",
+            vaults["home"]["id"], slug,
+        )
+    return slug, far_title
+
+
+# ── The mismatch ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_resolution_refuses_a_publication_whose_uri_names_another_vault(
+    pool, vaults, path,
+):
+    """The row belongs to `home`; its URI names `far`. Resolution must refuse."""
+    from app.services.publication_service import resolve_document_publication
+
+    slug, far_title = await _mismatch(pool, vaults, path)
+    publication = await _internal(slug)
+    # Guard the setup: the state under test has to actually exist, or the
+    # refusal below proves nothing.
+    assert vaults["far"]["name"] in publication["resource_uri"]
+    assert str(publication["vault_id"]) == str(vaults["home"]["id"])
+
+    with pytest.raises(NotFoundError) as excinfo:
+        data = await resolve_document_publication(publication)
+        # Report the title that came back, not a dict dump — it names WHICH
+        # failure this is. `Far vault original` means the cross-vault serve is
+        # still open. `Home vault document` means the vault_id binding landed
+        # but the URI-name cross-check was dropped, so a corrupt row now
+        # resolves silently to its own vault instead of refusing. Demanding a
+        # refusal here catches both; only the message tells them apart.
+        pytest.fail(
+            "resolution must refuse a publication whose vault_id disagrees "
+            "with the vault named in its resource_uri, but it served "
+            f"{data.get('title')!r} — content: {data.get('content')!r}"
+        )
+
+    assert far_title not in str(excinfo.value), (
+        "the 404 must not echo the far vault's document title back"
+    )
+
+
+# ── The mismatch, via oEmbed ─────────────────────────────────────
+#
+# oEmbed resolves a title on its own — it never calls
+# `resolve_document_publication` — so the binding on the content path does
+# not reach it. It is called directly rather than through the HTTP stack:
+# the route is a plain async function, and going through a TestClient would
+# drag in auth middleware and app lifespan for no added coverage of the one
+# query under test.
+
+
+_GENERIC_TITLE = "AKB Publication"
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_oembed_refuses_a_publication_whose_uri_names_another_vault(
+    pool, vaults, path,
+):
+    """A mismatched row must unfurl as the generic card, not another vault's
+    document title."""
+    from app.api.routes.public import oembed
+
+    slug, far_title = await _mismatch(pool, vaults, path)
+    publication = await _internal(slug)
+    # Guard the setup. `oembed` skips the document lookup entirely when the
+    # publication carries its own title or a password, so a fixture that
+    # produced either would make the assertion below pass without ever
+    # reaching the query under test.
+    assert not publication.get("title"), "the fixture must force the DB lookup"
+    assert not publication.get("password_hash"), "F1 would short-circuit the lookup"
+    assert vaults["far"]["name"] in publication["resource_uri"]
+    assert str(publication["vault_id"]) == str(vaults["home"]["id"])
+
+    card = await oembed(url=f"https://vault-binding.test.local/p/{slug}")
+
+    assert card["title"] != far_title, (
+        "oEmbed disclosed the title of a document in the vault NAMED by the "
+        "URI, which is not the vault this publication belongs to"
+    )
+    assert card["title"] != "Home vault document", (
+        "the vault_id binding landed but the URI-name cross-check was dropped: "
+        "a corrupt row now unfurls its own vault's document at that path "
+        "instead of falling through to the generic card"
+    )
+    assert card["title"] == _GENERIC_TITLE
+
+
+async def test_oembed_still_titles_an_ordinary_publication(pool, vaults):
+    """The binding must cost a legitimate unfurl nothing — a decoy document at
+    the same path in the other vault must not change the answer."""
+    from app.api.routes.public import oembed
+
+    path = "reports/q3.md"
+    await _create_doc(pool, vaults["far"], path, title="Decoy in the other vault")
+    await _create_doc(pool, vaults["home"], path, title="The published document")
+    slug = await _publish(vaults["home"]["name"], path)
+
+    card = await oembed(url=f"https://vault-binding.test.local/p/{slug}")
+
+    assert card["title"] == "The published document"
+
+
+# ── The negative: ordinary publications are untouched ────────────
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_an_ordinary_publication_still_resolves(pool, vaults, path):
+    """The binding must cost a legitimate resolution nothing.
+
+    Same fixture as the mismatch — a same-path document exists in the other
+    vault too — so this also pins that a document elsewhere at that path does
+    not disturb the right answer.
+    """
+    from app.services.publication_service import resolve_document_publication
+
+    await _create_doc(pool, vaults["far"], path, title="Decoy in the other vault")
+    await _create_doc(pool, vaults["home"], path, title="The published document")
+    slug = await _publish(vaults["home"]["name"], path)
+
+    data = await resolve_document_publication(await _internal(slug))
+
+    assert data["title"] == "The published document"
+    assert data["content_unavailable"] is False
+    assert f"vault={vaults['home']['name']}" in data["content"], (
+        "the body must come from the publication's own vault"
+    )
+    assert data["resource_type"] == "document"

--- a/docs/design/proposal/2026-08-04-publication-path-binding/README.md
+++ b/docs/design/proposal/2026-08-04-publication-path-binding/README.md
@@ -1,0 +1,73 @@
+---
+status: proposal
+stage: design
+created: 2026-08-04
+updated: 2026-08-04
+---
+
+# Publications resolve by path — bind cleanup and resolution to the vault
+
+## What this is
+
+Publications addressed their target document by a path-shaped `resource_uri`
+rather than by a document identity — a consequence of migration 022 collapsing
+the old `document_id` / `file_id` foreign keys into a single canonical URI. With
+`documents` keyed `UNIQUE(vault_id, path)`, a path can be reused, so publication
+cleanup on document delete has to be explicit and complete. It was not: cleanup
+lived in several inline copies and two delete paths omitted it.
+
+This item makes document-publication cleanup a single implementation reached from
+every delete path, and binds publication resolution to the publication's own
+vault.
+
+## What changed (PR 1)
+
+1. **One cleanup implementation.** The by-`resource_uri` cleanup existed in four
+   places; it is now one pair of helpers, called from every delete path with the
+   caller's transaction threaded through so cleanup and row-delete commit
+   together.
+
+2. **One place deletes a document.** `DocumentRepository.delete_with_publications`
+   replaces the plain row delete: it requires a caller-managed transaction, takes
+   `FOR UPDATE` on the row, reads the path back from the locked row, cleans
+   publications, then deletes. A static test allowlists every remaining
+   `DELETE FROM documents` so a new site is caught in review. The row lock also
+   serializes a publish that would otherwise race the delete.
+
+3. **Writes onto a claimed path are refused.** Create, move, and external-git
+   import reject a write to a path that a publication still claims but no document
+   owns — with an error naming the publication rather than deleting it.
+
+4. **Resolution is bound to the vault.** `resolve_document_publication` and the
+   oEmbed title lookup key on the publication's own `vault_id`, with the URI's
+   vault name demoted to a fail-closed cross-check — the binding the file path
+   already carried.
+
+5. **A file was publishable before its upload confirmed**, and the discard paths
+   left the publication behind; both now clean up.
+
+## Tests
+
+- `backend/tests/test_publication_resolution_e2e.sh` — new end-to-end suite covering
+  collection delete, move onto a claimed path, file publications under collection
+  delete, and the upload-discard paths. Each case first asserts the ordinary
+  behaviour so a later pass cannot come from a setup that silently no-ops.
+- `backend/tests/test_publications_e2e.sh` (907 lines) was not running in CI; the
+  e2e job now brings up MinIO and gates it.
+- `tests/concurrency/test_invariants_unit.py` was running in neither CI job; its
+  fixture now applies migrations and it is registered in the DB-backed job.
+
+## Direction
+
+Addressing a publication by a path rather than by an identity is what makes
+this area need care in the first place, and restoring an identity anchor —
+validated when a publication is created and again when it is resolved — is
+where this should end up. That is a schema change with its own rollout, so it
+is a separate piece of work rather than something folded in here.
+
+A few smaller consolidations follow from the same direction: giving the file
+cleanup helper the same URI-only signature the document one now has, and two
+CI-integrity improvements to how suite results are counted.
+
+Design detail, the reasoning behind each choice, and the review record are held
+in the team's internal notes rather than in this repository.

--- a/docs/design/proposal/2026-08-04-publication-path-binding/feedback/README.md
+++ b/docs/design/proposal/2026-08-04-publication-path-binding/feedback/README.md
@@ -1,0 +1,22 @@
+# Feedback
+
+Reviews conducted on this item, in order:
+
+- **Scope review** before implementation — rejected the first plan as too
+  narrow and established the broader containment the README describes.
+- **Per-change reviews** during implementation — each change was reviewed
+  before it landed. Several produced real corrections, the most consequential
+  being that the cleanup's URI had to be derived from the locked row rather
+  than supplied by the caller, since a caller iterating a snapshot can hold a
+  path that has since changed.
+- **Branch review** before opening the PR — guideline compliance, a bug scan,
+  historical context against the migration that created this area's fragility,
+  and a check that the change obeys the constraints recorded in the
+  surrounding code comments.
+
+Every test added here was confirmed to fail before its fix and to fail on its
+own assertion rather than on setup, and the static guards were confirmed to
+catch a planted violation.
+
+The review transcripts are held in the team's internal notes rather than in
+this repository.

--- a/docs/design/proposal/2026-08-04-publication-path-binding/rounds/README.md
+++ b/docs/design/proposal/2026-08-04-publication-path-binding/rounds/README.md
@@ -1,0 +1,24 @@
+# Rounds
+
+This item went through two design rounds before implementation and one
+correction round during it.
+
+- **Round 1** — scoped the fix. Established that cleanup had to be reachable
+  from every delete path rather than added to the two paths that omitted it,
+  because the paths that already had it each carried their own inline copy and
+  there was no single original to converge on.
+- **Round 2** — adjudicated how far the fix should reach. Concluded that closing
+  the delete paths is prospective only, and that a write onto a path a
+  publication still claims has to be refused as well. Also concluded that
+  binding publications to an identity rather than a path is the structural fix,
+  and deferred it to a follow-up rather than folding a schema change into the
+  containment work.
+- **Correction round** — three defects found while implementing, each verified
+  in the tree rather than inferred. They are summarised in the README's
+  "What changed" section; the ordering constraint one of them produced is
+  recorded as a docstring on the helper it applies to, since that is where it
+  needs to be read.
+
+The round notes themselves, the review transcripts, and the production
+inventory that informed the remediation ordering are held in the team's
+internal notes rather than in this repository.


### PR DESCRIPTION
## What this fixes

A publication addresses its document by a path-shaped `resource_uri` rather than
by an identity. Migration 022 collapsed the old `document_id` / `file_id` foreign
keys into that single column, which removed the database cascade and left
publication cleanup to be done explicitly on every path that deletes a document.

Of the three per-row delete paths, two did not do it. The one that did kept it as
an inline copy rather than something callable, so there was no single original for
the others to reach for. Because `documents` is `UNIQUE(vault_id, path)`, a
publication left behind still claims that path, and the next document to occupy it
is reached through the old link.

## What changed

**One cleanup implementation, reached from every delete path.** It runs on the
caller's connection, so it commits with the row delete rather than beside it — on a
separate connection the two commit independently and a crash between them leaves
exactly the state this is removing.

**One place deletes a document.** `DocumentRepository.delete` is replaced by
`delete_with_publications`, which requires a caller-managed transaction, takes
`FOR UPDATE` on the row, reads the path back from the locked row rather than
trusting the caller's copy, cleans publications, then deletes. Removing the plainer
method matters as much as adding this one — a new delete path can no longer pick
the option that does half the job, because it no longer exists. A static test
allowlists every remaining `DELETE FROM documents`, and each entry records how that
site's publications are handled.

The row lock also closes a window between the cleanup and the delete.
`create_publication` takes `FOR SHARE` on the same row before inserting, while the
deleter serialized on a `(vault_id, path)` advisory lock the publisher never
acquires — two namespaces that do not order against each other.

**Writes onto a claimed path are refused** at create, move and external-git import,
before the git write so a refusal does not leave git and PostgreSQL disagreeing.
The publication is not removed; the error names it and how to revoke it. Together
with the above, neither end of a path's lifecycle has to trust the other to have
been correct.

**Resolution is bound to the publication's own vault**, with the URI's vault name
demoted to a fail-closed cross-check — the binding the file path already carried.
Applied to both the page lookup and the oEmbed title lookup. Binding on `vault_id`
alone was tried and rejected: it stops the wrong lookup by quietly returning a
different vault's document, which is a different wrong answer rather than a
refusal.

**A file was publishable before its upload was confirmed**, and `confirm_upload`
discarded the row on two failure paths without cleaning up.

## Tests

`test_publication_resolution_e2e.sh` is new. Three suites that were running in
neither CI job now run: `test_publications_e2e.sh` (its only blocker was S3; MinIO
now comes up in the e2e job, pinned, with the bucket created explicitly),
`tests/concurrency/test_invariants_unit.py` (its fixture applied `init.sql` only,
so migration-created tables were missing against a fresh database), and
`tests/test_external_git_cascade_unit.py`.

Each new assertion was confirmed to fail before its fix, and to fail on its own
assertion rather than on setup. The static guards were confirmed to catch a planted
violation.

## Notes for review

`backend/app/repositories/` now imports from `app.services` in four function-local
imports, which it did not before. This is deliberate: `delete_with_publications`
belongs where it is precisely so that the repository has no plainer alternative to
offer, and moving it up a layer would put a row-only delete back within reach. The
local imports are the cost of avoiding an import cycle.

The design item is `docs/design/proposal/2026-08-04-publication-path-binding/`.
