### PR TITLE
feat: add app installation lifecycle and E2E runtime

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -154,6 +154,7 @@ jobs:
           tests/test_app_registry_migration_unit.py
           tests/test_app_identity_postgres.py
           tests/test_app_inventory_postgres.py
+          tests/test_app_lifecycle_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,39 +71,6 @@ jobs:
           pip install --upgrade pip
           pip install -e '.[dev]'
 
-      - name: Write CI config files
-        # pragma: allowlist secret
-        run: |  # pragma: allowlist secret
-          mkdir -p config /tmp/akb-vaults
-          cat > config/app.yaml <<'YAML'
-          db_host: localhost
-          db_port: 15432
-          db_name: akb
-          db_user: akb
-          public_base_url: http://localhost:8000
-          git_storage_path: /tmp/akb-vaults
-          vector_store_driver: pgvector
-          embed_base_url: http://localhost:8888/v1
-          embed_model: ci-embed-stub
-          embed_dimensions: 1536
-          llm_base_url: ""
-          llm_model: ""
-          rerank_enabled: false
-          # Backend and curl both run ON the runner, so the internal
-          # endpoint is also reachable by the client following a
-          # presigned URL — s3_public_url can stay unset and fall back
-          # to this one.
-          s3_endpoint_url: http://localhost:9000
-          s3_bucket: akb-files
-          YAML
-          cat > config/secret.yaml <<'YAML'
-          db_password: akb  # pragma: allowlist secret
-          jwt_secret: ci-only-jwt-secret-not-for-prod-use  # pragma: allowlist secret
-          embed_api_key: ci-stub-no-auth  # pragma: allowlist secret
-          s3_access_key: akb-ci  # pragma: allowlist secret
-          s3_secret_key: akb-ci-secret  # pragma: allowlist secret
-          YAML
-
       - name: Start MinIO (S3 for file publications)
         # pragma: allowlist secret
         run: |  # pragma: allowlist secret
@@ -148,127 +115,26 @@ jobs:
           print("buckets:", [b["Name"] for b in s3.list_buckets()["Buckets"]])
           PY
 
-      - name: Start embedding stub (background)
-        working-directory: backend
-        run: |
-          nohup python -m uvicorn scripts.ci.embed_stub:app \
-            --host 127.0.0.1 --port 8888 \
-            > /tmp/embed-stub.log 2>&1 &
-          for i in $(seq 1 20); do
-            if curl -fsS http://localhost:8888/healthz >/dev/null 2>&1; then
-              echo "embed stub ready"
-              break
-            fi
-            sleep 1
-          done
-
-      - name: Start backend (background)
-        run: |
-          # Run uvicorn from repo root so the ./config/ candidate hits.
-          nohup python -m uvicorn app.main:app \
-            --app-dir backend \
-            --host 127.0.0.1 --port 8000 \
-            > /tmp/backend.log 2>&1 &
-          # Wait for /readyz — cold start typically settles in ~20s;
-          # 90s ceiling is a safety net for slow CI runners.
-          for i in $(seq 1 45); do
-            if curl -fsS http://localhost:8000/readyz 2>/dev/null | grep -q '"status"'; then
-              echo "backend ready"
-              break
-            fi
-            sleep 2
-          done
-          curl -fsS http://localhost:8000/readyz || (echo "backend never came up"; tail -50 /tmp/backend.log; exit 1)
-
-      - name: Run canonical shell e2e suite
+      - name: Run canonical shell E2E
         env:
-          AKB_URL: http://localhost:8000
-          # test_jwt_revocation_e2e.sh bootstraps admins via direct SQL
-          # using `${AKB_PG_EXEC} psql -U ... -d ...`. Default targets
-          # kubectl/docker; here we point it at the service-container PG
-          # via env so psql connects to localhost:15432 with the right
-          # password.
-          AKB_PG_EXEC: env PGHOST=localhost PGPORT=15432 PGPASSWORD=akb  # pragma: allowlist secret
-          AKB_PG_USER: akb
-          AKB_PG_DB: akb
+          AKB_E2E_DATABASE_URL: postgresql://akb:akb@localhost:15432/akb  # pragma: allowlist secret
+          AKB_E2E_ORIGIN: http://localhost:8000
+          AKB_E2E_FIXTURE_ORIGIN: http://localhost:8889
+          AKB_E2E_SCENARIO: empty
+          AKB_E2E_READY_FILE: /tmp/akb-e2e-ready.json
+          AKB_E2E_S3_ENDPOINT: http://localhost:9000
+          AKB_E2E_S3_BUCKET: akb-files
+          AKB_E2E_S3_ACCESS_KEY: akb-ci  # pragma: allowlist secret
+          AKB_E2E_S3_SECRET_KEY: akb-ci-secret  # pragma: allowlist secret
         run: |
-          # Curated subset of CLAUDE.md's canonical list — every suite
-          # here exercises the HTTP/MCP surface end-to-end without
-          # needing the npm proxy or a real embedding provider.
-          #
-          # Deferred (need follow-up PRs):
-          #   - test_defensive_e2e.sh — its "search after delete"
-          #     assertion relies on the embedding pipeline producing
-          #     unique vectors per document; our CI stub returns a
-          #     fixed vector for every input, so cosine similarity is
-          #     constant and a deleted doc still scores as a near-hit
-          #     until the vector_delete_outbox drains. Wire MinIO +
-          #     a real embedding provider (or a smarter stub) to
-          #     re-enable.
-          #   - test_concurrency_repro_e2e.sh — T10 posts a
-          #     publication body with mode:"live" which the publication
-          #     model now rejects as extra_forbidden ("mode" is
-          #     output-only since the live/snapshot rewrite). Fix the
-          #     test in its own PR, then re-enable.
-          SUITES=(
-            test_probes_e2e.sh
-            test_mcp_e2e.sh
-            test_edit_e2e.sh
-            test_security_edge_e2e.sh
-            test_pg_rbac_e2e.sh
-            test_graph_replace_e2e.sh
-            test_relations_rest_e2e.sh
-            test_collection_lifecycle_e2e.sh
-            test_history_rest_e2e.sh
-            test_jwt_revocation_e2e.sh
-            test_table_constraints_e2e.sh
-            test_forbidden_permission_code_e2e.sh
-            test_okf_export_import_e2e.sh
-            # Publication resolution regression. Its S3-dependent
-            # sections (T3 file-publication cleanup, T4 failed-confirm
-            # cleanup) now RUN rather than self-skip, alongside the two
-            # document resolution cases (recursive collection delete,
-            # move-onto-orphan). NOTE: CI sums pass/fail only — a suite
-            # that skips a section still reports 0 failed, so the skip
-            # branches there are a fallback, not an accepted outcome.
-            test_publication_resolution_e2e.sh
-            # The publication feature's own suite — 127 assertions over
-            # documents, table queries, snapshots and files. Needs S3
-            # (section 0 uploads a file, and sections 9/13 publish it),
-            # which is why MinIO is brought up above. Nothing else here
-            # is CI-hostile: no proxy, no psql, no embedding assertions.
-            test_publications_e2e.sh
-          )
-          TOTAL_PASS=0
-          TOTAL_FAIL=0
-          FAILED=()
-          for s in "${SUITES[@]}"; do
-            echo "::group::$s"
-            OUT=$(bash "backend/tests/$s" 2>&1) && RC=0 || RC=$?
-            echo "$OUT" | tail -80
-            # Match both summary styles: some suites prefix with a
-            # box-drawing "║ Results:" line, others use bare "Results:"
-            # with leading whitespace. tail -1 picks the final summary.
-            SUMMARY=$(echo "$OUT" | grep -E '(║.*)?Results: *[0-9]+ passed' | tail -1)
-            P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+' || echo 0)
-            F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+' || echo 0)
-            TOTAL_PASS=$((TOTAL_PASS + ${P:-0}))
-            TOTAL_FAIL=$((TOTAL_FAIL + ${F:-0}))
-            echo "::endgroup::"
-            echo "▸ $s: ${P:-0} passed, ${F:-0} failed (rc=$RC)"
-            if [ "$RC" != "0" ] || [ "${F:-0}" != "0" ]; then
-              FAILED+=("$s")
-            fi
-          done
-          echo ""
-          echo "═════════════════════════════════════════"
-          echo "TOTAL: $TOTAL_PASS passed, $TOTAL_FAIL failed"
-          echo "═════════════════════════════════════════"
-          if [ ${#FAILED[@]} -gt 0 ]; then
-            echo "FAILED SUITES:"
-            for s in "${FAILED[@]}"; do echo "  - $s"; done
-            exit 1
-          fi
+          # GitHub Actions continues to own the PostgreSQL service container;
+          # --manage-postgres is reserved for isolated local/Crabbox runs.
+          # Keep output visible in the job log while retaining one artifact.
+          set -o pipefail
+          python backend/scripts/ci/e2e_runtime.py \
+            --scenario "$AKB_E2E_SCENARIO" \
+            --ready-file "$AKB_E2E_READY_FILE" \
+            --run-suites 2>&1 | tee /tmp/e2e-runtime.log
 
       - name: Upload backend logs on failure
         if: failure()
@@ -278,4 +144,5 @@ jobs:
           path: |
             /tmp/backend.log
             /tmp/embed-stub.log
+            /tmp/e2e-runtime.log
           if-no-files-found: ignore

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3326
+        "line_number": 3345
       }
     ],
     "backend/mcp_server/help.py": [

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,25 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added app installation lifecycle commands and status
+
+System and target Vault administrators can now install, inspect, uninstall,
+restore, or freshly re-provision an app through a Vault-keyed HTTP lifecycle
+surface backed by the existing desired-state registry. Install and fresh
+commands return `installing` after atomic creation of the next active grant;
+identical retries replay the same installation and generation, while
+conflicting release or capability requests fail with no partial mutation.
+Uninstall revokes the current grant and retains owned resources for explicit
+restore compatibility checks. Restore requires matching retained release,
+observed release, and schema fingerprints; fresh refuses retained resources and
+never reuses the old current pointer. App-token reads are limited to the
+principal's own live installation and its current `installation:read` grant.
+
+Responses, projections, and bounded audit metadata omit credentials, tokens,
+grant provenance, arbitrary worker payloads, and unrelated Vault metadata;
+lifecycle responses use `Cache-Control: no-store`. The backend version remains
+0.13.0 and no new migration or command table is introduced.
+
 ### Added app identity credential exchange and capability enforcement
 
 System administrators can now issue, list, rotate, and revoke exchange-only app

--- a/backend/app/api/routes/app_lifecycle.py
+++ b/backend/app/api/routes/app_lifecycle.py
@@ -1,0 +1,152 @@
+"""REST lifecycle commands and status for app installations."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import Field
+
+from app.api.deps import get_current_app, get_current_user, request_correlation_id
+from app.services.app_identity_service import AppPrincipal
+from app.services.app_lifecycle_service import (
+    authorize_lifecycle_admin,
+    get_installation_status,
+    get_installation_status_for_app,
+    put_installation,
+    uninstall_installation,
+)
+from app.services.auth_service import AuthenticatedUser
+from app.util.text import NFCModel
+
+router = APIRouter()
+
+LifecycleMode = Literal["install", "restore", "fresh"]
+CapabilityName = Annotated[
+    str,
+    Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$"),
+]
+
+
+class InstallationCommandRequest(NFCModel):
+    release_id: uuid.UUID
+    capabilities: list[CapabilityName] = Field(min_length=1, max_length=32)
+    mode: LifecycleMode = "install"
+
+
+def _mark_no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+def _set_command_status(response: Response, result: dict) -> None:
+    response.status_code = 200 if result["replayed"] else 202
+    _mark_no_store(response)
+
+
+@router.put(
+    "/apps/{app_id}/installations/{vault_id}",
+    summary="Install, restore, or freshly provision an app in a Vault",
+)
+async def put_app_installation(
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    req: InstallationCommandRequest,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    correlation_id = request_correlation_id(request)
+    await authorize_lifecycle_admin(
+        user,
+        app_id=app_id,
+        vault_id=vault_id,
+        action="app.installation.command",
+        correlation_id=correlation_id,
+    )
+    result = await put_installation(
+        app_id,
+        vault_id,
+        release_id=req.release_id,
+        capabilities=req.capabilities,
+        mode=req.mode,
+        correlation_id=correlation_id,
+        actor=user.username,
+        actor_id=user.user_id,
+    )
+    _set_command_status(response, result)
+    return result
+
+
+@router.get(
+    "/apps/{app_id}/installations/{vault_id}",
+    summary="Read an app installation status as a system or Vault administrator",
+)
+async def get_app_installation(
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    correlation_id = request_correlation_id(request)
+    await authorize_lifecycle_admin(
+        user,
+        app_id=app_id,
+        vault_id=vault_id,
+        action="app.installation.status",
+        correlation_id=correlation_id,
+    )
+    result = await get_installation_status(app_id, vault_id)
+    _mark_no_store(response)
+    return result
+
+
+@router.delete(
+    "/apps/{app_id}/installations/{vault_id}",
+    summary="Uninstall an app from a Vault without deleting retained resources",
+)
+async def delete_app_installation(
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    correlation_id = request_correlation_id(request)
+    await authorize_lifecycle_admin(
+        user,
+        app_id=app_id,
+        vault_id=vault_id,
+        action="app.installation.uninstall",
+        correlation_id=correlation_id,
+    )
+    result = await uninstall_installation(
+        app_id,
+        vault_id,
+        correlation_id=correlation_id,
+        actor=user.username,
+        actor_id=user.user_id,
+    )
+    _set_command_status(response, result)
+    return result
+
+
+@router.get(
+    "/app/installations/{vault_id}",
+    summary="Read the caller app's own installation status",
+)
+async def get_caller_app_installation(
+    vault_id: uuid.UUID,
+    request: Request,
+    response: Response,
+    principal: AppPrincipal = Depends(get_current_app),
+):
+    result = await get_installation_status_for_app(
+        principal,
+        vault_id=vault_id,
+        correlation_id=request_correlation_id(request),
+    )
+    _mark_no_store(response)
+    return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.api.routes import (
     access,
     activity,
     app_inventory,
+    app_lifecycle,
     agent_sessions,
     app_identity,
     auth,
@@ -263,12 +264,21 @@ async def _no_store_public_surfaces(request: Request, call_next):
         if path == base or path.startswith(base + "/"):
             response.headers["Cache-Control"] = "no-store"
             break
+    if (
+        path.startswith("/api/v1/app/installations/")
+        or (
+            path.startswith("/api/v1/apps/")
+            and "/installations/" in path
+        )
+    ):
+        response.headers["Cache-Control"] = "no-store"
     return response
 
 
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(app_identity.router, prefix="/api/v1", tags=["app-identity"])
 app.include_router(app_inventory.router, prefix="/api/v1", tags=["app-inventory"])
+app.include_router(app_lifecycle.router, prefix="/api/v1", tags=["app-lifecycle"])
 app.include_router(access.router, prefix="/api/v1", tags=["access"])
 app.include_router(documents.router, prefix="/api/v1", tags=["documents"])
 app.include_router(search.router, prefix="/api/v1", tags=["search"])

--- a/backend/app/services/app_lifecycle_service.py
+++ b/backend/app/services/app_lifecycle_service.py
@@ -97,6 +97,11 @@ def _capabilities(value: Any) -> list[str]:
 
 
 def _resource_payload(value: Any) -> list[dict[str, str]]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
     if not isinstance(value, list):
         return []
     result = []
@@ -123,6 +128,7 @@ def project_installation_status(row: Any) -> dict[str, Any]:
     latest_grant = None
     if row["latest_grant_generation"] is not None:
         latest_grant = {
+            "id": str(row["latest_grant_id"]),
             "generation": row["latest_grant_generation"],
             "status": row["latest_grant_status"],
             "capabilities": _capabilities(row["latest_grant_capabilities"]),
@@ -131,6 +137,7 @@ def project_installation_status(row: Any) -> dict[str, Any]:
     latest_active_grant = None
     if row["latest_active_grant_generation"] is not None:
         latest_active_grant = {
+            "id": str(row["latest_active_grant_id"]),
             "generation": row["latest_active_grant_generation"],
             "status": row["latest_active_grant_status"],
             "capabilities": _capabilities(row["latest_active_grant_capabilities"]),
@@ -206,9 +213,11 @@ _STATUS_SELECT = """
         installation.current_release_id,
         current_release.version AS current_version,
         installation.grant_generation,
+        latest_grant.id AS latest_grant_id,
         latest_grant.generation AS latest_grant_generation,
         latest_grant.status AS latest_grant_status,
         latest_grant.capabilities AS latest_grant_capabilities,
+        latest_active_grant.id AS latest_active_grant_id,
         latest_active_grant.generation AS latest_active_grant_generation,
         latest_active_grant.status AS latest_active_grant_status,
         latest_active_grant.capabilities AS latest_active_grant_capabilities,
@@ -231,14 +240,16 @@ _STATUS_SELECT = """
       LEFT JOIN app_installation_observed_states AS observed
         ON observed.installation_id = installation.id
       LEFT JOIN LATERAL (
-          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+          SELECT grant_row.id, grant_row.generation, grant_row.status,
+                 grant_row.capabilities
             FROM installation_grants AS grant_row
            WHERE grant_row.installation_id = installation.id
            ORDER BY grant_row.generation DESC
            LIMIT 1
       ) AS latest_grant ON TRUE
       LEFT JOIN LATERAL (
-          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+          SELECT grant_row.id, grant_row.generation, grant_row.status,
+                 grant_row.capabilities
             FROM installation_grants AS grant_row
            WHERE grant_row.installation_id = installation.id
              AND grant_row.status = 'active'

--- a/backend/app/services/app_lifecycle_service.py
+++ b/backend/app/services/app_lifecycle_service.py
@@ -1,0 +1,894 @@
+"""App installation lifecycle commands and status projection.
+
+The desired-state registry is the source of truth for installation lifecycle.
+Commands use the registry's existing uniqueness, generation, and immutability
+constraints; no separate command ledger is needed.  An app/Vault advisory
+transaction lock makes a retry or conflicting concurrent command observe one
+serialized state transition.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any, Sequence
+
+from app.db.postgres import get_pool
+from app.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
+from app.services.access_service import check_vault_access
+from app.services.app_identity_service import (
+    AppPrincipal,
+    SUPPORTED_APP_CAPABILITIES,
+    record_app_audit,
+)
+from app.services.app_inventory_service import (
+    classify_drift,
+    expected_schema_fingerprint,
+    sanitize_checkpoint,
+    sanitize_recent_error,
+)
+from app.services.auth_service import AuthenticatedUser
+
+LIFECYCLE_MODES = frozenset({"install", "restore", "fresh"})
+READABLE_APP_LIFECYCLES = frozenset({"installing", "active", "upgrading", "blocked"})
+
+_SAFE_CODE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+_SAFE_FINGERPRINT = re.compile(r"^[0-9A-Fa-f]{8,256}$")
+_APP_VAULT_LOCK_PREFIX = "app-installation"
+
+
+def _as_uuid(value: uuid.UUID | str, *, field: str) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValidationError(f"{field} must be a UUID") from exc
+
+
+def normalize_mode(mode: str | None) -> str:
+    value = "install" if mode is None else mode
+    if value not in LIFECYCLE_MODES:
+        raise ValidationError("mode must be one of install, restore, or fresh")
+    return value
+
+
+def normalize_capabilities(capabilities: Sequence[str]) -> list[str]:
+    if isinstance(capabilities, (str, bytes)) or not isinstance(capabilities, Sequence):
+        raise ValidationError("capabilities must be a non-empty list")
+    if not capabilities:
+        raise ValidationError("capabilities must not be empty")
+    if any(not isinstance(capability, str) or not capability for capability in capabilities):
+        raise ValidationError("capabilities must contain non-empty strings")
+    normalized = sorted(set(capabilities))
+    if not set(normalized).issubset(SUPPORTED_APP_CAPABILITIES):
+        raise ValidationError("capabilities contain an unsupported value")
+    return normalized
+
+
+def _safe_code(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_CODE.fullmatch(value) else None
+
+
+def _safe_fingerprint(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _SAFE_FINGERPRINT.fullmatch(value) else None
+
+
+def _release_payload(release_id: Any, version: Any) -> dict[str, Any] | None:
+    if release_id is None and version is None:
+        return None
+    return {
+        "id": str(release_id) if release_id is not None else None,
+        "version": version,
+    }
+
+
+def _capabilities(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return sorted({item for item in value if isinstance(item, str)})
+
+
+def _resource_payload(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("kind")
+        key = item.get("key")
+        status = item.get("status")
+        if not all(isinstance(field, str) for field in (kind, key, status)):
+            continue
+        result.append(
+            {
+                "kind": str(kind),
+                "key": str(key),
+                "status": str(status),
+            }
+        )
+    return result
+
+
+def project_installation_status(row: Any) -> dict[str, Any]:
+    """Project the public lifecycle status without secret/provenance fields."""
+    latest_grant = None
+    if row["latest_grant_generation"] is not None:
+        latest_grant = {
+            "generation": row["latest_grant_generation"],
+            "status": row["latest_grant_status"],
+            "capabilities": _capabilities(row["latest_grant_capabilities"]),
+        }
+
+    latest_active_grant = None
+    if row["latest_active_grant_generation"] is not None:
+        latest_active_grant = {
+            "generation": row["latest_active_grant_generation"],
+            "status": row["latest_active_grant_status"],
+            "capabilities": _capabilities(row["latest_active_grant_capabilities"]),
+        }
+
+    observed = None
+    if row["observed_generation"] is not None:
+        observed = {
+            "generation": row["observed_generation"],
+            "observed_at": (
+                row["observed_at"].isoformat() if row["observed_at"] else None
+            ),
+            "release": _release_payload(
+                row["observed_release_id"],
+                row["observed_release_version"],
+            ),
+            "schema_fingerprint": _safe_fingerprint(row["schema_fingerprint"]),
+            "grant_generation": row["observed_grant_generation"],
+            "checkpoint": sanitize_checkpoint(row["checkpoint"]),
+            "recent_error": sanitize_recent_error(row["recent_error"]),
+        }
+
+    drift = classify_drift(row)
+    result = {
+        "installation_id": str(row["installation_id"]),
+        "app_id": str(row["app_id"]),
+        "vault_id": str(row["vault_id"]),
+        "lifecycle": row["lifecycle"],
+        "desired_release": _release_payload(
+            row["desired_release_id"],
+            row["desired_version"],
+        ),
+        "current_release": _release_payload(
+            row["current_release_id"],
+            row["current_version"],
+        ),
+        "observed": observed,
+        "latest_grant": latest_grant,
+        "latest_active_grant": latest_active_grant,
+        "grant_generation": row["grant_generation"],
+        "resources": _resource_payload(row["resources"]),
+        "checkpoint": (
+            sanitize_checkpoint(row["checkpoint"])
+            if row["observed_generation"] is not None
+            else {}
+        ),
+        "recent_error": (
+            sanitize_recent_error(row["recent_error"])
+            if row["observed_generation"] is not None
+            else None
+        ),
+        "drift": drift,
+        "drift_classification": drift,
+        "created_at": row["created_at"].isoformat(),
+        "updated_at": row["updated_at"].isoformat(),
+    }
+    blocked_reason = _safe_code(row["blocked_reason"])
+    if blocked_reason is not None:
+        result["blocked_reason"] = blocked_reason
+    return result
+
+
+_STATUS_SELECT = """
+    SELECT
+        installation.id AS installation_id,
+        installation.app_id,
+        installation.vault_id,
+        installation.lifecycle,
+        installation.blocked_reason,
+        installation.desired_release_id,
+        desired.version AS desired_version,
+        desired.manifest AS desired_manifest,
+        installation.current_release_id,
+        current_release.version AS current_version,
+        installation.grant_generation,
+        latest_grant.generation AS latest_grant_generation,
+        latest_grant.status AS latest_grant_status,
+        latest_grant.capabilities AS latest_grant_capabilities,
+        latest_active_grant.generation AS latest_active_grant_generation,
+        latest_active_grant.status AS latest_active_grant_status,
+        latest_active_grant.capabilities AS latest_active_grant_capabilities,
+        observed.observed_generation,
+        observed.observed_at,
+        observed.observed_release_id,
+        observed.observed_release_version,
+        observed.schema_fingerprint,
+        observed.observed_grant_generation,
+        observed.checkpoint,
+        observed.recent_error,
+        COALESCE(resources.items, '[]'::jsonb) AS resources,
+        installation.created_at,
+        installation.updated_at
+      FROM vault_app_installations AS installation
+      LEFT JOIN app_releases AS desired
+        ON desired.id = installation.desired_release_id
+      LEFT JOIN app_releases AS current_release
+        ON current_release.id = installation.current_release_id
+      LEFT JOIN app_installation_observed_states AS observed
+        ON observed.installation_id = installation.id
+      LEFT JOIN LATERAL (
+          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+            FROM installation_grants AS grant_row
+           WHERE grant_row.installation_id = installation.id
+           ORDER BY grant_row.generation DESC
+           LIMIT 1
+      ) AS latest_grant ON TRUE
+      LEFT JOIN LATERAL (
+          SELECT grant_row.generation, grant_row.status, grant_row.capabilities
+            FROM installation_grants AS grant_row
+           WHERE grant_row.installation_id = installation.id
+             AND grant_row.status = 'active'
+           ORDER BY grant_row.generation DESC
+           LIMIT 1
+      ) AS latest_active_grant ON TRUE
+      LEFT JOIN LATERAL (
+          SELECT jsonb_agg(
+                     jsonb_build_object(
+                         'kind', resource.resource_kind,
+                         'key', resource.resource_key,
+                         'status', resource.status
+                     )
+                     ORDER BY resource.resource_kind, resource.resource_key
+                 ) AS items
+            FROM app_owned_resources AS resource
+           WHERE resource.installation_id = installation.id
+      ) AS resources ON TRUE
+"""
+
+
+async def authorize_lifecycle_admin(
+    user: AuthenticatedUser,
+    *,
+    app_id: uuid.UUID | str,
+    vault_id: uuid.UUID | str,
+    action: str,
+    correlation_id: str,
+) -> dict[str, Any]:
+    """Authorize owner/admin access without an existence oracle.
+
+    A non-admin caller gets the same generic 403 when the Vault is missing or
+    the caller lacks the required role.  Authorized system admins can receive
+    the normal not-found response for a missing Vault.
+    """
+    app_uuid = _as_uuid(app_id, field="app_id")
+    vault_uuid = _as_uuid(vault_id, field="vault_id")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        vault_name = await conn.fetchval(
+            "SELECT name FROM vaults WHERE id = $1",
+            vault_uuid,
+        )
+
+    if vault_name is None:
+        if user.is_admin:
+            record_app_audit(
+                action,
+                correlation_id=correlation_id,
+                outcome="error",
+                reason="vault_not_found",
+                actor=user.username,
+                actor_id=user.user_id,
+                app_id=app_uuid,
+                vault_id=vault_uuid,
+            )
+            raise NotFoundError("Vault", str(vault_uuid))
+        _record_user_denial(
+            action,
+            correlation_id=correlation_id,
+            app_id=app_uuid,
+            vault_id=vault_uuid,
+            user=user,
+            reason="vault_admin_required",
+        )
+
+    try:
+        access = await check_vault_access(
+            user.user_id,
+            vault_name,
+            required_role="admin",
+        )
+    except (ForbiddenError, NotFoundError):
+        _record_user_denial(
+            action,
+            correlation_id=correlation_id,
+            app_id=app_uuid,
+            vault_id=vault_uuid,
+            user=user,
+            reason="vault_admin_required",
+        )
+    return access
+
+
+def _record_user_denial(
+    action: str,
+    *,
+    correlation_id: str,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    user: AuthenticatedUser,
+    reason: str,
+) -> None:
+    record_app_audit(
+        action,
+        correlation_id=correlation_id,
+        outcome="error",
+        reason=reason,
+        actor=user.username,
+        actor_id=user.user_id,
+        app_id=app_id,
+        vault_id=vault_id,
+    )
+    raise ForbiddenError("App request denied")
+
+
+def _record_command_audit(
+    action: str,
+    *,
+    correlation_id: str,
+    actor: str,
+    actor_id: str,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    status: dict[str, Any],
+    replayed: bool,
+    deployment: str | None = None,
+) -> None:
+    record_app_audit(
+        action,
+        correlation_id=correlation_id,
+        outcome="ok",
+        reason="already_applied" if replayed else "accepted",
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_id,
+        deployment=deployment,
+        installation_id=status["installation_id"],
+        vault_id=vault_id,
+        generation=status["grant_generation"],
+    )
+
+
+def _record_command_error(
+    action: str,
+    *,
+    correlation_id: str,
+    actor: str,
+    actor_id: str,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    exc: Exception,
+    deployment: str | None = None,
+) -> None:
+    if isinstance(exc, ValidationError):
+        reason = "invalid_request"
+    elif isinstance(exc, ConflictError):
+        reason = "conflict"
+    elif isinstance(exc, NotFoundError):
+        reason = "not_found"
+    elif isinstance(exc, ForbiddenError):
+        reason = "denied"
+    else:
+        reason = "error"
+    record_app_audit(
+        action,
+        correlation_id=correlation_id,
+        outcome="error",
+        reason=reason,
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_id,
+        deployment=deployment,
+        vault_id=vault_id,
+    )
+
+
+async def _status_row(conn, app_id: uuid.UUID, vault_id: uuid.UUID) -> Any:
+    return await conn.fetchrow(
+        _STATUS_SELECT
+        + """
+         WHERE installation.app_id = $1
+           AND installation.vault_id = $2
+        """,
+        app_id,
+        vault_id,
+    )
+
+
+async def get_installation_status(
+    app_id: uuid.UUID | str,
+    vault_id: uuid.UUID | str,
+) -> dict[str, Any]:
+    app_uuid = _as_uuid(app_id, field="app_id")
+    vault_uuid = _as_uuid(vault_id, field="vault_id")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await _status_row(conn, app_uuid, vault_uuid)
+    if row is None:
+        raise NotFoundError("Installation", "not found")
+    result = project_installation_status(row)
+    result["command_status"] = "not_applicable"
+    return result
+
+
+async def get_installation_status_for_app(
+    principal: AppPrincipal,
+    *,
+    vault_id: uuid.UUID | str,
+    correlation_id: str,
+) -> dict[str, Any]:
+    vault_uuid = _as_uuid(vault_id, field="vault_id")
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            _STATUS_SELECT
+            + """
+             WHERE installation.app_id = $1
+               AND installation.vault_id = $2
+               AND installation.lifecycle = ANY($3::text[])
+               AND EXISTS (
+                   SELECT 1
+                     FROM installation_grants AS visible_grant
+                    WHERE visible_grant.installation_id = installation.id
+                      AND visible_grant.generation = installation.grant_generation
+                      AND visible_grant.status = 'active'
+                      AND 'installation:read' = ANY(visible_grant.capabilities)
+               )
+            """,
+            principal.app_id,
+            vault_uuid,
+            list(READABLE_APP_LIFECYCLES),
+        )
+    if row is None:
+        record_app_audit(
+            "app.installation.status",
+            correlation_id=correlation_id,
+            outcome="error",
+            reason="installation_read_denied",
+            actor=f"app:{principal.app_id}",
+            actor_id=str(principal.app_id),
+            app_id=principal.app_id,
+            deployment=principal.deployment,
+            vault_id=vault_uuid,
+            generation=principal.credential_generation,
+        )
+        raise ForbiddenError("App request denied")
+    result = project_installation_status(row)
+    result["command_status"] = "not_applicable"
+    record_app_audit(
+        "app.installation.status",
+        correlation_id=correlation_id,
+        outcome="ok",
+        reason="authorized",
+        actor=f"app:{principal.app_id}",
+        actor_id=str(principal.app_id),
+        app_id=principal.app_id,
+        deployment=principal.deployment,
+        installation_id=row["installation_id"],
+        vault_id=vault_uuid,
+        generation=row["grant_generation"],
+    )
+    return result
+
+
+async def put_installation(
+    app_id: uuid.UUID | str,
+    vault_id: uuid.UUID | str,
+    *,
+    release_id: uuid.UUID | str,
+    capabilities: Sequence[str],
+    mode: str | None,
+    correlation_id: str,
+    actor: str,
+    actor_id: str,
+) -> dict[str, Any]:
+    app_uuid = _as_uuid(app_id, field="app_id")
+    vault_uuid = _as_uuid(vault_id, field="vault_id")
+    action = (
+        f"app.installation.{mode}"
+        if isinstance(mode, str) and mode in LIFECYCLE_MODES
+        else "app.installation.command"
+    )
+    try:
+        release_uuid = _as_uuid(release_id, field="release_id")
+        normalized_mode = normalize_mode(mode)
+        normalized_capabilities = normalize_capabilities(capabilities)
+    except Exception as exc:
+        _record_command_error(
+            action,
+            correlation_id=correlation_id,
+            actor=actor,
+            actor_id=actor_id,
+            app_id=app_uuid,
+            vault_id=vault_uuid,
+            exc=exc,
+        )
+        raise
+    action = f"app.installation.{normalized_mode}"
+    try:
+        result, replayed = await _put_installation(
+            app_uuid,
+            vault_uuid,
+            release_uuid,
+            normalized_capabilities,
+            normalized_mode,
+        )
+    except Exception as exc:
+        _record_command_error(
+            action,
+            correlation_id=correlation_id,
+            actor=actor,
+            actor_id=actor_id,
+            app_id=app_uuid,
+            vault_id=vault_uuid,
+            exc=exc,
+        )
+        raise
+    _record_command_audit(
+        action,
+        correlation_id=correlation_id,
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_uuid,
+        vault_id=vault_uuid,
+        status=result,
+        replayed=replayed,
+    )
+    result["command_status"] = "already_applied" if replayed else "accepted"
+    result["replayed"] = replayed
+    return result
+
+
+async def _put_installation(
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    release_id: uuid.UUID,
+    capabilities: list[str],
+    mode: str,
+) -> tuple[dict[str, Any], bool]:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.fetchval(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"{_APP_VAULT_LOCK_PREFIX}:{app_id}:{vault_id}",
+            )
+            if not await conn.fetchval(
+                "SELECT 1 FROM app_definitions WHERE id = $1",
+                app_id,
+            ):
+                raise NotFoundError("App", "not found")
+            if not await conn.fetchval("SELECT 1 FROM vaults WHERE id = $1", vault_id):
+                raise NotFoundError("Vault", "not found")
+            if not await conn.fetchval(
+                "SELECT 1 FROM app_releases WHERE id = $1 AND app_id = $2",
+                release_id,
+                app_id,
+            ):
+                raise ConflictError("Release is not registered for this app")
+
+            installation = await conn.fetchrow(
+                """
+                SELECT *
+                  FROM vault_app_installations
+                 WHERE app_id = $1 AND vault_id = $2
+                 FOR UPDATE
+                """,
+                app_id,
+                vault_id,
+            )
+            if installation is None:
+                if mode != "install":
+                    raise ConflictError("restore or fresh requires an uninstalled installation")
+                installation_id = await conn.fetchval(
+                    """
+                    INSERT INTO vault_app_installations (
+                        app_id, vault_id, desired_release_id, current_release_id,
+                        lifecycle, blocked_reason
+                    )
+                    VALUES ($1, $2, $3, NULL, 'installing', NULL)
+                    RETURNING id
+                    """,
+                    app_id,
+                    vault_id,
+                    release_id,
+                )
+                await _issue_grant(conn, installation_id, 1, capabilities)
+                row = await _status_row(conn, app_id, vault_id)
+                return _require_status(row), False
+
+            current_grant = await conn.fetchrow(
+                """
+                SELECT generation, status, capabilities
+                  FROM installation_grants
+                 WHERE installation_id = $1
+                   AND generation = $2
+                """,
+                installation["id"],
+                installation["grant_generation"],
+            )
+            if _is_replay_state(installation, current_grant, release_id, capabilities):
+                row = await _status_row(conn, app_id, vault_id)
+                return _require_status(row), True
+
+            if mode == "install":
+                raise ConflictError(
+                    "Installation state differs; use restore or fresh explicitly"
+                )
+            if installation["lifecycle"] != "uninstalled":
+                raise ConflictError("restore or fresh requires an uninstalled installation")
+
+            if mode == "restore":
+                await _assert_restore_compatible(
+                    conn,
+                    installation,
+                    release_id,
+                )
+                await conn.execute(
+                    """
+                    UPDATE app_owned_resources
+                       SET status = 'owned'
+                     WHERE installation_id = $1 AND status = 'retained'
+                    """,
+                    installation["id"],
+                )
+                await conn.execute(
+                    """
+                    UPDATE vault_app_installations
+                       SET desired_release_id = $2,
+                           current_release_id = $2,
+                           lifecycle = 'active',
+                           blocked_reason = NULL
+                     WHERE id = $1
+                    """,
+                    installation["id"],
+                    release_id,
+                )
+            else:
+                if await conn.fetchval(
+                    """
+                    SELECT 1 FROM app_owned_resources
+                     WHERE installation_id = $1
+                    """,
+                    installation["id"],
+                ):
+                    raise ConflictError("Fresh install is blocked by retained resources")
+                await conn.execute(
+                    """
+                    UPDATE vault_app_installations
+                       SET desired_release_id = $2,
+                           current_release_id = NULL,
+                           lifecycle = 'installing',
+                           blocked_reason = NULL
+                     WHERE id = $1
+                    """,
+                    installation["id"],
+                    release_id,
+                )
+
+            await _issue_grant(
+                conn,
+                installation["id"],
+                installation["grant_generation"] + 1,
+                capabilities,
+            )
+            row = await _status_row(conn, app_id, vault_id)
+            return _require_status(row), False
+
+
+def _require_status(row: Any) -> Any:
+    if row is None:
+        raise ConflictError("Installation status could not be read")
+    return project_installation_status(row)
+
+
+def _is_replay_state(
+    installation: Any,
+    grant: Any,
+    release_id: uuid.UUID,
+    capabilities: list[str],
+) -> bool:
+    if installation["lifecycle"] not in {"installing", "active"}:
+        return False
+    if installation["desired_release_id"] != release_id:
+        return False
+    if installation["lifecycle"] == "installing":
+        if installation["current_release_id"] is not None:
+            return False
+    elif installation["current_release_id"] != release_id:
+        return False
+    return bool(
+        grant
+        and grant["status"] == "active"
+        and grant["generation"] == installation["grant_generation"]
+        and _capabilities(grant["capabilities"]) == capabilities
+    )
+
+
+async def _issue_grant(
+    conn: Any,
+    installation_id: uuid.UUID,
+    generation: int,
+    capabilities: list[str],
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO installation_grants (
+            installation_id, generation, status, capabilities, issuer, provenance
+        )
+        VALUES ($1, $2, 'active', $3, 'lifecycle_api', $4::jsonb)
+        """,
+        installation_id,
+        generation,
+        capabilities,
+        json.dumps({"source": "lifecycle_api"}),
+    )
+
+
+async def _assert_restore_compatible(
+    conn: Any,
+    installation: Any,
+    release_id: uuid.UUID,
+) -> None:
+    if installation["current_release_id"] != release_id:
+        raise ConflictError("Restore release is not compatible with the retained installation")
+    release = await conn.fetchrow(
+        "SELECT manifest FROM app_releases WHERE id = $1 AND app_id = $2",
+        release_id,
+        installation["app_id"],
+    )
+    observed = await conn.fetchrow(
+        """
+        SELECT observed_release_id, schema_fingerprint
+          FROM app_installation_observed_states
+         WHERE installation_id = $1
+        """,
+        installation["id"],
+    )
+    expected_schema = expected_schema_fingerprint(release["manifest"]) if release else None
+    observed_schema = observed["schema_fingerprint"] if observed else None
+    if (
+        release is None
+        or observed is None
+        or observed["observed_release_id"] != release_id
+        or expected_schema is None
+        or observed_schema is None
+        or expected_schema != observed_schema
+    ):
+        raise ConflictError("Restore compatibility is unknown or mismatched")
+
+
+async def uninstall_installation(
+    app_id: uuid.UUID | str,
+    vault_id: uuid.UUID | str,
+    *,
+    correlation_id: str,
+    actor: str,
+    actor_id: str,
+) -> dict[str, Any]:
+    app_uuid = _as_uuid(app_id, field="app_id")
+    vault_uuid = _as_uuid(vault_id, field="vault_id")
+    action = "app.installation.uninstall"
+    try:
+        result, replayed = await _uninstall_installation(app_uuid, vault_uuid)
+    except Exception as exc:
+        _record_command_error(
+            action,
+            correlation_id=correlation_id,
+            actor=actor,
+            actor_id=actor_id,
+            app_id=app_uuid,
+            vault_id=vault_uuid,
+            exc=exc,
+        )
+        raise
+    _record_command_audit(
+        action,
+        correlation_id=correlation_id,
+        actor=actor,
+        actor_id=actor_id,
+        app_id=app_uuid,
+        vault_id=vault_uuid,
+        status=result,
+        replayed=replayed,
+    )
+    result["command_status"] = "already_applied" if replayed else "accepted"
+    result["replayed"] = replayed
+    return result
+
+
+async def _uninstall_installation(
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+) -> tuple[dict[str, Any], bool]:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.fetchval(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"{_APP_VAULT_LOCK_PREFIX}:{app_id}:{vault_id}",
+            )
+            if not await conn.fetchval(
+                "SELECT 1 FROM app_definitions WHERE id = $1",
+                app_id,
+            ):
+                raise NotFoundError("App", "not found")
+            installation = await conn.fetchrow(
+                """
+                SELECT *
+                  FROM vault_app_installations
+                 WHERE app_id = $1 AND vault_id = $2
+                 FOR UPDATE
+                """,
+                app_id,
+                vault_id,
+            )
+            if installation is None:
+                raise NotFoundError("Installation", "not found")
+            if installation["lifecycle"] == "uninstalled":
+                row = await _status_row(conn, app_id, vault_id)
+                return _require_status(row), True
+
+            grant = await conn.fetchrow(
+                """
+                SELECT id, generation, status
+                  FROM installation_grants
+                 WHERE installation_id = $1
+                   AND generation = $2
+                """,
+                installation["id"],
+                installation["grant_generation"],
+            )
+            if grant is None or grant["status"] != "active":
+                raise ConflictError("Installation has no active current grant")
+            await conn.execute(
+                """
+                UPDATE installation_grants
+                   SET status = 'revoked', revoked_at = NOW()
+                 WHERE id = $1 AND status = 'active'
+                """,
+                grant["id"],
+            )
+            await conn.execute(
+                """
+                UPDATE app_owned_resources
+                   SET status = 'retained'
+                 WHERE installation_id = $1 AND status = 'owned'
+                """,
+                installation["id"],
+            )
+            await conn.execute(
+                """
+                UPDATE vault_app_installations
+                   SET desired_release_id = NULL,
+                       lifecycle = 'uninstalled',
+                       blocked_reason = NULL
+                 WHERE id = $1
+                """,
+                installation["id"],
+            )
+            row = await _status_row(conn, app_id, vault_id)
+            return _require_status(row), False

--- a/backend/scripts/ci/bootstrap_e2e_runtime.sh
+++ b/backend/scripts/ci/bootstrap_e2e_runtime.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Prepare an Ubuntu host and exec the repository-owned HTTP E2E runtime.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+readonly UV_VERSION="0.12.1"
+readonly DATA_ROOT="${AKB_E2E_BOOTSTRAP_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/akb-e2e-bootstrap}"
+readonly UV_BIN="$DATA_ROOT/bin/uv"
+readonly VENV="$DATA_ROOT/venv"
+
+if ! command -v curl >/dev/null 2>&1 \
+  || ! command -v docker >/dev/null 2>&1 \
+  || ! { docker compose version >/dev/null 2>&1 \
+    || sudo -n docker compose version >/dev/null 2>&1; }; then
+  sudo -n apt-get update
+  sudo -n env DEBIAN_FRONTEND=noninteractive NEEDRESTART_SUSPEND=1 \
+    apt-get install -y ca-certificates curl docker.io docker-compose-v2
+fi
+
+if ! docker info >/dev/null 2>&1 && ! sudo -n docker info >/dev/null 2>&1; then
+  sudo -n systemctl start docker
+fi
+
+if [[ -z "${AKB_E2E_DOCKER_ARGV:-}" ]]; then
+  if docker info >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    export AKB_E2E_DOCKER_ARGV="docker"
+  elif sudo -n docker info >/dev/null 2>&1 \
+    && sudo -n docker compose version >/dev/null 2>&1; then
+    export AKB_E2E_DOCKER_ARGV="sudo -n docker"
+  else
+    echo "Docker Engine with Compose is unavailable" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$DATA_ROOT/bin" "$DATA_ROOT/python" "$DATA_ROOT/cache"
+if [[ "$($UV_BIN --version 2>/dev/null || true)" != "uv $UV_VERSION" ]]; then
+  curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/$UV_VERSION/install.sh" \
+    | env UV_UNMANAGED_INSTALL="$DATA_ROOT/bin" sh
+fi
+if [[ "$($UV_BIN --version)" != "uv $UV_VERSION" ]]; then
+  echo "expected uv $UV_VERSION at $UV_BIN" >&2
+  exit 1
+fi
+
+export UV_CACHE_DIR="$DATA_ROOT/cache"
+export UV_PYTHON_INSTALL_DIR="$DATA_ROOT/python"
+export UV_PROJECT_ENVIRONMENT="$VENV"
+
+"$UV_BIN" python install 3.14
+if ! "$VENV/bin/python" -c \
+  'import sys; raise SystemExit(sys.version_info[:2] != (3, 14))' \
+  >/dev/null 2>&1; then
+  "$UV_BIN" venv --clear --python 3.14 "$VENV"
+fi
+"$UV_BIN" sync --project backend --locked --no-dev --python 3.14
+
+exec "$VENV/bin/python" backend/scripts/ci/e2e_runtime.py "$@"

--- a/backend/scripts/ci/bootstrap_e2e_runtime.sh
+++ b/backend/scripts/ci/bootstrap_e2e_runtime.sh
@@ -5,9 +5,14 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 
 readonly UV_VERSION="0.12.1"
+readonly UV_VERSION_PATTERN="^uv ${UV_VERSION//./\\.}( \\([^[:space:]]+\\))?$"
 readonly DATA_ROOT="${AKB_E2E_BOOTSTRAP_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/akb-e2e-bootstrap}"
 readonly UV_BIN="$DATA_ROOT/bin/uv"
 readonly VENV="$DATA_ROOT/venv"
+
+uv_version_is_expected() {
+  [[ "$1" =~ $UV_VERSION_PATTERN ]]
+}
 
 if ! command -v curl >/dev/null 2>&1 \
   || ! command -v docker >/dev/null 2>&1 \
@@ -35,11 +40,13 @@ if [[ -z "${AKB_E2E_DOCKER_ARGV:-}" ]]; then
 fi
 
 mkdir -p "$DATA_ROOT/bin" "$DATA_ROOT/python" "$DATA_ROOT/cache"
-if [[ "$($UV_BIN --version 2>/dev/null || true)" != "uv $UV_VERSION" ]]; then
+uv_output="$($UV_BIN --version 2>/dev/null || true)"
+if ! uv_version_is_expected "$uv_output"; then
   curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/$UV_VERSION/install.sh" \
     | env UV_UNMANAGED_INSTALL="$DATA_ROOT/bin" sh
 fi
-if [[ "$($UV_BIN --version)" != "uv $UV_VERSION" ]]; then
+uv_output="$($UV_BIN --version 2>/dev/null || true)"
+if ! uv_version_is_expected "$uv_output"; then
   echo "expected uv $UV_VERSION at $UV_BIN" >&2
   exit 1
 fi

--- a/backend/scripts/ci/e2e-postgres.compose.yml
+++ b/backend/scripts/ci/e2e-postgres.compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: akb
+      POSTGRES_PASSWORD: akb  # pragma: allowlist secret
+      POSTGRES_DB: akb
+    ports:
+      - "127.0.0.1:${AKB_E2E_POSTGRES_PORT:-15432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U akb"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -1001,7 +1001,10 @@ DECLARE
     table_name text;
 BEGIN
     FOR table_name IN
-        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+        SELECT tablename
+          FROM pg_tables
+         WHERE schemaname = 'public'
+           AND tablename <> 'schema_migrations'
     LOOP
         EXECUTE format('TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE', table_name);
     END LOOP;

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -458,7 +458,7 @@ async def _seed_app_lifecycle(
                         id, app_id, vault_id, desired_release_id,
                         current_release_id, lifecycle, blocked_reason,
                         grant_generation
-                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, 1)
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, 0)
                     """,
                     installation_id,
                     uuid.UUID(app["id"]),
@@ -469,22 +469,28 @@ async def _seed_app_lifecycle(
                     blocked_reason,
                 )
                 grant_id = uuid.uuid4()
-                grant_status = "revoked" if lifecycle == "uninstalled" else "active"
                 await connection.execute(
                     """
                     INSERT INTO installation_grants (
                         id, installation_id, generation, status,
                         capabilities, issuer, provenance, revoked_at
                     ) VALUES (
-                        $1, $2, 1, $3, $4, 'fixture', '{}'::jsonb,
-                        CASE WHEN $3 = 'revoked' THEN NOW() ELSE NULL END
+                        $1, $2, 1, 'active', $3, 'fixture', '{}'::jsonb, NULL
                     )
                     """,
                     grant_id,
                     installation_id,
-                    grant_status,
                     ["installation:read", "inventory:read"],
                 )
+                if lifecycle == "uninstalled":
+                    await connection.execute(
+                        """
+                        UPDATE installation_grants
+                           SET status = 'revoked', revoked_at = NOW()
+                         WHERE id = $1
+                        """,
+                        grant_id,
+                    )
                 resource_entry: dict[str, str] | None = None
                 if resource is not None:
                     resource_entry = {
@@ -1168,6 +1174,7 @@ class E2ERuntime:
         self.reset_lock = threading.Lock()
         self.ready = False
         self.failed = False
+        self.phase = "initialization"
 
     @property
     def backend_command(self) -> list[str]:
@@ -1357,19 +1364,31 @@ class E2ERuntime:
 
     def start(self) -> None:
         try:
+            self.phase = "remove_stale_artifacts"
             remove_ready_file(self.settings.ready_file)
             remove_fixture_artifacts(self.settings)
             if self.settings.manage_postgres:
+                self.phase = "postgres_start"
                 self._compose_up()
+            self.phase = "git_fixture_reset"
             clear_git_fixture_root()
+            self.phase = "database_reset"
             reset_database(self.settings.database_url)
+            self.phase = "config_write"
             write_runtime_config(self.settings, self.repo_root)
+            self.phase = "control_plane_start"
             self._start_control_server()
+            self.phase = "embedding_start"
             self.embed_process = self._start_process(self.embed_command, self.repo_root / "backend", EMBED_LOG)
+            self.phase = "embedding_ready"
             self._wait_for_embed()
+            self.phase = "backend_start"
             self._start_backend()
+            self.phase = "seed_scenario"
             manifest, credentials = seed_scenario(self.settings)
+            self.phase = "fixture_artifacts_write"
             write_fixture_artifacts(self.settings, manifest, credentials)
+            self.phase = "ready_file_write"
             self._write_ready()
         except BaseException:
             self.shutdown()
@@ -1377,14 +1396,21 @@ class E2ERuntime:
 
     def reset(self) -> None:
         with self.reset_lock:
+            self.phase = "backend_stop_for_reset"
             self._stop_backend()
             remove_fixture_artifacts(self.settings)
             try:
+                self.phase = "database_reset"
                 reset_database(self.settings.database_url)
+                self.phase = "git_fixture_reset"
                 clear_git_fixture_root()
+                self.phase = "backend_restart"
                 self._start_backend()
+                self.phase = "seed_scenario"
                 manifest, credentials = seed_scenario(self.settings)
+                self.phase = "fixture_artifacts_write"
                 write_fixture_artifacts(self.settings, manifest, credentials)
+                self.phase = "ready_file_write"
                 self._write_ready()
             except BaseException:
                 self._stop_backend()
@@ -1518,6 +1544,32 @@ class _ControlHandler(BaseHTTPRequestHandler):
         self._json(404, {"status": "not_found"})
 
 
+_SAFE_FAILURE_LABEL = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+_SAFE_SQLSTATE = re.compile(r"^[0-9A-Z]{5}$")
+
+
+def format_runtime_failure(phase: str, error: BaseException) -> str:
+    """Return stable diagnostics without serializing exception messages."""
+
+    safe_phase = phase if _SAFE_FAILURE_LABEL.fullmatch(phase) else "unknown"
+    error_class = type(error).__name__
+    safe_class = error_class if _SAFE_FAILURE_LABEL.fullmatch(error_class) else "Error"
+    fields = [f"phase={safe_phase}", f"category={safe_class}"]
+    sqlstate = getattr(error, "sqlstate", None)
+    if isinstance(sqlstate, str) and _SAFE_SQLSTATE.fullmatch(sqlstate):
+        fields.append("source=postgres")
+        fields.append(f"sqlstate={sqlstate}")
+        for attribute, label in (
+            ("constraint_name", "constraint"),
+            ("table_name", "table"),
+            ("column_name", "column"),
+        ):
+            value = getattr(error, attribute, None)
+            if isinstance(value, str) and _SAFE_FAILURE_LABEL.fullmatch(value):
+                fields.append(f"{label}={value}")
+    return "e2e runtime failed " + " ".join(fields)
+
+
 def main(argv: list[str] | None = None) -> int:
     try:
         settings = resolve_settings(argv)
@@ -1539,8 +1591,8 @@ def main(argv: list[str] | None = None) -> int:
         else:
             runtime.wait()
             exit_code = 1 if runtime.failed else 0
-    except Exception:
-        print("e2e runtime failed", file=sys.stderr)
+    except Exception as exc:
+        print(format_runtime_failure(runtime.phase, exc), file=sys.stderr)
         exit_code = 1
     finally:
         if not runtime.shutdown() and exit_code == 0:

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -70,7 +70,6 @@ CREDENTIAL_VARIABLES = (
     "AKB_E2E_WRITER_TOKEN",
     "AKB_E2E_FOREIGN_VAULT_ADMIN_TOKEN",
     "AKB_E2E_PRIMARY_APP_CREDENTIAL",
-    "AKB_E2E_PRIMARY_APP_TOKEN",
     "AKB_E2E_FOREIGN_APP_CREDENTIAL",
 )
 
@@ -786,12 +785,11 @@ async def _seed_app_lifecycle(
                         "conflict": primary_conflict_release,
                     },
                     "credential_env": CREDENTIAL_VARIABLES[5],
-                    "token_env": CREDENTIAL_VARIABLES[6],
                 },
                 "foreign": {
                     **foreign_app,
                     "releases": {"primary": foreign_release},
-                    "credential_env": CREDENTIAL_VARIABLES[7],
+                    "credential_env": CREDENTIAL_VARIABLES[6],
                 },
             },
             "vaults": {
@@ -877,12 +875,14 @@ async def _seed_app_lifecycle(
                 "app_status": {
                     "method": "GET",
                     "path": f"/api/v1/app/installations/{active_path}",
-                    "credential_env": CREDENTIAL_VARIABLES[6],
+                    "credential_env": CREDENTIAL_VARIABLES[5],
+                    "credential_exchange_task": "credential_exchange",
                 },
                 "foreign_app_status": {
                     "method": "GET",
                     "path": f"/api/v1/app/installations/{installations['foreign_active']['vault_id']}",
-                    "credential_env": CREDENTIAL_VARIABLES[7],
+                    "credential_env": CREDENTIAL_VARIABLES[6],
+                    "credential_exchange_task": "credential_exchange",
                 },
                 "credential_exchange": {
                     "method": "POST",
@@ -897,29 +897,11 @@ async def _seed_app_lifecycle(
             CREDENTIAL_VARIABLES[3]: writer_token,
             CREDENTIAL_VARIABLES[4]: foreign_token,
             CREDENTIAL_VARIABLES[5]: primary_credential,
-            CREDENTIAL_VARIABLES[7]: foreign_credential,
+            CREDENTIAL_VARIABLES[6]: foreign_credential,
         }
         return manifest, credentials
     finally:
         await connection.close()
-
-
-def _exchange_fixture_app_token(origin: str, credential: str) -> str:
-    request = Request(
-        f"{origin}/api/v1/auth/app-token",
-        data=json.dumps({"credential": credential}).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urlopen(request, timeout=10) as response:  # nosec B310
-            payload = json.loads(response.read(65536))
-    except (HTTPError, OSError, URLError, ValueError) as exc:
-        raise RuntimeError("fixture app token exchange failed") from exc
-    access_token = payload.get("access_token") if isinstance(payload, dict) else None
-    if not isinstance(access_token, str) or not access_token:
-        raise RuntimeError("fixture app token exchange returned no token")
-    return access_token
 
 
 def seed_scenario(settings: RuntimeSettings) -> tuple[dict[str, object] | None, dict[str, str] | None]:
@@ -934,10 +916,6 @@ def seed_scenario(settings: RuntimeSettings) -> tuple[dict[str, object] | None, 
             origin=settings.origin,
             fixture_origin=settings.fixture_origin,
         )
-    )
-    credentials[CREDENTIAL_VARIABLES[6]] = _exchange_fixture_app_token(
-        settings.origin,
-        credentials[CREDENTIAL_VARIABLES[5]],
     )
     return manifest, credentials
 

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -51,6 +51,9 @@ RUNTIME_TMP = Path(tempfile.gettempdir())
 DEFAULT_READY_FILE = str(RUNTIME_TMP / "akb-e2e-ready.json")
 EMBED_PORT = 8888
 BACKEND_PORT = 8000
+POSTGRES_READY_ATTEMPTS = 60
+POSTGRES_READY_INTERVAL = 1
+POSTGRES_PROBE_TIMEOUT = 2
 GIT_FIXTURE_ROOT = RUNTIME_TMP / "akb-vaults"
 EMBED_LOG = RUNTIME_TMP / "embed-stub.log"
 BACKEND_LOG = RUNTIME_TMP / "backend.log"
@@ -1044,6 +1047,24 @@ def reset_database(database_url: str) -> None:
     asyncio.run(_reset_database(database_url))
 
 
+async def _probe_postgres_connection(database_url: str) -> bool:
+    try:
+        import asyncpg
+
+        connection = await asyncpg.connect(database_url, timeout=POSTGRES_PROBE_TIMEOUT)
+    except Exception:
+        return False
+    try:
+        await connection.close()
+    except Exception:
+        return False
+    return True
+
+
+def _postgres_connection_ready(database_url: str) -> bool:
+    return asyncio.run(_probe_postgres_connection(database_url))
+
+
 def clear_git_fixture_root(root: Path = GIT_FIXTURE_ROOT) -> None:
     """Empty only the runtime-owned fixture directory, preserving the root."""
 
@@ -1246,7 +1267,7 @@ class E2ERuntime:
         )
 
     def _wait_for_postgres(self) -> None:
-        for _ in range(60):
+        for _ in range(POSTGRES_READY_ATTEMPTS):
             if self.stop_event.is_set():
                 raise RuntimeError("runtime stopped")
             containers = self._run_compose("ps", "-q", "postgres")
@@ -1259,10 +1280,11 @@ class E2ERuntime:
                     container_id,
                 )
                 if health.stdout.strip() == "healthy":
-                    return
+                    if _postgres_connection_ready(self.settings.database_url):
+                        return
                 if health.stdout.strip() in {"unhealthy", "exited", "dead"}:
                     break
-            self.stop_event.wait(1)
+            self.stop_event.wait(POSTGRES_READY_INTERVAL)
         raise RuntimeError("PostgreSQL Compose service did not become healthy")
 
     def _compose_up(self) -> None:

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -30,6 +31,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import uuid
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -43,6 +45,7 @@ DEFAULT_DATABASE_URL = "postgresql://akb:akb@localhost:15432/akb"  # pragma: all
 DEFAULT_ORIGIN = "http://localhost:8000"
 DEFAULT_FIXTURE_ORIGIN = "http://localhost:8889"
 DEFAULT_SCENARIO = "empty"
+APP_LIFECYCLE_SCENARIO = "app_lifecycle"
 DEFAULT_S3_BUCKET = "akb-files"
 RUNTIME_TMP = Path(tempfile.gettempdir())
 DEFAULT_READY_FILE = str(RUNTIME_TMP / "akb-e2e-ready.json")
@@ -55,7 +58,18 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_FILE = Path(__file__).resolve().with_name("e2e-postgres.compose.yml")
 DEFAULT_DOCKER_ARGV = "docker"
 COMPOSE_PROJECT_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
-SUPPORTED_SCENARIOS = frozenset({DEFAULT_SCENARIO})
+SUPPORTED_SCENARIOS = frozenset({DEFAULT_SCENARIO, APP_LIFECYCLE_SCENARIO})
+FIXTURE_MANIFEST_SCHEMA_VERSION = 1
+CREDENTIAL_VARIABLES = (
+    "AKB_E2E_SYSTEM_ADMIN_TOKEN",
+    "AKB_E2E_TARGET_VAULT_ADMIN_TOKEN",
+    "AKB_E2E_READER_TOKEN",
+    "AKB_E2E_WRITER_TOKEN",
+    "AKB_E2E_FOREIGN_VAULT_ADMIN_TOKEN",
+    "AKB_E2E_PRIMARY_APP_CREDENTIAL",
+    "AKB_E2E_PRIMARY_APP_TOKEN",
+    "AKB_E2E_FOREIGN_APP_CREDENTIAL",
+)
 
 
 @dataclass(frozen=True)
@@ -82,6 +96,7 @@ class RuntimeSettings:
     s3_bucket: str = ""
     s3_access_key: str = field(default="", repr=False)
     s3_secret_key: str = field(default="", repr=False)
+    app_token_secret: str = field(default="", repr=False)
 
 
 def parse_database_url(database_url: str) -> DatabaseSettings:
@@ -196,6 +211,7 @@ def render_secret_config(
     database: DatabaseSettings,
     s3_access_key: str = "",
     s3_secret_key: str = "",
+    app_token_secret: str = "",
 ) -> str:
     """Render the existing CI-only secrets without the source database URL."""
 
@@ -203,6 +219,7 @@ def render_secret_config(
         f"db_password: {_yaml_scalar(database.password)}  # pragma: allowlist secret",
         "jwt_secret: ci-only-jwt-secret-not-for-prod-use  # pragma: allowlist secret",
         "embed_api_key: ci-stub-no-auth  # pragma: allowlist secret",
+        f"app_token_secret: {_yaml_scalar(app_token_secret)}  # pragma: allowlist secret",
     ]
     if s3_access_key and s3_secret_key:
         lines.extend(
@@ -248,13 +265,701 @@ def write_runtime_config(settings: RuntimeSettings, repo_root: Path = REPO_ROOT)
     )
     _atomic_write(
         config_dir / "secret.yaml",
-        render_secret_config(database, settings.s3_access_key, settings.s3_secret_key),
+        render_secret_config(
+            database,
+            settings.s3_access_key,
+            settings.s3_secret_key,
+            settings.app_token_secret or secrets.token_urlsafe(32),
+        ),
         0o600,
     )
 
 
+def fixture_manifest_path(ready_file: Path) -> Path:
+    return ready_file.with_name(f"{ready_file.stem}.fixtures.json")
+
+
+def credential_profile_path(ready_file: Path) -> Path:
+    return ready_file.with_name(f"{ready_file.stem}.credentials.env")
+
+
+def fixture_artifact_paths(settings: RuntimeSettings) -> tuple[Path, Path]:
+    return (
+        fixture_manifest_path(settings.ready_file),
+        credential_profile_path(settings.ready_file),
+    )
+
+
+def remove_fixture_artifacts(settings: RuntimeSettings) -> None:
+    for path in fixture_artifact_paths(settings):
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def _fixture_material(prefix: str) -> tuple[str, str, str]:
+    raw = prefix + secrets.token_urlsafe(32)
+    return raw, hashlib.sha256(raw.encode()).hexdigest(), raw[:16]
+
+
+async def _seed_app_lifecycle(
+    database_url: str,
+    *,
+    origin: str,
+    fixture_origin: str,
+) -> tuple[dict[str, object], dict[str, str]]:
+    """Seed the small public lifecycle matrix in one database transaction."""
+
+    import asyncpg
+
+    namespace = secrets.token_hex(8)
+    connection = await asyncpg.connect(database_url, timeout=15)
+    try:
+        async with connection.transaction():
+            async def create_user(label: str, *, is_admin: bool = False) -> dict[str, str]:
+                user_id = uuid.uuid4()
+                username = f"e2e-{label}-{namespace}"
+                await connection.execute(
+                    """
+                    INSERT INTO users (
+                        id, username, email, password_hash, display_name,
+                        is_admin, account_status, account_kind
+                    ) VALUES ($1, $2, $3, 'fixture-disabled', $4, $5, 'active', 'human')
+                    """,
+                    user_id,
+                    username,
+                    f"{username}@example.invalid",
+                    label,
+                    is_admin,
+                )
+                return {"id": str(user_id), "username": username}
+
+            async def create_pat(
+                user: dict[str, str],
+                label: str,
+                scopes: list[str],
+            ) -> tuple[str, dict[str, str]]:
+                raw, token_hash, token_prefix = _fixture_material("akb_")
+                token_id = uuid.uuid4()
+                await connection.execute(
+                    """
+                    INSERT INTO tokens (
+                        id, user_id, name, token_hash, token_prefix,
+                        scopes, vault_scope, key_class
+                    ) VALUES ($1, $2, $3, $4, $5, $6, NULL, 'pat')
+                    """,
+                    token_id,
+                    uuid.UUID(user["id"]),
+                    f"e2e-{label}-{namespace}",
+                    token_hash,
+                    token_prefix,
+                    scopes,
+                )
+                return raw, {"id": str(token_id), "name": label}
+
+            async def create_vault(label: str, owner: dict[str, str]) -> dict[str, str]:
+                vault_id = uuid.uuid4()
+                name = f"e2e-{label}-{namespace}"
+                await connection.execute(
+                    """
+                    INSERT INTO vaults (id, name, git_path, owner_id)
+                    VALUES ($1, $2, $3, $4)
+                    """,
+                    vault_id,
+                    name,
+                    str(GIT_FIXTURE_ROOT / f"{name}.git"),
+                    uuid.UUID(owner["id"]),
+                )
+                return {"id": str(vault_id), "name": name, "owner_id": owner["id"]}
+
+            async def grant_vault(
+                vault: dict[str, str],
+                user: dict[str, str],
+                role: str,
+            ) -> None:
+                await connection.execute(
+                    """
+                    INSERT INTO vault_access (vault_id, user_id, role, granted_by)
+                    VALUES ($1, $2, $3, $2)
+                    ON CONFLICT (vault_id, user_id) DO UPDATE SET role = EXCLUDED.role
+                    """,
+                    uuid.UUID(vault["id"]),
+                    uuid.UUID(user["id"]),
+                    role,
+                )
+
+            async def create_app(label: str) -> dict[str, str]:
+                app_id = uuid.uuid4()
+                app_key = f"e2e-{label}-{namespace}"
+                await connection.execute(
+                    """
+                    INSERT INTO app_definitions (id, app_key, display_name, description)
+                    VALUES ($1, $2, $3, $4)
+                    """,
+                    app_id,
+                    app_key,
+                    f"E2E {label}",
+                    "Repository E2E lifecycle fixture",
+                )
+                return {"id": str(app_id), "app_key": app_key}
+
+            async def create_release(
+                app: dict[str, str],
+                version: str,
+                fingerprint: str,
+            ) -> dict[str, str]:
+                release_id = uuid.uuid4()
+                manifest = json.dumps(
+                    {
+                        "steps": [{"id": "prepare"}],
+                        "expected_schema_fingerprint": fingerprint,
+                    },
+                    separators=(",", ":"),
+                )
+                checksum = hashlib.sha256(manifest.encode()).hexdigest()
+                await connection.execute(
+                    """
+                    INSERT INTO app_releases (
+                        id, app_id, version, manifest, manifest_checksum
+                    ) VALUES ($1, $2, $3, $4::jsonb, $5)
+                    """,
+                    release_id,
+                    uuid.UUID(app["id"]),
+                    version,
+                    manifest,
+                    checksum,
+                )
+                return {
+                    "id": str(release_id),
+                    "version": version,
+                    "schema_fingerprint": fingerprint,
+                }
+
+            async def create_installation(
+                app: dict[str, str],
+                vault: dict[str, str],
+                release: dict[str, str],
+                *,
+                lifecycle: str,
+                resource: tuple[str, str] | None = None,
+                observed: bool = False,
+                observed_fingerprint: str | None = None,
+                blocked_reason: str | None = None,
+            ) -> dict[str, object]:
+                installation_id = uuid.uuid4()
+                desired_release_id = (
+                    uuid.UUID(release["id"]) if lifecycle != "uninstalled" else None
+                )
+                current_release_id = uuid.UUID(release["id"])
+                await connection.execute(
+                    """
+                    INSERT INTO vault_app_installations (
+                        id, app_id, vault_id, desired_release_id,
+                        current_release_id, lifecycle, blocked_reason,
+                        grant_generation
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, 1)
+                    """,
+                    installation_id,
+                    uuid.UUID(app["id"]),
+                    uuid.UUID(vault["id"]),
+                    desired_release_id,
+                    current_release_id,
+                    lifecycle,
+                    blocked_reason,
+                )
+                grant_id = uuid.uuid4()
+                grant_status = "revoked" if lifecycle == "uninstalled" else "active"
+                await connection.execute(
+                    """
+                    INSERT INTO installation_grants (
+                        id, installation_id, generation, status,
+                        capabilities, issuer, provenance, revoked_at
+                    ) VALUES (
+                        $1, $2, 1, $3, $4, 'fixture', '{}'::jsonb,
+                        CASE WHEN $3 = 'revoked' THEN NOW() ELSE NULL END
+                    )
+                    """,
+                    grant_id,
+                    installation_id,
+                    grant_status,
+                    ["installation:read", "inventory:read"],
+                )
+                resource_entry: dict[str, str] | None = None
+                if resource is not None:
+                    resource_entry = {
+                        "kind": resource[0],
+                        "key": resource[1],
+                        "status": "retained" if lifecycle == "uninstalled" else "owned",
+                    }
+                    await connection.execute(
+                        """
+                        INSERT INTO app_owned_resources (
+                            installation_id, vault_id, resource_kind,
+                            resource_key, status
+                        ) VALUES ($1, $2, $3, $4, $5)
+                        """,
+                        installation_id,
+                        uuid.UUID(vault["id"]),
+                        resource_entry["kind"],
+                        resource_entry["key"],
+                        resource_entry["status"],
+                    )
+                if observed:
+                    await connection.execute(
+                        """
+                        INSERT INTO app_installation_observed_states (
+                            installation_id, app_id, vault_id, observed_generation,
+                            observed_at, observed_release_id, observed_release_version,
+                            schema_fingerprint, observed_grant_generation,
+                            checkpoint, recent_error
+                        ) VALUES (
+                            $1, $2, $3, 1, NOW(), $4, $5, $6, 1,
+                            '{"phase":"ready"}'::jsonb, NULL
+                        )
+                        """,
+                        installation_id,
+                        uuid.UUID(app["id"]),
+                        uuid.UUID(vault["id"]),
+                        uuid.UUID(release["id"]),
+                        release["version"],
+                        observed_fingerprint or release["schema_fingerprint"],
+                    )
+                return {
+                    "id": str(installation_id),
+                    "app_id": app["id"],
+                    "vault_id": vault["id"],
+                    "release_id": release["id"],
+                    "lifecycle": lifecycle,
+                    "resource": resource_entry,
+                    "observed": observed,
+                    "observed_fingerprint": (
+                        observed_fingerprint or release["schema_fingerprint"]
+                        if observed
+                        else None
+                    ),
+                }
+
+            async def create_app_credential(
+                app: dict[str, str],
+                deployment: str,
+                *,
+                status: str = "active",
+            ) -> tuple[str | None, dict[str, str]]:
+                raw, credential_hash, credential_prefix = _fixture_material("akb_app_")
+                credential_id = uuid.uuid4()
+                await connection.execute(
+                    """
+                    INSERT INTO app_credentials (
+                        id, app_id, deployment, generation, credential_hash,
+                        credential_prefix, status, overlap_until, revoked_at
+                    ) VALUES (
+                        $1, $2, $3, 1, $4, $5, $6,
+                        CASE WHEN $6 = 'rotated' THEN NOW() - INTERVAL '1 second' ELSE NULL END,
+                        CASE WHEN $6 = 'revoked' THEN NOW() ELSE NULL END
+                    )
+                    """,
+                    credential_id,
+                    uuid.UUID(app["id"]),
+                    deployment,
+                    credential_hash,
+                    credential_prefix,
+                    status,
+                )
+                metadata = {
+                    "id": str(credential_id),
+                    "app_id": app["id"],
+                    "deployment": deployment,
+                    "status": status,
+                }
+                return (raw if status == "active" else None), metadata
+
+            system_admin = await create_user("system-admin", is_admin=True)
+            vault_admin = await create_user("vault-admin")
+            reader = await create_user("reader")
+            writer = await create_user("writer")
+            foreign_admin = await create_user("foreign-admin")
+
+            system_token, system_token_meta = await create_pat(
+                system_admin, "system-admin", ["read", "write", "admin"]
+            )
+            vault_token, vault_token_meta = await create_pat(
+                vault_admin, "vault-admin", ["read", "write", "admin"]
+            )
+            reader_token, reader_token_meta = await create_pat(
+                reader, "reader", ["read"]
+            )
+            writer_token, writer_token_meta = await create_pat(
+                writer, "writer", ["read", "write"]
+            )
+            foreign_token, foreign_token_meta = await create_pat(
+                foreign_admin, "foreign-admin", ["read", "write", "admin"]
+            )
+
+            target_active = await create_vault("target-active", vault_admin)
+            target_install = await create_vault("target-install", vault_admin)
+            target_blocked = await create_vault("target-blocked", vault_admin)
+            target_restore_compatible = await create_vault("target-restore-compatible", vault_admin)
+            target_restore_mismatch = await create_vault("target-restore-mismatch", vault_admin)
+            target_restore_unknown = await create_vault("target-restore-unknown", vault_admin)
+            target_fresh_collision = await create_vault("target-fresh-collision", vault_admin)
+            target_fresh_empty = await create_vault("target-fresh-empty", vault_admin)
+            foreign_vault = await create_vault("foreign", foreign_admin)
+            for vault in (
+                target_active,
+                target_install,
+                target_blocked,
+                target_restore_compatible,
+                target_restore_mismatch,
+                target_restore_unknown,
+                target_fresh_collision,
+                target_fresh_empty,
+            ):
+                await grant_vault(vault, reader, "reader")
+                await grant_vault(vault, writer, "writer")
+
+            primary_app = await create_app("primary")
+            foreign_app = await create_app("foreign")
+            primary_release = await create_release(primary_app, "1.0.0", "a" * 64)
+            primary_conflict_release = await create_release(primary_app, "2.0.0", "a" * 64)
+            foreign_release = await create_release(foreign_app, "1.0.0", "b" * 64)
+
+            installations = {
+                "active": await create_installation(
+                    primary_app,
+                    target_active,
+                    primary_release,
+                    lifecycle="active",
+                    resource=("managed_table", f"owned-{namespace}"),
+                    observed=True,
+                ),
+                "blocked": await create_installation(
+                    primary_app,
+                    target_blocked,
+                    primary_release,
+                    lifecycle="blocked",
+                    resource=("managed_table", f"blocked-{namespace}"),
+                    observed=True,
+                    blocked_reason="worker_timeout",
+                ),
+                "restore_compatible": await create_installation(
+                    primary_app,
+                    target_restore_compatible,
+                    primary_release,
+                    lifecycle="uninstalled",
+                    resource=("managed_table", f"restore-compatible-{namespace}"),
+                    observed=True,
+                ),
+                "restore_mismatch": await create_installation(
+                    primary_app,
+                    target_restore_mismatch,
+                    primary_release,
+                    lifecycle="uninstalled",
+                    resource=("managed_table", f"restore-mismatch-{namespace}"),
+                    observed=True,
+                    observed_fingerprint="c" * 64,
+                ),
+                "restore_unknown": await create_installation(
+                    primary_app,
+                    target_restore_unknown,
+                    primary_release,
+                    lifecycle="uninstalled",
+                    resource=("managed_table", f"restore-unknown-{namespace}"),
+                ),
+                "fresh_retained": await create_installation(
+                    primary_app,
+                    target_fresh_collision,
+                    primary_release,
+                    lifecycle="uninstalled",
+                    resource=("managed_table", f"fresh-retained-{namespace}"),
+                ),
+                "fresh_empty": await create_installation(
+                    primary_app,
+                    target_fresh_empty,
+                    primary_release,
+                    lifecycle="uninstalled",
+                ),
+                "foreign_active": await create_installation(
+                    foreign_app,
+                    foreign_vault,
+                    foreign_release,
+                    lifecycle="active",
+                    resource=("managed_table", f"foreign-{namespace}"),
+                    observed=True,
+                ),
+            }
+
+            primary_credential, primary_credential_meta = await create_app_credential(
+                primary_app, "production"
+            )
+            foreign_credential, foreign_credential_meta = await create_app_credential(
+                foreign_app, "production"
+            )
+            _, stale_credential_meta = await create_app_credential(
+                primary_app, "stale", status="rotated"
+            )
+            _, revoked_credential_meta = await create_app_credential(
+                primary_app, "revoked", status="revoked"
+            )
+
+        assert primary_credential is not None
+        assert foreign_credential is not None
+        primary_app_path = primary_app["id"]
+        install_path = target_install["id"]
+        active_path = target_active["id"]
+        manifest: dict[str, object] = {
+            "schema_version": FIXTURE_MANIFEST_SCHEMA_VERSION,
+            "scenario": APP_LIFECYCLE_SCENARIO,
+            "namespace": namespace,
+            "origin": origin,
+            "fixture_origin": fixture_origin,
+            "reset_url": f"{fixture_origin}/__e2e/reset",
+            "credential_variables": list(CREDENTIAL_VARIABLES),
+            "actors": {
+                "system_admin": {
+                    **system_admin,
+                    "token_env": CREDENTIAL_VARIABLES[0],
+                    "roles": ["system_admin"],
+                    "token_id": system_token_meta["id"],
+                },
+                "vault_admin": {
+                    **vault_admin,
+                    "token_env": CREDENTIAL_VARIABLES[1],
+                    "roles": ["owner", "admin", "writer"],
+                    "token_id": vault_token_meta["id"],
+                    "vault_ids": [
+                        target_active["id"],
+                        target_install["id"],
+                        target_blocked["id"],
+                        target_restore_compatible["id"],
+                        target_restore_mismatch["id"],
+                        target_restore_unknown["id"],
+                        target_fresh_collision["id"],
+                        target_fresh_empty["id"],
+                    ],
+                },
+                "reader": {
+                    **reader,
+                    "token_env": CREDENTIAL_VARIABLES[2],
+                    "roles": ["reader"],
+                    "token_id": reader_token_meta["id"],
+                    "vault_ids": [target_active["id"], target_install["id"]],
+                },
+                "writer": {
+                    **writer,
+                    "token_env": CREDENTIAL_VARIABLES[3],
+                    "roles": ["writer"],
+                    "token_id": writer_token_meta["id"],
+                    "vault_ids": [
+                        target_active["id"],
+                        target_install["id"],
+                        target_blocked["id"],
+                        target_restore_compatible["id"],
+                        target_restore_mismatch["id"],
+                        target_restore_unknown["id"],
+                        target_fresh_collision["id"],
+                        target_fresh_empty["id"],
+                    ],
+                },
+                "foreign_admin": {
+                    **foreign_admin,
+                    "token_env": CREDENTIAL_VARIABLES[4],
+                    "roles": ["owner", "admin", "writer"],
+                    "token_id": foreign_token_meta["id"],
+                    "vault_ids": [foreign_vault["id"]],
+                },
+            },
+            "apps": {
+                "primary": {
+                    **primary_app,
+                    "releases": {
+                        "primary": primary_release,
+                        "conflict": primary_conflict_release,
+                    },
+                    "credential_env": CREDENTIAL_VARIABLES[5],
+                    "token_env": CREDENTIAL_VARIABLES[6],
+                },
+                "foreign": {
+                    **foreign_app,
+                    "releases": {"primary": foreign_release},
+                    "credential_env": CREDENTIAL_VARIABLES[7],
+                },
+            },
+            "vaults": {
+                "active": target_active,
+                "install": target_install,
+                "blocked": target_blocked,
+                "restore_compatible": target_restore_compatible,
+                "restore_mismatch": target_restore_mismatch,
+                "restore_unknown": target_restore_unknown,
+                "fresh_retained": target_fresh_collision,
+                "fresh_empty": target_fresh_empty,
+                "foreign": foreign_vault,
+            },
+            "installations": installations,
+            "credentials": {
+                "primary": primary_credential_meta,
+                "foreign": foreign_credential_meta,
+                "stale": stale_credential_meta,
+                "revoked": revoked_credential_meta,
+            },
+            "endpoint_tasks": {
+                "install": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{install_path}",
+                    "release_id": primary_release["id"],
+                    "capabilities": ["installation:read"],
+                },
+                "replay": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{install_path}",
+                    "release_id": primary_release["id"],
+                    "capabilities": ["installation:read"],
+                },
+                "conflict": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{install_path}",
+                    "release_id": primary_conflict_release["id"],
+                    "capabilities": ["installation:read"],
+                },
+                "active_status": {
+                    "method": "GET",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{active_path}",
+                },
+                "uninstall": {
+                    "method": "DELETE",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{active_path}",
+                },
+                "restore_compatible": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{installations['restore_compatible']['vault_id']}",
+                    "release_id": primary_release["id"],
+                    "capabilities": ["installation:read"],
+                    "mode": "restore",
+                },
+                "restore_mismatch": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{installations['restore_mismatch']['vault_id']}",
+                    "release_id": primary_release["id"],
+                    "capabilities": ["installation:read"],
+                    "mode": "restore",
+                },
+                "restore_unknown": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{installations['restore_unknown']['vault_id']}",
+                    "release_id": primary_release["id"],
+                    "capabilities": ["installation:read"],
+                    "mode": "restore",
+                },
+                "fresh_retained": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{installations['fresh_retained']['vault_id']}",
+                    "release_id": primary_conflict_release["id"],
+                    "capabilities": ["installation:read"],
+                    "mode": "fresh",
+                },
+                "fresh_empty": {
+                    "method": "PUT",
+                    "path": f"/api/v1/apps/{primary_app_path}/installations/{installations['fresh_empty']['vault_id']}",
+                    "release_id": primary_conflict_release["id"],
+                    "capabilities": ["installation:read"],
+                    "mode": "fresh",
+                },
+                "app_status": {
+                    "method": "GET",
+                    "path": f"/api/v1/app/installations/{active_path}",
+                    "credential_env": CREDENTIAL_VARIABLES[6],
+                },
+                "foreign_app_status": {
+                    "method": "GET",
+                    "path": f"/api/v1/app/installations/{installations['foreign_active']['vault_id']}",
+                    "credential_env": CREDENTIAL_VARIABLES[7],
+                },
+                "credential_exchange": {
+                    "method": "POST",
+                    "path": "/api/v1/auth/app-token",
+                },
+            },
+        }
+        credentials = {
+            CREDENTIAL_VARIABLES[0]: system_token,
+            CREDENTIAL_VARIABLES[1]: vault_token,
+            CREDENTIAL_VARIABLES[2]: reader_token,
+            CREDENTIAL_VARIABLES[3]: writer_token,
+            CREDENTIAL_VARIABLES[4]: foreign_token,
+            CREDENTIAL_VARIABLES[5]: primary_credential,
+            CREDENTIAL_VARIABLES[7]: foreign_credential,
+        }
+        return manifest, credentials
+    finally:
+        await connection.close()
+
+
+def _exchange_fixture_app_token(origin: str, credential: str) -> str:
+    request = Request(
+        f"{origin}/api/v1/auth/app-token",
+        data=json.dumps({"credential": credential}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=10) as response:  # nosec B310
+            payload = json.loads(response.read(65536))
+    except (HTTPError, OSError, URLError, ValueError) as exc:
+        raise RuntimeError("fixture app token exchange failed") from exc
+    access_token = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(access_token, str) or not access_token:
+        raise RuntimeError("fixture app token exchange returned no token")
+    return access_token
+
+
+def seed_scenario(settings: RuntimeSettings) -> tuple[dict[str, object] | None, dict[str, str] | None]:
+    remove_fixture_artifacts(settings)
+    if settings.scenario == DEFAULT_SCENARIO:
+        return None, None
+    if settings.scenario != APP_LIFECYCLE_SCENARIO:
+        raise ValueError("unsupported E2E scenario")
+    manifest, credentials = asyncio.run(
+        _seed_app_lifecycle(
+            settings.database_url,
+            origin=settings.origin,
+            fixture_origin=settings.fixture_origin,
+        )
+    )
+    credentials[CREDENTIAL_VARIABLES[6]] = _exchange_fixture_app_token(
+        settings.origin,
+        credentials[CREDENTIAL_VARIABLES[5]],
+    )
+    return manifest, credentials
+
+
+def write_fixture_artifacts(
+    settings: RuntimeSettings,
+    manifest: dict[str, object] | None,
+    credentials: dict[str, str] | None,
+) -> None:
+    if manifest is None or credentials is None:
+        return
+    manifest_path, profile_path = fixture_artifact_paths(settings)
+    manifest_content = json.dumps(
+        manifest,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ) + "\n"
+    profile_content = "".join(
+        f"{name}={shlex.quote(credentials[name])}\n" for name in CREDENTIAL_VARIABLES
+    )
+    _atomic_write(manifest_path, manifest_content, 0o600)
+    try:
+        _atomic_write(profile_path, profile_content, 0o600)
+    except BaseException:
+        remove_fixture_artifacts(settings)
+        raise
+
+
 def ready_payload(settings: RuntimeSettings) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "schema_version": 1,
         "status": "ready",
         "origin": settings.origin,
@@ -262,10 +967,30 @@ def ready_payload(settings: RuntimeSettings) -> dict[str, object]:
         "reset_url": f"{settings.fixture_origin}/__e2e/reset",
         "scenario": settings.scenario,
     }
+    if settings.scenario == APP_LIFECYCLE_SCENARIO:
+        manifest_path, profile_path = fixture_artifact_paths(settings)
+        payload.update(
+            {
+                "fixture_manifest": str(manifest_path),
+                "credential_profile": str(profile_path),
+                "credential_variables": list(CREDENTIAL_VARIABLES),
+            }
+        )
+    return payload
 
 
 def reset_payload(settings: RuntimeSettings) -> dict[str, object]:
-    return {"ok": True, "scenario": settings.scenario}
+    payload: dict[str, object] = {"ok": True, "scenario": settings.scenario}
+    if settings.scenario == APP_LIFECYCLE_SCENARIO:
+        manifest_path, profile_path = fixture_artifact_paths(settings)
+        payload.update(
+            {
+                "fixture_manifest": str(manifest_path),
+                "credential_profile": str(profile_path),
+                "credential_variables": list(CREDENTIAL_VARIABLES),
+            }
+        )
+    return payload
 
 
 def write_ready_file(path: Path, payload: Mapping[str, object]) -> None:
@@ -559,6 +1284,7 @@ class E2ERuntime:
             "AKB_E2E_DATABASE_URL",
             "AKB_E2E_S3_ACCESS_KEY",
             "AKB_E2E_S3_SECRET_KEY",
+            *CREDENTIAL_VARIABLES,
         ):
             environment.pop(key, None)
         return environment
@@ -622,7 +1348,6 @@ class E2ERuntime:
     def _start_backend(self) -> None:
         self.backend_process = self._start_process(self.backend_command, self.repo_root, BACKEND_LOG)
         self._wait_for_backend()
-        self._write_ready()
 
     def _stop_backend(self) -> None:
         self.ready = False
@@ -633,6 +1358,7 @@ class E2ERuntime:
     def start(self) -> None:
         try:
             remove_ready_file(self.settings.ready_file)
+            remove_fixture_artifacts(self.settings)
             if self.settings.manage_postgres:
                 self._compose_up()
             clear_git_fixture_root()
@@ -642,6 +1368,9 @@ class E2ERuntime:
             self.embed_process = self._start_process(self.embed_command, self.repo_root / "backend", EMBED_LOG)
             self._wait_for_embed()
             self._start_backend()
+            manifest, credentials = seed_scenario(self.settings)
+            write_fixture_artifacts(self.settings, manifest, credentials)
+            self._write_ready()
         except BaseException:
             self.shutdown()
             raise
@@ -649,10 +1378,14 @@ class E2ERuntime:
     def reset(self) -> None:
         with self.reset_lock:
             self._stop_backend()
+            remove_fixture_artifacts(self.settings)
             try:
                 reset_database(self.settings.database_url)
                 clear_git_fixture_root()
                 self._start_backend()
+                manifest, credentials = seed_scenario(self.settings)
+                write_fixture_artifacts(self.settings, manifest, credentials)
+                self._write_ready()
             except BaseException:
                 self._stop_backend()
                 raise
@@ -709,6 +1442,7 @@ class E2ERuntime:
         self.ready = False
         try:
             remove_ready_file(self.settings.ready_file)
+            remove_fixture_artifacts(self.settings)
             if self.control_server is not None:
                 self.control_server.shutdown()
                 self.control_server.server_close()

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -1532,7 +1532,11 @@ class _ControlHandler(BaseHTTPRequestHandler):
         if path == "/__e2e/reset":
             try:
                 self.runtime.reset()
-            except BaseException:
+            except BaseException as exc:
+                print(
+                    format_runtime_failure(self.runtime.phase, exc),
+                    file=sys.stderr,
+                )
                 self._json(500, {"status": "reset_failed"})
                 return
             self._json(200, reset_payload(self.runtime.settings))

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -1339,7 +1339,8 @@ class E2ERuntime:
             status, body = _http_get(f"{self.settings.origin}/readyz")
             if status == 200:
                 try:
-                    if isinstance(json.loads(body), dict) and "status" in json.loads(body):
+                    payload = json.loads(body)
+                    if isinstance(payload, dict) and payload.get("status") == "ready":
                         return
                 except (TypeError, ValueError):
                     pass
@@ -1361,6 +1362,35 @@ class E2ERuntime:
         remove_ready_file(self.settings.ready_file)
         _terminate_process_group(self.backend_process)
         self.backend_process = None
+
+    def _managed_postgres_alive(self) -> bool:
+        containers = self._run_compose("ps", "-q", "postgres")
+        container_id = containers.stdout.strip()
+        if not container_id:
+            return False
+        state = self._run_docker(
+            "inspect",
+            "--format",
+            "{{.State.Status}} {{.State.Health.Status}}",
+            container_id,
+        )
+        return state.stdout.strip() == "running healthy"
+
+    def _dependencies_alive(self) -> bool:
+        with self.reset_lock:
+            if self.embed_process is None or self.embed_process.poll() is not None:
+                self.phase = "embedding_runtime"
+            elif self.backend_process is None or self.backend_process.poll() is not None:
+                self.phase = "backend_runtime"
+            elif self.settings.manage_postgres and not self._managed_postgres_alive():
+                self.phase = "postgres_runtime"
+            else:
+                return True
+            self.failed = True
+            self.ready = False
+            remove_ready_file(self.settings.ready_file)
+            self.stop_event.set()
+            return False
 
     def start(self) -> None:
         try:
@@ -1448,6 +1478,9 @@ class E2ERuntime:
         )
         try:
             while self.suite_process.poll() is None:
+                if not self._dependencies_alive():
+                    _terminate_process_group(self.suite_process)
+                    return 1
                 if self.stop_event.wait(0.5):
                     _terminate_process_group(self.suite_process)
                     return 130
@@ -1457,11 +1490,8 @@ class E2ERuntime:
 
     def wait(self) -> None:
         while not self.stop_event.wait(0.5):
-            for process in (self.embed_process, self.backend_process):
-                if process is not None and process.poll() is not None:
-                    self.failed = True
-                    self.stop_event.set()
-                    break
+            if not self._dependencies_alive():
+                return
 
     def shutdown(self) -> bool:
         cleanup_ok = True

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -1,0 +1,818 @@
+"""Project-neutral foreground runtime for the repository's HTTP E2E suites.
+
+The runtime keeps the CI topology deliberately small: it starts the existing
+embedding stub and backend against an externally supplied PostgreSQL service.
+The process itself is the supervisor.  Its fixture control plane is local-only
+and is separate from the product API:
+
+* ``GET /__e2e/health`` reports runtime health.
+* ``GET /__e2e/ready`` returns the public ready payload.
+* ``POST /__e2e/reset`` empties the external database and Git fixture root,
+  then restarts the same backend command.
+* ``POST /__e2e/stop`` requests graceful supervisor shutdown.
+
+The database URL is kept in memory only.  It is never written to generated
+configuration, the ready artifact, or runtime output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import secrets
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urlsplit
+from urllib.request import Request, urlopen
+
+
+DEFAULT_DATABASE_URL = "postgresql://akb:akb@localhost:15432/akb"  # pragma: allowlist secret
+DEFAULT_ORIGIN = "http://localhost:8000"
+DEFAULT_FIXTURE_ORIGIN = "http://localhost:8889"
+DEFAULT_SCENARIO = "empty"
+DEFAULT_S3_BUCKET = "akb-files"
+RUNTIME_TMP = Path(tempfile.gettempdir())
+DEFAULT_READY_FILE = str(RUNTIME_TMP / "akb-e2e-ready.json")
+EMBED_PORT = 8888
+BACKEND_PORT = 8000
+GIT_FIXTURE_ROOT = RUNTIME_TMP / "akb-vaults"
+EMBED_LOG = RUNTIME_TMP / "embed-stub.log"
+BACKEND_LOG = RUNTIME_TMP / "backend.log"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_FILE = Path(__file__).resolve().with_name("e2e-postgres.compose.yml")
+DEFAULT_DOCKER_ARGV = "docker"
+COMPOSE_PROJECT_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+SUPPORTED_SCENARIOS = frozenset({DEFAULT_SCENARIO})
+
+
+@dataclass(frozen=True)
+class DatabaseSettings:
+    host: str
+    port: int
+    name: str
+    user: str
+    password: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    database_url: str = field(repr=False)
+    origin: str = DEFAULT_ORIGIN
+    fixture_origin: str = DEFAULT_FIXTURE_ORIGIN
+    scenario: str = DEFAULT_SCENARIO
+    ready_file: Path = field(default_factory=lambda: Path(DEFAULT_READY_FILE))
+    run_suites: bool = False
+    manage_postgres: bool = False
+    compose_project: str = ""
+    docker_argv: tuple[str, ...] = ("docker",)
+    s3_endpoint: str = ""
+    s3_bucket: str = ""
+    s3_access_key: str = field(default="", repr=False)
+    s3_secret_key: str = field(default="", repr=False)
+
+
+def parse_database_url(database_url: str) -> DatabaseSettings:
+    """Extract only the fields needed by the existing app config."""
+
+    parsed = urlsplit(database_url)
+    if parsed.scheme not in {"postgres", "postgresql"} or not parsed.hostname:
+        raise ValueError("invalid database URL")
+    try:
+        port = parsed.port or 5432
+    except ValueError as exc:
+        raise ValueError("invalid database URL") from exc
+    name = parsed.path.lstrip("/")
+    if not name or not parsed.username:
+        raise ValueError("invalid database URL")
+    return DatabaseSettings(
+        host=parsed.hostname,
+        port=port,
+        name=unquote(name),
+        user=unquote(parsed.username),
+        password=unquote(parsed.password or ""),
+    )
+
+
+def _validate_compose_project(project: str) -> str:
+    if not COMPOSE_PROJECT_PATTERN.fullmatch(project):
+        raise ValueError("invalid compose project")
+    return project
+
+
+def _resolve_compose_project(value: str | None) -> str:
+    project = value or f"akb-e2e-{os.getpid()}-{secrets.token_hex(4)}"
+    return _validate_compose_project(project)
+
+
+def _resolve_docker_argv(value: str | None) -> tuple[str, ...]:
+    try:
+        argv = tuple(shlex.split(value or DEFAULT_DOCKER_ARGV))
+    except ValueError as exc:
+        raise ValueError("invalid docker argv") from exc
+    if not argv:
+        raise ValueError("docker argv is empty")
+    return argv
+
+
+def _validate_managed_database(database: DatabaseSettings) -> None:
+    if (
+        database.host not in {"localhost", "127.0.0.1"}
+        or database.name != "akb"
+        or database.user != "akb"
+        or database.password != "akb"  # pragma: allowlist secret
+    ):
+        raise ValueError("managed database must use the CI PostgreSQL settings")
+
+
+def _resolve_s3_settings(environ: Mapping[str, str]) -> tuple[str, str, str, str]:
+    endpoint = (environ.get("AKB_E2E_S3_ENDPOINT") or "").strip()
+    bucket = (environ.get("AKB_E2E_S3_BUCKET") or "").strip()
+    access_key = environ.get("AKB_E2E_S3_ACCESS_KEY") or ""
+    secret_key = environ.get("AKB_E2E_S3_SECRET_KEY") or ""
+    if not endpoint:
+        if any((bucket, access_key, secret_key)):
+            raise ValueError("S3 settings require an endpoint")
+        return "", "", "", ""
+    _validate_origin(endpoint)
+    bucket = bucket or DEFAULT_S3_BUCKET
+    if not bucket or any(char.isspace() for char in bucket):
+        raise ValueError("invalid S3 bucket")
+    if not access_key or not secret_key:
+        raise ValueError("S3 credentials are incomplete")
+    return endpoint, bucket, access_key, secret_key
+
+
+def _yaml_scalar(value: object) -> str:
+    text = str(value)
+    if text and all(char.isalnum() or char in "._/-:" for char in text):
+        return text
+    return json.dumps(text)
+
+
+def render_app_config(
+    database: DatabaseSettings,
+    origin: str,
+    s3_endpoint: str = "",
+    s3_bucket: str = "",
+) -> str:
+    """Render the same CI app settings that were previously inline in YAML."""
+
+    lines = [
+        f"db_host: {_yaml_scalar(database.host)}",
+        f"db_port: {database.port}",
+        f"db_name: {_yaml_scalar(database.name)}",
+        f"db_user: {_yaml_scalar(database.user)}",
+        f"public_base_url: {_yaml_scalar(origin)}",
+        "git_storage_path: /tmp/akb-vaults",
+        "vector_store_driver: pgvector",
+        "embed_base_url: http://localhost:8888/v1",
+        "embed_model: ci-embed-stub",
+        "embed_dimensions: 1536",
+        'llm_base_url: ""',
+        'llm_model: ""',
+        "rerank_enabled: false",
+        f"s3_endpoint_url: {_yaml_scalar(s3_endpoint)}" if s3_endpoint else 's3_endpoint_url: ""',
+    ]
+    if s3_endpoint:
+        lines.append(f"s3_bucket: {_yaml_scalar(s3_bucket)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_secret_config(
+    database: DatabaseSettings,
+    s3_access_key: str = "",
+    s3_secret_key: str = "",
+) -> str:
+    """Render the existing CI-only secrets without the source database URL."""
+
+    lines = [
+        f"db_password: {_yaml_scalar(database.password)}  # pragma: allowlist secret",
+        "jwt_secret: ci-only-jwt-secret-not-for-prod-use  # pragma: allowlist secret",
+        "embed_api_key: ci-stub-no-auth  # pragma: allowlist secret",
+    ]
+    if s3_access_key and s3_secret_key:
+        lines.extend(
+            [
+                f"s3_access_key: {_yaml_scalar(s3_access_key)}  # pragma: allowlist secret",
+                f"s3_secret_key: {_yaml_scalar(s3_secret_key)}  # pragma: allowlist secret",
+            ]
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary_name, path)
+        os.chmod(path, mode)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def write_runtime_config(settings: RuntimeSettings, repo_root: Path = REPO_ROOT) -> None:
+    database = parse_database_url(settings.database_url)
+    config_dir = repo_root / "config"
+    _atomic_write(
+        config_dir / "app.yaml",
+        render_app_config(database, settings.origin, settings.s3_endpoint, settings.s3_bucket),
+        0o644,
+    )
+    _atomic_write(
+        config_dir / "secret.yaml",
+        render_secret_config(database, settings.s3_access_key, settings.s3_secret_key),
+        0o600,
+    )
+
+
+def ready_payload(settings: RuntimeSettings) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": "ready",
+        "origin": settings.origin,
+        "fixture_origin": settings.fixture_origin,
+        "reset_url": f"{settings.fixture_origin}/__e2e/reset",
+        "scenario": settings.scenario,
+    }
+
+
+def reset_payload(settings: RuntimeSettings) -> dict[str, object]:
+    return {"ok": True, "scenario": settings.scenario}
+
+
+def write_ready_file(path: Path, payload: Mapping[str, object]) -> None:
+    content = json.dumps(dict(payload), sort_keys=True, separators=(",", ":")) + "\n"
+    _atomic_write(path, content, 0o600)
+
+
+def remove_ready_file(path: Path) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+def render_database_reset_sql() -> str:
+    """Return a schema-neutral reset for the externally provided CI database."""
+
+    return """
+DO $$
+DECLARE
+    table_name text;
+BEGIN
+    FOR table_name IN
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+    LOOP
+        EXECUTE format('TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE', table_name);
+    END LOOP;
+END
+$$;
+DROP SCHEMA IF EXISTS vector_index CASCADE;
+""".strip()
+
+
+async def _reset_database(database_url: str) -> None:
+    import asyncpg
+
+    connection = await asyncpg.connect(database_url, timeout=10)
+    try:
+        await connection.execute(render_database_reset_sql())
+    finally:
+        await connection.close()
+
+
+def reset_database(database_url: str) -> None:
+    asyncio.run(_reset_database(database_url))
+
+
+def clear_git_fixture_root(root: Path = GIT_FIXTURE_ROOT) -> None:
+    """Empty only the runtime-owned fixture directory, preserving the root."""
+
+    root.mkdir(parents=True, exist_ok=True)
+    for child in root.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+    os.chmod(root, 0o700)
+
+
+def _validate_origin(value: str, *, allow_ephemeral_port: bool = False) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"localhost", "127.0.0.1"}
+        or parsed.username
+        or parsed.password
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("origin must be a local HTTP origin")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("origin has an invalid port") from exc
+    if port is None or (port == 0 and not allow_ephemeral_port):
+        raise ValueError("origin must include a port")
+    return value.rstrip("/")
+
+
+def resolve_settings(argv: list[str] | None = None, environ: Mapping[str, str] | None = None) -> RuntimeSettings:
+    env = os.environ if environ is None else environ
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", default=env.get("AKB_E2E_SCENARIO") or DEFAULT_SCENARIO)
+    parser.add_argument("--ready-file", default=env.get("AKB_E2E_READY_FILE") or DEFAULT_READY_FILE)
+    parser.add_argument(
+        "--run-suites",
+        action="store_true",
+        help="run the repository-owned HTTP suite after readiness, then exit",
+    )
+    parser.add_argument(
+        "--manage-postgres",
+        action="store_true",
+        help="own the repository's PostgreSQL-only Compose service for this run",
+    )
+    args = parser.parse_args(argv)
+
+    scenario = args.scenario or DEFAULT_SCENARIO
+    if scenario not in SUPPORTED_SCENARIOS:
+        raise ValueError("unsupported E2E scenario")
+    database_url = env.get("AKB_E2E_DATABASE_URL") or DEFAULT_DATABASE_URL
+    database = parse_database_url(database_url)
+    if args.manage_postgres:
+        _validate_managed_database(database)
+    s3_endpoint, s3_bucket, s3_access_key, s3_secret_key = _resolve_s3_settings(env)
+    return RuntimeSettings(
+        database_url=database_url,
+        origin=_validate_origin(env.get("AKB_E2E_ORIGIN") or DEFAULT_ORIGIN),
+        fixture_origin=_validate_origin(env.get("AKB_E2E_FIXTURE_ORIGIN") or DEFAULT_FIXTURE_ORIGIN),
+        scenario=scenario,
+        ready_file=Path(args.ready_file).expanduser().resolve(),
+        run_suites=args.run_suites,
+        manage_postgres=args.manage_postgres,
+        compose_project=_resolve_compose_project(env.get("AKB_E2E_COMPOSE_PROJECT")),
+        docker_argv=_resolve_docker_argv(env.get("AKB_E2E_DOCKER_ARGV")),
+        s3_endpoint=s3_endpoint,
+        s3_bucket=s3_bucket,
+        s3_access_key=s3_access_key,
+        s3_secret_key=s3_secret_key,
+    )
+
+
+def _http_get(url: str) -> tuple[int, bytes]:
+    request = Request(url, method="GET")
+    try:
+        # Callers pass only fixed or _validate_origin-checked loopback URLs.
+        with urlopen(request, timeout=2) as response:  # nosec B310
+            return response.status, response.read(65536)
+    except HTTPError as exc:
+        return exc.code, b""
+    except (OSError, URLError):
+        return 0, b""
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    try:
+        process_group = os.getpgid(process.pid)
+    except ProcessLookupError:
+        return
+    try:
+        if process_group == os.getpgrp():
+            process.terminate()
+        else:
+            os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            if process_group == os.getpgrp():
+                process.kill()
+            else:
+                os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        process.wait(timeout=5)
+
+
+class E2ERuntime:
+    """Own the stub, backend, local fixture control plane, and their cleanup."""
+
+    def __init__(self, settings: RuntimeSettings, repo_root: Path = REPO_ROOT):
+        self.settings = settings
+        self.repo_root = repo_root
+        self.embed_process: subprocess.Popen[bytes] | None = None
+        self.backend_process: subprocess.Popen[bytes] | None = None
+        self.suite_process: subprocess.Popen[bytes] | None = None
+        self.compose_started = False
+        self.control_server: ThreadingHTTPServer | None = None
+        self.control_thread: threading.Thread | None = None
+        self.stop_event = threading.Event()
+        self.reset_lock = threading.Lock()
+        self.ready = False
+        self.failed = False
+
+    @property
+    def backend_command(self) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "app.main:app",
+            "--app-dir",
+            "backend",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(BACKEND_PORT),
+        ]
+
+    @property
+    def embed_command(self) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "scripts.ci.embed_stub:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(EMBED_PORT),
+        ]
+
+    def compose_argv(self, *arguments: str) -> list[str]:
+        if not self.settings.manage_postgres:
+            raise RuntimeError("PostgreSQL Compose is not enabled")
+        project = _validate_compose_project(self.settings.compose_project)
+        return [
+            *self.settings.docker_argv,
+            "compose",
+            "--project-name",
+            project,
+            "--file",
+            str(COMPOSE_FILE),
+            *arguments,
+        ]
+
+    def _compose_environment(self) -> dict[str, str]:
+        database = parse_database_url(self.settings.database_url)
+        _validate_managed_database(database)
+        environment = self._child_environment()
+        environment["AKB_E2E_POSTGRES_PORT"] = str(database.port)
+        return environment
+
+    def _run_compose(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            self.compose_argv(*arguments),
+            cwd=self.repo_root,
+            env=self._compose_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _run_docker(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [*self.settings.docker_argv, *arguments],
+            cwd=self.repo_root,
+            env=self._compose_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _wait_for_postgres(self) -> None:
+        for _ in range(60):
+            if self.stop_event.is_set():
+                raise RuntimeError("runtime stopped")
+            containers = self._run_compose("ps", "-q", "postgres")
+            container_id = containers.stdout.strip()
+            if container_id:
+                health = self._run_docker(
+                    "inspect",
+                    "--format",
+                    "{{.State.Health.Status}}",
+                    container_id,
+                )
+                if health.stdout.strip() == "healthy":
+                    return
+                if health.stdout.strip() in {"unhealthy", "exited", "dead"}:
+                    break
+            self.stop_event.wait(1)
+        raise RuntimeError("PostgreSQL Compose service did not become healthy")
+
+    def _compose_up(self) -> None:
+        # Mark ownership before the command so partial `up` state is cleaned
+        # by the same project-scoped `down` in the failure path.
+        self.compose_started = True
+        result = self._run_compose("up", "--detach")
+        if result.returncode != 0:
+            raise RuntimeError("PostgreSQL Compose startup failed")
+        self._wait_for_postgres()
+
+    def _compose_down(self) -> bool:
+        if not self.compose_started:
+            return True
+        try:
+            result = self._run_compose("down", "--volumes", "--remove-orphans")
+        except Exception:
+            self.compose_started = False
+            return False
+        self.compose_started = False
+        return result.returncode == 0
+
+    def _child_environment(self) -> dict[str, str]:
+        environment = os.environ.copy()
+        for key in (
+            "AKB_E2E_DATABASE_URL",
+            "AKB_E2E_S3_ACCESS_KEY",
+            "AKB_E2E_S3_SECRET_KEY",
+        ):
+            environment.pop(key, None)
+        return environment
+
+    def _start_process(self, command: list[str], cwd: Path, log_path: Path) -> subprocess.Popen[bytes]:
+        with log_path.open("ab") as log:
+            return subprocess.Popen(
+                command,
+                cwd=cwd,
+                env=self._child_environment(),
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+
+    def _start_control_server(self) -> None:
+        parsed = urlsplit(self.settings.fixture_origin)
+        assert parsed.port is not None
+        handler = type("E2EControlHandler", (_ControlHandler,), {"runtime": self})
+        self.control_server = ThreadingHTTPServer(("127.0.0.1", parsed.port), handler)
+        self.control_server.daemon_threads = True
+        self.control_thread = threading.Thread(
+            target=self.control_server.serve_forever,
+            name="e2e-control",
+            daemon=True,
+        )
+        self.control_thread.start()
+
+    def _wait_for_embed(self) -> None:
+        for _ in range(20):
+            if self.stop_event.is_set():
+                raise RuntimeError("runtime stopped")
+            status, _ = _http_get("http://127.0.0.1:8888/healthz")
+            if status == 200:
+                return
+            if self.embed_process is not None and self.embed_process.poll() is not None:
+                break
+            self.stop_event.wait(1)
+        raise RuntimeError("embedding stub did not become ready")
+
+    def _wait_for_backend(self) -> None:
+        for _ in range(45):
+            if self.stop_event.is_set():
+                raise RuntimeError("runtime stopped")
+            status, body = _http_get(f"{self.settings.origin}/readyz")
+            if status == 200:
+                try:
+                    if isinstance(json.loads(body), dict) and "status" in json.loads(body):
+                        return
+                except (TypeError, ValueError):
+                    pass
+            if self.backend_process is not None and self.backend_process.poll() is not None:
+                break
+            self.stop_event.wait(2)
+        raise RuntimeError("backend did not become ready")
+
+    def _write_ready(self) -> None:
+        write_ready_file(self.settings.ready_file, ready_payload(self.settings))
+        self.ready = True
+
+    def _start_backend(self) -> None:
+        self.backend_process = self._start_process(self.backend_command, self.repo_root, BACKEND_LOG)
+        self._wait_for_backend()
+        self._write_ready()
+
+    def _stop_backend(self) -> None:
+        self.ready = False
+        remove_ready_file(self.settings.ready_file)
+        _terminate_process_group(self.backend_process)
+        self.backend_process = None
+
+    def start(self) -> None:
+        try:
+            remove_ready_file(self.settings.ready_file)
+            if self.settings.manage_postgres:
+                self._compose_up()
+            clear_git_fixture_root()
+            reset_database(self.settings.database_url)
+            write_runtime_config(self.settings, self.repo_root)
+            self._start_control_server()
+            self.embed_process = self._start_process(self.embed_command, self.repo_root / "backend", EMBED_LOG)
+            self._wait_for_embed()
+            self._start_backend()
+        except BaseException:
+            self.shutdown()
+            raise
+
+    def reset(self) -> None:
+        with self.reset_lock:
+            self._stop_backend()
+            try:
+                reset_database(self.settings.database_url)
+                clear_git_fixture_root()
+                self._start_backend()
+            except BaseException:
+                self._stop_backend()
+                raise
+
+    def request_stop(self) -> None:
+        self.stop_event.set()
+
+    def suite_environment(self) -> dict[str, str]:
+        database = parse_database_url(self.settings.database_url)
+        environment = self._child_environment()
+        if self.settings.manage_postgres:
+            _validate_managed_database(database)
+            pg_exec = shlex.join(self.compose_argv("exec", "-T", "postgres"))
+            environment.pop("PGPASSWORD", None)
+        else:
+            pg_exec = f"env PGHOST={shlex.quote(database.host)} PGPORT={database.port}"
+            environment["PGPASSWORD"] = database.password
+        environment.update(
+            {
+                "AKB_URL": self.settings.origin,
+                "AKB_PG_EXEC": pg_exec,
+                "AKB_PG_USER": database.user,
+                "AKB_PG_DB": database.name,
+            }
+        )
+        return environment
+
+    def run_suites(self) -> int:
+        self.suite_process = subprocess.Popen(
+            ["bash", str(self.repo_root / "backend/scripts/ci/run_e2e_suites.sh")],
+            cwd=self.repo_root,
+            env=self.suite_environment(),
+            start_new_session=True,
+        )
+        try:
+            while self.suite_process.poll() is None:
+                if self.stop_event.wait(0.5):
+                    _terminate_process_group(self.suite_process)
+                    return 130
+            return self.suite_process.returncode or 0
+        finally:
+            self.suite_process = None
+
+    def wait(self) -> None:
+        while not self.stop_event.wait(0.5):
+            for process in (self.embed_process, self.backend_process):
+                if process is not None and process.poll() is not None:
+                    self.failed = True
+                    self.stop_event.set()
+                    break
+
+    def shutdown(self) -> bool:
+        cleanup_ok = True
+        self.ready = False
+        try:
+            remove_ready_file(self.settings.ready_file)
+            if self.control_server is not None:
+                self.control_server.shutdown()
+                self.control_server.server_close()
+                self.control_server = None
+            if self.control_thread is not None:
+                self.control_thread.join(timeout=5)
+                self.control_thread = None
+        except Exception:
+            cleanup_ok = False
+        for process in (self.suite_process, self.backend_process, self.embed_process):
+            try:
+                _terminate_process_group(process)
+            except Exception:
+                cleanup_ok = False
+        self.backend_process = None
+        self.embed_process = None
+        if not self._compose_down():
+            cleanup_ok = False
+        return cleanup_ok
+
+    def health_response(self) -> tuple[int, dict[str, object]]:
+        healthy = self.ready and not self.stop_event.is_set()
+        if self.backend_process is not None and self.backend_process.poll() is not None:
+            healthy = False
+        return (200 if healthy else 503), {"status": "ok" if healthy else "starting"}
+
+    def ready_response(self) -> tuple[int, dict[str, object]]:
+        if not self.ready:
+            return 503, {"status": "starting"}
+        return 200, ready_payload(self.settings)
+
+
+class _ControlHandler(BaseHTTPRequestHandler):
+    runtime: E2ERuntime
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _json(self, status: int, payload: Mapping[str, object]) -> None:
+        body = json.dumps(dict(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?", 1)[0]
+        if path == "/__e2e/health":
+            status, payload = self.runtime.health_response()
+            self._json(status, payload)
+            return
+        if path == "/__e2e/ready":
+            status, payload = self.runtime.ready_response()
+            self._json(status, payload)
+            return
+        self._json(404, {"status": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = self.path.split("?", 1)[0]
+        if path == "/__e2e/reset":
+            try:
+                self.runtime.reset()
+            except BaseException:
+                self._json(500, {"status": "reset_failed"})
+                return
+            self._json(200, reset_payload(self.runtime.settings))
+            return
+        if path == "/__e2e/stop":
+            self.runtime.request_stop()
+            self._json(202, {"status": "stopping"})
+            return
+        self._json(404, {"status": "not_found"})
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        settings = resolve_settings(argv)
+        runtime = E2ERuntime(settings)
+    except (ValueError, OSError):
+        print("e2e runtime configuration failed", file=sys.stderr)
+        return 2
+
+    def handle_signal(_signum: int, _frame: Any) -> None:
+        runtime.request_stop()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+    exit_code = 1
+    try:
+        runtime.start()
+        if settings.run_suites:
+            exit_code = runtime.run_suites()
+        else:
+            runtime.wait()
+            exit_code = 1 if runtime.failed else 0
+    except Exception:
+        print("e2e runtime failed", file=sys.stderr)
+        exit_code = 1
+    finally:
+        if not runtime.shutdown() and exit_code == 0:
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/ci/run_e2e_suites.sh
+++ b/backend/scripts/ci/run_e2e_suites.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run the repository's HTTP-only CI E2E suite with the existing aggregation semantics.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+# Curated subset of CLAUDE.md's canonical list — every suite here exercises
+# the HTTP/MCP surface end-to-end without needing the npm proxy or a real
+# embedding provider.
+#
+# Deferred (need follow-up PRs):
+#   - test_defensive_e2e.sh — its "search after delete" assertion relies on
+#     the embedding pipeline producing unique vectors per document; our CI
+#     stub returns a fixed vector for every input, so cosine similarity is
+#     constant and a deleted doc still scores as a near-hit until the
+#     vector_delete_outbox drains. Wire MinIO + a real embedding provider (or
+#     a smarter stub) to re-enable.
+#   - test_concurrency_repro_e2e.sh — T10 posts a publication body with
+#     mode:"live" which the publication model now rejects as extra_forbidden
+#     ("mode" is output-only since the live/snapshot rewrite). Fix the test in
+#     its own PR, then re-enable.
+SUITES=(
+  test_probes_e2e.sh
+  test_mcp_e2e.sh
+  test_edit_e2e.sh
+  test_security_edge_e2e.sh
+  test_pg_rbac_e2e.sh
+  test_graph_replace_e2e.sh
+  test_relations_rest_e2e.sh
+  test_collection_lifecycle_e2e.sh
+  test_history_rest_e2e.sh
+  test_jwt_revocation_e2e.sh
+  test_table_constraints_e2e.sh
+  test_forbidden_permission_code_e2e.sh
+  test_okf_export_import_e2e.sh
+)
+
+# The GitHub workflow also provides MinIO for the publication suites.  The
+# PostgreSQL-only Apple VM profile deliberately leaves this unset, so it
+# keeps the original suite set without pretending S3 is available.
+if [ -n "${AKB_E2E_S3_ENDPOINT:-}" ]; then
+  SUITES+=(
+    test_publication_resolution_e2e.sh
+    test_publications_e2e.sh
+  )
+fi
+
+TOTAL_PASS=0
+TOTAL_FAIL=0
+FAILED=()
+for s in "${SUITES[@]}"; do
+  echo "::group::$s"
+  OUT=$(bash "backend/tests/$s" 2>&1) && RC=0 || RC=$?
+  echo "$OUT" | tail -80
+  # Match both summary styles: some suites prefix with a box-drawing
+  # "║ Results:" line, others use bare "Results:" with leading whitespace.
+  SUMMARY=$(echo "$OUT" | grep -E '(║.*)?Results: *[0-9]+ passed' | tail -1)
+  P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+' || echo 0)
+  F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+' || echo 0)
+  TOTAL_PASS=$((TOTAL_PASS + ${P:-0}))
+  TOTAL_FAIL=$((TOTAL_FAIL + ${F:-0}))
+  echo "::endgroup::"
+  echo "▸ $s: ${P:-0} passed, ${F:-0} failed (rc=$RC)"
+  if [ "$RC" != "0" ] || [ "${F:-0}" != "0" ]; then
+    FAILED+=("$s")
+  fi
+done
+
+echo ""
+echo "═════════════════════════════════════════"
+echo "TOTAL: $TOTAL_PASS passed, $TOTAL_FAIL failed"
+echo "═════════════════════════════════════════"
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "FAILED SUITES:"
+  for s in "${FAILED[@]}"; do echo "  - $s"; done
+  exit 1
+fi

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ import.
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -30,7 +31,13 @@ _EXAMPLE_APP_YAML = _REPO_ROOT / "config" / "app.yaml.example"
 
 if not _BACKEND_APP_YAML.exists() and _EXAMPLE_APP_YAML.exists():
     _BACKEND_CFG_DIR.mkdir(parents=True, exist_ok=True)
-    _BACKEND_APP_YAML.write_text(_EXAMPLE_APP_YAML.read_text())
+    _BACKEND_APP_YAML.write_text(
+        _EXAMPLE_APP_YAML.read_text().replace(
+            "git_storage_path: /data/vaults",
+            f"git_storage_path: {tempfile.mkdtemp(prefix='akb-test-vaults-')}",
+            1,
+        )
+    )
 
 
 @pytest.fixture

--- a/backend/tests/test_app_lifecycle_postgres.py
+++ b/backend/tests/test_app_lifecycle_postgres.py
@@ -1,0 +1,533 @@
+"""Live PostgreSQL contract for app installation lifecycle commands."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import json
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.exceptions import ConflictError, ForbiddenError, ValidationError
+from app.services import app_lifecycle_service as lifecycle
+from app.services.app_identity_service import AppPrincipal
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATIONS = [
+    _BACKEND / "app" / "db" / "migrations" / "047_app_registry.py",
+    _BACKEND / "app" / "db" / "migrations" / "051_app_credentials.py",
+    _BACKEND / "app" / "db" / "migrations" / "052_app_inventory.py",
+]
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"Required PostgreSQL is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_app_lifecycle_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=12)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(_INIT_SQL)
+            for path in _MIGRATIONS:
+                await _load_migration(path).migrate(conn=conn)
+        yield pool
+    finally:
+        await pool.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+@pytest.fixture
+async def lifecycle_pool(monkeypatch):
+    async with _fresh_database() as pool:
+        monkeypatch.setattr(lifecycle, "get_pool", lambda: pool)
+        yield pool
+
+
+async def _app(pool, label: str) -> uuid.UUID:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "INSERT INTO app_definitions (app_key) VALUES ($1) RETURNING id",
+            f"{label}-{uuid.uuid4().hex}",
+        )
+
+
+async def _vault(pool, label: str) -> uuid.UUID:
+    name = f"{label}-{uuid.uuid4().hex[:12]}"
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+            name,
+            f"/tmp/{name}.git",
+        )
+
+
+async def _release(
+    pool,
+    app_id: uuid.UUID,
+    version: str,
+    *,
+    fingerprint: str | None = "a" * 64,
+) -> uuid.UUID:
+    manifest = {"steps": [{"id": "prepare"}]}
+    if fingerprint is not None:
+        manifest["expected_schema_fingerprint"] = fingerprint
+    encoded = json.dumps(manifest, separators=(",", ":"))
+    checksum = hashlib.sha256(encoded.encode()).hexdigest()
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            INSERT INTO app_releases (app_id, version, manifest, manifest_checksum)
+            VALUES ($1, $2, $3::jsonb, $4)
+            RETURNING id
+            """,
+            app_id,
+            version,
+            encoded,
+            checksum,
+        )
+
+
+async def _fixture_installation(
+    pool,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    release_id: uuid.UUID,
+    *,
+    lifecycle_name: str = "active",
+    capabilities: list[str] | None = None,
+    resource: tuple[str, str] | None = None,
+) -> uuid.UUID:
+    capabilities = capabilities or ["installation:read"]
+    async with pool.acquire() as conn:
+        installation_id = await conn.fetchval(
+            """
+            INSERT INTO vault_app_installations (
+                app_id, vault_id, desired_release_id, current_release_id, lifecycle
+            ) VALUES ($1, $2, $3, $3, $4)
+            RETURNING id
+            """,
+            app_id,
+            vault_id,
+            release_id,
+            lifecycle_name,
+        )
+        await conn.execute(
+            """
+            INSERT INTO installation_grants (
+                installation_id, generation, capabilities, issuer
+            ) VALUES ($1, 1, $2, 'fixture')
+            """,
+            installation_id,
+            capabilities,
+        )
+        if resource is not None:
+            await conn.execute(
+                """
+                INSERT INTO app_owned_resources (
+                    installation_id, vault_id, resource_kind, resource_key
+                ) VALUES ($1, $2, $3, $4)
+                """,
+                installation_id,
+                vault_id,
+                resource[0],
+                resource[1],
+            )
+    return installation_id
+
+
+async def _observed(
+    pool,
+    installation_id: uuid.UUID,
+    app_id: uuid.UUID,
+    vault_id: uuid.UUID,
+    release_id: uuid.UUID,
+    *,
+    fingerprint: str = "a" * 64,
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO app_installation_observed_states (
+                installation_id, app_id, vault_id, observed_generation,
+                observed_at, observed_release_id, observed_release_version,
+                schema_fingerprint, observed_grant_generation, checkpoint,
+                recent_error
+            ) VALUES (
+                $1, $2, $3, 2, NOW(), $4, '1.0.0', $5, 1,
+                '{"phase":"ready","token":"secret-marker"}'::jsonb,
+                '{"code":"worker_timeout","message":"secret-marker"}'::jsonb
+            )
+            """,
+            installation_id,
+            app_id,
+            vault_id,
+            release_id,
+            fingerprint,
+        )
+
+
+def _actor() -> dict[str, str]:
+    return {"correlation_id": str(uuid.uuid4()), "actor": "operator", "actor_id": str(uuid.uuid4())}
+
+
+def _principal(app_id: uuid.UUID) -> AppPrincipal:
+    return AppPrincipal(
+        app_id=app_id,
+        credential_id=uuid.uuid4(),
+        credential_generation=1,
+        deployment="test",
+        token_id="token-id",
+        expires_at=None,  # type: ignore[arg-type]
+    )
+
+
+async def _put(pool, app_id, vault_id, release_id, capabilities=None, mode="install"):
+    return await lifecycle.put_installation(
+        app_id,
+        vault_id,
+        release_id=release_id,
+        capabilities=capabilities or ["installation:read"],
+        mode=mode,
+        **_actor(),
+    )
+
+
+async def test_install_is_atomic_and_exact_replay_is_stable(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "install")
+    vault_id = await _vault(lifecycle_pool, "install")
+    release_id = await _release(lifecycle_pool, app_id, "1.0.0")
+
+    first = await _put(lifecycle_pool, app_id, vault_id, release_id)
+    replay = await _put(lifecycle_pool, app_id, vault_id, release_id)
+
+    assert first["command_status"] == "accepted"
+    assert first["replayed"] is False
+    assert first["lifecycle"] == "installing"
+    assert first["grant_generation"] == 1
+    assert replay["command_status"] == "already_applied"
+    assert replay["replayed"] is True
+    assert replay["installation_id"] == first["installation_id"]
+    assert replay["grant_generation"] == first["grant_generation"]
+
+    app_view = await lifecycle.get_installation_status_for_app(
+        _principal(app_id),
+        vault_id=vault_id,
+        correlation_id=str(uuid.uuid4()),
+    )
+    assert app_view["lifecycle"] == "installing"
+    assert app_view["command_status"] == "not_applicable"
+
+    async with lifecycle_pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_app_installations WHERE app_id = $1 AND vault_id = $2",
+            app_id,
+            vault_id,
+        ) == 1
+        assert await conn.fetchval(
+            "SELECT count(*) FROM installation_grants WHERE installation_id = $1",
+            uuid.UUID(first["installation_id"]),
+        ) == 1
+
+
+async def test_same_request_concurrency_has_one_winner_and_conflict_is_atomic(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "concurrent")
+    vault_id = await _vault(lifecycle_pool, "concurrent")
+    release_a = await _release(lifecycle_pool, app_id, "1.0.0")
+    release_b = await _release(lifecycle_pool, app_id, "2.0.0")
+
+    same_results = await asyncio.gather(
+        *[_put(lifecycle_pool, app_id, vault_id, release_a) for _ in range(6)]
+    )
+    assert sum(not result["replayed"] for result in same_results) == 1
+    assert len({result["installation_id"] for result in same_results}) == 1
+    assert {result["grant_generation"] for result in same_results} == {1}
+
+    conflict_results = await asyncio.gather(
+        _put(lifecycle_pool, app_id, vault_id, release_a),
+        _put(lifecycle_pool, app_id, vault_id, release_b),
+        return_exceptions=True,
+    )
+    assert sum(isinstance(result, ConflictError) for result in conflict_results) == 1
+    assert sum(isinstance(result, dict) for result in conflict_results) == 1
+
+    async with lifecycle_pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_app_installations WHERE app_id = $1 AND vault_id = $2",
+            app_id,
+            vault_id,
+        ) == 1
+        assert await conn.fetchval(
+            "SELECT count(*) FROM installation_grants WHERE installation_id = "
+            "(SELECT id FROM vault_app_installations WHERE app_id = $1 AND vault_id = $2)",
+            app_id,
+            vault_id,
+        ) == 1
+
+
+async def test_invalid_and_foreign_release_leave_no_partial_state(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "foreign")
+    foreign_app_id = await _app(lifecycle_pool, "other")
+    vault_id = await _vault(lifecycle_pool, "foreign")
+    foreign_release = await _release(lifecycle_pool, foreign_app_id, "1.0.0")
+
+    with pytest.raises(ConflictError):
+        await _put(lifecycle_pool, app_id, vault_id, foreign_release)
+
+    with pytest.raises(ValidationError):
+        await _put(
+            lifecycle_pool,
+            app_id,
+            vault_id,
+            uuid.uuid4(),
+            capabilities=["documents:write"],
+        )
+
+    async with lifecycle_pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_app_installations WHERE app_id = $1 AND vault_id = $2",
+            app_id,
+            vault_id,
+        ) == 0
+
+
+async def test_uninstall_revokes_and_retains_then_replays_without_deletion(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "uninstall")
+    vault_id = await _vault(lifecycle_pool, "uninstall")
+    release_id = await _release(lifecycle_pool, app_id, "1.0.0")
+    installation_id = await _fixture_installation(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        resource=("collection", "retained-key"),
+    )
+
+    first = await lifecycle.uninstall_installation(
+        app_id, vault_id, **_actor()
+    )
+    replay = await lifecycle.uninstall_installation(
+        app_id, vault_id, **_actor()
+    )
+
+    assert first["lifecycle"] == "uninstalled"
+    assert first["command_status"] == "accepted"
+    assert replay["command_status"] == "already_applied"
+    assert replay["grant_generation"] == first["grant_generation"] == 1
+
+    async with lifecycle_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT desired_release_id, current_release_id, lifecycle FROM vault_app_installations WHERE id = $1",
+            installation_id,
+        )
+        assert row["desired_release_id"] is None
+        assert row["current_release_id"] == release_id
+        assert row["lifecycle"] == "uninstalled"
+        assert await conn.fetchval(
+            "SELECT status FROM installation_grants WHERE installation_id = $1 AND generation = 1",
+            installation_id,
+        ) == "revoked"
+        assert await conn.fetchval(
+            "SELECT status FROM app_owned_resources WHERE installation_id = $1",
+            installation_id,
+        ) == "retained"
+
+    with pytest.raises(ForbiddenError):
+        await lifecycle.get_installation_status_for_app(
+            _principal(app_id),
+            vault_id=vault_id,
+            correlation_id=str(uuid.uuid4()),
+        )
+
+
+async def test_restore_requires_compatibility_and_creates_next_grant(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "restore")
+    vault_id = await _vault(lifecycle_pool, "restore")
+    release_id = await _release(lifecycle_pool, app_id, "1.0.0")
+    installation_id = await _fixture_installation(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        resource=("table", "retained-key"),
+    )
+    await _observed(lifecycle_pool, installation_id, app_id, vault_id, release_id)
+    await lifecycle.uninstall_installation(app_id, vault_id, **_actor())
+
+    restored = await _put(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        mode="restore",
+    )
+    replay = await _put(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        mode="restore",
+    )
+
+    assert restored["lifecycle"] == "active"
+    assert restored["grant_generation"] == 2
+    assert restored["command_status"] == "accepted"
+    assert replay["command_status"] == "already_applied"
+    assert "secret-marker" not in json.dumps(restored)
+    assert restored["checkpoint"] == {"phase": "ready"}
+    assert restored["recent_error"] == {"code": "worker_timeout"}
+
+    async with lifecycle_pool.acquire() as conn:
+        grants = await conn.fetch(
+            "SELECT generation, status FROM installation_grants WHERE installation_id = $1 ORDER BY generation",
+            installation_id,
+        )
+        assert [(row["generation"], row["status"]) for row in grants] == [
+            (1, "revoked"),
+            (2, "active"),
+        ]
+        assert await conn.fetchval(
+            "SELECT status FROM app_owned_resources WHERE installation_id = $1",
+            installation_id,
+        ) == "owned"
+
+
+async def test_restore_mismatch_and_fresh_collision_preserve_state(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "rollback")
+    vault_id = await _vault(lifecycle_pool, "rollback")
+    release_id = await _release(lifecycle_pool, app_id, "1.0.0")
+    installation_id = await _fixture_installation(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        resource=("table", "retained-key"),
+    )
+    await _observed(
+        lifecycle_pool,
+        installation_id,
+        app_id,
+        vault_id,
+        release_id,
+        fingerprint="b" * 64,
+    )
+    await lifecycle.uninstall_installation(app_id, vault_id, **_actor())
+
+    async with lifecycle_pool.acquire() as conn:
+        before = await conn.fetchrow(
+            """
+            SELECT i.desired_release_id, i.current_release_id, i.lifecycle,
+                   i.grant_generation,
+                   (SELECT count(*) FROM installation_grants g WHERE g.installation_id = i.id) AS grants,
+                   (SELECT jsonb_agg(jsonb_build_object('status', r.status) ORDER BY r.id)
+                      FROM app_owned_resources r WHERE r.installation_id = i.id) AS resources
+              FROM vault_app_installations i
+             WHERE i.id = $1
+            """,
+            installation_id,
+        )
+
+    with pytest.raises(ConflictError):
+        await _put(lifecycle_pool, app_id, vault_id, release_id, mode="restore")
+
+    async with lifecycle_pool.acquire() as conn:
+        after = await conn.fetchrow(
+            """
+            SELECT i.desired_release_id, i.current_release_id, i.lifecycle,
+                   i.grant_generation,
+                   (SELECT count(*) FROM installation_grants g WHERE g.installation_id = i.id) AS grants,
+                   (SELECT jsonb_agg(jsonb_build_object('status', r.status) ORDER BY r.id)
+                      FROM app_owned_resources r WHERE r.installation_id = i.id) AS resources
+              FROM vault_app_installations i
+             WHERE i.id = $1
+            """,
+            installation_id,
+        )
+    assert dict(after) == dict(before)
+
+    with pytest.raises(ConflictError):
+        await _put(lifecycle_pool, app_id, vault_id, release_id, mode="fresh")
+    async with lifecycle_pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT lifecycle FROM vault_app_installations WHERE id = $1",
+            installation_id,
+        ) == "uninstalled"
+        assert await conn.fetchval(
+            "SELECT count(*) FROM app_owned_resources WHERE installation_id = $1",
+            installation_id,
+        ) == 1
+
+
+async def test_fresh_without_retained_resources_clears_old_current_pointer(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "fresh")
+    vault_id = await _vault(lifecycle_pool, "fresh")
+    old_release = await _release(lifecycle_pool, app_id, "1.0.0")
+    new_release = await _release(lifecycle_pool, app_id, "2.0.0")
+    await _fixture_installation(lifecycle_pool, app_id, vault_id, old_release)
+    await lifecycle.uninstall_installation(app_id, vault_id, **_actor())
+
+    fresh = await _put(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        new_release,
+        mode="fresh",
+    )
+    assert fresh["lifecycle"] == "installing"
+    assert fresh["grant_generation"] == 2
+    assert fresh["desired_release"]["id"] == str(new_release)
+    assert fresh["current_release"] is None
+
+    async with lifecycle_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT desired_release_id, current_release_id, lifecycle
+              FROM vault_app_installations
+             WHERE app_id = $1 AND vault_id = $2
+            """,
+            app_id,
+            vault_id,
+        )
+        assert row["desired_release_id"] == new_release
+        assert row["current_release_id"] is None
+        assert row["lifecycle"] == "installing"

--- a/backend/tests/test_app_lifecycle_postgres.py
+++ b/backend/tests/test_app_lifecycle_postgres.py
@@ -624,7 +624,6 @@ async def test_runtime_seed_passes_registry_triggers_and_rotates_runtime_artifac
         first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[5]],
         correlation_id="runtime-seed-proof",
     )
-    first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] = first_token["access_token"]
     e2e_runtime.write_fixture_artifacts(settings, first_manifest, first_credentials)
     e2e_runtime.write_ready_file(settings.ready_file, e2e_runtime.ready_payload(settings))
 
@@ -661,7 +660,7 @@ async def test_runtime_seed_passes_registry_triggers_and_rotates_runtime_artifac
         second_credentials[e2e_runtime.CREDENTIAL_VARIABLES[5]],
         correlation_id="runtime-reset-proof",
     )
-    second_credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] = second_token["access_token"]
+    assert isinstance(second_token["access_token"], str)
     e2e_runtime.write_fixture_artifacts(settings, second_manifest, second_credentials)
     e2e_runtime.write_ready_file(settings.ready_file, e2e_runtime.ready_payload(settings))
 

--- a/backend/tests/test_app_lifecycle_postgres.py
+++ b/backend/tests/test_app_lifecycle_postgres.py
@@ -15,8 +15,10 @@ import asyncpg
 import pytest
 
 from app.exceptions import ConflictError, ForbiddenError, ValidationError
+from app.services import app_identity_service
 from app.services import app_lifecycle_service as lifecycle
 from app.services.app_identity_service import AppPrincipal
+from scripts.ci import e2e_runtime
 
 pytestmark = pytest.mark.asyncio
 
@@ -56,7 +58,7 @@ def _load_migration(path: Path):
 
 
 @asynccontextmanager
-async def _fresh_database():
+async def _fresh_database(*, include_dsn: bool = False):
     if not await _can_connect():
         if os.environ.get("REQUIRE_REAL_PG") == "1":
             pytest.fail(f"Required PostgreSQL is not reachable at {_DSN}")
@@ -70,7 +72,7 @@ async def _fresh_database():
             await conn.execute(_INIT_SQL)
             for path in _MIGRATIONS:
                 await _load_migration(path).migrate(conn=conn)
-        yield pool
+        yield (pool, _database_dsn(name)) if include_dsn else pool
     finally:
         await pool.close()
         await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
@@ -82,6 +84,18 @@ async def lifecycle_pool(monkeypatch):
     async with _fresh_database() as pool:
         monkeypatch.setattr(lifecycle, "get_pool", lambda: pool)
         yield pool
+
+
+@pytest.fixture
+async def runtime_database(monkeypatch):
+    async with _fresh_database(include_dsn=True) as database:
+        pool, dsn = database
+
+        async def get_pool():
+            return pool
+
+        monkeypatch.setattr(app_identity_service, "get_pool", get_pool)
+        yield pool, dsn
 
 
 async def _app(pool, label: str) -> uuid.UUID:
@@ -580,3 +594,82 @@ async def test_fresh_without_retained_resources_clears_old_current_pointer(lifec
         assert row["desired_release_id"] == new_release
         assert row["current_release_id"] is None
         assert row["lifecycle"] == "installing"
+
+
+async def test_runtime_seed_passes_registry_triggers_and_rotates_runtime_artifacts(
+    runtime_database,
+    monkeypatch,
+    tmp_path,
+):
+    pool, dsn = runtime_database
+    git_root = tmp_path / "vaults"
+    monkeypatch.setattr(e2e_runtime, "GIT_FIXTURE_ROOT", git_root)
+    monkeypatch.setattr(
+        app_identity_service,
+        "_configured_app_secret",
+        lambda: "test-app-signing-key",
+    )
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=dsn,
+        scenario=e2e_runtime.APP_LIFECYCLE_SCENARIO,
+        ready_file=tmp_path / "ready.json",
+    )
+
+    first_manifest, first_credentials = await e2e_runtime._seed_app_lifecycle(
+        dsn,
+        origin=settings.origin,
+        fixture_origin=settings.fixture_origin,
+    )
+    first_token = await app_identity_service.exchange_app_credential(
+        first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[5]],
+        correlation_id="runtime-seed-proof",
+    )
+    first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] = first_token["access_token"]
+    e2e_runtime.write_fixture_artifacts(settings, first_manifest, first_credentials)
+    e2e_runtime.write_ready_file(settings.ready_file, e2e_runtime.ready_payload(settings))
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT i.lifecycle, i.grant_generation, g.generation, g.status
+              FROM vault_app_installations AS i
+              JOIN installation_grants AS g ON g.installation_id = i.id
+             ORDER BY i.id, g.generation
+            """
+        )
+    assert len(rows) == 8
+    assert all(row["generation"] == 1 for row in rows)
+    assert sum(row["status"] == "active" for row in rows) == 3
+    assert sum(row["status"] == "revoked" for row in rows) == 5
+    assert all(row["grant_generation"] == 1 for row in rows)
+    assert isinstance(first_token["access_token"], str)
+    assert settings.ready_file.exists()
+
+    first_namespace = first_manifest["namespace"]
+    first_profile = e2e_runtime.credential_profile_path(settings.ready_file).read_text()
+    e2e_runtime.remove_ready_file(settings.ready_file)
+    e2e_runtime.remove_fixture_artifacts(settings)
+    await e2e_runtime._reset_database(dsn)
+    e2e_runtime.clear_git_fixture_root(git_root)
+
+    second_manifest, second_credentials = await e2e_runtime._seed_app_lifecycle(
+        dsn,
+        origin=settings.origin,
+        fixture_origin=settings.fixture_origin,
+    )
+    second_token = await app_identity_service.exchange_app_credential(
+        second_credentials[e2e_runtime.CREDENTIAL_VARIABLES[5]],
+        correlation_id="runtime-reset-proof",
+    )
+    second_credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] = second_token["access_token"]
+    e2e_runtime.write_fixture_artifacts(settings, second_manifest, second_credentials)
+    e2e_runtime.write_ready_file(settings.ready_file, e2e_runtime.ready_payload(settings))
+
+    manifest_path, profile_path = e2e_runtime.fixture_artifact_paths(settings)
+    assert second_manifest["namespace"] != first_namespace
+    assert json.loads(manifest_path.read_text())["namespace"] == second_manifest["namespace"]
+    assert first_namespace not in manifest_path.read_text()
+    assert first_profile != profile_path.read_text()
+    assert os.stat(manifest_path).st_mode & 0o777 == 0o600
+    assert os.stat(profile_path).st_mode & 0o777 == 0o600
+    assert os.stat(settings.ready_file).st_mode & 0o777 == 0o600

--- a/backend/tests/test_app_lifecycle_postgres.py
+++ b/backend/tests/test_app_lifecycle_postgres.py
@@ -270,6 +270,55 @@ async def test_install_is_atomic_and_exact_replay_is_stable(lifecycle_pool):
         ) == 1
 
 
+async def test_status_projects_grant_identity_and_resource_registry(lifecycle_pool):
+    app_id = await _app(lifecycle_pool, "status-projection")
+    vault_id = await _vault(lifecycle_pool, "status-projection")
+    release_id = await _release(lifecycle_pool, app_id, "1.0.0")
+    installation_id = await _fixture_installation(
+        lifecycle_pool,
+        app_id,
+        vault_id,
+        release_id,
+        resource=("collection", "lifecycle-resource"),
+    )
+    await _observed(lifecycle_pool, installation_id, app_id, vault_id, release_id)
+
+    async with lifecycle_pool.acquire() as conn:
+        first_grant_id = await conn.fetchval(
+            "SELECT id FROM installation_grants WHERE installation_id = $1 AND generation = 1",
+            installation_id,
+        )
+
+    installed = await lifecycle.get_installation_status(app_id, vault_id)
+    assert installed["latest_grant"]["id"] == str(first_grant_id)
+    assert installed["latest_active_grant"]["id"] == str(first_grant_id)
+    assert installed["resources"] == [
+        {"kind": "collection", "key": "lifecycle-resource", "status": "owned"}
+    ]
+
+    await lifecycle.uninstall_installation(app_id, vault_id, **_actor())
+    uninstalled = await lifecycle.get_installation_status(app_id, vault_id)
+    assert uninstalled["latest_grant"]["id"] == str(first_grant_id)
+    assert uninstalled["latest_active_grant"] is None
+    assert uninstalled["resources"] == [
+        {"kind": "collection", "key": "lifecycle-resource", "status": "retained"}
+    ]
+
+    restored = await _put(lifecycle_pool, app_id, vault_id, release_id, mode="restore")
+    async with lifecycle_pool.acquire() as conn:
+        second_grant_id = await conn.fetchval(
+            "SELECT id FROM installation_grants WHERE installation_id = $1 AND generation = 2",
+            installation_id,
+        )
+    assert restored["latest_grant"]["id"] == str(second_grant_id)
+
+    restored_status = await lifecycle.get_installation_status(app_id, vault_id)
+    assert restored_status["latest_active_grant"]["id"] == str(second_grant_id)
+    assert restored_status["resources"] == [
+        {"kind": "collection", "key": "lifecycle-resource", "status": "owned"}
+    ]
+
+
 async def test_same_request_concurrency_has_one_winner_and_conflict_is_atomic(lifecycle_pool):
     app_id = await _app(lifecycle_pool, "concurrent")
     vault_id = await _vault(lifecycle_pool, "concurrent")

--- a/backend/tests/test_app_lifecycle_routes_unit.py
+++ b/backend/tests/test_app_lifecycle_routes_unit.py
@@ -1,0 +1,162 @@
+"""HTTP ownership, status, and cache contracts for lifecycle routes."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_app, get_current_user
+from app.api.routes import app_lifecycle
+from app.exceptions import AKBError, ForbiddenError
+from app.main import akb_error_handler
+from app.services.app_identity_service import AppPrincipal
+from app.services.auth_service import AuthenticatedUser
+
+
+def _user(*, is_admin: bool = True) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        username="operator",
+        email="operator@example.com",
+        display_name=None,
+        is_admin=is_admin,
+        auth_method="jwt",
+    )
+
+
+def _principal(app_id: uuid.UUID) -> AppPrincipal:
+    return AppPrincipal(
+        app_id=app_id,
+        credential_id=uuid.uuid4(),
+        credential_generation=1,
+        deployment="test",
+        token_id="token-id",
+        expires_at=None,  # type: ignore[arg-type]
+    )
+
+
+def _client(
+    *,
+    user: AuthenticatedUser | None = None,
+    principal: AppPrincipal | None = None,
+) -> TestClient:
+    app = FastAPI()
+    app.add_exception_handler(AKBError, akb_error_handler)
+    app.include_router(app_lifecycle.router, prefix="/api/v1")
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    if principal is not None:
+        app.dependency_overrides[get_current_app] = lambda: principal
+    return TestClient(app)
+
+
+def _status(*, replayed: bool = False) -> dict:
+    return {
+        "installation_id": str(uuid.uuid4()),
+        "app_id": str(uuid.uuid4()),
+        "vault_id": str(uuid.uuid4()),
+        "lifecycle": "installing",
+        "grant_generation": 1,
+        "replayed": replayed,
+        "command_status": "already_applied" if replayed else "accepted",
+    }
+
+
+def test_admin_put_returns_accepted_and_no_store(monkeypatch):
+    app_id = uuid.uuid4()
+    vault_id = uuid.uuid4()
+    release_id = uuid.uuid4()
+    auth_calls = []
+    put_calls = []
+
+    async def fake_authorize(user, **kwargs):
+        auth_calls.append((user.username, kwargs))
+
+    async def fake_put(requested_app_id, requested_vault_id, **kwargs):
+        put_calls.append((requested_app_id, requested_vault_id, kwargs))
+        return _status()
+
+    monkeypatch.setattr(app_lifecycle, "authorize_lifecycle_admin", fake_authorize)
+    monkeypatch.setattr(app_lifecycle, "put_installation", fake_put)
+    response = _client(user=_user()).put(
+        f"/api/v1/apps/{app_id}/installations/{vault_id}",
+        json={
+            "release_id": str(release_id),
+            "capabilities": ["installation:read"],
+        },
+        headers={"x-correlation-id": "route-test"},
+    )
+
+    assert response.status_code == 202
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["pragma"] == "no-cache"
+    assert auth_calls[0][1]["action"] == "app.installation.command"
+    assert put_calls[0][0:2] == (app_id, vault_id)
+    assert put_calls[0][2]["mode"] == "install"
+    assert put_calls[0][2]["correlation_id"] == "route-test"
+
+
+def test_replayed_put_returns_ok(monkeypatch):
+    async def fake_authorize(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(app_lifecycle, "authorize_lifecycle_admin", fake_authorize)
+
+    async def fake_put(*_args, **_kwargs):
+        return _status(replayed=True)
+
+    monkeypatch.setattr(app_lifecycle, "put_installation", fake_put)
+    response = _client(user=_user()).put(
+        f"/api/v1/apps/{uuid.uuid4()}/installations/{uuid.uuid4()}",
+        json={"release_id": str(uuid.uuid4()), "capabilities": ["inventory:read"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["command_status"] == "already_applied"
+
+
+def test_denied_admin_request_stops_before_service(monkeypatch):
+    called = False
+
+    async def deny(*_args, **_kwargs):
+        raise ForbiddenError("App request denied")
+
+    async def forbidden(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(app_lifecycle, "authorize_lifecycle_admin", deny)
+    monkeypatch.setattr(app_lifecycle, "put_installation", forbidden)
+    response = _client(user=_user(is_admin=False)).put(
+        f"/api/v1/apps/{uuid.uuid4()}/installations/{uuid.uuid4()}",
+        json={"release_id": str(uuid.uuid4()), "capabilities": ["inventory:read"]},
+    )
+    assert response.status_code == 403
+    assert response.json()["message"] == "App request denied"
+    assert called is False
+
+
+def test_app_status_uses_token_principal_and_no_store(monkeypatch):
+    app_id = uuid.uuid4()
+    vault_id = uuid.uuid4()
+    principal = _principal(app_id)
+    calls = []
+
+    async def fake_status(requested_principal, *, vault_id, correlation_id):
+        calls.append((requested_principal, vault_id, correlation_id))
+        return _status()
+
+    monkeypatch.setattr(
+        app_lifecycle,
+        "get_installation_status_for_app",
+        fake_status,
+    )
+    response = _client(principal=principal).get(
+        f"/api/v1/app/installations/{vault_id}?app_id={uuid.uuid4()}"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert calls[0][0] is principal
+    assert calls[0][1] == vault_id

--- a/backend/tests/test_app_lifecycle_routes_unit.py
+++ b/backend/tests/test_app_lifecycle_routes_unit.py
@@ -53,11 +53,25 @@ def _client(
 
 
 def _status(*, replayed: bool = False) -> dict:
+    grant_id = str(uuid.uuid4())
     return {
         "installation_id": str(uuid.uuid4()),
         "app_id": str(uuid.uuid4()),
         "vault_id": str(uuid.uuid4()),
         "lifecycle": "installing",
+        "latest_grant": {
+            "id": grant_id,
+            "generation": 1,
+            "status": "active",
+            "capabilities": ["installation:read"],
+        },
+        "latest_active_grant": {
+            "id": grant_id,
+            "generation": 1,
+            "status": "active",
+            "capabilities": ["installation:read"],
+        },
+        "resources": [{"kind": "table", "key": "owned-key", "status": "owned"}],
         "grant_generation": 1,
         "replayed": replayed,
         "command_status": "already_applied" if replayed else "accepted",
@@ -160,3 +174,25 @@ def test_app_status_uses_token_principal_and_no_store(monkeypatch):
     assert response.headers["cache-control"] == "no-store"
     assert calls[0][0] is principal
     assert calls[0][1] == vault_id
+
+
+def test_admin_status_preserves_grant_identity_and_resources(monkeypatch):
+    expected = _status()
+
+    async def fake_authorize(*_args, **_kwargs):
+        return None
+
+    async def fake_status(*_args, **_kwargs):
+        return expected
+
+    monkeypatch.setattr(app_lifecycle, "authorize_lifecycle_admin", fake_authorize)
+    monkeypatch.setattr(app_lifecycle, "get_installation_status", fake_status)
+    response = _client(user=_user()).get(
+        f"/api/v1/apps/{expected['app_id']}/installations/{expected['vault_id']}"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["latest_grant"]["id"] == expected["latest_grant"]["id"]
+    assert body["latest_active_grant"]["id"] == expected["latest_active_grant"]["id"]
+    assert body["resources"] == expected["resources"]

--- a/backend/tests/test_app_lifecycle_unit.py
+++ b/backend/tests/test_app_lifecycle_unit.py
@@ -16,6 +16,7 @@ def _row(*, observed: bool = True, lifecycle_name: str = "installing") -> dict:
     app_id = uuid.uuid4()
     vault_id = uuid.uuid4()
     release_id = uuid.uuid4()
+    grant_id = uuid.uuid4()
     now = datetime.now(timezone.utc)
     return {
         "installation_id": uuid.uuid4(),
@@ -32,9 +33,11 @@ def _row(*, observed: bool = True, lifecycle_name: str = "installing") -> dict:
         "current_release_id": None if lifecycle_name == "installing" else release_id,
         "current_version": None if lifecycle_name == "installing" else "1.0.0",
         "grant_generation": 1,
+        "latest_grant_id": grant_id,
         "latest_grant_generation": 1,
         "latest_grant_status": "active",
         "latest_grant_capabilities": ["inventory:read", "installation:read"],
+        "latest_active_grant_id": grant_id,
         "latest_active_grant_generation": 1,
         "latest_active_grant_status": "active",
         "latest_active_grant_capabilities": [
@@ -95,6 +98,21 @@ def test_status_projection_redacts_payloads_and_unrelated_metadata():
     assert projected["recent_error"] == {"code": "worker_timeout"}
     assert projected["lifecycle"] == "installing"
     assert projected["current_release"] is None
+    assert projected["latest_grant"]["id"] == str(projected["latest_active_grant"]["id"])
+
+
+def test_status_projection_decodes_asyncpg_jsonb_resources():
+    row = _row()
+    row["resources"] = json.dumps(row["resources"])
+
+    projected = lifecycle.project_installation_status(row)
+
+    assert projected["latest_grant"]["id"] == str(row["latest_grant_id"])
+    assert projected["latest_active_grant"]["id"] == str(row["latest_active_grant_id"])
+    assert projected["resources"] == [
+        {"kind": "collection", "key": "owned-key", "status": "owned"},
+        {"kind": "table", "key": "retained-key", "status": "retained"},
+    ]
 
 
 def test_replay_requires_the_same_desired_release_and_active_grant():

--- a/backend/tests/test_app_lifecycle_unit.py
+++ b/backend/tests/test_app_lifecycle_unit.py
@@ -1,0 +1,125 @@
+"""Pure contracts for installation lifecycle normalization and projection."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services import app_lifecycle_service as lifecycle
+
+
+def _row(*, observed: bool = True, lifecycle_name: str = "installing") -> dict:
+    app_id = uuid.uuid4()
+    vault_id = uuid.uuid4()
+    release_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    return {
+        "installation_id": uuid.uuid4(),
+        "app_id": app_id,
+        "vault_id": vault_id,
+        "lifecycle": lifecycle_name,
+        "blocked_reason": None,
+        "desired_release_id": release_id,
+        "desired_version": "1.0.0",
+        "desired_manifest": {
+            "steps": [{"id": "prepare"}],
+            "expected_schema_fingerprint": "a" * 64,
+        },
+        "current_release_id": None if lifecycle_name == "installing" else release_id,
+        "current_version": None if lifecycle_name == "installing" else "1.0.0",
+        "grant_generation": 1,
+        "latest_grant_generation": 1,
+        "latest_grant_status": "active",
+        "latest_grant_capabilities": ["inventory:read", "installation:read"],
+        "latest_active_grant_generation": 1,
+        "latest_active_grant_status": "active",
+        "latest_active_grant_capabilities": [
+            "inventory:read",
+            "installation:read",
+        ],
+        "observed_generation": 2 if observed else None,
+        "observed_at": now if observed else None,
+        "observed_release_id": release_id if observed else None,
+        "observed_release_version": "1.0.0" if observed else None,
+        "schema_fingerprint": "a" * 64 if observed else None,
+        "observed_grant_generation": 1 if observed else None,
+        "checkpoint": {"phase": "ready", "token": "secret-marker"},
+        "recent_error": {
+            "code": "worker_timeout",
+            "message": "secret-marker",
+        },
+        "resources": [
+            {"kind": "collection", "key": "owned-key", "status": "owned"},
+            {"kind": "table", "key": "retained-key", "status": "retained"},
+        ],
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def test_capabilities_are_exactly_sorted_and_deduplicated():
+    assert lifecycle.normalize_capabilities(
+        ["inventory:read", "installation:read", "inventory:read"]
+    ) == ["installation:read", "inventory:read"]
+
+    with pytest.raises(ValidationError):
+        lifecycle.normalize_capabilities([])
+    with pytest.raises(ValidationError):
+        lifecycle.normalize_capabilities(["documents:write"])
+
+
+def test_mode_normalization_is_closed_and_defaults_to_install():
+    assert lifecycle.normalize_mode(None) == "install"
+    assert lifecycle.normalize_mode("fresh") == "fresh"
+    with pytest.raises(ValidationError):
+        lifecycle.normalize_mode("upgrade")
+
+
+def test_status_projection_redacts_payloads_and_unrelated_metadata():
+    projected = lifecycle.project_installation_status(_row())
+    serialized = json.dumps(projected, sort_keys=True)
+
+    assert "secret-marker" not in serialized
+    assert "worker_timeout" in serialized
+    assert "vault_name" not in projected
+    assert "provenance" not in serialized
+    assert projected["resources"] == [
+        {"kind": "collection", "key": "owned-key", "status": "owned"},
+        {"kind": "table", "key": "retained-key", "status": "retained"},
+    ]
+    assert projected["checkpoint"] == {"phase": "ready"}
+    assert projected["recent_error"] == {"code": "worker_timeout"}
+    assert projected["lifecycle"] == "installing"
+    assert projected["current_release"] is None
+
+
+def test_replay_requires_the_same_desired_release_and_active_grant():
+    row = _row()
+    grant = {
+        "generation": 1,
+        "status": "active",
+        "capabilities": ["installation:read", "inventory:read"],
+    }
+    assert lifecycle._is_replay_state(
+        row,
+        grant,
+        row["desired_release_id"],
+        ["installation:read", "inventory:read"],
+    )
+    assert not lifecycle._is_replay_state(
+        row,
+        grant,
+        uuid.uuid4(),
+        ["installation:read", "inventory:read"],
+    )
+    grant["capabilities"] = ["installation:read"]
+    assert not lifecycle._is_replay_state(
+        row,
+        grant,
+        row["desired_release_id"],
+        ["installation:read", "inventory:read"],
+    )

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -88,10 +88,10 @@ def test_app_lifecycle_credentials_use_project_neutral_names() -> None:
         "AKB_E2E_WRITER_TOKEN",
         "AKB_E2E_FOREIGN_VAULT_ADMIN_TOKEN",
         "AKB_E2E_PRIMARY_APP_CREDENTIAL",
-        "AKB_E2E_PRIMARY_APP_TOKEN",
         "AKB_E2E_FOREIGN_APP_CREDENTIAL",
     )
     assert all(name.startswith("AKB_E2E_") for name in e2e_runtime.CREDENTIAL_VARIABLES)
+    assert all(not name.endswith("_APP_TOKEN") for name in e2e_runtime.CREDENTIAL_VARIABLES)
 
 
 def test_empty_scenario_keeps_the_original_ready_and_reset_shapes(tmp_path: Path) -> None:
@@ -153,6 +153,8 @@ def test_fixture_artifacts_rotate_together_and_keep_credentials_private(tmp_path
     manifest_path, profile_path = e2e_runtime.fixture_artifact_paths(settings)
     assert json.loads(manifest_path.read_text())["namespace"] == "first"
     assert first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[1]] in profile_path.read_text()
+    profile_names = {line.split("=", 1)[0] for line in profile_path.read_text().splitlines()}
+    assert profile_names == set(e2e_runtime.CREDENTIAL_VARIABLES)
     assert os.stat(manifest_path).st_mode & 0o777 == 0o600
     assert os.stat(profile_path).st_mode & 0o777 == 0o600
 
@@ -185,17 +187,12 @@ def test_seed_scenario_rotates_app_lifecycle_artifacts_without_db_access(
         }
 
     monkeypatch.setattr(e2e_runtime, "_seed_app_lifecycle", fake_seed)
-    monkeypatch.setattr(
-        e2e_runtime,
-        "_exchange_fixture_app_token",
-        lambda _origin, _credential: "fixture-app-token",
-    )
     manifest, credentials = e2e_runtime.seed_scenario(settings)
 
     assert calls == [(e2e_runtime.DEFAULT_DATABASE_URL, settings.origin, settings.fixture_origin)]
     assert manifest == {"schema_version": 1, "scenario": "app_lifecycle"}
     assert credentials is not None
-    assert credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] == "fixture-app-token"
+    assert set(credentials) == set(e2e_runtime.CREDENTIAL_VARIABLES)
 
 
 def test_app_lifecycle_seed_is_transactional_and_manifest_is_redacted(
@@ -250,14 +247,10 @@ def test_app_lifecycle_seed_is_transactional_and_manifest_is_redacted(
     assert connection.closed is True
     assert len(connection.statements) >= 30
     assert manifest["scenario"] == e2e_runtime.APP_LIFECYCLE_SCENARIO
-    assert set(credentials) == (
-        set(e2e_runtime.CREDENTIAL_VARIABLES)
-        - {e2e_runtime.CREDENTIAL_VARIABLES[6]}
-    )
+    assert set(credentials) == set(e2e_runtime.CREDENTIAL_VARIABLES)
     assert all(
         credentials[name] not in serialized_manifest
         for name in e2e_runtime.CREDENTIAL_VARIABLES
-        if name != e2e_runtime.CREDENTIAL_VARIABLES[6]
     )
     for forbidden_field in (
         "credential_hash",
@@ -268,7 +261,11 @@ def test_app_lifecycle_seed_is_transactional_and_manifest_is_redacted(
     ):
         assert forbidden_field not in serialized_manifest
     assert manifest["actors"]["writer"]["token_env"] == e2e_runtime.CREDENTIAL_VARIABLES[3]  # type: ignore[index]
-    assert manifest["apps"]["primary"]["token_env"] == e2e_runtime.CREDENTIAL_VARIABLES[6]  # type: ignore[index]
+    assert manifest["apps"]["primary"]["credential_env"] == e2e_runtime.CREDENTIAL_VARIABLES[5]  # type: ignore[index]
+    assert "token_env" not in manifest["apps"]["primary"]  # type: ignore[operator]
+    assert manifest["apps"]["foreign"]["credential_env"] == e2e_runtime.CREDENTIAL_VARIABLES[6]  # type: ignore[index]
+    assert manifest["endpoint_tasks"]["app_status"]["credential_exchange_task"] == "credential_exchange"  # type: ignore[index]
+    assert manifest["endpoint_tasks"]["foreign_app_status"]["credential_exchange_task"] == "credential_exchange"  # type: ignore[index]
     assert len(manifest["installations"]) >= 7  # type: ignore[index]
 
 

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -392,6 +392,51 @@ def test_runtime_failure_diagnostic_is_phase_and_sqlstate_only() -> None:
     assert "credential-marker" not in diagnostic
 
 
+def test_reset_handler_reports_safe_failure_and_preserves_response_shape(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeResetError(Exception):
+        sqlstate = "23514"
+        constraint_name = None
+        table_name = "installation_grants"
+        column_name = None
+
+    class FakeRuntime:
+        phase = "database_reset"
+        settings = e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        )
+
+        def reset(self) -> None:
+            raise FakeResetError(
+                "credential-value-marker token-value-marker password-value-marker "
+                "database-url-marker sql-arg-marker"
+            )
+
+    handler = object.__new__(e2e_runtime._ControlHandler)
+    handler.path = "/__e2e/reset"
+    handler.runtime = FakeRuntime()
+    responses: list[tuple[int, dict[str, object]]] = []
+    handler._json = lambda status, payload: responses.append((status, dict(payload)))
+
+    handler.do_POST()
+
+    assert responses == [(500, {"status": "reset_failed"})]
+    diagnostic = capsys.readouterr().err
+    assert diagnostic == (
+        "e2e runtime failed phase=database_reset category=FakeResetError "
+        "source=postgres sqlstate=23514 table=installation_grants\n"
+    )
+    for marker in (
+        "credential-value-marker",
+        "token-value-marker",
+        "password-value-marker",
+        "database-url-marker",
+        "sql-arg-marker",
+    ):
+        assert marker not in diagnostic
+
+
 def test_database_reset_is_schema_neutral_and_does_not_embed_a_url() -> None:
     sql = e2e_runtime.render_database_reset_sql()
 

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -438,6 +438,7 @@ def test_database_reset_is_schema_neutral_and_does_not_embed_a_url() -> None:
     sql = e2e_runtime.render_database_reset_sql()
 
     assert "TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE" in sql
+    assert "tablename <> 'schema_migrations'" in sql
     assert "DROP SCHEMA IF EXISTS vector_index CASCADE" in sql
     assert e2e_runtime.DEFAULT_DATABASE_URL not in sql
 

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -556,6 +556,124 @@ def test_managed_suite_environment_derives_compose_exec_for_psql(tmp_path: Path)
     assert e2e_runtime.DEFAULT_DATABASE_URL not in environment["AKB_PG_EXEC"]
 
 
+def test_postgres_probe_opens_and_closes_a_real_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+
+    class Connection:
+        async def close(self) -> None:
+            events.append(("close",))
+
+    async def fake_connect(database_url: str, *, timeout: int) -> Connection:
+        events.append(("connect", database_url, timeout))
+        return Connection()
+
+    monkeypatch.setitem(sys.modules, "asyncpg", types.SimpleNamespace(connect=fake_connect))
+
+    assert e2e_runtime._postgres_connection_ready(e2e_runtime.DEFAULT_DATABASE_URL) is True
+    assert events == [
+        ("connect", e2e_runtime.DEFAULT_DATABASE_URL, e2e_runtime.POSTGRES_PROBE_TIMEOUT),
+        ("close",),
+    ]
+
+
+def test_wait_for_postgres_waits_for_published_dsn_after_container_health(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        )
+    )
+    probe_results = iter([False, True])
+    waits: list[int] = []
+    compose_calls: list[tuple[str, ...]] = []
+    docker_calls: list[tuple[str, ...]] = []
+
+    class Completed:
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    monkeypatch.setattr(
+        runtime,
+        "_run_compose",
+        lambda *args: compose_calls.append(args) or Completed("postgres-container\n"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_run_docker",
+        lambda *args: docker_calls.append(args) or Completed("healthy\n"),
+    )
+    monkeypatch.setattr(
+        e2e_runtime,
+        "_postgres_connection_ready",
+        lambda database_url: next(probe_results),
+    )
+    monkeypatch.setattr(runtime.stop_event, "wait", lambda seconds: waits.append(seconds))
+
+    runtime._wait_for_postgres()
+
+    assert len(compose_calls) == 2
+    assert len(docker_calls) == 2
+    assert waits == [e2e_runtime.POSTGRES_READY_INTERVAL]
+
+
+def test_wait_for_postgres_has_bounded_timeout_when_published_dsn_stays_unready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        )
+    )
+
+    class Completed:
+        stdout = "healthy\n"
+
+    monkeypatch.setattr(e2e_runtime, "POSTGRES_READY_ATTEMPTS", 2)
+    monkeypatch.setattr(runtime, "_run_compose", lambda *_args: Completed())
+    monkeypatch.setattr(runtime, "_run_docker", lambda *_args: Completed())
+    monkeypatch.setattr(e2e_runtime, "_postgres_connection_ready", lambda _url: False)
+    monkeypatch.setattr(runtime.stop_event, "wait", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="PostgreSQL Compose service") as error:
+        runtime._wait_for_postgres()
+
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in str(error.value)
+
+
+def test_wait_for_postgres_stops_before_connecting_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        )
+    )
+    runtime.request_stop()
+    monkeypatch.setattr(
+        e2e_runtime,
+        "_postgres_connection_ready",
+        lambda _url: pytest.fail("connection probe must not run after stop"),
+    )
+
+    with pytest.raises(RuntimeError, match="runtime stopped"):
+        runtime._wait_for_postgres()
+
+
 def test_start_failure_cleans_up_partial_compose_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     runtime = e2e_runtime.E2ERuntime(
         e2e_runtime.RuntimeSettings(

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import shlex
 import signal
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -68,9 +71,225 @@ def test_managed_settings_reject_unsafe_project() -> None:
         )
 
 
-def test_only_empty_scenario_is_supported() -> None:
+def test_supported_scenarios_include_app_lifecycle_and_reject_unknown() -> None:
+    settings = e2e_runtime.resolve_settings(["--scenario", "app_lifecycle"], {})
+
+    assert settings.scenario == e2e_runtime.APP_LIFECYCLE_SCENARIO
+    assert e2e_runtime.APP_LIFECYCLE_SCENARIO in e2e_runtime.SUPPORTED_SCENARIOS
     with pytest.raises(ValueError, match="unsupported"):
         e2e_runtime.resolve_settings(["--scenario", "other"], {})
+
+
+def test_app_lifecycle_credentials_use_project_neutral_names() -> None:
+    assert e2e_runtime.CREDENTIAL_VARIABLES == (
+        "AKB_E2E_SYSTEM_ADMIN_TOKEN",
+        "AKB_E2E_TARGET_VAULT_ADMIN_TOKEN",
+        "AKB_E2E_READER_TOKEN",
+        "AKB_E2E_WRITER_TOKEN",
+        "AKB_E2E_FOREIGN_VAULT_ADMIN_TOKEN",
+        "AKB_E2E_PRIMARY_APP_CREDENTIAL",
+        "AKB_E2E_PRIMARY_APP_TOKEN",
+        "AKB_E2E_FOREIGN_APP_CREDENTIAL",
+    )
+    assert all(name.startswith("AKB_E2E_") for name in e2e_runtime.CREDENTIAL_VARIABLES)
+
+
+def test_empty_scenario_keeps_the_original_ready_and_reset_shapes(tmp_path: Path) -> None:
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        ready_file=tmp_path / "ready.json",
+    )
+
+    assert e2e_runtime.ready_payload(settings)["scenario"] == "empty"
+    assert set(e2e_runtime.ready_payload(settings)) == {
+        "schema_version",
+        "status",
+        "origin",
+        "fixture_origin",
+        "reset_url",
+        "scenario",
+    }
+    assert e2e_runtime.reset_payload(settings) == {"ok": True, "scenario": "empty"}
+
+
+def test_app_lifecycle_ready_and_reset_expose_only_safe_artifact_metadata(tmp_path: Path) -> None:
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        scenario=e2e_runtime.APP_LIFECYCLE_SCENARIO,
+        ready_file=tmp_path / "ready.json",
+    )
+
+    ready = e2e_runtime.ready_payload(settings)
+    reset = e2e_runtime.reset_payload(settings)
+    manifest_path, profile_path = e2e_runtime.fixture_artifact_paths(settings)
+
+    assert ready["fixture_manifest"] == str(manifest_path)
+    assert ready["credential_profile"] == str(profile_path)
+    assert ready["credential_variables"] == list(e2e_runtime.CREDENTIAL_VARIABLES)
+    assert reset["fixture_manifest"] == str(manifest_path)
+    assert reset["credential_profile"] == str(profile_path)
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in json.dumps(ready)
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in json.dumps(reset)
+
+
+def test_fixture_artifacts_rotate_together_and_keep_credentials_private(tmp_path: Path) -> None:
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        scenario=e2e_runtime.APP_LIFECYCLE_SCENARIO,
+        ready_file=tmp_path / "ready.json",
+    )
+    first_value = "fixture-value-one"
+    second_value = "fixture-value-two"
+    first_manifest = {"schema_version": 1, "namespace": "first", "id": "first-id"}
+    second_manifest = {"schema_version": 1, "namespace": "second", "id": "second-id"}
+    first_credentials = {
+        name: first_value + name[-1] for name in e2e_runtime.CREDENTIAL_VARIABLES
+    }
+    second_credentials = {
+        name: second_value + name[-1] for name in e2e_runtime.CREDENTIAL_VARIABLES
+    }
+
+    e2e_runtime.write_fixture_artifacts(settings, first_manifest, first_credentials)
+    manifest_path, profile_path = e2e_runtime.fixture_artifact_paths(settings)
+    assert json.loads(manifest_path.read_text())["namespace"] == "first"
+    assert first_credentials[e2e_runtime.CREDENTIAL_VARIABLES[1]] in profile_path.read_text()
+    assert os.stat(manifest_path).st_mode & 0o777 == 0o600
+    assert os.stat(profile_path).st_mode & 0o777 == 0o600
+
+    e2e_runtime.write_fixture_artifacts(settings, second_manifest, second_credentials)
+    assert json.loads(manifest_path.read_text())["namespace"] == "second"
+    assert second_credentials[e2e_runtime.CREDENTIAL_VARIABLES[1]] in profile_path.read_text()
+    assert first_value not in profile_path.read_text()
+    assert first_value not in manifest_path.read_text()
+
+    e2e_runtime.remove_fixture_artifacts(settings)
+    assert not manifest_path.exists()
+    assert not profile_path.exists()
+
+
+def test_seed_scenario_rotates_app_lifecycle_artifacts_without_db_access(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        scenario=e2e_runtime.APP_LIFECYCLE_SCENARIO,
+        ready_file=tmp_path / "ready.json",
+    )
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_seed(database_url: str, *, origin: str, fixture_origin: str):
+        calls.append((database_url, origin, fixture_origin))
+        return {"schema_version": 1, "scenario": "app_lifecycle"}, {
+            name: "fixture-value-" + name[-1] for name in e2e_runtime.CREDENTIAL_VARIABLES
+        }
+
+    monkeypatch.setattr(e2e_runtime, "_seed_app_lifecycle", fake_seed)
+    monkeypatch.setattr(
+        e2e_runtime,
+        "_exchange_fixture_app_token",
+        lambda _origin, _credential: "fixture-app-token",
+    )
+    manifest, credentials = e2e_runtime.seed_scenario(settings)
+
+    assert calls == [(e2e_runtime.DEFAULT_DATABASE_URL, settings.origin, settings.fixture_origin)]
+    assert manifest == {"schema_version": 1, "scenario": "app_lifecycle"}
+    assert credentials is not None
+    assert credentials[e2e_runtime.CREDENTIAL_VARIABLES[6]] == "fixture-app-token"
+
+
+def test_app_lifecycle_seed_is_transactional_and_manifest_is_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeTransaction:
+        entered = False
+
+        async def __aenter__(self):
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.transaction_context = FakeTransaction()
+            self.statements: list[tuple[str, tuple[object, ...]]] = []
+            self.closed = False
+
+        def transaction(self) -> FakeTransaction:
+            return self.transaction_context
+
+        async def execute(self, statement: str, *args: object) -> None:
+            self.statements.append((statement, args))
+
+        async def close(self) -> None:
+            self.closed = True
+
+    connection = FakeConnection()
+
+    async def fake_connect(_database_url: str, *, timeout: int):
+        assert timeout == 15
+        return connection
+
+    monkeypatch.setitem(
+        sys.modules,
+        "asyncpg",
+        types.SimpleNamespace(connect=fake_connect),
+    )
+    manifest, credentials = asyncio.run(
+        e2e_runtime._seed_app_lifecycle(
+            e2e_runtime.DEFAULT_DATABASE_URL,
+            origin="http://localhost:8000",
+            fixture_origin="http://localhost:8889",
+        )
+    )
+
+    serialized_manifest = json.dumps(manifest)
+    assert connection.transaction_context.entered is True
+    assert connection.closed is True
+    assert len(connection.statements) >= 30
+    assert manifest["scenario"] == e2e_runtime.APP_LIFECYCLE_SCENARIO
+    assert set(credentials) == (
+        set(e2e_runtime.CREDENTIAL_VARIABLES)
+        - {e2e_runtime.CREDENTIAL_VARIABLES[6]}
+    )
+    assert all(
+        credentials[name] not in serialized_manifest
+        for name in e2e_runtime.CREDENTIAL_VARIABLES
+        if name != e2e_runtime.CREDENTIAL_VARIABLES[6]
+    )
+    for forbidden_field in (
+        "credential_hash",
+        "token_hash",
+        "password_hash",
+        "provenance",
+        "grant_id",
+    ):
+        assert forbidden_field not in serialized_manifest
+    assert manifest["actors"]["writer"]["token_env"] == e2e_runtime.CREDENTIAL_VARIABLES[3]  # type: ignore[index]
+    assert manifest["apps"]["primary"]["token_env"] == e2e_runtime.CREDENTIAL_VARIABLES[6]  # type: ignore[index]
+    assert len(manifest["installations"]) >= 7  # type: ignore[index]
+
+
+def test_child_environment_does_not_forward_fixture_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker = "fixture-value-not-forwarded"
+    monkeypatch.setenv(e2e_runtime.CREDENTIAL_VARIABLES[1], marker)
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            scenario=e2e_runtime.APP_LIFECYCLE_SCENARIO,
+            ready_file=tmp_path / "ready.json",
+        )
+    )
+
+    child_environment = runtime._child_environment()
+
+    assert e2e_runtime.CREDENTIAL_VARIABLES[1] not in child_environment
+    assert marker not in child_environment.values()
 
 
 def test_generated_config_contains_fields_not_the_database_url(tmp_path: Path) -> None:

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -671,6 +671,181 @@ def test_wait_for_postgres_stops_before_connecting_when_requested(
         runtime._wait_for_postgres()
 
 
+def test_backend_readiness_requires_the_ready_api_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+        )
+    )
+    responses = iter(
+        [
+            (200, b'{"status":"not_ready"}'),
+            (200, b'{"status":"ready"}'),
+        ]
+    )
+    requests: list[str] = []
+
+    class AliveProcess:
+        def poll(self) -> None:
+            return None
+
+    def fake_get(url: str) -> tuple[int, bytes]:
+        requests.append(url)
+        return next(responses)
+
+    runtime.backend_process = AliveProcess()  # type: ignore[assignment]
+    monkeypatch.setattr(e2e_runtime, "_http_get", fake_get)
+    monkeypatch.setattr(runtime.stop_event, "wait", lambda _seconds: False)
+
+    runtime._wait_for_backend()
+
+    assert requests == [f"{runtime.settings.origin}/readyz"] * 2
+
+
+def test_start_publishes_ready_only_after_fixture_reset_and_api_health(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    ready_file = tmp_path / "ready.json"
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=ready_file,
+        ),
+        repo_root=tmp_path,
+    )
+    events: list[str] = []
+
+    class AliveProcess:
+        def poll(self) -> None:
+            return None
+
+    def fixture_reset() -> None:
+        assert not ready_file.exists()
+        events.append("fixture_reset")
+
+    def api_health() -> None:
+        assert not ready_file.exists()
+        events.append("api_health")
+
+    real_write_ready_file = e2e_runtime.write_ready_file
+
+    def publish_ready(path: Path, payload: dict[str, object]) -> None:
+        assert events == ["git_reset", "fixture_reset", "api_health", "fixtures_written"]
+        real_write_ready_file(path, payload)
+        events.append("ready_published")
+
+    monkeypatch.setattr(e2e_runtime, "clear_git_fixture_root", lambda: events.append("git_reset"))
+    monkeypatch.setattr(e2e_runtime, "reset_database", lambda _url: fixture_reset())
+    monkeypatch.setattr(e2e_runtime, "write_runtime_config", lambda *_args: None)
+    monkeypatch.setattr(runtime, "_start_control_server", lambda: None)
+    monkeypatch.setattr(runtime, "_start_process", lambda *_args: AliveProcess())
+    monkeypatch.setattr(runtime, "_wait_for_embed", lambda: None)
+    monkeypatch.setattr(runtime, "_wait_for_backend", api_health)
+    monkeypatch.setattr(e2e_runtime, "seed_scenario", lambda _settings: (None, None))
+    monkeypatch.setattr(
+        e2e_runtime,
+        "write_fixture_artifacts",
+        lambda *_args: events.append("fixtures_written"),
+    )
+    monkeypatch.setattr(e2e_runtime, "write_ready_file", publish_ready)
+
+    runtime.start()
+
+    assert events[-1] == "ready_published"
+    assert json.loads(ready_file.read_text())["status"] == "ready"
+
+
+def test_fixture_reset_failure_never_leaves_a_ready_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    ready_file = tmp_path / "ready.json"
+    ready_file.write_text('{"status":"stale"}')
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=ready_file,
+        )
+    )
+
+    monkeypatch.setattr(e2e_runtime, "clear_git_fixture_root", lambda: None)
+    monkeypatch.setattr(
+        e2e_runtime,
+        "reset_database",
+        lambda _url: (_ for _ in ()).throw(RuntimeError("reset failed")),
+    )
+    monkeypatch.setattr(runtime, "shutdown", lambda: True)
+
+    with pytest.raises(RuntimeError, match="reset failed"):
+        runtime.start()
+
+    assert not ready_file.exists()
+    assert runtime.ready is False
+
+
+def test_backend_exit_invalidates_ready_and_marks_the_supervisor_failed(tmp_path: Path) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+        )
+    )
+
+    class Process:
+        def __init__(self, returncode: int | None) -> None:
+            self.returncode = returncode
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    runtime.embed_process = Process(None)  # type: ignore[assignment]
+    runtime.backend_process = Process(1)  # type: ignore[assignment]
+    runtime._write_ready()
+
+    assert runtime._dependencies_alive() is False
+    assert runtime.failed is True
+    assert runtime.phase == "backend_runtime"
+    assert runtime.stop_event.is_set()
+    assert not runtime.settings.ready_file.exists()
+
+
+def test_managed_postgres_exit_invalidates_ready_and_marks_the_supervisor_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        )
+    )
+
+    class AliveProcess:
+        def poll(self) -> None:
+            return None
+
+    class NoContainers:
+        stdout = ""
+
+    runtime.embed_process = AliveProcess()  # type: ignore[assignment]
+    runtime.backend_process = AliveProcess()  # type: ignore[assignment]
+    runtime._write_ready()
+    monkeypatch.setattr(runtime, "_run_compose", lambda *_args: NoContainers())
+
+    assert runtime._dependencies_alive() is False
+    assert runtime.failed is True
+    assert runtime.phase == "postgres_runtime"
+    assert runtime.stop_event.is_set()
+    assert not runtime.settings.ready_file.exists()
+
+
 def test_start_failure_cleans_up_partial_compose_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     runtime = e2e_runtime.E2ERuntime(
         e2e_runtime.RuntimeSettings(
@@ -751,6 +926,43 @@ def test_run_suites_calls_the_repository_owned_runner(monkeypatch: pytest.Monkey
     assert command == ["bash", str(tmp_path / "backend/scripts/ci/run_e2e_suites.sh")]
     assert options["cwd"] == tmp_path
     assert options["start_new_session"] is True
+
+
+def test_run_suites_returns_nonzero_when_a_dependency_dies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class Process:
+        def __init__(self, returncode: int | None) -> None:
+            self.returncode = returncode
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    suite_process = Process(None)
+    monkeypatch.setattr(e2e_runtime.subprocess, "Popen", lambda *_args, **_kwargs: suite_process)
+    terminated: list[object] = []
+    monkeypatch.setattr(
+        e2e_runtime,
+        "_terminate_process_group",
+        lambda process: terminated.append(process),
+    )
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            run_suites=True,
+        ),
+        repo_root=tmp_path,
+    )
+    runtime.embed_process = Process(None)  # type: ignore[assignment]
+    runtime.backend_process = Process(1)  # type: ignore[assignment]
+    runtime._write_ready()
+
+    assert runtime.run_suites() == 1
+    assert runtime.failed is True
+    assert terminated == [suite_process]
+    assert not runtime.settings.ready_file.exists()
 
 
 def test_process_teardown_targets_the_child_process_group(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -370,6 +370,28 @@ def test_reset_response_matches_the_shared_fixture_contract() -> None:
     assert e2e_runtime.reset_payload(settings) == {"ok": True, "scenario": "empty"}
 
 
+def test_runtime_failure_diagnostic_is_phase_and_sqlstate_only() -> None:
+    class FakePostgresError(Exception):
+        sqlstate = "23514"
+        constraint_name = None
+        table_name = "installation_grants"
+        column_name = None
+
+        def __str__(self) -> str:
+            return "postgresql://db.invalid/akb credential-marker"
+
+    diagnostic = e2e_runtime.format_runtime_failure(
+        "seed_scenario",
+        FakePostgresError("not emitted"),
+    )
+
+    assert diagnostic == (
+        "e2e runtime failed phase=seed_scenario category=FakePostgresError "
+        "source=postgres sqlstate=23514 table=installation_grants"
+    )
+    assert "credential-marker" not in diagnostic
+
+
 def test_database_reset_is_schema_neutral_and_does_not_embed_a_url() -> None:
     sql = e2e_runtime.render_database_reset_sql()
 

--- a/backend/tests/test_e2e_runtime.py
+++ b/backend/tests/test_e2e_runtime.py
@@ -1,0 +1,373 @@
+"""Focused, database-free checks for the repository-owned E2E runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import signal
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import e2e_runtime
+
+
+def test_default_settings_keep_the_existing_ci_database_and_origins() -> None:
+    settings = e2e_runtime.resolve_settings([], {})
+
+    assert settings.database_url == e2e_runtime.DEFAULT_DATABASE_URL
+    assert settings.origin == "http://localhost:8000"
+    assert settings.fixture_origin == "http://localhost:8889"
+    assert settings.scenario == "empty"
+
+
+def test_command_arguments_override_runtime_environment(tmp_path: Path) -> None:
+    settings = e2e_runtime.resolve_settings(
+        ["--scenario", "empty", "--ready-file", str(tmp_path / "ready.json")],
+        {
+            "AKB_E2E_DATABASE_URL": "postgresql://runner:" + "ci-passphrase@127.0.0.1:15432/e2e",
+            "AKB_E2E_ORIGIN": "http://127.0.0.1:18000",
+            "AKB_E2E_FIXTURE_ORIGIN": "http://127.0.0.1:18889",
+            "AKB_E2E_SCENARIO": "empty",
+        },
+    )
+
+    assert settings.ready_file == (tmp_path / "ready.json").resolve()
+    assert settings.origin == "http://127.0.0.1:18000"
+    assert settings.fixture_origin == "http://127.0.0.1:18889"
+    assert e2e_runtime.parse_database_url(settings.database_url).password == "ci-passphrase"  # pragma: allowlist secret
+    assert settings.run_suites is False
+
+
+def test_run_suites_flag_is_explicit() -> None:
+    settings = e2e_runtime.resolve_settings(["--run-suites"], {})
+
+    assert settings.run_suites is True
+
+
+def test_managed_settings_resolve_safe_project_and_docker_argv() -> None:
+    settings = e2e_runtime.resolve_settings(
+        ["--manage-postgres"],
+        {
+            "AKB_E2E_COMPOSE_PROJECT": "akb-e2e-unit",
+            "AKB_E2E_DOCKER_ARGV": "sudo -n docker",
+        },
+    )
+
+    assert settings.manage_postgres is True
+    assert settings.compose_project == "akb-e2e-unit"
+    assert settings.docker_argv == ("sudo", "-n", "docker")
+
+
+def test_managed_settings_reject_unsafe_project() -> None:
+    with pytest.raises(ValueError, match="compose project"):
+        e2e_runtime.resolve_settings(
+            ["--manage-postgres"],
+            {"AKB_E2E_COMPOSE_PROJECT": "unsafe/project"},
+        )
+
+
+def test_only_empty_scenario_is_supported() -> None:
+    with pytest.raises(ValueError, match="unsupported"):
+        e2e_runtime.resolve_settings(["--scenario", "other"], {})
+
+
+def test_generated_config_contains_fields_not_the_database_url(tmp_path: Path) -> None:
+    database_url = "postgresql://runner:" + "ci-passphrase@db.example.test:15432/e2e"
+    settings = e2e_runtime.RuntimeSettings(database_url=database_url, ready_file=tmp_path / "ready.json")
+
+    e2e_runtime.write_runtime_config(settings, tmp_path)
+    app_config = (tmp_path / "config" / "app.yaml").read_text()
+    secret_config = (tmp_path / "config" / "secret.yaml").read_text()
+
+    assert "db_host: db.example.test" in app_config
+    assert "db_port: 15432" in app_config
+    assert database_url not in app_config
+    assert database_url not in secret_config
+    assert os.stat(tmp_path / "config" / "secret.yaml").st_mode & 0o777 == 0o600
+
+
+def test_optional_s3_config_is_explicit_and_secret_file_stays_private(tmp_path: Path) -> None:
+    settings = e2e_runtime.resolve_settings(
+        [],
+        {
+            "AKB_E2E_S3_ENDPOINT": "http://localhost:9000",
+            "AKB_E2E_S3_ACCESS_KEY": "local-access",
+            "AKB_E2E_S3_SECRET_KEY": "local-value",  # pragma: allowlist secret
+        },
+    )
+
+    assert settings.s3_bucket == e2e_runtime.DEFAULT_S3_BUCKET
+    e2e_runtime.write_runtime_config(settings, tmp_path)
+    app_config = (tmp_path / "config" / "app.yaml").read_text()
+    secret_config = (tmp_path / "config" / "secret.yaml").read_text()
+
+    assert "s3_endpoint_url: http://localhost:9000" in app_config
+    assert "s3_bucket: akb-files" in app_config
+    assert "s3_access_key: local-access" in secret_config
+    assert "s3_secret_key: local-value" in secret_config
+    assert os.stat(tmp_path / "config" / "secret.yaml").st_mode & 0o777 == 0o600
+
+
+def test_optional_s3_config_requires_endpoint_and_both_credentials() -> None:
+    with pytest.raises(ValueError, match="endpoint"):
+        e2e_runtime.resolve_settings([], {"AKB_E2E_S3_BUCKET": "akb-files"})
+    with pytest.raises(ValueError, match="incomplete"):
+        e2e_runtime.resolve_settings(
+            [],
+            {
+                "AKB_E2E_S3_ENDPOINT": "http://localhost:9000",
+                "AKB_E2E_S3_ACCESS_KEY": "local-access",
+            },
+        )
+
+
+def test_ready_file_is_atomic_private_and_has_the_base_schema(tmp_path: Path) -> None:
+    ready_file = tmp_path / "nested" / "ready.json"
+    settings = e2e_runtime.RuntimeSettings(
+        database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+        ready_file=ready_file,
+    )
+
+    e2e_runtime.write_ready_file(ready_file, e2e_runtime.ready_payload(settings))
+    payload = json.loads(ready_file.read_text())
+
+    assert payload == {
+        "schema_version": 1,
+        "status": "ready",
+        "origin": "http://localhost:8000",
+        "fixture_origin": "http://localhost:8889",
+        "reset_url": "http://localhost:8889/__e2e/reset",
+        "scenario": "empty",
+    }
+    assert os.stat(ready_file).st_mode & 0o777 == 0o600
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in ready_file.read_text()
+
+
+def test_reset_response_matches_the_shared_fixture_contract() -> None:
+    settings = e2e_runtime.RuntimeSettings(database_url=e2e_runtime.DEFAULT_DATABASE_URL)
+
+    assert e2e_runtime.reset_payload(settings) == {"ok": True, "scenario": "empty"}
+
+
+def test_database_reset_is_schema_neutral_and_does_not_embed_a_url() -> None:
+    sql = e2e_runtime.render_database_reset_sql()
+
+    assert "TRUNCATE TABLE public.%I RESTART IDENTITY CASCADE" in sql
+    assert "DROP SCHEMA IF EXISTS vector_index CASCADE" in sql
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in sql
+
+
+def test_git_fixture_reset_only_empties_the_runtime_root(tmp_path: Path) -> None:
+    root = tmp_path / "vaults"
+    (root / "nested").mkdir(parents=True)
+    (root / "nested" / "fixture").write_text("fixture")
+    (root / "file").write_text("fixture")
+
+    e2e_runtime.clear_git_fixture_root(root)
+
+    assert list(root.iterdir()) == []
+    assert os.stat(root).st_mode & 0o777 == 0o700
+
+
+def test_child_commands_preserve_the_existing_uvicorn_topology(tmp_path: Path) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+        )
+    )
+
+    assert runtime.embed_command[-4:] == ["--host", "127.0.0.1", "--port", "8888"]
+    assert runtime.backend_command[-6:] == [
+        "--app-dir",
+        "backend",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8000",
+    ]
+    assert runtime.backend_command[:3] == [runtime.backend_command[0], "-m", "uvicorn"]
+
+
+def test_compose_argv_is_project_scoped_and_does_not_contain_database_url(tmp_path: Path) -> None:
+    database_url = e2e_runtime.DEFAULT_DATABASE_URL
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=database_url,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+            docker_argv=("sudo", "-n", "docker"),
+        ),
+        repo_root=tmp_path,
+    )
+
+    argv = runtime.compose_argv("up", "--detach")
+
+    assert argv[:7] == [
+        "sudo",
+        "-n",
+        "docker",
+        "compose",
+        "--project-name",
+        "akb-e2e-unit",
+        "--file",
+    ]
+    assert str(e2e_runtime.COMPOSE_FILE) in argv
+    assert argv[-2:] == ["up", "--detach"]
+    assert database_url not in argv
+
+
+def test_suite_environment_derives_pg_access_without_url_or_password_in_command(tmp_path: Path) -> None:
+    database_url = "postgresql://runner:" + "ci-passphrase@db.example.test:15432/e2e"
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=database_url,
+            origin="http://localhost:8000",
+            ready_file=tmp_path / "ready.json",
+            run_suites=True,
+        )
+    )
+
+    environment = runtime.suite_environment()
+
+    assert environment["AKB_URL"] == "http://localhost:8000"
+    assert environment["AKB_PG_EXEC"] == "env PGHOST=db.example.test PGPORT=15432"
+    assert environment["AKB_PG_USER"] == "runner"
+    assert environment["AKB_PG_DB"] == "e2e"
+    assert environment["PGPASSWORD"] == "ci-passphrase"  # pragma: allowlist secret
+    assert database_url not in environment["AKB_PG_EXEC"]
+
+
+def test_managed_suite_environment_derives_compose_exec_for_psql(tmp_path: Path) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        ),
+        repo_root=tmp_path,
+    )
+
+    environment = runtime.suite_environment()
+    pg_exec = shlex.split(environment["AKB_PG_EXEC"])
+
+    assert pg_exec == [
+        "docker",
+        "compose",
+        "--project-name",
+        "akb-e2e-unit",
+        "--file",
+        str(e2e_runtime.COMPOSE_FILE),
+        "exec",
+        "-T",
+        "postgres",
+    ]
+    assert "PGPASSWORD" not in environment
+    assert e2e_runtime.DEFAULT_DATABASE_URL not in environment["AKB_PG_EXEC"]
+
+
+def test_start_failure_cleans_up_partial_compose_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        ),
+        repo_root=tmp_path,
+    )
+    cleanup_calls: list[str] = []
+
+    def failed_up() -> None:
+        runtime.compose_started = True
+        raise RuntimeError("expected startup failure")
+
+    def fake_down() -> bool:
+        cleanup_calls.append("down")
+        runtime.compose_started = False
+        return True
+
+    monkeypatch.setattr(runtime, "_compose_up", failed_up)
+    monkeypatch.setattr(runtime, "_compose_down", fake_down)
+
+    with pytest.raises(RuntimeError, match="expected"):
+        runtime.start()
+
+    assert cleanup_calls == ["down"]
+    assert runtime.compose_started is False
+
+
+def test_signal_request_still_runs_project_cleanup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            manage_postgres=True,
+            compose_project="akb-e2e-unit",
+        ),
+        repo_root=tmp_path,
+    )
+    cleanup_calls: list[str] = []
+    runtime.compose_started = True
+    monkeypatch.setattr(runtime, "_compose_down", lambda: cleanup_calls.append("down") or True)
+
+    runtime.request_stop()
+    assert runtime.stop_event.is_set()
+    assert runtime.shutdown() is True
+    assert cleanup_calls == ["down"]
+
+
+def test_run_suites_calls_the_repository_owned_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[tuple[object, ...]] = []
+
+    class Completed:
+        returncode = 7
+
+        def poll(self) -> int:
+            return self.returncode
+
+    def fake_popen(*args: object, **kwargs: object) -> Completed:
+        calls.append((args, kwargs))
+        return Completed()
+
+    monkeypatch.setattr(e2e_runtime.subprocess, "Popen", fake_popen)
+    runtime = e2e_runtime.E2ERuntime(
+        e2e_runtime.RuntimeSettings(
+            database_url=e2e_runtime.DEFAULT_DATABASE_URL,
+            ready_file=tmp_path / "ready.json",
+            run_suites=True,
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert runtime.run_suites() == 7
+    args, options = calls[0]
+    command = args[0]
+    assert command == ["bash", str(tmp_path / "backend/scripts/ci/run_e2e_suites.sh")]
+    assert options["cwd"] == tmp_path
+    assert options["start_new_session"] is True
+
+
+def test_process_teardown_targets_the_child_process_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[tuple[object, ...]] = []
+
+    class FakeProcess:
+        pid = 123
+
+        def poll(self) -> None:
+            return None
+
+        def wait(self, timeout: int) -> None:
+            events.append(("wait", timeout))
+
+    monkeypatch.setattr(e2e_runtime.os, "getpgid", lambda _pid: 456)
+    monkeypatch.setattr(e2e_runtime.os, "getpgrp", lambda: 1)
+    monkeypatch.setattr(e2e_runtime.os, "killpg", lambda *args: events.append(("killpg", *args)))
+
+    e2e_runtime._terminate_process_group(FakeProcess())  # type: ignore[arg-type]
+
+    assert events == [("killpg", 456, signal.SIGTERM), ("wait", 10)]

--- a/backend/tests/test_e2e_runtime_bootstrap.py
+++ b/backend/tests/test_e2e_runtime_bootstrap.py
@@ -40,7 +40,7 @@ def test_bootstrap_prepares_locked_python_314_environment_and_execs_runtime(tmp_
     _write_executable(
         data_root / "bin/uv",
         "#!/usr/bin/env bash\n"
-        "if [[ \"${1:-}\" == --version ]]; then echo 'uv 0.12.1'; exit 0; fi\n"
+        "if [[ \"${1:-}\" == --version ]]; then echo 'uv 0.12.1 (aarch64-unknown-linux-gnu)'; exit 0; fi\n"
         "printf '%s\\n' \"$*\" >>\"$AKB_TEST_UV_LOG\"\n"
         "if [[ \"${1:-}\" == venv ]]; then\n"
         "  target=\"${!#}\"\n"

--- a/backend/tests/test_e2e_runtime_bootstrap.py
+++ b/backend/tests/test_e2e_runtime_bootstrap.py
@@ -1,0 +1,84 @@
+"""Focused checks for the Ubuntu E2E runtime bootstrap boundary."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "backend/scripts/ci/bootstrap_e2e_runtime.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def test_bootstrap_prepares_locked_python_314_environment_and_execs_runtime(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake-bin"
+    data_root = tmp_path / "bootstrap-data"
+    uv_log = tmp_path / "uv.log"
+    python_log = tmp_path / "python.log"
+    python_template = tmp_path / "python-template"
+
+    _write_executable(
+        fake_bin / "docker",
+        "#!/usr/bin/env bash\n"
+        "[[ \"$1\" == info || \"$1 $2\" == 'compose version' ]]\n",
+    )
+    _write_executable(
+        python_template,
+        "#!/usr/bin/env bash\n"
+        "if [[ \"${1:-}\" == -c ]]; then exit 0; fi\n"
+        "printf 'docker=%s\\n' \"${AKB_E2E_DOCKER_ARGV:-}\" >\"$AKB_TEST_PYTHON_LOG\"\n"
+        "printf 'arg=%s\\n' \"$@\" >>\"$AKB_TEST_PYTHON_LOG\"\n"
+        "exit 23\n",
+    )
+    _write_executable(
+        data_root / "bin/uv",
+        "#!/usr/bin/env bash\n"
+        "if [[ \"${1:-}\" == --version ]]; then echo 'uv 0.12.1'; exit 0; fi\n"
+        "printf '%s\\n' \"$*\" >>\"$AKB_TEST_UV_LOG\"\n"
+        "if [[ \"${1:-}\" == venv ]]; then\n"
+        "  target=\"${!#}\"\n"
+        "  mkdir -p \"$target/bin\"\n"
+        "  cp \"$AKB_TEST_PYTHON_TEMPLATE\" \"$target/bin/python\"\n"
+        "fi\n",
+    )
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "AKB_E2E_BOOTSTRAP_ROOT": str(data_root),
+            "AKB_TEST_PYTHON_LOG": str(python_log),
+            "AKB_TEST_PYTHON_TEMPLATE": str(python_template),
+            "AKB_TEST_UV_LOG": str(uv_log),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(BOOTSTRAP), "--manage-postgres", "--scenario", "empty"],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 23
+    assert uv_log.read_text().splitlines() == [
+        "python install 3.14",
+        f"venv --clear --python 3.14 {data_root / 'venv'}",
+        "sync --project backend --locked --no-dev --python 3.14",
+    ]
+    assert python_log.read_text().splitlines() == [
+        "docker=docker",
+        "arg=backend/scripts/ci/e2e_runtime.py",
+        "arg=--manage-postgres",
+        "arg=--scenario",
+        "arg=empty",
+    ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.10.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/docs/design/accepted/2026-08-04-app-installation-lifecycle/README.md
+++ b/docs/design/accepted/2026-08-04-app-installation-lifecycle/README.md
@@ -1,0 +1,90 @@
+---
+status: accepted
+stage: applied
+created: 2026-08-04
+updated: 2026-08-04
+---
+
+# App Installation Lifecycle
+
+## Decision
+
+Expose the existing app desired-state registry through a Vault-keyed HTTP
+lifecycle surface. The registry remains the source of truth; the API does not
+add a command ledger, idempotency table, migration, worker, or data-plane
+operation.
+
+Administrators use:
+
+```text
+PUT    /api/v1/apps/{app_id}/installations/{vault_id}
+GET    /api/v1/apps/{app_id}/installations/{vault_id}
+DELETE /api/v1/apps/{app_id}/installations/{vault_id}
+```
+
+The PUT body is `{release_id, capabilities, mode}`, where `mode` is
+`install`, `restore`, or `fresh` and defaults to `install`. Capabilities are
+deduplicated, sorted, non-empty, and limited to the existing
+`SUPPORTED_APP_CAPABILITIES` allowlist.
+
+The app-token read surface is deliberately app-scoped by the token principal:
+
+```text
+GET /api/v1/app/installations/{vault_id}
+```
+
+There is no app selector on this route. The service rechecks the live
+installation and current active grant, and permits only
+`installation:read` for `installing`, `active`, `upgrading`, or `blocked`
+installations.
+
+## State transitions
+
+- A first install creates one `installing` installation and generation-one
+  active grant in one transaction. Identical retries replay the same state and
+  return 200; a state-changing command returns 202.
+- Commands serialize on the app/Vault pair. Conflicting release or capability
+  requests return 409 without partial registry changes.
+- Uninstall revokes the active grant, clears desired state, moves owned
+  resources to `retained`, and preserves the current release and observation.
+  Repeated DELETE is a no-op replay.
+- Restore is explicit and requires the retained current release, matching
+  observed release, and matching expected/observed schema fingerprints. It
+  creates the next grant generation and changes retained resources back to
+  owned.
+- Fresh is explicit, refuses any retained resource, clears the old current
+  pointer, and starts a new `installing` generation only when no resource row
+  remains.
+
+## Authorization and projection
+
+System administrators and the target Vault owner/admin may use the
+administrator surface, subject to the existing Vault access and PAT-scope
+checks. Unauthorized users receive a generic 403 before app, release,
+installation, or Vault metadata is resolved. App tokens cannot mutate the
+lifecycle and can read only their own live installation with the required
+active grant capability.
+
+Status projects installation/app/Vault identifiers, lifecycle, desired/current
+and observed release data, grant generations and capabilities, resource
+kind/key/status, and sanitized checkpoint/error and release/schema/grant drift.
+Credential and token material, grant provenance, worker payloads, and unrelated
+Vault metadata are excluded. All lifecycle responses are marked
+`Cache-Control: no-store`.
+
+Every accepted, replayed, or denied command emits bounded audit metadata with
+the actor, app, installation when known, Vault, generation when known, result,
+reason, and correlation ID. Request bodies, capabilities, credentials, tokens,
+provenance, and worker payloads are never recorded.
+
+## Compatibility and non-goals
+
+The backend version remains `0.13.0`. Existing registry constraints enforce
+installation uniqueness, grant monotonicity, immutable grant identity, and
+retained-resource protection. Release registration, upgrades/re-consent,
+reconciliation, rollout, SDK generation, frontend/MCP proxy behavior, and
+retained-data deletion remain outside this surface.
+
+The governing scope and behavior are the accepted Delivery Contract in the
+AKB issue record. This repository document records the implemented public
+boundary and is not a second source of product requirements.


### PR DESCRIPTION
## 변경 내용

- 앱 설치 lifecycle의 install/status/uninstall/restore/fresh API와 기존 registry 기반 service를 추가했습니다.
- GitHub E2E의 PostgreSQL·embedding stub·backend 기동 흐름을 repository-owned foreground runtime으로 추출했습니다.
- 기존 E2E suite 목록과 실행 semantics를 유지하고, reusable runtime은 empty 및 app-lifecycle fixture 시나리오를 지원합니다.
- 짧은 수명의 사전 발급 app token을 fixture에 저장하지 않고, 장기 credential을 handoff한 뒤 기존 app-token 교환 endpoint를 즉시 사용하는 방식으로 정리했습니다.
- E2E reset이 migration ledger를 비워 backend 재기동 때 과거 migration을 재실행하던 문제를 수정해 `schema_migrations`를 reset 대상에서 보존합니다.

## 공개 계약 및 영향

- Admin/Vault-admin API: `PUT/GET/DELETE /api/v1/apps/{app_id}/installations/{vault_id}`
- App-token status 조회는 기존 `POST /api/v1/auth/app-token` 교환 흐름을 사용합니다.
- 새 migration이나 별도 command table 없이 기존 lifecycle registry와 grant/resource 상태 전이를 재사용합니다.
- GitHub Actions의 PostgreSQL/pgvector service topology와 backend readiness 경로는 유지됩니다.

## 검증

- Apple VM mapped live E2E: 396 passed, 0 failed
- Runtime focused tests: 41 passed
- Repository contributor gate (`scripts/check.sh`): passed
- ruff, mypy, bandit, detect-secrets, uv lock and shell syntax: passed
- Branch-aware default-P0 autoreview: clean
- Diff whitespace check: passed

## 잔여 위험

- API-only 변경이므로 visual evidence는 해당하지 않습니다.
- Hosted CI: static analysis, backend unit tests, pgvector live DB, shell live stack 모두 exact head에서 통과했습니다.
