### PR TITLE
ci(e2e): reject an unparsable assertion count, and close the publication suite's silent-coverage holes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -239,6 +239,18 @@ jobs:
             # is CI-hostile: no proxy, no psql, no embedding assertions.
             test_publications_e2e.sh
           )
+          # Suites allowed to report no assertion count. Adding an entry
+          # is a tracked decision (it means that suite's coverage stops
+          # being measured), not a way to quiet the gate — fix the
+          # suite's summary line instead. Intentionally empty.
+          EMPTY_COUNT_ALLOWED=()
+          is_empty_allowed() {
+            local suite="$1" allowed
+            for allowed in ${EMPTY_COUNT_ALLOWED[@]+"${EMPTY_COUNT_ALLOWED[@]}"}; do
+              [ "$allowed" = "$suite" ] && return 0
+            done
+            return 1
+          }
           TOTAL_PASS=0
           TOTAL_FAIL=0
           FAILED=()
@@ -246,10 +258,18 @@ jobs:
             echo "::group::$s"
             OUT=$(bash "backend/tests/$s" 2>&1) && RC=0 || RC=$?
             echo "$OUT" | tail -80
-            # Match both summary styles: some suites prefix with a
-            # box-drawing "║ Results:" line, others use bare "Results:"
-            # with leading whitespace. tail -1 picks the final summary.
-            SUMMARY=$(echo "$OUT" | grep -E '(║.*)?Results: *[0-9]+ passed' | tail -1)
+            # A suite's assertion count comes from a line containing
+            # "Results: N passed, M failed", optionally inside a
+            # box-drawing frame. BOTH counts are required: a line that
+            # carries only the passed count would leave F silently zero,
+            # which is the same dead gate half this check exists to
+            # close. Suites print other output after the summary (frame
+            # edges, skip notes, error dumps), so this takes the LAST
+            # matching line, not the last line of output — the count a
+            # suite reports last is the one that counts.
+            # `|| true`: no match is a real outcome the gate below
+            # reports on, not a reason to abort the step.
+            SUMMARY=$(echo "$OUT" | grep -E '(║.*)?Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1 || true)
             P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+' || echo 0)
             F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+' || echo 0)
             TOTAL_PASS=$((TOTAL_PASS + ${P:-0}))
@@ -257,6 +277,17 @@ jobs:
             echo "::endgroup::"
             echo "▸ $s: ${P:-0} passed, ${F:-0} failed (rc=$RC)"
             if [ "$RC" != "0" ] || [ "${F:-0}" != "0" ]; then
+              FAILED+=("$s")
+            elif [ "${P:-0}" = "0" ] && ! is_empty_allowed "$s"; then
+              # rc=0 with no assertions counted. A suite that returned
+              # early without asserting anything looks exactly like one
+              # that passed, so treat it as a failure rather than
+              # folding a silent 0 into the total.
+              if [ -z "$SUMMARY" ]; then
+                echo "::error::$s produced no parsable assertion count: no line matching 'Results: N passed, M failed' — a summary carrying only one of the two counts does not parse"
+              else
+                echo "::error::$s produced no parsable assertion count: summary line reported 0 passed ($SUMMARY)"
+              fi
               FAILED+=("$s")
             fi
           done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -210,6 +210,11 @@ jobs:
           #     model now rejects as extra_forbidden ("mode" is
           #     output-only since the live/snapshot rewrite). Fix the
           #     test in its own PR, then re-enable.
+          # Registering a suite here requires it to print a
+          # "Results: N passed, M failed" line — the gate below rejects a
+          # suite whose count it cannot parse. Several unregistered
+          # suites do not print one yet and would have to be adapted
+          # first.
           SUITES=(
             test_probes_e2e.sh
             test_mcp_e2e.sh
@@ -242,11 +247,11 @@ jobs:
           # Suites allowed to report no assertion count. Adding an entry
           # is a tracked decision (it means that suite's coverage stops
           # being measured), not a way to quiet the gate — fix the
-          # suite's summary line instead. Intentionally empty.
+          # suite's summary line instead.
           EMPTY_COUNT_ALLOWED=()
           is_empty_allowed() {
             local suite="$1" allowed
-            for allowed in ${EMPTY_COUNT_ALLOWED[@]+"${EMPTY_COUNT_ALLOWED[@]}"}; do
+            for allowed in "${EMPTY_COUNT_ALLOWED[@]}"; do
               [ "$allowed" = "$suite" ] && return 0
             done
             return 1
@@ -259,17 +264,22 @@ jobs:
             OUT=$(bash "backend/tests/$s" 2>&1) && RC=0 || RC=$?
             echo "$OUT" | tail -80
             # A suite's assertion count comes from a line containing
-            # "Results: N passed, M failed", optionally inside a
-            # box-drawing frame. BOTH counts are required: a line that
-            # carries only the passed count would leave F silently zero,
-            # which is the same dead gate half this check exists to
-            # close. Suites print other output after the summary (frame
-            # edges, skip notes, error dumps), so this takes the LAST
-            # matching line, not the last line of output — the count a
-            # suite reports last is the one that counts.
-            # `|| true`: no match is a real outcome the gate below
-            # reports on, not a reason to abort the step.
-            SUMMARY=$(echo "$OUT" | grep -E '(║.*)?Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1 || true)
+            # "Results: N passed, M failed". Unanchored, so whatever a
+            # suite wraps that phrase in is irrelevant. BOTH counts are
+            # required: a line carrying only the passed count leaves F
+            # silently zero, so it matches nothing here and lands on the
+            # "no parsable count" branch below. Suites print other output
+            # after the summary (frame edges, skip notes, error dumps),
+            # so this takes the LAST matching line, not the last line of
+            # output — the count a suite reports last is the one that
+            # counts.
+            # `|| true` is inert today and deliberate: the pipeline's
+            # status is tail's, which is 0 even when grep matched
+            # nothing. It only does work if pipefail is ever enabled on
+            # this step, where grep's exit 1 would otherwise abort it.
+            # Unlike the `|| echo 0` below, which IS load-bearing today —
+            # those pipelines end in a grep that returns 1 on no match.
+            SUMMARY=$(echo "$OUT" | grep -E 'Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1 || true)
             P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+' || echo 0)
             F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+' || echo 0)
             TOTAL_PASS=$((TOTAL_PASS + ${P:-0}))
@@ -281,8 +291,9 @@ jobs:
             elif [ "${P:-0}" = "0" ] && ! is_empty_allowed "$s"; then
               # rc=0 with no assertions counted. A suite that returned
               # early without asserting anything looks exactly like one
-              # that passed, so treat it as a failure rather than
-              # folding a silent 0 into the total.
+              # that ran and passed, so fail the build rather than let
+              # it read as a pass. (The 0 is already in the total above;
+              # this is what stops the total being believed.)
               if [ -z "$SUMMARY" ]; then
                 echo "::error::$s produced no parsable assertion count: no line matching 'Results: N passed, M failed' — a summary carrying only one of the two counts does not parse"
               else

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -237,7 +237,7 @@ jobs:
             # that skips a section still reports 0 failed, so the skip
             # branches there are a fallback, not an accepted outcome.
             test_publication_resolution_e2e.sh
-            # The publication feature's own suite — 127 assertions over
+            # The publication feature's own suite — 134 assertions over
             # documents, table queries, snapshots and files. Needs S3
             # (section 0 uploads a file, and sections 9/13 publish it),
             # which is why MinIO is brought up above. Nothing else here

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -238,7 +238,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "7ef88a05cecb3ee14534c186b61b00bc49f27e2d",
         "is_verified": false,
-        "line_number": 867
+        "line_number": 876
       }
     ],
     "deploy/docker-compose.yaml": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T04:12:07Z"
+  "generated_at": "2026-08-05T04:39:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 232,
+        "line_number": 240,
         "is_secret": false
       },
       {
@@ -223,7 +223,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 249,
         "is_secret": false
       },
       {
@@ -231,14 +231,14 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "3ed9fbbd10ebd33819a3f1ca19555520a58cc16f",
         "is_verified": false,
-        "line_number": 260
+        "line_number": 268
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "7ef88a05cecb3ee14534c186b61b00bc49f27e2d",
         "is_verified": false,
-        "line_number": 876
+        "line_number": 892
       }
     ],
     "deploy/docker-compose.yaml": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T04:39:13Z"
+  "generated_at": "2026-08-05T04:58:01Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 240,
+        "line_number": 261,
         "is_secret": false
       },
       {
@@ -223,7 +223,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 270,
         "is_secret": false
       },
       {
@@ -231,14 +231,14 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "3ed9fbbd10ebd33819a3f1ca19555520a58cc16f",
         "is_verified": false,
-        "line_number": 268
+        "line_number": 289
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "7ef88a05cecb3ee14534c186b61b00bc49f27e2d",
         "is_verified": false,
-        "line_number": 892
+        "line_number": 920
       }
     ],
     "deploy/docker-compose.yaml": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T04:58:01Z"
+  "generated_at": "2026-08-05T05:14:27Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 232,
         "is_secret": false
       },
       {
@@ -223,7 +223,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 232,
+        "line_number": 241,
         "is_secret": false
       },
       {
@@ -231,14 +231,14 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "3ed9fbbd10ebd33819a3f1ca19555520a58cc16f",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 260
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "7ef88a05cecb3ee14534c186b61b00bc49f27e2d",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 867
       }
     ],
     "deploy/docker-compose.yaml": [
@@ -5308,5 +5308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T04:08:17Z"
+  "generated_at": "2026-08-05T04:12:07Z"
 }

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -295,6 +295,22 @@ async def list_publications_route(
     resource_type: str | None = None,
     user: AuthenticatedUser = Depends(get_current_user),
 ):
+    """List every publication in the vault. Unpaginated by contract.
+
+    Two callers depend on the response being complete, and a `limit`/`offset`
+    pair added here would break them in opposite ways:
+
+    - `frontend/src/lib/api.ts` `listPublications` renders the vault's
+      publication list from one unbounded response, so a bound would silently
+      hide rows from the owner.
+    - `backend/tests/test_publications_e2e.sh` asserts the cascade on document
+      and file delete by counting matching rows here. A surviving row that fell
+      off the first page would count as zero and read as "cascade removed it" —
+      the assertion would pass for the wrong reason rather than fail, which is
+      the one failure mode a test cannot report on itself.
+
+    Paginating is fine; doing it without changing both is not.
+    """
     access = await check_vault_access(user.user_id, vault, required_role="reader")
     publications = await publication_service.list_publications(access["vault_id"], resource_type)
     return {"publications": publications}

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -889,12 +889,8 @@ _PUBLICATION_SELECT = (
 async def list_publications(vault_id: uuid.UUID, resource_type: str | None = None) -> list[dict]:
     """List active publications for a vault. Returns public dicts.
 
-    Returns every row, unpaginated. `test_publications_e2e.sh` asserts the
-    cascade on document/file delete by counting the rows this returns, so
-    adding a page bound here would let a surviving row fall off the first
-    page and be read as "cascade removed it" — the assertion would pass for
-    the wrong reason rather than fail. Bound this and that test needs a
-    matching change.
+    Returns every row, unpaginated. That is a contract two callers rely on —
+    see `list_publications_route` before adding a page bound.
     """
     pool = await get_pool()
     async with pool.acquire() as conn:

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -887,7 +887,15 @@ _PUBLICATION_SELECT = (
 
 
 async def list_publications(vault_id: uuid.UUID, resource_type: str | None = None) -> list[dict]:
-    """List active publications for a vault. Returns public dicts."""
+    """List active publications for a vault. Returns public dicts.
+
+    Returns every row, unpaginated. `test_publications_e2e.sh` asserts the
+    cascade on document/file delete by counting the rows this returns, so
+    adding a page bound here would let a surviving row fall off the first
+    page and be read as "cascade removed it" — the assertion would pass for
+    the wrong reason rather than fail. Bound this and that test needs a
+    matching change.
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
         if resource_type:

--- a/backend/tests/test_collection_lifecycle_e2e.sh
+++ b/backend/tests/test_collection_lifecycle_e2e.sh
@@ -400,9 +400,11 @@ echo ""
 echo "═══════════════════════════════════"
 if [ $FAIL -eq 0 ]; then
   echo "✓ All $PASS tests passed"
-  exit 0
 else
   echo "✗ $FAIL failures (of $((PASS+FAIL)) total)"
   printf '  - %s\n' "${ERRORS[@]}"
-  exit 1
 fi
+# Canonical summary, last line on both paths: the CI runner parses it
+# to tell "ran and passed" apart from "asserted nothing".
+echo "  Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] || exit 1

--- a/backend/tests/test_collection_lifecycle_e2e.sh
+++ b/backend/tests/test_collection_lifecycle_e2e.sh
@@ -404,7 +404,6 @@ else
   echo "✗ $FAIL failures (of $((PASS+FAIL)) total)"
   printf '  - %s\n' "${ERRORS[@]}"
 fi
-# Canonical summary, last line on both paths: the CI runner parses it
-# to tell "ran and passed" apart from "asserted nothing".
+# Canonical summary — the CI runner parses this line for the counts.
 echo "  Results: $PASS passed, $FAIL failed"
 [ $FAIL -eq 0 ] || exit 1

--- a/backend/tests/test_forbidden_permission_code_e2e.sh
+++ b/backend/tests/test_forbidden_permission_code_e2e.sh
@@ -84,7 +84,6 @@ echo "$R" | field "['code']" | grep -q . && fail "admin alter regression" "$R" |
 
 echo ""
 if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; fi
-# Canonical summary, last line on both paths: the CI runner parses it
-# to tell "ran and passed" apart from "asserted nothing".
+# Canonical summary — the CI runner parses this line for the counts.
 echo "── #221 e2e — Results: $PASS passed, $FAIL failed ──"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/backend/tests/test_forbidden_permission_code_e2e.sh
+++ b/backend/tests/test_forbidden_permission_code_e2e.sh
@@ -83,5 +83,8 @@ R=$(mcp "$APAT" "$ASID" akb_alter_table "{\"uri\":\"akb://$VAULT/table/t\",\"add
 echo "$R" | field "['code']" | grep -q . && fail "admin alter regression" "$R" || pass "admin alter still succeeds (no regression)"
 
 echo ""
-echo "── #221 e2e: $PASS passed, $FAIL failed ──"
-if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; exit 1; fi
+if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; fi
+# Canonical summary, last line on both paths: the CI runner parses it
+# to tell "ran and passed" apart from "asserted nothing".
+echo "── #221 e2e — Results: $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/backend/tests/test_probes_e2e.sh
+++ b/backend/tests/test_probes_e2e.sh
@@ -97,7 +97,6 @@ if [[ $FAIL -gt 0 ]]; then
   for e in "${ERRORS[@]}"; do echo "  - $e"; done
   echo ""
 fi
-# Canonical summary, last line on both paths: the CI runner parses it
-# to tell "ran and passed" apart from "asserted nothing".
+# Canonical summary — the CI runner parses this line for the counts.
 echo "  Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/backend/tests/test_probes_e2e.sh
+++ b/backend/tests/test_probes_e2e.sh
@@ -92,11 +92,12 @@ awk -v m="$max" 'BEGIN { exit !(m+0 < 3.0) }' \
 # ── Summary ──────────────────────────────────────────────────
 echo ""
 echo "───────────────────────────────────────────"
-echo "  passed: $PASS"
-echo "  failed: $FAIL"
 if [[ $FAIL -gt 0 ]]; then
-  echo ""
   echo "Failures:"
   for e in "${ERRORS[@]}"; do echo "  - $e"; done
-  exit 1
+  echo ""
 fi
+# Canonical summary, last line on both paths: the CI runner parses it
+# to tell "ran and passed" apart from "asserted nothing".
+echo "  Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -105,7 +105,7 @@ d = json.load(sys.stdin)
 forbidden = ["id", "publication_id", "public_url", "public_url_full",
              "public_base", "snapshot_s3_key", "password_hash", "vault_id"]
 found = [k for k in forbidden if k in d]
-if "slug" not in d:
+if not d.get("slug"):
     found.append("<not-a-publication-response>")
 print("PARSED:" + ",".join(found))' 2>/dev/null)
 [ "$LEAKS" = "PARSED:" ] && pass "Response excludes legacy/internal fields" || fail "Response shape" "${LEAKS:-unparsable body}: $R"
@@ -422,9 +422,13 @@ R=$(curl -sk "$BASE_URL/api/v1/public/$TQ_SLUG")
 MODE=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("mode",""))' 2>/dev/null)
 [ "$MODE" = "snapshot" ] && pass "Mode flipped to snapshot" || fail "Snapshot mode" "$MODE"
 
-# Insert new data — snapshot must NOT reflect it
-acurl -X POST "$BASE_URL/api/v1/tables/$VAULT/sql" -H "Content-Type: application/json" \
-  -d "{\"sql\":\"INSERT INTO products (name, category, price) VALUES ('SnapTest', 'food', 999)\"}" >/dev/null
+# Insert new data — snapshot must NOT reflect it. The INSERT is asserted: if it
+# never lands there is nothing for the snapshot to fail to reflect, and the
+# freeze assertion below would pass without exercising anything.
+POST_SNAP=$(acurl -X POST "$BASE_URL/api/v1/tables/$VAULT/sql" -H "Content-Type: application/json" \
+  -d "{\"sql\":\"INSERT INTO products (name, category, price) VALUES ('SnapTest', 'food', 999)\"}")
+PS_ROWS=$(echo "$POST_SNAP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("affected_rows"))' 2>/dev/null)
+[ "$PS_ROWS" = "1" ] && pass "post-snapshot row inserted" || fail "post-snapshot insert" "affected_rows=$PS_ROWS: $POST_SNAP"
 R=$(curl -sk "$BASE_URL/api/v1/public/$TQ_SLUG")
 # The frozen result set must still BE a result set. An error body or an empty
 # `rows` also contains no "SnapTest", so require the served snapshot rows first.
@@ -476,7 +480,7 @@ d = json.load(sys.stdin)
 if d.get("resource_type") != "file" or not d.get("mime_type"):
     print("BAD:not-a-file-publication-response")
 else:
-    print("OK:" + str(d.get("download_url", "")))' 2>/dev/null)
+    print("OK:present" if "download_url" in d else "OK:")' 2>/dev/null)
 [ "$DL" = "OK:" ] && pass "F4: no presigned download_url in file response" || fail "F4 download_url absent" "${DL:-unparsable body}: $R"
 
 # /raw proxies content (CORS-safe for browser)
@@ -514,9 +518,14 @@ CODE=$(acurl -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/files/$IDO
 [ "$CODE" = "200" ] && pass "second-vault file confirmed (200)" || fail "second-vault confirm" "HTTP $CODE"
 # attacker (owner of $VAULT) tries to publish vault-B's file UUID through $VAULT
 R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
-  -d "{\"resource_type\":\"file\",\"uri\":\"akb://$VAULT/file/$IFID\"}")
-IDOR_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
-[ -z "$IDOR_SLUG" ] && pass "cross-vault file publish REJECTED at create (IDOR closed)" || fail "cross-vault file IDOR" "created slug=$IDOR_SLUG"
+  -d "{\"resource_type\":\"file\",\"uri\":\"akb://$VAULT/file/$IFID\"}" -w '\n%{http_code}')
+IDOR_CODE=$(printf '%s' "$R" | tail -1)
+IDOR_SLUG=$(printf '%s' "$R" | sed '$d' | python3 -c 'import json,sys; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
+# An absent slug alone would also be satisfied by a 500 or an unparsable body, so
+# the expected 400 refusal is asserted alongside it.
+[ "$IDOR_CODE" = "400" ] && [ -z "$IDOR_SLUG" ] \
+  && pass "cross-vault file publish REJECTED at create (IDOR closed)" \
+  || fail "cross-vault file IDOR" "HTTP $IDOR_CODE, slug=${IDOR_SLUG:-<none>}: $R"
 acurl -X DELETE "$BASE_URL/api/v1/vaults/$IDOR_V" >/dev/null 2>&1
 
 # File view-count model (hard cap via view-grant): a page open counts one view
@@ -914,9 +923,16 @@ CSC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin)["
 acurl -X DELETE "$BASE_URL/api/v1/files/$VAULT/$FID" > /dev/null
 # An empty slug would request /public/ — 404 by routing, which is exactly what
 # "the publication was cascaded away" asserts. Require a real slug to check.
+# The public 404 is only the symptom: a publication row that outlived its file
+# also 404s. The owner's list is the condition — the row itself must be gone.
 if [ -n "$CSC_SLUG" ]; then
   CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$CSC_SLUG")
-  [ "$CODE" = "404" ] && pass "File delete cascades publications (404)" || fail "File cascade" "HTTP $CODE"
+  LEFT=$(acurl "$BASE_URL/api/v1/publications/$VAULT" | python3 -c "
+import json, sys
+print(sum(1 for p in json.load(sys.stdin)['publications'] if p.get('slug') == '$CSC_SLUG'))" 2>/dev/null)
+  [ "$CODE" = "404" ] && [ "$LEFT" = "0" ] \
+    && pass "File delete cascades publications (404 + row removed)" \
+    || fail "File cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}"
 else
   fail "File cascade" "no publication slug to check the cascade against: $R"
 fi
@@ -931,7 +947,12 @@ DOC_CSC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdi
 acurl -X DELETE "$BASE_URL/api/v1/documents/$VAULT/$CASCADE_DOC" > /dev/null
 if [ -n "$DOC_CSC_SLUG" ]; then
   CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_CSC_SLUG")
-  [ "$CODE" = "404" ] && pass "Document delete cascades publications (404)" || fail "Doc cascade" "HTTP $CODE"
+  LEFT=$(acurl "$BASE_URL/api/v1/publications/$VAULT" | python3 -c "
+import json, sys
+print(sum(1 for p in json.load(sys.stdin)['publications'] if p.get('slug') == '$DOC_CSC_SLUG'))" 2>/dev/null)
+  [ "$CODE" = "404" ] && [ "$LEFT" = "0" ] \
+    && pass "Document delete cascades publications (404 + row removed)" \
+    || fail "Doc cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}"
 else
   fail "Doc cascade" "no publication slug to check the cascade against: $R"
 fi
@@ -952,8 +973,9 @@ echo ""
 
 # ── 99. Cleanup ───────────────────────────────────────────
 echo "▸ 99. Cleanup"
-# Deleting the loaded vault is also the cascade check for a vault that still owns
-# publications, tables and files — so inspect the result instead of assuming it.
+# Deleting a vault that still owns publications, tables and files must at least
+# report success — inspect the result instead of assuming it. This checks the
+# acknowledgement only; it is not a check of the downstream cascade.
 DELV=$(mcp 99 akb_delete_vault "{\"vault\":\"$VAULT\"}" | mcp_text)
 DELOK=$(echo "$DELV" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("deleted"))' 2>/dev/null)
 [ "$DELOK" = "True" ] && pass "Cleanup: test vault deleted" || fail "Cleanup vault delete" "$DELV"

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -132,8 +132,16 @@ CU=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("co
 
 # F8: anonymous doc response must not leak the raw creator id, internal workflow
 # status, or created_at — only the resolved author display name is exposed.
-echo "$R" | python3 -c 'import json,sys; d=json.load(sys.stdin); leaked=[k for k in ("created_by","status","created_at") if k in d]; sys.exit(1 if leaked else 0)' \
-  && pass "F8: doc response omits created_by/status/created_at" || fail "F8 metadata leak" "$R"
+# An error body carries none of those three either, so the response is first
+# established as a resolved document publication.
+F8=$(echo "$R" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+if d.get("resource_type") != "document" or not d.get("title"):
+    print("BAD:not-a-document-publication-response")
+else:
+    print("OK:" + ",".join(k for k in ("created_by", "status", "created_at") if k in d))' 2>/dev/null)
+[ "$F8" = "OK:" ] && pass "F8: doc response omits created_by/status/created_at" || fail "F8 metadata leak" "${F8:-unparsable body}: $R"
 
 # F6: owner-capability probe — anonymous can't edit; the authenticated owner can.
 CE=$(curl -sk "$BASE_URL/api/v1/public/$DOC_SLUG/capabilities" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("can_edit"))' 2>/dev/null)
@@ -561,11 +569,14 @@ echo ""
 # ── 10. Embed + oEmbed ────────────────────────────────────
 echo "▸ 10. Embed + oEmbed"
 
-# Document /embed: same payload as the page GET, plus embed: true.
-CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
+# Document /embed: same payload as the page GET, plus embed: true. Deliberately
+# ONE request — /embed re-resolves through the counted path (public.py), so
+# fetching twice to read the status and the body separately would spend two views
+# on this publication and any later max_views on it would look like a product bug.
+R=$(curl -sk -w '\n%{http_code}' "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
+CODE=$(printf '%s' "$R" | tail -1)
+DEMB=$(printf '%s' "$R" | sed '$d' | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%s|%s" % (d.get("embed"), d.get("title","")))' 2>/dev/null)
 [ "$CODE" = "200" ] && pass "document /embed returns 200" || fail "document /embed" "HTTP $CODE"
-R=$(curl -sk "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
-DEMB=$(echo "$R" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%s|%s" % (d.get("embed"), d.get("title","")))' 2>/dev/null)
 [ "$DEMB" = "True|Pub Doc" ] && pass "document /embed carries embed=true + doc title" || fail "document /embed body" "${DEMB:-unparsable body}: $R"
 
 # embed returns the same shape with embed: true
@@ -713,12 +724,17 @@ case "$MCP_SHARE" in
   http://*|https://*) pass "MCP akb_publish: share_url absolute" ;;
   *) fail "MCP share_url" "$MCP_SHARE" ;;
 esac
+# Same absence-assertion shape as the REST check above: an error body and an
+# unparsable body both carry no legacy fields, so require a real publication.
 LEAKS=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 forbidden = ["publication_id","public_url","public_url_full","public_base"]
-print(",".join(k for k in forbidden if k in d))' 2>/dev/null)
-[ -z "$LEAKS" ] && pass "MCP akb_publish: no legacy fields" || fail "MCP legacy leak" "$LEAKS"
+found = [k for k in forbidden if k in d]
+if not d.get("slug"):
+    found.append("<not-a-publication-response>")
+print("PARSED:" + ",".join(found))' 2>/dev/null)
+[ "$LEAKS" = "PARSED:" ] && pass "MCP akb_publish: no legacy fields" || fail "MCP legacy leak" "${LEAKS:-unparsable body}: $R"
 
 # akb_unpublish by FILE uri — the bug case that 0.5.x silently rejected.
 FU_RES=$(mcp 18 akb_publish "{\"uri\":\"$FILE_URI\",\"resource_type\":\"file\"}" | mcp_text)

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -51,6 +51,23 @@ R=$(acurl -X POST "$BASE_URL/api/v1/vaults?name=$VAULT&description=Pub%20test")
 uri_file_id() { python3 -c "import sys; u=sys.stdin.read().strip(); print(u.rsplit('/',1)[-1] if u else '')"; }
 uri_doc_path() { python3 -c "import sys; u=sys.stdin.read().strip(); print(u.split('/doc/',1)[1] if '/doc/' in u else '')"; }
 
+# Helpers: split one `curl -w '\n%{http_code}'` response into its two halves, so
+# a status and a body can be asserted without paying for a second request. The
+# status is the last line; the body is everything before it, and `sed '$d'` drops
+# that appended line even when the body itself ends without a newline. A
+# transport failure yields code 000 and an empty body, which fails both
+# assertions rather than passing either.
+http_status() { printf '%s' "$1" | tail -1; }
+http_body()   { printf '%s' "$1" | sed '$d'; }
+
+# Helper: count the publications in a listing body that carry a given slug.
+# Reads the body on stdin and takes the slug via argv — this is the one value in
+# the suite that would otherwise be interpolated into python source, where a
+# quote in a slug would be a SyntaxError rather than a wrong answer.
+pub_rows_with_slug() {
+  python3 -c 'import json,sys; print(sum(1 for p in json.load(sys.stdin)["publications"] if p.get("slug") == sys.argv[1]))' "$1" 2>/dev/null
+}
+
 # Create a doc. Backend response carries `uri` + `path` only — there is no
 # legacy `doc_id` field. REST routes that take a `doc_id` accept the doc
 # path verbatim via document_repo.find_by_ref().
@@ -96,19 +113,22 @@ DOC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).g
 [ -n "$DOC_SLUG" ] && pass "Create document publication" || fail "Create doc pub" "$R"
 
 # Response shape: canonical public dict only — no internal/legacy fields.
-# The "PARSED:" marker is what makes this an absence assertion rather than a
-# silence assertion: an unparsable body prints nothing and an error body has no
-# `slug`, so neither can read as "no internal fields present".
+# Convention used by every absence assertion in this suite: the parser prints
+# `OK:` only when the body is the real response AND the field is absent, and
+# `BAD:<reason>` when the body is not that response at all. An unparsable body
+# prints nothing. All three are compared against the fixed string "OK:", so no
+# error path can read as "the field is correctly absent".
 LEAKS=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 forbidden = ["id", "publication_id", "public_url", "public_url_full",
              "public_base", "snapshot_s3_key", "password_hash", "vault_id"]
-found = [k for k in forbidden if k in d]
 if not d.get("slug"):
-    found.append("<not-a-publication-response>")
-print("PARSED:" + ",".join(found))' 2>/dev/null)
-[ "$LEAKS" = "PARSED:" ] && pass "Response excludes legacy/internal fields" || fail "Response shape" "${LEAKS:-unparsable body}: $R"
+    print("BAD:not-a-publication-response")
+else:
+    found = [k for k in forbidden if k in d]
+    print("OK:leaked=" + ",".join(found) if found else "OK:")' 2>/dev/null)
+[ "$LEAKS" = "OK:" ] && pass "Response excludes legacy/internal fields" || fail "Response shape" "${LEAKS:-unparsable body}: $R"
 
 # share_url is always absolute (AKB_PUBLIC_BASE_URL is startup-required).
 SU=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("share_url",""))' 2>/dev/null)
@@ -140,7 +160,8 @@ d = json.load(sys.stdin)
 if d.get("resource_type") != "document" or not d.get("title"):
     print("BAD:not-a-document-publication-response")
 else:
-    print("OK:" + ",".join(k for k in ("created_by", "status", "created_at") if k in d))' 2>/dev/null)
+    leaked = [k for k in ("created_by", "status", "created_at") if k in d]
+    print("OK:leaked=" + ",".join(leaked) if leaked else "OK:")' 2>/dev/null)
 [ "$F8" = "OK:" ] && pass "F8: doc response omits created_by/status/created_at" || fail "F8 metadata leak" "${F8:-unparsable body}: $R"
 
 # F6: owner-capability probe — anonymous can't edit; the authenticated owner can.
@@ -416,14 +437,14 @@ SS_AT=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get(
 # Snapshot response must not leak the internal s3 key. Establish the body is a
 # real snapshot response first — a failed snapshot call carries no s3 key either,
 # and that must not read as "the key is correctly hidden".
-HAS_S3=$(echo "$R" | python3 -c '
+SS_LEAK=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 if d.get("mode") != "snapshot":
-    print("not-a-snapshot-response")
+    print("BAD:not-a-snapshot-response")
 else:
-    print("yes" if "snapshot_s3_key" in d else "no")' 2>/dev/null)
-[ "$HAS_S3" = "no" ] && pass "Snapshot response hides snapshot_s3_key" || fail "Snapshot leak" "${HAS_S3:-unparsable body}: $R"
+    print("OK:leaks-snapshot_s3_key" if "snapshot_s3_key" in d else "OK:")' 2>/dev/null)
+[ "$SS_LEAK" = "OK:" ] && pass "Snapshot response hides snapshot_s3_key" || fail "Snapshot leak" "${SS_LEAK:-unparsable body}: $R"
 
 # After snapshot, /public returns mode=snapshot
 R=$(curl -sk "$BASE_URL/api/v1/public/$TQ_SLUG")
@@ -444,14 +465,16 @@ ROWS=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 rows = d.get("rows")
-if d.get("mode") != "snapshot" or not rows:
-    print("BAD")
+if d.get("mode") != "snapshot":
+    print("BAD:mode=" + str(d.get("mode")))
+elif not rows:
+    print("BAD:no-rows")
 else:
-    print("ROWS:" + ",".join(r["name"] for r in rows))' 2>/dev/null)
+    print("OK:" + ",".join(r["name"] for r in rows))' 2>/dev/null)
 case "$ROWS" in
-  ROWS:*SnapTest*) fail "Snapshot freeze" "serves post-snapshot INSERT: $ROWS" ;;
-  ROWS:*)          pass "Snapshot freezes data (no SnapTest)" ;;
-  *)               fail "Snapshot freeze" "no usable snapshot rows to check: $R" ;;
+  OK:*SnapTest*) fail "Snapshot freeze" "serves post-snapshot INSERT: $ROWS" ;;
+  OK:*)          pass "Snapshot freezes data (no SnapTest)" ;;
+  *)             fail "Snapshot freeze" "no usable snapshot rows to check: ${ROWS:-unparsable body}: $R" ;;
 esac
 
 # snapshot only supported for table_query
@@ -488,7 +511,7 @@ d = json.load(sys.stdin)
 if d.get("resource_type") != "file" or not d.get("mime_type"):
     print("BAD:not-a-file-publication-response")
 else:
-    print("OK:present" if "download_url" in d else "OK:")' 2>/dev/null)
+    print("OK:download_url-present" if "download_url" in d else "OK:")' 2>/dev/null)
 [ "$DL" = "OK:" ] && pass "F4: no presigned download_url in file response" || fail "F4 download_url absent" "${DL:-unparsable body}: $R"
 
 # /raw proxies content (CORS-safe for browser)
@@ -512,8 +535,11 @@ CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$FILE_SL
 # (`document_service._VAULT_NAME_RE`: lowercase alnum with single hyphens) —
 # an underscore here 422s and leaves the whole section with nothing to publish.
 IDOR_V="pubidor-$(date +%s)-$RANDOM"
-CODE=$(acurl -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/vaults?name=$IDOR_V&description=idor")
-[ "$CODE" = "200" ] && pass "second vault created" || fail "second vault create" "HTTP $CODE"
+# Body kept, not discarded: this is the step that silently 422'd on the old
+# underscore name, and the 422 detail names the offending field.
+R=$(acurl -w '\n%{http_code}' -X POST "$BASE_URL/api/v1/vaults?name=$IDOR_V&description=idor")
+CODE=$(http_status "$R")
+[ "$CODE" = "200" ] && pass "second vault created" || fail "second vault create" "HTTP $CODE: $(http_body "$R")"
 IINIT=$(acurl -X POST "$BASE_URL/api/v1/files/$IDOR_V/upload?filename=secret.txt&collection=s&mime_type=text/plain")
 IURI=$(echo "$IINIT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["uri"])' 2>/dev/null)
 IFID=$(printf '%s' "$IURI" | uri_file_id)
@@ -527,8 +553,8 @@ CODE=$(acurl -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/files/$IDO
 # attacker (owner of $VAULT) tries to publish vault-B's file UUID through $VAULT
 R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
   -d "{\"resource_type\":\"file\",\"uri\":\"akb://$VAULT/file/$IFID\"}" -w '\n%{http_code}')
-IDOR_CODE=$(printf '%s' "$R" | tail -1)
-IDOR_SLUG=$(printf '%s' "$R" | sed '$d' | python3 -c 'import json,sys; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
+IDOR_CODE=$(http_status "$R")
+IDOR_SLUG=$(http_body "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
 # An absent slug alone would also be satisfied by a 500 or an unparsable body, so
 # the expected 400 refusal is asserted alongside it.
 [ "$IDOR_CODE" = "400" ] && [ -z "$IDOR_SLUG" ] \
@@ -574,8 +600,8 @@ echo "▸ 10. Embed + oEmbed"
 # fetching twice to read the status and the body separately would spend two views
 # on this publication and any later max_views on it would look like a product bug.
 R=$(curl -sk -w '\n%{http_code}' "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
-CODE=$(printf '%s' "$R" | tail -1)
-DEMB=$(printf '%s' "$R" | sed '$d' | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%s|%s" % (d.get("embed"), d.get("title","")))' 2>/dev/null)
+CODE=$(http_status "$R")
+DEMB=$(http_body "$R" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%s|%s" % (d.get("embed"), d.get("title","")))' 2>/dev/null)
 [ "$CODE" = "200" ] && pass "document /embed returns 200" || fail "document /embed" "HTTP $CODE"
 [ "$DEMB" = "True|Pub Doc" ] && pass "document /embed carries embed=true + doc title" || fail "document /embed body" "${DEMB:-unparsable body}: $R"
 
@@ -724,17 +750,19 @@ case "$MCP_SHARE" in
   http://*|https://*) pass "MCP akb_publish: share_url absolute" ;;
   *) fail "MCP share_url" "$MCP_SHARE" ;;
 esac
-# Same absence-assertion shape as the REST check above: an error body and an
-# unparsable body both carry no legacy fields, so require a real publication.
+# Same OK:/BAD: absence-assertion shape as the REST check in section 1: an error
+# body and an unparsable body both carry no legacy fields, so require a real
+# publication before reading the absence as meaningful.
 LEAKS=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 forbidden = ["publication_id","public_url","public_url_full","public_base"]
-found = [k for k in forbidden if k in d]
 if not d.get("slug"):
-    found.append("<not-a-publication-response>")
-print("PARSED:" + ",".join(found))' 2>/dev/null)
-[ "$LEAKS" = "PARSED:" ] && pass "MCP akb_publish: no legacy fields" || fail "MCP legacy leak" "${LEAKS:-unparsable body}: $R"
+    print("BAD:not-a-publication-response")
+else:
+    found = [k for k in forbidden if k in d]
+    print("OK:leaked=" + ",".join(found) if found else "OK:")' 2>/dev/null)
+[ "$LEAKS" = "OK:" ] && pass "MCP akb_publish: no legacy fields" || fail "MCP legacy leak" "${LEAKS:-unparsable body}: $R"
 
 # akb_unpublish by FILE uri — the bug case that 0.5.x silently rejected.
 FU_RES=$(mcp 18 akb_publish "{\"uri\":\"$FILE_URI\",\"resource_type\":\"file\"}" | mcp_text)
@@ -943,12 +971,11 @@ acurl -X DELETE "$BASE_URL/api/v1/files/$VAULT/$FID" > /dev/null
 # also 404s. The owner's list is the condition — the row itself must be gone.
 if [ -n "$CSC_SLUG" ]; then
   CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$CSC_SLUG")
-  LEFT=$(acurl "$BASE_URL/api/v1/publications/$VAULT" | python3 -c "
-import json, sys
-print(sum(1 for p in json.load(sys.stdin)['publications'] if p.get('slug') == '$CSC_SLUG'))" 2>/dev/null)
+  PUBS=$(acurl "$BASE_URL/api/v1/publications/$VAULT")
+  LEFT=$(printf '%s' "$PUBS" | pub_rows_with_slug "$CSC_SLUG")
   [ "$CODE" = "404" ] && [ "$LEFT" = "0" ] \
     && pass "File delete cascades publications (404 + row removed)" \
-    || fail "File cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}"
+    || fail "File cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}: $PUBS"
 else
   fail "File cascade" "no publication slug to check the cascade against: $R"
 fi
@@ -963,12 +990,11 @@ DOC_CSC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdi
 acurl -X DELETE "$BASE_URL/api/v1/documents/$VAULT/$CASCADE_DOC" > /dev/null
 if [ -n "$DOC_CSC_SLUG" ]; then
   CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_CSC_SLUG")
-  LEFT=$(acurl "$BASE_URL/api/v1/publications/$VAULT" | python3 -c "
-import json, sys
-print(sum(1 for p in json.load(sys.stdin)['publications'] if p.get('slug') == '$DOC_CSC_SLUG'))" 2>/dev/null)
+  PUBS=$(acurl "$BASE_URL/api/v1/publications/$VAULT")
+  LEFT=$(printf '%s' "$PUBS" | pub_rows_with_slug "$DOC_CSC_SLUG")
   [ "$CODE" = "404" ] && [ "$LEFT" = "0" ] \
     && pass "Document delete cascades publications (404 + row removed)" \
-    || fail "Doc cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}"
+    || fail "Doc cascade" "HTTP $CODE, rows still listed=${LEFT:-unparsable}: $PUBS"
 else
   fail "Doc cascade" "no publication slug to check the cascade against: $R"
 fi

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -67,9 +67,12 @@ R=$(acurl -X POST "$BASE_URL/api/v1/tables/$VAULT" -H "Content-Type: application
 [ -n "$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)" ] \
   && pass "Table created" || fail "Table create" "$R"
 
-acurl -X POST "$BASE_URL/api/v1/tables/$VAULT/sql" -H "Content-Type: application/json" \
-  -d "{\"sql\":\"INSERT INTO products (name, category, price) VALUES ('Apple', 'food', 1), ('Bagel', 'food', 2), ('Chair', 'furniture', 50), ('Desk', 'furniture', 200)\"}" >/dev/null
-pass "Table seeded"
+# Seed rows. Every later table_query assertion counts on exactly these 4 rows,
+# so a silent seed failure must fail here rather than skew a row count downstream.
+SEED=$(acurl -X POST "$BASE_URL/api/v1/tables/$VAULT/sql" -H "Content-Type: application/json" \
+  -d "{\"sql\":\"INSERT INTO products (name, category, price) VALUES ('Apple', 'food', 1), ('Bagel', 'food', 2), ('Chair', 'furniture', 50), ('Desk', 'furniture', 200)\"}")
+SEEDED=$(echo "$SEED" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("affected_rows"))' 2>/dev/null)
+[ "$SEEDED" = "4" ] && pass "Table seeded (4 rows)" || fail "Table seed" "affected_rows=$SEEDED: $SEED"
 
 # Upload a JSON file. The init response surfaces only `uri`; the file UUID
 # (required by the confirm round-trip) is the trailing segment.
@@ -93,13 +96,19 @@ DOC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).g
 [ -n "$DOC_SLUG" ] && pass "Create document publication" || fail "Create doc pub" "$R"
 
 # Response shape: canonical public dict only — no internal/legacy fields.
+# The "PARSED:" marker is what makes this an absence assertion rather than a
+# silence assertion: an unparsable body prints nothing and an error body has no
+# `slug`, so neither can read as "no internal fields present".
 LEAKS=$(echo "$R" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 forbidden = ["id", "publication_id", "public_url", "public_url_full",
              "public_base", "snapshot_s3_key", "password_hash", "vault_id"]
-print(",".join(k for k in forbidden if k in d))' 2>/dev/null)
-[ -z "$LEAKS" ] && pass "Response excludes legacy/internal fields" || fail "Response shape" "leaks $LEAKS"
+found = [k for k in forbidden if k in d]
+if "slug" not in d:
+    found.append("<not-a-publication-response>")
+print("PARSED:" + ",".join(found))' 2>/dev/null)
+[ "$LEAKS" = "PARSED:" ] && pass "Response excludes legacy/internal fields" || fail "Response shape" "${LEAKS:-unparsable body}: $R"
 
 # share_url is always absolute (AKB_PUBLIC_BASE_URL is startup-required).
 SU=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("share_url",""))' 2>/dev/null)
@@ -396,9 +405,17 @@ SS_AT=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get(
 [ "$SS_MODE" = "snapshot" ] && pass "Snapshot response mode=snapshot" || fail "Snapshot mode" "$SS_MODE"
 [ -n "$SS_AT" ] && pass "Snapshot response carries snapshot_at" || fail "Snapshot at" "$SS_AT"
 
-# Snapshot response must not leak the internal s3 key
-HAS_S3=$(echo "$R" | python3 -c 'import json,sys; print("yes" if "snapshot_s3_key" in json.load(sys.stdin) else "no")' 2>/dev/null)
-[ "$HAS_S3" = "no" ] && pass "Snapshot response hides snapshot_s3_key" || fail "Snapshot leak" "exposes s3 key"
+# Snapshot response must not leak the internal s3 key. Establish the body is a
+# real snapshot response first — a failed snapshot call carries no s3 key either,
+# and that must not read as "the key is correctly hidden".
+HAS_S3=$(echo "$R" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+if d.get("mode") != "snapshot":
+    print("not-a-snapshot-response")
+else:
+    print("yes" if "snapshot_s3_key" in d else "no")' 2>/dev/null)
+[ "$HAS_S3" = "no" ] && pass "Snapshot response hides snapshot_s3_key" || fail "Snapshot leak" "${HAS_S3:-unparsable body}: $R"
 
 # After snapshot, /public returns mode=snapshot
 R=$(curl -sk "$BASE_URL/api/v1/public/$TQ_SLUG")
@@ -409,8 +426,21 @@ MODE=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("
 acurl -X POST "$BASE_URL/api/v1/tables/$VAULT/sql" -H "Content-Type: application/json" \
   -d "{\"sql\":\"INSERT INTO products (name, category, price) VALUES ('SnapTest', 'food', 999)\"}" >/dev/null
 R=$(curl -sk "$BASE_URL/api/v1/public/$TQ_SLUG")
-ROWS=$(echo "$R" | python3 -c 'import json,sys; rows=json.load(sys.stdin).get("rows",[]); print(",".join(r["name"] for r in rows))' 2>/dev/null)
-echo "$ROWS" | grep -q "SnapTest" && fail "Snapshot freeze" "leaked new data" || pass "Snapshot freezes data (no SnapTest)"
+# The frozen result set must still BE a result set. An error body or an empty
+# `rows` also contains no "SnapTest", so require the served snapshot rows first.
+ROWS=$(echo "$R" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+rows = d.get("rows")
+if d.get("mode") != "snapshot" or not rows:
+    print("BAD")
+else:
+    print("ROWS:" + ",".join(r["name"] for r in rows))' 2>/dev/null)
+case "$ROWS" in
+  ROWS:*SnapTest*) fail "Snapshot freeze" "serves post-snapshot INSERT: $ROWS" ;;
+  ROWS:*)          pass "Snapshot freezes data (no SnapTest)" ;;
+  *)               fail "Snapshot freeze" "no usable snapshot rows to check: $R" ;;
+esac
 
 # snapshot only supported for table_query
 R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
@@ -438,8 +468,16 @@ MIME=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("
 # proxied same-origin via /raw, so the vault name embedded in the S3 key can't
 # leak and the view stays counted + revocable.
 R=$(curl -sk "$BASE_URL/api/v1/public/$FILE_SLUG")
-DLURL=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("download_url",""))' 2>/dev/null)
-[ -z "$DLURL" ] && pass "F4: no presigned download_url in file response" || fail "F4 download_url absent" "$DLURL"
+# "OK:" only prints for a body that really is a resolved file publication, so a
+# 404/410 or an unparsable body cannot read as "download_url correctly absent".
+DL=$(echo "$R" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+if d.get("resource_type") != "file" or not d.get("mime_type"):
+    print("BAD:not-a-file-publication-response")
+else:
+    print("OK:" + str(d.get("download_url", "")))' 2>/dev/null)
+[ "$DL" = "OK:" ] && pass "F4: no presigned download_url in file response" || fail "F4 download_url absent" "${DL:-unparsable body}: $R"
 
 # /raw proxies content (CORS-safe for browser)
 RAW=$(curl -sk "$BASE_URL/api/v1/public/$FILE_SLUG/raw")
@@ -456,14 +494,24 @@ CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$FILE_SL
 # Cross-vault file IDOR: publishing ANOTHER vault's file UUID through my own vault
 # must be REJECTED at create time (else an anonymous viewer could read that vault's
 # file bytes through my publication).
-IDOR_V="pubidor_$RANDOM"
-acurl -X POST "$BASE_URL/api/v1/vaults?name=$IDOR_V&description=idor" >/dev/null
+# The setup is asserted step by step: if no file row is ever created in the
+# second vault, the publish below is refused for "no such file" and that would
+# read as the vault binding working. The name must fit the vault grammar
+# (`document_service._VAULT_NAME_RE`: lowercase alnum with single hyphens) —
+# an underscore here 422s and leaves the whole section with nothing to publish.
+IDOR_V="pubidor-$(date +%s)-$RANDOM"
+CODE=$(acurl -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/vaults?name=$IDOR_V&description=idor")
+[ "$CODE" = "200" ] && pass "second vault created" || fail "second vault create" "HTTP $CODE"
 IINIT=$(acurl -X POST "$BASE_URL/api/v1/files/$IDOR_V/upload?filename=secret.txt&collection=s&mime_type=text/plain")
 IURI=$(echo "$IINIT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["uri"])' 2>/dev/null)
 IFID=$(printf '%s' "$IURI" | uri_file_id)
 IURL=$(echo "$IINIT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["upload_url"])' 2>/dev/null)
-printf 'top-secret-from-vault-B' | curl -sk -X PUT "$IURL" -H "Content-Type: text/plain" --data-binary @- >/dev/null
-acurl -X POST "$BASE_URL/api/v1/files/$IDOR_V/$IFID/confirm" >/dev/null
+[ -n "$IFID" ] && [ -n "$IURL" ] && pass "second-vault upload initialized" || fail "second-vault upload init" "$IINIT"
+CODE=$(printf 'bytes-that-live-in-the-second-vault' | curl -sk -o /dev/null -w "%{http_code}" \
+  -X PUT "$IURL" -H "Content-Type: text/plain" --data-binary @-)
+[ "$CODE" = "200" ] && pass "second-vault file bytes uploaded (200)" || fail "second-vault upload PUT" "HTTP $CODE"
+CODE=$(acurl -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/files/$IDOR_V/$IFID/confirm")
+[ "$CODE" = "200" ] && pass "second-vault file confirmed (200)" || fail "second-vault confirm" "HTTP $CODE"
 # attacker (owner of $VAULT) tries to publish vault-B's file UUID through $VAULT
 R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
   -d "{\"resource_type\":\"file\",\"uri\":\"akb://$VAULT/file/$IFID\"}")
@@ -504,7 +552,13 @@ echo ""
 # ── 10. Embed + oEmbed ────────────────────────────────────
 echo "▸ 10. Embed + oEmbed"
 
-R=$(curl -sk "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed" 2>&1 || true)
+# Document /embed: same payload as the page GET, plus embed: true.
+CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
+[ "$CODE" = "200" ] && pass "document /embed returns 200" || fail "document /embed" "HTTP $CODE"
+R=$(curl -sk "$BASE_URL/api/v1/public/$DOC_SLUG_FOR_SNAP/embed")
+DEMB=$(echo "$R" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("%s|%s" % (d.get("embed"), d.get("title","")))' 2>/dev/null)
+[ "$DEMB" = "True|Pub Doc" ] && pass "document /embed carries embed=true + doc title" || fail "document /embed body" "${DEMB:-unparsable body}: $R"
+
 # embed returns the same shape with embed: true
 CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$TQ_SLUG/embed")
 [ "$CODE" = "200" ] && pass "/embed returns 200 for allowed publication" || fail "/embed" "HTTP $CODE"
@@ -732,6 +786,8 @@ MV0_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin).g
 if [ -n "$MV0_SLUG" ]; then
   CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$MV0_SLUG")
   [ "$CODE" = "410" ] && pass "max_views=0 → immediately 410" || fail "max_views=0" "HTTP $CODE"
+else
+  fail "max_views=0" "publish returned no slug, nothing to request: $R"
 fi
 
 # F4: images render inline through the same-origin /raw proxy (200 + image/png),
@@ -856,8 +912,14 @@ R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type
   -d "{\"resource_type\":\"file\",\"uri\":\"$FILE_URI\"}")
 CSC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin)["slug"])' 2>/dev/null)
 acurl -X DELETE "$BASE_URL/api/v1/files/$VAULT/$FID" > /dev/null
-CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$CSC_SLUG")
-[ "$CODE" = "404" ] && pass "File delete cascades publications (404)" || fail "File cascade" "HTTP $CODE"
+# An empty slug would request /public/ — 404 by routing, which is exactly what
+# "the publication was cascaded away" asserts. Require a real slug to check.
+if [ -n "$CSC_SLUG" ]; then
+  CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$CSC_SLUG")
+  [ "$CODE" = "404" ] && pass "File delete cascades publications (404)" || fail "File cascade" "HTTP $CODE"
+else
+  fail "File cascade" "no publication slug to check the cascade against: $R"
+fi
 
 # Cascade: document delete → publications cascade
 R=$(acurl -X POST "$BASE_URL/api/v1/documents" -H "Content-Type: application/json" \
@@ -867,12 +929,17 @@ R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type
   -d "{\"resource_type\":\"document\",\"uri\":\"akb://$VAULT/doc/$CASCADE_DOC\"}")
 DOC_CSC_SLUG=$(echo "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin)["slug"])' 2>/dev/null)
 acurl -X DELETE "$BASE_URL/api/v1/documents/$VAULT/$CASCADE_DOC" > /dev/null
-CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_CSC_SLUG")
-[ "$CODE" = "404" ] && pass "Document delete cascades publications (404)" || fail "Doc cascade" "HTTP $CODE"
+if [ -n "$DOC_CSC_SLUG" ]; then
+  CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$DOC_CSC_SLUG")
+  [ "$CODE" = "404" ] && pass "Document delete cascades publications (404)" || fail "Doc cascade" "HTTP $CODE"
+else
+  fail "Doc cascade" "no publication slug to check the cascade against: $R"
+fi
 
 # Cascade: empty vault delete
-mcp 90 akb_delete_vault "{\"vault\":\"${VAULT}-empty\"}" >/dev/null 2>&1
-pass "Empty vault deleted (cleanup)"
+DELV=$(mcp 90 akb_delete_vault "{\"vault\":\"${VAULT}-empty\"}" | mcp_text)
+DELOK=$(echo "$DELV" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("deleted"))' 2>/dev/null)
+[ "$DELOK" = "True" ] && pass "Empty vault deleted" || fail "Empty vault delete" "$DELV"
 
 # section_not_found field is True when filter missing
 R=$(acurl -X POST "$BASE_URL/api/v1/publications/$VAULT/create" -H "Content-Type: application/json" \
@@ -885,8 +952,11 @@ echo ""
 
 # ── 99. Cleanup ───────────────────────────────────────────
 echo "▸ 99. Cleanup"
-mcp 99 akb_delete_vault "{\"vault\":\"$VAULT\"}" >/dev/null 2>&1
-pass "Cleanup done"
+# Deleting the loaded vault is also the cascade check for a vault that still owns
+# publications, tables and files — so inspect the result instead of assuming it.
+DELV=$(mcp 99 akb_delete_vault "{\"vault\":\"$VAULT\"}" | mcp_text)
+DELOK=$(echo "$DELV" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("deleted"))' 2>/dev/null)
+[ "$DELOK" = "True" ] && pass "Cleanup: test vault deleted" || fail "Cleanup vault delete" "$DELV"
 
 # Terminate MCP session
 curl -sk -X DELETE "$BASE_URL/mcp/" -H "Authorization: Bearer $TOKEN" -H "Mcp-Session-Id: $SESS" >/dev/null 2>&1

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -228,5 +228,8 @@ R=$(mcp "$PAT" "$SID" akb_delete_vault "{\"vault\":\"$VAULT\"}")
 assert_ok "$R" "cleanup: ephemeral vault + tables deleted"
 
 echo ""
-echo "── #215 e2e: $PASS passed, $FAIL failed ──"
-if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; exit 1; fi
+if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; fi
+# Canonical summary, last line on both paths: the CI runner parses it
+# to tell "ran and passed" apart from "asserted nothing".
+echo "── #215 e2e — Results: $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -229,7 +229,6 @@ assert_ok "$R" "cleanup: ephemeral vault + tables deleted"
 
 echo ""
 if [ "$FAIL" -gt 0 ]; then printf '%s\n' "${ERRORS[@]}"; fi
-# Canonical summary, last line on both paths: the CI runner parses it
-# to tell "ran and passed" apart from "asserted nothing".
+# Canonical summary — the CI runner parses this line for the counts.
 echo "── #215 e2e — Results: $PASS passed, $FAIL failed ──"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/run_canonical_e2e.sh
+++ b/scripts/run_canonical_e2e.sh
@@ -23,7 +23,10 @@ TOTAL_FAIL=0
 for s in "${SUITES[@]}"; do
   echo "═══ $s ═══"
   OUT=$(bash "backend/tests/$s" 2>&1)
-  SUMMARY=$(echo "$OUT" | grep -E 'Results: [0-9]+ passed' | tail -1)
+  # Same summary pattern as .github/workflows/e2e.yml — both counts are
+  # required so a partial summary reports 0 rather than a silent zero
+  # for the failed count.
+  SUMMARY=$(echo "$OUT" | grep -E 'Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1)
   echo "  $SUMMARY"
   P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+')
   F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+')

--- a/scripts/run_regression.sh
+++ b/scripts/run_regression.sh
@@ -27,7 +27,10 @@ for s in "${SUITES[@]}"; do
   echo "═══ $s ═══"
   OUT=$(bash "backend/tests/$s" 2>&1)
   RC=$?
-  SUMMARY=$(echo "$OUT" | grep -E '^║.*Results:|^Results:' | tail -1)
+  # Same summary pattern as .github/workflows/e2e.yml — unanchored and
+  # requiring both counts, so a suite that indents or wraps its summary
+  # line still reports here.
+  SUMMARY=$(echo "$OUT" | grep -E 'Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1)
   echo "$SUMMARY"
   P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+' || echo 0)
   F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+' || echo 0)


### PR DESCRIPTION
## What this is

The shell-e2e job could not tell a suite that ran and passed from a suite that ran
nothing. Four registered suites were recorded as `0 passed, 0 failed (rc=0)` while
actually running and passing, and the suite that gates publication behaviour had eight
places where an assertion could pass for the wrong reason — plus one where it could
disappear from the count entirely.

Both halves are the same problem: a green run that is not evidence of anything.

Follows the CI-integrity direction noted in
`docs/design/proposal/2026-08-04-publication-path-binding/README.md`.

## 1. The runner now rejects an unparsable assertion count

The runner parses a summary line of the form `Results: N passed, M failed`. Four suites
ended with a different format, so `grep` missed them and the count fell through to `0`:

| suite | previous summary |
|---|---|
| `test_probes_e2e.sh` | `passed: N` / `failed: N` |
| `test_collection_lifecycle_e2e.sh` | `✓ All N tests passed` (success path only) |
| `test_table_constraints_e2e.sh` | `── #215 e2e: N passed, N failed ──` |
| `test_forbidden_permission_code_e2e.sh` | `── #221 e2e: N passed, N failed ──` |

All four `exit 1` on failure and the gate checks `RC != 0 || F != 0`, so this was not
letting a red suite through. The defect is narrower and structural: for a `0/0` suite the
`F != 0` half of the gate is dead and only the exit code is load-bearing, and the runner
cannot distinguish

- ran its assertions, passed, summary format unparsed; from
- returned early on a missing precondition, asserted nothing, exit 0.

Both print `0 passed, 0 failed (rc=0)`. The second is how a suite sits in the list
contributing nothing. `TOTAL` also understated real coverage, so it was not usable as a
coverage signal.

**Changes**

- A suite that exits 0 with no parsable count now fails, unless named in
  `EMPTY_COUNT_ALLOWED`. That list is empty; an entry means the suite's coverage stops
  being measured, so adding one is a tracked decision rather than a way to quiet the
  gate. This is the part that closes against a future suite arriving with yet another
  format — unifying today's formats alone would not.
- The error distinguishes "no summary line matched" from "summary line reported 0
  passed".
- The pattern now requires both counts. A line carrying only the passed count left the
  failed count silently zero, which is the same dead gate half. All 15 registered suites
  already print both.
- The four suites emit the canonical line as their last output on both the success and
  the failure path. Assertions and exit codes are unchanged.
- `scripts/run_regression.sh` and `scripts/run_canonical_e2e.sh` parsed with two further
  patterns; `run_regression.sh` was anchored, so it still reported 0/0 for two of the
  four even after they were fixed. All three parsers now share one pattern. The gate
  itself stays in CI — those two remain developer-facing runners.
- Registering a suite now requires it to print the canonical line; noted next to
  `SUITES=(`, since several unregistered suites do not yet.

`TOTAL` moves from 560 to 661 with no new tests written — 94 assertions that were
already running and being counted as zero, plus 7 from the suite below. The 42 belong to
`test_collection_lifecycle_e2e.sh`, which covers recursive collection delete.

## 2. Silent-coverage holes in the publication suite

This suite gates merges now, so a false green costs more than it used to. It is
deliberately not fail-fast and suppresses parser errors, so an early degradation carries
to the end: a failed setup leaves an empty variable and later assertions pass for the
wrong reason. All of these predate its CI registration.

1. **An assertion could disappear.** The `max_views=0` check sat inside an
   `if [ -n "$SLUG" ]` with no `else`, so a publish that returned no slug ran neither
   `pass` nor `fail`. The suite reported one fewer assertion and CI accepted it, because
   CI reads the failure count and never an expected total.
2. **Document `/embed` was a no-op** — the response was assigned and never inspected;
   the assertion on the following line was about a different publication.
3. **A cross-vault check was passing for the wrong reason** — and had never run at all.
   The second vault's name contained an underscore, which the vault name grammar
   rejects, so no vault and no file row ever existed; the publish was refused for "no
   such file" and the suite read that as the vault binding working. A refusal status
   alone cannot tell those two apart, which is why the setup steps are now asserted.
4. **Two cascade tests passed on an empty slug** — the request then goes to
   `/api/v1/public/` with no slug, which is naturally 404, and 404 is what the cascade
   asserts.
5. **Six absence-assertions passed against error responses** — a failed parse leaves an
   empty variable, so "field is absent" was satisfied by a body with no fields at all.
   Four were enumerated in review; a sweep for the same shape found two more.
6. **Three bookkeeping steps asserted nothing** — `pass` called without inspecting the
   result.

**Changes** — every `if [ -n ... ]` guard around an assertion gained an `else fail`;
setup steps (upload PUT, confirm, vault create) are asserted rather than inferred from a
non-empty id; absence-assertions first establish the response parsed and identified
itself before asserting a field is absent; bookkeeping steps check their result.
Adversarial review then tightened four more: the post-snapshot INSERT is asserted to
have landed, the cross-vault refusal asserts its status rather than accepting any error,
both cascade tests assert the publication row actually left the owner's list rather than
only that the URL 404s, and a `download_url` check distinguishes absent from
present-but-empty.

A follow-up pass put every one of those sites on a single `OK:` / `BAD:<reason>`
convention, moved the finding into the failure text rather than the encoding, and
extracted two helpers — a slug row-count that passes the slug via `argv` instead of
interpolating it into Python source, and the body/status split used by the two sites
that read both from one request.

127 assertions → 134.

## 3. One contract written down

`GET /api/v1/publications/{vault}` is unpaginated, and two callers depend on that: the
frontend renders a vault's publication list from one unbounded response, and the cascade
assertions above count matching rows in it. A `limit`/`offset` pair added there would
break them in opposite directions — hiding rows from the owner, and turning a surviving
row into a silently passing cascade assertion. Recorded on the endpoint, where such a
parameter would arrive.

## Verification

- Each of the four suites run against a live stack on both the success and the failure
  path: 13 / 42 / 32 / 7, canonical line last in both.
- The publication suite run at 134 passed, 0 failed.
- The gate logic exercised against synthetic suites covering: conforming pass, zero
  output, exit 0 with no summary, reported failures, `0 passed, 0 failed`, passed-count
  only, two count lines, an unrecognised format with the counts reversed, and an
  allowlisted suite. Identical decisions under `bash -e` (the default for this step) and
  under `bash -e -o pipefail`.
- All 15 registered suites confirmed to still parse under the tightened pattern, by
  rendering each suite's actual summary statement rather than reading it.
- Each hole proven closed by injecting the failure it should catch and confirming the
  suite goes red where it was previously green — including the two ways a body can be
  wrong (a parsable error body and an unparsable one), which fail differently.
- The `/embed` view-count change measured rather than argued: 2 views spent before, 1
  after.
- `scripts/check.sh` green.

## Not in this PR

- Extracting the runner loop into a script. It is now ~50 lines of bash with a helper
  function inside a YAML block scalar, and the only way to test it is to re-extract it.
  Worth doing; a separate decision.
- The parser accepts the canonical line anywhere in a suite's output, not only as the
  final summary. It measures coverage; it does not defend against a suite that
  misreports itself. Requiring the last line of output is not possible without editing
  every conforming suite, since they all print frame edges or skip notes afterward.
- Two error-extraction expressions in the publication suite read stdin twice, so the
  fallback branch always raises. Affects failure-message quality only, not whether an
  assertion passes.

## Risk

The cross-vault setup in the publication suite could always fail for environmental
reasons; it simply failed silently before. It is newly load-bearing in CI and will now
go red if it breaks, which is the point. The vault name is unique per run to remove the
one collision vector visible.
