### PR TITLE
feat(publications): restore a database-enforced document identity

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -159,7 +159,7 @@ jobs:
         # one path, and a row the product will not produce — nothing a mock
         # can stand in for.
         #
-        # Migration 053's whole product is a database guarantee — a composite
+        # Migration 058's whole product is a database guarantee — a composite
         # FK with ON DELETE CASCADE — so its tests issue raw SQL that bypasses
         # every application-level defence. There is nothing for a mock to
         # stand in for: the assertions are what PostgreSQL does with a DELETE
@@ -179,7 +179,7 @@ jobs:
           tests/test_pgvector_ext_bootstrap_e2e.py
           tests/test_migration_037_upgrade_unit.py
           tests/test_migration_050_drop_todos_unit.py
-          tests/test_migration_053_publication_identity_unit.py
+          tests/test_migration_058_publication_identity_unit.py
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
           tests/concurrency/test_native_ledger_b_core.py

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -131,6 +131,14 @@ jobs:
         # one path, and a row the product will not produce — nothing a mock
         # can stand in for.
         #
+        # Migration 053's whole product is a database guarantee — a composite
+        # FK with ON DELETE CASCADE — so its tests issue raw SQL that bypasses
+        # every application-level defence. There is nothing for a mock to
+        # stand in for: the assertions are what PostgreSQL does with a DELETE
+        # and a cross-vault UPDATE, plus a catalog comparison between a fresh
+        # init.sql database and a migrated one. Off this list it skips in both
+        # jobs and the schema could drift unnoticed.
+        #
         # The external-git cascade file needs a live PG *and* the real git
         # binary: it drives a reconcile over the in-process smart-HTTP git
         # fixture, publishes the mirrored document, then pushes an upstream
@@ -143,6 +151,7 @@ jobs:
           tests/test_pgvector_ext_bootstrap_e2e.py
           tests/test_migration_037_upgrade_unit.py
           tests/test_migration_050_drop_todos_unit.py
+          tests/test_migration_053_publication_identity_unit.py
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
           tests/concurrency/test_native_ledger_b_core.py

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -1087,36 +1087,51 @@ async def oembed(url: str, format: str = "json"):
         # bypass — return a generic card and skip every DB title lookup.
         title: str | None = "Protected AKB publication"
     else:
-        # Resolve a useful title. Parse the canonical URI to recover the
-        # resource handle — there are no separate id columns anymore.
+        # Resolve a useful title. Documents are found by `publications.
+        # document_id` (migration 053); the URI is parsed only for the file
+        # branch and for the legacy rows that column could not be backfilled
+        # for. An unfurl that titled the card from whatever now occupies the
+        # published path would name a document nobody published.
         from app.services.uri_service import parse_uri
         parsed = parse_uri(publication.get("resource_uri") or "")
         title = publication.get("title")
         if not title:
-            if rt == ResourceType.DOCUMENT and parsed and parsed.kind == "doc":
-                uri_vault, doc_path = parsed.vault, parsed.identifier
-                pool = await get_pool()
-                async with pool.acquire() as conn:
-                    doc_row = await conn.fetchrow(
-                        """
-                        SELECT d.title FROM documents d JOIN vaults v ON v.id = d.vault_id
-                         -- Bound to the publication's OWN vault_id, with the URI's
-                         -- vault name demoted to a cross-check — the same binding
-                         -- `resolve_document_publication` carries, and the one the
-                         -- file branch below has always had. Keyed on the URI's
-                         -- vault name alone, this returned the title of a document
-                         -- in whatever vault the URI named, which need not be this
-                         -- publication's vault. F1 above protects the publisher,
-                         -- who chose a password; nothing protected the third-party
-                         -- vault, which published nothing at all. No row leaves
-                         -- `title` None and the response falls through to the
-                         -- generic card below — fail closed.
-                         WHERE d.vault_id = $1 AND d.path = $2 AND v.name = $3
-                        """,
-                        to_uuid(publication["vault_id"]), doc_path, uri_vault,
-                    )
-                    if doc_row:
-                        title = doc_row["title"]
+            if rt == ResourceType.DOCUMENT:
+                doc_path = parsed.identifier if parsed and parsed.kind == "doc" else None
+                uri_vault = parsed.vault if parsed and parsed.kind == "doc" else None
+                raw_doc_id = publication.get("document_id")
+                doc_uuid = to_uuid(raw_doc_id) if raw_doc_id else None
+                if doc_uuid is not None or doc_path is not None:
+                    pool = await get_pool()
+                    async with pool.acquire() as conn:
+                        doc_row = await conn.fetchrow(
+                            """
+                            SELECT d.title FROM documents d JOIN vaults v ON v.id = d.vault_id
+                             -- Same two branches, same order of authority, as
+                             -- `resolve_document_publication` — the card and the
+                             -- body it previews must not be able to name
+                             -- different documents.
+                             --
+                             -- $2 (document_id) keys bound rows; the composite FK
+                             -- pins the vault, so no `v.name` cross-check there.
+                             -- The path branch is for backfill-NULL rows only,
+                             -- and keeps the cross-check: keyed on the URI's vault
+                             -- name alone this returned the title of a document in
+                             -- whatever vault the URI named, which need not be this
+                             -- publication's vault. F1 above protects the
+                             -- publisher, who chose a password; nothing protected
+                             -- the third-party vault, which published nothing at
+                             -- all. No row leaves `title` None and the response
+                             -- falls through to the generic card below — fail
+                             -- closed.
+                             WHERE d.vault_id = $1
+                               AND ( d.id = $2::uuid
+                                  OR ($2::uuid IS NULL AND d.path = $3 AND v.name = $4) )
+                            """,
+                            to_uuid(publication["vault_id"]), doc_uuid, doc_path, uri_vault,
+                        )
+                        if doc_row:
+                            title = doc_row["title"]
             elif rt == ResourceType.FILE and parsed and parsed.kind == "file":
                 file_uuid_str = parsed.identifier
                 pool = await get_pool()

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -1088,7 +1088,7 @@ async def oembed(url: str, format: str = "json"):
         title: str | None = "Protected AKB publication"
     else:
         # Resolve a useful title. Documents are found by `publications.
-        # document_id` (migration 053); the URI is parsed only for the file
+        # document_id` (migration 058); the URI is parsed only for the file
         # branch and for the legacy rows that column could not be backfilled
         # for. An unfurl that titled the card from whatever now occupies the
         # published path would name a document nobody published.

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -192,7 +192,13 @@ CREATE TABLE IF NOT EXISTS documents (
     content_hash_commit TEXT,          -- commit the content_hash projection was computed from
     tags TEXT[] DEFAULT '{}',
     metadata JSONB DEFAULT '{}',       -- extended metadata from frontmatter
-    UNIQUE(vault_id, path)
+    UNIQUE(vault_id, path),
+    -- Redundant as a guarantee about documents (id is already the PK), and
+    -- required all the same: publications reference (id, vault_id) as a pair
+    -- so the vault match is structural, and PostgreSQL will not accept a
+    -- composite FK without a unique constraint on exactly that column pair.
+    -- Named explicitly because migration 053 looks it up by name.
+    CONSTRAINT documents_id_vault_id_key UNIQUE (id, vault_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_documents_vault ON documents(vault_id);
@@ -397,12 +403,31 @@ CREATE TABLE IF NOT EXISTS publications (
 
     -- Canonical resource handle — `akb://{vault}/{type}/{identifier}`.
     -- NULL only for table_query publications, which surface a SQL query
-    -- rather than a single addressable resource. The cascade on
-    -- vault/document/file delete still works because vault_id has
-    -- ON DELETE CASCADE; document/file deletion bumps publications
-    -- via app-level cleanup (delete_publications_for_document /
-    -- delete_publications_for_file).
+    -- rather than a single addressable resource. This is the handle every
+    -- surface displays and the API returns; it is NOT the identity binding
+    -- (see document_id below) because a path is reusable.
     resource_uri TEXT,
+
+    -- The published document, when the publication has one.
+    --
+    -- NULLABLE, and that is not a placeholder for future tightening: rows
+    -- that predate migration 053 are bound only if the binding is
+    -- unambiguous, so "every document publication has a document_id" is a
+    -- property of rows created after the publish path started recording it,
+    -- not a schema invariant. table_query and file publications leave it
+    -- NULL by definition — file cleanup is still app-level
+    -- (delete_publications_for_file).
+    --
+    -- The FK is composite on purpose. Referencing documents(id) alone would
+    -- promise only that the document exists; pairing vault_id in makes "the
+    -- document is in the publication's own vault" structural instead of a
+    -- rule each write has to remember. Match type is the default (MATCH
+    -- SIMPLE) so a NULL document_id is exempt even though vault_id is NOT
+    -- NULL — MATCH FULL would forbid the NULL and is wrong here.
+    document_id UUID,
+    CONSTRAINT publications_document_fk
+        FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id)
+        ON DELETE CASCADE,
 
     -- For table_query type: stored canned SQL with :param placeholders
     query_sql TEXT,
@@ -434,6 +459,11 @@ CREATE TABLE IF NOT EXISTS publications (
 CREATE INDEX IF NOT EXISTS idx_publications_slug ON publications(slug);
 CREATE INDEX IF NOT EXISTS idx_publications_vault ON publications(vault_id);
 CREATE INDEX IF NOT EXISTS idx_publications_resource_uri ON publications(resource_uri) WHERE resource_uri IS NOT NULL;
+-- Referencing side of publications_document_fk: without it, every document
+-- delete seq-scans this table to find the rows to cascade. Partial because
+-- most rows are NULL and `document_id = $1` implies NOT NULL, so the cascade
+-- probe can still use it.
+CREATE INDEX IF NOT EXISTS idx_publications_document_id ON publications(document_id, vault_id) WHERE document_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_publications_expires ON publications(expires_at) WHERE expires_at IS NOT NULL;
 
 -- ============================================================

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -242,18 +242,27 @@ CREATE TABLE IF NOT EXISTS chunks (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks (source_type, source_id);
+-- Guarded: `source_type` and `source_id` arrive together with migration 006;
+-- see the note at the publications document_id guard below. 006 creates this
+-- index itself, so the boot that skips it here does not go without it.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'chunks'
+           AND column_name = 'source_type'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks (source_type, source_id);
+    END IF;
+END $$;
 -- Indexing-queue claim order (newest chunks first; see embed_worker._claim_batch).
 -- Also covers the retry-eligibility WHERE filter — a single partial
 -- index is enough; we used to keep idx_chunks_vector_pending alongside
 -- this for vector_next_attempt_at, but the planner was selecting the
 -- ORDER-BY-aligned index anyway, so the second one was dead weight.
--- Guarded on the column: `vector_indexed_at` arrives with migration 009, and
--- this file runs before any migration, so an unguarded reference would abort
--- init.sql on a database that predates it — see the note just below, which is
--- the same hazard handled by leaving idx_chunks_vault_id to migration 014.
--- Dead in practice (009 is applied everywhere), guarded so the pattern in this
--- file is uniform.
+-- Guarded: `vector_indexed_at` arrives with migration 009; see the note at the
+-- publications document_id guard below.
 DO $$
 BEGIN
     IF EXISTS (
@@ -311,8 +320,8 @@ CREATE TABLE IF NOT EXISTS vault_migrations (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_tables_vault ON vault_tables(vault_id);
--- Guarded on the column: `vault_tables.collection_id` arrives with migration 020. Dead in practice, guarded so every
--- statement in this file that names a migration-added column follows one rule.
+-- Guarded: `vault_tables.collection_id` arrives with migration 020; see the
+-- note at the publications document_id guard below.
 DO $$
 BEGIN
     IF EXISTS (
@@ -417,8 +426,8 @@ CREATE TABLE IF NOT EXISTS vault_files (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_files_vault ON vault_files(vault_id);
--- Guarded on the column: `vault_files.collection_id` arrives with migration 020. Dead in practice, guarded so every
--- statement in this file that names a migration-added column follows one rule.
+-- Guarded: `vault_files.collection_id` arrives with migration 020; see the
+-- note at the publications document_id guard below.
 DO $$
 BEGIN
     IF EXISTS (
@@ -498,10 +507,8 @@ CREATE TABLE IF NOT EXISTS publications (
 
 CREATE INDEX IF NOT EXISTS idx_publications_slug ON publications(slug);
 CREATE INDEX IF NOT EXISTS idx_publications_vault ON publications(vault_id);
--- Guarded on the column for the same reason as the cascade index below:
--- `resource_uri` arrives with migration 022. Dead in practice (022 is applied
--- everywhere) — guarded so every statement in this file that names a
--- migration-added column follows one rule.
+-- Guarded: `resource_uri` arrives with migration 022; see the note at the
+-- document_id guard below.
 DO $$
 BEGIN
     IF EXISTS (

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -463,7 +463,27 @@ CREATE INDEX IF NOT EXISTS idx_publications_resource_uri ON publications(resourc
 -- delete seq-scans this table to find the rows to cascade. Partial because
 -- most rows are NULL and `document_id = $1` implies NOT NULL, so the cascade
 -- probe can still use it.
-CREATE INDEX IF NOT EXISTS idx_publications_document_id ON publications(document_id, vault_id) WHERE document_id IS NOT NULL;
+--
+-- Guarded on the column, and that guard is load-bearing. This file is
+-- re-executed IN FULL on every boot, BEFORE any migration runs. On a database
+-- that has not reached migration 053 yet, the CREATE TABLE above is inert (the
+-- table exists) so `document_id` is absent — and a bare CREATE INDEX on it
+-- raises UndefinedColumn, which aborts init.sql and means the migration that
+-- would have added the column never runs. Every boot, forever. Any future
+-- index or ALTER here that names a column added by a migration needs the same
+-- treatment.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'publications'
+           AND column_name = 'document_id'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_publications_document_id
+            ON publications(document_id, vault_id) WHERE document_id IS NOT NULL;
+    END IF;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_publications_expires ON publications(expires_at) WHERE expires_at IS NOT NULL;
 
 -- ============================================================

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -248,9 +248,25 @@ CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks (source_type, source_id);
 -- index is enough; we used to keep idx_chunks_vector_pending alongside
 -- this for vector_next_attempt_at, but the planner was selecting the
 -- ORDER-BY-aligned index anyway, so the second one was dead weight.
-CREATE INDEX IF NOT EXISTS idx_chunks_indexing_queue
-    ON chunks (created_at DESC, id)
- WHERE vector_indexed_at IS NULL;
+-- Guarded on the column: `vector_indexed_at` arrives with migration 009, and
+-- this file runs before any migration, so an unguarded reference would abort
+-- init.sql on a database that predates it — see the note just below, which is
+-- the same hazard handled by leaving idx_chunks_vault_id to migration 014.
+-- Dead in practice (009 is applied everywhere), guarded so the pattern in this
+-- file is uniform.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'chunks'
+           AND column_name = 'vector_indexed_at'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_chunks_indexing_queue
+            ON chunks (created_at DESC, id)
+         WHERE vector_indexed_at IS NULL;
+    END IF;
+END $$;
 -- idx_chunks_vault_id is created by migration 014 because on a pre-existing
 -- DB the chunks table is older than the vault_id column. Putting the index
 -- here would fail on the very first init.sql pass after upgrade (column
@@ -295,7 +311,19 @@ CREATE TABLE IF NOT EXISTS vault_migrations (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_tables_vault ON vault_tables(vault_id);
-CREATE INDEX IF NOT EXISTS idx_vault_tables_collection ON vault_tables(collection_id);
+-- Guarded on the column: `vault_tables.collection_id` arrives with migration 020. Dead in practice, guarded so every
+-- statement in this file that names a migration-added column follows one rule.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'vault_tables'
+           AND column_name = 'collection_id'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_vault_tables_collection ON vault_tables(collection_id);
+    END IF;
+END $$;
 CREATE INDEX IF NOT EXISTS idx_vault_table_rows_table ON vault_table_rows(table_id);
 CREATE INDEX IF NOT EXISTS idx_vault_table_rows_data ON vault_table_rows USING gin(data);
 CREATE INDEX IF NOT EXISTS idx_vault_migrations_vault_applied
@@ -389,7 +417,19 @@ CREATE TABLE IF NOT EXISTS vault_files (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vault_files_vault ON vault_files(vault_id);
-CREATE INDEX IF NOT EXISTS idx_vault_files_collection ON vault_files(collection_id);
+-- Guarded on the column: `vault_files.collection_id` arrives with migration 020. Dead in practice, guarded so every
+-- statement in this file that names a migration-added column follows one rule.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'vault_files'
+           AND column_name = 'collection_id'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_vault_files_collection ON vault_files(collection_id);
+    END IF;
+END $$;
 
 -- ============================================================
 -- Publications (unified public-link feature for documents, tables, files)
@@ -458,7 +498,22 @@ CREATE TABLE IF NOT EXISTS publications (
 
 CREATE INDEX IF NOT EXISTS idx_publications_slug ON publications(slug);
 CREATE INDEX IF NOT EXISTS idx_publications_vault ON publications(vault_id);
-CREATE INDEX IF NOT EXISTS idx_publications_resource_uri ON publications(resource_uri) WHERE resource_uri IS NOT NULL;
+-- Guarded on the column for the same reason as the cascade index below:
+-- `resource_uri` arrives with migration 022. Dead in practice (022 is applied
+-- everywhere) — guarded so every statement in this file that names a
+-- migration-added column follows one rule.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'publications'
+           AND column_name = 'resource_uri'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_publications_resource_uri
+            ON publications(resource_uri) WHERE resource_uri IS NOT NULL;
+    END IF;
+END $$;
 -- Referencing side of publications_document_fk: without it, every document
 -- delete seq-scans this table to find the rows to cascade. Partial because
 -- most rows are NULL and `document_id = $1` implies NOT NULL, so the cascade

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -197,7 +197,7 @@ CREATE TABLE IF NOT EXISTS documents (
     -- required all the same: publications reference (id, vault_id) as a pair
     -- so the vault match is structural, and PostgreSQL will not accept a
     -- composite FK without a unique constraint on exactly that column pair.
-    -- Named explicitly because migration 053 looks it up by name.
+    -- Named explicitly because migration 058 looks it up by name.
     CONSTRAINT documents_id_vault_id_key UNIQUE (id, vault_id)
 );
 
@@ -460,7 +460,7 @@ CREATE TABLE IF NOT EXISTS publications (
     -- The published document, when the publication has one.
     --
     -- NULLABLE, and that is not a placeholder for future tightening: rows
-    -- that predate migration 053 are bound only if the binding is
+    -- that predate migration 058 are bound only if the binding is
     -- unambiguous, so "every document publication has a document_id" is a
     -- property of rows created after the publish path started recording it,
     -- not a schema invariant. table_query and file publications leave it
@@ -528,7 +528,7 @@ END $$;
 --
 -- Guarded on the column, and that guard is load-bearing. This file is
 -- re-executed IN FULL on every boot, BEFORE any migration runs. On a database
--- that has not reached migration 053 yet, the CREATE TABLE above is inert (the
+-- that has not reached migration 058 yet, the CREATE TABLE above is inert (the
 -- table exists) so `document_id` is absent — and a bare CREATE INDEX on it
 -- raises UndefinedColumn, which aborts init.sql and means the migration that
 -- would have added the column never runs. Every boot, forever. Any future

--- a/backend/app/db/migrations/022_publications_resource_uri.py
+++ b/backend/app/db/migrations/022_publications_resource_uri.py
@@ -20,6 +20,11 @@ After
         -- NULL                                              for table_query
     -- legacy document_id / file_id FK columns dropped.
 
+Migration 053 later re-introduces a `document_id` — not this one. It is an
+identity column with a composite (document_id, vault_id) FK, added alongside
+`resource_uri` rather than replacing it. `_already_applied` below is written
+so this migration cannot mistake that column for the one it removed.
+
 Migration logic
 ---------------
 1.  ALTER TABLE publications ADD COLUMN resource_uri TEXT (idempotent).
@@ -90,10 +95,25 @@ async def _column_exists(conn, table: str, column: str) -> bool:
 
 
 async def _already_applied(conn) -> bool:
+    """Applied ⇔ resource_uri exists and file_id is gone.
+
+    `document_id` is deliberately NOT part of this test, even though this
+    migration drops a column by that name. Migration 053 adds a *different*
+    document_id — an identity column with a composite FK — and init.sql
+    declares it, so on a fresh database this migration runs after a table
+    that already has one. Keying on document_id here would make 022 drop 053's
+    column on every fresh boot, to be re-added seconds later; a run that
+    stopped in between would leave the schema short a column that init.sql
+    says is there.
+
+    `file_id` is the safe marker: only this migration ever removed it and
+    nothing re-adds it, so its absence alongside resource_uri means the
+    collapse has happened. This is strictly more conservative than the
+    previous test — every database it skipped before, it still skips.
+    """
     has_uri = await _column_exists(conn, "publications", "resource_uri")
-    has_document_id = await _column_exists(conn, "publications", "document_id")
     has_file_id = await _column_exists(conn, "publications", "file_id")
-    return bool(has_uri and not has_document_id and not has_file_id)
+    return bool(has_uri and not has_file_id)
 
 
 async def _run(conn):

--- a/backend/app/db/migrations/022_publications_resource_uri.py
+++ b/backend/app/db/migrations/022_publications_resource_uri.py
@@ -110,6 +110,16 @@ async def _already_applied(conn) -> bool:
     nothing re-adds it, so its absence alongside resource_uri means the
     collapse has happened. This is strictly more conservative than the
     previous test — every database it skipped before, it still skips.
+
+    The one state it reads differently is a hand-built one: resource_uri
+    present, file_id gone, and a LEGACY single-column document_id still
+    there. This migration is transactional, so no ordinary history produces
+    it. If it somehow exists, 053 will try to add its composite FK over
+    whatever those legacy values are — and either every one of them names a
+    document in the publication's own vault, in which case the pre-022
+    bindings were right and are now enforced, or the constraint is refused
+    and the boot fails loudly with the rows to inspect. Neither outcome
+    silently discards data, which the old guard's `DROP COLUMN` would have.
     """
     has_uri = await _column_exists(conn, "publications", "resource_uri")
     has_file_id = await _column_exists(conn, "publications", "file_id")

--- a/backend/app/db/migrations/022_publications_resource_uri.py
+++ b/backend/app/db/migrations/022_publications_resource_uri.py
@@ -20,7 +20,7 @@ After
         -- NULL                                              for table_query
     -- legacy document_id / file_id FK columns dropped.
 
-Migration 053 later re-introduces a `document_id` — not this one. It is an
+Migration 058 later re-introduces a `document_id` — not this one. It is an
 identity column with a composite (document_id, vault_id) FK, added alongside
 `resource_uri` rather than replacing it. `_already_applied` below is written
 so this migration cannot mistake that column for the one it removed.
@@ -98,10 +98,10 @@ async def _already_applied(conn) -> bool:
     """Applied ⇔ resource_uri exists and file_id is gone.
 
     `document_id` is deliberately NOT part of this test, even though this
-    migration drops a column by that name. Migration 053 adds a *different*
+    migration drops a column by that name. Migration 058 adds a *different*
     document_id — an identity column with a composite FK — and init.sql
     declares it, so on a fresh database this migration runs after a table
-    that already has one. Keying on document_id here would make 022 drop 053's
+    that already has one. Keying on document_id here would make 022 drop 058's
     column on every fresh boot, to be re-added seconds later; a run that
     stopped in between would leave the schema short a column that init.sql
     says is there.
@@ -114,7 +114,7 @@ async def _already_applied(conn) -> bool:
     The one state it reads differently is a hand-built one: resource_uri
     present, file_id gone, and a LEGACY single-column document_id still
     there. This migration is transactional, so no ordinary history produces
-    it. If it somehow exists, 053 will try to add its composite FK over
+    it. If it somehow exists, 058 will try to add its composite FK over
     whatever those legacy values are — and either every one of them names a
     document in the publication's own vault, in which case the pre-022
     bindings were right and are now enforced, or the constraint is refused

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -156,12 +156,9 @@ This migration adopts a pre-existing valid index of that name via
 ``ADD CONSTRAINT … UNIQUE USING INDEX`` instead of rebuilding it, and drops
 one left invalid by an interrupted build before trying again.
 
-init.sql keeps the same shape, and has to stay runnable against a database
-that has NOT reached this migration yet: it is re-executed in full on every
-boot, before any migration. ``CREATE TABLE IF NOT EXISTS`` is inert on an
-existing table, but a bare ``CREATE INDEX`` on the new column is not — it
-raises ``UndefinedColumn`` and the boot never reaches the migrations. The
-index statement there is therefore guarded on the column's existence.
+init.sql keeps the same shape, with its ``document_id`` index guarded on the
+column's existence — see the note at that guard in ``init.sql`` for why an
+unguarded statement there is a boot loop.
 """
 
 from __future__ import annotations
@@ -203,6 +200,16 @@ _PUB_FK_SHAPE = (
     # see "Why the FK is composite" in the module docstring.
     "c", "a", "s", True,
 )
+
+# The DDL each shape above describes. Used both to install the constraint and
+# to say what was expected when something else is wearing its name, so the two
+# cannot drift apart.
+_DOC_UNIQUE_DDL = "UNIQUE (id, vault_id)"
+_PUB_FK_DDL = (
+    "FOREIGN KEY (document_id, vault_id) "
+    "REFERENCES documents (id, vault_id) ON DELETE CASCADE"
+)
+
 # Substring of `pg_get_indexdef` that pins the cascade index's columns and
 # predicate. Only the parts that carry meaning — the access method and schema
 # qualification in that string are formatting, and the table it sits on is
@@ -308,31 +315,18 @@ async def _constraint_shape(conn, table: str, name: str) -> tuple | None:
     )
 
 
-# Catalog codes → the words an operator would use. The raw tuple is what the
-# comparison needs; a raw tuple is not what someone reading a failed boot at
-# 3am should have to decode.
-_CONTYPE = {"f": "foreign key", "u": "unique", "p": "primary key", "c": "check"}
-_ACTION = {"a": "NO ACTION", "r": "RESTRICT", "c": "CASCADE", "n": "SET NULL",
-           "d": "SET DEFAULT", " ": "n/a"}
-_MATCH = {"f": "MATCH FULL", "p": "MATCH PARTIAL", "s": "MATCH SIMPLE", " ": "n/a"}
-
-
-def _describe_shape(shape: tuple) -> str:
-    contype, target, local_cols, target_cols, on_del, on_upd, match, valid = shape
-    return (
-        f"{_CONTYPE.get(contype, contype)} "
-        f"({', '.join(local_cols or [])})"
-        + (f" -> {target}({', '.join(target_cols or [])})" if target else "")
-        + f", on delete {_ACTION.get(on_del, on_del)}"
-        f", on update {_ACTION.get(on_upd, on_upd)}"
-        f", {_MATCH.get(match, match)}"
-        f", {'validated' if valid else 'NOT VALIDATED'}"
-    )
-
-
-async def _already_correct(conn, table: str, name: str, expected: tuple) -> bool:
+async def _already_correct(
+    conn, table: str, name: str, expected: tuple, ddl: str,
+) -> bool:
     """True when `name` is already the constraint we would create; raises when
-    something else is wearing the name."""
+    something else is wearing the name.
+
+    The two lines of the message are rendered differently on purpose: `found`
+    is PostgreSQL's own deparse of what is there, `expected` is the literal DDL
+    this migration would have run. Whitespace between them is not the
+    difference — the comparison above is over catalog columns, so if it fired,
+    something structural differs.
+    """
     found = await _constraint_shape(conn, table, name)
     if found is None:
         return False
@@ -341,9 +335,8 @@ async def _already_correct(conn, table: str, name: str, expected: tuple) -> bool
         raise RuntimeError(
             f"{table} already has a constraint named {name}, but it is not the "
             "one migration 053 installs.\n"
-            f"  found:    {_describe_shape(found)}\n"
-            f"  expected: {_describe_shape(expected)}\n"
-            f"  as declared: {definition}\n"
+            f"  found:    {definition}\n"
+            f"  expected: {ddl}\n"
             "Migration 053 will not silently accept it — inspect the constraint, "
             "then drop or rename it and re-run."
         )
@@ -357,7 +350,9 @@ async def _ensure_documents_identity_unique(conn) -> None:
     operator may have run ahead of time (or had cancelled underneath them):
     no index, a valid index of the right shape, or an invalid leftover.
     """
-    if await _already_correct(conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_SHAPE):
+    if await _already_correct(
+        conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_SHAPE, _DOC_UNIQUE_DDL,
+    ):
         return
 
     # Anything already wearing the name, whatever it is. Relation names are
@@ -466,7 +461,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
         _DOC_UNIQUE, _DOC_UNIQUE,
     )
     await conn.execute(
-        f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} UNIQUE (id, vault_id)"
+        f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} {_DOC_UNIQUE_DDL}"
     )
     logger.info("Migration 053: added %s on documents (id, vault_id)", _DOC_UNIQUE)
 
@@ -490,7 +485,9 @@ async def _ensure_publication_identity(conn) -> None:
     the query that lists the rows, and nothing is deleted or blanked.
     """
     have_column = await _column_exists(conn, "publications", "document_id")
-    have_fk = await _already_correct(conn, "publications", _PUB_FK, _PUB_FK_SHAPE)
+    have_fk = await _already_correct(
+        conn, "publications", _PUB_FK, _PUB_FK_SHAPE, _PUB_FK_DDL,
+    )
     if have_column and have_fk:
         return
 
@@ -501,9 +498,7 @@ async def _ensure_publication_identity(conn) -> None:
         if not have_fk:
             try:
                 await conn.execute(
-                    f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} "
-                    "FOREIGN KEY (document_id, vault_id) "
-                    "REFERENCES documents (id, vault_id) ON DELETE CASCADE"
+                    f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} {_PUB_FK_DDL}"
                 )
             except asyncpg.ForeignKeyViolationError as e:
                 raise RuntimeError(
@@ -737,10 +732,9 @@ async def _backfill(conn) -> dict:
         after = page[-1]["id"]
         examined += len(page)
 
-        ids: list = []
-        paths: list[str] = []
-        uris: list[str] = []
-        vaults: list[str] = []
+        # One row per candidate — (id, path, uri, vault_name) — rather than
+        # four lists that have to be kept the same length by hand.
+        candidates: list[tuple] = []
         for row in page:
             uri = row["resource_uri"]
             parsed = parse_uri(uri) if uri else None
@@ -757,12 +751,9 @@ async def _backfill(conn) -> dict:
                 if len(mismatch_sample) < _MISMATCH_SAMPLE:
                     mismatch_sample.append(row["id"])
                 continue
-            ids.append(row["id"])
-            paths.append(parsed.identifier)
-            uris.append(uri)
-            vaults.append(parsed.vault)
+            candidates.append((row["id"], parsed.identifier, uri, parsed.vault))
 
-        if not ids:
+        if not candidates:
             continue
 
         # The parse happened in Python a moment ago; the row can have moved
@@ -792,18 +783,14 @@ async def _backfill(conn) -> dict:
                AND d.created_at <= p.created_at
             RETURNING p.id
             """,
-            ids, paths, uris, vaults,
+            *[list(col) for col in zip(*candidates)],
         )
         # `updated_at` is deliberately not touched: this is a schema backfill,
         # not an edit anyone made to the publication.
         bound += len(updated)
 
         done = {r["id"] for r in updated}
-        left = [
-            (i, p, u, v)
-            for i, p, u, v in zip(ids, paths, uris, vaults, strict=True)
-            if i not in done
-        ]
+        left = [c for c in candidates if c[0] not in done]
         if left:
             changed, absent, reused = await _classify_leftovers(conn, left)
             changed_underfoot += changed

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -213,6 +213,9 @@ _PUB_INDEX_COLS = "(document_id, vault_id) WHERE (document_id IS NOT NULL)"
 # cancel regardless of how many publications a deployment has accumulated.
 _BATCH = 500
 
+# How many vault-mismatch publication ids the log names individually.
+_MISMATCH_SAMPLE = 20
+
 
 async def migrate(conn=None):
     if conn is None:
@@ -490,7 +493,11 @@ async def _backfill(conn) -> None:
     unreadable_uri = 0
     path_reused = 0
     no_document = 0
-    vault_mismatch: list = []
+    vault_mismatch = 0
+    # Bounded sample, not every id: the log names a handful so an operator can
+    # pull the rows, and the count carries the rest. A per-row list would be
+    # the one structure here whose size still tracked the table's.
+    mismatch_sample: list = []
     after: uuid_mod.UUID | None = None
 
     while True:
@@ -532,7 +539,9 @@ async def _backfill(conn) -> None:
                 # this row, and "some document exists at that path somewhere"
                 # is not evidence about which document this publication was
                 # made for.
-                vault_mismatch.append(row["id"])
+                vault_mismatch += 1
+                if len(mismatch_sample) < _MISMATCH_SAMPLE:
+                    mismatch_sample.append(row["id"])
                 continue
             ids.append(row["id"])
             paths.append(parsed.identifier)
@@ -599,19 +608,19 @@ async def _backfill(conn) -> None:
         "unreadable_uri=%d, vault_mismatch=%d, already_bound=%d, "
         "non_document_publications=%d (of %d document publications examined "
         "this run)",
-        bound, no_document, path_reused, unreadable_uri, len(vault_mismatch),
+        bound, no_document, path_reused, unreadable_uri, vault_mismatch,
         already_bound or 0, skipped_by_design or 0, examined,
     )
     if vault_mismatch:
         # The most interesting rows in the table if they exist: the vault the
         # URI names is not the vault the row belongs to. Ids only — enough to
         # pull the rows with a SELECT, without putting names or paths in a log.
-        shown = [str(i) for i in vault_mismatch[:20]]
         logger.warning(
             "Migration 053: %d document publication(s) name a vault other than "
             "their own and were left unbound. publication id(s): %s%s",
-            len(vault_mismatch), ", ".join(shown),
-            "" if len(vault_mismatch) <= 20 else " (first 20 shown)",
+            vault_mismatch, ", ".join(str(i) for i in mismatch_sample),
+            "" if vault_mismatch <= _MISMATCH_SAMPLE
+            else f" (first {_MISMATCH_SAMPLE} shown)",
         )
     if no_document or path_reused or unreadable_uri:
         logger.warning(

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -198,15 +198,24 @@ _PUB_INDEX = "idx_publications_document_id"
 _DOC_UNIQUE_SHAPE = ("u", None, ["id", "vault_id"], None, " ", " ", " ", True)
 _PUB_FK_SHAPE = (
     "f", "documents", ["document_id", "vault_id"], ["id", "vault_id"],
-    # c = CASCADE on delete; a = NO ACTION on update (so the vault half of the
-    # key cannot be moved out from under the pairing); s = MATCH SIMPLE (so a
-    # NULL document_id is exempt — see the module docstring).
+    # c = ON DELETE CASCADE, a = ON UPDATE NO ACTION, s = MATCH SIMPLE. Pinned
+    # rather than left to the defaults, because all three are load-bearing —
+    # see "Why the FK is composite" in the module docstring.
     "c", "a", "s", True,
 )
 # Substring of `pg_get_indexdef` that pins the cascade index's columns and
 # predicate. Only the parts that carry meaning — the access method and schema
 # qualification in that string are formatting, and the table it sits on is
 # checked against the catalog separately.
+#
+# Why this guard reads deparsed text while the documents one compares attnums:
+# a partial index's predicate has no catalog column to compare, only
+# `pg_get_indexdef` renders it, and the predicate is half of what makes this
+# index the right one. The constraint guards avoid the deparsed form because
+# there it would introduce a search_path dependency for no gain; here the
+# search_path-sensitive part (schema qualification) is excluded from the match
+# and the owning table is checked against the catalog instead. Neither is
+# legacy — they differ because the objects differ.
 _PUB_INDEX_COLS = "(document_id, vault_id) WHERE (document_id IS NOT NULL)"
 
 # Rows per UPDATE. Keeps any single statement well inside the pool's 30s
@@ -242,6 +251,20 @@ async def _column_exists(conn, table: str, column: str) -> bool:
         """,
         table, column,
     ))
+
+
+async def _constraint_def(conn, table: str, name: str) -> str | None:
+    """The constraint as PostgreSQL would declare it. Used only in error text —
+    the comparison itself goes through `_constraint_shape`, because this string
+    is search_path-dependent (see `_PUB_FK_SHAPE`)."""
+    return await conn.fetchval(
+        """
+        SELECT pg_get_constraintdef(oid) FROM pg_constraint
+         WHERE conname::text = $2::text
+           AND conrelid = to_regclass('public.' || $1::text)
+        """,
+        table, name,
+    )
 
 
 async def _constraint_shape(conn, table: str, name: str) -> tuple | None:
@@ -285,6 +308,28 @@ async def _constraint_shape(conn, table: str, name: str) -> tuple | None:
     )
 
 
+# Catalog codes → the words an operator would use. The raw tuple is what the
+# comparison needs; a raw tuple is not what someone reading a failed boot at
+# 3am should have to decode.
+_CONTYPE = {"f": "foreign key", "u": "unique", "p": "primary key", "c": "check"}
+_ACTION = {"a": "NO ACTION", "r": "RESTRICT", "c": "CASCADE", "n": "SET NULL",
+           "d": "SET DEFAULT", " ": "n/a"}
+_MATCH = {"f": "MATCH FULL", "p": "MATCH PARTIAL", "s": "MATCH SIMPLE", " ": "n/a"}
+
+
+def _describe_shape(shape: tuple) -> str:
+    contype, target, local_cols, target_cols, on_del, on_upd, match, valid = shape
+    return (
+        f"{_CONTYPE.get(contype, contype)} "
+        f"({', '.join(local_cols or [])})"
+        + (f" -> {target}({', '.join(target_cols or [])})" if target else "")
+        + f", on delete {_ACTION.get(on_del, on_del)}"
+        f", on update {_ACTION.get(on_upd, on_upd)}"
+        f", {_MATCH.get(match, match)}"
+        f", {'validated' if valid else 'NOT VALIDATED'}"
+    )
+
+
 async def _already_correct(conn, table: str, name: str, expected: tuple) -> bool:
     """True when `name` is already the constraint we would create; raises when
     something else is wearing the name."""
@@ -292,11 +337,13 @@ async def _already_correct(conn, table: str, name: str, expected: tuple) -> bool
     if found is None:
         return False
     if found != expected:
+        definition = await _constraint_def(conn, table, name)
         raise RuntimeError(
             f"{table} already has a constraint named {name}, but it is not the "
-            f"one migration 053 installs.\n  found:    {found}\n  expected: {expected}\n"
-            "(fields: contype, referenced table, local columns, referenced "
-            "columns, on-delete, on-update, match type, validated)\n"
+            "one migration 053 installs.\n"
+            f"  found:    {_describe_shape(found)}\n"
+            f"  expected: {_describe_shape(expected)}\n"
+            f"  as declared: {definition}\n"
             "Migration 053 will not silently accept it — inspect the constraint, "
             "then drop or rename it and re-run."
         )
@@ -313,26 +360,48 @@ async def _ensure_documents_identity_unique(conn) -> None:
     if await _already_correct(conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_SHAPE):
         return
 
+    # Anything already wearing the name, whatever it is. Relation names are
+    # unique per SCHEMA, not per table, so "an index called X exists" says
+    # nothing about which table it indexes — and the three branches below all
+    # act on `documents`. Read the owning table first, or an index belonging
+    # to some other table gets adopted, misreported, or dropped.
     existing = await conn.fetchrow(
         """
-        SELECT i.indisvalid                AS is_valid,
-               i.indisunique               AS is_unique,
-               i.indpred IS NOT NULL       AS is_partial,
-               i.indexprs IS NOT NULL      AS is_expression,
-               i.indkey::text              AS indkey,
+        SELECT c.relkind::text              AS relkind,
+               (SELECT t.relname::text FROM pg_class t
+                 WHERE t.oid = i.indrelid)  AS on_table,
+               i.indisvalid                 AS is_valid,
+               i.indisunique                AS is_unique,
+               i.indpred IS NOT NULL        AS is_partial,
+               i.indexprs IS NOT NULL       AS is_expression,
+               i.indkey::text               AS indkey,
                (SELECT a.attnum FROM pg_attribute a
                  WHERE a.attrelid = i.indrelid AND a.attname = 'id') AS id_attnum,
                (SELECT a.attnum FROM pg_attribute a
                  WHERE a.attrelid = i.indrelid AND a.attname = 'vault_id') AS vault_attnum
-          FROM pg_index i
-          JOIN pg_class c ON c.oid = i.indexrelid
-         WHERE c.relname = $1
-           AND c.relnamespace = 'public'::regnamespace
+          FROM pg_class c
+          LEFT JOIN pg_index i ON i.indexrelid = c.oid
+         WHERE c.oid = to_regclass('public.' || $1::text)
         """,
         _DOC_UNIQUE,
     )
 
     if existing is not None:
+        if existing["relkind"] != "i" or existing["on_table"] != "documents":
+            # Named, but not an index on documents. Falling through would hand
+            # the operator a bare "relation already exists" from the ALTER,
+            # with nothing to say which object is in the way.
+            what = (
+                f"an index on {existing['on_table']}"
+                if existing["relkind"] == "i"
+                else f"a relation of kind '{existing['relkind']}'"
+            )
+            raise RuntimeError(
+                f"The name {_DOC_UNIQUE} is already taken in schema public by "
+                f"{what}, not by an index on documents. Migration 053 needs that "
+                "name for the documents identity constraint — rename or drop the "
+                "other object and re-run. Nothing has been changed."
+            )
         expected_key = f"{existing['id_attnum']} {existing['vault_attnum']}"
         right_shape = (
             existing["is_unique"]
@@ -341,11 +410,16 @@ async def _ensure_documents_identity_unique(conn) -> None:
             and existing["indkey"] == expected_key
         )
         if not right_shape:
+            definition = await conn.fetchval(
+                "SELECT pg_get_indexdef(to_regclass('public.' || $1::text))",
+                _DOC_UNIQUE,
+            )
             raise RuntimeError(
                 f"An index named {_DOC_UNIQUE} already exists on documents but is "
-                "not a plain UNIQUE index on exactly (id, vault_id). Migration 053 "
-                "will not repurpose it — inspect it, then either drop it or add the "
-                "constraint by hand."
+                "not a plain UNIQUE index on exactly (id, vault_id).\n"
+                f"  found: {definition}\n"
+                "Migration 053 will not repurpose it — inspect it, then either "
+                "drop it or add the constraint by hand."
             )
         if existing["is_valid"]:
             # Adopt it: the constraint takes the index's name and no rebuild
@@ -374,8 +448,23 @@ async def _ensure_documents_identity_unique(conn) -> None:
             "CREATE INDEX CONCURRENTLY leaves one behind); dropping it before "
             "building the constraint", _DOC_UNIQUE,
         )
-        await conn.execute(f"DROP INDEX IF EXISTS {_DOC_UNIQUE}")
+        await conn.execute(f"DROP INDEX IF EXISTS public.{_DOC_UNIQUE}")
 
+    # Say this BEFORE the statement, not after. It is the one statement here
+    # whose cost scales with the table, it holds ACCESS EXCLUSIVE on documents
+    # while it builds, and if it exceeds the pool's 30s cancel the operator
+    # sees a crashlooping pod and a QueryCanceledError that the runner reports
+    # as "blocked on a lock" — which is not what happened. This line is then
+    # the last thing in the log before the stall, and it carries the remedy.
+    logger.info(
+        "Migration 053: building %s on documents (id, vault_id). This holds "
+        "ACCESS EXCLUSIVE on documents for the duration of an index build. If "
+        "it is cancelled at the 30s statement timeout and the migration keeps "
+        "retrying, build the index out of band and re-run — this migration "
+        "adopts an existing valid one instead of rebuilding: "
+        "CREATE UNIQUE INDEX CONCURRENTLY %s ON documents (id, vault_id);",
+        _DOC_UNIQUE, _DOC_UNIQUE,
+    )
     await conn.execute(
         f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} UNIQUE (id, vault_id)"
     )
@@ -389,9 +478,16 @@ async def _ensure_publication_identity(conn) -> None:
     an unconstrained UUID column on a live table, and anything that wrote a
     dangling or cross-vault value into that window would make every later
     attempt to add the constraint fail. The pair costs nothing to redo — the
-    column add is a catalog write and the FK's validation scan runs against
-    all-NULL data — so there is no progress worth preserving by splitting
-    them, and a great deal worth preserving by not leaving that window open.
+    column add is a catalog write, and when the column is new the FK's
+    validation scan runs against all-NULL data — so there is no progress worth
+    preserving by splitting them, and a great deal worth preserving by not
+    leaving that window open.
+
+    The one state where that scan is not free is a database that arrived here
+    with a `document_id` this migration did not add (see migration 022's
+    `_already_applied`). There the scan checks real values, and if any of them
+    fails the composite key the constraint is refused — reported below with
+    the query that lists the rows, and nothing is deleted or blanked.
     """
     have_column = await _column_exists(conn, "publications", "document_id")
     have_fk = await _already_correct(conn, "publications", _PUB_FK, _PUB_FK_SHAPE)
@@ -474,11 +570,106 @@ async def _ensure_publication_document_index(conn) -> None:
             "Migration 053: found an INVALID index named %s; dropping it before "
             "rebuilding", _PUB_INDEX,
         )
-        await conn.execute(f"DROP INDEX IF EXISTS {_PUB_INDEX}")
+        await conn.execute(f"DROP INDEX IF EXISTS public.{_PUB_INDEX}")
     await conn.execute(
         f"CREATE INDEX {_PUB_INDEX} "
         "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
     )
+    # Every other step says what it did. Without this one, a run that died
+    # during the documents index build and a run that died entering the
+    # backfill leave identical logs.
+    logger.info(
+        "Migration 053: created %s — the cascade's lookup path on the "
+        "referencing side", _PUB_INDEX,
+    )
+
+
+async def _classify_leftovers(conn, left: list[tuple]) -> tuple[int, int, int]:
+    """Why the UPDATE declined these rows, as ``(changed, absent, reused)``.
+
+    Three categories, and they are only worth reading if a row lands in the
+    right one: ``changed`` — the row is no longer what was parsed (its URI or
+    its vault name moved, or something else bound it); ``absent`` — the URI
+    still stands and no document occupies that path; ``reused`` — a document
+    occupies it but postdates the publication. That is the whole space,
+    because a row satisfying all of those would have been bound.
+
+    So this re-checks the UPDATE's own predicates instead of asking the weaker
+    "is anything at that path now", which would file a row that moved
+    underfoot as a reused path — a materially different thing to read in a log.
+    """
+    split = await conn.fetchrow(
+        """
+        WITH candidate AS (
+            SELECT pub_id, doc_path, uri, uri_vault
+              FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[])
+                AS t(pub_id, doc_path, uri, uri_vault)
+        ), state AS (
+            SELECT (p.id IS NOT NULL
+                    AND p.document_id IS NULL
+                    AND p.resource_type = 'document'
+                    AND p.resource_uri IS NOT DISTINCT FROM c.uri
+                    AND v.name IS NOT DISTINCT FROM c.uri_vault) AS unchanged,
+                   d.id IS NOT NULL AS path_occupied
+              FROM candidate c
+              LEFT JOIN publications p ON p.id = c.pub_id
+              LEFT JOIN vaults v ON v.id = p.vault_id
+              LEFT JOIN documents d
+                ON d.vault_id = p.vault_id AND d.path = c.doc_path
+        )
+        SELECT COUNT(*) FILTER (WHERE NOT unchanged)                    AS changed,
+               COUNT(*) FILTER (WHERE unchanged AND NOT path_occupied)  AS absent,
+               COUNT(*) FILTER (WHERE unchanged AND path_occupied)      AS reused
+          FROM state
+        """,
+        [r[0] for r in left], [r[1] for r in left],
+        [r[2] for r in left], [r[3] for r in left],
+    )
+    return split["changed"], split["absent"], split["reused"]
+
+
+def _log_backfill_summary(counts: dict, mismatch_sample: list) -> None:
+    """Report what the backfill did, by category.
+
+    Someone reads this to decide whether the result is trustworthy, so the
+    categories are named and counted separately rather than rolled into a
+    total — "bound=N, path_reused=1" and "bound=N, vault_mismatch=1" describe
+    very different databases.
+    """
+    logger.info(
+        "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
+        "unreadable_uri=%d, vault_mismatch=%d, changed_underfoot=%d, "
+        "already_bound=%d, non_document_publications=%d (of %d document "
+        "publications examined this run)",
+        counts["bound"], counts["no_document"], counts["path_reused"],
+        counts["unreadable_uri"], counts["vault_mismatch"],
+        counts["changed_underfoot"], counts["already_bound"],
+        counts["non_document_publications"], counts["examined"],
+    )
+    if counts["vault_mismatch"]:
+        # The most interesting rows in the table if they exist: the vault the
+        # URI names is not the vault the row belongs to. Ids only — enough to
+        # pull the rows with a SELECT, without putting names or paths in a log.
+        logger.warning(
+            "Migration 053: %d document publication(s) name a vault other than "
+            "their own and were left unbound. publication id(s): %s%s",
+            counts["vault_mismatch"], ", ".join(str(i) for i in mismatch_sample),
+            "" if counts["vault_mismatch"] <= _MISMATCH_SAMPLE
+            else f" (first {_MISMATCH_SAMPLE} shown)",
+        )
+    unbound = (
+        counts["no_document"] + counts["path_reused"]
+        + counts["unreadable_uri"] + counts["changed_underfoot"]
+    )
+    if unbound:
+        logger.warning(
+            "Migration 053: %d document publication(s) left unbound "
+            "(no_document=%d, path_reused=%d, unreadable_uri=%d, "
+            "changed_underfoot=%d). They keep working through resource_uri; "
+            "document_id stays NULL until they are re-published.",
+            unbound, counts["no_document"], counts["path_reused"],
+            counts["unreadable_uri"], counts["changed_underfoot"],
+        )
 
 
 async def _backfill(conn) -> dict:
@@ -614,40 +805,10 @@ async def _backfill(conn) -> dict:
             if i not in done
         ]
         if left:
-            # Why each leftover was left. The UPDATE can decline a row for four
-            # reasons and the counts are only worth reading if they name the
-            # right one, so this re-checks the same predicates rather than
-            # asking the weaker question "is anything at that path now" — which
-            # would file a row that moved underfoot as a reused path.
-            split = await conn.fetchrow(
-                """
-                WITH candidate AS (
-                    SELECT pub_id, doc_path, uri, uri_vault
-                      FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[])
-                        AS t(pub_id, doc_path, uri, uri_vault)
-                ), state AS (
-                    SELECT (p.id IS NOT NULL
-                            AND p.document_id IS NULL
-                            AND p.resource_uri IS NOT DISTINCT FROM c.uri
-                            AND v.name IS NOT DISTINCT FROM c.uri_vault) AS unchanged,
-                           d.id IS NOT NULL AS path_occupied
-                      FROM candidate c
-                      LEFT JOIN publications p ON p.id = c.pub_id
-                      LEFT JOIN vaults v ON v.id = p.vault_id
-                      LEFT JOIN documents d
-                        ON d.vault_id = p.vault_id AND d.path = c.doc_path
-                )
-                SELECT COUNT(*) FILTER (WHERE NOT unchanged)             AS changed,
-                       COUNT(*) FILTER (WHERE unchanged AND NOT path_occupied) AS absent,
-                       COUNT(*) FILTER (WHERE unchanged AND path_occupied)     AS reused
-                  FROM state
-                """,
-                [r[0] for r in left], [r[1] for r in left],
-                [r[2] for r in left], [r[3] for r in left],
-            )
-            changed_underfoot += split["changed"]
-            no_document += split["absent"]
-            path_reused += split["reused"]
+            changed, absent, reused = await _classify_leftovers(conn, left)
+            changed_underfoot += changed
+            no_document += absent
+            path_reused += reused
 
     counts = {
         "examined": examined,
@@ -660,34 +821,7 @@ async def _backfill(conn) -> dict:
         "already_bound": already_bound or 0,
         "non_document_publications": skipped_by_design or 0,
     }
-    logger.info(
-        "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
-        "unreadable_uri=%d, vault_mismatch=%d, changed_underfoot=%d, "
-        "already_bound=%d, non_document_publications=%d (of %d document "
-        "publications examined this run)",
-        bound, no_document, path_reused, unreadable_uri, vault_mismatch,
-        changed_underfoot, already_bound or 0, skipped_by_design or 0, examined,
-    )
-    if vault_mismatch:
-        # The most interesting rows in the table if they exist: the vault the
-        # URI names is not the vault the row belongs to. Ids only — enough to
-        # pull the rows with a SELECT, without putting names or paths in a log.
-        logger.warning(
-            "Migration 053: %d document publication(s) name a vault other than "
-            "their own and were left unbound. publication id(s): %s%s",
-            vault_mismatch, ", ".join(str(i) for i in mismatch_sample),
-            "" if vault_mismatch <= _MISMATCH_SAMPLE
-            else f" (first {_MISMATCH_SAMPLE} shown)",
-        )
-    unbound = no_document + path_reused + unreadable_uri + changed_underfoot
-    if unbound:
-        logger.warning(
-            "Migration 053: %d document publication(s) left unbound "
-            "(no_document=%d, path_reused=%d, unreadable_uri=%d, "
-            "changed_underfoot=%d). They keep working through resource_uri; "
-            "document_id stays NULL until they are re-published.",
-            unbound, no_document, path_reused, unreadable_uri, changed_underfoot,
-        )
+    _log_backfill_summary(counts, mismatch_sample)
     return counts
 
 

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -68,13 +68,25 @@ A row is bound only when all of the following hold:
      (guaranteed to be at most one by ``UNIQUE (vault_id, path)``).
   4. That document is not newer than the publication. A publication cannot
      have been created for a document that did not exist yet, so a newer
-     document at the path means the path was reused and the original target
-     is gone. This predicate can only refuse a binding, never invent one.
+     document at the path is proof the path was reused. Be clear about what
+     this is: a filter that removes some wrong answers, NOT proof that the
+     surviving ones are right. An *older* document moved onto the path after
+     the original was deleted would pass it. (The current write path refuses
+     a move onto a path some publication still claims, so that shape should
+     not be produced any more — but this migration is written for a database
+     whose history nobody has re-verified.) The predicate can only refuse a
+     binding, never invent one, which is the whole reason to keep it.
      Note that ``documents.created_at`` is written by the application and
      ``publications.created_at`` by the database, so the comparison inherits
      any clock skew between them: a publication created within that skew of
      its own document may be left NULL. That is the safe direction, and a
      NULL row keeps working exactly as it does today.
+
+Everything the parse produced is re-asserted inside the UPDATE — the row's
+``resource_uri`` must still be the string that was parsed, and its vault must
+still carry the name that string named. A publication moved, or a vault
+renamed, between the read and the write therefore leaves the row unbound
+rather than bound to what its old URI used to mean.
 
 Consequence, stated plainly: because NULL is allowed, "every document
 publication points at a document" is NOT a schema invariant after this
@@ -99,23 +111,39 @@ re-enters and completes, and a partially-bound table is a legitimate resting
 state, not damage.
 
 ``ADD CONSTRAINT … NOT VALID`` + ``VALIDATE CONSTRAINT`` was considered and
-rejected. It would save the initial scan of ``publications`` — a table with
-one row per published link — while still taking the same ACCESS EXCLUSIVE
-lock to write the catalog entry, and it would leave behind a constraint that
-is enforced but unverified if the second step never ran. The saving is not
-worth a state where the schema looks stronger than it is. (If ``publications``
-ever grew to a size where that scan mattered, this is the decision to revisit.)
+rejected. Adding the FK takes SHARE ROW EXCLUSIVE on both ``publications`` and
+``documents`` — measured, not assumed — which blocks writes to both for the
+duration of the validation scan. ``NOT VALID`` would take the same lock and
+skip the scan, so what it buys is exactly the length of one sequential scan of
+``publications``, a table with one row per published link. Against that it
+leaves a constraint that is enforced for new rows but unverified for old ones
+if the second step never ran, and a schema that looks stronger than it is is
+the failure mode this whole change is trying to remove. If ``publications``
+ever grows to where that scan is a real outage window, this is the decision to
+revisit — the split is mechanical.
 
 Locks and timeouts
 ------------------
 The runner sets ``lock_timeout = '5s'`` and the pool cancels any statement at
-30s, and both apply here. The one statement that does real work proportional
-to table size is the unique index behind ``documents_id_vault_id_key``; it is
-built plainly, not CONCURRENTLY, because a plain build inside its own implicit
-transaction leaves nothing behind when it is cancelled, whereas a cancelled
-CONCURRENTLY build leaves an *invalid* index that ``IF NOT EXISTS`` would then
-skip over forever. Failing loudly and retrying beats a schema that quietly
-believes it has an index.
+30s, and both apply here. ``lock_timeout`` bounds only the wait to ACQUIRE a
+lock, not how long one is held once acquired; the 30s cancel is what bounds
+the latter.
+
+Every statement in the backfill is bounded to ``_BATCH`` rows, so its cost
+does not scale with the table. Two DDL statements do scale:
+
+  * ``ALTER TABLE documents ADD CONSTRAINT documents_id_vault_id_key UNIQUE``
+    builds an index over ``documents`` while holding ACCESS EXCLUSIVE. This is
+    the worst statement here, and on a large enough table it will be cancelled
+    at 30s, roll back, and make no progress across retries.
+  * the FK's validation scan over ``publications``, under SHARE ROW EXCLUSIVE
+    on both tables.
+
+The index is built plainly, not CONCURRENTLY, because a plain build inside its
+own implicit transaction leaves nothing behind when it is cancelled, whereas a
+cancelled CONCURRENTLY build leaves an *invalid* index that ``IF NOT EXISTS``
+would then skip over forever. Failing loudly and retrying beats a schema that
+quietly believes it has an index.
 
 If ``documents`` is ever large enough that the in-line build cannot finish
 inside the 30s cancel, the escape hatch is to build the index out of band and
@@ -127,6 +155,13 @@ re-run:
 This migration adopts a pre-existing valid index of that name via
 ``ADD CONSTRAINT … UNIQUE USING INDEX`` instead of rebuilding it, and drops
 one left invalid by an interrupted build before trying again.
+
+init.sql keeps the same shape, and has to stay runnable against a database
+that has NOT reached this migration yet: it is re-executed in full on every
+boot, before any migration. ``CREATE TABLE IF NOT EXISTS`` is inert on an
+existing table, but a bare ``CREATE INDEX`` on the new column is not — it
+raises ``UndefinedColumn`` and the boot never reaches the migrations. The
+index statement there is therefore guarded on the column's existence.
 """
 
 from __future__ import annotations
@@ -134,7 +169,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+import uuid as uuid_mod
 from pathlib import Path
+
+import asyncpg
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
@@ -146,6 +184,16 @@ logger = logging.getLogger("akb.migration.053")
 _DOC_UNIQUE = "documents_id_vault_id_key"
 _PUB_FK = "publications_document_fk"
 _PUB_INDEX = "idx_publications_document_id"
+
+# Expected definitions, exactly as `pg_get_constraintdef` renders them. The
+# idempotency guards compare against these rather than against a name, so a
+# constraint that merely borrowed the name cannot pass for the real thing.
+_DOC_UNIQUE_DEF = "UNIQUE (id, vault_id)"
+_PUB_FK_DEF = (
+    "FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id) "
+    "ON DELETE CASCADE"
+)
+_PUB_INDEX_COLS = "(document_id, vault_id) WHERE (document_id IS NOT NULL)"
 
 # Rows per UPDATE. Keeps any single statement well inside the pool's 30s
 # cancel regardless of how many publications a deployment has accumulated.
@@ -173,15 +221,41 @@ async def _column_exists(conn, table: str, column: str) -> bool:
     ))
 
 
-async def _constraint_exists(conn, table: str, name: str) -> bool:
-    return bool(await conn.fetchval(
+async def _constraint_def(conn, table: str, name: str) -> str | None:
+    """The constraint's definition, or None if there is no constraint by that
+    name on that table.
+
+    Definition rather than existence on purpose. A name-only check would let a
+    CHECK constraint, an unvalidated FK, or an FK on the wrong columns wearing
+    the right name satisfy the idempotency guard — the migration would return
+    happily, get recorded in the ledger, and leave the guarantee it advertises
+    uninstalled. Comparing what the database actually built means a re-run
+    either finds the real thing or says so.
+    """
+    return await conn.fetchval(
         """
-        SELECT 1 FROM pg_constraint
+        SELECT pg_get_constraintdef(oid) FROM pg_constraint
          WHERE conname::text = $2::text
            AND conrelid = to_regclass('public.' || $1::text)
         """,
         table, name,
-    ))
+    )
+
+
+async def _already_correct(conn, table: str, name: str, expected: str) -> bool:
+    """True when `name` is already the constraint we would create; raises when
+    something else is wearing the name."""
+    found = await _constraint_def(conn, table, name)
+    if found is None:
+        return False
+    if found != expected:
+        raise RuntimeError(
+            f"{table} already has a constraint named {name}, but it is not the "
+            f"one migration 053 installs.\n  found:    {found}\n  expected: {expected}\n"
+            "Migration 053 will not silently accept it — inspect the constraint, "
+            "then drop or rename it and re-run."
+        )
+    return True
 
 
 async def _ensure_documents_identity_unique(conn) -> None:
@@ -191,7 +265,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
     operator may have run ahead of time (or had cancelled underneath them):
     no index, a valid index of the right shape, or an invalid leftover.
     """
-    if await _constraint_exists(conn, "documents", _DOC_UNIQUE):
+    if await _already_correct(conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_DEF):
         return
 
     existing = await conn.fetchrow(
@@ -256,25 +330,49 @@ async def _ensure_documents_identity_unique(conn) -> None:
     logger.info("Migration 053: added %s on documents (id, vault_id)", _DOC_UNIQUE)
 
 
-async def _ensure_publication_document_column(conn) -> None:
-    if await _column_exists(conn, "publications", "document_id"):
-        return
-    await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
-    logger.info("Migration 053: added publications.document_id (nullable)")
+async def _ensure_publication_identity(conn) -> None:
+    """Add the column and its foreign key as ONE unit.
 
-
-async def _ensure_publication_document_fk(conn) -> None:
-    if await _constraint_exists(conn, "publications", _PUB_FK):
+    Together, not one after the other: a column that exists without its FK is
+    an unconstrained UUID column on a live table, and anything that wrote a
+    dangling or cross-vault value into that window would make every later
+    attempt to add the constraint fail. The pair costs nothing to redo — the
+    column add is a catalog write and the FK's validation scan runs against
+    all-NULL data — so there is no progress worth preserving by splitting
+    them, and a great deal worth preserving by not leaving that window open.
+    """
+    have_column = await _column_exists(conn, "publications", "document_id")
+    have_fk = await _already_correct(conn, "publications", _PUB_FK, _PUB_FK_DEF)
+    if have_column and have_fk:
         return
-    await conn.execute(
-        f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} "
-        "FOREIGN KEY (document_id, vault_id) REFERENCES documents (id, vault_id) "
-        "ON DELETE CASCADE"
-    )
-    logger.info(
-        "Migration 053: added %s — (document_id, vault_id) → documents (id, vault_id) "
-        "ON DELETE CASCADE", _PUB_FK,
-    )
+
+    async with conn.transaction():
+        if not have_column:
+            await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
+            logger.info("Migration 053: added publications.document_id (nullable)")
+        if not have_fk:
+            try:
+                await conn.execute(
+                    f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} "
+                    f"{_PUB_FK_DEF}"
+                )
+            except asyncpg.ForeignKeyViolationError as e:
+                raise RuntimeError(
+                    "Migration 053 cannot add the publication identity constraint: "
+                    "publications already holds a document_id that does not name a "
+                    "document in that publication's own vault. Nothing here will "
+                    "delete or blank those rows — that is a decision for a human. "
+                    "List them with:\n"
+                    "  SELECT p.id, p.vault_id, p.document_id FROM publications p\n"
+                    "   WHERE p.document_id IS NOT NULL AND NOT EXISTS (\n"
+                    "     SELECT 1 FROM documents d\n"
+                    "      WHERE d.id = p.document_id AND d.vault_id = p.vault_id);\n"
+                    f"underlying error: {e}"
+                ) from e
+            logger.info(
+                "Migration 053: added %s — (document_id, vault_id) → "
+                "documents (id, vault_id) ON DELETE CASCADE", _PUB_FK,
+            )
 
 
 async def _ensure_publication_document_index(conn) -> None:
@@ -284,20 +382,43 @@ async def _ensure_publication_document_index(conn) -> None:
     to cascade. Partial on ``document_id IS NOT NULL`` because most rows are
     NULL after this migration and the cascade probe (``document_id = $1``)
     implies NOT NULL, so the planner can still use it.
+
+    Checked by definition rather than by `IF NOT EXISTS` alone, for the same
+    reason as the constraints: a same-named index over different columns would
+    otherwise be accepted silently.
     """
+    found = await conn.fetchval(
+        "SELECT pg_get_indexdef(indexrelid) FROM pg_index "
+        "WHERE indexrelid = to_regclass('public.' || $1::text)",
+        _PUB_INDEX,
+    )
+    if found is not None:
+        if _PUB_INDEX_COLS not in found:
+            raise RuntimeError(
+                f"An index named {_PUB_INDEX} already exists but is not the "
+                f"cascade index migration 053 creates.\n  found: {found}\n"
+                "Inspect it, then drop or rename it and re-run."
+            )
+        return
     await conn.execute(
-        f"CREATE INDEX IF NOT EXISTS {_PUB_INDEX} "
+        f"CREATE INDEX {_PUB_INDEX} "
         "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
     )
 
 
 async def _backfill(conn) -> None:
     """Bind existing document publications to their document, where that is
-    unambiguous. See the module docstring for the four conditions.
+    unambiguous. See the module docstring for the conditions.
 
     Re-runnable: only rows with ``document_id IS NULL`` are considered, so a
     second run binds nothing and reports the already-bound rows under their
     own count instead of adding them to this run's total.
+
+    Paged by primary key. Every statement here is bounded by ``_BATCH`` rows
+    so that neither the pool's 30s cancel nor this process's memory depends on
+    how many publications a deployment has accumulated. Rows bound by an
+    earlier page drop out of the predicate rather than shifting the window, so
+    the key order stays stable across pages.
     """
     already_bound = await conn.fetchval(
         "SELECT COUNT(*) FROM publications "
@@ -307,88 +428,110 @@ async def _backfill(conn) -> None:
         "SELECT COUNT(*) FROM publications WHERE resource_type <> 'document'"
     )
 
-    rows = await conn.fetch(
-        """
-        SELECT p.id, p.resource_uri, v.name AS vault_name
-          FROM publications p
-          JOIN vaults v ON v.id = p.vault_id
-         WHERE p.resource_type = 'document'
-           AND p.document_id IS NULL
-        """
-    )
-
-    candidate_ids: list = []
-    candidate_paths: list[str] = []
-    unreadable_uri = 0
-    vault_mismatch: list = []
-
-    for row in rows:
-        uri = row["resource_uri"]
-        parsed = parse_uri(uri) if uri else None
-        if parsed is None or parsed.kind != "doc" or not parsed.identifier:
-            unreadable_uri += 1
-            continue
-        if parsed.vault != row["vault_name"]:
-            # The URI names one vault and the row belongs to another. Do not
-            # bind it to anything: resolution already refuses to serve this
-            # row, and "some document exists at that path somewhere" is not
-            # evidence about which document this publication was made for.
-            vault_mismatch.append(row["id"])
-            continue
-        candidate_ids.append(row["id"])
-        candidate_paths.append(parsed.identifier)
-
+    examined = 0
     bound = 0
-    unbound_ids: list = []
-    unbound_paths: list[str] = []
-    for start in range(0, len(candidate_ids), _BATCH):
-        ids = candidate_ids[start:start + _BATCH]
-        paths = candidate_paths[start:start + _BATCH]
+    unreadable_uri = 0
+    path_reused = 0
+    no_document = 0
+    vault_mismatch: list = []
+    after = uuid_mod.UUID(int=0)
+
+    while True:
+        page = await conn.fetch(
+            """
+            SELECT p.id, p.resource_uri, v.name AS vault_name
+              FROM publications p
+              JOIN vaults v ON v.id = p.vault_id
+             WHERE p.resource_type = 'document'
+               AND p.document_id IS NULL
+               AND p.id > $1
+             ORDER BY p.id
+             LIMIT $2
+            """,
+            after, _BATCH,
+        )
+        if not page:
+            break
+        after = page[-1]["id"]
+        examined += len(page)
+
+        ids: list = []
+        paths: list[str] = []
+        uris: list[str] = []
+        vaults: list[str] = []
+        for row in page:
+            uri = row["resource_uri"]
+            parsed = parse_uri(uri) if uri else None
+            if parsed is None or parsed.kind != "doc" or not parsed.identifier:
+                unreadable_uri += 1
+                continue
+            if parsed.vault != row["vault_name"]:
+                # The URI names one vault and the row belongs to another. Do
+                # not bind it to anything: resolution already refuses to serve
+                # this row, and "some document exists at that path somewhere"
+                # is not evidence about which document this publication was
+                # made for.
+                vault_mismatch.append(row["id"])
+                continue
+            ids.append(row["id"])
+            paths.append(parsed.identifier)
+            uris.append(uri)
+            vaults.append(parsed.vault)
+
+        if not ids:
+            continue
+
+        # The parse happened in Python a moment ago; the row can have moved
+        # since. `p.resource_uri = c.uri` and `v.name = c.uri_vault` re-assert
+        # both inputs to that parse inside the same statement that writes the
+        # binding, so a URI rewritten by a concurrent move — or a vault renamed
+        # underneath it — leaves the row unbound instead of binding it to what
+        # its old URI used to mean. A later run re-reads it and decides again.
         updated = await conn.fetch(
             """
             WITH candidate AS (
-                SELECT pub_id, doc_path
-                  FROM unnest($1::uuid[], $2::text[]) AS t(pub_id, doc_path)
+                SELECT pub_id, doc_path, uri, uri_vault
+                  FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[])
+                    AS t(pub_id, doc_path, uri, uri_vault)
             )
             UPDATE publications p
                SET document_id = d.id
-              FROM candidate c, documents d
+              FROM candidate c, documents d, vaults v
              WHERE p.id = c.pub_id
                AND p.document_id IS NULL
                AND p.resource_type = 'document'
+               AND p.resource_uri = c.uri
+               AND v.id = p.vault_id
+               AND v.name = c.uri_vault
                AND d.vault_id = p.vault_id
                AND d.path = c.doc_path
                AND d.created_at <= p.created_at
             RETURNING p.id
             """,
-            ids, paths,
+            ids, paths, uris, vaults,
         )
         # `updated_at` is deliberately not touched: this is a schema backfill,
         # not an edit anyone made to the publication.
         bound += len(updated)
-        done = {r["id"] for r in updated}
-        for pub_id, path in zip(ids, paths, strict=True):
-            if pub_id not in done:
-                unbound_ids.append(pub_id)
-                unbound_paths.append(path)
 
-    # Split the leftovers: a path with no document at all versus a path now
-    # occupied by a document that postdates the publication.
-    path_reused = 0
-    for start in range(0, len(unbound_ids), _BATCH):
-        ids = unbound_ids[start:start + _BATCH]
-        paths = unbound_paths[start:start + _BATCH]
-        path_reused += await conn.fetchval(
-            """
-            SELECT COUNT(*)
-              FROM unnest($1::uuid[], $2::text[]) AS c(pub_id, doc_path)
-              JOIN publications p ON p.id = c.pub_id
-              JOIN documents d
-                ON d.vault_id = p.vault_id AND d.path = c.doc_path
-            """,
-            ids, paths,
-        )
-    no_document = len(unbound_ids) - path_reused
+        done = {r["id"] for r in updated}
+        left_ids = [i for i in ids if i not in done]
+        left_paths = [p for i, p in zip(ids, paths, strict=True) if i not in done]
+        if left_ids:
+            # Split the leftovers: a path with no document at all versus a
+            # path now occupied by a document the publication predates.
+            occupied = await conn.fetchval(
+                """
+                SELECT COUNT(*)
+                  FROM unnest($1::uuid[], $2::text[]) AS c(pub_id, doc_path)
+                  JOIN publications p ON p.id = c.pub_id
+                  JOIN documents d
+                    ON d.vault_id = p.vault_id AND d.path = c.doc_path
+                """,
+                left_ids, left_paths,
+            )
+            path_reused += occupied
+            no_document += len(left_ids) - occupied
 
     logger.info(
         "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
@@ -396,7 +539,7 @@ async def _backfill(conn) -> None:
         "non_document_publications=%d (of %d document publications examined "
         "this run)",
         bound, no_document, path_reused, unreadable_uri, len(vault_mismatch),
-        already_bound or 0, skipped_by_design or 0, len(rows),
+        already_bound or 0, skipped_by_design or 0, examined,
     )
     if vault_mismatch:
         # The most interesting rows in the table if they exist: the vault the
@@ -421,13 +564,16 @@ async def _backfill(conn) -> None:
 
 
 async def _run(conn):
-    # No enclosing transaction. Each step is idempotent on its own, so a run
-    # cancelled between steps re-enters and finishes; wrapping them together
-    # would instead throw away a completed index build because a later lock
-    # wait timed out.
-    await _ensure_publication_document_column(conn)
+    # No enclosing transaction over the whole migration. Each step is
+    # idempotent on its own, so a run cancelled between steps re-enters and
+    # finishes; wrapping everything together would instead throw away a
+    # completed index build because a later lock wait timed out.
+    #
+    # The FK target has to exist before the FK, and the column and the FK are
+    # added together (see `_ensure_publication_identity`) so no window opens
+    # in which the column exists unconstrained.
     await _ensure_documents_identity_unique(conn)
-    await _ensure_publication_document_fk(conn)
+    await _ensure_publication_identity(conn)
     await _ensure_publication_document_index(conn)
     await _backfill(conn)
 

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -185,14 +185,28 @@ _DOC_UNIQUE = "documents_id_vault_id_key"
 _PUB_FK = "publications_document_fk"
 _PUB_INDEX = "idx_publications_document_id"
 
-# Expected definitions, exactly as `pg_get_constraintdef` renders them. The
-# idempotency guards compare against these rather than against a name, so a
-# constraint that merely borrowed the name cannot pass for the real thing.
-_DOC_UNIQUE_DEF = "UNIQUE (id, vault_id)"
-_PUB_FK_DEF = (
-    "FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id) "
-    "ON DELETE CASCADE"
+# What the guards below require of an existing constraint, read out of the
+# catalog rather than out of `pg_get_constraintdef`. The deparsed text would be
+# easier to compare and is the wrong thing to compare: it is a reconstruction
+# whose relation names are qualified according to the session's search_path, so
+# the identical constraint can render as `REFERENCES documents(…)` or
+# `REFERENCES public.documents(…)` — and a guard that refuses the second one
+# would fail a boot over a formatting difference. Catalog columns do not move.
+#
+# (contype, referenced table, local cols, referenced cols, on-delete,
+#  on-update, match type, validated)
+_DOC_UNIQUE_SHAPE = ("u", None, ["id", "vault_id"], None, " ", " ", " ", True)
+_PUB_FK_SHAPE = (
+    "f", "documents", ["document_id", "vault_id"], ["id", "vault_id"],
+    # c = CASCADE on delete; a = NO ACTION on update (so the vault half of the
+    # key cannot be moved out from under the pairing); s = MATCH SIMPLE (so a
+    # NULL document_id is exempt — see the module docstring).
+    "c", "a", "s", True,
 )
+# Substring of `pg_get_indexdef` that pins the cascade index's columns and
+# predicate. Only the parts that carry meaning — the access method and schema
+# qualification in that string are formatting, and the table it sits on is
+# checked against the catalog separately.
 _PUB_INDEX_COLS = "(document_id, vault_id) WHERE (document_id IS NOT NULL)"
 
 # Rows per UPDATE. Keeps any single statement well inside the pool's 30s
@@ -221,37 +235,59 @@ async def _column_exists(conn, table: str, column: str) -> bool:
     ))
 
 
-async def _constraint_def(conn, table: str, name: str) -> str | None:
-    """The constraint's definition, or None if there is no constraint by that
-    name on that table.
+async def _constraint_shape(conn, table: str, name: str) -> tuple | None:
+    """The constraint's structure as the catalog records it, or None if no
+    constraint of that name exists on that table.
 
-    Definition rather than existence on purpose. A name-only check would let a
-    CHECK constraint, an unvalidated FK, or an FK on the wrong columns wearing
-    the right name satisfy the idempotency guard — the migration would return
-    happily, get recorded in the ledger, and leave the guarantee it advertises
-    uninstalled. Comparing what the database actually built means a re-run
-    either finds the real thing or says so.
+    Structure rather than existence on purpose. A name-only check would let a
+    CHECK constraint, an unvalidated FK, or an FK over the wrong columns
+    wearing the right name satisfy the idempotency guard — the migration would
+    return happily, get recorded in the ledger, and leave the guarantee it
+    advertises uninstalled.
     """
-    return await conn.fetchval(
+    row = await conn.fetchrow(
         """
-        SELECT pg_get_constraintdef(oid) FROM pg_constraint
-         WHERE conname::text = $2::text
-           AND conrelid = to_regclass('public.' || $1::text)
+        SELECT c.contype::text                                   AS contype,
+               (SELECT relname::text FROM pg_class
+                 WHERE oid = NULLIF(c.confrelid, 0))             AS target,
+               (SELECT array_agg(a.attname::text ORDER BY k.ord)
+                  FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+                  JOIN pg_attribute a
+                    ON a.attrelid = c.conrelid AND a.attnum = k.attnum) AS local_cols,
+               (SELECT array_agg(a.attname::text ORDER BY k.ord)
+                  FROM unnest(c.confkey) WITH ORDINALITY AS k(attnum, ord)
+                  JOIN pg_attribute a
+                    ON a.attrelid = c.confrelid AND a.attnum = k.attnum) AS target_cols,
+               c.confdeltype::text                               AS on_delete,
+               c.confupdtype::text                               AS on_update,
+               c.confmatchtype::text                             AS match_type,
+               c.convalidated                                    AS validated
+          FROM pg_constraint c
+         WHERE c.conname::text = $2::text
+           AND c.conrelid = to_regclass('public.' || $1::text)
         """,
         table, name,
     )
+    if row is None:
+        return None
+    return (
+        row["contype"], row["target"], row["local_cols"], row["target_cols"],
+        row["on_delete"], row["on_update"], row["match_type"], row["validated"],
+    )
 
 
-async def _already_correct(conn, table: str, name: str, expected: str) -> bool:
+async def _already_correct(conn, table: str, name: str, expected: tuple) -> bool:
     """True when `name` is already the constraint we would create; raises when
     something else is wearing the name."""
-    found = await _constraint_def(conn, table, name)
+    found = await _constraint_shape(conn, table, name)
     if found is None:
         return False
     if found != expected:
         raise RuntimeError(
             f"{table} already has a constraint named {name}, but it is not the "
             f"one migration 053 installs.\n  found:    {found}\n  expected: {expected}\n"
+            "(fields: contype, referenced table, local columns, referenced "
+            "columns, on-delete, on-update, match type, validated)\n"
             "Migration 053 will not silently accept it — inspect the constraint, "
             "then drop or rename it and re-run."
         )
@@ -265,7 +301,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
     operator may have run ahead of time (or had cancelled underneath them):
     no index, a valid index of the right shape, or an invalid leftover.
     """
-    if await _already_correct(conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_DEF):
+    if await _already_correct(conn, "documents", _DOC_UNIQUE, _DOC_UNIQUE_SHAPE):
         return
 
     existing = await conn.fetchrow(
@@ -342,7 +378,7 @@ async def _ensure_publication_identity(conn) -> None:
     them, and a great deal worth preserving by not leaving that window open.
     """
     have_column = await _column_exists(conn, "publications", "document_id")
-    have_fk = await _already_correct(conn, "publications", _PUB_FK, _PUB_FK_DEF)
+    have_fk = await _already_correct(conn, "publications", _PUB_FK, _PUB_FK_SHAPE)
     if have_column and have_fk:
         return
 
@@ -354,7 +390,8 @@ async def _ensure_publication_identity(conn) -> None:
             try:
                 await conn.execute(
                     f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} "
-                    f"{_PUB_FK_DEF}"
+                    "FOREIGN KEY (document_id, vault_id) "
+                    "REFERENCES documents (id, vault_id) ON DELETE CASCADE"
                 )
             except asyncpg.ForeignKeyViolationError as e:
                 raise RuntimeError(
@@ -383,23 +420,37 @@ async def _ensure_publication_document_index(conn) -> None:
     NULL after this migration and the cascade probe (``document_id = $1``)
     implies NOT NULL, so the planner can still use it.
 
-    Checked by definition rather than by `IF NOT EXISTS` alone, for the same
-    reason as the constraints: a same-named index over different columns would
-    otherwise be accepted silently.
+    Checked structurally rather than by `IF NOT EXISTS` alone, for the same
+    reason as the constraints. Index names are unique per schema, not per
+    table, so "a relation of this name exists" says nothing on its own: it
+    could be an index on another table, or an invalid leftover from a
+    cancelled concurrent build that enforces and accelerates nothing while
+    `IF NOT EXISTS` steps over it forever.
     """
-    found = await conn.fetchval(
-        "SELECT pg_get_indexdef(indexrelid) FROM pg_index "
-        "WHERE indexrelid = to_regclass('public.' || $1::text)",
+    found = await conn.fetchrow(
+        """
+        SELECT i.indisvalid                          AS is_valid,
+               i.indrelid = to_regclass('public.publications') AS on_publications,
+               pg_get_indexdef(i.indexrelid)         AS definition
+          FROM pg_index i
+         WHERE i.indexrelid = to_regclass('public.' || $1::text)
+        """,
         _PUB_INDEX,
     )
     if found is not None:
-        if _PUB_INDEX_COLS not in found:
+        if not found["on_publications"] or _PUB_INDEX_COLS not in found["definition"]:
             raise RuntimeError(
                 f"An index named {_PUB_INDEX} already exists but is not the "
-                f"cascade index migration 053 creates.\n  found: {found}\n"
+                f"cascade index migration 053 creates.\n  found: {found['definition']}\n"
                 "Inspect it, then drop or rename it and re-run."
             )
-        return
+        if found["is_valid"]:
+            return
+        logger.warning(
+            "Migration 053: found an INVALID index named %s; dropping it before "
+            "rebuilding", _PUB_INDEX,
+        )
+        await conn.execute(f"DROP INDEX IF EXISTS {_PUB_INDEX}")
     await conn.execute(
         f"CREATE INDEX {_PUB_INDEX} "
         "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
@@ -419,6 +470,12 @@ async def _backfill(conn) -> None:
     how many publications a deployment has accumulated. Rows bound by an
     earlier page drop out of the predicate rather than shifting the window, so
     the key order stays stable across pages.
+
+    Publication ids are random, so a row inserted concurrently below the
+    cursor is not visited by this run. That is not a defect to work around:
+    an unvisited row is simply an unbound row, which is a state this migration
+    already leaves behind by design and which resolution handles the same way
+    it does today.
     """
     already_bound = await conn.fetchval(
         "SELECT COUNT(*) FROM publications "
@@ -434,9 +491,13 @@ async def _backfill(conn) -> None:
     path_reused = 0
     no_document = 0
     vault_mismatch: list = []
-    after = uuid_mod.UUID(int=0)
+    after: uuid_mod.UUID | None = None
 
     while True:
+        # `after IS NULL` for the first page rather than starting from the
+        # all-zero UUID: nothing generates that id, but the column accepts it,
+        # and a sentinel that is also a legal key value would silently skip
+        # the one row that used it.
         page = await conn.fetch(
             """
             SELECT p.id, p.resource_uri, v.name AS vault_name
@@ -444,7 +505,7 @@ async def _backfill(conn) -> None:
               JOIN vaults v ON v.id = p.vault_id
              WHERE p.resource_type = 'document'
                AND p.document_id IS NULL
-               AND p.id > $1
+               AND ($1::uuid IS NULL OR p.id > $1)
              ORDER BY p.id
              LIMIT $2
             """,

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -218,12 +218,18 @@ _MISMATCH_SAMPLE = 20
 
 
 async def migrate(conn=None):
+    """Apply the migration. Returns the backfill's per-category counts.
+
+    The runner ignores the return value; it exists so the counts are a value
+    the caller can assert on rather than only a line in a log. What an
+    operator reads to decide whether a backfill can be trusted should be
+    something a test can hold to account.
+    """
     if conn is None:
         pool = await get_pool()
         async with pool.acquire() as new_conn:
-            await _run(new_conn)
-    else:
-        await _run(conn)
+            return await _run(new_conn)
+    return await _run(conn)
 
 
 async def _column_exists(conn, table: str, column: str) -> bool:
@@ -356,12 +362,19 @@ async def _ensure_documents_identity_unique(conn) -> None:
         # Invalid: the remains of a cancelled CONCURRENTLY build. It enforces
         # nothing and `IF NOT EXISTS` would step over it silently, so drop it
         # and build for real below.
+        #
+        # A plain DROP, not CONCURRENTLY. Dropping concurrently waits for every
+        # transaction that could be using the index — a wait `lock_timeout`
+        # does not bound, which makes it the statement here most likely to be
+        # cancelled at the pool's 30s limit — and it cannot run inside a
+        # transaction at all. All to avoid a brief lock while removing an
+        # index that is invalid, and therefore in use by nothing.
         logger.warning(
             "Migration 053: found an INVALID index named %s (a cancelled "
             "CREATE INDEX CONCURRENTLY leaves one behind); dropping it before "
             "building the constraint", _DOC_UNIQUE,
         )
-        await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_DOC_UNIQUE}")
+        await conn.execute(f"DROP INDEX IF EXISTS {_DOC_UNIQUE}")
 
     await conn.execute(
         f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} UNIQUE (id, vault_id)"
@@ -433,6 +446,7 @@ async def _ensure_publication_document_index(conn) -> None:
     found = await conn.fetchrow(
         """
         SELECT i.indisvalid                          AS is_valid,
+               i.indisunique                         AS is_unique,
                i.indrelid = to_regclass('public.publications') AS on_publications,
                pg_get_indexdef(i.indexrelid)         AS definition
           FROM pg_index i
@@ -441,7 +455,14 @@ async def _ensure_publication_document_index(conn) -> None:
         _PUB_INDEX,
     )
     if found is not None:
-        if not found["on_publications"] or _PUB_INDEX_COLS not in found["definition"]:
+        # `is_unique` is checked for the same reason the documents guard checks
+        # it, inverted: this one must NOT be unique. Adopting a UNIQUE index of
+        # that name would quietly forbid a second publication of one document.
+        if (
+            not found["on_publications"]
+            or found["is_unique"]
+            or _PUB_INDEX_COLS not in found["definition"]
+        ):
             raise RuntimeError(
                 f"An index named {_PUB_INDEX} already exists but is not the "
                 f"cascade index migration 053 creates.\n  found: {found['definition']}\n"
@@ -460,9 +481,10 @@ async def _ensure_publication_document_index(conn) -> None:
     )
 
 
-async def _backfill(conn) -> None:
+async def _backfill(conn) -> dict:
     """Bind existing document publications to their document, where that is
-    unambiguous. See the module docstring for the conditions.
+    unambiguous. See the module docstring for the conditions. Returns the
+    per-category counts it logs.
 
     Re-runnable: only rows with ``document_id IS NULL`` are considered, so a
     second run binds nothing and reports the already-bound rows under their
@@ -493,6 +515,7 @@ async def _backfill(conn) -> None:
     unreadable_uri = 0
     path_reused = 0
     no_document = 0
+    changed_underfoot = 0
     vault_mismatch = 0
     # Bounded sample, not every id: the log names a handful so an operator can
     # pull the rows, and the count carries the rest. A per-row list would be
@@ -585,31 +608,65 @@ async def _backfill(conn) -> None:
         bound += len(updated)
 
         done = {r["id"] for r in updated}
-        left_ids = [i for i in ids if i not in done]
-        left_paths = [p for i, p in zip(ids, paths, strict=True) if i not in done]
-        if left_ids:
-            # Split the leftovers: a path with no document at all versus a
-            # path now occupied by a document the publication predates.
-            occupied = await conn.fetchval(
+        left = [
+            (i, p, u, v)
+            for i, p, u, v in zip(ids, paths, uris, vaults, strict=True)
+            if i not in done
+        ]
+        if left:
+            # Why each leftover was left. The UPDATE can decline a row for four
+            # reasons and the counts are only worth reading if they name the
+            # right one, so this re-checks the same predicates rather than
+            # asking the weaker question "is anything at that path now" — which
+            # would file a row that moved underfoot as a reused path.
+            split = await conn.fetchrow(
                 """
-                SELECT COUNT(*)
-                  FROM unnest($1::uuid[], $2::text[]) AS c(pub_id, doc_path)
-                  JOIN publications p ON p.id = c.pub_id
-                  JOIN documents d
-                    ON d.vault_id = p.vault_id AND d.path = c.doc_path
+                WITH candidate AS (
+                    SELECT pub_id, doc_path, uri, uri_vault
+                      FROM unnest($1::uuid[], $2::text[], $3::text[], $4::text[])
+                        AS t(pub_id, doc_path, uri, uri_vault)
+                ), state AS (
+                    SELECT (p.id IS NOT NULL
+                            AND p.document_id IS NULL
+                            AND p.resource_uri IS NOT DISTINCT FROM c.uri
+                            AND v.name IS NOT DISTINCT FROM c.uri_vault) AS unchanged,
+                           d.id IS NOT NULL AS path_occupied
+                      FROM candidate c
+                      LEFT JOIN publications p ON p.id = c.pub_id
+                      LEFT JOIN vaults v ON v.id = p.vault_id
+                      LEFT JOIN documents d
+                        ON d.vault_id = p.vault_id AND d.path = c.doc_path
+                )
+                SELECT COUNT(*) FILTER (WHERE NOT unchanged)             AS changed,
+                       COUNT(*) FILTER (WHERE unchanged AND NOT path_occupied) AS absent,
+                       COUNT(*) FILTER (WHERE unchanged AND path_occupied)     AS reused
+                  FROM state
                 """,
-                left_ids, left_paths,
+                [r[0] for r in left], [r[1] for r in left],
+                [r[2] for r in left], [r[3] for r in left],
             )
-            path_reused += occupied
-            no_document += len(left_ids) - occupied
+            changed_underfoot += split["changed"]
+            no_document += split["absent"]
+            path_reused += split["reused"]
 
+    counts = {
+        "examined": examined,
+        "bound": bound,
+        "no_document": no_document,
+        "path_reused": path_reused,
+        "unreadable_uri": unreadable_uri,
+        "vault_mismatch": vault_mismatch,
+        "changed_underfoot": changed_underfoot,
+        "already_bound": already_bound or 0,
+        "non_document_publications": skipped_by_design or 0,
+    }
     logger.info(
         "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
-        "unreadable_uri=%d, vault_mismatch=%d, already_bound=%d, "
-        "non_document_publications=%d (of %d document publications examined "
-        "this run)",
+        "unreadable_uri=%d, vault_mismatch=%d, changed_underfoot=%d, "
+        "already_bound=%d, non_document_publications=%d (of %d document "
+        "publications examined this run)",
         bound, no_document, path_reused, unreadable_uri, vault_mismatch,
-        already_bound or 0, skipped_by_design or 0, examined,
+        changed_underfoot, already_bound or 0, skipped_by_design or 0, examined,
     )
     if vault_mismatch:
         # The most interesting rows in the table if they exist: the vault the
@@ -622,15 +679,16 @@ async def _backfill(conn) -> None:
             "" if vault_mismatch <= _MISMATCH_SAMPLE
             else f" (first {_MISMATCH_SAMPLE} shown)",
         )
-    if no_document or path_reused or unreadable_uri:
+    unbound = no_document + path_reused + unreadable_uri + changed_underfoot
+    if unbound:
         logger.warning(
             "Migration 053: %d document publication(s) left unbound "
-            "(no_document=%d, path_reused=%d, unreadable_uri=%d). They keep "
-            "working through resource_uri; document_id stays NULL until they "
-            "are re-published.",
-            no_document + path_reused + unreadable_uri,
-            no_document, path_reused, unreadable_uri,
+            "(no_document=%d, path_reused=%d, unreadable_uri=%d, "
+            "changed_underfoot=%d). They keep working through resource_uri; "
+            "document_id stays NULL until they are re-published.",
+            unbound, no_document, path_reused, unreadable_uri, changed_underfoot,
         )
+    return counts
 
 
 async def _run(conn):
@@ -645,7 +703,7 @@ async def _run(conn):
     await _ensure_documents_identity_unique(conn)
     await _ensure_publication_identity(conn)
     await _ensure_publication_document_index(conn)
-    await _backfill(conn)
+    return await _backfill(conn)
 
 
 async def _main():

--- a/backend/app/db/migrations/053_publication_document_identity.py
+++ b/backend/app/db/migrations/053_publication_document_identity.py
@@ -1,0 +1,443 @@
+"""Migration 053: give document publications a database-enforced identity.
+
+What this adds
+--------------
+    publications.document_id UUID                       -- nullable, see below
+    documents  UNIQUE (id, vault_id)                    -- FK target
+    publications FOREIGN KEY (document_id, vault_id)
+        REFERENCES documents (id, vault_id) ON DELETE CASCADE
+    partial index on publications (document_id, vault_id)
+
+Migration 022 collapsed ``publications.document_id`` and
+``publications.file_id`` into a single path-shaped ``resource_uri`` and, with
+them, dropped the cascade the database used to enforce. Everything that keeps
+a publication and its document consistent has been Python-level since: one
+repository method deletes documents and their publications together, a write
+onto a path some publication still claims is refused, and resolution is bound
+to the publication's own vault. Those hold for callers that go through the
+application. A direct ``psql`` session, a future migration, or an admin script
+that talks to the table does not go through the application. ``FOREIGN KEY …
+ON DELETE CASCADE`` does, because there is no code path that can forget it.
+
+Files are out of scope. ``resource_uri`` stays: ``table_query`` publications
+have no resource id at all, the column is part of the API response shape, and
+the ``move``-time URI rewrite still keeps it current.
+
+Why the FK is composite, and why a simple one would be wrong
+------------------------------------------------------------
+``FOREIGN KEY (document_id) REFERENCES documents (id)`` would guarantee only
+that the document exists. A publication in vault X could point at a document
+in vault Y and satisfy it. Pairing the vault into the key makes "the document
+lives in the publication's own vault" a structural property of the row rather
+than another rule every future write has to remember — which is the whole
+reason for preferring a constraint to a check in code.
+
+``documents.id`` is already the primary key, so ``UNIQUE (id, vault_id)`` adds
+no new guarantee about documents; PostgreSQL simply requires a unique
+constraint on exactly the referenced column pair before it will accept the
+composite reference.
+
+The match type is the default (MATCH SIMPLE) and that matters: a row with
+``document_id IS NULL`` is exempt from the constraint even though ``vault_id``
+is NOT NULL. MATCH FULL would forbid the NULL entirely and turn every
+un-bindable legacy row into a migration failure. Do not "tighten" it.
+
+What the backfill binds — and what it deliberately leaves alone
+---------------------------------------------------------------
+The only handle an existing publication has on its document is
+``resource_uri``, which names a path, and paths are reusable
+(``documents`` is ``UNIQUE (vault_id, path)``). Binding a row to "whatever
+document occupies that path now" would, for any row that had drifted, have the
+new FK certify the drift permanently. So the backfill binds only rows where
+the answer is unambiguous, and leaves ``document_id`` NULL for everything
+else. It never deletes a row: the publication carries its slug, creator,
+creation time, restrictions and view count, and that record is the input a
+human needs to decide what to do with it.
+
+A row is bound only when all of the following hold:
+
+  1. ``resource_type = 'document'`` and ``resource_uri`` parses as a document
+     URI. Parsing goes through ``uri_service.parse_uri`` — the same function
+     the resolver uses — so the backfill cannot bind a row the resolver would
+     not serve, and a URI shape neither can read stays NULL.
+  2. The vault named in the URI equals the name of the vault the publication
+     belongs to. A row whose two vault identifiers disagree is NOT bound, no
+     matter what document exists at that path anywhere; it is logged as its
+     own category. Resolution already refuses to serve such a row.
+  3. Exactly one document sits at that path in the publication's own vault
+     (guaranteed to be at most one by ``UNIQUE (vault_id, path)``).
+  4. That document is not newer than the publication. A publication cannot
+     have been created for a document that did not exist yet, so a newer
+     document at the path means the path was reused and the original target
+     is gone. This predicate can only refuse a binding, never invent one.
+     Note that ``documents.created_at`` is written by the application and
+     ``publications.created_at`` by the database, so the comparison inherits
+     any clock skew between them: a publication created within that skew of
+     its own document may be left NULL. That is the safe direction, and a
+     NULL row keeps working exactly as it does today.
+
+Consequence, stated plainly: because NULL is allowed, "every document
+publication points at a document" is NOT a schema invariant after this
+migration. It becomes one only for rows created once the publish path records
+the id. Nothing here should be read as proving the column is populated.
+
+Ordering: constrain BEFORE backfill
+-----------------------------------
+The FK is added while every ``document_id`` is still NULL, which makes its
+initial validation trivially satisfiable, and — the actual point — it means
+the database checks every binding the backfill writes, at the moment it is
+written. The classical expand → backfill → constrain order would have the
+backfill write bindings nothing had verified and then certify them wholesale
+in one statement. That is the failure mode this migration exists to avoid, so
+the order is inverted on purpose.
+
+For the same reason this is one migration and not three. The steps have a
+fixed order, the runner applies them back-to-back at boot, and splitting them
+would add ledger entries without giving an operator any new place to
+intervene. Each step is independently idempotent instead: an interrupted run
+re-enters and completes, and a partially-bound table is a legitimate resting
+state, not damage.
+
+``ADD CONSTRAINT … NOT VALID`` + ``VALIDATE CONSTRAINT`` was considered and
+rejected. It would save the initial scan of ``publications`` — a table with
+one row per published link — while still taking the same ACCESS EXCLUSIVE
+lock to write the catalog entry, and it would leave behind a constraint that
+is enforced but unverified if the second step never ran. The saving is not
+worth a state where the schema looks stronger than it is. (If ``publications``
+ever grew to a size where that scan mattered, this is the decision to revisit.)
+
+Locks and timeouts
+------------------
+The runner sets ``lock_timeout = '5s'`` and the pool cancels any statement at
+30s, and both apply here. The one statement that does real work proportional
+to table size is the unique index behind ``documents_id_vault_id_key``; it is
+built plainly, not CONCURRENTLY, because a plain build inside its own implicit
+transaction leaves nothing behind when it is cancelled, whereas a cancelled
+CONCURRENTLY build leaves an *invalid* index that ``IF NOT EXISTS`` would then
+skip over forever. Failing loudly and retrying beats a schema that quietly
+believes it has an index.
+
+If ``documents`` is ever large enough that the in-line build cannot finish
+inside the 30s cancel, the escape hatch is to build the index out of band and
+re-run:
+
+    CREATE UNIQUE INDEX CONCURRENTLY documents_id_vault_id_key
+        ON documents (id, vault_id);
+
+This migration adopts a pre-existing valid index of that name via
+``ADD CONSTRAINT … UNIQUE USING INDEX`` instead of rebuilding it, and drops
+one left invalid by an interrupted build before trying again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from app.db.postgres import close_pool, get_pool, init_db
+from app.services.uri_service import parse_uri
+
+logger = logging.getLogger("akb.migration.053")
+
+_DOC_UNIQUE = "documents_id_vault_id_key"
+_PUB_FK = "publications_document_fk"
+_PUB_INDEX = "idx_publications_document_id"
+
+# Rows per UPDATE. Keeps any single statement well inside the pool's 30s
+# cancel regardless of how many publications a deployment has accumulated.
+_BATCH = 500
+
+
+async def migrate(conn=None):
+    if conn is None:
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _column_exists(conn, table: str, column: str) -> bool:
+    return bool(await conn.fetchval(
+        """
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = $1
+           AND column_name = $2
+        """,
+        table, column,
+    ))
+
+
+async def _constraint_exists(conn, table: str, name: str) -> bool:
+    return bool(await conn.fetchval(
+        """
+        SELECT 1 FROM pg_constraint
+         WHERE conname::text = $2::text
+           AND conrelid = to_regclass('public.' || $1::text)
+        """,
+        table, name,
+    ))
+
+
+async def _ensure_documents_identity_unique(conn) -> None:
+    """``documents UNIQUE (id, vault_id)`` — the composite FK's target.
+
+    Three states to handle, because the index build is the one step an
+    operator may have run ahead of time (or had cancelled underneath them):
+    no index, a valid index of the right shape, or an invalid leftover.
+    """
+    if await _constraint_exists(conn, "documents", _DOC_UNIQUE):
+        return
+
+    existing = await conn.fetchrow(
+        """
+        SELECT i.indisvalid                AS is_valid,
+               i.indisunique               AS is_unique,
+               i.indpred IS NOT NULL       AS is_partial,
+               i.indexprs IS NOT NULL      AS is_expression,
+               i.indkey::text              AS indkey,
+               (SELECT a.attnum FROM pg_attribute a
+                 WHERE a.attrelid = i.indrelid AND a.attname = 'id') AS id_attnum,
+               (SELECT a.attnum FROM pg_attribute a
+                 WHERE a.attrelid = i.indrelid AND a.attname = 'vault_id') AS vault_attnum
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = $1
+           AND c.relnamespace = 'public'::regnamespace
+        """,
+        _DOC_UNIQUE,
+    )
+
+    if existing is not None:
+        expected_key = f"{existing['id_attnum']} {existing['vault_attnum']}"
+        right_shape = (
+            existing["is_unique"]
+            and not existing["is_partial"]
+            and not existing["is_expression"]
+            and existing["indkey"] == expected_key
+        )
+        if not right_shape:
+            raise RuntimeError(
+                f"An index named {_DOC_UNIQUE} already exists on documents but is "
+                "not a plain UNIQUE index on exactly (id, vault_id). Migration 053 "
+                "will not repurpose it — inspect it, then either drop it or add the "
+                "constraint by hand."
+            )
+        if existing["is_valid"]:
+            # Adopt it: the constraint takes the index's name and no rebuild
+            # happens. This is the out-of-band build path documented above.
+            logger.info(
+                "Migration 053: adopting the pre-existing valid index %s as the "
+                "documents identity constraint (no rebuild)", _DOC_UNIQUE,
+            )
+            await conn.execute(
+                f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} "
+                f"UNIQUE USING INDEX {_DOC_UNIQUE}"
+            )
+            return
+        # Invalid: the remains of a cancelled CONCURRENTLY build. It enforces
+        # nothing and `IF NOT EXISTS` would step over it silently, so drop it
+        # and build for real below.
+        logger.warning(
+            "Migration 053: found an INVALID index named %s (a cancelled "
+            "CREATE INDEX CONCURRENTLY leaves one behind); dropping it before "
+            "building the constraint", _DOC_UNIQUE,
+        )
+        await conn.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_DOC_UNIQUE}")
+
+    await conn.execute(
+        f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} UNIQUE (id, vault_id)"
+    )
+    logger.info("Migration 053: added %s on documents (id, vault_id)", _DOC_UNIQUE)
+
+
+async def _ensure_publication_document_column(conn) -> None:
+    if await _column_exists(conn, "publications", "document_id"):
+        return
+    await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
+    logger.info("Migration 053: added publications.document_id (nullable)")
+
+
+async def _ensure_publication_document_fk(conn) -> None:
+    if await _constraint_exists(conn, "publications", _PUB_FK):
+        return
+    await conn.execute(
+        f"ALTER TABLE publications ADD CONSTRAINT {_PUB_FK} "
+        "FOREIGN KEY (document_id, vault_id) REFERENCES documents (id, vault_id) "
+        "ON DELETE CASCADE"
+    )
+    logger.info(
+        "Migration 053: added %s — (document_id, vault_id) → documents (id, vault_id) "
+        "ON DELETE CASCADE", _PUB_FK,
+    )
+
+
+async def _ensure_publication_document_index(conn) -> None:
+    """Index the referencing side of the FK.
+
+    Without it every document delete seq-scans ``publications`` to find rows
+    to cascade. Partial on ``document_id IS NOT NULL`` because most rows are
+    NULL after this migration and the cascade probe (``document_id = $1``)
+    implies NOT NULL, so the planner can still use it.
+    """
+    await conn.execute(
+        f"CREATE INDEX IF NOT EXISTS {_PUB_INDEX} "
+        "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
+    )
+
+
+async def _backfill(conn) -> None:
+    """Bind existing document publications to their document, where that is
+    unambiguous. See the module docstring for the four conditions.
+
+    Re-runnable: only rows with ``document_id IS NULL`` are considered, so a
+    second run binds nothing and reports the already-bound rows under their
+    own count instead of adding them to this run's total.
+    """
+    already_bound = await conn.fetchval(
+        "SELECT COUNT(*) FROM publications "
+        "WHERE resource_type = 'document' AND document_id IS NOT NULL"
+    )
+    skipped_by_design = await conn.fetchval(
+        "SELECT COUNT(*) FROM publications WHERE resource_type <> 'document'"
+    )
+
+    rows = await conn.fetch(
+        """
+        SELECT p.id, p.resource_uri, v.name AS vault_name
+          FROM publications p
+          JOIN vaults v ON v.id = p.vault_id
+         WHERE p.resource_type = 'document'
+           AND p.document_id IS NULL
+        """
+    )
+
+    candidate_ids: list = []
+    candidate_paths: list[str] = []
+    unreadable_uri = 0
+    vault_mismatch: list = []
+
+    for row in rows:
+        uri = row["resource_uri"]
+        parsed = parse_uri(uri) if uri else None
+        if parsed is None or parsed.kind != "doc" or not parsed.identifier:
+            unreadable_uri += 1
+            continue
+        if parsed.vault != row["vault_name"]:
+            # The URI names one vault and the row belongs to another. Do not
+            # bind it to anything: resolution already refuses to serve this
+            # row, and "some document exists at that path somewhere" is not
+            # evidence about which document this publication was made for.
+            vault_mismatch.append(row["id"])
+            continue
+        candidate_ids.append(row["id"])
+        candidate_paths.append(parsed.identifier)
+
+    bound = 0
+    unbound_ids: list = []
+    unbound_paths: list[str] = []
+    for start in range(0, len(candidate_ids), _BATCH):
+        ids = candidate_ids[start:start + _BATCH]
+        paths = candidate_paths[start:start + _BATCH]
+        updated = await conn.fetch(
+            """
+            WITH candidate AS (
+                SELECT pub_id, doc_path
+                  FROM unnest($1::uuid[], $2::text[]) AS t(pub_id, doc_path)
+            )
+            UPDATE publications p
+               SET document_id = d.id
+              FROM candidate c, documents d
+             WHERE p.id = c.pub_id
+               AND p.document_id IS NULL
+               AND p.resource_type = 'document'
+               AND d.vault_id = p.vault_id
+               AND d.path = c.doc_path
+               AND d.created_at <= p.created_at
+            RETURNING p.id
+            """,
+            ids, paths,
+        )
+        # `updated_at` is deliberately not touched: this is a schema backfill,
+        # not an edit anyone made to the publication.
+        bound += len(updated)
+        done = {r["id"] for r in updated}
+        for pub_id, path in zip(ids, paths, strict=True):
+            if pub_id not in done:
+                unbound_ids.append(pub_id)
+                unbound_paths.append(path)
+
+    # Split the leftovers: a path with no document at all versus a path now
+    # occupied by a document that postdates the publication.
+    path_reused = 0
+    for start in range(0, len(unbound_ids), _BATCH):
+        ids = unbound_ids[start:start + _BATCH]
+        paths = unbound_paths[start:start + _BATCH]
+        path_reused += await conn.fetchval(
+            """
+            SELECT COUNT(*)
+              FROM unnest($1::uuid[], $2::text[]) AS c(pub_id, doc_path)
+              JOIN publications p ON p.id = c.pub_id
+              JOIN documents d
+                ON d.vault_id = p.vault_id AND d.path = c.doc_path
+            """,
+            ids, paths,
+        )
+    no_document = len(unbound_ids) - path_reused
+
+    logger.info(
+        "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
+        "unreadable_uri=%d, vault_mismatch=%d, already_bound=%d, "
+        "non_document_publications=%d (of %d document publications examined "
+        "this run)",
+        bound, no_document, path_reused, unreadable_uri, len(vault_mismatch),
+        already_bound or 0, skipped_by_design or 0, len(rows),
+    )
+    if vault_mismatch:
+        # The most interesting rows in the table if they exist: the vault the
+        # URI names is not the vault the row belongs to. Ids only — enough to
+        # pull the rows with a SELECT, without putting names or paths in a log.
+        shown = [str(i) for i in vault_mismatch[:20]]
+        logger.warning(
+            "Migration 053: %d document publication(s) name a vault other than "
+            "their own and were left unbound. publication id(s): %s%s",
+            len(vault_mismatch), ", ".join(shown),
+            "" if len(vault_mismatch) <= 20 else " (first 20 shown)",
+        )
+    if no_document or path_reused or unreadable_uri:
+        logger.warning(
+            "Migration 053: %d document publication(s) left unbound "
+            "(no_document=%d, path_reused=%d, unreadable_uri=%d). They keep "
+            "working through resource_uri; document_id stays NULL until they "
+            "are re-published.",
+            no_document + path_reused + unreadable_uri,
+            no_document, path_reused, unreadable_uri,
+        )
+
+
+async def _run(conn):
+    # No enclosing transaction. Each step is idempotent on its own, so a run
+    # cancelled between steps re-enters and finishes; wrapping them together
+    # would instead throw away a completed index build because a later lock
+    # wait timed out.
+    await _ensure_publication_document_column(conn)
+    await _ensure_documents_identity_unique(conn)
+    await _ensure_publication_document_fk(conn)
+    await _ensure_publication_document_index(conn)
+    await _backfill(conn)
+
+
+async def _main():
+    await init_db()
+    await migrate()
+    await close_pool()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_main())

--- a/backend/app/db/migrations/058_publication_document_identity.py
+++ b/backend/app/db/migrations/058_publication_document_identity.py
@@ -1,4 +1,4 @@
-"""Migration 053: give document publications a database-enforced identity.
+"""Migration 058: give document publications a database-enforced identity.
 
 What this adds
 --------------
@@ -176,7 +176,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 from app.db.postgres import close_pool, get_pool, init_db
 from app.services.uri_service import parse_uri
 
-logger = logging.getLogger("akb.migration.053")
+logger = logging.getLogger("akb.migration.058")
 
 _DOC_UNIQUE = "documents_id_vault_id_key"
 _PUB_FK = "publications_document_fk"
@@ -334,10 +334,10 @@ async def _already_correct(
         definition = await _constraint_def(conn, table, name)
         raise RuntimeError(
             f"{table} already has a constraint named {name}, but it is not the "
-            "one migration 053 installs.\n"
+            "one migration 058 installs.\n"
             f"  found:    {definition}\n"
             f"  expected: {ddl}\n"
-            "Migration 053 will not silently accept it — inspect the constraint, "
+            "Migration 058 will not silently accept it — inspect the constraint, "
             "then drop or rename it and re-run."
         )
     return True
@@ -393,7 +393,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
             )
             raise RuntimeError(
                 f"The name {_DOC_UNIQUE} is already taken in schema public by "
-                f"{what}, not by an index on documents. Migration 053 needs that "
+                f"{what}, not by an index on documents. Migration 058 needs that "
                 "name for the documents identity constraint — rename or drop the "
                 "other object and re-run. Nothing has been changed."
             )
@@ -413,14 +413,14 @@ async def _ensure_documents_identity_unique(conn) -> None:
                 f"An index named {_DOC_UNIQUE} already exists on documents but is "
                 "not a plain UNIQUE index on exactly (id, vault_id).\n"
                 f"  found: {definition}\n"
-                "Migration 053 will not repurpose it — inspect it, then either "
+                "Migration 058 will not repurpose it — inspect it, then either "
                 "drop it or add the constraint by hand."
             )
         if existing["is_valid"]:
             # Adopt it: the constraint takes the index's name and no rebuild
             # happens. This is the out-of-band build path documented above.
             logger.info(
-                "Migration 053: adopting the pre-existing valid index %s as the "
+                "Migration 058: adopting the pre-existing valid index %s as the "
                 "documents identity constraint (no rebuild)", _DOC_UNIQUE,
             )
             await conn.execute(
@@ -439,7 +439,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
         # transaction at all. All to avoid a brief lock while removing an
         # index that is invalid, and therefore in use by nothing.
         logger.warning(
-            "Migration 053: found an INVALID index named %s (a cancelled "
+            "Migration 058: found an INVALID index named %s (a cancelled "
             "CREATE INDEX CONCURRENTLY leaves one behind); dropping it before "
             "building the constraint", _DOC_UNIQUE,
         )
@@ -452,7 +452,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
     # as "blocked on a lock" — which is not what happened. This line is then
     # the last thing in the log before the stall, and it carries the remedy.
     logger.info(
-        "Migration 053: building %s on documents (id, vault_id). This holds "
+        "Migration 058: building %s on documents (id, vault_id). This holds "
         "ACCESS EXCLUSIVE on documents for the duration of an index build. If "
         "it is cancelled at the 30s statement timeout and the migration keeps "
         "retrying, build the index out of band and re-run — this migration "
@@ -463,7 +463,7 @@ async def _ensure_documents_identity_unique(conn) -> None:
     await conn.execute(
         f"ALTER TABLE documents ADD CONSTRAINT {_DOC_UNIQUE} {_DOC_UNIQUE_DDL}"
     )
-    logger.info("Migration 053: added %s on documents (id, vault_id)", _DOC_UNIQUE)
+    logger.info("Migration 058: added %s on documents (id, vault_id)", _DOC_UNIQUE)
 
 
 async def _ensure_publication_identity(conn) -> None:
@@ -494,7 +494,7 @@ async def _ensure_publication_identity(conn) -> None:
     async with conn.transaction():
         if not have_column:
             await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
-            logger.info("Migration 053: added publications.document_id (nullable)")
+            logger.info("Migration 058: added publications.document_id (nullable)")
         if not have_fk:
             try:
                 await conn.execute(
@@ -502,7 +502,7 @@ async def _ensure_publication_identity(conn) -> None:
                 )
             except asyncpg.ForeignKeyViolationError as e:
                 raise RuntimeError(
-                    "Migration 053 cannot add the publication identity constraint: "
+                    "Migration 058 cannot add the publication identity constraint: "
                     "publications already holds a document_id that does not name a "
                     "document in that publication's own vault. Nothing here will "
                     "delete or blank those rows — that is a decision for a human. "
@@ -514,7 +514,7 @@ async def _ensure_publication_identity(conn) -> None:
                     f"underlying error: {e}"
                 ) from e
             logger.info(
-                "Migration 053: added %s — (document_id, vault_id) → "
+                "Migration 058: added %s — (document_id, vault_id) → "
                 "documents (id, vault_id) ON DELETE CASCADE", _PUB_FK,
             )
 
@@ -556,13 +556,13 @@ async def _ensure_publication_document_index(conn) -> None:
         ):
             raise RuntimeError(
                 f"An index named {_PUB_INDEX} already exists but is not the "
-                f"cascade index migration 053 creates.\n  found: {found['definition']}\n"
+                f"cascade index migration 058 creates.\n  found: {found['definition']}\n"
                 "Inspect it, then drop or rename it and re-run."
             )
         if found["is_valid"]:
             return
         logger.warning(
-            "Migration 053: found an INVALID index named %s; dropping it before "
+            "Migration 058: found an INVALID index named %s; dropping it before "
             "rebuilding", _PUB_INDEX,
         )
         await conn.execute(f"DROP INDEX IF EXISTS public.{_PUB_INDEX}")
@@ -574,7 +574,7 @@ async def _ensure_publication_document_index(conn) -> None:
     # during the documents index build and a run that died entering the
     # backfill leave identical logs.
     logger.info(
-        "Migration 053: created %s — the cascade's lookup path on the "
+        "Migration 058: created %s — the cascade's lookup path on the "
         "referencing side", _PUB_INDEX,
     )
 
@@ -632,7 +632,7 @@ def _log_backfill_summary(counts: dict, mismatch_sample: list) -> None:
     very different databases.
     """
     logger.info(
-        "Migration 053 backfill: bound=%d, no_document=%d, path_reused=%d, "
+        "Migration 058 backfill: bound=%d, no_document=%d, path_reused=%d, "
         "unreadable_uri=%d, vault_mismatch=%d, changed_underfoot=%d, "
         "already_bound=%d, non_document_publications=%d (of %d document "
         "publications examined this run)",
@@ -646,7 +646,7 @@ def _log_backfill_summary(counts: dict, mismatch_sample: list) -> None:
         # URI names is not the vault the row belongs to. Ids only — enough to
         # pull the rows with a SELECT, without putting names or paths in a log.
         logger.warning(
-            "Migration 053: %d document publication(s) name a vault other than "
+            "Migration 058: %d document publication(s) name a vault other than "
             "their own and were left unbound. publication id(s): %s%s",
             counts["vault_mismatch"], ", ".join(str(i) for i in mismatch_sample),
             "" if counts["vault_mismatch"] <= _MISMATCH_SAMPLE
@@ -658,7 +658,7 @@ def _log_backfill_summary(counts: dict, mismatch_sample: list) -> None:
     )
     if unbound:
         logger.warning(
-            "Migration 053: %d document publication(s) left unbound "
+            "Migration 058: %d document publication(s) left unbound "
             "(no_document=%d, path_reused=%d, unreadable_uri=%d, "
             "changed_underfoot=%d). They keep working through resource_uri; "
             "document_id stays NULL until they are re-published.",

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -139,12 +139,6 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
     until the lock clears (the server also kills idle-in-transaction holders
     at 60s). The pooled connection's state is reset on release, so the
     per-migration `SET lock_timeout` does not leak to other callers.
-
-    A migration may return a summary dict — what it examined, changed and
-    declined to change. Most return nothing; one that does gets it recorded
-    here, so a data-touching migration's outcome is in the boot log next to
-    the line saying it ran, rather than only wherever that migration chose to
-    log it. Returning None stays the norm.
     """
     import logging
     log = logging.getLogger("akb.migrations")
@@ -152,9 +146,7 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
         try:
             async with pool.acquire() as conn:
                 await conn.execute("SET lock_timeout = '5s'")
-                summary = await module.migrate(conn=conn)
-                if summary is not None:
-                    log.info("Migration %s summary: %s", filename, summary)
+                await module.migrate(conn=conn)
                 await conn.execute(
                     "INSERT INTO schema_migrations (filename) VALUES ($1) "
                     "ON CONFLICT (filename) DO NOTHING",

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -234,7 +234,7 @@ async def _apply_migrations() -> None:
         "055_native_revision_m1_file_storage.py",    # M1 confirmed-only File transfer/CAS metadata
         "056_native_revision_m1_file_constraints.py", # M1 File placement discriminator integrity
         "057_native_revision_m1_payload_placement.py", # M1 placement-scoped payload deduplication
-        "053_publication_document_identity.py",  # publications.document_id + composite FK (document_id, vault_id) → documents(id, vault_id) ON DELETE CASCADE; conservative backfill
+        "058_publication_document_identity.py",  # publications.document_id + composite FK (document_id, vault_id) → documents(id, vault_id) ON DELETE CASCADE; conservative backfill
     ):
         if filename in applied:
             continue

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -139,6 +139,12 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
     until the lock clears (the server also kills idle-in-transaction holders
     at 60s). The pooled connection's state is reset on release, so the
     per-migration `SET lock_timeout` does not leak to other callers.
+
+    A migration may return a summary dict — what it examined, changed and
+    declined to change. Most return nothing; one that does gets it recorded
+    here, so a data-touching migration's outcome is in the boot log next to
+    the line saying it ran, rather than only wherever that migration chose to
+    log it. Returning None stays the norm.
     """
     import logging
     log = logging.getLogger("akb.migrations")
@@ -146,7 +152,9 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
         try:
             async with pool.acquire() as conn:
                 await conn.execute("SET lock_timeout = '5s'")
-                await module.migrate(conn=conn)
+                summary = await module.migrate(conn=conn)
+                if summary is not None:
+                    log.info("Migration %s summary: %s", filename, summary)
                 await conn.execute(
                     "INSERT INTO schema_migrations (filename) VALUES ($1) "
                     "ON CONFLICT (filename) DO NOTHING",

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -229,6 +229,7 @@ async def _apply_migrations() -> None:
         "050_drop_todos.py",                     # archive todos → todos_archive, drop todos: entrypoint-less since PR #43 and the source of the NOT NULL account-deletion failure
         "051_app_credentials.py",                # exchange-only deployment credentials for app principals
         "052_app_inventory.py",                  # observed installation state and sealed rollout snapshots
+        "053_publication_document_identity.py",  # publications.document_id + composite FK (document_id, vault_id) → documents(id, vault_id) ON DELETE CASCADE; conservative backfill
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -361,9 +361,11 @@ class DocumentRepository:
         to it. Returns True when a row was actually removed.
 
         **This is the only place an ordinary document row may be deleted.**
-        Publications lost their ``document_id`` FK in migration 022, so
-        nothing cascades: a delete that skips the publication cleanup leaves
-        a slug that still resolves *by path*, and because ``documents`` is
+        Migration 053 restored a database cascade, but only for publications
+        that carry a ``document_id``; the column is nullable and rows the
+        backfill could not bind unambiguously are exempt from the FK. For
+        those, nothing cascades: a delete that skips the publication cleanup
+        leaves a slug that still resolves *by path*, and because ``documents`` is
         ``UNIQUE(vault_id, path)`` the next document created at that path
         would then be reached through that old link. Of the three per-row
         delete paths, two omitted the cleanup — and they omitted it because

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -361,7 +361,7 @@ class DocumentRepository:
         to it. Returns True when a row was actually removed.
 
         **This is the only place an ordinary document row may be deleted.**
-        Migration 053 restored a database cascade, but only for publications
+        Migration 058 restored a database cascade, but only for publications
         that carry a ``document_id``; the column is nullable and rows the
         backfill could not bind unambiguously are exempt from the FK. For
         those, nothing cascades: a delete that skips the publication cleanup

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -303,9 +303,10 @@ class CollectionService:
                 # concurrent writers across the entire vault.
 
                 # The row delete goes through the repository chokepoint, which
-                # carries the publication cascade with it. `publications` lost
-                # its `document_id` FK in migration 022, so nothing cascades —
-                # and this loop, deleting the rows by hand, is where that was
+                # carries the publication cascade with it. Migration 053's FK
+                # cascades only publications that carry a `document_id`, so a
+                # legacy row the backfill left NULL still needs the explicit
+                # cleanup — and this loop, deleting the rows by hand, is where that was
                 # first forgotten: the orphaned publication's slug still
                 # resolved by path, and since `documents` is
                 # UNIQUE(vault_id, path), the next document created (or moved)

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -304,7 +304,7 @@ class CollectionService:
                 # concurrent writers across the entire vault.
 
                 # The row delete goes through the repository chokepoint, which
-                # carries the publication cascade with it. Migration 053's FK
+                # carries the publication cascade with it. Migration 058's FK
                 # cascades only publications that carry a `document_id`, so a
                 # legacy row the backfill left NULL still needs the explicit
                 # cleanup — and this loop, deleting the rows by hand, is where that was

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -245,13 +245,13 @@ def _certified_content_hash(md_content: str) -> str:
 # Newest publication slug for one document — the reverse of publication
 # resolution, and the query behind `is_public` / `public_slug`.
 #
-# Keyed on `publications.document_id`, which since migration 053 is the
+# Keyed on `publications.document_id`, which since migration 058 is the
 # binding for a document publication: a UUID under a composite
 # FK (document_id, vault_id) → documents(id, vault_id). Matching that
 # cannot answer with a publication belonging to some other document, and
 # cannot answer with one belonging to some other vault.
 #
-# The `resource_uri` branch is a FALLBACK, and only for rows the 053
+# The `resource_uri` branch is a FALLBACK, and only for rows the 058
 # backfill could not bind unambiguously (`document_id IS NULL`). It is kept
 # on purpose: without it those publications would report `is_public: false`
 # on a document whose slug still serves its body — telling an author their
@@ -1169,7 +1169,7 @@ class DocumentService:
             # path-shaped `resource_uri` the API returns and the cleanup /
             # orphan-guard helpers match on — from going stale. Matching on
             # the old URI rather than on `document_id` is deliberate: it also
-            # catches rows the migration-053 backfill left with a NULL
+            # catches rows the migration-058 backfill left with a NULL
             # `document_id`, which are precisely the ones nothing else keeps
             # current.
             await conn.execute(
@@ -1472,9 +1472,9 @@ class DocumentService:
         )
         # The row delete and the publication cascade are ONE call. That
         # cascade used to be an inline DELETE here (between migrations 022
-        # and 053 publications had no `document_id`, so nothing cascaded),
+        # and 058 publications had no `document_id`, so nothing cascaded),
         # and the two OTHER per-row delete paths — the collection cascade's
-        # doc loop and the external-git tombstone — never got a copy. 053
+        # doc loop and the external-git tombstone — never got a copy. 058
         # restored a database cascade, but only for rows that carry a
         # `document_id`; rows it could not bind are still removed by this
         # call alone. With no single

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -261,11 +261,11 @@ def _certified_content_hash(md_content: str) -> str:
 # `create_publication` refuses a document publication without an id.
 #
 # `vault_id = $1` scopes BOTH branches, and is the part that was missing:
-# the previous query matched `resource_uri` across every vault, so a reader
-# holding a document at path P learned that some other vault carries a
-# publication for P, and got its slug. `document_id = $2` alone would have
-# been enough for the primary branch (the composite FK pins the vault), but
-# the predicate sits on the query so the fallback cannot be wrong either.
+# the previous query matched `resource_uri` with no vault predicate at all,
+# so its answer was not scoped to the vault being asked about.
+# `document_id = $2` alone would have been enough for the primary branch (the
+# composite FK pins the vault), but the predicate sits on the query so the
+# fallback cannot be wrong either.
 #
 # ORDER BY created_at DESC matches `publishDoc()` in the frontend, which
 # reuses the first entry `listPublications` returns.

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -242,6 +242,67 @@ def _certified_content_hash(md_content: str) -> str:
     return _body_content_hash(canonical_body)
 
 
+# Newest publication slug for one document — the reverse of publication
+# resolution, and the query behind `is_public` / `public_slug`.
+#
+# Keyed on `publications.document_id`, which since migration 053 is the
+# binding for a document publication: a UUID under a composite
+# FK (document_id, vault_id) → documents(id, vault_id). Matching that
+# cannot answer with a publication belonging to some other document, and
+# cannot answer with one belonging to some other vault.
+#
+# The `resource_uri` branch is a FALLBACK, and only for rows the 053
+# backfill could not bind unambiguously (`document_id IS NULL`). It is kept
+# on purpose: without it those publications would report `is_public: false`
+# on a document whose slug still serves its body — telling an author their
+# document is private while it is reachable is a worse answer than the
+# imprecision the fallback carries. It disappears on its own as those rows
+# are re-published or removed; nothing new lands in it, because
+# `create_publication` refuses a document publication without an id.
+#
+# `vault_id = $1` scopes BOTH branches, and is the part that was missing:
+# the previous query matched `resource_uri` across every vault, so a reader
+# holding a document at path P learned that some other vault carries a
+# publication for P, and got its slug. `document_id = $2` alone would have
+# been enough for the primary branch (the composite FK pins the vault), but
+# the predicate sits on the query so the fallback cannot be wrong either.
+#
+# ORDER BY created_at DESC matches `publishDoc()` in the frontend, which
+# reuses the first entry `listPublications` returns.
+_PUBLIC_SLUG_SQL = """
+    SELECT slug
+      FROM publications
+     WHERE vault_id = $1
+       AND resource_type = 'document'
+       AND (
+             document_id = $2::uuid
+          OR (document_id IS NULL AND resource_uri = $3)
+       )
+     ORDER BY created_at DESC
+     LIMIT 1
+"""
+
+
+async def newest_public_slug(
+    conn,
+    *,
+    vault_id: uuid.UUID,
+    document_id: uuid.UUID | None,
+    resource_uri: str,
+) -> str | None:
+    """Newest publication slug bound to one document, or None.
+
+    ``document_id`` may be None for a caller that has no ``documents`` row to
+    name (the native-ledger arm keeps no legacy projection). The primary
+    branch then matches nothing — ``document_id = NULL`` is NULL, not true —
+    and the vault-scoped URI fallback answers. See ``_PUBLIC_SLUG_SQL``.
+
+    One function rather than one query per service on purpose: these were two
+    copies, and both carried the same missing ``vault_id`` predicate.
+    """
+    return await conn.fetchval(_PUBLIC_SLUG_SQL, vault_id, document_id, resource_uri)
+
+
 # Vault-name grammar: lowercase alphanumeric segments joined by SINGLE
 # hyphens (no leading / trailing / consecutive hyphens). The physical name
 # of a vault table is `vt_{sanitize(vault)}__{sanitize(table)}` where
@@ -625,10 +686,9 @@ class DocumentService:
         _, body = _parse_markdown(content)
         content_hash, hash_algorithm = await self._ensure_document_hash(doc_repo, row, body)
 
-        # Derive published state from the publications table. We pick the
-        # newest matching publication so the UI is consistent with publishDoc()
-        # which reuses the first entry returned by listPublications (DESC order).
-        public_slug = await self._get_public_slug(row["vault_name"], row["path"])
+        # Derive published state from the publications table, keyed on this
+        # document's own id.
+        public_slug = await self._get_public_slug(row)
 
         return DocumentResponse(
             uri=doc_uri(row["vault_name"], row["path"]),
@@ -687,7 +747,7 @@ class DocumentService:
                 flags=_re.DOTALL,
             )
 
-        public_slug = await self._get_public_slug(row["vault_name"], row["path"])
+        public_slug = await self._get_public_slug(row)
         content_hash = _body_content_hash(body)
 
         return DocumentResponse(
@@ -770,20 +830,22 @@ class DocumentService:
                 e["author_name"] = name
         return entries
 
-    async def _get_public_slug(self, vault_name: str, doc_path: str) -> str | None:
-        """Return the newest publication slug for a document, or None.
-        Looks up by the canonical resource_uri rather than the dropped
-        `publications.document_id` FK column."""
+    async def _get_public_slug(self, row: dict) -> str | None:
+        """Newest publication slug for the document `row`, or None.
+
+        Takes the whole row rather than (vault, path): the lookup keys on
+        `publications.document_id`, so it needs the identity the caller
+        already resolved, and re-deriving it from a path here would put back
+        the indirection this keys on the id to avoid. See
+        `newest_public_slug`.
+        """
         pool = await get_pool()
         async with pool.acquire() as conn:
-            return await conn.fetchval(
-                """
-                SELECT slug FROM publications
-                WHERE resource_uri = $1 AND resource_type = 'document'
-                ORDER BY created_at DESC
-                LIMIT 1
-                """,
-                doc_uri(vault_name, doc_path),
+            return await newest_public_slug(
+                conn,
+                vault_id=row["vault_id"],
+                document_id=row["id"],
+                resource_uri=doc_uri(row["vault_name"], row["path"]),
             )
 
     # ── Update ────────────────────────────────────────────────
@@ -1101,6 +1163,15 @@ class DocumentService:
             new_uri = doc_uri(vault, new_path)
             await self._relink_edges(conn, vault_id, "source_uri", old_uri, new_uri)
             await self._relink_edges(conn, vault_id, "target_uri", old_uri, new_uri)
+            # A move does NOT change which document a publication is bound to:
+            # `publications.document_id` is the binding and identity is what a
+            # move preserves. This rewrite keeps the DERIVED half — the
+            # path-shaped `resource_uri` the API returns and the cleanup /
+            # orphan-guard helpers match on — from going stale. Matching on
+            # the old URI rather than on `document_id` is deliberate: it also
+            # catches rows the migration-053 backfill left with a NULL
+            # `document_id`, which are precisely the ones nothing else keeps
+            # current.
             await conn.execute(
                 "UPDATE publications SET resource_uri = $1 WHERE vault_id = $2 AND resource_uri = $3",
                 new_uri, vault_id, old_uri,
@@ -1400,10 +1471,13 @@ class DocumentService:
             },
         )
         # The row delete and the publication cascade are ONE call. That
-        # cascade used to be an inline DELETE here (publications lost their
-        # `document_id` FK in migration 022, so nothing cascades), and the
-        # two OTHER per-row delete paths — the collection cascade's doc loop
-        # and the external-git tombstone — never got a copy. With no single
+        # cascade used to be an inline DELETE here (between migrations 022
+        # and 053 publications had no `document_id`, so nothing cascaded),
+        # and the two OTHER per-row delete paths — the collection cascade's
+        # doc loop and the external-git tombstone — never got a copy. 053
+        # restored a database cascade, but only for rows that carry a
+        # `document_id`; rows it could not bind are still removed by this
+        # call alone. With no single
         # original to call, writing a new delete path correctly meant
         # knowing to write the second statement at all. It now
         # lives inside `delete_with_publications`, which also takes the row

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -615,7 +615,7 @@ class ExternalGitService:
                 # they survive the delete and dangle on the next BFS.
                 await delete_document_relations(conn, vault_name, path)
                 # The row delete and the publication cascade are one call
-                # through the repository chokepoint. Migration 053's FK only
+                # through the repository chokepoint. Migration 058's FK only
                 # cascades rows that carry a `document_id`, which the
                 # backfill could not give every legacy row, so the tombstone
                 # still has to drop the publication itself, on THIS

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -615,9 +615,11 @@ class ExternalGitService:
                 # they survive the delete and dangle on the next BFS.
                 await delete_document_relations(conn, vault_name, path)
                 # The row delete and the publication cascade are one call
-                # through the repository chokepoint. `publications` lost its
-                # `document_id` FK in migration 022, so the tombstone has to
-                # drop the publication itself, on THIS connection: without it,
+                # through the repository chokepoint. Migration 053's FK only
+                # cascades rows that carry a `document_id`, which the
+                # backfill could not give every legacy row, so the tombstone
+                # still has to drop the publication itself, on THIS
+                # connection: without it,
                 # an upstream commit that removes a mirrored path leaves a
                 # slug that still resolves by path — and a later upstream
                 # commit re-adding that path (a revert, a rename back)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -167,7 +167,9 @@ class NativeDocumentService(DocumentService):
                 created_by,
             )
 
-    async def _public_slug(self, vault: str, path: str) -> str | None:
+    async def _public_slug(
+        self, vault_id: uuid.UUID, vault: str, path: str
+    ) -> str | None:
         """Newest publication slug for the document at ``path``, or None.
 
         Shares one query with the legacy arm (``newest_public_slug``) instead
@@ -176,12 +178,15 @@ class NativeDocumentService(DocumentService):
         told a reader that another vault carries a publication for the same
         path and handed over its slug.
 
+        ``vault_id`` is passed in rather than resolved here: every caller has
+        already resolved it through ``_current``, and ``_vault_id`` is an
+        uncached pool checkout plus a query.
+
         ``document_id=None`` is passed deliberately. This arm does not write
         the legacy ``documents`` projection, so there is no id to name here;
         the vault-scoped ``resource_uri`` fallback is what answers, and it is
         scoped either way.
         """
-        vault_id = await self._vault_id(vault)
         pool = await self._pool()
         async with pool.acquire() as conn:
             return await newest_public_slug(
@@ -195,6 +200,7 @@ class NativeDocumentService(DocumentService):
         self,
         *,
         vault: str,
+        vault_id: uuid.UUID,
         current: NativeRevisionSnapshot,
         selected: NativeRevisionSnapshot | None = None,
     ) -> DocumentResponse:
@@ -202,7 +208,13 @@ class NativeDocumentService(DocumentService):
         current_fm, _ = _parse_markdown(current.text)
         _, selected_body = _parse_markdown(selected.text)
         created_by = current_fm.get("created_by")
-        public_slug = await self._public_slug(vault, current.path)
+        # Two independent single-row reads on separate connections; run them
+        # together rather than paying two serialized pool checkouts per
+        # document read.
+        public_slug, created_by_name = await asyncio.gather(
+            self._public_slug(vault_id, vault, current.path),
+            self._created_by_name(created_by),
+        )
         return DocumentResponse(
             uri=doc_uri(vault, current.path),
             vault=vault,
@@ -213,7 +225,7 @@ class NativeDocumentService(DocumentService):
             summary=current_fm.get("summary"),
             domain=current_fm.get("domain"),
             created_by=created_by,
-            created_by_name=await self._created_by_name(created_by),
+            created_by_name=created_by_name,
             created_at=current_fm.get("created_at") or current.resource_created_at,
             updated_at=current.resource_updated_at,
             current_commit=selected.revision_id,
@@ -301,8 +313,8 @@ class NativeDocumentService(DocumentService):
         )
 
     async def get(self, vault: str, doc_ref: str) -> DocumentResponse:
-        _, current = await self._current(vault, doc_ref)
-        return await self._response(vault=vault, current=current)
+        vault_id, current = await self._current(vault, doc_ref)
+        return await self._response(vault=vault, vault_id=vault_id, current=current)
 
     async def get_at_commit(
         self,
@@ -319,7 +331,9 @@ class NativeDocumentService(DocumentService):
             reference=current.path,
             revision_id=version,
         )
-        return await self._response(vault=vault, current=current, selected=selected)
+        return await self._response(
+            vault=vault, vault_id=vault_id, current=current, selected=selected,
+        )
 
     async def update(
         self,

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -33,6 +33,7 @@ from app.services.document_service import (
     _certified_content_hash,
     _compose_markdown,
     _parse_markdown,
+    newest_public_slug,
 )
 from app.services.native_revision_service import NativeRevisionService, NativeRevisionSnapshot
 from app.services.resource_hash import HASH_ALGORITHM
@@ -167,17 +168,27 @@ class NativeDocumentService(DocumentService):
             )
 
     async def _public_slug(self, vault: str, path: str) -> str | None:
+        """Newest publication slug for the document at ``path``, or None.
+
+        Shares one query with the legacy arm (``newest_public_slug``) instead
+        of keeping a second copy — the two copies had drifted into the same
+        defect, a ``resource_uri`` match with no ``vault_id`` predicate, which
+        told a reader that another vault carries a publication for the same
+        path and handed over its slug.
+
+        ``document_id=None`` is passed deliberately. This arm does not write
+        the legacy ``documents`` projection, so there is no id to name here;
+        the vault-scoped ``resource_uri`` fallback is what answers, and it is
+        scoped either way.
+        """
+        vault_id = await self._vault_id(vault)
         pool = await self._pool()
         async with pool.acquire() as conn:
-            return await conn.fetchval(
-                """
-                SELECT slug
-                  FROM publications
-                 WHERE resource_uri = $1 AND resource_type = 'document'
-                 ORDER BY created_at DESC
-                 LIMIT 1
-                """,
-                doc_uri(vault, path),
+            return await newest_public_slug(
+                conn,
+                vault_id=vault_id,
+                document_id=None,
+                resource_uri=doc_uri(vault, path),
             )
 
     async def _response(

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -208,13 +208,16 @@ class NativeDocumentService(DocumentService):
         current_fm, _ = _parse_markdown(current.text)
         _, selected_body = _parse_markdown(selected.text)
         created_by = current_fm.get("created_by")
-        # Two independent single-row reads on separate connections; run them
-        # together rather than paying two serialized pool checkouts per
-        # document read.
-        public_slug, created_by_name = await asyncio.gather(
-            self._public_slug(vault_id, vault, current.path),
-            self._created_by_name(created_by),
-        )
+        # Sequential on purpose. These two reads are independent and a
+        # `gather` would save one round trip, but each takes its own pool
+        # connection, so overlapping them doubles this path's peak checkouts
+        # per document read to buy a saving that is worth nothing here — this
+        # arm is measurement-only and is not the default backend. It also
+        # changes failure behaviour: under `gather` a raise in one no longer
+        # stops the other, which runs on to completion with its result (or its
+        # own exception) discarded. Not worth either, for zero live gain.
+        public_slug = await self._public_slug(vault_id, vault, current.path)
+        created_by_name = await self._created_by_name(created_by)
         return DocumentResponse(
             uri=doc_uri(vault, current.path),
             vault=vault,

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -1143,13 +1143,30 @@ async def resolve_document_publication(publication: dict) -> dict:
     if publication["resource_type"] != ResourceType.DOCUMENT:
         raise PublicationError("Not a document publication", status_code=400)
 
-    # Parse the canonical URI to find the underlying doc row.
+    # **Which document this slug serves is decided by `document_id`.** Since
+    # migration 053 that column is the publication's binding to its document,
+    # under a composite FK (document_id, vault_id) → documents(id, vault_id),
+    # so a bound row names one document and that document is in the
+    # publication's own vault. Reading it here is the point of having it:
+    # `resource_uri` is a path, `documents` is UNIQUE(vault_id, path), and a
+    # path is reusable, so resolving by path asks "what lives there now?"
+    # rather than "what was published?". Those two questions had the same
+    # answer only for as long as one UPDATE — the move-time URI rewrite in
+    # `document_service.move` — was never missed. A constraint the read path
+    # does not read protects nothing.
     from app.services.uri_service import parse_uri
     uri = publication.get("resource_uri")
+    raw_doc_id = publication.get("document_id")
+    doc_uuid = to_uuid(raw_doc_id) if raw_doc_id else None
+
     parsed = parse_uri(uri) if uri else None
-    if parsed is None or parsed.kind != "doc":
+    doc_path = parsed.identifier if parsed and parsed.kind == "doc" else None
+    uri_vault = parsed.vault if parsed and parsed.kind == "doc" else None
+    if doc_uuid is None and doc_path is None:
+        # Only the legacy branch needs a readable URI. A bound row resolves
+        # without one, which also means a mirrored document whose path
+        # contains braces — a URI `parse_uri` refuses — is now servable.
         raise NotFoundError("Document", str(uri))
-    uri_vault, doc_path = parsed.vault, parsed.identifier
 
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -1166,19 +1183,32 @@ async def resolve_document_publication(publication: dict) -> dict:
             -- user_directory.resolve_display_names.
             LEFT JOIN users u
                 ON u.id::text = d.created_by OR u.username = d.created_by
-            -- Bind to the publication's own vault_id (not the vault NAME
-            -- parsed out of resource_uri) so this can't be satisfied by a
-            -- same-path document in another vault (cross-vault IDOR) — the
-            -- same binding `resolve_file_publication` puts on vault_files.
-            -- `v.name = $3` is then the cross-check, not the lookup key: v is
-            -- joined on the pinned vault_id, so requiring it to equal the
-            -- URI's vault name means a row whose resource_uri disagrees with
-            -- its vault_id matches nothing and 404s. Fail closed — serving
-            -- the publication's own document at that path instead would be a
-            -- silent partial success on a row that is, either way, corrupt.
-            WHERE d.vault_id = $1 AND d.path = $2 AND v.name = $3
+            -- Bound to the publication's own vault_id in BOTH branches, so
+            -- neither can be satisfied by a same-path document in another
+            -- vault — the same binding `resolve_file_publication` puts on
+            -- vault_files.
+            --
+            -- $2 (document_id) is the lookup key when the row carries one.
+            -- No `v.name` cross-check on that branch, deliberately: the FK
+            -- already pins the document to this vault, so the URI's vault
+            -- name adds nothing — and requiring it to agree would re-break
+            -- exactly what keying on the id fixes, turning a publication
+            -- whose URI drifted into a 404 instead of resolving it to the
+            -- document its publisher chose.
+            --
+            -- The path branch is for rows the migration-053 backfill could
+            -- not bind (document_id IS NULL), where the URI is still the
+            -- only handle. There `v.name = $4` remains the cross-check, not
+            -- the lookup key: v is joined on the pinned vault_id, so a row
+            -- whose resource_uri disagrees with its vault_id matches nothing
+            -- and 404s. Fail closed — nothing identifies the intended
+            -- document on that branch, so serving whatever sits at the path
+            -- would be a silent partial success on a corrupt row.
+            WHERE d.vault_id = $1
+              AND ( d.id = $2::uuid
+                 OR ($2::uuid IS NULL AND d.path = $3 AND v.name = $4) )
             """,
-            to_uuid(publication["vault_id"]), doc_path, uri_vault,
+            to_uuid(publication["vault_id"]), doc_uuid, doc_path, uri_vault,
         )
         if doc_row is None:
             raise NotFoundError("Document", str(uri))

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -1174,6 +1174,7 @@ async def resolve_document_publication(publication: dict) -> dict:
             """
             SELECT d.path, d.title, d.doc_type, d.status, d.summary, d.domain,
                    d.created_by, d.created_at, d.updated_at, d.tags,
+                   d.current_commit,
                    v.name AS vault_name,
                    COALESCE(u.display_name, u.username) AS created_by_name
             FROM documents d
@@ -1218,8 +1219,24 @@ async def resolve_document_publication(publication: dict) -> dict:
     try:
         # Git read is blocking filesystem I/O — offload it so a document page
         # open / download never stalls the single event loop (503 risk class).
+        #
+        # **Read at the row's own commit, not the floating vault HEAD.** The
+        # query above establishes identity by `document_id`; reading HEAD at
+        # `d.path` would hand it straight back, because the connection is
+        # released first and a path is reusable. A move plus a new document
+        # onto the vacated path between the two would serve that document's
+        # BYTES under this publication's title, tags and author attribution —
+        # the same substitution the id lookup exists to prevent, re-entered
+        # one statement later. Pinning the commit makes the body and the
+        # metadata come from one document by construction.
+        #
+        # `DocumentService.get` pins the same way and for the same reason
+        # (recorded there as E03); the anonymous path is the one that had not.
+        # A NULL `current_commit` (legacy rows) falls back to HEAD inside
+        # `read_file`, which is the pre-existing behaviour for those rows.
         raw = await asyncio.to_thread(
-            _get_doc_service().git.read_file, doc_row["vault_name"], doc_row["path"]
+            _get_doc_service().git.read_file,
+            doc_row["vault_name"], doc_row["path"], doc_row["current_commit"],
         )
         if raw:
             body = frontmatter.loads(raw).content

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -774,7 +774,7 @@ async def assert_no_orphan_publication_for_document(
     (409) when ``path``'s canonical URI already carries a publication and no
     document occupies the path.
 
-    **Why a write has to care about publications at all.** Migration 053
+    **Why a write has to care about publications at all.** Migration 058
     gave document publications a ``document_id`` under a composite FK with
     ``ON DELETE CASCADE``, and every publication created since carries one —
     those rows cannot outlive their document, with no code involved. But the
@@ -1144,7 +1144,7 @@ async def resolve_document_publication(publication: dict) -> dict:
         raise PublicationError("Not a document publication", status_code=400)
 
     # **Which document this slug serves is decided by `document_id`.** Since
-    # migration 053 that column is the publication's binding to its document,
+    # migration 058 that column is the publication's binding to its document,
     # under a composite FK (document_id, vault_id) → documents(id, vault_id),
     # so a bound row names one document and that document is in the
     # publication's own vault. Reading it here is the point of having it:
@@ -1197,7 +1197,7 @@ async def resolve_document_publication(publication: dict) -> dict:
             -- whose URI drifted into a 404 instead of resolving it to the
             -- document its publisher chose.
             --
-            -- The path branch is for rows the migration-053 backfill could
+            -- The path branch is for rows the migration-058 backfill could
             -- not bind (document_id IS NULL), where the URI is still the
             -- only handle. There `v.name = $4` remains the cross-check, not
             -- the lookup key: v is joined on the pinned vault_id, so a row

--- a/backend/app/services/publication_service.py
+++ b/backend/app/services/publication_service.py
@@ -33,7 +33,7 @@ from app.services import file_service, table_service
 from app.services.s3_delete_worker import enqueue_delete as _enqueue_s3_delete
 from app.services.document_service import DocumentService
 from app.services.revision_backend import get_document_service
-from app.services.uri_service import parse_uri
+from app.services.uri_service import doc_uri, parse_uri
 
 logger = logging.getLogger("akb.publications")
 
@@ -266,6 +266,7 @@ async def create_publication(
     vault_id: uuid.UUID,
     resource_type: str,
     resource_uri: str | None = None,
+    document_id: uuid.UUID | None = None,
     query_sql: str | None = None,
     query_vault_names: list[str] | None = None,
     query_params: dict | None = None,
@@ -290,16 +291,41 @@ async def create_publication(
     option, which keeps the create surface free of a field that means
     nothing for document/file publications.
 
-    `resource_uri` is the canonical handle for the publishable resource.
-    Required for `resource_type ∈ {document, file}`. For `table_query`,
-    `resource_uri` stays None — the publishable surface is the SQL itself.
+    **Which column binds a document publication to its document.**
+    ``document_id`` does, and only it: a UUID under a composite
+    ``FOREIGN KEY (document_id, vault_id) REFERENCES documents (id, vault_id)
+    ON DELETE CASCADE``, so a bound row cannot name a document outside its
+    own vault and cannot outlive that document. It is REQUIRED for
+    ``resource_type='document'``.
+
+    ``resource_uri`` is retained and still written, but for documents it is
+    DERIVED — the path-shaped rendering of the same binding, kept current by
+    the ``move``-time rewrite in ``document_service.move``. It stays because
+    ``table_query`` publications have no resource id at all, because it is
+    part of the API response shape, and because the cleanup and guard helpers
+    that predate ``document_id`` match on it. Read identity off
+    ``document_id``; read the human-facing location off ``resource_uri``.
+    Never resolve one from the other's path — carrying both and re-deriving
+    the id from the path is exactly what let a publication bind to a document
+    its publisher never chose.
+
+    For ``file`` the URI is still the only handle (``file_id`` is out of
+    scope here). For ``table_query`` both stay None — the publishable
+    surface is the SQL itself.
     """
     if resource_type not in ResourceType.ALL:
         raise ValueError(f"Invalid resource_type: {resource_type}")
 
     # Validate that the right resource fields are present
-    if resource_type == ResourceType.DOCUMENT and not resource_uri:
-        raise ValueError("resource_uri is required for resource_type='document'")
+    if resource_type == ResourceType.DOCUMENT:
+        if not resource_uri:
+            raise ValueError("resource_uri is required for resource_type='document'")
+        # Refused here rather than defaulted to NULL. The column is nullable
+        # only because rows predating it exist; nothing created from here on
+        # may add another unbound one, and a caller that cannot name the
+        # document it resolved has no business publishing it.
+        if document_id is None:
+            raise ValueError("document_id is required for resource_type='document'")
     if resource_type == ResourceType.FILE and not resource_uri:
         raise ValueError("resource_uri is required for resource_type='file'")
     if resource_type == ResourceType.TABLE_QUERY:
@@ -337,8 +363,7 @@ async def create_publication(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            # Re-check resource existence INSIDE the publish TX, against
-            # the canonical resource_uri the caller resolved. Closes the
+            # Re-check resource existence INSIDE the publish TX. Closes the
             # publish/delete race: without this, `document_service.delete`
             # could cascade-clean publications (zero rows) before we
             # INSERT below, leaving an orphan publication that points
@@ -349,20 +374,82 @@ async def create_publication(
             # after our INSERT commits — meaning either the publication
             # lands first and delete cleans it, or delete commits first
             # and we abort with ResourceVanished.
-            if resource_type == ResourceType.DOCUMENT and resource_uri:
-                parsed = parse_uri(resource_uri)
-                doc_path_for_check = (
-                    parsed.identifier if parsed and parsed.kind == "doc" else None
+            #
+            # **For documents the predicate is the id, not the path.** The
+            # caller resolved a specific document one connection ago and
+            # handed us its `document_id`; re-finding "whatever occupies
+            # that path now" would silently accept a different document,
+            # because `documents` is UNIQUE(vault_id, path) and a path is
+            # reusable. That window is small — two `pool.acquire()` calls
+            # inside one request — but the structural point stands on its
+            # own: the row we lock, the row we verify, and the row we store
+            # are one row, named the same way throughout, and re-deriving
+            # identity from a path is what made two of them able to differ.
+            # `FOR SHARE` is unchanged and load-bearing: it is what makes a
+            # concurrent delete queue behind this INSERT rather than race it
+            # (see `DocumentRepository.delete_with_publications`).
+            if resource_type == ResourceType.DOCUMENT:
+                # Read the vault NAME back through the same locked read, so
+                # the URI this compares against is rendered from the document
+                # row itself rather than from anything the caller assembled.
+                # `FOR SHARE OF d` locks only `documents` — taking a lock on
+                # `vaults` too would serialize this against unrelated writes
+                # across the whole vault.
+                bound = await conn.fetchrow(
+                    """
+                    SELECT d.path, v.name AS vault_name
+                      FROM documents d
+                      JOIN vaults v ON v.id = d.vault_id
+                     WHERE d.id = $1 AND d.vault_id = $2
+                     FOR SHARE OF d
+                    """,
+                    document_id, vault_id,
                 )
-                if doc_path_for_check is not None:
-                    found = await conn.fetchval(
-                        "SELECT 1 FROM documents WHERE vault_id = $1 AND path = $2 FOR SHARE",
-                        vault_id, doc_path_for_check,
+                if bound is None:
+                    raise ValueError(
+                        f"Document not found (resource was deleted concurrently): {resource_uri}"
                     )
-                    if not found:
+                # Compared as rendered URIs, not by parsing the caller's.
+                # `parse_uri` refuses paths containing braces, which
+                # external-git mirrors legitimately carry (see
+                # `delete_publications_by_doc_uri`) — parsing would turn
+                # those into a hard failure at publish. Rendering instead
+                # needs no grammar to hold, and it checks the vault name in
+                # the URI at the same time: `resource_uri` and the row's own
+                # (vault, path) agree, or nothing is written.
+                expected_uri = doc_uri(bound["vault_name"], bound["path"])
+                if resource_uri != expected_uri:
+                    # Two different failures, and they are worth separating
+                    # because they ask the caller for different things. A
+                    # vault name has no `/` in its grammar, so the prefix
+                    # test tells them apart without a parse.
+                    if not (resource_uri or "").startswith(
+                        f"akb://{bound['vault_name']}/"
+                    ):
+                        # The URI names a vault other than the one this row
+                        # is being stored against. Caller bug, not a race:
+                        # every production caller builds the URI from the
+                        # same vault it passes. Refusing at the write is the
+                        # point — resolution already declines to SERVE such a
+                        # row, so without this the table could hold one that
+                        # nothing will ever answer for.
                         raise ValueError(
-                            f"Document not found (resource was deleted concurrently): {resource_uri}"
+                            f"Publication vault does not match its document "
+                            f"(document is {expected_uri}): {resource_uri}"
                         )
+                    # The document still exists — it moved. Distinguishable
+                    # only now that the check knows which document it is
+                    # looking for; by path this was indistinguishable from
+                    # the delete above, or worse, satisfied by whatever moved
+                    # onto the vacated path. Fail rather than store the stale
+                    # URI: for documents `resource_uri` is derived from
+                    # `document_id`, and resolution still reads the URI — a
+                    # row where the two disagree does not just look wrong, it
+                    # serves wrong.
+                    raise ValueError(
+                        f"Document moved concurrently (it is now {expected_uri}); "
+                        f"publish again: {resource_uri}"
+                    )
             elif resource_type == ResourceType.FILE and resource_uri:
                 file_uuid_for_check = resource_uri.rsplit("/", 1)[-1]
                 try:
@@ -385,19 +472,19 @@ async def create_publication(
                 """
                 WITH inserted AS (
                     INSERT INTO publications (
-                        slug, vault_id, resource_type, resource_uri,
+                        slug, vault_id, resource_type, resource_uri, document_id,
                         query_sql, query_vault_names, query_params,
                         password_hash, max_views, expires_at,
                         mode, section_filter, allow_embed, title, created_by
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-                            'live', $11, $12, $13, $14)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                            'live', $12, $13, $14, $15)
                     RETURNING *
                 )
                 SELECT p.*, v.name AS vault
                   FROM inserted p JOIN vaults v ON v.id = p.vault_id
                 """,
-                slug, vault_id, resource_type, resource_uri,
+                slug, vault_id, resource_type, resource_uri, document_id,
                 query_sql, query_vault_names, json.dumps(query_params or {}),
                 pwd_hash, max_views, expires_at,
                 section_filter, allow_embed, title, created_by,
@@ -429,6 +516,12 @@ async def create_publication_for_vault(
     Resolves vault name → vault_id, doc_id → document UUID, validates
     file_id format, parses expires_in, then delegates to create_publication.
     Raises ValueError for any invalid input (caller maps to HTTP/MCP error).
+
+    **The document UUID this resolves is what gets stored**, not just the
+    path rendered from it. `create_publication` re-verifies by that id under
+    a row lock, so the document the caller asked for is the document the
+    publication ends up bound to. Passing only the path made those two
+    separable.
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -440,20 +533,26 @@ async def create_publication_for_vault(
     from app.services.uri_service import doc_uri, file_uri
 
     resource_uri: str | None = None
+    resolved_document_id: uuid.UUID | None = None
     resolved_query_vaults = query_vault_names
 
     if resource_type == ResourceType.DOCUMENT:
         if not doc_id:
             raise ValueError("doc_id required for resource_type='document'")
         # Resolve the caller's `doc_id` (path, UUID, or d-prefix id —
-        # find_by_ref_with_conn handles all three) to the canonical
-        # path under this vault, then build the URI.
+        # find_by_ref_with_conn handles all three) to a document row under
+        # this vault. Keep BOTH halves of what that lookup found: the id is
+        # the binding `create_publication` stores and re-verifies under its
+        # row lock, the path is only how the URI renders. Keeping the path
+        # alone is what let the publication land on a different document
+        # than the one resolved here.
         from app.repositories.document_repo import DocumentRepository
         doc_repo = DocumentRepository(pool)
         async with pool.acquire() as conn:
             doc_row = await doc_repo.find_by_ref_with_conn(conn, vault_id, doc_id)
         if not doc_row:
             raise ValueError(f"Document not found: {doc_id}")
+        resolved_document_id = doc_row["id"]
         resource_uri = doc_uri(vault_name, doc_row["path"])
     elif resource_type == ResourceType.FILE:
         if not file_id:
@@ -498,6 +597,7 @@ async def create_publication_for_vault(
         vault_id=vault_id,
         resource_type=resource_type,
         resource_uri=resource_uri,
+        document_id=resolved_document_id,
         query_sql=query_sql,
         query_vault_names=resolved_query_vaults,
         query_params=query_params,
@@ -674,17 +774,22 @@ async def assert_no_orphan_publication_for_document(
     (409) when ``path``'s canonical URI already carries a publication and no
     document occupies the path.
 
-    **Why a write has to care about publications at all.** A document
-    publication is bound to its document only by a path-shaped URI —
-    migration 022 dropped the ``document_id`` FK — and ``documents`` is
-    ``UNIQUE(vault_id, path)``, so paths are reusable. A publication that
-    outlives its document therefore still claims that path: the next
-    document to occupy it would be reached through the old link.
+    **Why a write has to care about publications at all.** Migration 053
+    gave document publications a ``document_id`` under a composite FK with
+    ``ON DELETE CASCADE``, and every publication created since carries one —
+    those rows cannot outlive their document, with no code involved. But the
+    column is nullable, because rows that predate it could not all be bound
+    unambiguously; a row left NULL is still held to its document by nothing
+    but a path-shaped ``resource_uri``, and ``documents`` is
+    ``UNIQUE(vault_id, path)``, so paths are reusable. Such a publication
+    outliving its document still claims that path: the next document to
+    occupy it would be reached through the old link.
     ``DocumentRepository.delete_with_publications`` keeps a delete from
     leaving one behind. This guard covers the other direction — a write
     arriving at a path some earlier state already left a claim on — so the
     two together mean neither end of a path's lifecycle has to trust the
-    other to have been correct.
+    other to have been correct. Both remain necessary for exactly as long as
+    one NULL ``document_id`` remains.
 
     **The URI is built HERE, from (vault_name, path) — the caller never
     assembles one.** Getting the URI right is the whole check: one that is

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1070,7 +1070,8 @@ async def test_publish_delete_race_leaves_no_orphan_publication(pool, vault, mon
         # 1) Publisher queues FIRST. Its FOR SHARE conflicts with the
         #    blocker's FOR UPDATE, so it parks before inserting anything.
         pub_task = asyncio.create_task(create_publication(
-            vault_id=vid, resource_type="document", resource_uri=uri, title="Q3",
+            vault_id=vid, resource_type="document", resource_uri=uri,
+            document_id=did, title="Q3",
         ))
         await _await_blocked(
             watch, count=1, contains="FOR SHARE",
@@ -1195,7 +1196,8 @@ async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeyp
 
             # Publisher parks on the uncommitted delete.
             pub_task = asyncio.create_task(create_publication(
-                vault_id=vid, resource_type="document", resource_uri=uri, title="Q4",
+                vault_id=vid, resource_type="document", resource_uri=uri,
+                document_id=did, title="Q4",
             ))
             await _await_blocked(
                 watch, count=1, contains="FOR SHARE",
@@ -1213,3 +1215,281 @@ async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeyp
             "SELECT COUNT(*) FROM publications WHERE resource_uri = $1", uri,
         )
     assert rows == 0, "a publication must not be created for a deleted document"
+
+
+# ── The publisher's own handoff: resolve → INSERT ─────────────────────
+#
+# `create_publication_for_vault` resolves the caller's doc_id to a document
+# on one pooled connection, and `create_publication` INSERTs on another.
+# Nothing spans the two — no transaction, no lock, no snapshot — so the
+# document is unheld in between. That gap is milliseconds wide and lives
+# inside a single request; the three tests below force it open on purpose
+# rather than waiting for it, because what is being pinned is not the odds
+# of hitting it but which value carries identity across it.
+#
+# Before this change only the PATH crossed the gap, and the INSERT re-found
+# the document by that path. `documents` is UNIQUE(vault_id, path) and paths
+# are reusable, so "the document at path P" is not a stable name for a
+# document — the publisher could resolve one document and publish another.
+# Now the resolved id crosses, the re-check keys on it, and the row stores
+# it (`publications.document_id`, migration 053).
+#
+# The interleaving is injected by wrapping `create_publication` itself: the
+# wrapper runs at exactly the moment the resolve has finished and the INSERT
+# has not started, which is the window, and then calls the real function
+# with the arguments the resolve produced. Those arguments are captured, so
+# a test cannot pass by the resolve having quietly seen the *new* document.
+
+
+async def _insert_doc(pool, *, doc_id, vault_id, path, title) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, $3, $4, 'report', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            doc_id, vault_id, path, title,
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_binds_the_publication_to_the_document_it_resolved(
+    pool, vault, monkeypatch,
+):
+    """The invariant, stated positively: a publication created from here on
+    carries the id of the document its publisher resolved.
+
+    No interleaving — this is the ordinary path. It is the test that says the
+    binding is written at all, so the two failure tests below cannot both be
+    satisfied by a publisher that simply never succeeds.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication_for_vault
+    from app.services.uri_service import doc_uri
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    path = "reports/q5.md"
+    await _insert_doc(pool, doc_id=did, vault_id=vid, path=path, title="Q5")
+
+    pub = await create_publication_for_vault(
+        vault_name=vname, resource_type="document", doc_id=path,
+        title="Q5 (public)",
+    )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT document_id, vault_id, resource_uri FROM publications "
+            " WHERE slug = $1",
+            pub["slug"],
+        )
+
+    assert row is not None, "the publication row is missing"
+    assert row["document_id"] == did, (
+        "the publication is not bound to the document that was resolved "
+        f"(document_id={row['document_id']}, expected {did}). A NULL here "
+        "means the identity was dropped between resolve and INSERT and the "
+        "row is held to its document by a reusable path alone."
+    )
+    # The composite FK already forbids a cross-vault pair; asserting it keeps
+    # the expectation visible next to the id.
+    assert row["vault_id"] == vid
+    # `resource_uri` is retained and still written — derived, for documents,
+    # from the same binding.
+    assert row["resource_uri"] == doc_uri(vname, path)
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_when_another_document_takes_the_resolved_path(
+    pool, vault, monkeypatch,
+):
+    """Document A is resolved, then deleted, and B is created at A's path —
+    all before the INSERT. The publisher must fail, not publish B.
+
+    The delete is clean (through the chokepoint, publications and all), so
+    nothing earlier on this branch catches it: there is no orphan for the
+    write-side guard to refuse, the delete had no publication to cascade, and
+    B is in the same vault so the resolution binding is satisfied. The only
+    thing that can tell A from B here is the id the publisher resolved.
+
+    Pre-change this is RED: `create_publication` re-found the document by
+    path, found B, and published it under a link the caller asked for A.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication_for_vault
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid, vname = vault["id"], vault["name"]
+    did_a, did_b = uuid.uuid4(), uuid.uuid4()
+    path = "reports/q6.md"
+    await _insert_doc(pool, doc_id=did_a, vault_id=vid, path=path, title="A")
+
+    doc_repo = DocumentRepository(pool)
+    real_create = publication_service.create_publication
+    handed_off: dict = {}
+
+    async def _swap_the_document_then_insert(**kwargs):
+        handed_off.update(kwargs)
+        async with pool.acquire() as c:
+            tx = c.transaction()
+            await tx.start()
+            await doc_repo.delete_with_publications(c, doc_id=did_a, vault_id=vid)
+            await tx.commit()
+        await _insert_doc(pool, doc_id=did_b, vault_id=vid, path=path, title="B")
+        return await real_create(**kwargs)
+
+    monkeypatch.setattr(
+        publication_service, "create_publication", _swap_the_document_then_insert,
+    )
+
+    with pytest.raises(ValueError, match="deleted concurrently"):
+        await create_publication_for_vault(
+            vault_name=vname, resource_type="document", doc_id=path,
+            title="A (public)",
+        )
+
+    # Pin that the resolve really did see A. Without this the test could pass
+    # for the wrong reason — a resolve that ran late and never held A at all.
+    assert handed_off.get("document_id") == did_a, (
+        "the resolve did not hand A's id to the INSERT "
+        f"(got {handed_off.get('document_id')!r}); the window this test "
+        "exists to force was not exercised."
+    )
+
+    async with pool.acquire() as conn:
+        pubs = await conn.fetch(
+            "SELECT slug, document_id FROM publications WHERE vault_id = $1", vid,
+        )
+        b_still_there = await conn.fetchval(
+            "SELECT COUNT(*) FROM documents WHERE id = $1", did_b,
+        )
+    assert b_still_there == 1, "B should be untouched — it was never the target"
+    assert not pubs, (
+        f"a publication was created anyway: {[dict(r) for r in pubs]}. "
+        "Whoever wrote B never asked for it to be publicly readable."
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_when_the_resolved_document_moves_off_its_path(
+    pool, vault, monkeypatch,
+):
+    """The other half of the same gap: A is not deleted, it MOVES, and B
+    lands on the path A vacated.
+
+    By path this was indistinguishable from a plain delete — worse, it was
+    satisfied by B and published it. By id it is now its own case, and the
+    error says so, because "your document moved, publish again" and "your
+    document is gone" ask the caller for different things.
+
+    It also pins that a stale URI is never stored: `document_id` and
+    `resource_uri` describe the same document or the publication is not
+    written.
+
+    Pre-change this is RED for the same reason as the test above.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication_for_vault
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid, vname = vault["id"], vault["name"]
+    did_a, did_b = uuid.uuid4(), uuid.uuid4()
+    path = "reports/q7.md"
+    moved_to = "archive/q7.md"
+    await _insert_doc(pool, doc_id=did_a, vault_id=vid, path=path, title="A")
+
+    real_create = publication_service.create_publication
+    handed_off: dict = {}
+
+    async def _move_a_then_insert(**kwargs):
+        handed_off.update(kwargs)
+        async with pool.acquire() as c:
+            await c.execute(
+                "UPDATE documents SET path = $1 WHERE id = $2", moved_to, did_a,
+            )
+        await _insert_doc(pool, doc_id=did_b, vault_id=vid, path=path, title="B")
+        return await real_create(**kwargs)
+
+    monkeypatch.setattr(
+        publication_service, "create_publication", _move_a_then_insert,
+    )
+
+    with pytest.raises(ValueError, match="moved concurrently"):
+        await create_publication_for_vault(
+            vault_name=vname, resource_type="document", doc_id=path,
+            title="A (public)",
+        )
+
+    assert handed_off.get("document_id") == did_a, (
+        "the resolve did not hand A's id to the INSERT "
+        f"(got {handed_off.get('document_id')!r}); the window this test "
+        "exists to force was not exercised."
+    )
+
+    async with pool.acquire() as conn:
+        pubs = await conn.fetch(
+            "SELECT slug, document_id, resource_uri FROM publications "
+            " WHERE vault_id = $1",
+            vid,
+        )
+    assert not pubs, (
+        f"a publication was created anyway: {[dict(r) for r in pubs]}. "
+        "Either it points at B — which nobody published — or it points at A "
+        "under the path A no longer occupies."
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_a_uri_that_names_another_vault(
+    pool, vault, monkeypatch,
+):
+    """The same comparison, reached from the caller's side rather than a race.
+
+    `create_publication` is the low-level function; it does no vault-access
+    check of its own and no production caller reaches it directly. Verifying
+    the stored URI against the one the LOCKED document row renders means it
+    can no longer persist a row whose two vault identifiers disagree —
+    resolution already declines to serve such a row, so the write is where
+    it should have been refused.
+
+    The document is real and in this vault; only the URI's vault component
+    is wrong, which is the whole point: the id being valid is not enough.
+    """
+    from app.services import publication_service
+    from app.services.publication_service import create_publication
+
+    monkeypatch.setattr(
+        publication_service.settings, "public_base_url",
+        "https://race.test.local", raising=False,
+    )
+
+    vid = vault["id"]
+    did = uuid.uuid4()
+    path = "reports/q8.md"
+    await _insert_doc(pool, doc_id=did, vault_id=vid, path=path, title="Q8")
+
+    with pytest.raises(ValueError, match="vault does not match"):
+        await create_publication(
+            vault_id=vid, resource_type="document",
+            resource_uri="akb://some-other-vault/coll/reports/doc/q8.md",
+            document_id=did, title="Q8",
+        )
+
+    async with pool.acquire() as conn:
+        pubs = await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE vault_id = $1", vid,
+        )
+    assert pubs == 0, "a vault-mismatched publication must not be stored"

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1036,7 +1036,7 @@ async def test_publish_delete_race_leaves_no_orphan_publication(pool, vault, mon
 
     **What this test stopped proving.** The publication it creates is now
     bound (`document_id` is required for a document publication), so
-    migration 053's ON DELETE CASCADE removes it too — the final assertion
+    migration 058's ON DELETE CASCADE removes it too — the final assertion
     below holds even with the explicit cleanup deleted outright. Verified,
     not assumed. So this is now a test of the END STATE, and the FK is what
     guarantees it. The lock ordering and the explicit cleanup are what a
@@ -1169,7 +1169,7 @@ async def test_delete_cleanup_removes_a_legacy_publication_the_cascade_cannot_re
 ):
     """The same lock-ordering proof, on the one population the FK is blind to.
 
-    Migration 053's ON DELETE CASCADE only reaches publications that carry a
+    Migration 058's ON DELETE CASCADE only reaches publications that carry a
     `document_id`, and the column is nullable precisely because the backfill
     could not bind every pre-existing row. For a row it left NULL, the
     deleter's explicit publication cleanup is the ONLY thing that removes it
@@ -1179,7 +1179,7 @@ async def test_delete_cleanup_removes_a_legacy_publication_the_cascade_cannot_re
     The publisher here is hand-rolled rather than `create_publication`: that
     function now refuses to create an unbound document publication, which is
     the point of the change, so the legacy shape has to be written directly.
-    What it reproduces is exactly the pre-053 publisher — take `FOR SHARE`
+    What it reproduces is exactly the pre-058 publisher — take `FOR SHARE`
     on the document row, then INSERT — so the lock choreography under test is
     the real one.
 
@@ -1361,7 +1361,7 @@ async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeyp
 # are reusable, so "the document at path P" is not a stable name for a
 # document — the publisher could resolve one document and publish another.
 # Now the resolved id crosses, the re-check keys on it, and the row stores
-# it (`publications.document_id`, migration 053).
+# it (`publications.document_id`, migration 058).
 #
 # The interleaving is injected by wrapping `create_publication` itself: the
 # wrapper runs at exactly the moment the resolve has finished and the INSERT

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1190,14 +1190,10 @@ async def test_delete_cleanup_removes_a_legacy_publication_the_cascade_cannot_re
     did = uuid.uuid4()
     path = "reports/legacy.md"
     uri = f"akb://{vname}/coll/reports/doc/legacy.md"
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
-            "created_at, updated_at, current_commit, tags, metadata) VALUES "
-            "($1, $2, $3, 'Legacy', 'report', 'draft', NOW(), NOW(), 'cafef00d', "
-            "'{}'::text[], '{}'::jsonb)",
-            did, vid, path,
-        )
+    # Only the publication's NULL `document_id` below is load-bearing here —
+    # the document itself is ordinary, so it goes through the shared helper
+    # rather than a hand-written INSERT that would read as deliberate.
+    await _insert_doc(pool, doc_id=did, vault_id=vid, path=path, title="Legacy")
 
     doc_repo = DocumentRepository(pool)
     blocker = await asyncpg.connect(_DSN)

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1033,6 +1033,18 @@ async def test_publish_delete_race_leaves_no_orphan_publication(pool, vault, mon
     publication it never saw survived the document it pointed at. With
     FOR UPDATE taken first, the deleter's cleanup runs downstream of the
     lock, sees the freshly committed row, and removes it.
+
+    **What this test stopped proving.** The publication it creates is now
+    bound (`document_id` is required for a document publication), so
+    migration 053's ON DELETE CASCADE removes it too — the final assertion
+    below holds even with the explicit cleanup deleted outright. Verified,
+    not assumed. So this is now a test of the END STATE, and the FK is what
+    guarantees it. The lock ordering and the explicit cleanup are what a
+    publication the FK cannot reach still depends on, and that is pinned
+    separately by
+    ``test_delete_cleanup_removes_a_legacy_publication_the_cascade_cannot_reach``
+    below. Do not delete this one in favour of that: between them they say
+    the invariant holds for both populations.
     """
     from app.services import publication_service
     from app.services.publication_service import create_publication
@@ -1152,6 +1164,124 @@ async def test_publish_delete_race_leaves_no_orphan_publication(pool, vault, mon
 
 
 @pytest.mark.asyncio
+async def test_delete_cleanup_removes_a_legacy_publication_the_cascade_cannot_reach(
+    pool, vault,
+):
+    """The same lock-ordering proof, on the one population the FK is blind to.
+
+    Migration 053's ON DELETE CASCADE only reaches publications that carry a
+    `document_id`, and the column is nullable precisely because the backfill
+    could not bind every pre-existing row. For a row it left NULL, the
+    deleter's explicit publication cleanup is the ONLY thing that removes it
+    — so this is where the FOR UPDATE-before-cleanup ordering still has to
+    be correct, and the only place a test can still tell.
+
+    The publisher here is hand-rolled rather than `create_publication`: that
+    function now refuses to create an unbound document publication, which is
+    the point of the change, so the legacy shape has to be written directly.
+    What it reproduces is exactly the pre-053 publisher — take `FOR SHARE`
+    on the document row, then INSERT — so the lock choreography under test is
+    the real one.
+
+    RED if the cleanup runs before the row lock, and equally RED if the
+    cleanup is removed: nothing else can delete this row.
+    """
+    vid, vname = vault["id"], vault["name"]
+    did = uuid.uuid4()
+    path = "reports/legacy.md"
+    uri = f"akb://{vname}/coll/reports/doc/legacy.md"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, $3, 'Legacy', 'report', 'draft', NOW(), NOW(), 'cafef00d', "
+            "'{}'::text[], '{}'::jsonb)",
+            did, vid, path,
+        )
+
+    doc_repo = DocumentRepository(pool)
+    blocker = await asyncpg.connect(_DSN)
+    watch = await asyncpg.connect(_DSN)
+    try:
+        btx = blocker.transaction()
+        await btx.start()
+        await blocker.fetchval(
+            "SELECT id FROM documents WHERE id = $1 FOR UPDATE", did,
+        )
+
+        async def _publish_unbound() -> None:
+            async with pool.acquire() as c:
+                tx = c.transaction()
+                await tx.start()
+                try:
+                    await c.fetchval(
+                        "SELECT 1 FROM documents WHERE id = $1 AND vault_id = $2 "
+                        "FOR SHARE",
+                        did, vid,
+                    )
+                    await c.execute(
+                        "INSERT INTO publications (slug, vault_id, resource_type, "
+                        "resource_uri, document_id, mode, allow_embed, query_params) "
+                        "VALUES ($1, $2, 'document', $3, NULL, 'live', true, "
+                        "'{}'::jsonb)",
+                        "legacyslug000001", vid, uri,
+                    )
+                except BaseException:
+                    await tx.rollback()
+                    raise
+                await tx.commit()
+
+        # Publisher queues FIRST, deleter SECOND — same order as the bound
+        # case above, so the deleter's cleanup is the side under test.
+        pub_task = asyncio.create_task(_publish_unbound())
+        await _await_blocked(
+            watch, count=1, contains="FOR SHARE",
+            what="the legacy publisher to park on the document row",
+        )
+
+        async def _delete() -> bool:
+            async with pool.acquire() as c:
+                tx = c.transaction()
+                await tx.start()
+                try:
+                    out = await doc_repo.delete_with_publications(
+                        c, doc_id=did, vault_id=vid,
+                    )
+                except BaseException:
+                    await tx.rollback()
+                    raise
+                await tx.commit()
+                return out
+
+        del_task = asyncio.create_task(_delete())
+        await _await_blocked(
+            watch, count=2, contains="documents",
+            what="the delete to park behind the legacy publisher",
+        )
+
+        await btx.commit()
+        await pub_task
+        deleted = await del_task
+    finally:
+        if not blocker.is_closed():
+            await blocker.close()
+        await watch.close()
+
+    assert deleted is True, "the delete must have removed the document row"
+
+    async with pool.acquire() as conn:
+        orphans = await conn.fetch(
+            "SELECT slug, document_id FROM publications WHERE resource_uri = $1", uri,
+        )
+    assert not orphans, (
+        "ORPHAN PUBLICATION SURVIVED the delete "
+        f"({[dict(r) for r in orphans]}). Its `document_id` is NULL, so the "
+        "foreign key could not take it — the deleter's own cleanup, running "
+        "downstream of the row lock, is the only thing that removes it."
+    )
+
+
+@pytest.mark.asyncio
 async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeypatch):
     """The other interleaving: the deleter wins the row, so the publisher's
     FOR SHARE re-check finds nothing and `create_publication` fails closed
@@ -1223,9 +1353,12 @@ async def test_publish_aborts_when_the_delete_holds_the_row(pool, vault, monkeyp
 # on one pooled connection, and `create_publication` INSERTs on another.
 # Nothing spans the two — no transaction, no lock, no snapshot — so the
 # document is unheld in between. That gap is milliseconds wide and lives
-# inside a single request; the three tests below force it open on purpose
-# rather than waiting for it, because what is being pinned is not the odds
-# of hitting it but which value carries identity across it.
+# inside a single request; the two interleaving tests below force it open on
+# purpose rather than waiting for it, because what is being pinned is not the
+# odds of hitting it but which value carries identity across it. The first
+# test takes no interleaving at all — it is the positive statement that the
+# binding gets written on the ordinary path, without which the other two
+# could be satisfied by a publisher that never succeeds.
 #
 # Before this change only the PATH crossed the gap, and the INSERT re-found
 # the document by that path. `documents` is UNIQUE(vault_id, path) and paths
@@ -1399,6 +1532,7 @@ async def test_publish_refuses_when_the_resolved_document_moves_off_its_path(
     """
     from app.services import publication_service
     from app.services.publication_service import create_publication_for_vault
+    from app.services.uri_service import doc_uri
 
     monkeypatch.setattr(
         publication_service.settings, "public_base_url",
@@ -1438,13 +1572,29 @@ async def test_publish_refuses_when_the_resolved_document_moves_off_its_path(
         f"(got {handed_off.get('document_id')!r}); the window this test "
         "exists to force was not exercised."
     )
+    # The URI that crossed the gap is A's ORIGINAL path — the stale one. That
+    # is what makes this the move case and not the delete case: the id is
+    # still live, and it is the id/URI disagreement that has to be caught.
+    assert handed_off.get("resource_uri") == doc_uri(vname, path), (
+        f"the resolve handed over {handed_off.get('resource_uri')!r}, not the "
+        "pre-move URI; this is not the interleaving the test describes."
+    )
 
     async with pool.acquire() as conn:
+        a_now, b_now = await conn.fetchval(
+            "SELECT path FROM documents WHERE id = $1", did_a,
+        ), await conn.fetchval(
+            "SELECT path FROM documents WHERE id = $1", did_b,
+        )
         pubs = await conn.fetch(
             "SELECT slug, document_id, resource_uri FROM publications "
             " WHERE vault_id = $1",
             vid,
         )
+    assert (a_now, b_now) == (moved_to, path), (
+        f"setup did not hold: A is at {a_now!r} and B at {b_now!r}; the test "
+        "needs A moved off the path and B sitting on it."
+    )
     assert not pubs, (
         f"a publication was created anyway: {[dict(r) for r in pubs]}. "
         "Either it points at B — which nobody published — or it points at A "

--- a/backend/tests/test_document_hash_contract_unit.py
+++ b/backend/tests/test_document_hash_contract_unit.py
@@ -117,7 +117,7 @@ async def test_document_get_computes_body_hash_and_repairs_projection(monkeypatc
     async def fake_repos():
         return _FakeVaultRepo(vault_id), doc_repo, object()
 
-    async def fake_public_slug(vault: str, path: str) -> None:
+    async def fake_public_slug(row: dict) -> None:
         return None
 
     monkeypatch.setattr(service, "_repos", fake_repos)
@@ -168,7 +168,7 @@ async def test_document_get_hashes_empty_body_as_valid_content(monkeypatch) -> N
     async def fake_repos():
         return _FakeVaultRepo(vault_id), doc_repo, object()
 
-    async def fake_public_slug(vault: str, path: str) -> None:
+    async def fake_public_slug(row: dict) -> None:
         return None
 
     monkeypatch.setattr(service, "_repos", fake_repos)
@@ -274,7 +274,7 @@ async def test_document_get_reads_body_at_current_commit_not_head(monkeypatch) -
     async def fake_repos():
         return _FakeVaultRepo(uuid.uuid4()), _FakeDocRepo(row), object()
 
-    async def fake_public_slug(vault: str, path: str) -> None:
+    async def fake_public_slug(row: dict) -> None:
         return None
 
     monkeypatch.setattr(service, "_repos", fake_repos)
@@ -471,7 +471,7 @@ async def test_get_after_put_confirms_hash_and_self_heal_is_noop(monkeypatch) ->
     async def fake_repos():
         return _FakeVaultRepo(uuid.uuid4()), get_repo, object()
 
-    async def fake_public_slug(vault: str, path: str) -> None:
+    async def fake_public_slug(row: dict) -> None:
         return None
 
     monkeypatch.setattr(service, "_repos", fake_repos)

--- a/backend/tests/test_external_git_cascade_unit.py
+++ b/backend/tests/test_external_git_cascade_unit.py
@@ -212,7 +212,7 @@ async def _publication_row(pool, slug: str) -> dict | None:
     return dict(row) if row else None
 
 
-async def _publish_mirrored(mirror, path: str) -> str:
+async def _publish_mirrored(pool, mirror, path: str) -> str:
     """Publish a mirrored document.
 
     Deliberately `create_publication` and not the REST/MCP surface: publishing
@@ -220,12 +220,18 @@ async def _publish_mirrored(mirror, path: str) -> str:
     user (invariant 1, pinned below). The service function has no mirror check,
     which is exactly why the cascade has to be correct anyway — this is the one
     seam through which a mirror publication could ever exist.
+
+    The document's id is read back and passed: a document publication is bound
+    by `document_id`, and `create_publication` refuses one without it.
     """
     from app.services.publication_service import create_publication
+    row = await _doc_row(pool, mirror.vault_id, path)
+    assert row is not None, f"no mirrored document at {path!r} to publish"
     pub = await create_publication(
         vault_id=mirror.vault_id,
         resource_type="document",
         resource_uri=doc_uri(mirror.name, path),
+        document_id=row["id"],
         title="Q3 (public)",
     )
     return pub["slug"]
@@ -287,7 +293,7 @@ async def test_upstream_delete_takes_the_publication_with_the_document(
         f"the row at {_MIRRORED_PATH} did not come from the mirror import: {indexed}"
     )
 
-    slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+    slug = await _publish_mirrored(pool, mirror, _MIRRORED_PATH)
 
     # The link is genuinely live before the delete — if it were not, the
     # assertions after the delete would prove nothing.
@@ -349,7 +355,7 @@ async def test_an_upstream_revert_cannot_resurrect_the_old_slug(
     assert first["added"] == 1, first
     before = await _doc_row(pool, mirror.vault_id, _MIRRORED_PATH)
     assert before is not None
-    slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+    slug = await _publish_mirrored(pool, mirror, _MIRRORED_PATH)
 
     mirror.fixture.remove_path(mirror.repo_name, _MIRRORED_PATH)
     second = await mirror.svc.reconcile(mirror.vault_id, mirror.name)
@@ -384,8 +390,8 @@ async def test_an_untouched_publication_survives_an_unrelated_upstream_delete(
         files={_MIRRORED_PATH: _MIRRORED_BODY, other: "# Q2\n\nStill here.\n"},
     )
     await mirror.svc.reconcile(mirror.vault_id, mirror.name)
-    keep_slug = await _publish_mirrored(mirror, other)
-    drop_slug = await _publish_mirrored(mirror, _MIRRORED_PATH)
+    keep_slug = await _publish_mirrored(pool, mirror, other)
+    drop_slug = await _publish_mirrored(pool, mirror, _MIRRORED_PATH)
 
     mirror.fixture.remove_path(mirror.repo_name, _MIRRORED_PATH)
     result = await mirror.svc.reconcile(mirror.vault_id, mirror.name)

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -1,0 +1,422 @@
+"""Live-PostgreSQL contract for migration 053 (publication document identity).
+
+What 053 adds is a *database* guarantee — a composite FK with ON DELETE
+CASCADE — so every assertion here goes through SQL that bypasses the
+application entirely. That is the point of the change: the Python-level
+cleanup paths already work, and a test that drove them would prove nothing
+about the case they do not cover (a direct psql session, a later migration,
+an admin script). Each cascade and refusal below is issued as raw SQL against
+a real database.
+
+Covered:
+
+  * a fresh `init.sql` database and a database that reached the same point
+    through the migration end up with the identical catalog for both tables —
+    compared from `pg_constraint` / `pg_index`, not by reading the files;
+  * deleting a `documents` row in SQL takes its publications with it;
+  * the composite FK refuses a publication bound to a document in another
+    vault, which a single-column FK would accept;
+  * the backfill binds only what is unambiguous — a vault-name mismatch, a
+    path with no document, a path whose document postdates the publication,
+    and an unreadable URI are all left NULL, and no row is ever deleted;
+  * re-running changes nothing, at the level of both catalog and rows;
+  * an invalid index left by a cancelled `CREATE INDEX CONCURRENTLY` is
+    replaced rather than silently accepted, a valid one is adopted without a
+    rebuild, and an unrelated index wearing the name fails loudly;
+  * migration 022, which drops a column of the same name, does not eat this
+    one on a fresh database.
+
+Runs in a disposable database so it never touches a dev DB's data. Registered
+in the `pgvector e2e (live DB)` CI job, which sets `AKB_TEST_DSN` and
+`REQUIRE_REAL_PG=1`; without that registration it would skip in both jobs and
+be a gate that never fires.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+# The additions 053 makes. Dropping these from an init.sql database
+# reconstructs the pre-053 shape, which is what the migration has to turn
+# back into the post-053 shape.
+_UNDO_053 = """
+ALTER TABLE publications DROP CONSTRAINT publications_document_fk;
+DROP INDEX idx_publications_document_id;
+ALTER TABLE publications DROP COLUMN document_id;
+ALTER TABLE documents DROP CONSTRAINT documents_id_vault_id_key;
+"""
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _load(filename: str):
+    """Load a migration from source (NOT import_module, which could honour a
+    stale __pycache__ .pyc and mask a source regression)."""
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"mig_{filename[:3]}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database(*, undo_053: bool = False):
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_pub_identity_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    base, _ = _DSN.rsplit("/", 1)
+    conn = await asyncpg.connect(f"{base}/{name}")
+    try:
+        await conn.execute(_INIT_SQL)
+        if undo_053:
+            await conn.execute(_UNDO_053)
+        yield conn
+    finally:
+        await conn.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _apply(conn) -> None:
+    await _load("053_publication_document_identity.py").migrate(conn=conn)
+
+
+# ------------------------------------------------------------------
+# Fixtures the tests build by hand. Deliberately raw SQL: a publication
+# created through the service layer would be correct by construction, and
+# these tests exist to describe rows that are not.
+# ------------------------------------------------------------------
+
+
+async def _vault(conn, name: str) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+        name, f"/tmp/{name}.git",
+    )
+
+
+async def _document(conn, vault_id: uuid.UUID, path: str, **kw) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO documents (vault_id, path, title, created_at) "
+        "VALUES ($1, $2, $3, COALESCE($4, NOW())) RETURNING id",
+        vault_id, path, kw.get("title", path), kw.get("created_at"),
+    )
+
+
+async def _publication(conn, vault_id: uuid.UUID, uri: str | None, **kw) -> uuid.UUID:
+    return await conn.fetchval(
+        "INSERT INTO publications (slug, vault_id, resource_type, resource_uri, created_at) "
+        "VALUES ($1, $2, $3, $4, COALESCE($5, NOW())) RETURNING id",
+        kw.get("slug", uuid.uuid4().hex[:16]), vault_id,
+        kw.get("resource_type", "document"), uri, kw.get("created_at"),
+    )
+
+
+async def _shape(conn) -> dict:
+    """The catalog for both tables, in a form two databases can be compared on.
+
+    Constraint definitions come from `pg_get_constraintdef` and index
+    definitions from `pg_get_indexdef`, so this compares what the database
+    actually built rather than the SQL anyone wrote.
+    """
+    constraints = await conn.fetch(
+        """
+        SELECT c.conrelid::regclass::text AS tbl, c.conname::text AS name,
+               pg_get_constraintdef(c.oid) AS def, c.convalidated
+          FROM pg_constraint c
+         WHERE c.conrelid IN ('publications'::regclass, 'documents'::regclass)
+         ORDER BY tbl, name
+        """
+    )
+    indexes = await conn.fetch(
+        """
+        SELECT i.indrelid::regclass::text AS tbl,
+               pg_get_indexdef(i.indexrelid) AS def, i.indisvalid
+          FROM pg_index i
+         WHERE i.indrelid IN ('publications'::regclass, 'documents'::regclass)
+         ORDER BY tbl, def
+        """
+    )
+    columns = await conn.fetch(
+        """
+        SELECT table_name, column_name, data_type, is_nullable
+          FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name IN ('publications', 'documents')
+         ORDER BY table_name, column_name
+        """
+    )
+    return {
+        "constraints": [tuple(r) for r in constraints],
+        "indexes": [tuple(r) for r in indexes],
+        "columns": [tuple(r) for r in columns],
+    }
+
+
+async def test_migrated_database_matches_a_fresh_init_sql_database():
+    async with _fresh_database() as fresh:
+        expected = await _shape(fresh)
+
+    async with _fresh_database(undo_053=True) as migrated:
+        # Sanity: the undo really did reconstruct a pre-053 shape.
+        assert await _shape(migrated) != expected
+        await _apply(migrated)
+        assert await _shape(migrated) == expected
+
+    # And every piece is actually present, so a mutual absence cannot pass.
+    assert any(
+        name == "publications_document_fk"
+        and "FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id) "
+            "ON DELETE CASCADE" in definition
+        for _, name, definition, _ in expected["constraints"]
+    )
+    assert any(
+        name == "documents_id_vault_id_key" and "UNIQUE (id, vault_id)" in definition
+        for _, name, definition, _ in expected["constraints"]
+    )
+    assert all(valid for *_, valid in expected["indexes"])
+    assert all(validated for *_, validated in expected["constraints"])
+
+
+async def test_deleting_the_document_row_in_sql_takes_the_publication_with_it():
+    async with _fresh_database(undo_053=True) as conn:
+        vault = await _vault(conn, f"cascade-{uuid.uuid4().hex[:8]}")
+        doc = await _document(conn, vault, "reports/q3.md")
+        pub = await _publication(
+            conn, vault,
+            f"akb://{await conn.fetchval('SELECT name FROM vaults WHERE id=$1', vault)}"
+            "/coll/reports/doc/q3.md",
+        )
+        await _apply(conn)
+        assert await conn.fetchval(
+            "SELECT document_id FROM publications WHERE id = $1", pub
+        ) == doc
+
+        # No service, no repository, no Python-level cleanup — the single
+        # statement every application-level defence is unable to see.
+        await conn.execute("DELETE FROM documents WHERE id = $1", doc)
+
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE id = $1", pub
+        ) == 0
+
+
+async def test_composite_fk_refuses_a_document_from_another_vault():
+    async with _fresh_database() as conn:
+        vault_a = await _vault(conn, f"own-{uuid.uuid4().hex[:8]}")
+        vault_b = await _vault(conn, f"other-{uuid.uuid4().hex[:8]}")
+        doc_a = await _document(conn, vault_a, "notes.md")
+        doc_b = await _document(conn, vault_b, "notes.md")
+        pub = await _publication(conn, vault_a, "akb://x/doc/notes.md")
+
+        # Same vault: accepted.
+        await conn.execute(
+            "UPDATE publications SET document_id = $2 WHERE id = $1", pub, doc_a
+        )
+
+        # Other vault: refused. A single-column FK REFERENCES documents(id)
+        # would accept this — doc_b exists — which is why the key is composite.
+        with pytest.raises(asyncpg.ForeignKeyViolationError) as exc:
+            await conn.execute(
+                "UPDATE publications SET document_id = $2 WHERE id = $1", pub, doc_b
+            )
+        assert exc.value.sqlstate == "23503"
+
+        # Inserting one that way is refused too, not just updating.
+        with pytest.raises(asyncpg.ForeignKeyViolationError):
+            await conn.execute(
+                "INSERT INTO publications (slug, vault_id, resource_type, document_id) "
+                "VALUES ($1, $2, 'document', $3)",
+                uuid.uuid4().hex[:16], vault_a, doc_b,
+            )
+
+        # And the row that was legitimately bound is untouched by the refusals.
+        assert await conn.fetchval(
+            "SELECT document_id FROM publications WHERE id = $1", pub
+        ) == doc_a
+
+
+async def test_backfill_binds_only_unambiguous_rows_and_deletes_nothing():
+    async with _fresh_database(undo_053=True) as conn:
+        own = f"own-{uuid.uuid4().hex[:8]}"
+        elsewhere = f"elsewhere-{uuid.uuid4().hex[:8]}"
+        vault = await _vault(conn, own)
+        other_vault = await _vault(conn, elsewhere)
+
+        bindable_doc = await _document(conn, vault, "reports/q3.md")
+        root_doc = await _document(conn, vault, "notes.md")
+
+        bindable = await _publication(conn, vault, f"akb://{own}/coll/reports/doc/q3.md")
+        root = await _publication(conn, vault, f"akb://{own}/doc/notes.md")
+
+        # The URI names a vault other than the one the row belongs to, and a
+        # document DOES exist at that path in the named vault. Fail closed.
+        await _document(conn, other_vault, "shared.md")
+        mismatch = await _publication(conn, vault, f"akb://{elsewhere}/doc/shared.md")
+
+        # The same disagreement, with a same-path document in the row's OWN
+        # vault as well. This is the case that isolates the vault-name check:
+        # the vault predicate in the UPDATE is satisfied here, so only the
+        # name comparison can refuse it — and it has to, because resolution
+        # refuses to serve a row whose two vault identifiers disagree.
+        await _document(conn, other_vault, "both.md")
+        await _document(conn, vault, "both.md")
+        mismatch_both = await _publication(conn, vault, f"akb://{elsewhere}/doc/both.md")
+
+        # No document at the path at all.
+        no_document = await _publication(conn, vault, f"akb://{own}/doc/gone.md")
+
+        # A document exists at the path but was created after the publication,
+        # so it cannot be the document the publication was made for.
+        reused_at = await conn.fetchval("SELECT NOW() - INTERVAL '1 hour'")
+        reused = await _publication(
+            conn, vault, f"akb://{own}/doc/reused.md", created_at=reused_at
+        )
+        await _document(conn, vault, "reused.md")
+
+        # Not a URI this codebase can read.
+        unreadable = await _publication(conn, vault, f"akb://{own}/doc/{{template}}.md")
+
+        # Other resource types are not this migration's business.
+        table_query = await _publication(
+            conn, vault, None, resource_type="table_query"
+        )
+        file_pub = await _publication(
+            conn, vault, f"akb://{own}/file/{uuid.uuid4()}", resource_type="file"
+        )
+
+        before = await conn.fetchval("SELECT COUNT(*) FROM publications")
+        await _apply(conn)
+
+        bound = {
+            r["id"]: r["document_id"]
+            for r in await conn.fetch("SELECT id, document_id FROM publications")
+        }
+        assert bound[bindable] == bindable_doc
+        assert bound[root] == root_doc
+        for pub in (
+            mismatch, mismatch_both, no_document, reused, unreadable,
+            table_query, file_pub,
+        ):
+            assert bound[pub] is None
+
+        # Nothing was deleted: the slug, creator and view count of an
+        # unbindable row are the record a human needs to act on it.
+        assert await conn.fetchval("SELECT COUNT(*) FROM publications") == before
+
+
+async def test_rerunning_changes_nothing():
+    async with _fresh_database(undo_053=True) as conn:
+        own = f"idem-{uuid.uuid4().hex[:8]}"
+        vault = await _vault(conn, own)
+        await _document(conn, vault, "notes.md")
+        await _publication(conn, vault, f"akb://{own}/doc/notes.md")
+        await _publication(conn, vault, f"akb://{own}/doc/absent.md")
+
+        await _apply(conn)
+        shape = await _shape(conn)
+        rows = await conn.fetch("SELECT * FROM publications ORDER BY id")
+
+        await _apply(conn)
+
+        assert await _shape(conn) == shape
+        assert await conn.fetch("SELECT * FROM publications ORDER BY id") == rows
+
+
+async def test_index_left_invalid_by_a_cancelled_build_is_replaced():
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "CREATE UNIQUE INDEX documents_id_vault_id_key ON documents (id, vault_id)"
+        )
+        # What a cancelled CREATE INDEX CONCURRENTLY leaves behind. `IF NOT
+        # EXISTS` would step over this and the migration would believe it had
+        # an index it cannot use.
+        await conn.execute(
+            "UPDATE pg_index SET indisvalid = false "
+            "WHERE indexrelid = 'documents_id_vault_id_key'::regclass"
+        )
+
+        await _apply(conn)
+
+        assert await conn.fetchval(
+            "SELECT indisvalid FROM pg_index "
+            "WHERE indexrelid = 'documents_id_vault_id_key'::regclass"
+        ) is True
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM pg_constraint WHERE conname = 'documents_id_vault_id_key'"
+        ) == 1
+
+
+async def test_a_valid_index_built_out_of_band_is_adopted_not_rebuilt():
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "CREATE UNIQUE INDEX documents_id_vault_id_key ON documents (id, vault_id)"
+        )
+        before = await conn.fetchval(
+            "SELECT 'documents_id_vault_id_key'::regclass::oid"
+        )
+
+        await _apply(conn)
+
+        # Same index object, now owned by the constraint: the escape hatch for
+        # a table too large to index inside the pool's statement timeout.
+        assert await conn.fetchval(
+            "SELECT 'documents_id_vault_id_key'::regclass::oid"
+        ) == before
+        assert await conn.fetchval(
+            "SELECT conindid FROM pg_constraint WHERE conname = 'documents_id_vault_id_key'"
+        ) == before
+
+
+async def test_an_unrelated_index_wearing_the_name_fails_loudly():
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "CREATE INDEX documents_id_vault_id_key ON documents (vault_id, path)"
+        )
+        with pytest.raises(RuntimeError, match="will not repurpose it"):
+            await _apply(conn)
+
+
+async def test_migration_022_does_not_drop_the_identity_column():
+    """022 drops a column called document_id. 053 adds a different one, and
+    init.sql declares it — so on a fresh database 022 runs against a table
+    that already has one. It must leave it alone."""
+    async with _fresh_database() as conn:
+        await _load("022_publications_resource_uri.py").migrate(conn=conn)
+
+        assert await conn.fetchval(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'publications' AND column_name = 'document_id'"
+        ) == 1
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM pg_constraint WHERE conname = 'publications_document_fk'"
+        ) == 1

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -207,6 +207,55 @@ async def test_migrated_database_matches_a_fresh_init_sql_database():
     assert all(validated for *_, validated in expected["constraints"])
 
 
+async def test_init_sql_still_runs_against_a_database_that_predates_the_migration():
+    """init.sql is re-executed IN FULL on every boot, BEFORE any migration.
+
+    So every statement in it has to be inert against a database that has not
+    reached 053 yet. `CREATE TABLE IF NOT EXISTS` is; a bare `CREATE INDEX` on
+    the new column is not — it raises UndefinedColumn, aborts init_db(), and
+    the migration that would have added the column never runs. Every boot,
+    forever. This test is the reason that statement is guarded.
+    """
+    async with _fresh_database(undo_053=True) as conn:
+        assert await conn.fetchval(
+            "SELECT 1 FROM information_schema.columns WHERE table_name = 'publications' "
+            "AND column_name = 'document_id'"
+        ) is None
+
+        await conn.execute(_INIT_SQL)  # must not raise
+
+        # It must also not have invented the index on a column that is absent.
+        assert await conn.fetchval(
+            "SELECT to_regclass('public.idx_publications_document_id')"
+        ) is None
+
+        await _apply(conn)
+
+        # And once the column is there, a later boot's init.sql is a clean
+        # no-op over the shape the migration built.
+        shape = await _shape(conn)
+        await conn.execute(_INIT_SQL)
+        assert await _shape(conn) == shape
+
+
+async def test_a_document_cannot_be_moved_out_from_under_a_publication():
+    """The FK's ON UPDATE is NO ACTION (the default), so the vault half of the
+    key cannot be changed to break the pairing either."""
+    async with _fresh_database() as conn:
+        vault_a = await _vault(conn, f"stay-{uuid.uuid4().hex[:8]}")
+        vault_b = await _vault(conn, f"move-{uuid.uuid4().hex[:8]}")
+        doc = await _document(conn, vault_a, "notes.md")
+        pub = await _publication(conn, vault_a, "akb://x/doc/notes.md")
+        await conn.execute(
+            "UPDATE publications SET document_id = $2 WHERE id = $1", pub, doc
+        )
+
+        with pytest.raises(asyncpg.ForeignKeyViolationError):
+            await conn.execute(
+                "UPDATE documents SET vault_id = $2 WHERE id = $1", doc, vault_b
+            )
+
+
 async def test_deleting_the_document_row_in_sql_takes_the_publication_with_it():
     async with _fresh_database(undo_053=True) as conn:
         vault = await _vault(conn, f"cascade-{uuid.uuid4().hex[:8]}")

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -203,6 +203,11 @@ async def test_migrated_database_matches_a_fresh_init_sql_database():
         name == "documents_id_vault_id_key" and "UNIQUE (id, vault_id)" in definition
         for _, name, definition, _ in expected["constraints"]
     )
+    assert any(
+        "idx_publications_document_id" in definition
+        and "(document_id, vault_id) WHERE (document_id IS NOT NULL)" in definition
+        for _, definition, _ in expected["indexes"]
+    )
     assert all(valid for *_, valid in expected["indexes"])
     assert all(validated for *_, validated in expected["constraints"])
 
@@ -453,6 +458,124 @@ async def test_an_unrelated_index_wearing_the_name_fails_loudly():
         )
         with pytest.raises(RuntimeError, match="will not repurpose it"):
             await _apply(conn)
+
+
+async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():
+    """Idempotency is not "something by that name exists". Index and constraint
+    names are unique per schema, not per table, so a name says nothing about
+    what is behind it."""
+    # A CHECK constraint wearing the FK's name.
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "ALTER TABLE publications ADD COLUMN document_id UUID, "
+            "ADD CONSTRAINT publications_document_fk CHECK (view_count >= 0)"
+        )
+        with pytest.raises(RuntimeError, match="not the one migration 053 installs"):
+            await _apply(conn)
+
+    # An FK of the right name on the right table, but single-column — the
+    # shape this whole change exists to replace.
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "ALTER TABLE publications ADD COLUMN document_id UUID, "
+            "ADD CONSTRAINT publications_document_fk "
+            "FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE"
+        )
+        with pytest.raises(RuntimeError, match="not the one migration 053 installs"):
+            await _apply(conn)
+
+    # An index of the right name and columns, but on another table.
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute(
+            "CREATE TABLE decoy (document_id UUID, vault_id UUID); "
+            "CREATE INDEX idx_publications_document_id "
+            "ON decoy (document_id, vault_id) WHERE document_id IS NOT NULL"
+        )
+        with pytest.raises(RuntimeError, match="not the cascade index"):
+            await _apply(conn)
+
+
+async def test_an_invalid_cascade_index_is_rebuilt_not_stepped_over():
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
+        await conn.execute(
+            "CREATE INDEX idx_publications_document_id "
+            "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
+        )
+        await conn.execute(
+            "UPDATE pg_index SET indisvalid = false "
+            "WHERE indexrelid = 'idx_publications_document_id'::regclass"
+        )
+
+        await _apply(conn)
+
+        assert await conn.fetchval(
+            "SELECT indisvalid FROM pg_index "
+            "WHERE indexrelid = 'idx_publications_document_id'::regclass"
+        ) is True
+
+
+async def test_a_pre_existing_bad_binding_stops_the_migration_without_touching_it():
+    """If document_id already holds a value the composite key would reject, the
+    migration fails loudly and changes nothing. Blanking or deleting those rows
+    is a decision for a human, not a side effect of a boot."""
+    async with _fresh_database(undo_053=True) as conn:
+        vault_a = await _vault(conn, f"bad-a-{uuid.uuid4().hex[:8]}")
+        vault_b = await _vault(conn, f"bad-b-{uuid.uuid4().hex[:8]}")
+        other_doc = await _document(conn, vault_b, "notes.md")
+        await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
+        pub = await _publication(conn, vault_a, "akb://x/doc/notes.md")
+        await conn.execute(
+            "UPDATE publications SET document_id = $2 WHERE id = $1", pub, other_doc
+        )
+
+        with pytest.raises(RuntimeError, match="does not name a document"):
+            await _apply(conn)
+
+        # The row is untouched and the connection is still usable.
+        assert await conn.fetchval(
+            "SELECT document_id FROM publications WHERE id = $1", pub
+        ) == other_doc
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM pg_constraint WHERE conname = 'publications_document_fk'"
+        ) == 0
+
+
+async def test_the_backfill_pages_through_more_rows_than_one_batch():
+    """_BATCH is 500; the paging loop has to visit everything, exactly once."""
+    module = _load("053_publication_document_identity.py")
+    total = module._BATCH * 2 + 7
+
+    async with _fresh_database(undo_053=True) as conn:
+        name = f"paged-{uuid.uuid4().hex[:8]}"
+        vault = await _vault(conn, name)
+        await conn.execute(
+            "INSERT INTO documents (vault_id, path, title) "
+            "SELECT $1, 'p/' || g || '.md', 'doc' FROM generate_series(1, $2) g",
+            vault, total,
+        )
+        await conn.execute(
+            "INSERT INTO publications (slug, vault_id, resource_type, resource_uri) "
+            "SELECT 'slug-' || g, $1, 'document', $2 || '/coll/p/doc/' || g || '.md' "
+            "  FROM generate_series(1, $3) g",
+            vault, f"akb://{name}", total,
+        )
+
+        await _apply(conn)
+
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM publications WHERE document_id IS NULL"
+        ) == 0
+        # Each publication bound to its OWN document, not to some other page's.
+        assert await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM publications p JOIN documents d ON d.id = p.document_id
+             WHERE p.resource_uri <> 'akb://' || $1 || '/coll/p/doc/' ||
+                   split_part(d.path, '/', 2)
+            """,
+            name,
+        ) == 0
+        assert await conn.fetchval("SELECT COUNT(DISTINCT document_id) FROM publications") == total
 
 
 async def test_migration_022_does_not_drop_the_identity_column():

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -224,14 +224,8 @@ async def test_migrated_database_matches_a_fresh_init_sql_database():
 
 
 async def test_init_sql_still_runs_against_a_database_that_predates_the_migration():
-    """init.sql is re-executed IN FULL on every boot, BEFORE any migration.
-
-    So every statement in it has to be inert against a database that has not
-    reached 053 yet. `CREATE TABLE IF NOT EXISTS` is; a bare `CREATE INDEX` on
-    the new column is not — it raises UndefinedColumn, aborts init_db(), and
-    the migration that would have added the column never runs. Every boot,
-    forever. This test is the reason that statement is guarded.
-    """
+    """The boot loop the document_id guard in init.sql exists to prevent — see
+    the note at that guard for why an unguarded statement there is fatal."""
     async with _fresh_database(undo_053=True) as conn:
         assert await conn.fetchval(
             "SELECT 1 FROM information_schema.columns WHERE table_name = 'publications' "
@@ -254,10 +248,9 @@ async def test_init_sql_still_runs_against_a_database_that_predates_the_migratio
         assert await _shape(conn) == shape
 
 
-# Every column named by a STANDALONE statement in init.sql that some
-# migration adds. A database that predates the migration has the table but not
-# the column, and init.sql runs first, so each of these needs a guard or the
-# boot aborts before migrations can fix anything.
+# Every column named by a STANDALONE statement in init.sql that some migration
+# adds — each needs a guard, or the boot aborts before migrations can fix
+# anything (see the note at the document_id guard in init.sql).
 #
 # Hand-maintained, so it catches a guard being REMOVED, not a new unguarded
 # statement being added. To re-derive it: for every standalone statement in
@@ -267,14 +260,22 @@ async def test_init_sql_still_runs_against_a_database_that_predates_the_migratio
 # version, which needs no judgement: replay every historical `init.sql` in this
 # repo's history against the current one and look for errors —
 # `git log --format=%h -- backend/app/db/init.sql`, apply each to a fresh
-# database, then apply HEAD's over it. That is how the last two entries here
-# were found.
+# database, then apply HEAD's over it. That is how two of these entries were
+# found.
+#
+# Do NOT read that replay as exhaustive. It cannot find the `chunks` entry:
+# every recorded revision of init.sql already declares `source_type` inline in
+# `CREATE TABLE chunks`, so no replay produces a database missing it. Migration
+# 006 is the only surviving evidence that such tables exist, from before this
+# file's recorded history — which is why the judgement-based derivation above
+# is not redundant with the replay.
 _MIGRATION_ADDED_COLUMNS = [
     ("publications", "document_id", "idx_publications_document_id"),   # 053
     ("publications", "resource_uri", "idx_publications_resource_uri"),  # 022
     ("chunks", "vector_indexed_at", "idx_chunks_indexing_queue"),       # 009
     ("vault_tables", "collection_id", "idx_vault_tables_collection"),   # 020
     ("vault_files", "collection_id", "idx_vault_files_collection"),     # 020
+    ("chunks", "source_type", "idx_chunks_source"),                     # 006
 ]
 
 
@@ -282,7 +283,8 @@ _MIGRATION_ADDED_COLUMNS = [
 async def test_init_sql_survives_a_database_missing_a_migration_added_column(
     table, column, index,
 ):
-    """The boot-loop class, as a rule rather than one instance of it.
+    """The boot-loop class (see the note at init.sql's document_id guard), as a
+    rule rather than one instance of it.
 
     All but the first are dead in practice — their migrations are applied
     everywhere — and they are checked anyway, because the cost of the rule

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -30,6 +30,16 @@ Runs in a disposable database so it never touches a dev DB's data. Registered
 in the `pgvector e2e (live DB)` CI job, which sets `AKB_TEST_DSN` and
 `REQUIRE_REAL_PG=1`; without that registration it would skip in both jobs and
 be a gate that never fires.
+
+Two environment requirements, neither of which degrades to a skip — on a
+database that does not grant them these fail with an unrelated permission
+error rather than saying what is missing:
+
+  * CREATEDB, for the disposable database every test runs in;
+  * superuser, for the two invalid-index tests. There is no supported way to
+    ask PostgreSQL for an invalid index, so they write `pg_index.indisvalid`
+    directly. Both the dev compose stack and the CI service container run as
+    the database owner, which has it.
 """
 
 from __future__ import annotations
@@ -248,6 +258,17 @@ async def test_init_sql_still_runs_against_a_database_that_predates_the_migratio
 # migration adds. A database that predates the migration has the table but not
 # the column, and init.sql runs first, so each of these needs a guard or the
 # boot aborts before migrations can fix anything.
+#
+# Hand-maintained, so it catches a guard being REMOVED, not a new unguarded
+# statement being added. To re-derive it: for every standalone statement in
+# init.sql (anything outside a `CREATE TABLE IF NOT EXISTS` body — those are
+# inert on an existing table), check whether the columns it names are added by
+# a migration rather than present since that table's creation. The empirical
+# version, which needs no judgement: replay every historical `init.sql` in this
+# repo's history against the current one and look for errors —
+# `git log --format=%h -- backend/app/db/init.sql`, apply each to a fresh
+# database, then apply HEAD's over it. That is how the last two entries here
+# were found.
 _MIGRATION_ADDED_COLUMNS = [
     ("publications", "document_id", "idx_publications_document_id"),   # 053
     ("publications", "resource_uri", "idx_publications_resource_uri"),  # 022
@@ -559,6 +580,46 @@ async def test_an_unrelated_index_wearing_the_name_fails_loudly():
         )
         with pytest.raises(RuntimeError, match="will not repurpose it"):
             await _apply(conn)
+
+
+@pytest.mark.parametrize("valid", [True, False])
+@pytest.mark.parametrize("right_shape", [True, False])
+async def test_an_index_of_that_name_on_another_table_is_never_touched(
+    valid, right_shape,
+):
+    """Relation names are unique per schema, not per table.
+
+    All three branches of the documents guard act on `documents`, so reading a
+    decoy on another table as though it were the real one is not one bug but
+    three — and the worst of them is silent: the invalid branch DROPPED the
+    decoy and reported success. Every combination is checked because the
+    branch taken depends on both validity and shape.
+    """
+    async with _fresh_database(undo_053=True) as conn:
+        columns = "(id, vault_id)" if right_shape else "(vault_id, path)"
+        await conn.execute(
+            "CREATE TABLE decoy (id UUID, vault_id UUID, path TEXT)"
+        )
+        await conn.execute(
+            f"CREATE {'UNIQUE ' if right_shape else ''}INDEX "
+            f"documents_id_vault_id_key ON decoy {columns}"
+        )
+        if not valid:
+            await conn.execute(
+                "UPDATE pg_index SET indisvalid = false "
+                "WHERE indexrelid = 'documents_id_vault_id_key'::regclass"
+            )
+
+        with pytest.raises(RuntimeError, match="not by an index on documents"):
+            await _apply(conn)
+
+        # The decoy is untouched — same object, same validity.
+        survivor = await conn.fetchrow(
+            "SELECT i.indrelid::regclass::text AS tbl, i.indisvalid FROM pg_index i "
+            "WHERE i.indexrelid = 'documents_id_vault_id_key'::regclass"
+        )
+        assert survivor["tbl"] == "decoy"
+        assert survivor["indisvalid"] is valid
 
 
 async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():

--- a/backend/tests/test_migration_053_publication_identity_unit.py
+++ b/backend/tests/test_migration_053_publication_identity_unit.py
@@ -106,8 +106,9 @@ async def _fresh_database(*, undo_053: bool = False):
         await admin.close()
 
 
-async def _apply(conn) -> None:
-    await _load("053_publication_document_identity.py").migrate(conn=conn)
+async def _apply(conn) -> dict:
+    """Apply the migration, returning the backfill's per-category counts."""
+    return await _load("053_publication_document_identity.py").migrate(conn=conn)
 
 
 # ------------------------------------------------------------------
@@ -241,6 +242,38 @@ async def test_init_sql_still_runs_against_a_database_that_predates_the_migratio
         shape = await _shape(conn)
         await conn.execute(_INIT_SQL)
         assert await _shape(conn) == shape
+
+
+# Every column named by a STANDALONE statement in init.sql that some
+# migration adds. A database that predates the migration has the table but not
+# the column, and init.sql runs first, so each of these needs a guard or the
+# boot aborts before migrations can fix anything.
+_MIGRATION_ADDED_COLUMNS = [
+    ("publications", "document_id", "idx_publications_document_id"),   # 053
+    ("publications", "resource_uri", "idx_publications_resource_uri"),  # 022
+    ("chunks", "vector_indexed_at", "idx_chunks_indexing_queue"),       # 009
+    ("vault_tables", "collection_id", "idx_vault_tables_collection"),   # 020
+    ("vault_files", "collection_id", "idx_vault_files_collection"),     # 020
+]
+
+
+@pytest.mark.parametrize("table,column,index", _MIGRATION_ADDED_COLUMNS)
+async def test_init_sql_survives_a_database_missing_a_migration_added_column(
+    table, column, index,
+):
+    """The boot-loop class, as a rule rather than one instance of it.
+
+    All but the first are dead in practice — their migrations are applied
+    everywhere — and they are checked anyway, because the cost of the rule
+    being unevenly applied is that the next person reads the guarded
+    statements as optional.
+    """
+    async with _fresh_database() as conn:
+        await conn.execute(f"ALTER TABLE {table} DROP COLUMN {column} CASCADE")
+
+        await conn.execute(_INIT_SQL)  # must not raise
+
+        assert await conn.fetchval(f"SELECT to_regclass('public.{index}')") is None
 
 
 async def test_a_document_cannot_be_moved_out_from_under_a_publication():
@@ -388,6 +421,74 @@ async def test_backfill_binds_only_unambiguous_rows_and_deletes_nothing():
         assert await conn.fetchval("SELECT COUNT(*) FROM publications") == before
 
 
+async def test_the_backfill_reports_a_count_for_every_category(caplog):
+    """The per-category counts are a contract, not debug output.
+
+    They are what an operator reads to decide whether a backfill can be
+    trusted, so a row landing in the wrong bucket is a real defect even when
+    the end state is right — "48 bound, 1 path reused" and "48 bound, 1 vault
+    mismatch" describe very different databases and would prompt very
+    different decisions. Asserting only that unbindable rows end up NULL
+    cannot tell those apart.
+    """
+    async with _fresh_database(undo_053=True) as conn:
+        own = f"counts-{uuid.uuid4().hex[:8]}"
+        elsewhere = f"counts-other-{uuid.uuid4().hex[:8]}"
+        vault = await _vault(conn, own)
+        other_vault = await _vault(conn, elsewhere)
+
+        # bound
+        await _document(conn, vault, "keep.md")
+        await _publication(conn, vault, f"akb://{own}/doc/keep.md")
+        # no_document
+        await _publication(conn, vault, f"akb://{own}/doc/gone.md")
+        # path_reused — document postdates the publication
+        older = await conn.fetchval("SELECT NOW() - INTERVAL '1 hour'")
+        await _publication(conn, vault, f"akb://{own}/doc/reused.md", created_at=older)
+        await _document(conn, vault, "reused.md")
+        # vault_mismatch — with a same-path document in the row's OWN vault, so
+        # only the vault-name comparison can refuse it
+        await _document(conn, vault, "both.md")
+        await _document(conn, other_vault, "both.md")
+        await _publication(conn, vault, f"akb://{elsewhere}/doc/both.md")
+        # unreadable_uri
+        await _publication(conn, vault, f"akb://{own}/doc/{{template}}.md")
+        # non_document_publications
+        await _publication(conn, vault, None, resource_type="table_query")
+        await _publication(
+            conn, vault, f"akb://{own}/file/{uuid.uuid4()}", resource_type="file"
+        )
+
+        with caplog.at_level("INFO", logger="akb.migration.053"):
+            first = await _apply(conn)
+
+        assert first == {
+            "examined": 5,
+            "bound": 1,
+            "no_document": 1,
+            "path_reused": 1,
+            "unreadable_uri": 1,
+            "vault_mismatch": 1,
+            "changed_underfoot": 0,
+            "already_bound": 0,
+            "non_document_publications": 2,
+        }
+        # The log an operator reads carries the same figures as the return
+        # value a test can assert on — otherwise only one of them is checked.
+        summary = next(
+            r.getMessage() for r in caplog.records if "backfill:" in r.getMessage()
+        )
+        for key, value in first.items():
+            if key == "examined":
+                continue
+            assert f"{key}={value}" in summary, f"{key} missing from {summary!r}"
+
+        # Re-run: the bound row moves into already_bound and is not counted
+        # again, and every refusal is reported identically.
+        second = await _apply(conn)
+        assert second == {**first, "examined": 4, "bound": 0, "already_bound": 1}
+
+
 async def test_rerunning_changes_nothing():
     async with _fresh_database(undo_053=True) as conn:
         own = f"idem-{uuid.uuid4().hex[:8]}"
@@ -494,6 +595,17 @@ async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():
         with pytest.raises(RuntimeError, match="not the cascade index"):
             await _apply(conn)
 
+    # Right name, right table, right columns — but UNIQUE, which would let a
+    # document be published exactly once.
+    async with _fresh_database(undo_053=True) as conn:
+        await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
+        await conn.execute(
+            "CREATE UNIQUE INDEX idx_publications_document_id "
+            "ON publications (document_id, vault_id) WHERE document_id IS NOT NULL"
+        )
+        with pytest.raises(RuntimeError, match="not the cascade index"):
+            await _apply(conn)
+
 
 async def test_an_invalid_cascade_index_is_rebuilt_not_stepped_over():
     async with _fresh_database(undo_053=True) as conn:
@@ -542,9 +654,15 @@ async def test_a_pre_existing_bad_binding_stops_the_migration_without_touching_i
 
 
 async def test_the_backfill_pages_through_more_rows_than_one_batch():
-    """_BATCH is 500; the paging loop has to visit everything, exactly once."""
+    """_BATCH is 500; the paging loop has to visit everything, exactly once.
+
+    Including the row whose id is all zeroes. Nothing generates that id, but
+    the column accepts it, and a cursor that started from it with a strict `>`
+    would skip exactly that row — silently, since every other row still binds.
+    """
     module = _load("053_publication_document_identity.py")
     total = module._BATCH * 2 + 7
+    zero_id = uuid.UUID(int=0)
 
     async with _fresh_database(undo_053=True) as conn:
         name = f"paged-{uuid.uuid4().hex[:8]}"
@@ -560,22 +678,37 @@ async def test_the_backfill_pages_through_more_rows_than_one_batch():
             "  FROM generate_series(1, $3) g",
             vault, f"akb://{name}", total,
         )
+        # The lowest possible key, sorting before every generated one.
+        zero_doc = await _document(conn, vault, "zero.md")
+        await conn.execute(
+            "INSERT INTO publications (id, slug, vault_id, resource_type, resource_uri) "
+            "VALUES ($1, 'slug-zero', $2, 'document', $3)",
+            zero_id, vault, f"akb://{name}/doc/zero.md",
+        )
 
         await _apply(conn)
 
         assert await conn.fetchval(
+            "SELECT document_id FROM publications WHERE id = $1", zero_id
+        ) == zero_doc
+        assert await conn.fetchval(
             "SELECT COUNT(*) FROM publications WHERE document_id IS NULL"
         ) == 0
         # Each publication bound to its OWN document, not to some other page's.
+        # (The root-level `zero.md` row is asserted separately above; this
+        # covers the generated in-collection ones.)
         assert await conn.fetchval(
             """
             SELECT COUNT(*) FROM publications p JOIN documents d ON d.id = p.document_id
-             WHERE p.resource_uri <> 'akb://' || $1 || '/coll/p/doc/' ||
+             WHERE d.path LIKE 'p/%'
+               AND p.resource_uri <> 'akb://' || $1 || '/coll/p/doc/' ||
                    split_part(d.path, '/', 2)
             """,
             name,
         ) == 0
-        assert await conn.fetchval("SELECT COUNT(DISTINCT document_id) FROM publications") == total
+        assert await conn.fetchval(
+            "SELECT COUNT(DISTINCT document_id) FROM publications"
+        ) == total + 1
 
 
 async def test_migration_022_does_not_drop_the_identity_column():

--- a/backend/tests/test_migration_058_publication_identity_unit.py
+++ b/backend/tests/test_migration_058_publication_identity_unit.py
@@ -1,6 +1,6 @@
-"""Live-PostgreSQL contract for migration 053 (publication document identity).
+"""Live-PostgreSQL contract for migration 058 (publication document identity).
 
-What 053 adds is a *database* guarantee — a composite FK with ON DELETE
+What 058 adds is a *database* guarantee — a composite FK with ON DELETE
 CASCADE — so every assertion here goes through SQL that bypasses the
 application entirely. That is the point of the change: the Python-level
 cleanup paths already work, and a test that drove them would prove nothing
@@ -63,10 +63,10 @@ _DSN = os.environ.get(
     "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
 )
 
-# The additions 053 makes. Dropping these from an init.sql database
-# reconstructs the pre-053 shape, which is what the migration has to turn
-# back into the post-053 shape.
-_UNDO_053 = """
+# The additions 058 makes. Dropping these from an init.sql database
+# reconstructs the pre-058 shape, which is what the migration has to turn
+# back into the post-058 shape.
+_UNDO_058 = """
 ALTER TABLE publications DROP CONSTRAINT publications_document_fk;
 DROP INDEX idx_publications_document_id;
 ALTER TABLE publications DROP COLUMN document_id;
@@ -95,7 +95,7 @@ def _load(filename: str):
 
 
 @asynccontextmanager
-async def _fresh_database(*, undo_053: bool = False):
+async def _fresh_database(*, undo_058: bool = False):
     if not await _can_connect(_DSN):
         if os.environ.get("REQUIRE_REAL_PG") == "1":
             pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
@@ -107,8 +107,8 @@ async def _fresh_database(*, undo_053: bool = False):
     conn = await asyncpg.connect(f"{base}/{name}")
     try:
         await conn.execute(_INIT_SQL)
-        if undo_053:
-            await conn.execute(_UNDO_053)
+        if undo_058:
+            await conn.execute(_UNDO_058)
         yield conn
     finally:
         await conn.close()
@@ -118,7 +118,7 @@ async def _fresh_database(*, undo_053: bool = False):
 
 async def _apply(conn) -> dict:
     """Apply the migration, returning the backfill's per-category counts."""
-    return await _load("053_publication_document_identity.py").migrate(conn=conn)
+    return await _load("058_publication_document_identity.py").migrate(conn=conn)
 
 
 # ------------------------------------------------------------------
@@ -197,8 +197,8 @@ async def test_migrated_database_matches_a_fresh_init_sql_database():
     async with _fresh_database() as fresh:
         expected = await _shape(fresh)
 
-    async with _fresh_database(undo_053=True) as migrated:
-        # Sanity: the undo really did reconstruct a pre-053 shape.
+    async with _fresh_database(undo_058=True) as migrated:
+        # Sanity: the undo really did reconstruct a pre-058 shape.
         assert await _shape(migrated) != expected
         await _apply(migrated)
         assert await _shape(migrated) == expected
@@ -226,7 +226,7 @@ async def test_migrated_database_matches_a_fresh_init_sql_database():
 async def test_init_sql_still_runs_against_a_database_that_predates_the_migration():
     """The boot loop the document_id guard in init.sql exists to prevent — see
     the note at that guard for why an unguarded statement there is fatal."""
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         assert await conn.fetchval(
             "SELECT 1 FROM information_schema.columns WHERE table_name = 'publications' "
             "AND column_name = 'document_id'"
@@ -270,7 +270,7 @@ async def test_init_sql_still_runs_against_a_database_that_predates_the_migratio
 # file's recorded history — which is why the judgement-based derivation above
 # is not redundant with the replay.
 _MIGRATION_ADDED_COLUMNS = [
-    ("publications", "document_id", "idx_publications_document_id"),   # 053
+    ("publications", "document_id", "idx_publications_document_id"),   # 058
     ("publications", "resource_uri", "idx_publications_resource_uri"),  # 022
     ("chunks", "vector_indexed_at", "idx_chunks_indexing_queue"),       # 009
     ("vault_tables", "collection_id", "idx_vault_tables_collection"),   # 020
@@ -318,7 +318,7 @@ async def test_a_document_cannot_be_moved_out_from_under_a_publication():
 
 
 async def test_deleting_the_document_row_in_sql_takes_the_publication_with_it():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         vault = await _vault(conn, f"cascade-{uuid.uuid4().hex[:8]}")
         doc = await _document(conn, vault, "reports/q3.md")
         pub = await _publication(
@@ -376,7 +376,7 @@ async def test_composite_fk_refuses_a_document_from_another_vault():
 
 
 async def test_backfill_binds_only_unambiguous_rows_and_deletes_nothing():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         own = f"own-{uuid.uuid4().hex[:8]}"
         elsewhere = f"elsewhere-{uuid.uuid4().hex[:8]}"
         vault = await _vault(conn, own)
@@ -454,7 +454,7 @@ async def test_the_backfill_reports_a_count_for_every_category(caplog):
     different decisions. Asserting only that unbindable rows end up NULL
     cannot tell those apart.
     """
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         own = f"counts-{uuid.uuid4().hex[:8]}"
         elsewhere = f"counts-other-{uuid.uuid4().hex[:8]}"
         vault = await _vault(conn, own)
@@ -482,7 +482,7 @@ async def test_the_backfill_reports_a_count_for_every_category(caplog):
             conn, vault, f"akb://{own}/file/{uuid.uuid4()}", resource_type="file"
         )
 
-        with caplog.at_level("INFO", logger="akb.migration.053"):
+        with caplog.at_level("INFO", logger="akb.migration.058"):
             first = await _apply(conn)
 
         assert first == {
@@ -513,7 +513,7 @@ async def test_the_backfill_reports_a_count_for_every_category(caplog):
 
 
 async def test_rerunning_changes_nothing():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         own = f"idem-{uuid.uuid4().hex[:8]}"
         vault = await _vault(conn, own)
         await _document(conn, vault, "notes.md")
@@ -531,7 +531,7 @@ async def test_rerunning_changes_nothing():
 
 
 async def test_index_left_invalid_by_a_cancelled_build_is_replaced():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "CREATE UNIQUE INDEX documents_id_vault_id_key ON documents (id, vault_id)"
         )
@@ -555,7 +555,7 @@ async def test_index_left_invalid_by_a_cancelled_build_is_replaced():
 
 
 async def test_a_valid_index_built_out_of_band_is_adopted_not_rebuilt():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "CREATE UNIQUE INDEX documents_id_vault_id_key ON documents (id, vault_id)"
         )
@@ -576,7 +576,7 @@ async def test_a_valid_index_built_out_of_band_is_adopted_not_rebuilt():
 
 
 async def test_an_unrelated_index_wearing_the_name_fails_loudly():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "CREATE INDEX documents_id_vault_id_key ON documents (vault_id, path)"
         )
@@ -597,7 +597,7 @@ async def test_an_index_of_that_name_on_another_table_is_never_touched(
     decoy and reported success. Every combination is checked because the
     branch taken depends on both validity and shape.
     """
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         columns = "(id, vault_id)" if right_shape else "(vault_id, path)"
         await conn.execute(
             "CREATE TABLE decoy (id UUID, vault_id UUID, path TEXT)"
@@ -629,27 +629,27 @@ async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():
     names are unique per schema, not per table, so a name says nothing about
     what is behind it."""
     # A CHECK constraint wearing the FK's name.
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "ALTER TABLE publications ADD COLUMN document_id UUID, "
             "ADD CONSTRAINT publications_document_fk CHECK (view_count >= 0)"
         )
-        with pytest.raises(RuntimeError, match="not the one migration 053 installs"):
+        with pytest.raises(RuntimeError, match="not the one migration 058 installs"):
             await _apply(conn)
 
     # An FK of the right name on the right table, but single-column — the
     # shape this whole change exists to replace.
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "ALTER TABLE publications ADD COLUMN document_id UUID, "
             "ADD CONSTRAINT publications_document_fk "
             "FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE"
         )
-        with pytest.raises(RuntimeError, match="not the one migration 053 installs"):
+        with pytest.raises(RuntimeError, match="not the one migration 058 installs"):
             await _apply(conn)
 
     # An index of the right name and columns, but on another table.
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute(
             "CREATE TABLE decoy (document_id UUID, vault_id UUID); "
             "CREATE INDEX idx_publications_document_id "
@@ -660,7 +660,7 @@ async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():
 
     # Right name, right table, right columns — but UNIQUE, which would let a
     # document be published exactly once.
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
         await conn.execute(
             "CREATE UNIQUE INDEX idx_publications_document_id "
@@ -671,7 +671,7 @@ async def test_a_constraint_that_only_borrowed_the_name_is_not_accepted():
 
 
 async def test_an_invalid_cascade_index_is_rebuilt_not_stepped_over():
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         await conn.execute("ALTER TABLE publications ADD COLUMN document_id UUID")
         await conn.execute(
             "CREATE INDEX idx_publications_document_id "
@@ -694,7 +694,7 @@ async def test_a_pre_existing_bad_binding_stops_the_migration_without_touching_i
     """If document_id already holds a value the composite key would reject, the
     migration fails loudly and changes nothing. Blanking or deleting those rows
     is a decision for a human, not a side effect of a boot."""
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         vault_a = await _vault(conn, f"bad-a-{uuid.uuid4().hex[:8]}")
         vault_b = await _vault(conn, f"bad-b-{uuid.uuid4().hex[:8]}")
         other_doc = await _document(conn, vault_b, "notes.md")
@@ -723,11 +723,11 @@ async def test_the_backfill_pages_through_more_rows_than_one_batch():
     the column accepts it, and a cursor that started from it with a strict `>`
     would skip exactly that row — silently, since every other row still binds.
     """
-    module = _load("053_publication_document_identity.py")
+    module = _load("058_publication_document_identity.py")
     total = module._BATCH * 2 + 7
     zero_id = uuid.UUID(int=0)
 
-    async with _fresh_database(undo_053=True) as conn:
+    async with _fresh_database(undo_058=True) as conn:
         name = f"paged-{uuid.uuid4().hex[:8]}"
         vault = await _vault(conn, name)
         await conn.execute(
@@ -775,7 +775,7 @@ async def test_the_backfill_pages_through_more_rows_than_one_batch():
 
 
 async def test_migration_022_does_not_drop_the_identity_column():
-    """022 drops a column called document_id. 053 adds a different one, and
+    """022 drops a column called document_id. 058 adds a different one, and
     init.sql declares it — so on a fresh database 022 runs against a table
     that already has one. It must leave it alone."""
     async with _fresh_database() as conn:

--- a/backend/tests/test_publication_path_claim_guard_unit.py
+++ b/backend/tests/test_publication_path_claim_guard_unit.py
@@ -177,7 +177,7 @@ async def _orphan_the_publication(pool, doc_id: uuid.UUID) -> None:
     was resolved from, under a composite FK with ON DELETE CASCADE — so even
     the raw DELETE below takes the publication with it, and no orphan
     results. What survives a document is a row whose `document_id` is NULL: a
-    publication predating migration 053 that the backfill could not bind
+    publication predating migration 058 that the backfill could not bind
     unambiguously, which is exempt from the FK. Clearing the column is how
     this manufactures one, and those legacy rows are the population this
     guard still exists for. The guard stops being reachable at all once the

--- a/backend/tests/test_publication_path_claim_guard_unit.py
+++ b/backend/tests/test_publication_path_claim_guard_unit.py
@@ -171,8 +171,24 @@ async def _orphan_the_publication(pool, doc_id: uuid.UUID) -> None:
     Deliberately NOT `delete_with_publications` — this reproduces what the
     pre-fix delete paths did, which is the only way to reach the state the
     guard exists for now that the product refuses to produce it.
+
+    **`document_id` is cleared first, and that narrows what an orphan can
+    now be.** A publication created today carries the id of the document it
+    was resolved from, under a composite FK with ON DELETE CASCADE — so even
+    the raw DELETE below takes the publication with it, and no orphan
+    results. What survives a document is a row whose `document_id` is NULL: a
+    publication predating migration 053 that the backfill could not bind
+    unambiguously, which is exempt from the FK. Clearing the column is how
+    this manufactures one, and those legacy rows are the population this
+    guard still exists for. The guard stops being reachable at all once the
+    last NULL is gone; until then it is the only thing standing between such
+    a row and the next document to occupy its path.
     """
     async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE publications SET document_id = NULL WHERE document_id = $1",
+            doc_id,
+        )
         await conn.execute("DELETE FROM documents WHERE id = $1", doc_id)
 
 

--- a/backend/tests/test_publication_resolution_vault_binding_unit.py
+++ b/backend/tests/test_publication_resolution_vault_binding_unit.py
@@ -370,3 +370,168 @@ async def test_an_ordinary_publication_still_resolves(pool, vaults, path):
         "the body must come from the publication's own vault"
     )
     assert data["resource_type"] == "document"
+
+
+# ── Identity outlives the URI ────────────────────────────────────
+#
+# The two lookups above are bound to the publication's `vault_id`, which
+# settles WHICH VAULT. It does not settle WHICH DOCUMENT: both still found
+# the row by `d.path` parsed out of `resource_uri`, and `documents` is
+# UNIQUE(vault_id, path), so a path names whatever occupies it now rather
+# than what was published.
+#
+# `create_publication` refuses to store a publication whose `document_id` and
+# `resource_uri` disagree, so they agree when the row is written. Nothing
+# keeps them agreeing afterwards except one statement — the move-time URI
+# rewrite in `document_service.move`. That is a single place that has to
+# remember, which is the shape this branch exists to remove, and the FK
+# cannot help because it constrains a column the read path did not read.
+#
+# So the desync below is written in raw SQL. That is not a shortcut around a
+# product path; it IS the threat model — a direct psql session, a future
+# migration, an admin script, or a fourth move path that forgets the rewrite.
+# The squatter is inserted raw for a second reason: creating it through the
+# repository is REFUSED by `assert_no_orphan_publication_for_document`, which
+# is the product working. These tests are about what happens when something
+# has already got past that.
+
+
+async def _raw_insert_doc(pool, vault: dict, path: str, *, title: str) -> uuid.UUID:
+    """Insert a documents row bypassing the repository's orphan guard."""
+    doc_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (id, vault_id, path, title, doc_type, status, "
+            "created_at, updated_at, current_commit, tags, metadata) VALUES "
+            "($1, $2, $3, $4, 'note', 'draft', NOW(), NOW(), 'c', "
+            "'{}'::text[], '{}'::jsonb)",
+            doc_id, vault["id"], path, title,
+        )
+    return doc_id
+
+
+async def _desync_uri_from_document(pool, vaults, published_path: str, moved_to: str):
+    """Publish a document, then move it WITHOUT rewriting the publication's
+    URI, and drop a different document onto the path it vacated.
+
+    Returns (slug, published_doc_id, squatter_doc_id).
+    """
+    published_id = await _create_doc(
+        pool, vaults["home"], published_path, title="The published document",
+    )
+    slug = await _publish(vaults["home"]["name"], published_path)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE documents SET path = $1 WHERE id = $2", moved_to, published_id,
+        )
+    squatter_id = await _raw_insert_doc(
+        pool, vaults["home"], published_path, title="Never published by anyone",
+    )
+    return slug, published_id, squatter_id
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_resolution_follows_the_document_not_the_stale_path(pool, vaults, path):
+    """A bound publication whose `resource_uri` has gone stale must still serve
+    the document it was published for.
+
+    This is what `document_id` is FOR. Pre-change this is RED and serves
+    "Never published by anyone" — the body, title, tags and author attribution
+    of a document whose owner made no publishing choice at all — because the
+    lookup asked which document sits at the published path rather than which
+    document was published.
+    """
+    from app.services.publication_service import resolve_document_publication
+    from app.services.uri_service import doc_uri
+
+    moved_to = "archive/moved-away.md"
+    slug, published_id, squatter_id = await _desync_uri_from_document(
+        pool, vaults, path, moved_to,
+    )
+    publication = await _internal(slug)
+
+    # Guard the setup: the row must be BOUND and its URI must be STALE, or
+    # this test proves nothing about which of the two the lookup followed.
+    home = vaults["home"]["name"]
+    assert publication["document_id"] == str(published_id), (
+        "the publication must carry the published document's id"
+    )
+    assert publication["resource_uri"] == doc_uri(home, path), (
+        "the URI must still render the OLD path — that is the desync under test"
+    )
+    assert publication["resource_uri"] != doc_uri(home, moved_to)
+
+    data = await resolve_document_publication(publication)
+
+    assert data["title"] == "The published document", (
+        f"resolution served {data['title']!r}. The publication is bound to the "
+        "document its publisher chose; following the stale path instead serves "
+        "a document nobody published."
+    )
+    assert f"path={moved_to}" in data["content"], (
+        "the BODY must be read from the document's current path, not the "
+        f"stale one — got {data['content']!r}"
+    )
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_oembed_follows_the_document_not_the_stale_path(pool, vaults, path):
+    """The unfurl must name the same document the body comes from.
+
+    Kept alongside the content test on purpose: a card that titles itself from
+    the stale path while the page serves the bound document is two answers to
+    one slug.
+    """
+    from app.api.routes.public import oembed
+
+    slug, _published_id, _squatter_id = await _desync_uri_from_document(
+        pool, vaults, path, "archive/moved-away.md",
+    )
+    publication = await _internal(slug)
+    assert not publication.get("title"), "the fixture must force the DB lookup"
+    assert not publication.get("password_hash"), "F1 would short-circuit the lookup"
+
+    card = await oembed(url=f"https://vault-binding.test.local/p/{slug}")
+
+    assert card["title"] == "The published document", (
+        f"oEmbed titled the card {card['title']!r} — the document now sitting "
+        "at the published path, not the one that was published"
+    )
+
+
+# ── The legacy branch still works, and is still vault-scoped ─────
+#
+# `document_id` is nullable: rows predating migration 053 that the backfill
+# could not bind unambiguously are exempt from the FK and carry NULL. For
+# those the URI is still the only handle, so the path branch has to keep
+# working — and keep its vault-name cross-check, which is what the two
+# `_mismatch` tests above now exercise (they clear `document_id` precisely so
+# the legacy branch is the one under test).
+
+
+@pytest.mark.parametrize("path", _PATH_SHAPES)
+async def test_a_legacy_unbound_publication_still_resolves_by_path(pool, vaults, path):
+    """A NULL `document_id` row must still serve its document.
+
+    Without this the change would silently 404 every publication the backfill
+    left unbound — the population that has been public the longest.
+    """
+    from app.services.publication_service import resolve_document_publication
+
+    await _create_doc(pool, vaults["far"], path, title="Decoy in the other vault")
+    await _create_doc(pool, vaults["home"], path, title="The published document")
+    slug = await _publish(vaults["home"]["name"], path)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE publications SET document_id = NULL WHERE slug = $1", slug,
+        )
+
+    publication = await _internal(slug)
+    assert publication["document_id"] is None, "the fixture must exercise the NULL branch"
+
+    data = await resolve_document_publication(publication)
+
+    assert data["title"] == "The published document"
+    assert f"vault={vaults['home']['name']}" in data["content"], (
+        "the legacy branch must still be scoped to the publication's own vault"
+    )

--- a/backend/tests/test_publication_resolution_vault_binding_unit.py
+++ b/backend/tests/test_publication_resolution_vault_binding_unit.py
@@ -221,6 +221,19 @@ async def _mismatch(pool, vaults, path: str) -> tuple[str, str]:
     A document at `path` exists in BOTH vaults. The publication is created
     against `far` — so its URI names `far` — and then reassigned to `home`.
     Returns (slug, far_title).
+
+    **`document_id` is cleared first, and that is the whole story of which
+    rows this guard still protects.** A publication created today carries the
+    id of the document it was resolved from, under a composite
+    FK (document_id, vault_id) → documents(id, vault_id): moving the row to
+    another vault is refused by PostgreSQL, because `far`'s document is not in
+    `home`. So a bound row simply cannot reach the mismatched state below.
+    What can is a row whose `document_id` is NULL — a publication predating
+    migration 053 that the backfill could not bind unambiguously, which is
+    exempt from the FK. Clearing the column is how this manufactures one, and
+    those legacy rows are exactly the population the read-side vault binding
+    still has to refuse. It stops being reachable at all once the last NULL
+    is gone.
     """
     far_title = "Far vault original"
     await _create_doc(pool, vaults["far"], path, title=far_title)
@@ -228,7 +241,8 @@ async def _mismatch(pool, vaults, path: str) -> tuple[str, str]:
     slug = await _publish(vaults["far"]["name"], path)
     async with pool.acquire() as conn:
         await conn.execute(
-            "UPDATE publications SET vault_id = $1 WHERE slug = $2",
+            "UPDATE publications SET document_id = NULL, vault_id = $1 "
+            " WHERE slug = $2",
             vaults["home"]["id"], slug,
         )
     return slug, far_title

--- a/backend/tests/test_publication_resolution_vault_binding_unit.py
+++ b/backend/tests/test_publication_resolution_vault_binding_unit.py
@@ -234,7 +234,7 @@ async def _mismatch(pool, vaults, path: str) -> tuple[str, str]:
     another vault is refused by PostgreSQL, because `far`'s document is not in
     `home`. So a bound row simply cannot reach the mismatched state below.
     What can is a row whose `document_id` is NULL — a publication predating
-    migration 053 that the backfill could not bind unambiguously, which is
+    migration 058 that the backfill could not bind unambiguously, which is
     exempt from the FK. Clearing the column is how this manufactures one, and
     those legacy rows are exactly the population the read-side vault binding
     still has to refuse. It stops being reachable at all once the last NULL
@@ -513,7 +513,7 @@ async def test_oembed_follows_the_document_not_the_stale_path(pool, vaults, path
 
 # ── The legacy branch still works, and is still vault-scoped ─────
 #
-# `document_id` is nullable: rows predating migration 053 that the backfill
+# `document_id` is nullable: rows predating migration 058 that the backfill
 # could not bind unambiguously are exempt from the FK and carry NULL. For
 # those the URI is still the only handle, so the path branch has to keep
 # working — and keep its vault-name cross-check, which is what the two

--- a/backend/tests/test_publication_resolution_vault_binding_unit.py
+++ b/backend/tests/test_publication_resolution_vault_binding_unit.py
@@ -172,13 +172,18 @@ def _git_content(monkeypatch):
     mask a positive assertion on content, so return a body keyed by
     (vault, path) instead — which also makes "whose document came back"
     checkable from the content itself, not just the title.
+
+    The body echoes the `commit` argument too, so a test can tell a read
+    pinned to the document's own commit from one that floated to the vault
+    HEAD. `commit` defaults to None so a caller that stops passing it fails
+    an assertion rather than a signature check.
     """
     from app.services import publication_service
 
     class _Git:
         @staticmethod
-        def read_file(vault_name: str, path: str) -> str:
-            return f"# body\n\nvault={vault_name} path={path}\n"
+        def read_file(vault_name: str, path: str, commit: str | None = None) -> str:
+            return f"# body\n\nvault={vault_name} path={path} commit={commit}\n"
 
     class _DocService:
         git = _Git()
@@ -484,12 +489,19 @@ async def test_oembed_follows_the_document_not_the_stale_path(pool, vaults, path
     """
     from app.api.routes.public import oembed
 
-    slug, _published_id, _squatter_id = await _desync_uri_from_document(
+    from app.services.uri_service import doc_uri
+
+    slug, published_id, _squatter_id = await _desync_uri_from_document(
         pool, vaults, path, "archive/moved-away.md",
     )
     publication = await _internal(slug)
     assert not publication.get("title"), "the fixture must force the DB lookup"
     assert not publication.get("password_hash"), "F1 would short-circuit the lookup"
+    # Same setup guards the content test carries: the row must be BOUND and
+    # its URI STALE, or a green run here says nothing about which branch
+    # answered.
+    assert publication["document_id"] == str(published_id)
+    assert publication["resource_uri"] == doc_uri(vaults["home"]["name"], path)
 
     card = await oembed(url=f"https://vault-binding.test.local/p/{slug}")
 
@@ -535,3 +547,65 @@ async def test_a_legacy_unbound_publication_still_resolves_by_path(pool, vaults,
     assert f"vault={vaults['home']['name']}" in data["content"], (
         "the legacy branch must still be scoped to the publication's own vault"
     )
+
+
+async def test_resolution_reads_the_body_at_the_documents_own_commit(pool, vaults):
+    """Selecting the right row is only half of serving the right document.
+
+    The query establishes identity by `document_id`, then the connection is
+    released and the body is read from Git. Reading the floating vault HEAD at
+    `d.path` hands the identity straight back: a path is reusable, so a move
+    plus a new document onto the vacated path between the two reads serves
+    THAT document's bytes under this publication's title, tags and author.
+
+    `DocumentService.get` pins its read to the row's `current_commit` for the
+    same reason, recorded there as E03. The anonymous path is the one that did
+    not, which is the read that needs it most.
+
+    Pre-change this is RED with `commit=None` — the tell for a HEAD read.
+    """
+    from app.services.publication_service import resolve_document_publication
+
+    path = "reports/q3.md"
+    await _create_doc(pool, vaults["home"], path, title="The published document")
+    slug = await _publish(vaults["home"]["name"], path)
+
+    data = await resolve_document_publication(await _internal(slug))
+
+    # `_create_doc` writes commit_hash="c" * 40, so that is this document's
+    # recorded commit — and the fake Git echoes whatever the resolver asked
+    # for. `commit=None` means the body came from wherever the vault HEAD
+    # happened to be, which is not necessarily this document at all.
+    assert f"commit={'c' * 40}" in data["content"], (
+        "the body must be read at the document's recorded commit, not the "
+        f"floating vault HEAD — got {data['content']!r}"
+    )
+
+
+async def test_a_bound_publication_never_falls_back_to_the_path(pool, vaults):
+    """The two branches must be mutually exclusive, not merely ordered.
+
+    A bound row whose `document_id` finds nothing must 404 rather than serve
+    whatever occupies its published path. Note this state is UNREACHABLE in
+    the table — the composite FK cascades the publication away with its
+    document, which is the point of having it — so the publication dict is
+    doctored directly. That makes this a test of the predicate rather than of
+    a live shape: it fails if the `$2::uuid IS NULL` guard is ever dropped,
+    which would make both branches eligible and leave which document gets
+    served up to whichever row PostgreSQL happened to return first.
+    """
+    from app.services.publication_service import resolve_document_publication
+
+    path = "reports/q3.md"
+    await _create_doc(pool, vaults["home"], path, title="The path occupant")
+    slug = await _publish(vaults["home"]["name"], path)
+
+    publication = dict(await _internal(slug))
+    publication["document_id"] = str(uuid.uuid4())  # names no document
+
+    with pytest.raises(NotFoundError):
+        data = await resolve_document_publication(publication)
+        pytest.fail(
+            "a bound publication whose document_id matches nothing must 404; "
+            f"it fell back to the path and served {data.get('title')!r}"
+        )

--- a/docs/design/proposal/2026-08-05-publication-document-identity/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/README.md
@@ -1,0 +1,133 @@
+---
+status: proposal
+stage: design
+created: 2026-08-05
+updated: 2026-08-05
+---
+
+# Publications carry a document identity again
+
+## What this is
+
+Migration 022 replaced `publications.document_id` and `publications.file_id`
+with a single canonical `resource_uri`, and in doing so dropped the two
+`ON DELETE CASCADE` foreign keys those columns carried. Since `documents` is
+keyed `UNIQUE(vault_id, path)`, a path can be freed and reoccupied — so a
+publication addressed by a path names a location, not a document.
+
+The item that preceded this one made document-publication cleanup reachable
+from every delete path and bound resolution to the publication's own vault.
+Every defence it added is Python-level. Its Direction section named restoring
+an identity anchor as a separate piece of work with its own rollout; this is
+that work.
+
+This item restores the identity column and moves the paths that decide *which
+document a publication means* onto it. Files are deliberately out of scope —
+see Boundaries.
+
+## What changes
+
+1. **A document identity column with a composite foreign key.** Migration 053
+   adds `publications.document_id`, a `UNIQUE (id, vault_id)` constraint on
+   `documents` to serve as the reference target, and
+
+   ```sql
+   FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id)
+     ON DELETE CASCADE
+   ```
+
+   The composite form is the point. `FOREIGN KEY (document_id) REFERENCES
+   documents(id)` would guarantee only that the document exists — a publication
+   in one vault pointing at a document in another satisfies it. The composite
+   form makes vault agreement a structural property rather than one more rule
+   the code has to remember, which is the reason for the whole item.
+
+2. **The publisher keeps the identity it resolved.** Publishing resolves a
+   caller-supplied reference to a document and then inserts a row. Those are
+   two steps, and the identity has to survive between them: the id the resolve
+   step produces is now carried through, re-verified under the row lock the
+   insert already took, and stored.
+
+3. **Resolution reads the identity.** Both directions moved — document → slug
+   (the public-slug lookups) and slug → document (public resolution and the
+   oEmbed title lookup). The second is the one that decides which document a
+   link stands for, so it is the one the identity column exists to serve.
+
+4. **The body is read at the document's own commit.** Selecting a row and
+   reading its bytes are two steps as well, and the same reasoning applies —
+   an identity established by the first is not worth much if the second does
+   not use it. The read is pinned to `documents.current_commit`, the same fix
+   already applied to the authenticated read path.
+
+5. **`resource_uri` stays, demoted.** `table_query` publications have no
+   resource, so the column has to exist, and the API response already exposes
+   it. For document publications it is now derived; `document_id` holds the
+   binding.
+
+## Backfill
+
+Existing rows have only their URI to go on. Binding them to "whatever document
+that path points at now" would let the new foreign key permanently certify a
+wrong binding, and that is not reversible. The migration binds only what is
+unambiguous and leaves everything else NULL:
+
+- the URI must parse and name this publication's own vault;
+- exactly one document must occupy that path in that vault;
+- the document must not post-date the publication.
+
+Every refusal is counted and logged by category. No row is deleted — a
+publication row is the only record of its slug, creator, restrictions and view
+count.
+
+The conditions are filters, not proof. They remove some wrong answers and
+cannot remove all of them, so a bound row means self-consistent, not verified.
+Establishing that a given deployment's pre-existing rows are correct is not
+something a migration can do; it is a separate step, and it is not described
+here.
+
+## Consequences
+
+**`document_id` cannot be `NOT NULL` yet.** "Every document publication points
+at a document" is enforced in code, not in the schema, for as long as one
+backfilled NULL remains. Three code sites and two tests exist only for that
+population and become unreachable when it empties. Nothing currently detects
+that day — a follow-up should count the population and install the CHECK when
+it reaches zero, so the cleanup has one trigger rather than several independent
+judgment calls.
+
+**The migration cannot vouch for what it binds.** It is written to be safe on a
+database it knows nothing about, and safe means it declines to guess rather
+than that its answers are confirmed. Confirming them is an operational step
+that belongs to whoever runs it.
+
+**Two guards from the previous item narrowed.** The orphan-write guard and the
+explicit cleanup in the delete chokepoint now protect only unbound rows; the
+foreign key covers the rest. Their tests had to clear `document_id` to
+reproduce the state at all, which is the honest reproduction rather than a
+weakened assertion.
+
+## Boundaries
+
+**Files are unchanged.** `vault_files` ids are not reusable the way paths are,
+so an orphaned file publication fails closed rather than resolving onto a
+different resource — the defect shape does not carry over. The cost of the
+asymmetry sits on the cleanup side instead, where a canonical URI is
+reconstructed from three mutable inputs and matched as text; the open backlog
+items about file publication URIs and cleanup normalisation are instances of
+that. A `file_id` column would collapse them and would need no judgment in its
+backfill, which makes it the cheaper half of the same idea — but it is a second
+schema change and belongs in its own item.
+
+**`resource_uri` is not removed** and the move-time URI rewrite stays. Removing
+either is a contract change.
+
+## Rollout
+
+A schema change with a backfill, so it has ordering constraints and a
+verification step that a code change would not. Migration ordering, lock
+behaviour and the out-of-band index build are recorded in the migration module
+itself; the sequencing and verification a given deployment needs are an
+operational matter and are not described here.
+
+Detailed reasoning, review transcripts and the operational record are held in
+the team's internal notes rather than in this repository.

--- a/docs/design/proposal/2026-08-05-publication-document-identity/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/README.md
@@ -27,7 +27,7 @@ see Boundaries.
 
 ## What changes
 
-1. **A document identity column with a composite foreign key.** Migration 053
+1. **A document identity column with a composite foreign key.** Migration 058
    adds `publications.document_id`, a `UNIQUE (id, vault_id)` constraint on
    `documents` to serve as the reference target, and
 

--- a/docs/design/proposal/2026-08-05-publication-document-identity/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/README.md
@@ -89,8 +89,10 @@ here.
 
 **`document_id` cannot be `NOT NULL` yet.** "Every document publication points
 at a document" is enforced in code, not in the schema, for as long as one
-backfilled NULL remains. Three code sites and two tests exist only for that
-population and become unreachable when it empties. Nothing currently detects
+backfilled NULL remains. Three code sites and seven tests across three files
+exist only for that population and become unreachable when it empties — the
+tests are the sharper cost, because they will keep passing green while
+exercising a shape that no longer occurs. Nothing currently detects
 that day — a follow-up should count the population and install the CHECK when
 it reaches zero, so the cleanup has one trigger rather than several independent
 judgment calls.
@@ -100,11 +102,14 @@ database it knows nothing about, and safe means it declines to guess rather
 than that its answers are confirmed. Confirming them is an operational step
 that belongs to whoever runs it.
 
-**Two guards from the previous item narrowed.** The orphan-write guard and the
-explicit cleanup in the delete chokepoint now protect only unbound rows; the
-foreign key covers the rest. Their tests had to clear `document_id` to
-reproduce the state at all, which is the honest reproduction rather than a
-weakened assertion.
+**Two guards from the previous item are now unreachable for bound rows.**
+Neither the orphan-write guard nor the explicit cleanup in the delete
+chokepoint changed — both still match on `resource_uri`, with no reference to
+`document_id`. What changed is the state space around them: a bound row cannot
+reach the orphaned condition either one exists to catch, because the foreign
+key removes it first. So in practice only unbound rows reach them. Their tests
+clear `document_id` to reproduce the pre-key state, which is the honest
+reproduction rather than a weakened assertion.
 
 ## Boundaries
 
@@ -112,7 +117,9 @@ weakened assertion.
 so an orphaned file publication fails closed rather than resolving onto a
 different resource — the defect shape does not carry over. The cost of the
 asymmetry sits on the cleanup side instead, where a canonical URI is
-reconstructed from three mutable inputs and matched as text; the open backlog
+reconstructed from three inputs — one of which drifts underfoot, since a
+file's collection can be cleared out from under it — and matched as text; the
+open backlog
 items about file publication URIs and cleanup normalisation are instances of
 that. A `file_id` column would collapse them and would need no judgment in its
 backfill, which makes it the cheaper half of the same idea — but it is a second

--- a/docs/design/proposal/2026-08-05-publication-document-identity/feedback/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/feedback/README.md
@@ -1,0 +1,58 @@
+# Feedback
+
+Reviews conducted on this item, in order:
+
+- **Per-change reviews during implementation.** Each of the two parts went
+  through a specification-compliance review and then a code-quality review
+  before the next part started. Both produced real corrections.
+
+  The specification review of the schema work verified its claims by mutation
+  rather than by reading — replacing the composite foreign key with a simple
+  one, weakening the cascade, removing each guard in turn — and confirmed that
+  each mutation failed the test that was supposed to catch it. Two mutations
+  survived, which is how the item learned that its per-category backfill
+  counters were untested and that one of its two vault-name checks was pinned
+  only jointly with the other.
+
+  The quality review of the same work found that a fix applied to one of two
+  sibling catalog guards had not been applied to the other, and reproduced all
+  three of the resulting misbehaviours — including a case where the migration
+  dropped an index on an unrelated table, logged a warning asserting it was
+  something else, and reported success.
+
+- **Adversarial external review** on each part. On the schema work it found an
+  unguarded index in `init.sql` that would abort initialisation on any database
+  predating the migration — and because that file runs in full on every boot,
+  before migrations, the migration that would have added the column never runs.
+  An unrecoverable startup failure, introduced by this item and caught before
+  it left the branch. On the read-path work it found the unpinned body read
+  described in the rounds notes.
+
+- **Quality pass over the finished branch**, along four independent angles
+  (reuse, simplification, efficiency, depth). The depth angle produced the
+  forward-path correction. The efficiency angle measured rather than reasoned:
+  it confirmed the fallback query still uses the new partial index under a
+  forced generic plan, which is what matters given every statement is prepared,
+  and it found one redundant lookup this item had introduced.
+
+- **Code review over the finished branch**, along five angles (guideline
+  compliance, defect scan, historical context, prior review feedback, comment
+  fidelity). One finding: this item's own design record was missing, which is
+  what this folder now answers.
+
+  The historical angle is worth recording. It established that the migration
+  ledger post-dates the migration whose guard this item changes, so that change
+  is inert on any previously-booted database and matters only on a fresh one —
+  where the previous guard would have destroyed the column this item adds, one
+  migration before it was re-created. It also traced the body-read fix to its
+  original and confirmed the reapplication matches rather than diverges.
+
+Verification is recorded in the branch: the cascade and the vault refusal were
+each demonstrated through raw SQL, bypassing the application entirely, which is
+the only way to show a database-enforced guarantee is actually enforced by the
+database. The initialisation hazard was reproduced by hand — failure first,
+then recovery, then the full boot path — rather than accepted on the strength
+of a passing test.
+
+Detailed review transcripts are held in the team's internal notes rather than
+in this repository.

--- a/docs/design/proposal/2026-08-05-publication-document-identity/feedback/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/feedback/README.md
@@ -29,8 +29,8 @@ Reviews conducted on this item, in order:
   described in the rounds notes.
 
 - **Quality pass over the finished branch**, along four independent angles
-  (reuse, simplification, efficiency, depth). The depth angle produced the
-  forward-path correction. The efficiency angle measured rather than reasoned:
+  (reuse, simplification, efficiency, altitude). The altitude angle produced
+  the forward-path correction. The efficiency angle measured rather than reasoned:
   it confirmed the fallback query still uses the new partial index under a
   forced generic plan, which is what matters given every statement is prepared,
   and it found one redundant lookup this item had introduced.

--- a/docs/design/proposal/2026-08-05-publication-document-identity/rounds/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/rounds/README.md
@@ -1,0 +1,55 @@
+# Rounds
+
+This item was designed in two parts, each with its own correction rounds, plus
+one round that reopened a decision after implementation.
+
+- **Part A — the schema.** Established the composite foreign key over a simple
+  one. A first pass assumed that a foreign key on `document_id` alone would
+  bring vault agreement with it; it does not, and the correction is why
+  `documents` gained `UNIQUE (id, vault_id)` as a reference target.
+
+  Also settled the migration's internal order against the classical
+  expand/backfill/constrain shape: the constraint is added **before** the
+  backfill, while every value is still NULL, so the database checks each
+  binding as it is written rather than certifying a whole batch at the end.
+  Constrain-last would have reproduced the failure the item exists to remove.
+
+  `NOT VALID` was evaluated and rejected — it takes the same lock and skips
+  only a scan of a table with one row per published link, at the cost of a
+  constraint that is enforced but unverified. A plain index build was chosen
+  over `CONCURRENTLY` because a cancelled concurrent build leaves an invalid
+  index that `IF NOT EXISTS` then steps over silently; the migration adopts a
+  valid index built out of band instead, which is the escape hatch if the
+  reference table is ever too large to index inline.
+
+- **Part B — the read and write paths.** Scoped to carrying the resolved id
+  from resolve to insert, and to moving the reverse lookups onto it.
+
+- **Correction round — the forward path.** A review pointed out that the item
+  had moved the *reverse* lookups onto the identity and left the *forward*
+  ones on the path, which is backwards with respect to consequence: the reverse
+  direction answers a question an author asks about their own document, the
+  forward direction decides what a link stands for. It also observed that
+  refusing a disagreeing pair at write time establishes agreement at creation
+  and nothing afterwards — what keeps them agreeing is a single statement in
+  the move path, which is the same "one place must remember" shape the item
+  exists to abolish, and a foreign key cannot help while it constrains a column
+  no read path reads. The forward paths moved.
+
+- **Correction round — the body read.** Immediately after, an adversarial
+  review observed that the change had not gone far enough: choosing a row and
+  reading its content are separate steps, and an identity used only for the
+  first is not carried by the second. The codebase had already named and fixed
+  this class on the authenticated read path; the public one had not been. The
+  same pin was applied.
+
+- **Cleanup round.** Four review angles over the finished branch produced a
+  sixth unguarded reference in `init.sql` to a column that arrives with a
+  migration (found by reading migrations, not by the replay technique
+  documented alongside the guards, which is structurally blind to columns older
+  than that file's recorded history), and a set of smaller simplifications.
+  Several proposed simplifications were declined and the reasons recorded:
+  collapsing the publish-time refusals into one message would cost the only
+  branch a real user reaches its actionable wording, and removing the
+  "changed underfoot" refusal category would make a log conflate two materially
+  different stories.

--- a/docs/design/proposal/2026-08-05-publication-document-identity/rounds/README.md
+++ b/docs/design/proposal/2026-08-05-publication-document-identity/rounds/README.md
@@ -43,7 +43,8 @@ one round that reopened a decision after implementation.
   this class on the authenticated read path; the public one had not been. The
   same pin was applied.
 
-- **Cleanup round.** Four review angles over the finished branch produced a
+- **Cleanup round**, interleaved with the corrections above rather than
+  strictly after them. Four review angles over the finished branch produced a
   sixth unguarded reference in `init.sql` to a column that arrives with a
   migration (found by reading migrations, not by the replay technique
   documented alongside the guards, which is structurally blind to columns older


### PR DESCRIPTION
## What this is

Migration 022 replaced `publications.document_id` and `publications.file_id` with a
single canonical `resource_uri`, and in doing so dropped the two `ON DELETE CASCADE`
foreign keys those columns carried. `documents` is `UNIQUE(vault_id, path)`, so a path
can be freed and reoccupied — which means a publication addressed by a path names a
location rather than a document.

The preceding item (#325) made document-publication cleanup reachable from every delete
path and bound resolution to the publication's own vault. Every defence it added is
Python-level: a static test allowlists each remaining `DELETE FROM documents`, but that
only constrains what goes through Python. Direct SQL, a future migration, and admin
scripts are not covered.

This restores the identity column and moves the paths that decide *which document a
publication means* onto it. Design item:
`docs/design/proposal/2026-08-05-publication-document-identity/`.

## What changes

**1. A document identity column with a composite foreign key** (migration 053).

```sql
ALTER TABLE documents   ADD CONSTRAINT documents_id_vault_id_key UNIQUE (id, vault_id);
ALTER TABLE publications ADD COLUMN document_id UUID;
ALTER TABLE publications ADD CONSTRAINT publications_document_fk
  FOREIGN KEY (document_id, vault_id) REFERENCES documents(id, vault_id) ON DELETE CASCADE;
```

The composite form is the point. `FOREIGN KEY (document_id) REFERENCES documents(id)`
guarantees only that the document exists — a publication in one vault pointing at a
document in another satisfies it. The composite form makes vault agreement structural
rather than one more rule the code has to remember.

The constraint is added **before** the backfill, while every value is still NULL, so the
database checks each binding as it is written. Constrain-last would have written
bindings nothing had verified and then certified the batch in one statement.

**2. The publisher keeps the identity it resolved.** Publishing resolves a caller
reference to a document and then inserts a row; the id from the resolve step is now
carried through, re-verified under the row lock the insert already took, and stored.

**3. Both lookup directions read the identity.** Document → slug (the public-slug
lookups) and slug → document (public resolution and the oEmbed title lookup). The second
is what decides which document a link stands for.

**4. The body is read at the document's own commit.** Choosing a row and reading its
content are separate steps; the read is now pinned to `documents.current_commit`, the
same fix already applied to the authenticated read path.

**5. `resource_uri` stays, demoted.** `table_query` publications have no resource so the
column must exist, and the API already exposes it. For documents it is now derived.

## Backfill

Existing rows have only their URI to go on, and binding them to whatever occupies that
path now would let the new foreign key permanently certify a wrong binding. The
migration binds only what is unambiguous and leaves everything else NULL: the URI must
parse and name the publication's own vault, exactly one document must occupy that path
in that vault, and the document must not post-date the publication.

Every refusal is counted and logged by category. No row is deleted — a publication row
is the only record of its slug, creator, restrictions and view count. The conditions are
filters, not proof; a bound row means self-consistent, not verified.

## Consequences

`document_id` **cannot be `NOT NULL`** while backfilled NULLs remain, so "every document
publication points at a document" is enforced in code, not schema. Three code sites and
two tests exist only for that population. A follow-up should count it and install the
CHECK at zero, so the cleanup has one trigger rather than several independent judgment
calls years apart.

**Two guards from #325 narrowed** — the orphan-write guard and the explicit cleanup in
the delete chokepoint now cover only unbound rows; the foreign key covers the rest. Their
tests had to clear `document_id` to reach the state at all, which is the honest
reproduction rather than a weakened assertion.

**Files are unchanged.** `vault_files` ids are not reusable the way paths are, so the
defect shape does not carry over. The cost of the asymmetry sits on the cleanup side, and
the open items about file publication URIs and cleanup normalisation are instances of it;
a `file_id` column would collapse them and needs no judgment in its backfill, which makes
it the cheaper half of the same idea — but it is a second schema change.

## Verification

- The cascade and the vault refusal are each demonstrated through **raw SQL**, bypassing
  the application entirely — the only way to show a database-enforced guarantee is
  actually enforced by the database. A composite-FK mutation to a single-column FK fails
  five tests, so the distinction is proven rather than asserted.
- The migration is idempotent, re-entrant at every step boundary, and a database built
  from `init.sql` plus the full chain was compared against one built by the real upgrade
  path — 80 catalog entries, identical.
- The startup hazard the branch introduced in `init.sql` was reproduced by hand — failure
  first, then recovery, then the full boot path — rather than accepted on a passing test.
  A sweep then found five further statements of the same shape; all six are now guarded
  and each is covered.
- 26 migration tests, backend unit 1764 passed, `test_publication_resolution_e2e.sh` 37/0,
  `test_publications_e2e.sh` 127/0, `scripts/check.sh` green.
- Reviewed along four quality angles and five code-review angles. The forward-lookup
  change and the commit pin both came out of that process rather than the original plan.

## Not in this PR

- File publications (`file_id` and its cleanup path).
- Making `document_id` `NOT NULL`, or a CHECK — not possible while backfilled NULLs
  exist.
- `section_filter` falls back to the full document when its heading no longer matches.
  Pre-existing, pinned by an e2e assertion as intended behaviour, and a product decision
  rather than a bug fix.
