### PR TITLE
feat(akb-mcp): survive backend/VPN outages without a session restart (2.1.0)

### DIFF
--- a/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/README.md
+++ b/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/README.md
@@ -1,0 +1,127 @@
+---
+status: proposal
+stage: design
+created: 2026-08-05
+updated: 2026-08-05
+---
+
+# MCP stdio proxy survives backend/VPN outages without a session restart
+
+## What this is
+
+The `akb-mcp` stdio proxy (`packages/akb-mcp-client`) bridges a client's
+stdio MCP transport to the AKB backend's Streamable HTTP `/mcp/` endpoint.
+When the VPN (or backend) is down for a long stretch, the AKB server
+silently disappears from the client's tool namespace for the rest of the
+session — `mcp__akb__*` tools stay gone even after connectivity returns,
+until the client/session is restarted.
+
+This item decouples the **client-visible liveness** of the proxy from
+**backend reachability**, so a transient or long outage degrades and
+recovers instead of permanently de-registering the server.
+
+## Root cause
+
+The proxy answered the MCP `initialize` handshake by round-tripping to the
+backend (`_rpc("initialize", …)`). A stdio MCP server that returns an error
+to `initialize` is treated by the client as *failed to initialize* and is
+dropped for the whole session. So:
+
+1. VPN down at proxy/session startup → backend `initialize` fails.
+2. Client marks the AKB server failed, never registers its tools.
+3. VPN returns; `claude mcp list` shows the server healthy, but the running
+   session's tool namespace was fixed at startup — tools do not come back
+   without a restart.
+
+The proxy **process** was alive the entire time. The defect was the
+coupling: making client-visible liveness depend on a backend round-trip.
+
+Naive "infinite retry" on tool calls does **not** fix this (the server is
+already de-registered) and introduces a worse footgun — a tool call that
+hangs forever on a blackholed connection.
+
+## Design
+
+Client-visible liveness is served locally; the backend session is managed
+out of band.
+
+1. **Local `initialize`.** The proxy answers the handshake itself — echoes
+   the client's `protocolVersion` (fallback `2025-06-18`), advertises
+   `capabilities.tools.listChanged = true`, reports `serverInfo`. The server
+   always registers, backend up or down. (Consistent with prior behavior,
+   the client's `notifications/initialized` is not forwarded; the backend
+   accepts `tools/*` after a bare `initialize` over this transport.)
+
+2. **Backend session, single-flight.** `_ensureBackend()` lazily performs
+   the backend `initialize` (capturing `mcp-session-id`) under a
+   single-flight lock, returning a boolean — never throwing. Used by both
+   the monitor and `_forward`.
+
+3. **Resilient `tools/list`.** Serves a live or cached backend tool list.
+   With the backend unreachable and no cache, it degrades to the local file
+   tools only (a valid partial response) and sets `_servedDegraded`. The
+   backend list is cached on first success; decoration (file-param
+   injection + appended file tools) never mutates the cache.
+
+4. **Background reconnect monitor.** Exponential backoff (1s → 30s cap),
+   effectively forever while the client is connected (`_closed` on stdin
+   EOF stops it). On (re)connect it refreshes the tool cache and, if the
+   client had been served a degraded list, pushes
+   `notifications/tools/list_changed` — the full toolset reappears with no
+   session restart. Idempotent: at most one loop runs.
+
+5. **Non-fatal tool calls.** A connection error in `_forward` marks the
+   backend not-ready, kicks the monitor, and retries; a persistent outage
+   surfaces a normal JSON-RPC error for that single call rather than tearing
+   anything down.
+
+6. **Connect-phase timeout.** `AKB_MCP_CONNECT_TIMEOUT_MS` (default 10s)
+   arms only while a socket is still `connecting`, so a blackholed
+   connection is detected quickly — separate from the generous 5-min
+   response timeout retained for legitimately slow ops (`akb_delete_vault`
+   on large vaults). Liveness probes (`initialize`/`tools/list` from the
+   monitor) use this short timeout so the loop cycles fast.
+
+## Why not the alternatives
+
+- **Literal infinite retry per tool call** — hangs the agent on a dead
+  connection and still leaves the server de-registered. Rejected.
+- **Backend-driven `initialize` with more retries** — still couples
+  liveness to reachability; more retries only widen the startup stall.
+- **A separate local sidecar/proxy server** — more moving parts and a new
+  failure surface for what is a client-liveness decoupling problem.
+
+## Known limitation
+
+If the backend goes silent mid-session on an already **established**
+keep-alive socket (no RST), the *first* in-flight tool call can wait up to
+the response timeout before the retry/monitor kick in. Subsequent calls
+fail fast because the monitor has flipped the ready flag. A first-byte
+timeout shorter than 5 min would close this, at the cost of risking
+false aborts on legitimately slow operations — deferred deliberately.
+
+## Scope / non-goals
+
+- No change to tool behavior, auth (PAT bearer), or the S3 file-transfer
+  path.
+- Backend `/mcp/` (`http_app.py`) is unchanged. This is a pure client-side
+  proxy resilience change.
+- OAuth/`--transport http` remote registration is a separate connection
+  path and out of scope.
+
+## Verification
+
+- `packages/akb-mcp-client/test/reconnect.test.mjs` (new): local
+  `initialize`, degraded `tools/list`, cache decoration without mutation,
+  monitor `list_changed` on recovery (and silence when never degraded),
+  `_forward` retry/recover/surface, process survival.
+- `packages/akb-mcp-client/test/contract.test.mjs`: unchanged, still green.
+- `npm test` in the package runs both.
+
+## Release
+
+- Proxy is versioned independently: **2.0.4 → 2.1.0** (`package.json`,
+  `server.json`, `CHANGELOG.md`).
+- Proxy changes require an **npm publish**, which is a deliberate human
+  gate — not performed by the agent. After publish: git tag + GitHub
+  Release per the repo's proxy release flow.

--- a/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/feedback/README.md
+++ b/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/feedback/README.md
@@ -1,0 +1,27 @@
+# Feedback
+
+- **PM origin.** Raised from an observed production symptom: after a long VPN
+  outage the `akb` server vanished from a running Claude Code session's tool
+  namespace (`mcp__akb__*` gone) while `claude mcp list` still reported the
+  stdio proxy healthy. The diagnosis that startup-time `initialize` coupling —
+  not retry count — was the cause came out of that discussion.
+
+- **Verification run on the branch.**
+  - `node test/reconnect.test.mjs` — 8/8: local `initialize` (backend down),
+    protocol-version fallback, degraded `tools/list` → file tools only,
+    cached full list served with `file` param injected and cache left
+    unmutated, monitor emits `list_changed` on recovery from degraded, monitor
+    stays silent when never degraded, `_forward` retries-then-surfaces a
+    connection error (process survives), `_forward` recovers on a later attempt.
+  - `node test/contract.test.mjs` — 6/6 unchanged (file-transfer destructure
+    contract).
+  - `node --check lib/proxy.mjs` — clean.
+
+- **Gaps / not covered.** No full stdin→stdout integration test driving the
+  real `start()` loop against a mock HTTP backend that flips down→up; the
+  branch logic is covered at unit level by stubbing `_rpc`/`_ensureBackend`.
+  The mid-session dead-keepalive first-call stall (see README limitation) is
+  documented, not tested.
+
+- **Release gate.** Proxy code changed → npm publish required, which is a
+  human-only step. Not performed by the agent.

--- a/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/rounds/README.md
+++ b/docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/rounds/README.md
@@ -1,0 +1,28 @@
+# Rounds
+
+- **Framing correction.** The request arrived as "make the proxy infinite-retry
+  so it recovers after a long VPN drop." Reading the code showed infinite retry
+  is the wrong lever: the proxy process never dies on connection failure — a
+  failed backend `initialize` makes the *client* drop the server for the whole
+  session. The fix therefore targets the handshake coupling, not the retry
+  count. Literal per-call infinite retry was rejected for adding a hang-forever
+  footgun without addressing de-registration.
+
+- **Recovery mechanism.** A background reconnect that only re-establishes the
+  session is not enough when the client was handed a degraded (file-tools-only)
+  list at startup — the client would keep showing the partial toolset. Settled
+  on advertising `tools.listChanged` at the local `initialize` and pushing
+  `notifications/tools/list_changed` on recovery, so the full toolset returns
+  without a session restart.
+
+- **Timeout split.** Kept the deliberate 5-min response timeout (added in 2.0.2
+  for large `akb_delete_vault` cascades) and added a separate short
+  connect-phase timeout for blackhole detection, rather than shortening the one
+  timeout and risking false aborts on slow ops. The mid-session dead-keepalive
+  edge was acknowledged as a known limitation rather than papered over.
+
+- **Backend-handshake consistency.** Verified the pre-existing proxy already
+  dropped the client's `notifications/initialized` (never forwarded it), so a
+  locally-answered `initialize` plus a bare backend `initialize` matches the
+  previously-working request sequence — no new dependency on an `initialized`
+  notification.

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 2.1.0 — survive backend/VPN outages without a session restart
+
+Resilience fix for the failure mode where a long VPN/backend outage
+silently drops the AKB server from a client's tool namespace for the rest
+of the session.
+
+**Root cause**: `initialize` used to round-trip to the backend. If the
+backend was unreachable at handshake time (VPN down at startup), the
+handshake failed and the MCP client dropped the whole server for the
+session — so even after connectivity returned, `mcp__akb__*` tools stayed
+gone until the client/session was restarted. The proxy process itself was
+alive the whole time; the coupling of *client-visible liveness* to
+*backend reachability* was the bug.
+
+**What changed** — client-visible liveness is now decoupled from backend
+reachability:
+
+- **`initialize` is answered locally.** The server always registers, even
+  with the backend down. It echoes the client's protocol version and
+  advertises `tools.listChanged`.
+- **`tools/list` degrades gracefully.** With the backend unreachable and
+  nothing cached, it serves the local file tools only (a valid, if partial,
+  response) instead of erroring. The backend tool list is cached on first
+  success and served thereafter.
+- **A background reconnect monitor** re-establishes the backend session
+  with exponential backoff (1s → 30s cap), effectively forever while the
+  client stays connected. On recovery from a degraded list it pushes
+  `notifications/tools/list_changed`, so the full toolset reappears
+  **without a session restart**.
+- **Tool calls never kill the proxy.** A connection error marks the backend
+  not-ready, kicks the monitor, and retries; a persistent outage surfaces a
+  normal JSON-RPC error for that one call rather than tearing anything down.
+- **A short connect-phase timeout** (`AKB_MCP_CONNECT_TIMEOUT_MS`, default
+  10s) detects a blackholed connection quickly, separate from the generous
+  5-min response timeout kept for legitimately slow operations
+  (`akb_delete_vault` on large vaults).
+
+No changes to tool behavior, auth, or the file-transfer path. Fully
+backward compatible.
+
+**Known limitation**: if the backend goes silent mid-session on an already
+*established* keep-alive socket (no RST), the *first* in-flight tool call
+can wait up to the response timeout before the retry/monitor kick in;
+subsequent calls fail fast because the monitor has flipped the ready flag.
+
 ## 2.0.4 — MCP Registry: add `mcpName`
 
 No code change. Adds `"mcpName": "io.github.dnotitia/akb"` to

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -216,6 +216,16 @@ const FILE_TOOL_NAMES = new Set(FILE_TOOLS.map((t) => t.name));
 // Tools where proxy injects a `file` param as alternative to `content`
 const FILE_CONTENT_TOOLS = new Set(["akb_put", "akb_update"]);
 
+// Kept in sync with package.json `version`. Reported to the client in the
+// local `initialize` response, so it must not silently drift on a proxy
+// behaviour change. There is no import of package.json here to keep lib/
+// zero-dependency and load-safe across Node versions.
+const PROXY_VERSION = "2.1.0";
+
+// Fallback MCP protocol version echoed to the client when its `initialize`
+// request omits one. We otherwise echo the client's requested version.
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
 export class AKBProxy {
   constructor({ url, pat, insecure = false }) {
     this.url = new URL(url);
@@ -224,6 +234,31 @@ export class AKBProxy {
     this.sessionId = null;
     this.msgId = 0;
     this._initialized = false;
+    // ── Backend-liveness state (decoupled from client liveness) ──────
+    // The client's view of this server must NOT depend on backend
+    // reachability: a stdio MCP server that fails `initialize` is dropped
+    // by the client for the whole session (the VPN-down-at-startup bug).
+    // So we answer `initialize` locally and manage the backend session
+    // out of band via a background monitor.
+    this._clientInitParams = null; // client initialize params, replayed to backend
+    this._backendReady = false; // backend MCP session established
+    this._connecting = null; // in-flight backend-connect promise (single-flight lock)
+    this._cachedTools = null; // last successful backend tools/list result (raw)
+    this._servedDegraded = false; // client was handed a fallback (file-tools-only) list
+    this._monitorRunning = false; // background reconnect monitor active
+    this._closed = false; // stdin closed / shutting down
+  }
+
+  _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // Short timeout for backend liveness probes (initialize / tools-list) so
+  // the reconnect monitor cycles quickly and a single tool call fails fast
+  // when the backend is unreachable, instead of blocking on the generous
+  // per-request timeout used for legitimately slow operations.
+  _probeTimeoutMs() {
+    return Number(process.env.AKB_MCP_CONNECT_TIMEOUT_MS) || 10000;
   }
 
   async start() {
@@ -250,6 +285,9 @@ export class AKBProxy {
         this._writeError(msg.id, -32603, err.message);
       }
     }
+    // stdin closed → client disconnected. Stop the background monitor so
+    // the process can exit cleanly instead of looping forever.
+    this._closed = true;
   }
 
   async _handle(msg) {
@@ -307,29 +345,88 @@ export class AKBProxy {
   }
 
   async _initialize(id, params) {
-    const resp = await this._rpc("initialize", params);
+    // Answer the handshake LOCALLY — never round-trip to the backend here.
+    // This is the crux of the reconnect fix: the client considers this MCP
+    // server initialized (and keeps it registered for the whole session)
+    // regardless of whether the backend is reachable right now. If the VPN
+    // is down at startup, the server still registers; tools recover once
+    // connectivity returns (see the monitor + tools/list_changed path).
+    this._clientInitParams = params || null;
     this._initialized = true;
-    return { jsonrpc: "2.0", id, result: resp };
+    // Kick off the backend session + tool prefetch in the background.
+    this._startBackendMonitor();
+
+    const protocolVersion =
+      (params && typeof params.protocolVersion === "string" && params.protocolVersion) ||
+      MCP_PROTOCOL_VERSION;
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion,
+        // Advertise listChanged so we can push the real toolset after a
+        // degraded (backend-unreachable) tools/list is recovered.
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: "akb-mcp", version: PROXY_VERSION },
+      },
+    };
+  }
+
+  // Decorate a raw backend tools/list result with the proxy-local file
+  // tools and the injected `file` param. Never mutates the cached result.
+  _decorateTools(resp) {
+    const tools = (resp.tools || []).map((t) => {
+      if (FILE_CONTENT_TOOLS.has(t.name) && t.inputSchema?.properties) {
+        return {
+          ...t,
+          inputSchema: {
+            ...t.inputSchema,
+            properties: {
+              ...t.inputSchema.properties,
+              file: {
+                type: "string",
+                description:
+                  "Local file path to read as document body (alternative to content). " +
+                  "Provide either file or content, not both.",
+              },
+            },
+          },
+        };
+      }
+      return { ...t };
+    });
+    tools.push(...FILE_TOOLS);
+    return { ...resp, tools };
   }
 
   async _toolsList(id, params) {
-    const resp = await this._rpc("tools/list", params || {});
-    const tools = resp.tools || [];
-
-    // Inject `file` param into tools that support local file → content resolution
-    for (const tool of tools) {
-      if (FILE_CONTENT_TOOLS.has(tool.name) && tool.inputSchema?.properties) {
-        tool.inputSchema.properties.file = {
-          type: "string",
-          description:
-            "Local file path to read as document body (alternative to content). " +
-            "Provide either file or content, not both.",
-        };
+    // Serve a live or cached backend tool list. If the backend is
+    // unreachable and nothing is cached, degrade to the local file tools
+    // only — a valid (partial) response the client can register — and mark
+    // the list stale so the monitor re-lists it on recovery. Never error
+    // the whole tools/list on backend unreachability.
+    let resp = this._cachedTools;
+    if (!resp) {
+      const ok = await this._ensureBackend();
+      if (ok) {
+        try {
+          resp = await this._syncTools();
+        } catch {
+          resp = null;
+        }
       }
     }
 
-    tools.push(...FILE_TOOLS);
-    return { jsonrpc: "2.0", id, result: { ...resp, tools } };
+    if (!resp) {
+      this._servedDegraded = true;
+      this._startBackendMonitor();
+      process.stderr.write(
+        "[akb-mcp] backend unreachable — serving file tools only; will re-list on recovery\n",
+      );
+      return { jsonrpc: "2.0", id, result: { tools: [...FILE_TOOLS] } };
+    }
+
+    return { jsonrpc: "2.0", id, result: this._decorateTools(resp) };
   }
 
   // ── File-to-content resolution ─────────────────────────
@@ -621,7 +718,7 @@ export class AKBProxy {
 
   // ── AKB HTTP helper ───────────────────────────────────────
 
-  _http(method, path, body = null, extraHeaders = {}) {
+  _http(method, path, body = null, extraHeaders = {}, opts = {}) {
     return new Promise((resolve, reject) => {
       const isHttps = this.url.protocol === "https:";
       const doRequest = isHttps ? httpsRequest : httpRequest;
@@ -647,7 +744,22 @@ export class AKBProxy {
       };
       if (isHttps && this.insecure) opts.rejectUnauthorized = false;
 
+      // Connect-phase timeout, separate from the (long) response timeout.
+      // A VPN blackhole leaves a brand-new socket stuck in `connecting`;
+      // without this the request would hang until the 5-min response
+      // timeout. We only arm it for sockets still connecting — reused
+      // keep-alive sockets are already established.
+      let connectTimer = null;
+      const connectMs = this._probeTimeoutMs();
+      const clearConnectTimer = () => {
+        if (connectTimer) {
+          clearTimeout(connectTimer);
+          connectTimer = null;
+        }
+      };
+
       const req = doRequest(opts, (res) => {
+        clearConnectTimer();
         let data = "";
         res.setEncoding("utf8");
         res.on("data", (chunk) => (data += chunk));
@@ -660,17 +772,117 @@ export class AKBProxy {
         });
       });
 
-      req.on("error", reject);
+      req.on("socket", (socket) => {
+        if (socket.connecting) {
+          connectTimer = setTimeout(() => {
+            req.destroy(new Error(`Connect timeout (${Math.round(connectMs / 1000)}s)`));
+          }, connectMs);
+          socket.once("connect", clearConnectTimer);
+        }
+      });
+
+      req.on("error", (err) => {
+        clearConnectTimer();
+        reject(err);
+      });
       // Default 5 min — destructive ops like `akb_delete_vault` on
       // large vaults (7K+ docs) take well over 30s for the backend
       // cascade (chunks + vector outbox + git cleanup). Hardcoding
       // 30s caused the client to abort while the backend continued
       // processing, leaving the operator with a misleading timeout
-      // error. Override via `AKB_MCP_REQUEST_TIMEOUT_MS`.
-      const reqTimeoutMs = Number(process.env.AKB_MCP_REQUEST_TIMEOUT_MS) || 300000;
+      // error. Override via `AKB_MCP_REQUEST_TIMEOUT_MS`, or per-call via
+      // `opts.timeoutMs` (liveness probes use the short probe timeout).
+      const reqTimeoutMs =
+        opts.timeoutMs || Number(process.env.AKB_MCP_REQUEST_TIMEOUT_MS) || 300000;
       req.setTimeout(reqTimeoutMs, () => req.destroy(new Error(`Request timeout (${Math.round(reqTimeoutMs / 1000)}s)`)));
       if (body) req.write(body);
       req.end();
+    });
+  }
+
+  // ── Backend session + reconnect monitor ───────────────────
+
+  // A connection/session failure that a background reconnect can recover
+  // from — as opposed to a genuine application error we must surface.
+  _isConnError(message) {
+    return /session|404|ECONNREFUSED|ECONNRESET|socket hang up|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENETDOWN|ENOTFOUND|EPIPE|timeout|unreachable/i.test(
+      message || "",
+    );
+  }
+
+  // Establish the backend MCP session (the `initialize` handshake that
+  // yields an mcp-session-id) if not already up. Single-flight: concurrent
+  // callers share one in-flight attempt. Returns true on success, false on
+  // failure — never throws — so callers can degrade gracefully.
+  async _ensureBackend() {
+    if (this._backendReady) return true;
+    if (this._connecting) return this._connecting;
+    this._connecting = (async () => {
+      try {
+        const initParams = this._clientInitParams || {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: "akb-mcp-client", version: PROXY_VERSION },
+        };
+        await this._rpc("initialize", initParams, { timeoutMs: this._probeTimeoutMs() });
+        this._backendReady = true;
+        return true;
+      } catch {
+        this._backendReady = false;
+        return false;
+      } finally {
+        this._connecting = null;
+      }
+    })();
+    return this._connecting;
+  }
+
+  // Fetch and cache the backend tool list. Caller is responsible for having
+  // an established session. Uses the short probe timeout.
+  async _syncTools() {
+    const resp = await this._rpc("tools/list", {}, { timeoutMs: this._probeTimeoutMs() });
+    this._cachedTools = resp;
+    return resp;
+  }
+
+  // Background loop that keeps trying to (re)establish the backend session
+  // with exponential backoff — effectively forever while the client is
+  // connected. On (re)connect it refreshes the tool cache and, if the
+  // client was previously handed a degraded list, pushes a
+  // tools/list_changed notification so the full toolset reappears WITHOUT a
+  // session restart. Idempotent: at most one loop runs at a time.
+  _startBackendMonitor() {
+    if (this._monitorRunning || this._closed) return;
+    this._monitorRunning = true;
+
+    const loop = async () => {
+      let delay = 1000;
+      const maxDelay = 30000;
+      while (!this._closed) {
+        const ok = await this._ensureBackend();
+        if (ok) {
+          try {
+            await this._syncTools();
+            if (this._servedDegraded) {
+              this._servedDegraded = false;
+              this._notify("notifications/tools/list_changed", {});
+              process.stderr.write("[akb-mcp] backend recovered — re-listing tools\n");
+            }
+            break; // connected + synced; idle until a forward detects a drop
+          } catch {
+            // initialize succeeded but tools/list failed — treat as not
+            // ready and keep retrying.
+            this._backendReady = false;
+          }
+        }
+        await this._sleep(delay);
+        delay = Math.min(maxDelay, delay * 2);
+      }
+      this._monitorRunning = false;
+    };
+
+    loop().catch(() => {
+      this._monitorRunning = false;
     });
   }
 
@@ -681,37 +893,26 @@ export class AKBProxy {
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
+        if (!this._backendReady) {
+          const ok = await this._ensureBackend();
+          if (!ok) throw new Error("backend unreachable");
+        }
         const resp = await this._rpc(msg.method, msg.params || {});
         return { jsonrpc: "2.0", id: msg.id, result: resp };
       } catch (err) {
-        const isSessionError =
-          err.message.includes("session") ||
-          err.message.includes("Session") ||
-          err.message.includes("404") ||
-          err.message.includes("ECONNREFUSED") ||
-          err.message.includes("ECONNRESET") ||
-          err.message.includes("socket hang up");
-
-        if (isSessionError && attempt < maxRetries) {
-          process.stderr.write(
-            `[akb-mcp] Connection lost, reconnecting (attempt ${attempt + 1})...\n`
-          );
+        if (this._isConnError(err.message)) {
+          // Drop the dead session and let the background monitor restore
+          // it. The proxy process and the client-visible server stay
+          // alive, so calls recover once connectivity returns.
+          this._backendReady = false;
           this.sessionId = null;
-          this._initialized = false;
+          this._startBackendMonitor();
 
-          try {
-            await this._rpc("initialize", {
-              protocolVersion: "2025-03-26",
-              capabilities: {},
-              clientInfo: { name: "akb-mcp-client", version: "2.0.0" },
-            });
-            this._initialized = true;
-            process.stderr.write("[akb-mcp] Reconnected.\n");
-            continue;
-          } catch (reconnectErr) {
+          if (attempt < maxRetries) {
             process.stderr.write(
-              `[akb-mcp] Reconnect failed: ${reconnectErr.message}\n`
+              `[akb-mcp] backend unreachable, retrying (attempt ${attempt + 1})...\n`,
             );
+            continue;
           }
         }
         throw err;
@@ -719,7 +920,7 @@ export class AKBProxy {
     }
   }
 
-  async _rpc(method, params) {
+  async _rpc(method, params, rpcOpts = {}) {
     this.msgId++;
     const body = JSON.stringify({
       jsonrpc: "2.0",
@@ -737,7 +938,13 @@ export class AKBProxy {
       headers["mcp-session-id"] = this.sessionId;
     }
 
-    const resp = await this._http("POST", this.url.pathname, Buffer.from(body), headers);
+    const resp = await this._http(
+      "POST",
+      this.url.pathname,
+      Buffer.from(body),
+      headers,
+      { timeoutMs: rpcOpts.timeoutMs },
+    );
 
     if (resp.headers["mcp-session-id"]) {
       this.sessionId = resp.headers["mcp-session-id"];
@@ -761,6 +968,12 @@ export class AKBProxy {
 
   _write(obj) {
     process.stdout.write(JSON.stringify(obj) + "\n");
+  }
+
+  // Emit a JSON-RPC notification (no id) to the client. Used for
+  // notifications/tools/list_changed after a backend recovery.
+  _notify(method, params) {
+    this._write({ jsonrpc: "2.0", method, params: params || {} });
   }
 
   _writeError(id, code, message) {

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,10 +1,13 @@
 {
   "name": "akb-mcp",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {
     "akb-mcp": "./bin/akb-mcp.mjs"
+  },
+  "scripts": {
+    "test": "node test/contract.test.mjs && node test/reconnect.test.mjs"
   },
   "type": "module",
   "files": ["bin/", "lib/", "CHANGELOG.md"],

--- a/packages/akb-mcp-client/test/reconnect.test.mjs
+++ b/packages/akb-mcp-client/test/reconnect.test.mjs
@@ -1,0 +1,193 @@
+// Resilience contract for the proxy's connection lifecycle.
+//
+// Covers the VPN-drop failure mode: the client-visible MCP server must
+// survive backend unreachability. `initialize` is answered locally,
+// `tools/list` degrades gracefully, and a background monitor restores the
+// full toolset (via tools/list_changed) once connectivity returns — all
+// without killing the proxy process. No real network calls — backend RPCs
+// are stubbed.
+//
+// Run with: node packages/akb-mcp-client/test/reconnect.test.mjs
+
+import assert from "node:assert/strict";
+import { AKBProxy } from "../lib/proxy.mjs";
+
+let pass = 0;
+let fail = 0;
+const pending = [];
+function itAsync(name, fn) {
+  pending.push(
+    fn().then(
+      () => {
+        pass++;
+        console.log(`  ✓ ${name}`);
+      },
+      (e) => {
+        fail++;
+        console.log(`  ✗ ${name}: ${e.stack || e.message}`);
+      },
+    ),
+  );
+}
+
+const tick = (ms = 10) => new Promise((r) => setTimeout(r, ms));
+function newProxy() {
+  return new AKBProxy({ url: "http://akb.test/mcp", pat: "test-pat" });
+}
+const fileToolNames = ["akb_put_file", "akb_get_file", "akb_delete_file"];
+
+// ── initialize is answered locally, never blocking on the backend ────
+
+itAsync("initialize responds locally even when the backend is down", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {}; // don't spin a real monitor here
+  proxy._ensureBackend = async () => false; // backend unreachable
+
+  const res = await proxy._initialize(1, {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "c", version: "1" },
+  });
+
+  assert.equal(res.result.protocolVersion, "2025-06-18", "echoes client protocol version");
+  assert.equal(res.result.capabilities.tools.listChanged, true, "advertises listChanged");
+  assert.equal(res.result.serverInfo.name, "akb-mcp");
+  assert.equal(proxy._initialized, true);
+});
+
+itAsync("initialize falls back to a default protocol version when omitted", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {};
+  const res = await proxy._initialize(1, { capabilities: {} });
+  assert.match(res.result.protocolVersion, /^\d{4}-\d{2}-\d{2}$/);
+});
+
+// ── tools/list degrades to file tools when the backend is unreachable ─
+
+itAsync("tools/list serves file tools only when backend is down and nothing cached", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {};
+  proxy._ensureBackend = async () => false;
+
+  const res = await proxy._toolsList(2, {});
+  const names = res.result.tools.map((t) => t.name);
+
+  assert.deepEqual(names.sort(), [...fileToolNames].sort(), "only file tools served");
+  assert.equal(proxy._servedDegraded, true, "flags the degraded list for later re-list");
+});
+
+itAsync("tools/list serves the full decorated list from cache", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {};
+  proxy._cachedTools = {
+    tools: [
+      { name: "akb_put", inputSchema: { type: "object", properties: {} } },
+      { name: "akb_search", inputSchema: { type: "object", properties: {} } },
+    ],
+  };
+
+  const res = await proxy._toolsList(3, {});
+  const names = res.result.tools.map((t) => t.name);
+
+  for (const n of ["akb_put", "akb_search", ...fileToolNames]) {
+    assert.ok(names.includes(n), `expected ${n} in tools`);
+  }
+  const put = res.result.tools.find((t) => t.name === "akb_put");
+  assert.ok(put.inputSchema.properties.file, "file param injected into akb_put");
+  assert.equal(proxy._servedDegraded, false, "cached full list is not degraded");
+  // The cache must not be mutated by decoration.
+  assert.ok(
+    !proxy._cachedTools.tools[0].inputSchema.properties.file,
+    "cached tool schema left untouched",
+  );
+});
+
+// ── background monitor recovers the toolset after an outage ──────────
+
+itAsync("monitor emits tools/list_changed after backend recovers from a degraded list", async () => {
+  const proxy = newProxy();
+  proxy._servedDegraded = true; // client was previously handed file-tools-only
+  proxy._ensureBackend = async () => {
+    proxy._backendReady = true;
+    return true;
+  };
+  proxy._syncTools = async () => ({ tools: [] });
+  const notes = [];
+  proxy._notify = (method) => notes.push(method);
+
+  proxy._startBackendMonitor();
+  await tick();
+
+  assert.ok(notes.includes("notifications/tools/list_changed"), "list_changed pushed on recovery");
+  assert.equal(proxy._servedDegraded, false, "degraded flag cleared");
+  proxy._closed = true;
+});
+
+itAsync("monitor stays silent on recovery when the list was never degraded", async () => {
+  const proxy = newProxy();
+  proxy._servedDegraded = false;
+  proxy._ensureBackend = async () => {
+    proxy._backendReady = true;
+    return true;
+  };
+  proxy._syncTools = async () => ({ tools: [] });
+  const notes = [];
+  proxy._notify = (method) => notes.push(method);
+
+  proxy._startBackendMonitor();
+  await tick();
+
+  assert.equal(notes.length, 0, "no spurious list_changed when nothing was degraded");
+  proxy._closed = true;
+});
+
+// ── _forward never kills the process; it recovers or surfaces an error ─
+
+itAsync("_forward retries a connection error then surfaces it (process survives)", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {}; // observe restart without spinning a loop
+  let restarts = 0;
+  const origNoop = proxy._startBackendMonitor;
+  proxy._startBackendMonitor = () => {
+    restarts++;
+    origNoop();
+  };
+  proxy._backendReady = true;
+  let calls = 0;
+  proxy._rpc = async () => {
+    calls++;
+    throw new Error("ECONNRESET");
+  };
+
+  await assert.rejects(() => proxy._forward({ method: "tools/call", id: 5, params: {} }));
+  assert.equal(proxy._backendReady, false, "marks backend not-ready");
+  assert.ok(restarts >= 1, "kicks the reconnect monitor");
+  assert.ok(calls >= 3, "attempted the initial call plus retries");
+});
+
+itAsync("_forward recovers on a later attempt once the backend returns", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {};
+  proxy._backendReady = true;
+  let calls = 0;
+  proxy._rpc = async () => {
+    calls++;
+    if (calls === 1) throw new Error("socket hang up");
+    return { ok: true };
+  };
+  proxy._ensureBackend = async () => {
+    proxy._backendReady = true;
+    return true;
+  };
+
+  const res = await proxy._forward({ method: "tools/call", id: 7, params: {} });
+  assert.equal(res.result.ok, true, "second attempt succeeds");
+  assert.equal(calls, 2);
+});
+
+// ── Summary ──────────────────────────────────────────────────────────
+
+await Promise.all(pending);
+console.log("");
+console.log(`  Passed: ${pass}   Failed: ${fail}`);
+process.exit(fail > 0 ? 1 : 0);

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dnotitia/akb",
     "source": "github"
   },
-  "version": "2.0.4",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "akb-mcp",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

A long VPN/backend outage silently dropped the AKB server from a client's tool namespace for the rest of the session — `mcp__akb__*` tools stayed gone even after connectivity returned, until the session was restarted. `claude mcp list` meanwhile showed the stdio proxy healthy.

**Root cause**: `initialize` round-tripped to the backend. A stdio MCP server that fails `initialize` is dropped by the client for the whole session. The proxy *process* was alive the entire time — the bug was coupling client-visible liveness to backend reachability. Naive "infinite retry" on tool calls does not fix this (server already de-registered) and adds a hang-forever footgun.

## Change — decouple client-visible liveness from backend reachability

- **`initialize` answered locally** — echoes the client protocol version, advertises `tools.listChanged`. Server always registers, backend up or down.
- **`tools/list` degrades gracefully** — backend unreachable + nothing cached → serve local file tools only (valid partial response); backend list cached and served thereafter. Cache never mutated by decoration.
- **Background reconnect monitor** — exponential backoff (1s→30s), effectively forever while the client is connected. On recovery from a degraded list it pushes `notifications/tools/list_changed`, so the full toolset reappears **without a session restart**.
- **Tool calls never kill the proxy** — a connection error marks the backend not-ready, kicks the monitor, retries, then surfaces a normal JSON-RPC error for that one call.
- **Short connect-phase timeout** (`AKB_MCP_CONNECT_TIMEOUT_MS`, default 10s) for blackhole detection, separate from the 5-min response timeout kept for slow ops (`akb_delete_vault`).

No change to tool behavior, auth (PAT bearer), or the S3 file-transfer path. Backend `/mcp/` untouched — pure client-side proxy resilience.

## Known limitation

If the backend goes silent mid-session on an already-established keep-alive socket (no RST), the *first* in-flight tool call can wait up to the response timeout before retry/monitor kick in; subsequent calls fail fast.

## Verification

- `packages/akb-mcp-client` `npm test` → 14/14 (contract 6 + new reconnect 8).
- `node --check` clean; detect-secrets clean.
- Local `scripts/check.sh`: backend (ruff/mypy/bandit) + frontend eslint green; frontend `tsc` failed only on uninstalled local storybook deps (env, unrelated to this JS-only change) — CI runs the authoritative full check with a clean install.

## Release

Proxy versioned independently **2.0.4 → 2.1.0** (`package.json` + `server.json` + `CHANGELOG.md`). Design record under `docs/design/proposal/2026-08-05-mcp-proxy-resilient-reconnect/`. npm publish is a deliberate human gate — done from `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKNbAkEvtnS4sywxiFpDWB