### PR TITLE
test: revive the native derived-pipeline live-PG suite

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -174,6 +174,15 @@ jobs:
         # The delete path it covers is a tree diff, a row lock and a cascade
         # across three tables — mock any of it and the test stops covering the
         # thing that would leak.
+        #
+        # The native derived-pipeline file drives the real worker/grep
+        # contract against migrations 048/053/054's actual constraints
+        # (payload placement check, native_derived_heads FKs, the
+        # retry_count/next_attempt_at/delivery_outcome columns) — a mock
+        # would agree with itself instead of proving the ledger's CHECKs
+        # and triggers hold. It was absent from this list with a
+        # since-renumbered migration tuple, so it silently self-skipped in
+        # both jobs.
         run: >
           pytest
           tests/test_pgvector_ext_bootstrap_e2e.py
@@ -183,6 +192,7 @@ jobs:
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
           tests/concurrency/test_native_ledger_b_core.py
+          tests/concurrency/test_native_derived_pipeline.py
           tests/test_m1_file_measurement_pg.py
           tests/test_native_revision_m1_payload_placement_migration.py
           tests/concurrency/test_invariants_unit.py

--- a/backend/tests/concurrency/test_native_derived_pipeline.py
+++ b/backend/tests/concurrency/test_native_derived_pipeline.py
@@ -49,14 +49,14 @@ async def _fresh_database():
     pool = None
     try:
         await conn.execute((_BACKEND / "app" / "db" / "init.sql").read_text())
-        for number in (5, 6, 48, 49, 50):
+        for number in (5, 6, 48, 53, 54):
             path = next((_BACKEND / "app" / "db" / "migrations").glob(f"{number:03d}_*.py"))
             spec = importlib.util.spec_from_file_location(f"native_derived_{number}", path)
             assert spec is not None and spec.loader is not None
             migration = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(migration)
             await migration.migrate(conn=conn)
-            if number == 50:
+            if number == 54:
                 await migration.migrate(conn=conn)  # startup retry is idempotent
         await conn.close()
         pool = await asyncpg.create_pool(dsn, min_size=1, max_size=8)


### PR DESCRIPTION
The only integration coverage for the native derived consumer (C3 worker semantics, the text-file direct-grep delivery, and the live-PG grep ACL/collection boundary) has been silently dead: `tests/concurrency/test_native_derived_pipeline.py` still loaded migrations `(5, 6, 48, 49, 50)` from before the renumbering that made 049/050 `external_git_quarantine`/`drop_todos` and moved the native ones to 053/054. Against a real PostgreSQL every test in the file errors in the fixture; without one it self-skips — and the file was absent from the live-PG CI list, so the DB-free job green-washed it.

- Fix the tuple to `(5, 6, 48, 53, 54)` (055/056/057 verified unnecessary: the file touches none of the tables/columns they add, and 057 no-ops outside a measurement-named database).
- Keep the startup-retry idempotency check on its original target under its new number (old 050 = new 054), rather than relocating it onto 048, whose re-run `test_native_ledger_b_core.py` already covers.
- Add the file to the `pgvector-e2e` job so it can never die silently again.

Observed against a disposable postgres:16, twice (implementation and independent verification): the revived file 7 passed; `test_native_ledger_b_core.py` 54 passed; `test_m1_file_measurement_pg.py` 21 passed; combined 82 passed. Fail-closed under `REQUIRE_REAL_PG=1` with an unreachable DSN confirmed (7 failed, not skipped); self-skip without it confirmed (7 skipped).

Part of the P1 (additive core proof) preparation series; found as risk R1 in the P1 gap analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcTyzcrzMgCN7pxArJZqk