### PR TITLE
feat(native): expose the C5 failpoint seam at both composition roots

### DIFF
--- a/backend/app/services/m1_native_text_file_bridge.py
+++ b/backend/app/services/m1_native_text_file_bridge.py
@@ -7,11 +7,20 @@ authorities after a failure.  ``_BoundPool`` adapts the existing native service
 and PostgreSQL BodyStore to a caller-owned connection; their nested
 transactions become asyncpg savepoints and the outer File transaction remains
 the only commit boundary.
+
+Because the confirm is a *composite* transaction, this bridge is also the only
+place a C5 failpoint can be injected where the risk actually lives.  A failure
+raised inside the nested ledger publish must unwind the savepoint *and* the
+outer ``vault_files`` transaction, leaving no public File row, no ledger rows
+and no orphan visible state.  ``install_m1_native_text_file_bridge`` therefore
+accepts the same deterministic test-only hook the native service documents;
+production installation leaves it unset.
 """
 
 from __future__ import annotations
 
 import uuid
+from functools import partial
 from typing import Any, cast
 
 import asyncpg
@@ -27,7 +36,7 @@ from app.services.m1_file_measurement import (
     register_native_text_file_services,
 )
 from app.services.m1_pg_body_store import M1PgBodyStore
-from app.services.native_revision_service import NativeRevisionService
+from app.services.native_revision_service import Failpoint, NativeRevisionService
 
 
 _MUTATION_NAMESPACE = uuid.UUID("8d881f1f-72a0-4bd6-9c06-f02a5cc19c33")
@@ -54,7 +63,10 @@ class _BoundPool:
         return _BoundAcquire(self.conn)
 
 
-def _service_on(conn: asyncpg.Connection) -> NativeRevisionService:
+def _service_on(
+    conn: asyncpg.Connection,
+    failpoint: Failpoint | None = None,
+) -> NativeRevisionService:
     # The composed services only call Pool.acquire(); every call must resolve
     # to the transaction-owning connection above.  The casts are limited to
     # this measurement-only adapter instead of weakening production types.
@@ -63,6 +75,7 @@ def _service_on(conn: asyncpg.Connection) -> NativeRevisionService:
         pool,
         repository=NativeRevisionRepository(pool),
         payload_store=M1PgBodyStore(pool),
+        failpoint=failpoint,
     )
 
 
@@ -73,10 +86,12 @@ def _mutation_id(kind: str, *parts: object) -> uuid.UUID:
 async def _publish(
     conn: object,
     request: NativeTextPublishRequest,
+    *,
+    failpoint: Failpoint | None = None,
 ) -> NativeTextPublication:
     if not isinstance(conn, asyncpg.Connection):
         raise AKBError("native text File publisher requires a PostgreSQL transaction", status_code=503)
-    result = await _service_on(conn).create_text(
+    result = await _service_on(conn, failpoint).create_text(
         namespace_id=request.vault_id,
         surface="file",
         path=request.logical_path,
@@ -125,10 +140,15 @@ async def _open(
     )
 
 
-async def _delete(conn: object, request: NativeTextDeleteRequest) -> None:
+async def _delete(
+    conn: object,
+    request: NativeTextDeleteRequest,
+    *,
+    failpoint: Failpoint | None = None,
+) -> None:
     if not isinstance(conn, asyncpg.Connection):
         raise AKBError("native text File deleter requires a PostgreSQL transaction", status_code=503)
-    result = await _service_on(conn).delete_resource(
+    result = await _service_on(conn, failpoint).delete_resource(
         namespace_id=request.vault_id,
         surface="file",
         path=request.logical_path,
@@ -148,10 +168,18 @@ async def _delete(conn: object, request: NativeTextDeleteRequest) -> None:
         raise AKBError("native text File delete returned the wrong lineage", status_code=502)
 
 
-def install_m1_native_text_file_bridge() -> None:
-    """Install the guarded process callbacks after migrations have completed."""
+def install_m1_native_text_file_bridge(*, failpoint: Failpoint | None = None) -> None:
+    """Install the guarded process callbacks after migrations have completed.
+
+    ``failpoint`` is the native service's deterministic test-only hook; it is
+    bound onto the two callbacks that publish authority inside the caller's
+    File transaction.  Production installation must leave it unset, and unset
+    it composes the same ``NativeRevisionService`` as before.  ``_open`` is
+    deliberately excluded: it reads on its own pool connection outside any
+    File transaction and crosses no authority boundary.
+    """
     register_native_text_file_services(
-        publisher=_publish,
+        publisher=partial(_publish, failpoint=failpoint),
         opener=_open,
-        deleter=_delete,
+        deleter=partial(_delete, failpoint=failpoint),
     )

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -37,7 +37,11 @@ from app.services.document_service import (
     newest_public_slug,
     validate_vault_name,
 )
-from app.services.native_revision_service import NativeRevisionService, NativeRevisionSnapshot
+from app.services.native_revision_service import (
+    Failpoint,
+    NativeRevisionService,
+    NativeRevisionSnapshot,
+)
 from app.services.resource_hash import HASH_ALGORITHM
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import doc_uri
@@ -65,10 +69,20 @@ class NativeRevisionUnsupportedSurfaceError(AKBError):
 class NativeDocumentService(DocumentService):
     """Document lifecycle adapter preserving existing request/response models."""
 
-    def __init__(self, *, pool: asyncpg.Pool | None = None):
+    def __init__(
+        self,
+        *,
+        pool: asyncpg.Pool | None = None,
+        failpoint: Failpoint | None = None,
+    ):
         # Deliberately do not call DocumentService.__init__: that would create
         # the legacy Git adapter before a request is even served.
         self._injected_pool = pool
+        # ``failpoint`` carries the native service's deterministic test-only
+        # hook down to the substrate this facade composes; production
+        # composition must leave it unset.  Left unset, ``_native`` builds
+        # exactly the service it built before this seam existed.
+        self._failpoint = failpoint
 
     async def _pool(self) -> asyncpg.Pool:
         return self._injected_pool or await get_pool()
@@ -82,7 +96,7 @@ class NativeDocumentService(DocumentService):
         return vault_id
 
     async def _native(self) -> NativeRevisionService:
-        return NativeRevisionService(await self._pool())
+        return NativeRevisionService(await self._pool(), failpoint=self._failpoint)
 
     @staticmethod
     async def _yield_after_head_race(race_count: int) -> None:

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -14,7 +14,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import Final, Protocol
 
 import asyncpg
 
@@ -28,6 +28,30 @@ from app.services.m1_reference_payload_store import (
 
 
 Failpoint = Callable[[str], Awaitable[None] | None]
+
+FAILPOINT_BOUNDARIES: Final[tuple[str, ...]] = (
+    "payload.before_prepare",
+    "payload.after_verified",
+    "payload.after_prepare_before_tx",
+    "authority.after_resource",
+    "authority.after_manifest",
+    "authority.after_revision",
+    "authority.after_head",
+    "authority.after_path",
+    "authority.after_alias",
+    "authority.after_activity",
+    "authority.after_invalidation",
+    "authority.before_commit",
+    "authority.after_commit_before_response",
+)
+"""Every boundary name ``_hit`` dispatches, in publication order.
+
+A failpoint is a callable that receives *every* boundary and decides for
+itself which one to act on, so a misspelled name simply never fires and the
+injection silently measures nothing.  Injection sites assert membership in
+this tuple instead; ``_hit`` rejects a name that is missing from it so the
+registry cannot drift behind the service.
+"""
 
 
 class TextPayloadStore(Protocol):
@@ -110,6 +134,8 @@ class NativeRevisionService:
     async def _hit(self, name: str) -> None:
         if self.failpoint is None:
             return
+        if name not in FAILPOINT_BOUNDARIES:
+            raise ValueError(f"Native failpoint boundary is not registered: {name}")
         value = self.failpoint(name)
         if inspect.isawaitable(value):
             await value

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -28,7 +28,10 @@ from app.services.native_document_service import (
 )
 from app.services.native_derived_worker import NativeDerivedWorker
 from app.services.native_revision_backend import NativeRevisionBackend
-from app.services.native_revision_service import NativeRevisionService
+from app.services.native_revision_service import (
+    FAILPOINT_BOUNDARIES,
+    NativeRevisionService,
+)
 
 
 pytestmark = pytest.mark.asyncio
@@ -1998,6 +2001,130 @@ async def test_committed_response_lost_retry_returns_same_revision_once():
             changed = _create_args(vault_id, mutation_id=mutation_id)
             changed["payload"] = "different retry"
             await service.create_text(**changed)
+
+
+async def test_document_facade_failpoint_seam_reaches_put_and_update_boundaries():
+    """C5 must be injectable through the Document facade, not only under it.
+
+    The facade builds its own ``NativeRevisionService`` per call, so before
+    the constructor seam existed a C5 case had to overwrite the private
+    ``_native`` coroutine to reach a boundary.  Assert the exact dispatch
+    order for both mutations so a boundary that stops firing is a failure
+    rather than a silently shorter list.
+    """
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        seen: list[str] = []
+
+        async def record(name: str) -> None:
+            seen.append(name)
+
+        documents = NativeDocumentService(pool=pool, failpoint=record)
+        created = await documents.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="seam",
+                title="Seam",
+                content="created",
+            ),
+            agent_id="seam",
+        )
+        assert seen == [
+            "payload.before_prepare",
+            "payload.after_verified",
+            "payload.after_prepare_before_tx",
+            "authority.after_resource",
+            "authority.after_manifest",
+            "authority.after_revision",
+            "authority.after_head",
+            "authority.after_path",
+            "authority.after_alias",
+            "authority.after_activity",
+            "authority.after_invalidation",
+            "authority.before_commit",
+            "authority.after_commit_before_response",
+        ]
+
+        seen.clear()
+        updated = await documents.update(
+            vault,
+            created.path,
+            DocumentUpdateRequest(content="second"),
+            agent_id="seam",
+        )
+        assert updated.previous_commit == created.commit_hash
+        assert seen == [
+            "payload.before_prepare",
+            "payload.after_verified",
+            "payload.after_prepare_before_tx",
+            "authority.after_manifest",
+            "authority.after_revision",
+            "authority.after_head",
+            "authority.after_path",
+            "authority.after_activity",
+            "authority.after_invalidation",
+            "authority.before_commit",
+            "authority.after_commit_before_response",
+        ]
+        assert set(seen) <= set(FAILPOINT_BOUNDARIES)
+        assert await _authority_counts(pool) == {
+            "native_resources": 1,
+            "native_revisions": 2,
+            "native_payload_manifests": 2,
+            "native_revision_activity": 2,
+            "native_invalidation_intents": 2,
+        }
+
+
+@pytest.mark.parametrize(
+    ("boundary", "error"),
+    [
+        ("authority.after_revision", RuntimeError("injected put failure")),
+        # The facade retries a slug-less put only on the path-collision
+        # ConflictError it raises itself.  A ConflictError from anywhere else
+        # must surface, not spin the loop forever against a failpoint that
+        # fires again on every attempt.
+        ("authority.before_commit", ConflictError("Native Revision conflict: injected")),
+    ],
+)
+async def test_document_facade_injected_failure_surfaces_without_a_retry_loop_hang(
+    boundary: str, error: Exception,
+):
+    assert boundary in FAILPOINT_BOUNDARIES
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+
+        async def failpoint(name: str) -> None:
+            if name == boundary:
+                raise error
+
+        documents = NativeDocumentService(pool=pool, failpoint=failpoint)
+        with pytest.raises(type(error), match="injected"):
+            await asyncio.wait_for(
+                documents.put(
+                    # No slug: this is the arm with the resolve-and-retry loop.
+                    DocumentPutRequest(
+                        vault=vault,
+                        collection="notes",
+                        title="Injected",
+                        content="must not be published",
+                    ),
+                    agent_id="seam",
+                ),
+                timeout=10,
+            )
+
+        assert await _authority_counts(pool) == {
+            "native_resources": 0,
+            "native_revisions": 0,
+            "native_payload_manifests": 0,
+            "native_revision_activity": 0,
+            "native_invalidation_intents": 0,
+        }
 
 
 async def test_create_idempotency_fingerprint_includes_requested_resource_identity():

--- a/backend/tests/test_m1_file_measurement_pg.py
+++ b/backend/tests/test_m1_file_measurement_pg.py
@@ -23,7 +23,10 @@ from app.services.m1_native_grep_service import M1NativeGrepService
 from app.services.m1_pg_body_store import M1PgBodyStore
 from app.services.m1_reference_payload_store import M1ReferencePayloadStore
 from app.services.native_derived_worker import NativeDerivedWorker
-from app.services.native_revision_service import NativeRevisionService
+from app.services.native_revision_service import (
+    FAILPOINT_BOUNDARIES,
+    NativeRevisionService,
+)
 
 
 _DSN = os.environ.get("AKB_M1_FILE_TEST_DSN")
@@ -1223,3 +1226,246 @@ async def test_recursive_collection_delete_rolls_back_native_tombstone_on_later_
         "lifecycle": "live",
         "head_revision_id": create_revision_id,
     }
+
+
+_NATIVE_AUTHORITY_TABLES = (
+    "native_resources",
+    "native_payload_manifests",
+    "native_revisions",
+    "native_revision_activity",
+    "native_invalidation_intents",
+)
+
+
+async def _native_authority_counts(pool, resource_id: uuid.UUID) -> dict[str, int]:
+    async with pool.acquire() as conn:
+        return {
+            table: await conn.fetchval(
+                f"SELECT count(*) FROM {table} WHERE resource_id = $1", resource_id,
+            )
+            for table in _NATIVE_AUTHORITY_TABLES
+        }
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        # Prepared *inside* the caller's File transaction, unlike the
+        # standalone-pool arm where the verified body survives a rollback.
+        "payload.after_prepare_before_tx",
+        "authority.after_resource",
+        "authority.after_manifest",
+        "authority.after_revision",
+        "authority.after_head",
+        "authority.after_path",
+        "authority.after_alias",
+        "authority.after_activity",
+        "authority.after_invalidation",
+        "authority.before_commit",
+    ],
+)
+@pytest.mark.asyncio
+async def test_composite_file_confirm_failpoint_leaves_no_partial_authority_and_retries_once(
+    context, monkeypatch, boundary,
+):
+    """C5 at the riskiest boundary AKB has: a composite File confirm.
+
+    ``MeasurementFileService.confirm_upload`` owns the outer ``vault_files``
+    transaction and the bridged ledger publish runs inside it as a savepoint.
+    A failure injected into the nested publish must therefore unwind *both*:
+    no public File row, no rows in any of the five native authority tables,
+    no path alias and no verified body.  The transfer intent is the one thing
+    that must survive, because it is what makes the retry possible — and the
+    clean retry must land exactly one activity event and one durable
+    invalidation intent, not two.
+    """
+    from app.services import m1_native_text_file_bridge as bridge
+
+    pool, vault_id, _denied, vault_name = context
+    assert boundary in FAILPOINT_BOUNDARIES
+
+    async def test_pool():
+        return pool
+
+    monkeypatch.setattr(bridge, "get_pool", test_pool)
+
+    fired: list[str] = []
+
+    async def failpoint(name: str) -> None:
+        fired.append(name)
+        if name == boundary:
+            raise RuntimeError(f"injected:{name}")
+
+    bridge.install_m1_native_text_file_bridge(failpoint=failpoint)
+
+    service = m1.MeasurementFileService()
+    data = b"composite confirm body\nsecond line\n"
+    digest = hashlib.sha256(data).hexdigest()
+    initiated = await service.initiate_upload(
+        vault_name=vault_name,
+        vault_id=vault_id,
+        collection="src",
+        filename="composite.py",
+        actor_id="c5-test",
+        mime_type="text/x-python",
+        description="composite failpoint",
+        content_hash=digest,
+    )
+    file_id = uuid.UUID(initiated["file_id"])
+    await service.transfer(_token(initiated["upload_url"]), method="PUT", body=data)
+
+    with pytest.raises(RuntimeError, match=f"injected:{boundary}"):
+        await service.confirm_upload(vault_id, initiated["file_id"], content_hash=digest)
+
+    assert fired[-1] == boundary
+    assert await _native_authority_counts(pool, file_id) == dict.fromkeys(
+        _NATIVE_AUTHORITY_TABLES, 0,
+    )
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_files WHERE id = $1", file_id,
+        ) == 0
+        assert await conn.fetchval(
+            "SELECT count(*) FROM native_resource_path_aliases WHERE namespace_id = $1",
+            vault_id,
+        ) == 0
+        assert await conn.fetchval(
+            "SELECT count(*) FROM m1_reference_payloads WHERE digest = $1", digest,
+        ) == 0
+        # The only durable residue is the transfer intent the retry needs.
+        assert await conn.fetchval(
+            "SELECT count(*) FROM m1_file_transfer_intents WHERE file_id = $1", file_id,
+        ) == 1
+    assert await service.list_files(vault_id, vault_name, None, 50) == []
+    with pytest.raises(NotFoundError):
+        await service.get_download_url(vault_id, initiated["file_id"])
+
+    # Reinstall production-shaped (no failpoint) and retry the same confirm.
+    bridge.install_m1_native_text_file_bridge()
+    confirmed = await service.confirm_upload(
+        vault_id, initiated["file_id"], content_hash=digest,
+    )
+    assert confirmed["file_id"] == initiated["file_id"]
+    assert confirmed["uri"] == initiated["uri"]
+    assert confirmed["storage_driver"] == "native_text"
+    assert confirmed["native_resource_id"] == initiated["file_id"]
+    assert confirmed["content_hash"] == digest
+
+    assert await _native_authority_counts(pool, file_id) == dict.fromkeys(
+        _NATIVE_AUTHORITY_TABLES, 1,
+    )
+    async with pool.acquire() as conn:
+        activity = await conn.fetchrow(
+            "SELECT action, revision_id, actor FROM native_revision_activity WHERE resource_id = $1",
+            file_id,
+        )
+        intent = await conn.fetchrow(
+            """
+            SELECT reason, revision_id, claimed_at, completed_at, last_error
+              FROM native_invalidation_intents
+             WHERE resource_id = $1
+            """,
+            file_id,
+        )
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_files WHERE id = $1", file_id,
+        ) == 1
+        assert await conn.fetchval(
+            "SELECT count(*) FROM m1_file_transfer_intents WHERE file_id = $1", file_id,
+        ) == 0
+    assert dict(activity) == {
+        "action": "create",
+        "revision_id": confirmed["native_revision_id"],
+        "actor": "c5-test",
+    }
+    # Durable means still owed: the retry left a pending intent for the
+    # invalidation worker, not a completed or already-claimed one.
+    assert dict(intent) == {
+        "reason": "create",
+        "revision_id": confirmed["native_revision_id"],
+        "claimed_at": None,
+        "completed_at": None,
+        "last_error": None,
+    }
+
+    download = await service.get_download_url(vault_id, initiated["file_id"])
+    assert await service.transfer(_token(download["download_url"]), method="GET") == data
+    assert [item["file_id"] for item in await service.list_files(vault_id, vault_name, None, 50)] == [
+        initiated["file_id"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_composite_confirm_discards_a_ledger_publish_that_already_reported_commit(
+    context, monkeypatch,
+):
+    """In a composite transaction the ledger's own "commit" is not one.
+
+    ``authority.after_commit_before_response`` fires once the nested publish
+    has released its savepoint.  On the standalone pool that boundary models
+    a lost response over a *durable* Revision, and the retry replays it
+    idempotently.  Bridged into a File confirm there is no such Revision: the
+    outer ``vault_files`` transaction is still the only commit boundary, so
+    the whole publication is discarded.  What this test asserts is exactly
+    that non-durability — zero rows after the failure, one row after the
+    retry.  It does *not* assert that the retry took the fresh-lineage path
+    rather than the replay path: the aborted revision id never reached the
+    database, so the exactly-one counts cannot tell the two apart, and
+    fresh-lineage is an inference from the rollback rather than an observed
+    fact.  Pinning the non-durability keeps the boundary's name from being
+    read as a durability claim on this path.
+    """
+    from app.services import m1_native_text_file_bridge as bridge
+
+    pool, vault_id, _denied, vault_name = context
+
+    async def test_pool():
+        return pool
+
+    monkeypatch.setattr(bridge, "get_pool", test_pool)
+
+    fired = False
+
+    async def failpoint(name: str) -> None:
+        nonlocal fired
+        if name == "authority.after_commit_before_response" and not fired:
+            fired = True
+            raise RuntimeError("injected:response-lost")
+
+    bridge.install_m1_native_text_file_bridge(failpoint=failpoint)
+
+    service = m1.MeasurementFileService()
+    data = b"savepoint release is not a commit\n"
+    digest = hashlib.sha256(data).hexdigest()
+    initiated = await service.initiate_upload(
+        vault_name=vault_name,
+        vault_id=vault_id,
+        collection="src",
+        filename="after_commit.py",
+        actor_id="c5-test",
+        mime_type="text/x-python",
+        description="composite after-commit",
+        content_hash=digest,
+    )
+    file_id = uuid.UUID(initiated["file_id"])
+    await service.transfer(_token(initiated["upload_url"]), method="PUT", body=data)
+
+    with pytest.raises(RuntimeError, match="injected:response-lost"):
+        await service.confirm_upload(vault_id, initiated["file_id"], content_hash=digest)
+
+    assert fired is True
+    assert await _native_authority_counts(pool, file_id) == dict.fromkeys(
+        _NATIVE_AUTHORITY_TABLES, 0,
+    )
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT count(*) FROM vault_files WHERE id = $1", file_id,
+        ) == 0
+
+    confirmed = await service.confirm_upload(
+        vault_id, initiated["file_id"], content_hash=digest,
+    )
+    assert confirmed["storage_driver"] == "native_text"
+    assert await _native_authority_counts(pool, file_id) == dict.fromkeys(
+        _NATIVE_AUTHORITY_TABLES, 1,
+    )

--- a/backend/tests/test_native_failpoint_seam_unit.py
+++ b/backend/tests/test_native_failpoint_seam_unit.py
@@ -1,0 +1,167 @@
+"""Unit contract for the C5 failpoint injection seam at both composition roots.
+
+Conformance case C5 injects a deterministic failure at a named transaction
+boundary and then proves the mutation left no partial authority.  The
+boundaries live inside ``NativeRevisionService``, but a C5 test never builds
+that service directly in production shape — the two roots above it do.  This
+file pins the seam itself, with no database:
+
+* the registry of legal boundary names is complete and self-enforcing, so a
+  typo'd injection fails loudly instead of silently never firing;
+* ``NativeDocumentService`` and the M1 text-File bridge each thread an
+  injected failpoint down to the service they compose;
+* with nothing injected, both roots compose exactly what they composed
+  before the seam existed.
+
+The behavioural halves — a boundary actually firing mid-mutation, and the
+composite File-confirm rollback — need real PostgreSQL and live in
+``tests/concurrency/test_native_ledger_b_core.py`` and
+``tests/test_m1_file_measurement_pg.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services import m1_file_measurement as m1
+from app.services import m1_native_text_file_bridge as bridge
+from app.services import native_revision_service as native
+from app.services.native_document_service import NativeDocumentService
+from app.services.native_revision_service import (
+    FAILPOINT_BOUNDARIES,
+    NativeRevisionService,
+)
+
+
+_SERVICE_SOURCE = Path(native.__file__).read_text()
+_ADAPTER_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "native_revision_m1_adapter.py"
+)
+
+
+def _load_adapter():
+    """Load the M1 harness adapter, which is a script rather than a package."""
+    spec = importlib.util.spec_from_file_location("native_revision_m1_adapter", _ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_bridge_registration():
+    m1.reset_native_text_file_services_for_tests()
+    yield
+    m1.reset_native_text_file_services_for_tests()
+
+
+def test_registry_is_frozen_unique_and_covers_every_dispatched_boundary():
+    dispatched = set(re.findall(r'_hit\("([^"]+)"\)', _SERVICE_SOURCE))
+    assert dispatched, "no _hit call sites found; the scan regex has rotted"
+    assert isinstance(FAILPOINT_BOUNDARIES, tuple)
+    assert len(set(FAILPOINT_BOUNDARIES)) == len(FAILPOINT_BOUNDARIES)
+    # Both directions matter.  A dispatched-but-unregistered name makes the
+    # registry a lie; a registered-but-undispatched name is a boundary a C5
+    # case would wait on forever.
+    assert set(FAILPOINT_BOUNDARIES) == dispatched
+
+
+def test_m1_harness_adapter_only_asks_for_registered_boundaries():
+    """The C5 harness names boundaries by hand; hold it to the registry.
+
+    ``_hit`` raises on an unregistered name, but only once a run reaches that
+    boundary — a mistyped entry in the adapter's own map would surface as a
+    late measurement failure on a live database.  Compare the two statically
+    instead.
+    """
+    adapter = _load_adapter()
+    requested = set(adapter.ACTUAL_FAILPOINTS.values())
+    assert requested, "the adapter's boundary map is empty; this assertion is vacuous"
+    assert requested <= set(FAILPOINT_BOUNDARIES)
+    # Its own key list must stay in step with the map it indexes.
+    assert set(adapter.PRECOMMIT_BOUNDARIES) == set(adapter.ACTUAL_FAILPOINTS)
+
+
+async def test_hit_rejects_an_unregistered_boundary_only_when_injected():
+    seen: list[str] = []
+
+    unset = NativeRevisionService(object(), repository=object(), payload_store=object())  # type: ignore[arg-type]
+    # Production leaves the hook unset, so the guard must cost nothing and
+    # change nothing on that path.
+    assert await unset._hit("authority.after_typo") is None
+
+    injected = NativeRevisionService(
+        object(),  # type: ignore[arg-type]
+        repository=object(),  # type: ignore[arg-type]
+        payload_store=object(),  # type: ignore[arg-type]
+        failpoint=seen.append,
+    )
+    with pytest.raises(ValueError, match="not registered: authority.after_typo"):
+        await injected._hit("authority.after_typo")
+    assert seen == []
+
+
+@pytest.mark.parametrize("boundary", FAILPOINT_BOUNDARIES)
+async def test_hit_dispatches_sync_and_async_failpoints_for_every_boundary(boundary: str):
+    sync_seen: list[str] = []
+    async_seen: list[str] = []
+
+    async def async_failpoint(name: str) -> None:
+        async_seen.append(name)
+
+    for failpoint, seen in ((sync_seen.append, sync_seen), (async_failpoint, async_seen)):
+        service = NativeRevisionService(
+            object(),  # type: ignore[arg-type]
+            repository=object(),  # type: ignore[arg-type]
+            payload_store=object(),  # type: ignore[arg-type]
+            failpoint=failpoint,
+        )
+        await service._hit(boundary)
+        assert seen == [boundary]
+
+
+async def test_document_facade_threads_the_failpoint_into_the_service_it_builds():
+    pool_marker = object()
+
+    async def failpoint(name: str) -> None:  # pragma: no cover - never invoked here
+        raise AssertionError(name)
+
+    injected = await NativeDocumentService(pool=pool_marker, failpoint=failpoint)._native()  # type: ignore[arg-type]
+    assert injected.failpoint is failpoint
+    assert injected.pool is pool_marker
+
+    default = await NativeDocumentService(pool=pool_marker)._native()  # type: ignore[arg-type]
+    assert default.failpoint is None
+
+
+async def test_text_file_bridge_threads_the_failpoint_into_the_bound_service():
+    conn_marker = object()
+
+    async def failpoint(name: str) -> None:  # pragma: no cover - never invoked here
+        raise AssertionError(name)
+
+    injected = bridge._service_on(conn_marker, failpoint)  # type: ignore[arg-type]
+    assert injected.failpoint is failpoint
+    assert bridge._service_on(conn_marker).failpoint is None  # type: ignore[arg-type]
+
+
+def test_installing_the_bridge_binds_the_failpoint_to_both_authority_callbacks():
+    async def failpoint(name: str) -> None:  # pragma: no cover - never invoked here
+        raise AssertionError(name)
+
+    bridge.install_m1_native_text_file_bridge(failpoint=failpoint)
+    assert m1._native_text_publisher.func is bridge._publish  # type: ignore[union-attr]
+    assert m1._native_text_publisher.keywords == {"failpoint": failpoint}  # type: ignore[union-attr]
+    assert m1._native_text_deleter.func is bridge._delete  # type: ignore[union-attr]
+    assert m1._native_text_deleter.keywords == {"failpoint": failpoint}  # type: ignore[union-attr]
+    # The opener reads on its own pool connection outside any File
+    # transaction; it crosses no authority boundary, so it stays unbound.
+    assert m1._native_text_opener is bridge._open
+
+    bridge.install_m1_native_text_file_bridge()
+    assert m1._native_text_publisher.keywords == {"failpoint": None}  # type: ignore[union-attr]
+    assert m1._native_text_deleter.keywords == {"failpoint": None}  # type: ignore[union-attr]


### PR DESCRIPTION
Conformance case C5 must prove that a failure at any authority boundary leaves no partial state. The failpoint machinery exists in `NativeRevisionService`, but neither composition root above it could inject one — so the single riskiest claim, the composite File confirm (an outer `vault_files` transaction with the ledger publish nested as a savepoint), was unprovable.

- Optional keyword-only `failpoint=None` threaded at both roots (`NativeDocumentService`, `install_m1_native_text_file_bridge` via install-time partial binding); unset, both build byte-identical services. `_open` deliberately unbound — it reads outside any File transaction.
- `FAILPOINT_BOUNDARIES` frozen registry (13 names) + `_hit` rejection of unknown names when a hook is installed; a DB-free test source-scans the dispatch sites and asserts set equality both ways, and a second one asserts the M1 adapter only asks for registered names — a typo'd boundary now fails at collection time instead of as a late live-measurement failure.
- The composite proof: at ten boundaries from `payload.after_prepare_before_tx` through `authority.before_commit`, an injected failure inside the bridged ledger publish leaves zero `vault_files` rows, zero rows in all five native authority tables, zero aliases and zero verified bodies — the transfer intent is the only residue, which is what makes the clean retry possible; that retry lands exactly one activity and one durable invalidation intent.

Two recorded observations for the C5/C8 fixtures: the prepared body does not survive a composite rollback (re-prepared on retry — a different cost model than the standalone measurement), and `authority.after_commit_before_response` on the bridged path is a savepoint release, not a commit — its test pins non-durability, with fresh-lineage-vs-replay stated as inference.

Implemented and independently verified on disposable PostgreSQL: new unit file 19 passed; `test_native_ledger_b_core.py` 57 (was 54); `test_m1_file_measurement_pg.py` 32 (was 21); DB-free gate 1569 passed / 0 failed; ruff and mypy clean. Part of the P1 preparation series (risk R4 in the gap analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcTyzcrzMgCN7pxArJZqk
