### PR TITLE
feat(native): place facade document bodies on the PG BodyStore

### DIFF
--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -689,7 +689,10 @@ class NativeRevisionRepository:
                 """
                 SELECT rs.resource_id, rs.current_path AS path,
                        rs.head_revision_id AS revision_id, rs.updated_at,
-                       v.name AS vault_name, p.canonical_bytes
+                       v.name AS vault_name,
+                       pm.digest, pm.byte_size, pm.encoding,
+                       pm.selected_placement, pm.verification_profile,
+                       p.canonical_bytes
                   FROM native_resources rs
                   JOIN vaults v ON v.id = rs.namespace_id
                   JOIN native_revisions rv

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -37,6 +37,7 @@ from app.services.document_service import (
     newest_public_slug,
     validate_vault_name,
 )
+from app.services.m1_pg_body_store import M1PgBodyStore
 from app.services.native_revision_service import (
     Failpoint,
     NativeRevisionService,
@@ -96,7 +97,30 @@ class NativeDocumentService(DocumentService):
         return vault_id
 
     async def _native(self) -> NativeRevisionService:
-        return NativeRevisionService(await self._pool(), failpoint=self._failpoint)
+        """Compose the substrate on the frozen P1 searchable-body placement.
+
+        This method is the composition root for every Document written through
+        the public facade, so it is where P1 selects ``pg-bodystore-v1`` — the
+        same placement ``m1_native_text_file_bridge`` already injects for
+        native text Files. Documents and Files therefore land on one body
+        store instead of two.
+
+        The injection deliberately does **not** move into
+        ``NativeRevisionService``'s own default. The M1 measurement adapters
+        (``backend/scripts/native_revision_m1_adapter.py`` and its siblings)
+        construct ``NativeRevisionService(pool)`` directly and must keep
+        reproducing the historical ``m1-reference-payload-v1`` behaviour their
+        recorded runs were measured against; changing the default would
+        silently re-label every replay of an already-published measurement.
+
+        Historical Revisions keep the placement recorded in their immutable
+        manifest, so a namespace is mixed by design during the transition.
+        Readers dispatch on ``selected_placement`` rather than assuming one.
+        """
+        pool = await self._pool()
+        return NativeRevisionService(
+            pool, payload_store=M1PgBodyStore(pool), failpoint=self._failpoint
+        )
 
     @staticmethod
     async def _yield_after_head_race(race_count: int) -> None:

--- a/backend/app/services/native_revision_backend.py
+++ b/backend/app/services/native_revision_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import difflib
 import uuid
 from datetime import UTC, datetime
@@ -13,8 +14,11 @@ from app.db.postgres import get_pool
 from app.exceptions import NotFoundError
 from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.document_service import _parse_markdown
-from app.services.m1_reference_payload_store import M1ReferencePayloadStore
 from app.services.native_document_service import NativeDocumentService
+from app.services.native_payload_verification import (
+    payload_store_for_placement,
+    verify_native_head_body,
+)
 from app.services.native_revision_service import NativeRevisionService
 
 
@@ -112,10 +116,24 @@ class NativeRevisionBackend:
             vault=vault,
             limit=limit,
         )
+        return await asyncio.to_thread(self._verified_changes, rows)
+
+    @staticmethod
+    def _verified_changes(rows: list[dict]) -> list[dict[str, Any]]:
+        """Bind every listed body to its manifest before reading a title from it.
+
+        This list used to decode ``canonical_bytes`` with no verification at
+        all, which trusted the payload table more than every other native read
+        path (grep, search, and the derived worker all verify). It also could
+        not survive P1's mixed corpus, because a title has to be parsed out of
+        bodies stored under either placement. Verification is fail-closed and
+        runs off the event loop: SHA-256 over the whole listed corpus is not
+        request-thread work.
+        """
         changes: list[dict[str, Any]] = []
         for row in rows:
-            raw = bytes(row["canonical_bytes"]).decode("utf-8")
-            metadata, _ = _parse_markdown(raw)
+            canonical = verify_native_head_body(row)
+            metadata, _ = _parse_markdown(canonical.decode("utf-8", errors="strict"))
             changes.append(
                 {
                     "doc_id": str(row["resource_id"]),
@@ -148,10 +166,19 @@ class NativeRevisionBackend:
         return vault_id, resource
 
     async def _revision_bytes(self, row: dict) -> bytes | None:
+        """Open one historical Revision body through its own placement.
+
+        ``selected_placement`` is an immutable per-Revision manifest fact. A
+        document created before P1 and replaced after it has a
+        ``m1-reference-payload-v1`` parent and a ``pg-bodystore-v1`` child, so
+        hardcoding either adapter makes native diff fail closed on one side of
+        the pair.
+        """
         locator = row.get("private_locator")
         if locator is None:
             return None
-        return await M1ReferencePayloadStore(await self._pool()).open_verified(locator)
+        store = payload_store_for_placement(await self._pool(), row["selected_placement"])
+        return await store.open_verified(locator)
 
     async def document_diff(
         self,

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -25,6 +25,7 @@ from app.services.m1_reference_payload_store import (
     PreparedReferencePayload,
     ReferencePayloadIntegrityError,
 )
+from app.services.native_payload_verification import payload_store_for_placement
 
 
 Failpoint = Callable[[str], Awaitable[None] | None]
@@ -1225,10 +1226,30 @@ class NativeRevisionService:
         )
         return resource, rows
 
+    def _read_store(self, selected_placement: str) -> TextPayloadStore:
+        """Select the verified adapter this Revision's manifest actually names.
+
+        Writes keep using the configured ``payload_store``; reads must follow
+        the immutable placement recorded at publication time. Since P1 put
+        facade Documents on the PostgreSQL BodyStore, one namespace can hold
+        both historical ``m1-reference-payload-v1`` bodies and new
+        ``pg-bodystore-v1`` bodies, and each adapter's ``_verify_row`` refuses
+        the other's placement — so a single hardcoded reader would fail closed
+        on half of a mixed corpus.
+
+        A store that declares no placement is an injected test double; it is
+        used as-is instead of being replaced by a real adapter.
+        """
+        configured = getattr(self.payload_store, "selected_placement", None)
+        if configured is None or configured == selected_placement:
+            return self.payload_store
+        return payload_store_for_placement(self.pool, selected_placement)
+
     async def _snapshot_from_row(self, row: dict) -> NativeRevisionSnapshot:
         if row["payload_manifest_id"] is None or row["private_locator"] is None:
             raise ReferencePayloadIntegrityError("Live native Head does not pin a payload manifest")
-        payload_bytes = await self.payload_store.open_verified(row["private_locator"])
+        store = self._read_store(row["selected_placement"])
+        payload_bytes = await store.open_verified(row["private_locator"])
         text = await asyncio.to_thread(_verify_snapshot_payload, payload_bytes, row)
         return NativeRevisionSnapshot(
             resource_id=row["resource_id"],

--- a/backend/tests/concurrency/test_native_derived_pipeline.py
+++ b/backend/tests/concurrency/test_native_derived_pipeline.py
@@ -42,14 +42,20 @@ async def _fresh_database():
             pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
         pytest.skip(f"Postgres not reachable at {_DSN}")
     admin = await asyncpg.connect(_DSN)
-    name = f"akb_native_derived_{uuid.uuid4().hex[:10]}"
+    # Measurement-prefixed on purpose: migration 057 is name-gated, and only a
+    # database named for the measurement arm can ever receive a native write
+    # (see `app/config.py`). Under any other name 057 self-disables and the
+    # fixture silently keeps migration 053's one-placement-per-namespace
+    # trigger — a schema no real native write ever meets, and one P1's mixed
+    # placements would trip the moment this pipeline covers a facade write.
+    name = f"akb_revision_m1_measurement_derived_{uuid.uuid4().hex[:10]}"
     await admin.execute(f'CREATE DATABASE "{name}"')
     dsn = f"{_DSN.rsplit('/', 1)[0]}/{name}"
     conn = await asyncpg.connect(dsn)
     pool = None
     try:
         await conn.execute((_BACKEND / "app" / "db" / "init.sql").read_text())
-        for number in (5, 6, 48, 53, 54):
+        for number in (5, 6, 48, 53, 54, 57):
             path = next((_BACKEND / "app" / "db" / "migrations").glob(f"{number:03d}_*.py"))
             spec = importlib.util.spec_from_file_location(f"native_derived_{number}", path)
             assert spec is not None and spec.loader is not None

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -20,7 +20,8 @@ import pytest
 from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.native_revision_repo import NativeRevisionRepository
-from app.services.m1_pg_body_store import M1PgBodyStore
+from app.services.m1_native_grep_service import M1NativeGrepService
+from app.services.m1_pg_body_store import M1PgBodyStore, PgBodyIntegrityError
 from app.services.m1_reference_payload_store import M1ReferencePayloadStore
 from app.services.native_document_service import (
     NativeDocumentService,
@@ -82,7 +83,16 @@ async def _fresh_database(*, with_derived: bool = False, pool_max_size: int = 8)
             pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
         pytest.skip(f"Postgres not reachable at {_DSN}")
     admin = await asyncpg.connect(_DSN)
-    name = f"akb_native_{uuid.uuid4().hex[:12]}"
+    # The disposable database must carry the measurement prefix. Migration 057
+    # self-disables on any other name, so a fixture called `akb_native_*`
+    # silently kept migration 053's one-placement-per-namespace trigger — a
+    # schema no native write can ever actually meet, because `app/config.py`
+    # and `revision_backend._assert_native_measurement_safety()` refuse the
+    # native arm unless `db_name` is exactly `akb_revision_m1_measurement`.
+    # Naming the fixture this way makes it the same 048+053+057 schema the
+    # only legal native-write deployment has, which is what P1's deliberately
+    # mixed-placement namespaces need.
+    name = f"akb_revision_m1_measurement_bcore_{uuid.uuid4().hex[:12]}"
     await admin.execute(f'CREATE DATABASE "{name}"')
     dsn = _database_dsn(name)
     conn = await asyncpg.connect(dsn)
@@ -2223,6 +2233,292 @@ async def test_default_reference_payload_document_is_applied_to_searchable_deriv
                 created.resource_id,
                 created.revision_id,
             ) > 0
+
+
+async def _owned_vault(pool: asyncpg.Pool, vault_id: uuid.UUID) -> tuple[uuid.UUID, str]:
+    """Give the fixture vault a real owner so grep/recent-changes can read it."""
+    async with pool.acquire() as conn:
+        owner_id = await conn.fetchval(
+            """
+            INSERT INTO users (username, email, password_hash)
+            VALUES ($1, $2, 'disabled') RETURNING id
+            """,
+            f"placement-{uuid.uuid4().hex}",
+            f"placement-{uuid.uuid4().hex}@invalid.example",
+        )
+        await conn.execute("UPDATE vaults SET owner_id = $1 WHERE id = $2", owner_id, vault_id)
+        vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+    return owner_id, vault
+
+
+async def _head_placement(pool: asyncpg.Pool, resource_id: uuid.UUID) -> str:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            SELECT pm.selected_placement
+              FROM native_resources rs
+              JOIN native_revisions rv
+                ON rv.resource_id = rs.resource_id
+               AND rv.revision_id = rs.head_revision_id
+              JOIN native_payload_manifests pm
+                ON pm.payload_manifest_id = rv.payload_manifest_id
+             WHERE rs.resource_id = $1
+            """,
+            resource_id,
+        )
+
+
+async def test_facade_document_body_lands_on_the_pg_body_store_and_still_deduplicates():
+    """P1 unification: a Document written through the facade is a PG BodyStore body."""
+    async with _fresh_database() as (pool, vault_id):
+        _owner_id, vault = await _owned_vault(pool, vault_id)
+        documents = NativeDocumentService(pool=pool)
+        created = await documents.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="unified",
+                title="Unified note",
+                content="unified placement body",
+            ),
+            agent_id="m1-writer",
+        )
+
+        async with pool.acquire() as conn:
+            manifest = await conn.fetchrow(
+                """
+                SELECT pm.selected_placement, pm.verification_profile,
+                       pm.private_locator, pm.digest, pm.byte_size,
+                       p.selected_placement AS payload_placement,
+                       p.canonical_bytes
+                  FROM native_revisions rv
+                  JOIN native_payload_manifests pm
+                    ON pm.payload_manifest_id = rv.payload_manifest_id
+                  JOIN m1_reference_payloads p
+                    ON p.payload_id = pm.private_locator
+                 WHERE rv.revision_id = $1
+                """,
+                created.commit_hash,
+            )
+        assert manifest["selected_placement"] == M1PgBodyStore.selected_placement
+        assert manifest["payload_placement"] == M1PgBodyStore.selected_placement
+        assert manifest["verification_profile"] == M1PgBodyStore.verification_profile
+
+        canonical = bytes(manifest["canonical_bytes"])
+        assert manifest["digest"] == hashlib.sha256(canonical).hexdigest()
+        assert manifest["byte_size"] == len(canonical)
+
+        # Content-addressed dedup still holds: re-preparing the exact bytes the
+        # facade published reuses the same body row rather than writing a copy.
+        pg_store = M1PgBodyStore(pool)
+        replayed = await pg_store.prepare_text(namespace_id=vault_id, payload=canonical)
+        assert replayed.payload_id == manifest["private_locator"]
+
+        # ...and dedup stays placement-scoped, so the pre-P1 adapter can still
+        # hold the identical bytes as its own separately verified body.
+        reference = await M1ReferencePayloadStore(pool).prepare_text(
+            namespace_id=vault_id, payload=canonical,
+        )
+        assert reference.payload_id != manifest["private_locator"]
+        assert reference.selected_placement == M1ReferencePayloadStore.selected_placement
+
+        async with pool.acquire() as conn:
+            placements = await conn.fetch(
+                """
+                SELECT selected_placement, count(*)::int AS bodies
+                  FROM m1_reference_payloads
+                 WHERE namespace_id = $1
+                 GROUP BY selected_placement
+                 ORDER BY selected_placement
+                """,
+                vault_id,
+            )
+        assert [(row["selected_placement"], row["bodies"]) for row in placements] == [
+            (M1ReferencePayloadStore.selected_placement, 1),
+            (M1PgBodyStore.selected_placement, 1),
+        ]
+
+
+async def test_mixed_placement_namespace_stays_readable_across_every_native_reader():
+    """A pre-P1 body and a post-P1 body must coexist in one namespace.
+
+    Migrating historical rows is explicitly not part of P1, so the reference
+    placement survives forever on Revisions published before the switch. Every
+    reader therefore has to dispatch on the manifest's ``selected_placement``:
+    a pinned read of the old Revision, a diff that spans the placement change,
+    the recent-changes list, and grep all have to keep verifying.
+    """
+    async with _fresh_database() as (pool, vault_id):
+        owner_id, vault = await _owned_vault(pool, vault_id)
+        documents = NativeDocumentService(pool=pool)
+        backend = NativeRevisionBackend(pool=pool, document_service=documents)
+
+        # A pre-P1 Document: the scaffolding path, on the reference adapter.
+        legacy_body = "---\ntitle: Legacy note\ntype: note\n---\nshared-token before\n"
+        legacy = await NativeRevisionService(pool).create_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/legacy.md",
+            payload=legacy_body,
+            actor="pre-p1-writer",
+            mutation_id=uuid.uuid4(),
+            message="[put] notes/legacy.md",
+            subject="[put] notes/legacy.md",
+            summary="pre-P1 revision",
+        )
+        # A second Document that never gets touched again, so the namespace
+        # still has a live reference-placement Head after the switch.
+        untouched = await NativeRevisionService(pool).create_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/untouched.md",
+            payload="---\ntitle: Untouched\n---\nshared-token untouched\n",
+            actor="pre-p1-writer",
+            mutation_id=uuid.uuid4(),
+            message="[put] notes/untouched.md",
+            subject="[put] notes/untouched.md",
+            summary="pre-P1 revision",
+        )
+
+        # The post-P1 facade replaces the first Document in place.
+        updated = await documents.update(
+            vault,
+            "notes/legacy.md",
+            DocumentUpdateRequest(
+                content="shared-token after",
+                message="unify placement",
+                expected_commit=legacy.revision_id,
+            ),
+            agent_id="p1-writer",
+        )
+        assert updated.previous_commit == legacy.revision_id
+
+        async with pool.acquire() as conn:
+            lineage = await conn.fetch(
+                """
+                SELECT rv.revision_id, pm.selected_placement
+                  FROM native_revisions rv
+                  JOIN native_payload_manifests pm
+                    ON pm.payload_manifest_id = rv.payload_manifest_id
+                 WHERE rv.resource_id = $1
+                 ORDER BY rv.occurred_at, rv.revision_id
+                """,
+                legacy.resource_id,
+            )
+        assert [row["revision_id"] for row in lineage] == [
+            legacy.revision_id,
+            updated.commit_hash,
+        ]
+        assert [row["selected_placement"] for row in lineage] == [
+            M1ReferencePayloadStore.selected_placement,
+            M1PgBodyStore.selected_placement,
+        ]
+        assert await _head_placement(pool, untouched.resource_id) == (
+            M1ReferencePayloadStore.selected_placement
+        )
+
+        # 1. A pinned read of the pre-P1 Revision, through the facade that now
+        #    writes the other placement.
+        pinned = await documents.get_at_commit(vault, "notes/legacy.md", legacy.revision_id)
+        assert pinned.content == "shared-token before"
+        assert pinned.current_commit == legacy.revision_id
+        assert pinned.metadata_is_current is True
+        current = await documents.get(vault, "notes/legacy.md")
+        assert current.content == "shared-token after"
+
+        # 2. A native diff whose parent and child sit on different placements.
+        diff = await backend.document_diff(vault, "notes/legacy.md", updated.commit_hash)
+        assert diff is not None
+        assert diff["type"] == "modified"
+        assert "-shared-token before" in diff["diff"]
+        assert "+shared-token after" in diff["diff"]
+        creation_diff = await backend.document_diff(
+            vault, "notes/legacy.md", legacy.revision_id,
+        )
+        assert creation_diff is not None
+        assert creation_diff["type"] == "added"
+        assert "+shared-token before" in creation_diff["diff"]
+
+        # 3. recent_changes spans both placements and verifies both bodies.
+        recent = await backend.recent_changes(str(owner_id), vault=vault, limit=20)
+        assert {(row["path"], row["title"]) for row in recent} == {
+            ("notes/legacy.md", "Legacy note"),
+            ("notes/untouched.md", "Untouched"),
+        }
+        assert {row["commit"] for row in recent} == {
+            updated.commit_hash,
+            untouched.revision_id,
+        }
+
+        # 4. grep scans both placements in one bounded pass.
+        grep = await M1NativeGrepService(pool).grep(
+            "shared-token",
+            user_id=owner_id,
+            vaults=[vault],
+        )
+        assert grep["total_resources"] == 2
+        assert {row["path"] for row in grep["results"]} == {
+            "notes/legacy.md",
+            "notes/untouched.md",
+        }
+        assert {row["revision"] for row in grep["results"]} == {
+            updated.commit_hash,
+            untouched.revision_id,
+        }
+
+
+async def test_recent_changes_refuses_a_body_that_no_longer_matches_its_manifest():
+    """recent_changes must verify, not decode-and-trust.
+
+    The schema already blocks this corruption (a CHECK on the stored digest
+    plus a row-immutability trigger), so the test removes those guards inside
+    its disposable database to prove the read path does not depend on them —
+    the same fail-closed contract grep, search, and the derived worker hold.
+    """
+    async with _fresh_database() as (pool, vault_id):
+        owner_id, vault = await _owned_vault(pool, vault_id)
+        documents = NativeDocumentService(pool=pool)
+        backend = NativeRevisionBackend(pool=pool, document_service=documents)
+        created = await documents.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="notes",
+                slug="verified",
+                title="Verified note",
+                content="honest body",
+            ),
+            agent_id="m1-writer",
+        )
+        assert (await backend.recent_changes(str(owner_id), vault=vault, limit=5))[0][
+            "commit"
+        ] == created.commit_hash
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                ALTER TABLE m1_reference_payloads
+                    DISABLE TRIGGER trg_m1_reference_payloads_immutable;
+                ALTER TABLE m1_reference_payloads
+                    DROP CONSTRAINT m1_reference_payloads_digest_matches;
+                """
+            )
+            # Same length, same encoding, no NUL: only the digest can catch it.
+            tampered = await conn.fetchval(
+                """
+                UPDATE m1_reference_payloads
+                   SET canonical_bytes = overlay(
+                           canonical_bytes PLACING $2 FROM 1 FOR 1
+                       )
+                 WHERE namespace_id = $1
+                 RETURNING octet_length(canonical_bytes)
+                """,
+                vault_id,
+                b"X",
+            )
+            assert tampered is not None
+
+        with pytest.raises(PgBodyIntegrityError, match="digest mismatch"):
+            await backend.recent_changes(str(owner_id), vault=vault, limit=5)
 
 
 async def test_schema_enforces_revision_identity_head_ownership_and_immutable_facts():


### PR DESCRIPTION
P1 owner decision: searchable bodies unify on the PG BodyStore. Documents written through `NativeDocumentService` now place on `pg-bodystore-v1` — the same placement the text-File bridge already injects — while `NativeRevisionService`'s own default deliberately stays on the reference store so the M1 measurement adapters keep reproducing the runs they were measured against. Historical Revisions keep the placement recorded in their immutable manifest; namespaces are mixed by design during the transition, and readers dispatch instead of assuming.

Four placement-blind readers found and fixed (each proven by reverting the fix and watching its test fail):

- `NativeRevisionService._snapshot_from_row` opened every body with the configured **write** store — the load-bearing one; without it a pinned read of a pre-P1 Revision dies on either side of the switch. New `_read_store()` dispatches on the manifest's `selected_placement`; writes unchanged.
- `NativeRevisionBackend._revision_bytes` hardcoded the reference store — native diff broke across a parent/child pair spanning the switch.
- `NativeRevisionBackend.recent_changes` returned **unverified** decoded bytes — a pre-existing defect independent of P1, the only native read path that trusted payload bytes without binding them to the manifest. Now verified off the event loop; its regression test drops the schema's digest CHECK and immutability trigger inside the disposable DB so the read path, not the schema, is what's tested.
- `list_recent_document_heads` extended to return the manifest facts verification needs (projection-only; no envelope widened).

No trigger migration: native writes cannot reach a database where the 053 mixing trigger survives (exact-name config gates), and 057 already dropped it on the only legal deployment. The live-PG failures were fixture artifacts — disposable DBs named `akb_native*` kept a schema production never has; fixtures now use the measurement naming the rest of the suite already uses. 048/053 placement CHECKs untouched; the pre-057 state is still proven by its migration test.

A new mixed-corpus test drives all four legs across the placement boundary (pinned get, diff both directions, verified recent_changes, grep) with nothing mocked.

Implementation and independent verification each reproduced: b_core 57→60 with this branch's three additions after rebase on #333, derived-pipeline 7, file-measurement 32, failpoint unit 19 — 118 passed combined post-rebase; full DB-free gate 1921 passed; ruff and mypy clean. Performance of the unified configuration is unmeasured by M1; P1 is semantic acceptance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcTyzcrzMgCN7pxArJZqk
