### PR TITLE
feat(native): make body placement observable without exposing locators

### DIFF
--- a/backend/app/api/routes/files.py
+++ b/backend/app/api/routes/files.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from app.api.deps import get_current_user, require_delegated_actor
 from app.config import settings
 from app.exceptions import AKBError
+from app.models.file import BodyPlacementObservation
 from app.services.access_service import (
     FILE_UPLOAD_WRITE_ACTION,
     check_delegated_vault_writer,
@@ -154,6 +155,36 @@ async def list_files(
     access = await check_vault_access(user.user_id, vault, required_role="reader")
     files = await file_service.list_files(access["vault_id"], vault, collection, limit)
     return {"kind": "file", "vault": vault, "items": files, "total": len(files)}
+
+
+@router.get(
+    "/files/{vault}/body-placements",
+    response_model=BodyPlacementObservation,
+    operation_id="filesGetVaultBodyPlacements",
+    summary="Body placement census for a vault (measurement builds only)",
+)
+async def get_body_placements(
+    vault: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Report which native body placements a vault's bodies still use.
+
+    Makes the M1 placement decision observable from outside without exposing
+    any internal address: the response is an aggregate of counts and byte sums
+    keyed by the closed placement identifiers, and carries no resource id, no
+    payload id, no locator, and no digest values.
+
+    Authorization matches the neighbouring measurement read `GET /files/{vault}`
+    (vault reader): the census is strictly less specific than the file listing
+    a reader can already fetch, so it introduces no new permission model.
+
+    Deployments that keep the direct-S3 File driver have no measurement facade
+    at all, so this route answers 404 there — same discipline as the guarded
+    transfer capability. It stays in the published schema because, unlike that
+    route, its path holds no secret and clients need a typed shape for it.
+    """
+    access = await check_vault_access(user.user_id, vault, required_role="reader")
+    return await file_service.namespace_placement_observation(access["vault_id"], vault)
 
 
 @router.delete("/files/{vault}/{file_id}", summary="Delete a file")

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -307,6 +307,12 @@ class GrepResult(BaseModel):
     resource_type: str | None = None
     revision: str | None = None
     content_hash: str | None = None
+    # Which body placement the matched Head bytes were read from, from the
+    # closed native set. Native rows (Document and File alike) carry it; the
+    # legacy Document grep branch leaves it None and `response_model_exclude_none`
+    # keeps that response byte-identical. Never an address — no payload id,
+    # no locator.
+    payload_placement: str | None = None
     matches: list[GrepMatch] = Field(default_factory=list)
 
 

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -1,0 +1,55 @@
+"""Typed REST contracts for the File surface's measurement-only reads.
+
+The legacy File routes still return untyped dicts (a known codegen gap the
+OpenAPI contract layer papers over with `AkbJsonObject`). New File routes are
+typed at the source instead, so the published schema is generated from the
+same declaration the handler returns.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class BodyPlacementTotals(BaseModel):
+    """One placement's bounded footprint inside a vault namespace."""
+
+    selected_placement: str = Field(
+        description=(
+            "Body placement identifier from the closed native set "
+            "(`pg-bodystore-v1`, `m1-reference-payload-v1`). It names a "
+            "storage strategy, not an address: nothing can be dereferenced "
+            "from it."
+        ),
+    )
+    bodies: int = Field(description="Verified bodies stored under this placement.")
+    body_bytes: int = Field(description="Sum of the canonical byte sizes of those bodies.")
+    distinct_digests: int = Field(
+        description=(
+            "How many distinct content digests those bodies cover. A count "
+            "only — digest values are content hashes of user bodies and are "
+            "never enumerated."
+        ),
+    )
+
+
+class BodyPlacementObservation(BaseModel):
+    """Namespace-level placement census used for unification-purity checks.
+
+    A vault reporting a single `pg-bodystore-v1` row has zero reference
+    residue. The converse does not hold: the census counts payload-store
+    rows, and those can outlive the Revisions that referenced them (the
+    manifest -> payload foreign key is ON DELETE NO ACTION and nothing
+    reaps payload rows), so a fully migrated namespace still reports two
+    rows if one orphaned reference-placement body is left behind. Two rows
+    therefore means residue of some kind — orphaned or live — not
+    necessarily that live Heads are still mixed.
+    """
+
+    vault: str
+    placements: list[BodyPlacementTotals] = Field(
+        default_factory=list,
+        description="One row per placement present in the namespace, sorted by placement.",
+    )
+    total_bodies: int
+    total_body_bytes: int

--- a/backend/app/repositories/vault_files_repo.py
+++ b/backend/app/repositories/vault_files_repo.py
@@ -14,6 +14,21 @@ from __future__ import annotations
 import uuid
 
 
+# The measurement File reads resolve the placement of the body a confirmed
+# native-text row is pinned to. The join is on the row's own Head identity
+# (`native_resource_id` + `native_revision_id`), so it names the manifest that
+# revision published and nothing later. It yields the placement STRING only —
+# `private_locator` / `payload_manifest_id` are internal addresses and are
+# never selected here. Binary rows have no native identity and get NULL.
+_MEASUREMENT_PLACEMENT_JOIN = """
+          LEFT JOIN native_revisions nr
+                 ON nr.resource_id = vf.native_resource_id
+                AND nr.revision_id = vf.native_revision_id
+          LEFT JOIN native_payload_manifests pm
+                 ON pm.payload_manifest_id = nr.payload_manifest_id
+"""
+
+
 async def insert_or_adopt(
     conn,
     *,
@@ -93,9 +108,11 @@ async def insert_or_adopt_measurement_confirmed(
         SELECT vf.id, vf.vault_id, v.name AS vault_name, vf.collection_id, c.path AS collection,
                vf.name, vf.mime_type, vf.size_bytes, vf.description,
                vf.content_hash, vf.storage_driver, vf.storage_locator,
-               vf.native_resource_id, vf.native_revision_id
+               vf.native_resource_id, vf.native_revision_id,
+               pm.selected_placement AS payload_placement
           FROM vault_files vf JOIN vaults v ON v.id = vf.vault_id
           LEFT JOIN collections c ON c.id = vf.collection_id
+        """ + _MEASUREMENT_PLACEMENT_JOIN + """
          WHERE vf.vault_id = $1
            AND vf.collection_id IS NOT DISTINCT FROM $2
            AND vf.name = $3 AND vf.content_hash = $4
@@ -124,9 +141,11 @@ async def list_measurement_confirmed(
         """
         SELECT vf.id, vf.vault_id, v.name AS vault_name, c.path AS collection, vf.name, vf.mime_type,
                vf.size_bytes, vf.content_hash, vf.hash_algorithm, vf.storage_driver,
-               vf.storage_locator
+               vf.storage_locator, vf.native_resource_id, vf.native_revision_id,
+               pm.selected_placement AS payload_placement
           FROM vault_files vf JOIN vaults v ON v.id = vf.vault_id
           LEFT JOIN collections c ON c.id = vf.collection_id
+        """ + _MEASUREMENT_PLACEMENT_JOIN + """
          WHERE vf.vault_id = $1 AND vf.storage_driver IS NOT NULL
         """ + collection_clause + f" ORDER BY vf.created_at DESC LIMIT ${len(params)}",
         *params,
@@ -165,9 +184,10 @@ async def find_measurement_by_id(conn, vault_id: uuid.UUID, file_id: uuid.UUID) 
         SELECT vf.id, vf.vault_id, v.name AS vault_name, c.path AS collection, vf.name, vf.mime_type,
                vf.size_bytes, vf.description, vf.content_hash,
                vf.storage_driver, vf.storage_locator, vf.native_resource_id,
-               vf.native_revision_id
+               vf.native_revision_id, pm.selected_placement AS payload_placement
           FROM vault_files vf JOIN vaults v ON v.id = vf.vault_id
           LEFT JOIN collections c ON c.id = vf.collection_id
+        """ + _MEASUREMENT_PLACEMENT_JOIN + """
          WHERE vf.id = $1 AND vf.vault_id = $2 AND vf.storage_driver IS NOT NULL
         """, file_id, vault_id,
     )
@@ -183,9 +203,11 @@ async def find_measurement_exact(
         SELECT vf.id, vf.vault_id, v.name AS vault_name, c.path AS collection,
                vf.name, vf.mime_type, vf.size_bytes, vf.description,
                vf.content_hash, vf.storage_driver, vf.storage_locator,
-               vf.native_resource_id, vf.native_revision_id
+               vf.native_resource_id, vf.native_revision_id,
+               pm.selected_placement AS payload_placement
           FROM vault_files vf JOIN vaults v ON v.id = vf.vault_id
           LEFT JOIN collections c ON c.id = vf.collection_id
+        """ + _MEASUREMENT_PLACEMENT_JOIN + """
          WHERE vf.vault_id = $1
            AND vf.collection_id IS NOT DISTINCT FROM $2
            AND vf.name = $3 AND vf.content_hash = $4

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -701,6 +701,20 @@ class FileService:
             raise NotFoundError("File transfer", token)
         return await self._measurement.transfer(token, body=body, method=method)
 
+    async def namespace_placement_observation(
+        self, vault_id: uuid.UUID, vault_name: str,
+    ) -> dict:
+        """Report which body placements a vault's native bodies still use.
+
+        Measurement-only, and gated exactly like
+        `transfer_measurement_capability`: outside M1 measurement mode the
+        facade does not exist, so the surface is simply absent (404) rather
+        than answering with an empty or synthesized census.
+        """
+        if self._measurement is None:
+            raise NotFoundError("File placement observation", vault_name)
+        return await self._measurement.namespace_placement_observation(vault_id, vault_name)
+
 
 async def index_file_metadata(
     file_id: str,

--- a/backend/app/services/m1_file_measurement.py
+++ b/backend/app/services/m1_file_measurement.py
@@ -18,7 +18,7 @@ from app.repositories import vault_files_repo
 from app.repositories.document_repo import CollectionRepository
 from app.services.adapters import s3_adapter
 from app.services.m1_binary_store import BinaryStore, FilesystemCAS, PreparedBinary, S3CAS
-from app.services.m1_pg_body_store import M1_PG_TEXT_MAX_BYTES
+from app.services.m1_pg_body_store import M1_PG_TEXT_MAX_BYTES, M1PgBodyStore
 from app.services.resource_hash import HASH_ALGORITHM, is_sha256_hex
 from app.services.uri_service import file_uri
 from app.util.text import normalize_collection_path, validate_file_name
@@ -566,6 +566,46 @@ class MeasurementFileService:
             "storage_version": None,
             "native_resource_id": str(row["native_resource_id"]) if row.get("native_resource_id") else None,
             "native_revision_id": row.get("native_revision_id"),
+            # Which body placement this File's Head is pinned to, read straight
+            # off the manifest the revision published. The placement strings are
+            # a closed, non-dereferenceable set, so this is an observation, not
+            # an address — no payload_id / private_locator / storage path.
+            #
+            # Binary Files report `null` rather than dropping the key: placement
+            # is a text-body concept, their CAS is already named by
+            # `storage_driver`, and this envelope's convention for "not
+            # applicable to this row" is an explicit null (`etag`,
+            # `storage_version`, `native_resource_id` all behave that way), which
+            # keeps every item of a mixed listing the same shape.
+            "payload_placement": (
+                row.get("payload_placement") if row["storage_driver"] == "native_text" else None
+            ),
+        }
+
+    async def namespace_placement_observation(
+        self, vault_id: uuid.UUID, vault_name: str,
+    ) -> dict:
+        """Report the namespace's body placements as a bounded aggregate.
+
+        This is the unification-purity instrument: it answers "is this vault
+        100% pg-bodystore-v1, or is there reference residue left" without
+        naming a single resource, digest value, or internal address.
+        """
+        pool = await get_pool()
+        totals = await M1PgBodyStore(pool).namespace_placement_totals(vault_id)
+        return {
+            "vault": vault_name,
+            "placements": [
+                {
+                    "selected_placement": total.selected_placement,
+                    "bodies": total.bodies,
+                    "body_bytes": total.body_bytes,
+                    "distinct_digests": total.distinct_digests,
+                }
+                for total in totals
+            ],
+            "total_bodies": sum(total.bodies for total in totals),
+            "total_body_bytes": sum(total.body_bytes for total in totals),
         }
 
 

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -239,6 +239,10 @@ def _scan_bodies_sync(
                 "title": body.title,
                 "revision": body.revision_id,
                 "content_hash": body.digest,
+                # The placement the matched Head bytes were read from. It is a
+                # member of a closed, non-dereferenceable set — never the
+                # manifest's private_locator or any payload id.
+                "payload_placement": body.selected_placement,
                 "matches": lines,
                 "_body_index": body_index,
             })
@@ -868,6 +872,15 @@ class M1NativeGrepService:
                         "content_hash": row["content_hash"],
                     }
                 )
+            # Placement rides on every native row, Document included: the P1
+            # observability item exists precisely because Documents moved onto
+            # the PG BodyStore, so hiding it from Document rows would leave the
+            # unification unobservable on the surface that reads their bytes.
+            # The key is only emitted when the native row actually carries one,
+            # so the legacy Document-only grep branch — which never sets it —
+            # keeps its byte-identical response.
+            if row.get("payload_placement"):
+                public["payload_placement"] = row["payload_placement"]
             clean.append(public)
         result: dict[str, Any] = {
             "pattern": pattern,

--- a/backend/app/services/m1_pg_body_store.py
+++ b/backend/app/services/m1_pg_body_store.py
@@ -26,6 +26,22 @@ M1_PG_TEXT_MAX_BYTES = 10 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
+class NamespacePlacementTotals:
+    """One placement's bounded footprint inside a measurement namespace.
+
+    Deliberately id-free and digest-value-free: `selected_placement` is a
+    member of the closed, non-dereferenceable placement set, and the digest
+    column is only ever reduced to a cardinality.  Nothing here can be turned
+    back into an address for a user body.
+    """
+
+    selected_placement: str
+    bodies: int
+    body_bytes: int
+    distinct_digests: int
+
+
+@dataclass(frozen=True, slots=True)
 class VerifiedPgTextBody:
     """Receipt-quality facts returned only after byte-level verification."""
 
@@ -233,3 +249,42 @@ class M1PgBodyStore:
                 self.selected_placement,
             )
         return dict(row)
+
+    async def namespace_placement_totals(
+        self, namespace_id: uuid.UUID,
+    ) -> list[NamespacePlacementTotals]:
+        """Group every verified body in one namespace by its selected placement.
+
+        `namespace_residue` answers "what is left on MY placement"; this answers
+        "which placements does this namespace still use at all", which is the
+        unification-purity question the M1 ADR carried into P1.  A namespace
+        that reports a single `pg-bodystore-v1` row has zero reference residue.
+
+        The projection is intentionally an aggregate: counts and a byte sum per
+        placement, plus the *cardinality* of distinct digests.  Digest strings
+        are content hashes of user bodies and are never enumerated, and neither
+        `payload_id` nor any manifest identifier is selected.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT selected_placement,
+                       COUNT(*)::int AS bodies,
+                       COALESCE(SUM(byte_size), 0)::bigint AS body_bytes,
+                       COUNT(DISTINCT digest)::int AS distinct_digests
+                  FROM m1_reference_payloads
+                 WHERE namespace_id = $1
+                 GROUP BY selected_placement
+                 ORDER BY selected_placement
+                """,
+                namespace_id,
+            )
+        return [
+            NamespacePlacementTotals(
+                selected_placement=row["selected_placement"],
+                bodies=row["bodies"],
+                body_bytes=row["body_bytes"],
+                distinct_digests=row["distinct_digests"],
+            )
+            for row in rows
+        ]

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -903,7 +903,10 @@ Each replaced document gets its own git commit and is re-indexed for search.
 Each result includes `uri`, `vault`, `path`, `title`, and `matches` — a list of
 `{section, text}` showing the section path and matched line.
 File results additionally include `resource_type: "file"`, their canonical URI,
-`revision`, and `content_hash`. If snippets hit response safety bounds,
+`revision`, and `content_hash`. On the native measurement backend every result
+also carries `payload_placement` — which body placement the matched bytes were
+read from; it names a storage strategy, never an address. If snippets hit
+response safety bounds,
 `truncated` is true and `truncation` reports the applied match/byte limits.
 When replace is used, response also includes `replaced_docs` count and `replacements` list.""",
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -446,7 +446,9 @@ TOOLS = [
                     "description": (
                         "Guarded native M1 W3b measurement mode: include admitted searchable "
                         "text Files as well as Documents. File results include resource_type=file, "
-                        "their canonical akb:// URI, revision, and content_hash. Binary Files are "
+                        "their canonical akb:// URI, revision, and content_hash; native results "
+                        "also report payload_placement, the body placement their bytes were read "
+                        "from. Binary Files are "
                         "never searchable. Rejected unless the exact native measurement backend "
                         "and dedicated database guard are active."
                     ),

--- a/backend/tests/test_file_idempotent_upload_unit.py
+++ b/backend/tests/test_file_idempotent_upload_unit.py
@@ -172,6 +172,72 @@ async def test_default_s3_facade_keeps_accepting_slash_names(monkeypatch):
         )
 
 
+async def test_default_s3_facade_exposes_no_placement_observation(monkeypatch):
+    """Placement observability is measurement-only: absent, not empty, here.
+
+    `native_revision_m1_file_driver = s3_current` means no measurement facade
+    was ever constructed, so the census surface must answer 404 exactly like
+    the guarded transfer capability does — never a synthesized census.
+    """
+    from app.exceptions import NotFoundError
+    from app.services import file_service as fs
+
+    monkeypatch.setattr(fs, "measurement_enabled", lambda: False)
+    service = fs.FileService()
+
+    with pytest.raises(NotFoundError) as err:
+        await service.namespace_placement_observation(uuid.uuid4(), "team")
+    assert err.value.status_code == 404
+
+
+async def test_default_s3_facade_file_envelope_is_unchanged(monkeypatch):
+    """The non-measurement File envelope gains nothing — not even a null key."""
+    from app.services import file_service as fs
+
+    monkeypatch.setattr(fs, "measurement_enabled", lambda: False)
+    service = fs.FileService()
+    vault_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+
+    class _Conn:
+        async def fetchrow(self, *_args, **_kwargs):
+            return None
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _pool():
+        return _Pool()
+
+    async def _rows(_conn, _vault_id, **_kwargs):
+        return [{
+            "id": file_id, "collection": None, "name": "page.html",
+            "mime_type": "text/html", "size_bytes": 12,
+            "content_hash": _HASH_A, "hash_algorithm": "sha256",
+            "etag": None, "storage_version": None, "description": "",
+            "created_by": "tester", "created_at": None,
+        }]
+
+    monkeypatch.setattr(fs, "get_pool", _pool)
+    monkeypatch.setattr(fs.vault_files_repo, "list_for_vault", _rows)
+
+    items = await service.list_files(vault_id, "team")
+
+    assert set(items[0]) == {
+        "kind", "uri", "collection", "name", "mime_type", "size_bytes",
+        "content_hash", "hash_algorithm", "etag", "storage_version",
+        "description", "created_by", "created_at",
+    }
+
+
 # ── the constraint itself, against a real Postgres ───────────────
 
 

--- a/backend/tests/test_m1_file_measurement_pg.py
+++ b/backend/tests/test_m1_file_measurement_pg.py
@@ -15,9 +15,12 @@ import pytest
 import pytest_asyncio
 
 from app.config import settings
-from app.exceptions import AKBError, NotFoundError
+from app.exceptions import AKBError, ForbiddenError, NotFoundError
+from app.models.file import BodyPlacementObservation
 from app.repositories import vault_files_repo
 from app.services import m1_file_measurement as m1
+from app.services.auth_service import AuthenticatedUser
+from app.services.file_service import FileService
 from app.services.m1_binary_store import PreparedBinary
 from app.services.m1_native_grep_service import M1NativeGrepService
 from app.services.m1_pg_body_store import M1PgBodyStore
@@ -1469,3 +1472,204 @@ async def test_composite_confirm_discards_a_ledger_publish_that_already_reported
     assert await _native_authority_counts(pool, file_id) == dict.fromkeys(
         _NATIVE_AUTHORITY_TABLES, 1,
     )
+
+
+def _measurement_user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()), username="placement-observer",
+        email="placement@invalid.example", display_name=None, is_admin=False,
+        auth_method="pat", token_id=None, key_class=None, token_scopes=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_envelope_observes_body_placement_without_any_locator(
+    context, monkeypatch,
+):
+    """Per-resource observability: which placement holds THIS File's body.
+
+    The whole point of the P1 item is that a fixture can bind an object to its
+    placement from the outside. The envelope therefore has to agree across
+    confirm, download, and list, and it must never carry an address.
+    """
+    from app.services import m1_native_text_file_bridge as bridge
+
+    pool, vault_id, _denied, vault_name = context
+
+    async def test_pool():
+        return pool
+
+    monkeypatch.setattr(bridge, "get_pool", test_pool)
+    bridge.install_m1_native_text_file_bridge()
+    service = m1.MeasurementFileService()
+
+    text = await _confirmed_native_text_file(
+        vault_id=vault_id, vault_name=vault_name, collection="notes",
+        filename="observable.txt", body=b"observable native text\n",
+    )
+    binary = await _confirmed_binary_file(
+        vault_id=vault_id, vault_name=vault_name, collection="notes",
+        filename="observable.bin", body=b"binary\x00bytes",
+    )
+
+    assert text["storage_driver"] == "native_text"
+    assert text["payload_placement"] == M1PgBodyStore.selected_placement
+    # Binary Files report null: placement is a text-body concept and their CAS
+    # is already named by storage_driver.
+    assert binary["storage_driver"] == "fscas"
+    assert binary["payload_placement"] is None
+
+    download = await service.get_download_url(vault_id, text["file_id"])
+    listed = {
+        item["file_id"]: item
+        for item in await service.list_files(vault_id, vault_name, None, 50)
+    }
+
+    assert download["payload_placement"] == M1PgBodyStore.selected_placement
+    assert listed[text["file_id"]]["payload_placement"] == (
+        M1PgBodyStore.selected_placement
+    )
+    assert listed[text["file_id"]]["native_revision_id"] == text["native_revision_id"]
+    assert listed[binary["file_id"]]["payload_placement"] is None
+
+    forbidden = {
+        "payload_id", "private_locator", "payload_manifest_id",
+        "storage_locator", "s3_key",
+    }
+    for envelope in (text, binary, download, *listed.values()):
+        assert forbidden.isdisjoint(envelope)
+
+
+@pytest.mark.asyncio
+async def test_namespace_placement_observation_counts_both_placements(
+    context, monkeypatch,
+):
+    """Namespace aggregate: is this vault unified, or is there residue left?
+
+    After the Document unification a namespace that also holds a pre-existing
+    reference-placement Head is mixed, and the census has to say so — with
+    counts only, never an id or a digest value.
+    """
+    from app.services import m1_native_text_file_bridge as bridge
+
+    pool, vault_id, denied_vault_id, vault_name = context
+
+    async def test_pool():
+        return pool
+
+    monkeypatch.setattr(bridge, "get_pool", test_pool)
+    bridge.install_m1_native_text_file_bridge()
+    service = m1.MeasurementFileService()
+
+    empty = await service.namespace_placement_observation(vault_id, vault_name)
+    assert empty == {
+        "vault": vault_name, "placements": [],
+        "total_bodies": 0, "total_body_bytes": 0,
+    }
+
+    unified_body = b"unified document body\n"
+    await NativeRevisionService(pool, payload_store=M1PgBodyStore(pool)).create_text(
+        namespace_id=vault_id, surface="document", path="notes/unified.md",
+        payload=unified_body, actor="placement-observer", mutation_id=uuid.uuid4(),
+        expected_digest=hashlib.sha256(unified_body).hexdigest(),
+        expected_size=len(unified_body),
+    )
+    historical_body = b"historical document body\n"
+    await NativeRevisionService(
+        pool, payload_store=M1ReferencePayloadStore(pool),
+    ).create_text(
+        namespace_id=vault_id, surface="document", path="notes/historical.md",
+        payload=historical_body, actor="placement-observer", mutation_id=uuid.uuid4(),
+        expected_digest=hashlib.sha256(historical_body).hexdigest(),
+        expected_size=len(historical_body),
+    )
+    file_body = b"observable native file\n"
+    await _confirmed_native_text_file(
+        vault_id=vault_id, vault_name=vault_name, collection="notes",
+        filename="census.txt", body=file_body,
+    )
+
+    observation = await service.namespace_placement_observation(vault_id, vault_name)
+
+    assert observation == {
+        "vault": vault_name,
+        "placements": [
+            {
+                "selected_placement": M1ReferencePayloadStore.selected_placement,
+                "bodies": 1,
+                "body_bytes": len(historical_body),
+                "distinct_digests": 1,
+            },
+            {
+                "selected_placement": M1PgBodyStore.selected_placement,
+                "bodies": 2,
+                "body_bytes": len(unified_body) + len(file_body),
+                "distinct_digests": 2,
+            },
+        ],
+        "total_bodies": 3,
+        "total_body_bytes": len(historical_body) + len(unified_body) + len(file_body),
+    }
+    # Namespace-scoped: a second vault in the same database is not counted.
+    assert await service.namespace_placement_observation(
+        denied_vault_id, "denied",
+    ) == {
+        "vault": "denied", "placements": [],
+        "total_bodies": 0, "total_body_bytes": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_body_placement_route_is_reader_guarded_and_absent_without_measurement(
+    context, monkeypatch,
+):
+    """Authorization matches the neighbouring measurement read; off means 404."""
+    from app.api.routes import files as files_routes
+    from app.services import file_service as file_service_module
+
+    pool, vault_id, _denied, vault_name = context
+
+    async def test_pool():
+        return pool
+
+    monkeypatch.setattr(file_service_module, "get_pool", test_pool)
+    checks: list[tuple[str, str, str]] = []
+
+    async def allow(user_id, vault, *, required_role="reader", **_kwargs):
+        checks.append((user_id, vault, required_role))
+        return {"vault_id": vault_id, "role": required_role}
+
+    monkeypatch.setattr(files_routes, "check_vault_access", allow)
+    monkeypatch.setattr(files_routes, "file_service", FileService())
+    user = _measurement_user()
+
+    payload = await files_routes.get_body_placements(vault=vault_name, user=user)
+
+    assert checks == [(user.user_id, vault_name, "reader")]
+    assert BodyPlacementObservation.model_validate(payload).vault == vault_name
+
+    # A denied vault never reaches the service.
+    reached = False
+
+    async def deny(*_args, **_kwargs):
+        raise ForbiddenError("no reader grant")
+
+    async def unreachable(*_args, **_kwargs):
+        nonlocal reached
+        reached = True
+
+    monkeypatch.setattr(files_routes, "check_vault_access", deny)
+    monkeypatch.setattr(
+        files_routes.file_service, "namespace_placement_observation", unreachable,
+    )
+    with pytest.raises(ForbiddenError):
+        await files_routes.get_body_placements(vault=vault_name, user=user)
+    assert reached is False
+
+    # Measurement off: the facade does not exist, so neither does the surface.
+    monkeypatch.setattr(files_routes, "check_vault_access", allow)
+    monkeypatch.setattr(file_service_module, "measurement_enabled", lambda: False)
+    monkeypatch.setattr(files_routes, "file_service", FileService())
+    with pytest.raises(NotFoundError) as missing:
+        await files_routes.get_body_placements(vault=vault_name, user=user)
+    assert missing.value.status_code == 404

--- a/backend/tests/test_m1_pg_body_grep_unit.py
+++ b/backend/tests/test_m1_pg_body_grep_unit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import re
 import threading
 import time
 import uuid
@@ -166,6 +167,7 @@ async def test_bounded_regex_worker_preserves_exact_match_receipt(monkeypatch):
         "title": "main.py",
         "revision": body.revision_id,
         "content_hash": body.digest,
+        "payload_placement": M1PgBodyStore.selected_placement,
         "matches": [
             {"line": 1, "text": "Needful"},
             {"line": 2, "text": "needle"},
@@ -750,6 +752,117 @@ async def test_regex_worker_rejects_serialized_output_over_hard_cap(monkeypatch)
         await service.grep(
             "needle", user_id=uuid.uuid4(), regex=True, include_text_files=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_grep_items_report_each_head_placement_without_any_locator(monkeypatch):
+    """Placement is observable per resource; addresses never are."""
+    unified = HeadBody(
+        namespace_id=uuid.uuid4(),
+        vault="measure",
+        resource_id=uuid.uuid4(),
+        surface="document",
+        path="notes/unified.md",
+        revision_id="a" * 40,
+        digest="b" * 64,
+        byte_size=len(b"needle unified\n"),
+        canonical_bytes=b"needle unified\n",
+        selected_placement=M1PgBodyStore.selected_placement,
+    )
+    historical = HeadBody(
+        namespace_id=unified.namespace_id,
+        vault="measure",
+        resource_id=uuid.uuid4(),
+        surface="document",
+        path="notes/historical.md",
+        revision_id="c" * 40,
+        digest="d" * 64,
+        byte_size=len(b"needle historical\n"),
+        canonical_bytes=b"needle historical\n",
+        selected_placement=M1ReferencePayloadStore.selected_placement,
+    )
+    text_file = HeadBody(
+        namespace_id=unified.namespace_id,
+        vault="measure",
+        resource_id=uuid.uuid4(),
+        surface="file",
+        path="src/main.py",
+        revision_id="e" * 40,
+        digest="f" * 64,
+        byte_size=len(b"needle file\n"),
+        canonical_bytes=b"needle file\n",
+        selected_placement=M1PgBodyStore.selected_placement,
+    )
+    service = M1NativeGrepService(object())  # type: ignore[arg-type]
+
+    async def head_bodies(**_kwargs):
+        return [unified, historical, text_file]
+
+    monkeypatch.setattr(service, "_head_bodies", head_bodies)
+    internal = await service.grep(
+        "needle", user_id=uuid.uuid4(), include_text_files=True,
+    )
+    public = M1NativeGrepService._public_response(
+        pattern="needle", regex=False, native=internal,
+    )
+
+    assert [row["payload_placement"] for row in internal["results"]] == [
+        M1PgBodyStore.selected_placement,
+        M1ReferencePayloadStore.selected_placement,
+        M1PgBodyStore.selected_placement,
+    ]
+    assert [row["payload_placement"] for row in public["results"]] == [
+        M1PgBodyStore.selected_placement,
+        M1ReferencePayloadStore.selected_placement,
+        M1PgBodyStore.selected_placement,
+    ]
+    forbidden = {"payload_id", "private_locator", "payload_manifest_id", "namespace_id"}
+    for row in internal["results"] + public["results"]:
+        assert forbidden.isdisjoint(row)
+
+
+@pytest.mark.asyncio
+async def test_namespace_placement_totals_group_without_ids_or_digest_values():
+    class _AggregateConn:
+        def __init__(self):
+            self.sql = ""
+            self.params = ()
+
+        async def fetch(self, sql, *params):
+            self.sql = sql
+            self.params = params
+            return [
+                {
+                    "selected_placement": M1ReferencePayloadStore.selected_placement,
+                    "bodies": 2,
+                    "body_bytes": 30,
+                    "distinct_digests": 1,
+                },
+                {
+                    "selected_placement": M1PgBodyStore.selected_placement,
+                    "bodies": 3,
+                    "body_bytes": 44,
+                    "distinct_digests": 3,
+                },
+            ]
+
+    conn = _AggregateConn()
+    namespace_id = uuid.uuid4()
+
+    totals = await M1PgBodyStore(_Pool(conn)).namespace_placement_totals(namespace_id)
+
+    assert [(row.selected_placement, row.bodies, row.body_bytes, row.distinct_digests) for row in totals] == [
+        (M1ReferencePayloadStore.selected_placement, 2, 30, 1),
+        (M1PgBodyStore.selected_placement, 3, 44, 3),
+    ]
+    assert conn.params == (namespace_id,)
+    assert "GROUP BY selected_placement" in conn.sql
+    # The projection must stay an aggregate: no addresses, no bodies, and the
+    # digest column only ever reduced to a cardinality.
+    for forbidden in ("payload_id", "private_locator", "canonical_bytes", "prepared_at"):
+        assert forbidden not in conn.sql
+    assert re.findall(r"\bdigest\b", conn.sql) == ["digest"]
+    assert "COUNT(DISTINCT digest)" in conn.sql
 
 
 def test_regex_worker_rejects_when_process_slots_are_exhausted(monkeypatch):

--- a/backend/tests/test_mcp_grep_text_files_unit.py
+++ b/backend/tests/test_mcp_grep_text_files_unit.py
@@ -89,6 +89,7 @@ async def test_mcp_grep_passes_explicit_text_file_measurement_argument(monkeypat
 @pytest.mark.asyncio
 async def test_public_native_grep_file_identity_and_default_exclusion(monkeypatch):
     from app.services.m1_native_grep_service import HeadBody, M1NativeGrepService
+    from app.services.m1_pg_body_store import M1PgBodyStore
 
     document = HeadBody(
         namespace_id=uuid.uuid4(),
@@ -127,6 +128,10 @@ async def test_public_native_grep_file_identity_and_default_exclusion(monkeypatc
 
     assert [row["uri"] for row in legacy["results"]] == [document.uri]
     assert "resource_type" not in legacy["results"][0]
+    # Placement is not part of the File-only additive head identity: it rides
+    # on every native row, so a Document-only native grep still reports which
+    # placement its bytes came from.
+    assert legacy["results"][0]["payload_placement"] == M1PgBodyStore.selected_placement
     assert with_files["results"][1] == {
         "uri": file.uri,
         "vault": "measurement",
@@ -136,6 +141,7 @@ async def test_public_native_grep_file_identity_and_default_exclusion(monkeypatc
         "resource_type": "file",
         "revision": file.revision_id,
         "content_hash": file.digest,
+        "payload_placement": M1PgBodyStore.selected_placement,
     }
 
 

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import threading
 import uuid
 
@@ -450,6 +451,201 @@ async def test_native_hydration_verification_and_decode_run_off_event_loop(monke
 
     assert results[0].title == "Hydrated"
     assert verify_threads
+
+
+class _StubAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _StubPool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return _StubAcquire(self.conn)
+
+
+class _LegacyChunkConn:
+    """Serves the one chunk query the legacy Document-only grep branch runs."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.sql = ""
+
+    async def fetch(self, sql, *_params):
+        self.sql = sql
+        return self.rows
+
+
+class _NativeHeadConn:
+    """Serves the native arm's aggregate guard + Head body fetch."""
+
+    def __init__(self, row):
+        self.row = row
+
+    def transaction(self, **_kwargs):
+        return _StubAcquire(self)
+
+    async def fetchrow(self, _sql, *_params):
+        return {"resource_count": 1, "total_bytes": self.row["byte_size"]}
+
+    async def fetch(self, _sql, *_params):
+        return [self.row]
+
+
+def _legacy_arm(monkeypatch) -> None:
+    from app.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "document_revision_backend", "bare_git_current")
+    monkeypatch.setattr(app_settings, "native_revision_m1_measurement_only", False)
+    monkeypatch.setattr(app_settings, "db_name", "akb")
+
+
+def _native_arm(monkeypatch) -> None:
+    from app.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "document_revision_backend", "native_ledger_m1")
+    monkeypatch.setattr(app_settings, "native_revision_m1_measurement_only", True)
+    monkeypatch.setattr(app_settings, "db_name", "akb_revision_m1_measurement")
+
+
+def _install_pool(monkeypatch, conn) -> None:
+    from app.services import search_service
+
+    async def get_test_pool():
+        return _StubPool(conn)
+
+    monkeypatch.setattr(search_service, "get_pool", get_test_pool)
+
+
+@pytest.mark.asyncio
+async def test_legacy_document_grep_response_has_no_placement_key(monkeypatch):
+    """Byte-invariance proof: the native-arm-OFF grep response is unchanged.
+
+    Placement observability is additive on the native arm only. The legacy
+    Document-only branch builds its own result dicts and must keep the exact
+    frozen key set, both as the service dict and after REST serialization
+    (`response_model_exclude_none=True`, which is how the earlier additive
+    fields stay invisible here too).
+    """
+    _legacy_arm(monkeypatch)
+    conn = _LegacyChunkConn([
+        {
+            "doc_id": str(uuid.uuid4()),
+            "vault": "legacy",
+            "path": "notes/guide.md",
+            "title": "Guide",
+            "metadata": {},
+            "section_path": "Intro",
+            "content": "needle body\n",
+            "chunk_index": 0,
+        },
+    ])
+    _install_pool(monkeypatch, conn)
+
+    response = await SearchService().grep(
+        pattern="needle", vault="legacy", user_id=str(uuid.uuid4()),
+    )
+
+    assert response == {
+        "pattern": "needle",
+        "regex": False,
+        "returned_docs": 1,
+        "returned_matches": 1,
+        "total_docs": 1,
+        "total_matches": 1,
+        "truncated": False,
+        "results": [{
+            "uri": "akb://legacy/coll/notes/doc/guide.md",
+            "vault": "legacy",
+            "path": "notes/guide.md",
+            "title": "Guide",
+            "matches": [{"section": "Intro", "text": "needle body"}],
+        }],
+    }
+    serialized = GrepResponse.model_validate(
+        {"kind": "grep", **response},
+    ).model_dump(exclude_none=True)
+    assert set(serialized["results"][0]) == {"uri", "vault", "path", "title", "matches"}
+    assert "payload_placement" not in json.dumps(serialized)
+
+
+@pytest.mark.asyncio
+async def test_native_arm_grep_response_reports_the_head_placement(monkeypatch):
+    """The same call on the native arm makes the Document's placement visible."""
+    _native_arm(monkeypatch)
+    assert active_document_source_type(
+        backend="native_ledger_m1",
+        measurement_only=True,
+        database="akb_revision_m1_measurement",
+    ) == "native_document"
+    body = b"needle body\n"
+    conn = _NativeHeadConn({
+        "namespace_id": uuid.uuid4(),
+        "vault": "measure",
+        "resource_id": uuid.uuid4(),
+        "surface": "document",
+        "current_path": "notes/guide.md",
+        "head_revision_id": "a" * 40,
+        "digest": hashlib.sha256(body).hexdigest(),
+        "byte_size": len(body),
+        "encoding": "utf-8",
+        "selected_placement": M1PgBodyStore.selected_placement,
+        "verification_profile": "sha256-size-utf8-v1",
+        "canonical_bytes": body,
+    })
+    _install_pool(monkeypatch, conn)
+
+    response = await SearchService().grep(
+        pattern="needle", vault="measure", user_id=str(uuid.uuid4()),
+    )
+
+    result = response["results"][0]
+    assert result["payload_placement"] == M1PgBodyStore.selected_placement
+    assert {"payload_id", "private_locator", "payload_manifest_id"}.isdisjoint(result)
+    serialized = GrepResponse.model_validate(
+        {"kind": "grep", **response},
+    ).model_dump(exclude_none=True)
+    assert serialized["results"][0]["payload_placement"] == (
+        M1PgBodyStore.selected_placement
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_arm_grep_reports_a_historical_reference_placement(monkeypatch):
+    """A row that never moved still reports its own placement, not the default."""
+    _native_arm(monkeypatch)
+    body = b"needle body\n"
+    conn = _NativeHeadConn({
+        "namespace_id": uuid.uuid4(),
+        "vault": "measure",
+        "resource_id": uuid.uuid4(),
+        "surface": "document",
+        "current_path": "notes/historical.md",
+        "head_revision_id": "b" * 40,
+        "digest": hashlib.sha256(body).hexdigest(),
+        "byte_size": len(body),
+        "encoding": "utf-8",
+        "selected_placement": M1ReferencePayloadStore.selected_placement,
+        "verification_profile": "sha256-size-utf8-v1",
+        "canonical_bytes": body,
+    })
+    _install_pool(monkeypatch, conn)
+
+    response = await SearchService().grep(
+        pattern="needle", vault="measure", user_id=str(uuid.uuid4()),
+    )
+
+    assert response["results"][0]["payload_placement"] == (
+        M1ReferencePayloadStore.selected_placement
+    )
 
 
 def test_native_search_metadata_verification_rejects_unknown_placement():


### PR DESCRIPTION
The M1 ADR approved B-text with one recorded gap: "the placement is bound as an operator declaration and verified from source — what is missing is observation." This makes body placement observable from outside, in the two owner-chosen forms, without exposing a single locator.

**Per-resource envelope fields.** The measurement File envelope gains `payload_placement`, sourced from the row's own Head's manifest via a LEFT JOIN whose multiplicity is bounded by DDL (`native_revisions` UNIQUE, `native_payload_manifests` PK) — LEFT because `vault_files` has no FK to `native_revisions`, so INNER would silently drop rows. Binary files carry an explicit `null`, matching the envelope's existing not-applicable convention. Native grep rows — Documents included, since the Document→PG-BodyStore unification is precisely what must be observable — gain `payload_placement`; the legacy branch cannot emit the key even on the raw-dict MCP path (the emit is conditional inside the native-only response builder), and a new regression test pins the legacy response byte-exactly with the real legacy configuration, not a mock.

**Namespace census.** `GET /files/{vault}/body-placements` returns per-placement `{bodies, body_bytes, distinct_digests}` (cardinality only, never a digest value), vault-reader authorization copied literally from the file listing, measurement-off → 404 through the same gate as the transfer capability, OpenAPI-included with a pydantic response model. Route matching probed against the real router: a file cannot be named `body-placements` (file_id is a UUID). The docstring states only the sound direction: a single `pg-bodystore-v1` row means zero reference residue; the converse is qualified because payload rows can outlive their Revisions.

**Defect found and fixed en route**: the measurement listing never selected `native_resource_id`/`native_revision_id`, reporting null Head identity where confirm/download reported values; nothing pinned the null.

A schema fact worth recording: the File envelope and grep read placement from different tables, but they cannot disagree — the composite FK carries `selected_placement` from the manifest back to the payload row.

Verified independently (disposable pgvector/pg16, all counts reproduced): file-measurement 35, pg-body-grep 31, search-selection 18, idempotent-upload 25, mcp-grep 6, b_core 60 untouched; DB-free gate 1576 passed / 0 failed; ruff, mypy, bandit clean. Non-exposure of `payload_id` / `private_locator` / `payload_manifest_id` / `storage_locator` / `s3_key` / digest enumerations is asserted by test, not claimed.

Follow-ups recorded, not blocking: a vault literally named `transfer` cannot reach the census (pre-existing route-shadowing hazard, fails closed); payload rows are never reaped, so census residue can be orphaned rather than live.

Part of the P1 preparation series (the ADR's B-text carry-over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcTyzcrzMgCN7pxArJZqk
