### PR TITLE
fix(grep): make replace write the document set the caller asked for (#338, #315, #341)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 357,
+        "line_number": 358,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1151,
+        "line_number": 1165,
         "is_secret": false
       }
     ],
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T05:14:27Z"
+  "generated_at": "2026-08-07T13:27:48Z"
 }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -484,6 +484,18 @@ class Settings(BaseModel):
     # caller (MCP, REST, internal) is bounded uniformly.
     search_limit_max: int = Field(default=50, ge=1)
 
+    # Hard ceiling on how many documents a single `grep(replace=...)` may
+    # rewrite. Deliberately NOT `search_limit_max`: that one bounds the
+    # snippet payload, and reusing it as the write bound is what made a
+    # find-and-replace silently rewrite only the first 50 matches and report
+    # success (issue #315). `limit` is now preview-only; this is the write
+    # bound, and it fails CLOSED — a replace whose scope exceeds it is
+    # rejected with zero writes rather than truncated, so the caller narrows
+    # the scope deliberately instead of discovering a partial rewrite later.
+    # Each replaced document costs one git commit plus one re-index, which is
+    # what keeps this a bounded number rather than "all of them".
+    grep_replace_max_docs: int = Field(default=500, ge=1)
+
     # Push the ACL filter down to VAULT granularity in the vector store (issue
     # #189 Phase 2). When True AND the driver is pgvector AND a search has no
     # doc-level filter (collection/doc_type/tags/source_uris), search filters by

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -323,6 +323,10 @@ class GrepReplacement(BaseModel):
     path: str | None = None
     title: str | None = None
     commit: str | None = None
+    # The commit the document moved OFF. A replace is one commit per
+    # document with no transaction spanning them, so a run that aborts
+    # part-way is only unwindable if each entry carries both ends.
+    previous_commit: str | None = None
     error: str | None = None
 
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -27,6 +27,7 @@ from app.services.vector_store import VectorHit, get_vector_store
 from app.services.vector_store.base import VectorStoreUnavailable, supports_vault_filter
 from app.services.rerank_service import RerankError, rerank
 from app.services.uri_service import parse_uri
+from app.util.text import like_escape
 
 logger = logging.getLogger("akb.search")
 
@@ -62,6 +63,42 @@ def _configured_document_source_type() -> str:
         measurement_only=settings.native_revision_m1_measurement_only,
         database=settings.db_name,
     )
+
+
+def collection_containment_sql(column: str, collection: str, params: list) -> str:
+    """Build an anchored, escaped "inside this collection" predicate.
+
+    Appends the two bound values to `params` and returns the SQL fragment
+    referencing them by 1-based position:
+
+        (<column> = $exact OR <column> LIKE $prefix ESCAPE '\\')
+
+    Two things the old `<column> LIKE $n || '%'` got wrong (issue #338):
+
+    * **No escaping.** The raw collection name was spliced in as a LIKE
+      pattern, so a `_` or `%` inside a perfectly ordinary name acted as
+      a wildcard — `my_docs` also matched `myXdocs`, and `%` matched the
+      caller's whole accessible corpus. `like_escape` + `ESCAPE '\\'`
+      makes those characters literal.
+    * **No anchor.** A bare `prefix%` match also admitted every
+      prefix-adjacent sibling, so `core` swept in `core-extra/...`.
+      Anchoring on `{prefix}/` confines it to real descendants.
+
+    This is the containment rule the native arm already implements
+    (`m1_native_grep_service._head_bodies`) and the one conformance case
+    C7b pins as the target: `path == prefix or path.startswith(prefix + "/")`.
+    The exact-match arm is what makes a *collection* path column
+    (`collections.path`, `resources.current_path`) include the collection
+    row itself; on `documents.path` it is inert, because a document path
+    is always composed by `util.text.doc_path` and so always carries a
+    `.md` filename segment. It is kept there anyway so all three call
+    sites read as the same rule rather than as three dialects of it.
+    """
+    prefix = collection.strip("/")
+    params.append(prefix)
+    exact = len(params)
+    params.append(like_escape(prefix) + "/%")
+    return f"({column} = ${exact} OR {column} LIKE ${len(params)} ESCAPE '\\')"
 
 # Strips the indexing-time enrichment block emitted by
 # `build_doc_metadata_header`. The block is `TITLE: ...\n` followed by
@@ -219,14 +256,8 @@ class SearchService:
             params.append(vaults)
             conditions.append(f"v.name = ANY(${len(params)})")
         if collection:
-            prefix = collection.strip("/")
-            escaped_prefix = (
-                prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            )
-            params.extend([prefix, f"{escaped_prefix}/%"])
             conditions.append(
-                f"(r.current_path = ${len(params) - 1} OR "
-                f"r.current_path LIKE ${len(params)} ESCAPE '\\')"
+                collection_containment_sql("r.current_path", collection, params)
             )
         if user_uuid is not None and not is_admin:
             params.append(user_uuid)
@@ -458,8 +489,9 @@ class SearchService:
                     conditions.append(f"v.name = ANY(${idx})")
                     params.append(vaults); idx += 1
                 if collection:
-                    conditions.append(f"d.path LIKE ${idx} || '%'")
-                    params.append(collection); idx += 1
+                    conditions.append(
+                        collection_containment_sql("d.path", collection, params)
+                    ); idx += 2
                 if doc_type:
                     conditions.append(f"d.doc_type = ${idx}")
                     params.append(doc_type); idx += 1
@@ -536,10 +568,13 @@ class SearchService:
                     if collection:
                         # vault_files.collection (TEXT) was dropped in
                         # migration 020 → collection_id FK. Filter via the
-                        # joined collections.path with a prefix match, same
-                        # semantics as the documents branch above.
-                        f_conds.append(f"c.path LIKE ${len(f_params) + 1} || '%'")
-                        f_params.append(collection)
+                        # joined collections.path, same containment rule as
+                        # the documents branch above. The join is a LEFT
+                        # JOIN, so a file with no collection has a NULL
+                        # `c.path` and drops out of both arms — unchanged.
+                        f_conds.append(
+                            collection_containment_sql("c.path", collection, f_params)
+                        )
                     acl_sql, acl_params = _vault_acl(len(f_params) + 1)
                     if acl_sql:
                         f_conds.append(acl_sql)
@@ -1167,9 +1202,13 @@ class SearchService:
                 idx += 1
 
             if collection:
-                conditions.append(f"d.path LIKE ${idx} || '%'")
-                params.append(collection)
-                idx += 1
+                # Anchored + escaped (#338). This filter selects the exact
+                # document set that `replace=` below rewrites, so an
+                # over-match here is a write outside the caller's scope.
+                conditions.append(
+                    collection_containment_sql("d.path", collection, params)
+                )
+                idx += 2
 
             where_sql = " AND ".join(conditions)
             # No prefetch cap. The old `LIMIT (limit * 5)` cap was inherited
@@ -1284,15 +1323,43 @@ class SearchService:
         result_docs = matched_docs[:limit]
         returned_matches = sum(len(d["matches"]) for d in result_docs)
 
-        # Replace mode: apply find-and-replace on each matching document.
-        # Service-layer `doc_service.update` still wants the doc path
-        # (which find_by_ref accepts) — we pass `path` rather than re-
-        # parsing the URI we just built.
+        # ── Replace mode ─────────────────────────────────────────────
+        # Scope is the FULL matched set, not the `limit` preview slice.
+        # `limit` is documented as an output knob and is clamped to 50, so
+        # driving the rewrite from `result_docs` silently dropped every match
+        # past the 50th while reporting success — and two ordinary cases
+        # (a case-only replacement, or a replacement containing the pattern)
+        # never drained on retry because the same first-50 docs were selected
+        # each time. Issue #315.
+        #
+        # The write bound is now its own budget, checked BEFORE any write and
+        # failing closed: too wide a scope is rejected whole rather than
+        # truncated, so the caller narrows it deliberately.
         replaced: list[dict] = []
-        if replace is not None and result_docs and doc_service:
-            re_flags = 0 if case_sensitive else _re.IGNORECASE
+        replace_docs = matched_docs if replace is not None and doc_service else []
+        if replace_docs and total_docs > settings.grep_replace_max_docs:
+            return {
+                "error": (
+                    f"replace scope is {total_docs} documents, over the "
+                    f"{settings.grep_replace_max_docs}-document limit; nothing was "
+                    f"written. Narrow the scope (vault/collection/pattern), or "
+                    f"preview it with count_only=true / files_with_matches=true."
+                ),
+                "code": "replace_scope_too_large",
+                "pattern": pattern,
+                "regex": regex,
+                "total_docs": total_docs,
+                "total_matches": total_matches,
+                "max_replacements": settings.grep_replace_max_docs,
+            }
 
-            for doc_info in result_docs:
+        if replace is not None and doc_service and replace_docs:
+            re_flags = 0 if case_sensitive else _re.IGNORECASE
+            literal_replacement = replace  # narrowed, for the closure below
+            # Service-layer `doc_service.update` still wants the doc path
+            # (which find_by_ref accepts) — we pass `path` rather than
+            # re-parsing the URI we just built.
+            for doc_info in replace_docs:
                 doc_vault = doc_info["vault"]
                 doc_path = doc_info["path"]
                 doc_uri_str = doc_info["uri"]
@@ -1305,14 +1372,41 @@ class SearchService:
 
                 body = doc.content or ""
 
-                if regex:
-                    new_body = _re.sub(pattern, replace, body, flags=re_flags)
-                else:
-                    if case_sensitive:
+                # `replace` is a regex replacement TEMPLATE only when the
+                # caller asked for regex — that is the documented contract
+                # ("supports backreferences when regex=true"). In non-regex
+                # mode it must be literal on BOTH case branches: the
+                # case-sensitive branch used `str.replace` (literal) while the
+                # case-insensitive one passed the string to `_re.sub`, so on
+                # the default path `TODO\1` raised, `[\g<0>]` expanded, and
+                # `C:\new` wrote a newline. A function replacement is inserted
+                # verbatim, which makes the two branches agree.
+                try:
+                    if regex:
+                        new_body = _re.sub(pattern, replace, body, flags=re_flags)
+                    elif case_sensitive:
                         new_body = body.replace(pattern, replace)
                     else:
-                        # Case-insensitive non-regex replace
-                        new_body = _re.sub(_re.escape(pattern), replace, body, flags=_re.IGNORECASE)
+                        new_body = _re.sub(
+                            _re.escape(pattern), lambda _m: literal_replacement,
+                            body, flags=_re.IGNORECASE,
+                        )
+                except _re.error as e:
+                    # A bad regex template is a property of (pattern, replace),
+                    # not of this document, so it fails on the first document
+                    # that would have changed — i.e. with zero writes behind
+                    # it. Reject the whole call rather than emit one identical
+                    # error per document.
+                    return {
+                        "error": f"Invalid regex replacement: {e}",
+                        "code": "invalid_replacement",
+                        "pattern": pattern,
+                        "regex": regex,
+                        "total_docs": total_docs,
+                        "total_matches": total_matches,
+                        "replaced_docs": len(replaced),
+                        "replacements": replaced,
+                    }
 
                 if new_body == body:
                     continue  # no actual change
@@ -1322,12 +1416,41 @@ class SearchService:
                     content=new_body,
                     message=f"grep replace: '{pattern}' → '{replace}'",
                 )
-                result = await doc_service.update(doc_vault, doc_path, req, agent_id=agent_id)
+                try:
+                    result = await doc_service.update(
+                        doc_vault, doc_path, req, agent_id=agent_id
+                    )
+                except Exception as e:
+                    # Each document is its own commit — there is no transaction
+                    # spanning the loop — so a mid-loop failure (write-lane
+                    # contention, a concurrent edit losing the OCC check) leaves
+                    # the earlier documents committed. Returning the ledger of
+                    # what already landed is the only way the caller can tell
+                    # what to undo or resume from; letting the exception escape
+                    # discards it. Issue #315.
+                    logger.warning(
+                        "grep replace aborted at %s after %d document(s): %s",
+                        doc_uri_str, len(replaced), e,
+                    )
+                    return {
+                        "error": f"replace aborted at {doc_uri_str}: {e}",
+                        "code": "replace_incomplete",
+                        "pattern": pattern,
+                        "regex": regex,
+                        "total_docs": total_docs,
+                        "total_matches": total_matches,
+                        "replaced_docs": len(replaced),
+                        "replacements": replaced,
+                        "remaining_docs": total_docs - len(replaced),
+                    }
                 replaced.append({
                     "uri": doc_uri_str,
                     "path": doc_path,
                     "title": doc_info["title"],
                     "commit": result.commit_hash,
+                    # The commit this document moved OFF, so a caller
+                    # unwinding a partial run has both ends of each edit.
+                    "previous_commit": result.previous_commit,
                 })
 
         # Build response — strip internal handles (`_doc_pk`, `metadata`)
@@ -1348,12 +1471,22 @@ class SearchService:
             "results": clean_results,
         }
         if resp["truncated"]:
-            resp["hint"] = (
+            hint = (
                 f"Showing {len(clean_results)} of {total_docs} matching docs "
                 f"(limit={limit}, {returned_matches} of {total_matches} line matches). "
                 f"For full counts use count_only=true; for the full URI list use "
                 f"files_with_matches=true."
             )
+            if replace is not None:
+                # `truncated` has only ever described the snippet payload, but
+                # while replace was driven by the same slice it also, silently,
+                # described the rewrite. It no longer does — say so, so the
+                # flag is not read as "the replace was cut short too".
+                hint += (
+                    f" `truncated` refers to this preview only: replace covered "
+                    f"all {total_docs} matching docs."
+                )
+            resp["hint"] = hint
 
         if total_matches == 0 and not regex:
             metachars = set("|.*+?()[]{}^$\\")

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -167,7 +167,8 @@ akb_edit(uri="akb://v/doc/path/to/file.md", old_string="old text", new_string="n
 
 ## akb_grep — Exact Text Search & Replace
 Find exact strings or regex patterns across documents. Use when you need precision, not meaning.
-Add `replace` to find-and-replace across all matching documents in one call.
+Add `replace` to find-and-replace across all matching documents in one call
+(every match in scope — `limit` only trims the preview that comes back).
 
 ```
 akb_grep(pattern="PostgreSQL 14")                                      # Find exact string
@@ -856,6 +857,9 @@ Unlike akb_search (semantic), this finds **exact matches** — use it for
 specific terms, URLs, code snippets, version numbers, error codes, etc.
 
 Optionally pass `replace` to find-and-replace across all matching documents.
+The rewrite covers the whole matched scope, not just the `limit` documents
+shown; if that scope is wider than the server's replace budget the call is
+rejected outright and nothing is written.
 
 ## Parameters
 | Param | Required | Description |
@@ -865,8 +869,8 @@ Optionally pass `replace` to find-and-replace across all matching documents.
 | collection | | Limit to a specific collection |
 | regex | | Treat pattern as regex (default: false) |
 | case_sensitive | | Case-sensitive match (default: false) |
-| replace | | Replacement string — triggers find-and-replace mode |
-| limit | | Max documents to return (default 20) |
+| replace | | Replacement string — triggers find-and-replace mode. Literal unless regex=true |
+| limit | | Max documents to return (default 20). Output only — does not bound `replace` |
 | count_only | | Return exact per-resource counts without snippets |
 | measurement_include_text_files | | Guarded native measurement mode: include admitted searchable text Files; binary Files stay excluded |
 
@@ -898,6 +902,8 @@ akb_grep(pattern="v(\\d+)\\.1", vault="eng", regex=true, replace="v\\1.2")
 
 **Tip:** Run grep WITHOUT replace first to preview matches, then add replace.
 Each replaced document gets its own git commit and is re-indexed for search.
+Backreferences only apply when regex=true — with regex=false the replacement
+goes in exactly as typed, so `C:\\new` stays `C:\\new`.
 
 ## Result Structure
 Each result includes `uri`, `vault`, `path`, `title`, and `matches` — a list of
@@ -908,7 +914,12 @@ also carries `payload_placement` — which body placement the matched bytes were
 read from; it names a storage strategy, never an address. If snippets hit
 response safety bounds,
 `truncated` is true and `truncation` reports the applied match/byte limits.
-When replace is used, response also includes `replaced_docs` count and `replacements` list.""",
+When replace is used, response also includes `replaced_docs` count and
+`replacements` list (each with `commit` and `previous_commit`). `truncated`
+describes the preview only — it never means the rewrite was cut short. A
+replace that would exceed the server budget returns `code:
+"replace_scope_too_large"` with nothing written; one that fails part-way
+returns `code: "replace_incomplete"` plus the documents already committed.""",
 
     "akb_drill_down": """# akb_drill_down — Section-Level Reader
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -419,7 +419,8 @@ TOOLS = [
             "Unlike akb_search (semantic/meaning-based), this finds exact string matches — "
             "use it for specific terms, URLs, code snippets, version numbers, etc. "
             "Returns matching documents (each with its `uri`) and matched lines. "
-            "Optionally pass `replace` to find-and-replace across all matching documents. "
+            "Optionally pass `replace` to find-and-replace across all matching documents "
+            "(every match in scope, not just the `limit` shown). "
             "Three response shapes (mutually exclusive): default lines, `count_only=true` "
             "(grep -c — per-doc counts + total, no snippets), `files_with_matches=true` "
             "(grep -l — just the URIs that contain the pattern). "
@@ -436,8 +437,8 @@ TOOLS = [
                 "collection": {"type": "string", "description": "Limit to a specific collection"},
                 "regex": {"type": "boolean", "default": False, "description": "Treat pattern as PostgreSQL regex. REQUIRED to use alternation (|), wildcards (.*), character classes, anchors, etc. When false (default), the entire pattern including any metacharacters is matched literally."},
                 "case_sensitive": {"type": "boolean", "default": False, "description": "Case-sensitive matching (default: case-insensitive)"},
-                "replace": {"type": "string", "description": "Replacement string. If provided, replaces all matches in EVERY matching document across the search scope (git commit + re-index per doc). Supports regex backreferences (\\1, \\2) when regex=true. For precise edits to a single known document, prefer akb_edit instead."},
-                "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 50, "description": "Max documents to return"},
+                "replace": {"type": "string", "description": "Replacement string. If provided, replaces all matches in EVERY matching document across the search scope (git commit + re-index per doc) — independently of `limit`, which only bounds the returned preview. Supports regex backreferences (\\1, \\2) when regex=true; with regex=false the replacement is inserted literally, backslashes and all. A scope wider than the server's replace budget is REJECTED with nothing written, so preview it first with count_only=true. For precise edits to a single known document, prefer akb_edit instead."},
+                "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 50, "description": "Max documents to return. Output only — it does NOT bound what `replace` rewrites."},
                 "count_only": {"type": "boolean", "default": False, "description": "Return counts only (grep -c semantics). Response: {pattern, total_matches, total_docs, by_doc:{uri:count,...}}. Use for 'how many X are there?' questions — much cheaper than fetching every line."},
                 "files_with_matches": {"type": "boolean", "default": False, "description": "Return only the URIs that contain matches (grep -l semantics). Response: {pattern, n_files, files:[uri,...]}. Use for 'which documents mention X?' questions."},
                 "measurement_include_text_files": {

--- a/backend/tests/test_grep_replace_scope_unit.py
+++ b/backend/tests/test_grep_replace_scope_unit.py
@@ -1,0 +1,433 @@
+"""Unit tests for what `SearchService.grep(replace=...)` writes — issues #338, #315.
+
+Three defects lived in the same handful of lines, all of the form "the
+rewrite touches the wrong thing":
+
+  * **#338 — too many documents.** The `collection` filter compiled to
+    `d.path LIKE $n || '%'`: unescaped, so a `_` or `%` in an ordinary
+    collection name acted as a wildcard, and unanchored, so `core` also
+    swept in the sibling collection `core-extra/`. Every one of those
+    documents got a git commit and a re-index.
+  * **#315 — too few documents.** The replace loop iterated
+    `matched_docs[:limit]` with `limit` clamped to 50, so a wider scope was
+    silently rewritten in part and reported as done.
+  * **wrong bytes.** With `regex=false` the two case branches disagreed:
+    `case_sensitive=True` used `str.replace` (literal) while the default
+    `case_sensitive=False` passed the string to `_re.sub`, making it a
+    regex *template* — so `TODO\\1` raised mid-loop, `[\\g<0>]` expanded,
+    and `C:\\new` wrote a newline.
+
+The DB is mocked, but not vacuously: `_FakeConn` evaluates the collection
+predicate the query actually emits, including `ESCAPE` semantics, so the
+"prefix-adjacent sibling is untouched" assertion #338 asks for is made
+end-to-end against `doc_service.update` call records rather than by
+eyeballing the SQL string.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+from app.services import search_service
+from app.services.search_service import SearchService, collection_containment_sql
+
+# asyncio_mode = "auto" (pyproject) marks the async tests; the sync
+# predicate tests below must NOT carry an asyncio mark.
+
+
+# ── a faithful-enough LIKE ────────────────────────────────────────────
+# Translating `LIKE ... ESCAPE '\'` to a regex is the only way the fake
+# conn can filter the corpus the way PostgreSQL would. Verified against
+# PostgreSQL 16 for the cases exercised below.
+def _like_match(value: str, pattern: str) -> bool:
+    out, i = [], 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "\\" and i + 1 < len(pattern):
+            out.append(re.escape(pattern[i + 1]))
+            i += 2
+            continue
+        out.append({"%": ".*", "_": "."}.get(ch, re.escape(ch)))
+        i += 1
+    return re.fullmatch("".join(out), value, re.DOTALL) is not None
+
+
+class _FakeConn:
+    """asyncpg-conn stand-in for `grep`'s single chunk query.
+
+    Applies the two clauses under test — the content match and the
+    collection containment — against `corpus`. The ACL clause is bound but
+    not evaluated; it is orthogonal to what these tests pin.
+    """
+
+    def __init__(self, corpus: list[dict]):
+        self.corpus = corpus
+        self.sql: str | None = None
+        self.params: tuple = ()
+
+    async def fetch(self, sql: str, *params):
+        self.sql, self.params = sql, params
+        pos = 0
+        pattern = params[pos]; pos += 1
+        if "v.name = ANY(" in sql:
+            pos += 1
+        if "vault_access" in sql:
+            pos += 1
+        coll_exact = coll_like = None
+        if "ESCAPE" in sql:
+            coll_exact, coll_like = params[pos], params[pos + 1]
+
+        # `c.content ~`/`~*` in regex mode, `LIKE`/`ILIKE` otherwise.
+        is_regex = "c.content ~" in sql
+        ci = "ILIKE" in sql or "~*" in sql
+
+        rows = []
+        for row in self.corpus:
+            if is_regex:
+                if not re.search(pattern, row["content"], re.I if ci else 0):
+                    continue
+            elif ci:
+                if pattern.lower() not in row["content"].lower():
+                    continue
+            elif pattern not in row["content"]:
+                continue
+            if coll_like is not None and not (
+                row["path"] == coll_exact or _like_match(row["path"], coll_like)
+            ):
+                continue
+            rows.append(row)
+        return rows
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        conn = self._conn
+
+        class _CM:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, *a):
+                return False
+
+        return _CM()
+
+
+class _Doc:
+    def __init__(self, content):
+        self.content = content
+
+
+class _PutResult:
+    def __init__(self, commit_hash, previous_commit):
+        self.commit_hash = commit_hash
+        self.previous_commit = previous_commit
+
+
+class _FakeDocService:
+    """Records every write. `fail_on` makes the Nth update raise."""
+
+    def __init__(self, bodies: dict[str, str], fail_on: int | None = None):
+        self.bodies = bodies
+        self.fail_on = fail_on
+        self.updated: list[tuple[str, str, str]] = []  # (vault, path, new_body)
+
+    async def get(self, vault, path):
+        return _Doc(self.bodies[path])
+
+    async def update(self, vault, path, req, agent_id=None):
+        if self.fail_on is not None and len(self.updated) == self.fail_on:
+            raise RuntimeError("write lane busy")
+        self.updated.append((vault, path, req.content))
+        n = len(self.updated)
+        return _PutResult(f"commit{n}", f"parent{n}")
+
+
+def _chunk(path: str, content: str, *, vault: str = "v", title: str = "T") -> dict:
+    return {
+        "doc_id": str(uuid.uuid5(uuid.NAMESPACE_URL, path)),
+        "vault": vault,
+        "path": path,
+        "title": title,
+        "metadata": None,
+        "section_path": "# S",
+        "content": content,
+        "chunk_index": 0,
+    }
+
+
+def _wire(monkeypatch, corpus, doc_service=None):
+    conn = _FakeConn(corpus)
+    monkeypatch.setattr(search_service, "get_pool", lambda: _async(_FakePool(conn)))
+    return conn, doc_service
+
+
+async def _async(v):
+    return v
+
+
+# ── #338: containment predicate ───────────────────────────────────────
+
+def test_containment_sql_is_anchored_and_escaped():
+    params: list = []
+    sql = collection_containment_sql("d.path", "core", params)
+    assert sql == "(d.path = $1 OR d.path LIKE $2 ESCAPE '\\')"
+    assert params == ["core", "core/%"]
+
+
+def test_containment_sql_escapes_like_metacharacters_in_a_real_name():
+    params: list = []
+    collection_containment_sql("d.path", "my_docs", params)
+    # The `_` must reach PostgreSQL escaped, or it matches any character.
+    assert params == ["my_docs", "my\\_docs/%"]
+    assert _like_match("my_docs/a.md", params[1])
+    assert not _like_match("myXdocs/a.md", params[1])
+
+
+def test_containment_sql_neutralises_a_wildcard_collection():
+    params: list = []
+    collection_containment_sql("d.path", "%", params)
+    assert params == ["%", "\\%/%"]
+    assert not _like_match("secret/x.md", params[1])
+
+
+def test_containment_sql_tolerates_surrounding_slashes():
+    params: list = []
+    collection_containment_sql("d.path", "/core/", params)
+    assert params == ["core", "core/%"]
+
+
+def test_containment_admits_descendants_and_excludes_prefix_siblings():
+    params: list = []
+    collection_containment_sql("d.path", "core", params)
+    like = params[1]
+    assert _like_match("core/a.md", like)
+    assert _like_match("core/deep/b.md", like)          # nested, still inside
+    assert not _like_match("core-extra/b.md", like)     # the #338 leak
+    assert not _like_match("coreutils.md", like)
+
+
+async def test_replace_scoped_to_a_collection_leaves_the_sibling_untouched(monkeypatch):
+    """The regression #338 asks for: a rewrite scoped to `core` must not
+    commit anything in `core-extra`."""
+    corpus = [
+        _chunk("core/a.md", "needle here"),
+        _chunk("core/deep/b.md", "needle nested"),
+        _chunk("core-extra/prefix-adjacent.md", "needle adjacent"),
+    ]
+    docs = _FakeDocService({
+        "core/a.md": "needle here",
+        "core/deep/b.md": "needle nested",
+        "core-extra/prefix-adjacent.md": "needle adjacent",
+    })
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", collection="core", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    touched = {p for _, p, _ in docs.updated}
+    assert touched == {"core/a.md", "core/deep/b.md"}
+    assert "core-extra/prefix-adjacent.md" not in touched
+    assert resp["replaced_docs"] == 2
+
+
+async def test_every_placeholder_is_bound_with_all_filters_on(monkeypatch):
+    """The containment predicate binds TWO params where the old one bound one.
+
+    Every `$n` downstream of it shifts, and a fake connection will happily
+    accept a query whose placeholders no longer line up with its params —
+    only PostgreSQL would reject that. Pin the invariant here instead.
+    """
+    conn = _FakeConn([_chunk("core/a.md", "needle")])
+    monkeypatch.setattr(search_service, "get_pool", lambda: _async(_FakePool(conn)))
+
+    await SearchService().grep(
+        "needle", vault="v", collection="core", regex=True,
+        case_sensitive=True, user_id=str(uuid.uuid4()),
+    )
+
+    used = {int(n) for n in re.findall(r"\$(\d+)", conn.sql)}
+    assert used == set(range(1, len(conn.params) + 1)), (
+        f"placeholders {sorted(used)} vs {len(conn.params)} bound params"
+    )
+    # ...and the containment pair is the last thing bound, in order.
+    assert conn.params[-2:] == ("core", "core/%")
+
+
+async def test_replace_scoped_to_an_underscore_collection_is_not_a_wildcard(monkeypatch):
+    corpus = [_chunk("my_docs/a.md", "needle"), _chunk("myXdocs/a.md", "needle")]
+    docs = _FakeDocService({"my_docs/a.md": "needle", "myXdocs/a.md": "needle"})
+    _wire(monkeypatch, corpus)
+
+    await SearchService().grep(
+        "needle", vault="v", collection="my_docs", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+    assert [p for _, p, _ in docs.updated] == ["my_docs/a.md"]
+
+
+# ── #315: replace covers the whole matched set ────────────────────────
+
+async def test_replace_covers_every_match_not_just_the_limit_page(monkeypatch):
+    n = 60  # > search_limit_max (50), so the old slice could never reach these
+    corpus = [_chunk(f"c/{i:03}.md", "needle") for i in range(n)]
+    docs = _FakeDocService({f"c/{i:03}.md": "needle" for i in range(n)})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="thread", limit=5,
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert len(docs.updated) == n
+    assert resp["replaced_docs"] == n
+    # `limit` still governs the preview, and only the preview.
+    assert resp["returned_docs"] == 5
+    assert resp["total_docs"] == n
+    assert resp["truncated"] is True
+    assert "replace covered all 60 matching docs" in resp["hint"]
+
+
+async def test_replace_over_budget_is_rejected_with_zero_writes(monkeypatch):
+    monkeypatch.setattr(search_service.settings, "grep_replace_max_docs", 10)
+    corpus = [_chunk(f"c/{i:03}.md", "needle") for i in range(11)]
+    docs = _FakeDocService({f"c/{i:03}.md": "needle" for i in range(11)})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert docs.updated == []          # fails CLOSED — nothing written
+    assert resp["code"] == "replace_scope_too_large"
+    assert resp["total_docs"] == 11
+    assert resp["max_replacements"] == 10
+    assert "replaced_docs" not in resp
+
+
+async def test_replace_at_exactly_the_budget_is_allowed(monkeypatch):
+    monkeypatch.setattr(search_service.settings, "grep_replace_max_docs", 10)
+    corpus = [_chunk(f"c/{i:03}.md", "needle") for i in range(10)]
+    docs = _FakeDocService({f"c/{i:03}.md": "needle" for i in range(10)})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+    assert resp["replaced_docs"] == 10
+
+
+async def test_empty_replacement_is_still_a_write_and_still_budgeted(monkeypatch):
+    """`replace=""` deletes every match — truthiness must not gate the budget."""
+    monkeypatch.setattr(search_service.settings, "grep_replace_max_docs", 2)
+    corpus = [_chunk(f"c/{i}.md", "needle") for i in range(3)]
+    docs = _FakeDocService({f"c/{i}.md": "needle" for i in range(3)})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+    assert docs.updated == []
+    assert resp["code"] == "replace_scope_too_large"
+
+
+# ── the replacement string is data, not a template ────────────────────
+
+@pytest.mark.parametrize("case_sensitive", [True, False])
+@pytest.mark.parametrize(
+    "replacement",
+    [r"C:\new", r"TODO\1", r"[\g<0>]", r"back\\slash", "plain"],
+)
+async def test_non_regex_replacement_is_literal_on_both_case_branches(
+    monkeypatch, case_sensitive, replacement
+):
+    corpus = [_chunk("c/a.md", "see TODO here")]
+    docs = _FakeDocService({"c/a.md": "see TODO here"})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "TODO", vault="v", replace=replacement, case_sensitive=case_sensitive,
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert "error" not in resp
+    assert [b for _, _, b in docs.updated] == [f"see {replacement} here"]
+
+
+async def test_regex_replacement_still_expands_backreferences(monkeypatch):
+    corpus = [_chunk("c/a.md", "v1.1 released")]
+    docs = _FakeDocService({"c/a.md": "v1.1 released"})
+    _wire(monkeypatch, corpus)
+
+    await SearchService().grep(
+        r"v(\d+)\.1", vault="v", regex=True, replace=r"v\1.2",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+    assert [b for _, _, b in docs.updated] == ["v1.2 released"]
+
+
+async def test_bad_regex_replacement_template_writes_nothing(monkeypatch):
+    corpus = [_chunk(f"c/{i}.md", "TODO") for i in range(3)]
+    docs = _FakeDocService({f"c/{i}.md": "TODO" for i in range(3)})
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "TODO", vault="v", regex=True, replace=r"\1",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert docs.updated == []
+    assert resp["code"] == "invalid_replacement"
+    assert resp["replaced_docs"] == 0
+
+
+# ── a partial run is recoverable ──────────────────────────────────────
+
+async def test_a_mid_loop_write_failure_reports_what_already_committed(monkeypatch):
+    corpus = [_chunk(f"c/{i}.md", "needle") for i in range(5)]
+    docs = _FakeDocService(
+        {f"c/{i}.md": "needle" for i in range(5)}, fail_on=2
+    )
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert len(docs.updated) == 2
+    assert resp["code"] == "replace_incomplete"
+    assert resp["replaced_docs"] == 2
+    assert resp["remaining_docs"] == 3
+    # Both ends of every landed edit, so the caller can unwind or resume.
+    assert [r["commit"] for r in resp["replacements"]] == ["commit1", "commit2"]
+    assert [r["previous_commit"] for r in resp["replacements"]] == ["parent1", "parent2"]
+
+
+async def test_an_unreadable_document_is_reported_without_aborting_the_run(monkeypatch):
+    """A missing doc is per-document (unlike a bad template), so the rest
+    of the scope still gets rewritten."""
+    corpus = [_chunk(f"c/{i}.md", "needle") for i in range(3)]
+    bodies = {f"c/{i}.md": "needle" for i in range(3)}
+    del bodies["c/1.md"]
+    docs = _FakeDocService(bodies)
+    _wire(monkeypatch, corpus)
+
+    resp = await SearchService().grep(
+        "needle", vault="v", replace="thread",
+        doc_service=docs, agent_id="a", user_id=str(uuid.uuid4()),
+    )
+
+    assert [p for _, p, _ in docs.updated] == ["c/0.md", "c/2.md"]
+    assert resp["replaced_docs"] == 3  # 2 commits + 1 recorded failure
+    assert [r.get("error") for r in resp["replacements"]] == [None, "not found", None]


### PR DESCRIPTION
Three defects, one function, one shape: **`grep(replace=…)` wrote the wrong
thing.** They were worth fixing together because two of them are the same loop
disagreeing about *which* documents, and the third decides *what bytes* go into
them — and widening the scope without fixing the bytes would have widened the
blast radius of an uncaught exception.

| | defect | direction of the error |
|---|---|---|
| **#338** | `collection` filter was an unanchored, unescaped `LIKE` | rewrote documents **outside** the requested scope |
| **#315** | replace iterated `matched_docs[:limit]`, `limit` capped at 50 | rewrote **only part** of the requested scope, silently |
| **#341** | non-regex replacement was literal on one case branch, a regex template on the other | wrote **the wrong bytes**, or raised mid-loop |

## #338 — scope containment

The filter compiled to `d.path LIKE $n || '%'`. Unescaped, so a `_` or `%` in a
perfectly ordinary collection name was a wildcard; unanchored, so `core` also
admitted the sibling collection `core-extra/`. Every swept-in document got its
own git commit and re-index.

The product already had the right rule in three places — the native arm
(`m1_native_grep_service._head_bodies`), the repo layer
(`document_repo.list_docs_under` and friends), and conformance case **C7b**,
which pins it as the *target* containment: `path == prefix or
path.startswith(prefix + "/")`. `search_service` was the outlier that never
adopted it. This adds one `collection_containment_sql` helper emitting

```sql
(<column> = $exact OR <column> LIKE $prefix ESCAPE '\')
```

over `like_escape(prefix) + "/%"`, and applies it at **all three** sites — the
grep write path plus the two read-path siblings at `:461` and `:541` that #338
also names. It replaces two hand-inlined copies of the escape triple-replace
with the existing `util.text.like_escape`.

The exact-match arm is inert on `documents.path` (a document path is always
composed by `doc_path()` and carries a `.md` segment) and load-bearing on
`collections.path` / `resources.current_path`. Kept everywhere so the three
sites read as one rule rather than three dialects — and so legacy does not
diverge from the contract C7b pins for P2.

## #315 — replace covers the scope, and fails closed

`limit` is documented as an output knob and clamped to 50, so driving the
rewrite from `result_docs` dropped every match past the 50th while reporting
success. Worse, it did not converge on retry: a case-only replacement
(`postgresql` → `PostgreSQL`) leaves the doc matching but unchanged, so the same
first 50 documents were re-selected forever.

Replace now covers the full matched set. `limit` governs the preview only, and
says so in the response hint when both are in play. The write gets its **own**
bound — `grep_replace_max_docs` (default 500) — which **fails closed**: a scope
wider than the budget is rejected with `code: "replace_scope_too_large"` and
**nothing written**, pointing the caller at `count_only` / `files_with_matches`.
Truncating a write silently is what caused this; truncating it loudly would too.

A partial run is now recoverable, which it was not: `doc_service.update` moved
inside the guard, every entry carries `previous_commit` as well as `commit`, and
an abort returns `code: "replace_incomplete"` with the ledger of what already
landed instead of letting the exception discard it.

## #341 — the replacement string is data, not a template

Found while reading the same eight lines. With `regex=false`, `case_sensitive=True`
used `str.replace` (literal) but the **default** `case_sensitive=False` passed the
string to `_re.sub`, making it a regex replacement template:

```
replacement    case_sensitive=True     case_sensitive=False (default)
TODO\1         literal                 raises re.error, uncaught, mid-write-loop
[\g<0>]        literal                 expands to the matched text
C:\new         literal                 writes a newline
```

A function replacement is inserted verbatim, so both branches now agree.
Backreferences remain a regex-mode feature (as documented), and a bad template
is now reported rather than escaping.

## Verification

```
backend unit  -k 'not _e2e'   1608 passed, 398 skipped, 36 deselected, 0 failed
                              (1582 at base; the delta is exactly this PR's 26)
ruff 0.15.16                  All checks passed
mypy 2.1.0 --python-version 3.14   Success: no issues found in 243 source files
bandit 1.9.4 medium+          0
```

**The mocked tests are not vacuous.** `_FakeConn` evaluates the collection
predicate the query actually emits, `ESCAPE` semantics and all, so
"the prefix-adjacent sibling is untouched" is asserted end-to-end against
`doc_service.update` call records rather than by eyeballing a SQL string. That
mini-`LIKE` was cross-checked against **PostgreSQL 16 on 12 cases, 0
disagreements**.

Two things a fake connection structurally cannot catch, so both were checked
against a real database:

- **Parameter drift.** The containment predicate binds *two* params where the
  old one bound one, so every downstream `$n` shifts. A fake conn accepts a
  query whose placeholders no longer match its params; PostgreSQL does not.
  Pinned by `test_every_placeholder_is_bound_with_all_filters_on`.
- **The SQL itself.** The exact SQL and params `grep()` builds were executed
  against a disposable PostgreSQL 16 with a real schema and a corpus containing
  `core/`, `core/deep/`, `core-extra/`, `my_docs/`, `myXdocs/` and a root
  `coreutils.md` — **6 scenarios, 0 mismatches**, including `collection="%"` and
  `collection="cor_"` now returning nothing instead of the whole vault.

**Not run:** the 15-suite shell E2E gate (needs a live backend, MinIO and an
embedding stub). `test_graph_replace_e2e.sh:169-198` is the tripwire there — it
asserts `replaced_docs == 3` on 3 documents and `≥ 1` on a regex+collection
call, both far under the budget and inside a collection with no prefix-adjacent
sibling, so it should be unaffected.

## Harness impact: none by default

Conformance case **C7a** records this exact bug as `C7A-D02` with disposition
`record_projection_only`. Its default offline run replays a frozen transcript
against a stdlib oracle that deliberately reimplements the buggy `sql_like()` —
it never calls the product, so `run.sh --case C7a` keeps passing unchanged. Only
an explicit live re-run through `AKB_NATIVE_REVISION_C7A_TRANSCRIPT` against a
fixed AKB would fail, and it fails with the designed message
`"C7A-D02 is no longer exercised…"` — the signal to retire the defect record.
That retirement is a workbench change, not part of this PR.

## Registered, not fixed

- **#342** — the native arm caps its replace at `resource_limit` exactly as
  legacy did. Filed rather than fixed here: it is gated measurement code the P1
  exit audit just cleared at `d8c1bee`, and widening this PR into it would mean
  re-establishing the C7b evidence in the same change. It is a **cutover
  precondition**, same shape as #340.
- `agent_memory_service` builds LIKE patterns from `sanitise_agent_id` /
  `sanitise_session_id` output, which deliberately preserves `_`, unescaped.
  Read-only and confined to the caller's own private vault, so at most a
  same-user cross-session lookup ambiguity — recorded, not filed.
- The audit line for a grep replace still records no `pattern`, no `replace`,
  and no `replaced_docs` (`audit_log.py:372-380`; `pattern` is not in
  `_TARGET_KEYS`). That gap matters more now that a single call can touch up to
  the budget, but extending the audit payload is a product decision, not a
  bug fix.

Closes #338, #315, #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rcTyzcrzMgCN7pxArJZqk
