### PR TITLE
fix(frontend): enforce the Storybook route contract

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ backend reachable at `AKB_URL` (defaults to `http://localhost:8000`).
 
 ## Adding routes
 
-Routes are declared in `src/main.tsx` inside the `<Routes>` block.
-Doc routes are nested under `VaultShell`; the doc-create route
-(`/vault/:name/doc/new`) sits *before* `/vault/:name/doc/:id` so the
-literal `new` segment matches first.
+The canonical route/component/shell map lives in `src/app-route-contract.ts`.
+`src/app-routes.tsx` renders that contract for both the real application and
+Storybook's routed page scenarios. Update the contract test whenever a route,
+page component, auth/public boundary, or shell owner changes.

--- a/frontend/STORYBOOK.md
+++ b/frontend/STORYBOOK.md
@@ -1,0 +1,64 @@
+# Storybook contract
+
+AKB Storybook is curated scenario documentation for the frontend source at the
+current repository revision. It is not the source of truth for application
+runtime behavior, and it does not claim parity with whichever frontend build is
+currently deployed.
+
+## What Storybook is for
+
+- Reviewing representative visual and interaction states in isolation.
+- Exercising deterministic component and page scenarios with browser-rendered
+  Storybook tests.
+- Documenting the design system and important empty, loading, error, permission,
+  and success states.
+
+Storybook passing means those curated scenarios rendered under the Storybook
+adapter. Application correctness still requires the unit checks and real-app
+Playwright coverage appropriate to the change.
+
+## Intentional runtime differences
+
+| Concern | Application | Storybook |
+|---|---|---|
+| Navigation | `BrowserRouter` and browser history | `MemoryRouter` with a story-defined entry |
+| Network | Configured backend | MSW scenario handlers; unmatched requests are bypassed |
+| Authentication | Persisted login/session state and redirects | A story-controlled mock token and auth responses |
+| Query behavior | 30-second stale time and one query retry | No stale time and no query or mutation retries |
+| State lifetime | Normal navigation and browser storage lifetime | Isolated story render with scenario reset behavior |
+
+Because of those differences, Storybook alone must not be used to approve auth
+and redirect behavior, history/navigation state, retry and cache behavior,
+unhandled network behavior, or production integration. Focus management,
+permissions, asynchronous failure/recovery, resize and collapse behavior, and
+canvas interactions also need direct interaction coverage at the appropriate
+test layer rather than incidental page rendering.
+
+## Route ownership
+
+The application and Storybook both render `src/app-routes.tsx`. The canonical
+path, component, and boundary map lives in `src/app-route-contract.ts`; the
+contract distinguishes public/auth routes, `Layout` routes, and `VaultShell`
+routes. `src/__tests__/app-route-contract.test.ts` is an intentional review gate:
+route changes must update its expected contract.
+
+This shared tree prevents Storybook from retaining an obsolete route, page
+component, redirect, or shell owner after the application changes. It does not
+make the surrounding Storybook runtime equivalent to the application runtime.
+
+## Review checklist
+
+Run the frontend gate for every Storybook change:
+
+```sh
+pnpm design:check
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm build-storybook
+pnpm test:storybook
+```
+
+Add a direct story when a stateful surface benefits from isolated visual review,
+and add a real-app test when the behavior depends on browser routing, persisted
+auth, live integration, caching/retries, resizing, or canvas input.

--- a/frontend/src/__tests__/app-route-contract.test.ts
+++ b/frontend/src/__tests__/app-route-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appRouteContract } from "@/app-route-contract";
+import { appRouteBoundaryForPath, appRouteContract } from "@/app-route-contract";
 
 describe("application route contract", () => {
   it("keeps route, component, and shell ownership explicit", () => {
@@ -32,5 +32,31 @@ describe("application route contract", () => {
   it("does not declare duplicate paths", () => {
     const paths = appRouteContract.map(({ path }) => path);
     expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("resolves every declared route to its contract boundary", () => {
+    for (const route of appRouteContract) {
+      const pathname = route.path === "*"
+        ? "/route-not-declared-elsewhere"
+        : route.path.replace(/:[^/]+/g, "example");
+      expect(appRouteBoundaryForPath(pathname)).toBe(route.boundary);
+    }
+  });
+
+  it.each([
+    ["/auth", "auth"],
+    ["/auth/forgot", "auth"],
+    ["/p/storybook-guide", "public"],
+    ["/", "app-layout"],
+    ["/vault/new", "app-layout"],
+    ["/search", "app-layout"],
+    ["/vault", "vault-shell"],
+    ["/vault/akb", "vault-shell"],
+    ["/vault/akb/doc/new", "vault-shell"],
+    ["/vault/akb/doc/overview%2Fvault-skill.md", "vault-shell"],
+    ["/vault/akb/skill", "vault-shell"],
+    ["/stale/route", "app-layout"],
+  ] as const)("resolves %s to the %s boundary", (pathname, boundary) => {
+    expect(appRouteBoundaryForPath(pathname)).toBe(boundary);
   });
 });

--- a/frontend/src/__tests__/app-route-contract.test.ts
+++ b/frontend/src/__tests__/app-route-contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { appRouteContract } from "@/app-route-contract";
+
+describe("application route contract", () => {
+  it("keeps route, component, and shell ownership explicit", () => {
+    expect(appRouteContract).toEqual([
+      { path: "/auth", component: "AuthPage", boundary: "auth" },
+      { path: "/auth/forgot", component: "AuthForgotPage", boundary: "auth" },
+      { path: "/auth/callback", component: "AuthCallbackPage", boundary: "auth" },
+      { path: "/p/:slug", component: "PublicationPage", boundary: "public" },
+      { path: "/", component: "HomePage", boundary: "app-layout" },
+      { path: "/vault/new", component: "VaultNewPage", boundary: "app-layout" },
+      { path: "/vault", component: "VaultIndexPage", boundary: "vault-shell" },
+      { path: "/vault/:name", component: "VaultPage", boundary: "vault-shell" },
+      { path: "/vault/:name/doc/new", component: "DocumentNewPage", boundary: "vault-shell" },
+      { path: "/vault/:name/doc/:id", component: "DocumentPage", boundary: "vault-shell" },
+      { path: "/vault/:name/table/:table", component: "TablePage", boundary: "vault-shell" },
+      { path: "/vault/:name/file/:id", component: "FilePage", boundary: "vault-shell" },
+      { path: "/vault/:name/graph", component: "GraphPage", boundary: "vault-shell" },
+      { path: "/vault/:name/publications", component: "PublicationsPage", boundary: "vault-shell" },
+      { path: "/vault/:name/members", component: "VaultMembersPage", boundary: "vault-shell" },
+      { path: "/vault/:name/settings", component: "VaultSettingsPage", boundary: "vault-shell" },
+      { path: "/vault/:name/activity", component: "VaultActivityPage", boundary: "vault-shell" },
+      { path: "/vault/:name/search", component: "SearchPage", boundary: "vault-shell" },
+      { path: "/vault/:name/skill", component: "SkillRedirect", boundary: "vault-shell" },
+      { path: "/search", component: "SearchPage", boundary: "app-layout" },
+      { path: "/settings", component: "SettingsPage", boundary: "app-layout" },
+      { path: "*", component: "NotFoundPage", boundary: "app-layout" },
+    ]);
+  });
+
+  it("does not declare duplicate paths", () => {
+    const paths = appRouteContract.map(({ path }) => path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/frontend/src/app-route-contract.ts
+++ b/frontend/src/app-route-contract.ts
@@ -1,0 +1,41 @@
+export type AppRouteBoundary = "auth" | "public" | "app-layout" | "vault-shell";
+
+export interface AppRouteDefinition {
+  path: string;
+  component: string;
+  boundary: AppRouteBoundary;
+}
+
+/**
+ * Canonical route/component ownership for the AKB frontend.
+ *
+ * Both the browser application and Storybook's routed page scenarios render
+ * from this contract. Keep the component name explicit: the contract test is
+ * intentionally a review gate for route, page, and shell-owner changes.
+ */
+export const appRouteContract = [
+  { path: "/auth", component: "AuthPage", boundary: "auth" },
+  { path: "/auth/forgot", component: "AuthForgotPage", boundary: "auth" },
+  { path: "/auth/callback", component: "AuthCallbackPage", boundary: "auth" },
+  { path: "/p/:slug", component: "PublicationPage", boundary: "public" },
+  { path: "/", component: "HomePage", boundary: "app-layout" },
+  { path: "/vault/new", component: "VaultNewPage", boundary: "app-layout" },
+  { path: "/vault", component: "VaultIndexPage", boundary: "vault-shell" },
+  { path: "/vault/:name", component: "VaultPage", boundary: "vault-shell" },
+  { path: "/vault/:name/doc/new", component: "DocumentNewPage", boundary: "vault-shell" },
+  { path: "/vault/:name/doc/:id", component: "DocumentPage", boundary: "vault-shell" },
+  { path: "/vault/:name/table/:table", component: "TablePage", boundary: "vault-shell" },
+  { path: "/vault/:name/file/:id", component: "FilePage", boundary: "vault-shell" },
+  { path: "/vault/:name/graph", component: "GraphPage", boundary: "vault-shell" },
+  { path: "/vault/:name/publications", component: "PublicationsPage", boundary: "vault-shell" },
+  { path: "/vault/:name/members", component: "VaultMembersPage", boundary: "vault-shell" },
+  { path: "/vault/:name/settings", component: "VaultSettingsPage", boundary: "vault-shell" },
+  { path: "/vault/:name/activity", component: "VaultActivityPage", boundary: "vault-shell" },
+  { path: "/vault/:name/search", component: "SearchPage", boundary: "vault-shell" },
+  { path: "/vault/:name/skill", component: "SkillRedirect", boundary: "vault-shell" },
+  { path: "/search", component: "SearchPage", boundary: "app-layout" },
+  { path: "/settings", component: "SettingsPage", boundary: "app-layout" },
+  { path: "*", component: "NotFoundPage", boundary: "app-layout" },
+] as const satisfies readonly AppRouteDefinition[];
+
+export type AppRouteComponentName = (typeof appRouteContract)[number]["component"];

--- a/frontend/src/app-route-contract.ts
+++ b/frontend/src/app-route-contract.ts
@@ -1,3 +1,5 @@
+import { matchRoutes, type RouteObject } from "react-router-dom";
+
 export type AppRouteBoundary = "auth" | "public" | "app-layout" | "vault-shell";
 
 export interface AppRouteDefinition {
@@ -39,3 +41,15 @@ export const appRouteContract = [
 ] as const satisfies readonly AppRouteDefinition[];
 
 export type AppRouteComponentName = (typeof appRouteContract)[number]["component"];
+
+type BoundaryRouteObject = RouteObject & { boundary: AppRouteBoundary };
+
+const boundaryRouteObjects: BoundaryRouteObject[] = appRouteContract.map(
+  ({ path, boundary }) => ({ path, boundary }),
+);
+
+/** Resolve ownership with the same specificity ranking React Router uses. */
+export function appRouteBoundaryForPath(pathname: string): AppRouteBoundary | undefined {
+  const matches = matchRoutes<BoundaryRouteObject>(boundaryRouteObjects, pathname);
+  return matches?.at(-1)?.route.boundary;
+}

--- a/frontend/src/app-routes.tsx
+++ b/frontend/src/app-routes.tsx
@@ -1,0 +1,89 @@
+import type { ComponentType } from "react";
+import { Navigate, Route, Routes, useParams } from "react-router-dom";
+import { Layout } from "@/components/layout";
+import { VaultShell } from "@/components/vault-shell";
+import AuthPage from "@/pages/auth";
+import AuthForgotPage from "@/pages/auth-forgot";
+import AuthCallbackPage from "@/pages/auth-callback";
+import HomePage from "@/pages/home";
+import VaultPage from "@/pages/vault";
+import VaultIndexPage from "@/pages/vault-index";
+import VaultNewPage from "@/pages/vault-new";
+import DocumentPage from "@/pages/document";
+import DocumentNewPage from "@/pages/document-new";
+import TablePage from "@/pages/table";
+import FilePage from "@/pages/file";
+import GraphPage from "@/pages/graph";
+import SearchPage from "@/pages/search";
+import SettingsPage from "@/pages/settings";
+import PublicationsPage from "@/pages/publications";
+import PublicationPage from "@/pages/public-publication";
+import VaultMembersPage from "@/pages/vault-members";
+import VaultSettingsPage from "@/pages/vault-settings";
+import VaultActivityPage from "@/pages/vault-activity";
+import NotFoundPage from "@/pages/not-found";
+import {
+  appRouteContract,
+  type AppRouteBoundary,
+  type AppRouteComponentName,
+} from "@/app-route-contract";
+
+// Old /vault/:name/skill URLs redirect to the underlying guide document.
+function SkillRedirect() {
+  const { name } = useParams<{ name: string }>();
+  if (!name) return <Navigate to="/" replace />;
+  return (
+    <Navigate
+      to={`/vault/${name}/doc/${encodeURIComponent("overview/vault-skill.md")}`}
+      replace
+    />
+  );
+}
+
+const routeComponents = {
+  AuthPage,
+  AuthForgotPage,
+  AuthCallbackPage,
+  PublicationPage,
+  HomePage,
+  VaultNewPage,
+  VaultIndexPage,
+  VaultPage,
+  DocumentNewPage,
+  DocumentPage,
+  TablePage,
+  FilePage,
+  GraphPage,
+  PublicationsPage,
+  VaultMembersPage,
+  VaultSettingsPage,
+  VaultActivityPage,
+  SearchPage,
+  SkillRedirect,
+  SettingsPage,
+  NotFoundPage,
+} satisfies Record<AppRouteComponentName, ComponentType>;
+
+function renderRoutes(boundaries: readonly AppRouteBoundary[]) {
+  return appRouteContract
+    .filter((route) => boundaries.includes(route.boundary))
+    .map((route) => {
+      const Component = routeComponents[route.component];
+      return <Route key={`${route.boundary}:${route.path}`} path={route.path} element={<Component />} />;
+    });
+}
+
+/** The route tree shared by the production BrowserRouter and Storybook MemoryRouter. */
+export function AppRoutes() {
+  return (
+    <Routes>
+      {renderRoutes(["auth", "public"])}
+      <Route element={<Layout />}>
+        {renderRoutes(["app-layout"])}
+        <Route element={<VaultShell />}>
+          {renderRoutes(["vault-shell"])}
+        </Route>
+      </Route>
+    </Routes>
+  );
+}

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, useNavigate, Navigate, useLocation, useSearchParams, matchPath } from "react-router-dom";
+import { Link, Outlet, useNavigate, Navigate, useLocation, useSearchParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { Search as SearchIcon } from "lucide-react";
 import { getToken } from "@/lib/api";
@@ -8,25 +8,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Logo } from "@/components/logo";
 import { IndexingBadge } from "@/components/status-badge";
 import { ErrorBoundary } from "@/components/error-boundary";
-
-const VAULT_SHELL_PATTERNS = [
-  "/vault",
-  "/vault/:name",
-  "/vault/:name/doc/:id",
-  "/vault/:name/table/:table",
-  "/vault/:name/file/:id",
-  "/vault/:name/graph",
-  "/vault/:name/publications",
-  "/vault/:name/search",
-  "/vault/:name/members",
-  "/vault/:name/settings",
-  "/vault/:name/activity",
-];
-
-function isVaultShellRoute(pathname: string): boolean {
-  if (pathname === "/vault/new") return false;
-  return VAULT_SHELL_PATTERNS.some((p) => !!matchPath({ path: p, end: true }, pathname));
-}
+import { appRouteBoundaryForPath } from "@/app-route-contract";
 
 type SearchMode = "dense" | "literal";
 
@@ -58,7 +40,7 @@ export function Layout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, searchParams]);
 
-  const wide = isVaultShellRoute(location.pathname);
+  const wide = appRouteBoundaryForPath(location.pathname) === "vault-shell";
   const { data: health } = useHealth(!!getToken());
 
   if (!getToken()) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,29 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Layout } from "@/components/layout";
-import { VaultShell } from "@/components/vault-shell";
-import AuthPage from "@/pages/auth";
-import AuthForgotPage from "@/pages/auth-forgot";
-import AuthCallbackPage from "@/pages/auth-callback";
-import HomePage from "@/pages/home";
-import VaultPage from "@/pages/vault";
-import VaultIndexPage from "@/pages/vault-index";
-import VaultNewPage from "@/pages/vault-new";
-import DocumentPage from "@/pages/document";
-import DocumentNewPage from "@/pages/document-new";
-import TablePage from "@/pages/table";
-import FilePage from "@/pages/file";
-import GraphPage from "@/pages/graph";
-import SearchPage from "@/pages/search";
-import SettingsPage from "@/pages/settings";
-import PublicationsPage from "@/pages/publications";
-import PublicationPage from "@/pages/public-publication";
-import VaultMembersPage from "@/pages/vault-members";
-import VaultSettingsPage from "@/pages/vault-settings";
-import VaultActivityPage from "@/pages/vault-activity";
-import NotFoundPage from "@/pages/not-found";
+import { AppRoutes } from "@/app-routes";
 import "./index.css";
 
 // Vite dispatches `vite:preloadError` on window when a dynamically-imported
@@ -44,19 +23,6 @@ window.addEventListener("vite:preloadError", (event) => {
   window.location.reload();
 });
 
-// Old /vault/:name/skill URLs now redirect to the underlying guide doc;
-// removed the dedicated page because it duplicated DocumentPage.
-function SkillRedirect() {
-  const { name } = useParams<{ name: string }>();
-  if (!name) return <Navigate to="/" replace />;
-  return (
-    <Navigate
-      to={`/vault/${name}/doc/${encodeURIComponent("overview/vault-skill.md")}`}
-      replace
-    />
-  );
-}
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { staleTime: 30_000, retry: 1, refetchOnWindowFocus: false },
@@ -66,41 +32,9 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/auth" element={<AuthPage />} />
-        <Route path="/auth/forgot" element={<AuthForgotPage />} />
-        <Route path="/auth/callback" element={<AuthCallbackPage />} />
-        <Route path="/p/:slug" element={<PublicationPage />} />
-        <Route element={<Layout />}>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/vault/new" element={<VaultNewPage />} />
-          <Route element={<VaultShell />}>
-            {/* /vault is the "no vault selected" state of the workspace shell —
-                it keeps the same chrome (title bar + sidebar) as a vault, with a
-                guidance body, so moving in/out of a vault never shifts layout. */}
-            <Route path="/vault" element={<VaultIndexPage />} />
-            <Route path="/vault/:name" element={<VaultPage />} />
-            <Route path="/vault/:name/doc/new" element={<DocumentNewPage />} />
-            <Route path="/vault/:name/doc/:id" element={<DocumentPage />} />
-            <Route path="/vault/:name/table/:table" element={<TablePage />} />
-            <Route path="/vault/:name/file/:id" element={<FilePage />} />
-            <Route path="/vault/:name/graph" element={<GraphPage />} />
-            <Route path="/vault/:name/publications" element={<PublicationsPage />} />
-            <Route path="/vault/:name/members" element={<VaultMembersPage />} />
-            <Route path="/vault/:name/settings" element={<VaultSettingsPage />} />
-            <Route path="/vault/:name/activity" element={<VaultActivityPage />} />
-            <Route path="/vault/:name/search" element={<SearchPage />} />
-            <Route path="/vault/:name/skill" element={<SkillRedirect />} />
-          </Route>
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          {/* Catch-all: an unmatched URL used to render a blank page with no
-              recovery. Render NotFound inside the shell instead. */}
-          <Route path="*" element={<NotFoundPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/frontend/src/stories/components-akb-actions.stories.tsx
+++ b/frontend/src/stories/components-akb-actions.stories.tsx
@@ -115,7 +115,8 @@ export const RoleChangeSuccess: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole("button", { name: /Change role for writer-user/i }));
     await userEvent.click(await within(document.body).findByRole("menuitemradio", { name: "writer" }));
-    await expect(canvas.getByRole("button", { name: /Change role for writer-user/i })).toHaveTextContent("writer");
+    const trigger = canvas.getByRole("button", { name: /Change role for writer-user/i });
+    await expect(await within(trigger).findByText("writer")).toBeVisible();
   },
 };
 

--- a/frontend/src/stories/page-route-shell.tsx
+++ b/frontend/src/stories/page-route-shell.tsx
@@ -1,58 +1,4 @@
-import { Navigate, Route, Routes, useParams } from "react-router-dom";
-import { Layout } from "@/components/layout";
-import { VaultShell } from "@/components/vault-shell";
-import AuthPage from "@/pages/auth";
-import AuthCallbackPage from "@/pages/auth-callback";
-import AuthForgotPage from "@/pages/auth-forgot";
-import DocumentNewPage from "@/pages/document-new";
-import DocumentPage from "@/pages/document";
-import FilePage from "@/pages/file";
-import GraphPage from "@/pages/graph";
-import HomePage from "@/pages/home";
-import NotFoundPage from "@/pages/not-found";
-import PublicationPage from "@/pages/public-publication";
-import PublicationsPage from "@/pages/publications";
-import SearchPage from "@/pages/search";
-import SettingsPage from "@/pages/settings";
-import TablePage from "@/pages/table";
-import VaultActivityPage from "@/pages/vault-activity";
-import VaultIndexPage from "@/pages/vault-index";
-import VaultMembersPage from "@/pages/vault-members";
-import VaultNewPage from "@/pages/vault-new";
-import VaultPage from "@/pages/vault";
-import VaultSettingsPage from "@/pages/vault-settings";
-
-export const routeClassification = {
-  publicRoutes: ["/p/:slug"],
-  authRoutes: ["/auth", "/auth/forgot", "/auth/callback"],
-  appLayoutRoutes: ["/", "/vault/new", "/search", "/settings", "*"],
-  vaultShellRoutes: [
-    "/vault",
-    "/vault/:name",
-    "/vault/:name/doc/new",
-    "/vault/:name/doc/:id",
-    "/vault/:name/table/:table",
-    "/vault/:name/file/:id",
-    "/vault/:name/graph",
-    "/vault/:name/publications",
-    "/vault/:name/members",
-    "/vault/:name/settings",
-    "/vault/:name/activity",
-    "/vault/:name/search",
-    "/vault/:name/skill",
-  ],
-} as const;
-
-function SkillRedirect() {
-  const { name } = useParams<{ name: string }>();
-  if (!name) return <Navigate to="/" replace />;
-  return (
-    <Navigate
-      to={`/vault/${name}/doc/${encodeURIComponent("overview/vault-skill.md")}`}
-      replace
-    />
-  );
-}
+import { AppRoutes } from "@/app-routes";
 
 function resetWorkspaceChrome() {
   if (typeof window === "undefined") return;
@@ -60,37 +6,8 @@ function resetWorkspaceChrome() {
   window.localStorage.setItem("akb.vaultRailCollapsed", "0");
 }
 
+/** Storybook adapter for the canonical application route tree. */
 export function AkbRouteTree() {
   resetWorkspaceChrome();
-
-  return (
-    <Routes>
-      <Route path="/auth" element={<AuthPage />} />
-      <Route path="/auth/forgot" element={<AuthForgotPage />} />
-      <Route path="/auth/callback" element={<AuthCallbackPage />} />
-      <Route path="/p/:slug" element={<PublicationPage />} />
-      <Route element={<Layout />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/vault/new" element={<VaultNewPage />} />
-        <Route element={<VaultShell />}>
-          <Route path="/vault" element={<VaultIndexPage />} />
-          <Route path="/vault/:name" element={<VaultPage />} />
-          <Route path="/vault/:name/doc/new" element={<DocumentNewPage />} />
-          <Route path="/vault/:name/doc/:id" element={<DocumentPage />} />
-          <Route path="/vault/:name/table/:table" element={<TablePage />} />
-          <Route path="/vault/:name/file/:id" element={<FilePage />} />
-          <Route path="/vault/:name/graph" element={<GraphPage />} />
-          <Route path="/vault/:name/publications" element={<PublicationsPage />} />
-          <Route path="/vault/:name/members" element={<VaultMembersPage />} />
-          <Route path="/vault/:name/settings" element={<VaultSettingsPage />} />
-          <Route path="/vault/:name/activity" element={<VaultActivityPage />} />
-          <Route path="/vault/:name/search" element={<SearchPage />} />
-          <Route path="/vault/:name/skill" element={<SkillRedirect />} />
-        </Route>
-        <Route path="/search" element={<SearchPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Route>
-    </Routes>
-  );
+  return <AppRoutes />;
 }

--- a/frontend/src/stories/storybook-guidelines.stories.tsx
+++ b/frontend/src/stories/storybook-guidelines.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { CheckCircle2, CircleDashed, FlaskConical } from "lucide-react";
+import { CheckCircle2, CircleDashed, FlaskConical, ShieldAlert } from "lucide-react";
 import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Panel, PanelHeader } from "@/components/ui/panel";
 import { CodeSnippet } from "@/components/ui/code-snippet";
 
 const meta = {
-  title: "Foundation/Storybook instructions",
+  title: "Foundation/Storybook contract",
   parameters: {
     layout: "padded",
   },
@@ -23,20 +23,24 @@ const coverage = [
   ["Tests", "Storybook build plus Vitest browser render checks for every story"],
 ] as const;
 
+const runtimeDifferences = [
+  ["Routing", "MemoryRouter with a story-defined entry, not browser history"],
+  ["Network", "MSW scenario handlers; unmatched requests are bypassed"],
+  ["Authentication", "A story-controlled token and mocked auth responses"],
+  ["Queries", "No stale time or retries; the app caches briefly and retries once"],
+] as const;
+
 export const GoalAndCoverage: Story = {
   name: "Goal and coverage rules",
   render: () => (
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <Panel>
-        <PanelHeader
-          label="Storybook goal"
-          right={<Badge variant="info-outline">AKB FE</Badge>}
-        />
+        <PanelHeader label="Storybook contract" right={<Badge variant="info-outline">Curated scenarios</Badge>} />
         <div className="space-y-4 p-5">
-          <Alert variant="info" title="Working agreement">
-            Stories should document real AKB interface states, not decorative
-            one-offs. Prefer token classes and existing primitives, mirror app
-            providers in preview, and mock network/state at the Storybook layer.
+          <Alert variant="warning" title="Representative, not authoritative">
+            Storybook documents curated states for the current repository source.
+            It is not proof of application-runtime behavior and does not claim to
+            match the currently deployed frontend.
           </Alert>
           <div className="grid gap-3 md:grid-cols-2">
             {coverage.map(([label, description]) => (
@@ -55,13 +59,32 @@ export const GoalAndCoverage: Story = {
         </div>
       </Panel>
       <Panel>
+        <PanelHeader label="Intentional runtime differences" count={runtimeDifferences.length} />
+        <div className="space-y-3 p-5">
+          {runtimeDifferences.map(([label, description]) => (
+            <div key={label} className="flex gap-3 text-sm">
+              <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-warning" aria-hidden />
+              <div>
+                <div className="font-medium text-foreground">{label}</div>
+                <p className="text-foreground-muted">{description}</p>
+              </div>
+            </div>
+          ))}
+          <Alert variant="info" title="Use the real application test layer for runtime behavior">
+            Auth redirects, browser history, caching and retries, unhandled network
+            calls, persisted state, resizing, and canvas interactions are outside
+            Storybook's fidelity claim.
+          </Alert>
+        </div>
+      </Panel>
+      <Panel>
         <PanelHeader label="Definition of done" count={4} />
         <div className="grid gap-3 p-5 md:grid-cols-2">
           {[
             "Every story renders in light and dark through the toolbar.",
             "Network-dependent stories use MSW, not a live backend.",
             "Interactive controls include at least one play-function smoke path where useful.",
-            "pnpm run build-storybook and pnpm run test:storybook pass before shipping.",
+            "pnpm build-storybook and pnpm test:storybook pass before shipping.",
           ].map((item) => (
             <div key={item} className="flex gap-2 text-sm text-foreground">
               <CircleDashed className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
@@ -80,7 +103,7 @@ export const GoalAndCoverage: Story = {
       />
       <div className="flex items-center gap-2 text-xs text-foreground-muted">
         <FlaskConical className="h-4 w-4" aria-hidden />
-        Scenarios expand from low-level primitives outward to full routed pages.
+        Routed page stories use the canonical AppRoutes tree; Storybook remains a runtime adapter around it.
       </div>
     </main>
   ),


### PR DESCRIPTION
## Summary

- define one canonical route, page-component, and shell-boundary contract for the application
- render that contract from both the production BrowserRouter and the Storybook MemoryRouter adapter
- derive Layout workspace behavior from the same contract using React Router specificity ranking
- add contract and boundary regression tests so route ownership changes require an explicit review update
- document Storybook as curated repository-state scenarios, including its intentional routing, auth, network, and query-cache differences
- make an existing asynchronous role-change story wait for the visible state update

## Scope

This implements the narrow first step identified in #265: remove the duplicated Storybook route tree and make the Storybook runtime boundary explicit. Direct scenarios for additional stateful surfaces can continue to be tracked in that issue without treating this adapter as production-runtime proof.

## Verification

- npm run design:check
- npm run typecheck
- npm run lint
- npm run test (370 tests)
- npm run build
- npm run build-storybook
- npm run test:storybook (109 browser tests)
- built-application preview smoke check for the root auth redirect, forgot-password route, and public publication route with no console errors

## Security and operational notes

- no backend, database, deployment, permission, or authentication-policy changes
- no production data, credentials, host details, or private deployment configuration included
- Storybook remains isolated through mocked scenario state and does not gain access to application secrets

Addresses #265