### PR TITLE
fix(grep): separate replacement budget from result limit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3347
+        "line_number": 3349
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T10:11:39Z"
+  "generated_at": "2026-08-11T10:25:54Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3337
+        "line_number": 3347
       }
     ],
     "backend/mcp_server/help.py": [
@@ -158,7 +158,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 357,
+        "line_number": 359,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1154,
+        "line_number": 1158,
         "is_secret": false
       }
     ],
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-10T12:26:45Z"
+  "generated_at": "2026-08-11T10:11:39Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -16,6 +16,8 @@ every matching document. Replacement receipts include both the new and previous
 commit, and a failure after earlier commits returns those completed receipts plus
 the failed document instead of discarding the partial result. The audit stream
 records a bounded summary and one metadata-only receipt per committed document.
+Literal-mode replacements now also preserve backslashes as ordinary text;
+replacement-template backreferences remain exclusive to regex mode.
 
 ### Added app installation lifecycle commands
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,16 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Fixed scoped grep replacement completeness and recovery
+
+`akb_grep(replace=...)` now treats `limit` only as a response-preview bound and
+uses a separate `max_replacements` write budget. A scope larger than that budget
+is rejected before any document changes, while an accepted scope is applied to
+every matching document. Replacement receipts include both the new and previous
+commit, and a failure after earlier commits returns those completed receipts plus
+the failed document instead of discarding the partial result. The audit stream
+records a bounded summary and one metadata-only receipt per committed document.
+
 ### Added app installation lifecycle commands
 
 Added administrator install, restore, fresh, status, and uninstall commands

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -342,6 +342,53 @@ def _target_of(args: dict) -> str | None:
     return None
 
 
+def _grep_replace_meta(args: dict, result) -> dict | None:
+    """Bounded summary for the argument-driven ``akb_grep`` write mode."""
+    if args.get("replace") is None or not isinstance(result, dict):
+        return None
+    return {
+        "total_docs": result.get("total_docs"),
+        "max_replacements": result.get("max_replacements"),
+        "replaced_docs": result.get("replaced_docs", 0),
+        "unchanged_docs": result.get("unchanged_docs", 0),
+        "replacement_complete": result.get("replacement_complete", False),
+    }
+
+
+def _record_grep_replace_receipts(args: dict, user, result) -> None:
+    """Emit one compact recovery receipt per committed grep replacement.
+
+    The summary tool record cannot identify every document without becoming one
+    potentially large JSON line.  Individual metadata-only receipts keep each
+    line bounded while retaining the new and previous commit needed to inspect
+    or revert a partial multi-document operation.  Bodies and replacement text
+    are deliberately excluded.
+    """
+    if args.get("replace") is None or not isinstance(result, dict):
+        return
+    replacements = result.get("replacements")
+    if not isinstance(replacements, list):
+        return
+    for replacement in replacements:
+        if not isinstance(replacement, dict) or not replacement.get("uri"):
+            continue
+        target = f"uri={replacement['uri']}"
+        if len(target) > _TARGET_MAX:
+            target = target[:_TARGET_MAX] + "…"
+        record(
+            action="akb_grep.replace",
+            actor=getattr(user, "username", None),
+            actor_id=getattr(user, "user_id", None),
+            vault=(args.get("vault") if isinstance(args, dict) else None),
+            target=target,
+            outcome="ok",
+            meta={
+                "commit": replacement.get("commit"),
+                "previous_commit": replacement.get("previous_commit"),
+            },
+        )
+
+
 def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) -> None:
     """Audit one MCP tool call from the dispatch chokepoint. ``user`` is the
     resolved _MCPUser; ``result`` is the handler's return envelope (or the
@@ -369,6 +416,8 @@ def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) 
     if isinstance(result, dict) and (result.get("error") is not None or result.get("code")):
         outcome = "error"
         code = result.get("code")
+    if name == "akb_grep" and is_write:
+        _record_grep_replace_receipts(args, user, result)
     record(
         action=name,
         actor=getattr(user, "username", None),
@@ -377,6 +426,7 @@ def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) 
         target=(_target_of(args) if isinstance(args, dict) else None),
         outcome=outcome,
         code=code,
+        meta=(_grep_replace_meta(args, result) if name == "akb_grep" and is_write else None),
     )
 
 

--- a/backend/app/services/grep_replace.py
+++ b/backend/app/services/grep_replace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from app.exceptions import ValidationError
 from app.util.errors import BULK_TOO_LARGE, err, exception_envelope
 
@@ -12,6 +14,34 @@ from app.util.errors import BULK_TOO_LARGE, err, exception_envelope
 # can narrow the vault/collection scope when a larger migration is required.
 DEFAULT_MAX_REPLACEMENTS = 50
 MAX_REPLACEMENTS = 1_000
+
+
+def apply_grep_replacement(
+    text: str,
+    pattern: str,
+    replacement: str,
+    *,
+    regex: bool,
+    case_sensitive: bool,
+) -> str:
+    """Apply grep replacement while keeping literal-mode replacements literal."""
+    if regex:
+        flags = 0 if case_sensitive else re.IGNORECASE
+        return re.sub(pattern, replacement, text, flags=flags)
+    if case_sensitive:
+        return text.replace(pattern, replacement)
+
+    # ``re.sub`` is needed for case-insensitive literal matching, but a plain
+    # replacement string would still interpret ``\\1``, ``\\t``, and similar
+    # sequences as a regex replacement template.  A callable preserves the
+    # caller's replacement bytes exactly; backreferences remain available only
+    # in the explicitly requested regex mode.
+    return re.sub(
+        re.escape(pattern),
+        lambda _match: replacement,
+        text,
+        flags=re.IGNORECASE,
+    )
 
 
 def validate_max_replacements(value: int) -> int:

--- a/backend/app/services/grep_replace.py
+++ b/backend/app/services/grep_replace.py
@@ -1,0 +1,58 @@
+"""Shared guards and recovery envelopes for multi-document grep replacement."""
+
+from __future__ import annotations
+
+from app.exceptions import ValidationError
+from app.util.errors import BULK_TOO_LARGE, err, exception_envelope
+
+
+# ``limit`` controls only the response preview.  Replacement has its own
+# caller-declared budget so a broad pattern cannot silently turn into a larger
+# write than intended.  The hard ceiling also keeps one request bounded; callers
+# can narrow the vault/collection scope when a larger migration is required.
+DEFAULT_MAX_REPLACEMENTS = 50
+MAX_REPLACEMENTS = 1_000
+
+
+def validate_max_replacements(value: int) -> int:
+    """Validate the independent write budget used by grep replacement."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError("max_replacements must be an integer")
+    if value < 1 or value > MAX_REPLACEMENTS:
+        raise ValidationError(f"max_replacements must be between 1 and {MAX_REPLACEMENTS}")
+    return value
+
+
+def replacement_budget_error(*, total_docs: int, max_replacements: int) -> dict:
+    """Return a fail-closed envelope before any replacement write starts."""
+    return err(
+        f"grep replace matched {total_docs} documents, exceeding the "
+        f"max_replacements budget of {max_replacements}; no writes were applied",
+        code=BULK_TOO_LARGE,
+        hint=(
+            "Preview the scope with count_only=true or files_with_matches=true, "
+            "then narrow the scope or retry with a sufficient max_replacements budget."
+        ),
+        total_docs=total_docs,
+        max_replacements=max_replacements,
+        writes_applied=0,
+    )
+
+
+def replacement_failure_error(
+    exc: Exception,
+    *,
+    failed_uri: str,
+    committed_replacements: int,
+) -> dict:
+    """Preserve a canonical error plus recovery metadata after a partial write."""
+    envelope = exception_envelope(exc)
+    details = dict(envelope.get("details") or {})
+    details.update(
+        {
+            "failed_uri": failed_uri,
+            "committed_replacements": committed_replacements,
+        }
+    )
+    envelope["details"] = details
+    return envelope

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -26,6 +26,7 @@ from app.exceptions import AKBError, ForbiddenError, ValidationError
 from app.services.document_service import _parse_markdown
 from app.services.grep_replace import (
     DEFAULT_MAX_REPLACEMENTS,
+    apply_grep_replacement,
     replacement_budget_error,
     replacement_failure_error,
     validate_max_replacements,
@@ -301,19 +302,16 @@ def _replace_bodies_sync(
     regex: bool,
     case_sensitive: bool,
 ) -> list[str]:
-    replacements = []
-    for body in bodies:
-        search_text = body.search_text
-        if regex:
-            flags = 0 if case_sensitive else re.IGNORECASE
-            replacements.append(re.sub(pattern, replace, search_text, flags=flags))
-        elif case_sensitive:
-            replacements.append(search_text.replace(pattern, replace))
-        else:
-            replacements.append(
-                re.sub(re.escape(pattern), replace, search_text, flags=re.IGNORECASE)
-            )
-    return replacements
+    return [
+        apply_grep_replacement(
+            body.search_text,
+            pattern,
+            replace,
+            regex=regex,
+            case_sensitive=case_sensitive,
+        )
+        for body in bodies
+    ]
 
 
 def _regex_child(

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -24,6 +24,12 @@ import asyncpg
 
 from app.exceptions import AKBError, ForbiddenError, ValidationError
 from app.services.document_service import _parse_markdown
+from app.services.grep_replace import (
+    DEFAULT_MAX_REPLACEMENTS,
+    replacement_budget_error,
+    replacement_failure_error,
+    validate_max_replacements,
+)
 from app.services.m1_pg_body_store import M1PgBodyStore
 from app.services.native_payload_verification import (
     payload_store_for_placement,
@@ -147,6 +153,7 @@ def _scan_bodies_sync(
     case_sensitive: bool,
     mode: Literal["default", "count_only", "files_with_matches"] = "default",
     resource_limit: int = 20,
+    collect_matched_body_indexes: bool = False,
     limits: GrepScanLimits | None = None,
 ) -> dict[str, Any]:
     """Run exact Head matching with bounded response materialization."""
@@ -157,6 +164,7 @@ def _scan_bodies_sync(
     items: list[dict[str, Any]] = []
     by_resource: dict[str, int] = {}
     resources: list[dict[str, Any]] = []
+    matched_body_indexes: list[int] = []
     total_resources = 0
     total_matches = 0
     materialized_matches = 0
@@ -221,6 +229,8 @@ def _scan_bodies_sync(
             continue
         total_resources += 1
         total_matches += resource_matches
+        if collect_matched_body_indexes:
+            matched_body_indexes.append(body_index)
         if mode == "count_only":
             by_resource[body.uri] = resource_matches
         elif mode == "files_with_matches":
@@ -253,6 +263,7 @@ def _scan_bodies_sync(
         "items": items,
         "by_resource": by_resource,
         "resources": resources,
+        "matched_body_indexes": matched_body_indexes,
         "total_resources": total_resources,
         "total_matches": total_matches,
         "materialized_matches": materialized_matches,
@@ -636,6 +647,7 @@ class M1NativeGrepService:
         count_only: bool = False,
         files_with_matches: bool = False,
         limit: int = 20,
+        max_replacements: int = DEFAULT_MAX_REPLACEMENTS,
         replace: str | None = None,
         actor: str | None = None,
         include_text_files: bool = False,
@@ -650,6 +662,8 @@ class M1NativeGrepService:
             raise ValidationError("native grep replace does not support File resources")
         if replace is not None and not actor:
             raise ValidationError("actor is required for native grep replacement")
+        if replace is not None:
+            max_replacements = validate_max_replacements(max_replacements)
         if limit < 1 or limit > 1000:
             raise ValidationError("limit must be between 1 and 1000")
         if len(pattern.encode("utf-8")) > NATIVE_GREP_MAX_PATTERN_BYTES:
@@ -694,6 +708,7 @@ class M1NativeGrepService:
                         "case_sensitive": case_sensitive,
                         "mode": mode,
                         "resource_limit": limit,
+                        "collect_matched_body_indexes": replace is not None,
                         "limits": scan_limits,
                     },
                     NATIVE_GREP_REGEX_TIMEOUT_SECONDS,
@@ -714,6 +729,7 @@ class M1NativeGrepService:
                 case_sensitive=case_sensitive,
                 mode=mode,
                 resource_limit=limit,
+                collect_matched_body_indexes=replace is not None,
                 limits=scan_limits,
             )
         matched = scanned["items"]
@@ -737,10 +753,19 @@ class M1NativeGrepService:
             resources = scanned["resources"]
             return {**base, "n_resources": len(resources), "resources": resources}
 
-        selected = matched
         replacements: list[dict[str, Any]] = []
-        if replace is not None:
-            selected_bodies = [item["_body"] for item in selected]
+        unchanged_resources = 0
+        replacement_error: dict[str, Any] | None = None
+        if replace is not None and scanned["total_resources"] > max_replacements:
+            replacement_error = replacement_budget_error(
+                total_docs=scanned["total_resources"],
+                max_replacements=max_replacements,
+            )
+        elif replace is not None:
+            selected_bodies = [
+                bodies[index]
+                for index in scanned["matched_body_indexes"]
+            ]
             # Validate every matched Head before starting the first mutation:
             # mixed placement is permitted across the scan, but an unknown
             # placement must not leave an earlier replacement committed.
@@ -779,14 +804,14 @@ class M1NativeGrepService:
                     regex=False,
                     case_sensitive=case_sensitive,
                 )
-            for item, new_search_text, payload_store in zip(
-                selected,
+            for head_body, new_search_text, payload_store in zip(
+                selected_bodies,
                 replacement_texts,
                 payload_stores,
                 strict=True,
             ):
-                head_body: HeadBody = item["_body"]
                 if new_search_text == head_body.search_text:
+                    unchanged_resources += 1
                     continue
                 if head_body.surface == "document":
                     metadata, _ = _parse_markdown(head_body.text)
@@ -795,25 +820,45 @@ class M1NativeGrepService:
                     new_text = _compose_markdown(metadata, new_search_text)
                 else:
                     new_text = new_search_text
-                result = await NativeRevisionService(
-                    self.pool,
-                    payload_store=payload_store,
-                ).replace_text(
-                    namespace_id=head_body.namespace_id,
-                    surface=head_body.surface,
-                    path=head_body.path,
-                    payload=new_text,
-                    actor=actor or "",
-                    mutation_id=uuid.uuid4(),
-                    expected_revision_id=head_body.revision_id,
-                    expected_resource_id=head_body.resource_id,
-                    message=f"grep replace: {pattern!r}",
+                try:
+                    result = await NativeRevisionService(
+                        self.pool,
+                        payload_store=payload_store,
+                    ).replace_text(
+                        namespace_id=head_body.namespace_id,
+                        surface=head_body.surface,
+                        path=head_body.path,
+                        payload=new_text,
+                        actor=actor or "",
+                        mutation_id=uuid.uuid4(),
+                        expected_revision_id=head_body.revision_id,
+                        expected_resource_id=head_body.resource_id,
+                        message=f"grep replace: {pattern!r}",
+                    )
+                except Exception as exc:  # noqa: BLE001 — return recovery receipt
+                    replacement_error = replacement_failure_error(
+                        exc,
+                        failed_uri=head_body.uri,
+                        committed_replacements=len(replacements),
+                    )
+                    break
+                replacements.append(
+                    {
+                        "uri": head_body.uri,
+                        "path": head_body.path,
+                        "title": head_body.title,
+                        "revision": result.revision_id,
+                        "previous_revision": getattr(
+                            result,
+                            "parent_revision_id",
+                            head_body.revision_id,
+                        ),
+                    }
                 )
-                replacements.append({"uri": head_body.uri, "revision": result.revision_id})
 
         clean = [
             {key: value for key, value in item.items() if not key.startswith("_")}
-            for item in selected
+            for item in matched
         ]
         response: dict[str, Any] = {
             **base,
@@ -829,8 +874,17 @@ class M1NativeGrepService:
             }
         if replace is not None:
             response.update(
-                {"replace": replace, "replaced_resources": len(replacements), "replacements": replacements}
+                {
+                    "replace": replace,
+                    "max_replacements": max_replacements,
+                    "replaced_resources": len(replacements),
+                    "unchanged_resources": unchanged_resources,
+                    "replacement_complete": replacement_error is None,
+                    "replacements": replacements,
+                }
             )
+            if replacement_error is not None:
+                response.update(replacement_error)
         return response
 
     @staticmethod
@@ -895,23 +949,31 @@ class M1NativeGrepService:
         if "truncation" in native:
             result["truncation"] = native["truncation"]
         if "replace" in native:
-            replacements_by_uri = {row["uri"]: row for row in native.get("replacements", [])}
             result.update(
                 {
                     "replace": native["replace"],
+                    "max_replacements": native.get(
+                        "max_replacements",
+                        DEFAULT_MAX_REPLACEMENTS,
+                    ),
                     "replaced_docs": native.get("replaced_resources", 0),
+                    "unchanged_docs": native.get("unchanged_resources", 0),
+                    "replacement_complete": native.get("replacement_complete", True),
                     "replacements": [
                         {
                             "uri": row["uri"],
                             "path": row["path"],
                             "title": row["title"],
-                            "commit": replacements_by_uri[row["uri"]]["revision"],
+                            "commit": row["revision"],
+                            "previous_commit": row.get("previous_revision"),
                         }
-                        for row in native.get("results", [])
-                        if row["uri"] in replacements_by_uri
+                        for row in native.get("replacements", [])
                     ],
                 }
             )
+            for key in ("error", "code", "hint", "details"):
+                if key in native:
+                    result[key] = native[key]
         return result
 
     async def grep_public(self, pattern: str, **kwargs) -> dict[str, Any]:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -23,6 +23,12 @@ from app.exceptions import ValidationError
 from app.models.document import SearchResponse, SearchResult
 from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
+from app.services.grep_replace import (
+    DEFAULT_MAX_REPLACEMENTS,
+    replacement_budget_error,
+    replacement_failure_error,
+    validate_max_replacements,
+)
 from app.services.vector_store import VectorHit, get_vector_store
 from app.services.vector_store.base import VectorStoreUnavailable, supports_vault_filter
 from app.services.rerank_service import RerankError, rerank
@@ -1046,6 +1052,7 @@ class SearchService:
         agent_id: str | None = None,
         user_id: str | None = None,
         limit: int = 20,
+        max_replacements: int = DEFAULT_MAX_REPLACEMENTS,
         count_only: bool = False,
         files_with_matches: bool = False,
         measurement_include_text_files: bool = False,
@@ -1080,6 +1087,8 @@ class SearchService:
                 "error": "replace= is incompatible with count_only / files_with_matches",
                 "pattern": pattern,
             }
+        if replace is not None:
+            max_replacements = validate_max_replacements(max_replacements)
 
         # Validate regex pattern early to give a clear error
         if regex:
@@ -1124,6 +1133,7 @@ class SearchService:
                 replace=replace,
                 actor=agent_id,
                 limit=limit,
+                max_replacements=max_replacements,
                 count_only=count_only,
                 files_with_matches=files_with_matches,
                 include_text_files=measurement_include_text_files,
@@ -1284,50 +1294,78 @@ class SearchService:
         result_docs = matched_docs[:limit]
         returned_matches = sum(len(d["matches"]) for d in result_docs)
 
-        # Replace mode: apply find-and-replace on each matching document.
+        # Replace mode: apply find-and-replace on each matching document.  The
+        # response ``limit`` remains a preview-only knob; writes are governed by
+        # the independent, caller-visible ``max_replacements`` budget.
         # Service-layer `doc_service.update` still wants the doc path
         # (which find_by_ref accepts) — we pass `path` rather than re-
         # parsing the URI we just built.
         replaced: list[dict] = []
-        if replace is not None and result_docs and doc_service:
+        unchanged_docs = 0
+        replacement_error: dict | None = None
+        if replace is not None and total_docs > max_replacements:
+            replacement_error = replacement_budget_error(
+                total_docs=total_docs,
+                max_replacements=max_replacements,
+            )
+        elif replace is not None and matched_docs and doc_service:
             re_flags = 0 if case_sensitive else _re.IGNORECASE
 
-            for doc_info in result_docs:
+            for doc_info in matched_docs:
                 doc_vault = doc_info["vault"]
                 doc_path = doc_info["path"]
                 doc_uri_str = doc_info["uri"]
 
                 try:
                     doc = await doc_service.get(doc_vault, doc_path)
-                except Exception:
-                    replaced.append({"uri": doc_uri_str, "error": "not found"})
-                    continue
+                    body = doc.content or ""
 
-                body = doc.content or ""
-
-                if regex:
-                    new_body = _re.sub(pattern, replace, body, flags=re_flags)
-                else:
-                    if case_sensitive:
-                        new_body = body.replace(pattern, replace)
+                    if regex:
+                        new_body = _re.sub(pattern, replace, body, flags=re_flags)
                     else:
-                        # Case-insensitive non-regex replace
-                        new_body = _re.sub(_re.escape(pattern), replace, body, flags=_re.IGNORECASE)
+                        if case_sensitive:
+                            new_body = body.replace(pattern, replace)
+                        else:
+                            # Case-insensitive non-regex replace
+                            new_body = _re.sub(
+                                _re.escape(pattern),
+                                replace,
+                                body,
+                                flags=_re.IGNORECASE,
+                            )
 
-                if new_body == body:
-                    continue  # no actual change
+                    if new_body == body:
+                        unchanged_docs += 1
+                        continue
 
-                from app.models.document import DocumentUpdateRequest
-                req = DocumentUpdateRequest(
-                    content=new_body,
-                    message=f"grep replace: '{pattern}' → '{replace}'",
-                )
-                result = await doc_service.update(doc_vault, doc_path, req, agent_id=agent_id)
+                    from app.models.document import DocumentUpdateRequest
+                    req = DocumentUpdateRequest(
+                        content=new_body,
+                        message=f"grep replace: '{pattern}' → '{replace}'",
+                        # Do not overwrite a concurrent edit made after the
+                        # replacement body was read.
+                        expected_commit=doc.current_commit,
+                    )
+                    result = await doc_service.update(
+                        doc_vault,
+                        doc_path,
+                        req,
+                        agent_id=agent_id,
+                    )
+                except Exception as exc:  # noqa: BLE001 — return recovery receipt
+                    replacement_error = replacement_failure_error(
+                        exc,
+                        failed_uri=doc_uri_str,
+                        committed_replacements=len(replaced),
+                    )
+                    break
+
                 replaced.append({
                     "uri": doc_uri_str,
                     "path": doc_path,
                     "title": doc_info["title"],
                     "commit": result.commit_hash,
+                    "previous_commit": result.previous_commit,
                 })
 
         # Build response — strip internal handles (`_doc_pk`, `metadata`)
@@ -1367,8 +1405,13 @@ class SearchService:
 
         if replace is not None:
             resp["replace"] = replace
+            resp["max_replacements"] = max_replacements
             resp["replaced_docs"] = len(replaced)
+            resp["unchanged_docs"] = unchanged_docs
+            resp["replacement_complete"] = replacement_error is None
             resp["replacements"] = replaced
+            if replacement_error is not None:
+                resp.update(replacement_error)
         return resp
 
     async def drill_down(self, vault: str, doc_id: str, section: str | None = None) -> list[dict]:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -25,6 +25,7 @@ from app.services import sparse_encoder
 from app.services.index_service import CHUNK_HEADER_KEYS, generate_embeddings
 from app.services.grep_replace import (
     DEFAULT_MAX_REPLACEMENTS,
+    apply_grep_replacement,
     replacement_budget_error,
     replacement_failure_error,
     validate_max_replacements,
@@ -1139,6 +1140,9 @@ class SearchService:
                 include_text_files=measurement_include_text_files,
             )
 
+        if replace is not None and doc_service is None:
+            raise ValidationError("doc_service is required for legacy grep replacement")
+
         pool = await get_pool()
         async with pool.acquire() as conn:
             conditions = []
@@ -1308,9 +1312,7 @@ class SearchService:
                 total_docs=total_docs,
                 max_replacements=max_replacements,
             )
-        elif replace is not None and matched_docs and doc_service:
-            re_flags = 0 if case_sensitive else _re.IGNORECASE
-
+        elif replace is not None and matched_docs:
             for doc_info in matched_docs:
                 doc_vault = doc_info["vault"]
                 doc_path = doc_info["path"]
@@ -1320,19 +1322,13 @@ class SearchService:
                     doc = await doc_service.get(doc_vault, doc_path)
                     body = doc.content or ""
 
-                    if regex:
-                        new_body = _re.sub(pattern, replace, body, flags=re_flags)
-                    else:
-                        if case_sensitive:
-                            new_body = body.replace(pattern, replace)
-                        else:
-                            # Case-insensitive non-regex replace
-                            new_body = _re.sub(
-                                _re.escape(pattern),
-                                replace,
-                                body,
-                                flags=_re.IGNORECASE,
-                            )
+                    new_body = apply_grep_replacement(
+                        body,
+                        pattern,
+                        replace,
+                        regex=regex,
+                        case_sensitive=case_sensitive,
+                    )
 
                     if new_body == body:
                         unchanged_docs += 1

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -867,7 +867,7 @@ Optionally pass `replace` to find-and-replace across all matching documents.
 | collection | | Limit to a specific collection |
 | regex | | Treat pattern as regex (default: false) |
 | case_sensitive | | Case-sensitive match (default: false) |
-| replace | | Replacement string — triggers find-and-replace mode |
+| replace | | Replacement string — literal unless `regex=true`, which enables backreferences |
 | limit | | Max documents to return (default 20; does not limit writes) |
 | max_replacements | | Replace write budget (default 50, maximum 1000); larger scopes fail before writing |
 | count_only | | Return exact per-resource counts without snippets |

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -168,6 +168,8 @@ akb_edit(uri="akb://v/doc/path/to/file.md", old_string="old text", new_string="n
 ## akb_grep — Exact Text Search & Replace
 Find exact strings or regex patterns across documents. Use when you need precision, not meaning.
 Add `replace` to find-and-replace across all matching documents in one call.
+`limit` controls only the returned preview; `max_replacements` is the separate
+write budget and rejects the call before any write when the scope is larger.
 
 ```
 akb_grep(pattern="PostgreSQL 14")                                      # Find exact string
@@ -866,7 +868,8 @@ Optionally pass `replace` to find-and-replace across all matching documents.
 | regex | | Treat pattern as regex (default: false) |
 | case_sensitive | | Case-sensitive match (default: false) |
 | replace | | Replacement string — triggers find-and-replace mode |
-| limit | | Max documents to return (default 20) |
+| limit | | Max documents to return (default 20; does not limit writes) |
+| max_replacements | | Replace write budget (default 50, maximum 1000); larger scopes fail before writing |
 | count_only | | Return exact per-resource counts without snippets |
 | measurement_include_text_files | | Guarded native measurement mode: include admitted searchable text Files; binary Files stay excluded |
 
@@ -896,7 +899,8 @@ akb_grep(pattern="PostgreSQL 14", vault="eng", replace="PostgreSQL 16")
 akb_grep(pattern="v(\\d+)\\.1", vault="eng", regex=true, replace="v\\1.2")
 ```
 
-**Tip:** Run grep WITHOUT replace first to preview matches, then add replace.
+**Tip:** Run grep WITHOUT replace first to preview matches, then add replace with
+`max_replacements` set high enough for the intended scope.
 Each replaced document gets its own git commit and is re-indexed for search.
 
 ## Result Structure

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -32,6 +32,7 @@ from mcp.types import TextContent
 from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError, WriteBusyError
 from app.services.document_service import EditError
+from app.services.grep_replace import DEFAULT_MAX_REPLACEMENTS
 from app.services.revision_backend import get_revision_backend
 from app.services.search_service import SearchService
 from app.services.kg_service import get_resource_relations, get_graph, get_provenance, link_resources, unlink_resources
@@ -765,6 +766,7 @@ async def _handle_grep(args: dict, uid: str, user: _MCPUser) -> dict:
         agent_id=user.username if replace is not None else None,
         user_id=uid,
         limit=args.get("limit", 20),
+        max_replacements=args.get("max_replacements", DEFAULT_MAX_REPLACEMENTS),
         count_only=args.get("count_only", False),
         files_with_matches=args.get("files_with_matches", False),
         measurement_include_text_files=args.get("measurement_include_text_files", False),

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -438,8 +438,8 @@ TOOLS = [
                 "collection": {"type": "string", "description": "Limit to a specific collection"},
                 "regex": {"type": "boolean", "default": False, "description": "Treat pattern as PostgreSQL regex. REQUIRED to use alternation (|), wildcards (.*), character classes, anchors, etc. When false (default), the entire pattern including any metacharacters is matched literally."},
                 "case_sensitive": {"type": "boolean", "default": False, "description": "Case-sensitive matching (default: case-insensitive)"},
-                "replace": {"type": "string", "description": "Replacement string. If provided and the full scope fits max_replacements, replaces all matches in EVERY matching document (git commit + re-index per doc); otherwise writes nothing. Supports regex backreferences (\\1, \\2) when regex=true. For precise edits to a single known document, prefer akb_edit instead."},
-                "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 50, "description": "Max documents to return"},
+                "replace": {"type": "string", "description": "Replacement string. If provided and the full scope fits max_replacements, replaces all matches in EVERY matching document (git commit + re-index per doc); otherwise writes nothing. Treated literally when regex=false; supports regex backreferences (\\1, \\2) only when regex=true. For precise edits to a single known document, prefer akb_edit instead."},
+                "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 50, "description": "Max documents to return; does not limit replacement writes"},
                 "max_replacements": {
                     "type": "integer",
                     "default": DEFAULT_MAX_REPLACEMENTS,

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -35,6 +35,7 @@ URI-addressable.
 from mcp.types import Tool
 
 from app.services import template_registry
+from app.services.grep_replace import DEFAULT_MAX_REPLACEMENTS, MAX_REPLACEMENTS
 from app.services.kg_service import LINK_RELATION_TYPES
 
 # The link/unlink relation vocabulary is defined once in kg_service; the
@@ -419,7 +420,8 @@ TOOLS = [
             "Unlike akb_search (semantic/meaning-based), this finds exact string matches — "
             "use it for specific terms, URLs, code snippets, version numbers, etc. "
             "Returns matching documents (each with its `uri`) and matched lines. "
-            "Optionally pass `replace` to find-and-replace across all matching documents. "
+            "Optionally pass `replace` to find-and-replace across all matching documents; "
+            "the call writes nothing if the scope exceeds `max_replacements`. "
             "Three response shapes (mutually exclusive): default lines, `count_only=true` "
             "(grep -c — per-doc counts + total, no snippets), `files_with_matches=true` "
             "(grep -l — just the URIs that contain the pattern). "
@@ -436,8 +438,20 @@ TOOLS = [
                 "collection": {"type": "string", "description": "Limit to a specific collection"},
                 "regex": {"type": "boolean", "default": False, "description": "Treat pattern as PostgreSQL regex. REQUIRED to use alternation (|), wildcards (.*), character classes, anchors, etc. When false (default), the entire pattern including any metacharacters is matched literally."},
                 "case_sensitive": {"type": "boolean", "default": False, "description": "Case-sensitive matching (default: case-insensitive)"},
-                "replace": {"type": "string", "description": "Replacement string. If provided, replaces all matches in EVERY matching document across the search scope (git commit + re-index per doc). Supports regex backreferences (\\1, \\2) when regex=true. For precise edits to a single known document, prefer akb_edit instead."},
+                "replace": {"type": "string", "description": "Replacement string. If provided and the full scope fits max_replacements, replaces all matches in EVERY matching document (git commit + re-index per doc); otherwise writes nothing. Supports regex backreferences (\\1, \\2) when regex=true. For precise edits to a single known document, prefer akb_edit instead."},
                 "limit": {"type": "integer", "default": 20, "minimum": 1, "maximum": 50, "description": "Max documents to return"},
+                "max_replacements": {
+                    "type": "integer",
+                    "default": DEFAULT_MAX_REPLACEMENTS,
+                    "minimum": 1,
+                    "maximum": MAX_REPLACEMENTS,
+                    "description": (
+                        "Maximum documents a replace call may rewrite, independent of the "
+                        "response limit. If the full scope matches more documents, the call "
+                        "fails before writing anything. Preview with count_only or "
+                        "files_with_matches, then set this budget to cover the intended scope."
+                    ),
+                },
                 "count_only": {"type": "boolean", "default": False, "description": "Return counts only (grep -c semantics). Response: {pattern, total_matches, total_docs, by_doc:{uri:count,...}}. Use for 'how many X are there?' questions — much cheaper than fetching every line."},
                 "files_with_matches": {"type": "boolean", "default": False, "description": "Return only the URIs that contain matches (grep -l semantics). Response: {pattern, n_files, files:[uri,...]}. Use for 'which documents mention X?' questions."},
                 "measurement_include_text_files": {

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -138,6 +138,48 @@ def test_read_tool_invoked_as_a_write_is_still_audited(audit_dir, monkeypatch):
     )
 
 
+def test_grep_replace_audit_records_commit_recovery_receipts(audit_dir):
+    class _U:
+        username, user_id = "bob", "u2"
+
+    audit_log.record_tool(
+        "akb_grep",
+        {"vault": "v", "pattern": "x", "replace": "y", "max_replacements": 2},
+        _U(),
+        {
+            "total_docs": 2,
+            "replaced_docs": 1,
+            "unchanged_docs": 0,
+            "max_replacements": 2,
+            "replacement_complete": False,
+            "replacements": [
+                {
+                    "uri": "akb://v/doc/a.md",
+                    "commit": "new-commit",
+                    "previous_commit": "parent-commit",
+                }
+            ],
+            "error": "write stopped",
+            "code": "write_busy",
+        },
+        is_write=True,
+    )
+
+    rows = [
+        json.loads(line)
+        for line in _read_lines(audit_dir / f"akb-audit-{_today()}.jsonl")
+    ]
+    assert [row["action"] for row in rows] == ["akb_grep.replace", "akb_grep"]
+    assert rows[0]["target"] == "uri=akb://v/doc/a.md"
+    assert rows[0]["meta"] == {
+        "commit": "new-commit",
+        "previous_commit": "parent-commit",
+    }
+    assert rows[1]["outcome"] == "error"
+    assert rows[1]["meta"]["replacement_complete"] is False
+    assert rows[1]["meta"]["replaced_docs"] == 1
+
+
 def test_read_only_set_agrees_with_the_mcp_scope_table(tmp_path, monkeypatch):
     """The two classifications must not drift: a tool that needs
     `akb:vault:write` to invoke is by definition state-changing, so it

--- a/backend/tests/test_graph_replace_e2e.sh
+++ b/backend/tests/test_graph_replace_e2e.sh
@@ -176,10 +176,18 @@ for i in 1 2 3; do
 done
 pass "3 docs with OLD_PLACEHOLDER created"
 
-# Replace OLD_PLACEHOLDER → NEW_VALUE across all
-R=$(m1 "akb_grep" "{\"pattern\":\"OLD_PLACEHOLDER\",\"vault\":\"$VAULT1\",\"replace\":\"NEW_VALUE\"}")
+# A replacement budget smaller than the full scope must fail before writing.
+R=$(m1 "akb_grep" "{\"pattern\":\"OLD_PLACEHOLDER\",\"vault\":\"$VAULT1\",\"replace\":\"SHOULD_NOT_APPEAR\",\"limit\":1,\"max_replacements\":2}")
+BUDGET_CODE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('code',''))" 2>/dev/null)
+[ "$BUDGET_CODE" = "bulk_too_large" ] && pass "Replace budget fails closed" || fail "Replace budget" "$R"
+
+# Replace OLD_PLACEHOLDER → NEW_VALUE across all.  limit=1 bounds only the
+# returned preview; max_replacements authorizes the full three-document write.
+R=$(m1 "akb_grep" "{\"pattern\":\"OLD_PLACEHOLDER\",\"vault\":\"$VAULT1\",\"replace\":\"NEW_VALUE\",\"limit\":1,\"max_replacements\":3}")
 REPLACED_COUNT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('replaced_docs',0) or len(d.get('replaced',d.get('replacements',[]))))" 2>/dev/null)
 [ "$REPLACED_COUNT" = "3" ] && pass "Replaced in $REPLACED_COUNT documents" || fail "Grep replace" "expected 3, got $REPLACED_COUNT"
+PARENT_COUNT=$(echo "$R" | python3 -c "import sys,json; print(sum(bool(x.get('previous_commit')) for x in json.load(sys.stdin).get('replacements',[])))" 2>/dev/null)
+[ "$PARENT_COUNT" = "3" ] && pass "Replacement receipts include previous commits" || fail "Replace receipts" "$R"
 
 # Verify replacement (wait for the post-replace re-index)
 wait_for_indexing

--- a/backend/tests/test_grep_replace_unit.py
+++ b/backend/tests/test_grep_replace_unit.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.exceptions import WriteBusyError
+from app.services import search_service
+from app.services.search_service import SearchService
+
+
+def _rows(count: int, pattern: str = "TODO") -> list[dict]:
+    return [
+        {
+            "doc_id": str(uuid.uuid4()),
+            "vault": "test-vault",
+            "path": f"docs/{index:03d}.md",
+            "title": f"Document {index}",
+            "metadata": {},
+            "section_path": None,
+            "content": f"{pattern} item {index}",
+            "chunk_index": 0,
+        }
+        for index in range(count)
+    ]
+
+
+class _Connection:
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+
+    async def fetch(self, *_args):
+        return self.rows
+
+
+class _Acquire:
+    def __init__(self, connection: _Connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Pool:
+    def __init__(self, rows: list[dict]):
+        self.connection = _Connection(rows)
+
+    def acquire(self):
+        return _Acquire(self.connection)
+
+
+class _Documents:
+    def __init__(self, rows: list[dict], *, fail_path: str | None = None):
+        self.contents = {row["path"]: row["content"] for row in rows}
+        self.fail_path = fail_path
+        self.get_calls: list[str] = []
+        self.update_calls: list[tuple[str, object]] = []
+
+    async def get(self, _vault: str, path: str):
+        self.get_calls.append(path)
+        return SimpleNamespace(
+            content=self.contents[path],
+            current_commit=f"parent-{path}",
+        )
+
+    async def update(self, _vault: str, path: str, request, *, agent_id=None):
+        self.update_calls.append((path, request))
+        if path == self.fail_path:
+            raise WriteBusyError("test-vault", 1.0)
+        self.contents[path] = request.content
+        return SimpleNamespace(
+            commit_hash=f"commit-{path}",
+            previous_commit=f"parent-{path}",
+        )
+
+
+@pytest.fixture
+def legacy_grep(monkeypatch):
+    async def configure(rows: list[dict]):
+        pool = _Pool(rows)
+
+        async def get_pool():
+            return pool
+
+        monkeypatch.setattr(search_service, "get_pool", get_pool)
+        monkeypatch.setattr(
+            search_service,
+            "_configured_document_source_type",
+            lambda: search_service.LEGACY_DOCUMENT_SOURCE,
+        )
+        return SearchService()
+
+    return configure
+
+
+@pytest.mark.asyncio
+async def test_replace_applies_to_full_scope_while_limit_only_bounds_preview(legacy_grep):
+    # Exercise the original hard ceiling directly: response limit cannot exceed
+    # 50, but an explicitly budgeted write may cover a larger matching scope.
+    rows = _rows(51)
+    service = await legacy_grep(rows)
+    documents = _Documents(rows)
+
+    result = await service.grep(
+        "TODO",
+        vault="test-vault",
+        replace="TODO(owner)",
+        doc_service=documents,
+        agent_id="tester",
+        limit=1,
+        max_replacements=51,
+    )
+
+    assert result["returned_docs"] == 1
+    assert result["total_docs"] == 51
+    assert result["truncated"] is True
+    assert result["replaced_docs"] == 51
+    assert result["replacement_complete"] is True
+    assert len(result["replacements"]) == 51
+    assert all(row["previous_commit"] for row in result["replacements"])
+    assert all(content.startswith("TODO(owner)") for content in documents.contents.values())
+    assert all(request.expected_commit == f"parent-{path}" for path, request in documents.update_calls)
+
+
+@pytest.mark.asyncio
+async def test_replace_budget_rejects_full_scope_before_reading_or_writing(legacy_grep):
+    rows = _rows(3)
+    service = await legacy_grep(rows)
+    documents = _Documents(rows)
+
+    result = await service.grep(
+        "TODO",
+        vault="test-vault",
+        replace="done",
+        doc_service=documents,
+        agent_id="tester",
+        limit=1,
+        max_replacements=2,
+    )
+
+    assert result["code"] == "bulk_too_large"
+    assert result["details"] == {
+        "total_docs": 3,
+        "max_replacements": 2,
+        "writes_applied": 0,
+    }
+    assert result["replacement_complete"] is False
+    assert result["replacements"] == []
+    assert documents.get_calls == []
+    assert documents.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_replace_failure_returns_committed_receipts_and_stops(legacy_grep):
+    rows = _rows(3)
+    service = await legacy_grep(rows)
+    documents = _Documents(rows, fail_path=rows[1]["path"])
+
+    result = await service.grep(
+        "TODO",
+        vault="test-vault",
+        replace="done",
+        doc_service=documents,
+        agent_id="tester",
+        limit=1,
+        max_replacements=3,
+    )
+
+    assert result["code"] == "write_busy"
+    assert result["replacement_complete"] is False
+    assert result["replaced_docs"] == 1
+    assert result["replacements"][0]["previous_commit"] == f"parent-{rows[0]['path']}"
+    assert result["details"]["failed_uri"].endswith("/doc/001.md")
+    assert result["details"]["committed_replacements"] == 1
+    assert [path for path, _request in documents.update_calls] == [
+        rows[0]["path"],
+        rows[1]["path"],
+    ]

--- a/backend/tests/test_grep_replace_unit.py
+++ b/backend/tests/test_grep_replace_unit.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.exceptions import WriteBusyError
+from app.exceptions import ValidationError, WriteBusyError
 from app.services import search_service
 from app.services.search_service import SearchService
 
@@ -124,6 +124,38 @@ async def test_replace_applies_to_full_scope_while_limit_only_bounds_preview(leg
     assert all(row["previous_commit"] for row in result["replacements"])
     assert all(content.startswith("TODO(owner)") for content in documents.contents.values())
     assert all(request.expected_commit == f"parent-{path}" for path, request in documents.update_calls)
+
+
+@pytest.mark.asyncio
+async def test_literal_replace_preserves_backslashes(legacy_grep):
+    rows = _rows(1, pattern="todo")
+    service = await legacy_grep(rows)
+    documents = _Documents(rows)
+    replacement = r"C:\temp\1"
+
+    result = await service.grep(
+        "TODO",
+        vault="test-vault",
+        replace=replacement,
+        doc_service=documents,
+        agent_id="tester",
+    )
+
+    assert result["replacement_complete"] is True
+    assert documents.contents[rows[0]["path"]] == f"{replacement} item 0"
+
+
+@pytest.mark.asyncio
+async def test_legacy_replace_requires_document_service(legacy_grep):
+    service = await legacy_grep(_rows(1))
+
+    with pytest.raises(ValidationError, match="doc_service is required"):
+        await service.grep(
+            "TODO",
+            vault="test-vault",
+            replace="done",
+            agent_id="tester",
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_m1_pg_body_grep_unit.py
+++ b/backend/tests/test_m1_pg_body_grep_unit.py
@@ -284,6 +284,112 @@ async def test_native_grep_document_replace_uses_its_head_placement(
 
 
 @pytest.mark.asyncio
+async def test_native_grep_replace_uses_full_scope_beyond_response_limit(monkeypatch):
+    body_bytes = b"---\ntitle: Document\n---\nTODO item\n"
+    bodies = [
+        HeadBody(
+            namespace_id=uuid.uuid4(),
+            vault="measure",
+            resource_id=uuid.uuid4(),
+            surface="document",
+            path=f"notes/{index}.md",
+            revision_id=str(index) * 40,
+            digest=hashlib.sha256(body_bytes).hexdigest(),
+            byte_size=len(body_bytes),
+            canonical_bytes=body_bytes,
+        )
+        for index in range(1, 4)
+    ]
+    service = M1NativeGrepService(object())  # type: ignore[arg-type]
+    calls = []
+
+    async def head_bodies(**_kwargs):
+        return bodies
+
+    async def require_write_access(**_kwargs):
+        return None
+
+    class _Native:
+        async def replace_text(self, **kwargs):
+            calls.append(kwargs)
+            return type(
+                "Result",
+                (),
+                {
+                    "revision_id": f"new-{len(calls)}",
+                    "parent_revision_id": kwargs["expected_revision_id"],
+                },
+            )()
+
+    monkeypatch.setattr(service, "_head_bodies", head_bodies)
+    monkeypatch.setattr(service, "_require_write_access", require_write_access)
+    monkeypatch.setattr(native_grep, "NativeRevisionService", lambda *_args, **_kwargs: _Native())
+
+    result = await service.grep_public(
+        "TODO",
+        user_id=uuid.uuid4(),
+        replace="TODO(owner)",
+        actor="tester",
+        limit=1,
+        max_replacements=3,
+    )
+
+    assert result["returned_docs"] == 1
+    assert result["total_docs"] == 3
+    assert result["replaced_docs"] == 3
+    assert len(result["replacements"]) == 3
+    assert [row["previous_commit"] for row in result["replacements"]] == [
+        body.revision_id for body in bodies
+    ]
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_native_grep_replace_budget_fails_before_mutation(monkeypatch):
+    body_bytes = b"---\ntitle: Document\n---\nTODO item\n"
+    bodies = [
+        HeadBody(
+            namespace_id=uuid.uuid4(),
+            vault="measure",
+            resource_id=uuid.uuid4(),
+            surface="document",
+            path=f"notes/{index}.md",
+            revision_id=str(index) * 40,
+            digest=hashlib.sha256(body_bytes).hexdigest(),
+            byte_size=len(body_bytes),
+            canonical_bytes=body_bytes,
+        )
+        for index in range(1, 4)
+    ]
+    service = M1NativeGrepService(object())  # type: ignore[arg-type]
+    calls = []
+
+    async def head_bodies(**_kwargs):
+        return bodies
+
+    class _Native:
+        async def replace_text(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(service, "_head_bodies", head_bodies)
+    monkeypatch.setattr(native_grep, "NativeRevisionService", lambda *_args, **_kwargs: _Native())
+
+    result = await service.grep_public(
+        "TODO",
+        user_id=uuid.uuid4(),
+        replace="done",
+        actor="tester",
+        limit=1,
+        max_replacements=2,
+    )
+
+    assert result["code"] == "bulk_too_large"
+    assert result["replacement_complete"] is False
+    assert result["replacements"] == []
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_native_grep_prevalidates_all_head_placements_before_replacing(monkeypatch):
     body_bytes = b"---\ntitle: Document\n---\nneedle body\n"
     bodies = [

--- a/backend/tests/test_m1_pg_body_grep_unit.py
+++ b/backend/tests/test_m1_pg_body_grep_unit.py
@@ -325,10 +325,11 @@ async def test_native_grep_replace_uses_full_scope_beyond_response_limit(monkeyp
     monkeypatch.setattr(service, "_require_write_access", require_write_access)
     monkeypatch.setattr(native_grep, "NativeRevisionService", lambda *_args, **_kwargs: _Native())
 
+    replacement = r"C:\temp\1"
     result = await service.grep_public(
         "TODO",
         user_id=uuid.uuid4(),
-        replace="TODO(owner)",
+        replace=replacement,
         actor="tester",
         limit=1,
         max_replacements=3,
@@ -342,6 +343,7 @@ async def test_native_grep_replace_uses_full_scope_beyond_response_limit(monkeyp
         body.revision_id for body in bodies
     ]
     assert len(calls) == 3
+    assert all(f"{replacement} item" in call["payload"] for call in calls)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_grep_text_files_unit.py
+++ b/backend/tests/test_mcp_grep_text_files_unit.py
@@ -23,6 +23,11 @@ def test_akb_grep_schema_exposes_guarded_text_file_measurement_argument():
     replacement_budget = grep.inputSchema["properties"]["max_replacements"]
     assert replacement_budget["default"] == 50
     assert replacement_budget["maximum"] == 1000
+    assert (
+        "treated literally"
+        in grep.inputSchema["properties"]["replace"]["description"].lower()
+    )
+    assert "does not limit replacement writes" in grep.inputSchema["properties"]["limit"]["description"]
     assert argument["type"] == "boolean"
     assert argument["default"] is False
     assert "guarded native" in argument["description"].lower()

--- a/backend/tests/test_mcp_grep_text_files_unit.py
+++ b/backend/tests/test_mcp_grep_text_files_unit.py
@@ -20,6 +20,9 @@ def test_akb_grep_schema_exposes_guarded_text_file_measurement_argument():
     argument = grep.inputSchema["properties"]["measurement_include_text_files"]
 
     assert grep.inputSchema["properties"]["pattern"]["minLength"] == 1
+    replacement_budget = grep.inputSchema["properties"]["max_replacements"]
+    assert replacement_budget["default"] == 50
+    assert replacement_budget["maximum"] == 1000
     assert argument["type"] == "boolean"
     assert argument["default"] is False
     assert "guarded native" in argument["description"].lower()
@@ -53,6 +56,7 @@ async def test_mcp_grep_preserves_legacy_scope_and_defaults_to_documents(monkeyp
     assert access_checks == [("user-1", "legacy-vault", "reader")]
     assert grep_calls[0]["vault"] == "legacy-vault"
     assert grep_calls[0]["collection"] == "notes"
+    assert grep_calls[0]["max_replacements"] == 50
     assert grep_calls[0]["measurement_include_text_files"] is False
 
 
@@ -77,6 +81,7 @@ async def test_mcp_grep_passes_explicit_text_file_measurement_argument(monkeypat
         {
             "pattern": "needle",
             "vault": "measurement",
+            "max_replacements": 17,
             "measurement_include_text_files": True,
         },
         user.user_id,
@@ -84,6 +89,7 @@ async def test_mcp_grep_passes_explicit_text_file_measurement_argument(monkeypat
     )
 
     assert grep_calls[0]["measurement_include_text_files"] is True
+    assert grep_calls[0]["max_replacements"] == 17
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Treat `limit` as an output-preview bound and apply an accepted replace operation to the full matching document scope.
- Add an independent `max_replacements` budget (default 50, maximum 1000) that rejects oversized scopes before any write.
- Return new and previous commit receipts, stop after the first write failure, and preserve completed receipts for recovery.
- Keep legacy and native revision backends aligned, use optimistic commit checks, and emit metadata-only audit receipts for committed replacements.
- Preserve replacement text literally when `regex=false`; regex replacement backreferences remain available only when explicitly enabled.

## Verification

- Ruff, mypy, Bandit, and detect-secrets checks passed for the backend changes.
- Related unit and contract tests — 76 passed.
- Focused MCP integration checks against a rebuilt Compose deployment — fail-closed budget, `limit=1` full-scope write, parent receipts, and one application per document all passed.
- Full backend suite — 1797 passed, 206 skipped; 4 pre-existing fake-clock capacity-adapter failures reproduce when the unchanged test file is run alone.

## Scope

This is a data-integrity fix. Authorization and vault ACL behavior are unchanged. Audit receipts contain canonical URIs and commit identifiers only; document bodies and replacement text are not recorded.

Fixes #315