### PR TITLE
ci: make shell E2E coverage explicit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "backend/scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 87
       }
     ],
     "backend/scripts/ci/dependency-compose.yaml": [
@@ -270,7 +270,7 @@
         "filename": "backend/tests/test_e2e_runtime_unit.py",
         "hashed_secret": "e4b2fc073450eb73ac13305ba129b049865f69e2",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 120
       }
     ],
     "backend/tests/test_publications_e2e.sh": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-10T12:26:45Z"
+  "generated_at": "2026-08-11T10:01:54Z"
 }

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -24,30 +24,24 @@ AKB_URL=http://localhost:8000 bash backend/tests/test_publications_e2e.sh
 ```
 
 The shared curated gate is implemented by
-`backend/scripts/ci/e2e_suite_runner.py`. Its current 15-suite list is:
+`backend/scripts/ci/e2e_suite_runner.py`. `CURATED_SUITES` is the executable
+list, while `DEFERRED_SUITE_GROUPS` is the explicit opt-out list with reviewed
+reasons. Every `backend/tests/*_e2e.sh` file must appear in exactly one side of
+that manifest. The static check and the live gate both fail when a suite is
+unclassified, duplicated, overlaps both sides, or no longer exists.
 
-1. `test_probes_e2e.sh`
-2. `test_mcp_e2e.sh`
-3. `test_edit_e2e.sh`
-4. `test_security_edge_e2e.sh`
-5. `test_pg_rbac_e2e.sh`
-6. `test_graph_replace_e2e.sh`
-7. `test_relations_rest_e2e.sh`
-8. `test_collection_lifecycle_e2e.sh`
-9. `test_history_rest_e2e.sh`
-10. `test_jwt_revocation_e2e.sh`
-11. `test_table_constraints_e2e.sh`
-12. `test_forbidden_permission_code_e2e.sh`
-13. `test_okf_export_import_e2e.sh`
-14. `test_publication_resolution_e2e.sh`
-15. `test_publications_e2e.sh`
+Validate the manifest without starting any services:
+
+```bash
+python backend/scripts/ci/e2e_suite_runner.py --check-manifest
+```
 
 The runner is fail-closed. Each suite must finish successfully and provide a
 complete `Results: N passed, M failed` line. A missing summary, a non-zero
 suite return code, any failed assertion, or an unexpected zero-count suite
-fails the gate. `EMPTY_COUNT_ALLOWED` is intentionally empty. Keep this
-runner and the hosted workflow aligned; `scripts/run_canonical_e2e.sh` is not
-the curated gate's source of truth.
+fails the gate. `EMPTY_COUNT_ALLOWED` is intentionally empty. Hosted CI,
+the isolated runtime, and `scripts/run_canonical_e2e.sh` all execute this same
+runner, so there is no second suite array to keep synchronized.
 
 ### 2. Repository-owned isolated runtime
 
@@ -211,7 +205,7 @@ When changing this area, preserve all of the following:
 - backend, embedding stub, fixture control, and suite runner remain host-side
   processes;
 - Python `>=3.14` and `backend/uv.lock` are used with `uv sync --locked`;
-- the 15-suite list and fail-closed assertion-count semantics remain shared;
+- the suite manifest and fail-closed assertion-count semantics remain shared;
 - descriptor stdout stays parseable as one schema v2 JSON line; and
 - runtime state stays private and outside the checkout.
 

--- a/backend/scripts/ci/e2e_suite_runner.py
+++ b/backend/scripts/ci/e2e_suite_runner.py
@@ -1,7 +1,8 @@
-"""Run the exact curated HTTP E2E suite used by hosted CI.
+"""Run and validate the exact curated HTTP E2E suite used by hosted CI.
 
 The list and count handling live here so an isolated host gate and GitHub Actions
-cannot silently drift.  A suite must report both counts in its final matching
+cannot silently drift. Every shell E2E suite must be either executed or explicitly
+deferred with a reason. A suite must report both counts in its final matching
 ``Results: N passed, M failed`` line; otherwise the gate fails closed.
 """
 
@@ -28,16 +29,145 @@ CURATED_SUITES: tuple[str, ...] = (
     "test_edit_e2e.sh",
     "test_security_edge_e2e.sh",
     "test_pg_rbac_e2e.sh",
+    "test_vault_scope_e2e.sh",
+    "test_vault_scope_sql_e2e.sh",
+    "test_vault_write_policy_e2e.sh",
     "test_graph_replace_e2e.sh",
     "test_relations_rest_e2e.sh",
     "test_collection_lifecycle_e2e.sh",
     "test_history_rest_e2e.sh",
+    "test_author_resolution_e2e.sh",
+    "test_agent_sessions_e2e.sh",
     "test_jwt_revocation_e2e.sh",
     "test_table_constraints_e2e.sh",
+    "test_row_read_e2e.sh",
+    "test_row_write_e2e.sh",
     "test_forbidden_permission_code_e2e.sh",
     "test_okf_export_import_e2e.sh",
+    "test_resource_hash_e2e.sh",
+    "test_events_emit_e2e.sh",
+    "test_s3_delete_outbox_e2e.sh",
     "test_publication_resolution_e2e.sh",
     "test_publications_e2e.sh",
+)
+
+
+@dataclass(frozen=True)
+class DeferredSuiteGroup:
+    """Suites intentionally kept outside the bounded hosted gate."""
+
+    reason: str
+    suites: tuple[str, ...]
+
+
+# This is the reviewed opt-out side of the manifest. Keep reasons actionable:
+# adding a file here makes its lack of hosted execution intentional and visible.
+DEFERRED_SUITE_GROUPS: tuple[DeferredSuiteGroup, ...] = (
+    DeferredSuiteGroup(
+        reason=(
+            "current assertion expects 403 for a reused non-admin credential, "
+            "while password invalidation returns 401; align the contract first"
+        ),
+        suites=("test_auth_password_e2e.sh",),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "the synthetic database-only file fixture no longer appears through browse; "
+            "replace it with the supported upload flow before admission"
+        ),
+        suites=("test_collection_hierarchy_e2e.sh",),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "the malformed write-AST case expects method_not_allowed while request "
+            "validation currently returns invalid_argument; align the contract first"
+        ),
+        suites=("test_row_read_security_e2e.sh",),
+    ),
+    DeferredSuiteGroup(
+        reason=("requires an optional external service or network dependency not owned by the hosted runtime"),
+        suites=(
+            "test_external_git_e2e.sh",
+            "test_mcp_oauth_e2e.sh",
+            "test_seahorse_db_e2e.sh",
+        ),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "requires the Node stdio proxy and local-filesystem behavior, which the "
+            "backend-only runtime does not provide"
+        ),
+        suites=(
+            "test_put_file_param_e2e.sh",
+            "test_put_slug_e2e.sh",
+            "test_stdio_files_e2e.sh",
+        ),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "requires Kubernetes or backend-container process/storage control outside "
+            "the repository-owned runtime contract"
+        ),
+        suites=(
+            "test_hybrid_chaos_e2e.sh",
+            "test_hybrid_edge_e2e.sh",
+            "test_hybrid_git_e2e.sh",
+            "test_hybrid_invariants_e2e.sh",
+            "test_hybrid_lifecycle_e2e.sh",
+            "test_hybrid_ops_e2e.sh",
+            "test_pgvector_driver_e2e.sh",
+            "test_self_heal_e2e.sh",
+        ),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "long-running hybrid-search probe with timing assumptions and a noncanonical "
+            "summary; harden for the deterministic embedding stub before admission"
+        ),
+        suites=(
+            "test_hybrid_access_e2e.sh",
+            "test_hybrid_boundary_e2e.sh",
+            "test_hybrid_integration_e2e.sh",
+            "test_hybrid_misc_e2e.sh",
+            "test_hybrid_search_e2e.sh",
+            "test_hybrid_security_e2e.sh",
+            "test_hybrid_stress_e2e.sh",
+        ),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "fixed-vector embedding stub cannot make the post-delete similarity "
+            "assertion deterministic; use a content-sensitive stub before admission"
+        ),
+        suites=("test_defensive_e2e.sh",),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "publication concurrency case still sends the retired mode=live input; "
+            "update the fixture to the current publication contract first"
+        ),
+        suites=("test_concurrency_repro_e2e.sh",),
+    ),
+    DeferredSuiteGroup(
+        reason=(
+            "broad legacy or overlapping regression suite retained for on-demand runs outside the bounded hosted gate"
+        ),
+        suites=(
+            "test_e2e.sh",
+            "test_edge_extra_e2e.sh",
+            "test_edge_more_e2e.sh",
+            "test_unified_browse_edges_e2e.sh",
+        ),
+    ),
+    DeferredSuiteGroup(
+        reason=("targeted on-demand suite still needs the fail-closed Results: N passed, M failed summary contract"),
+        suites=(
+            "test_help_skill_template_e2e.sh",
+            "test_skill_e2e.sh",
+            "test_table_crud_envelope_e2e.sh",
+            "test_vault_templates_e2e.sh",
+        ),
+    ),
 )
 
 # Deliberately empty.  Adding an exception removes measured coverage and must
@@ -80,6 +210,52 @@ def parse_assertion_summary(output: str) -> tuple[int, int, str] | None:
     return int(match.group(1)), int(match.group(2)), match.group(0)
 
 
+def validate_suite_manifest(repo_root: Path) -> tuple[str, ...]:
+    """Return all manifest errors without starting the live E2E runtime."""
+
+    tests_dir = repo_root / "backend" / "tests"
+    discovered = {path.name for path in tests_dir.glob("*_e2e.sh") if path.is_file()}
+    curated = list(CURATED_SUITES)
+    deferred = [suite for group in DEFERRED_SUITE_GROUPS for suite in group.suites]
+    errors: list[str] = []
+
+    duplicate_curated = sorted({name for name in curated if curated.count(name) > 1})
+    duplicate_deferred = sorted({name for name in deferred if deferred.count(name) > 1})
+    reasonless_groups = [
+        index for index, group in enumerate(DEFERRED_SUITE_GROUPS, start=1) if not group.reason.strip()
+    ]
+    overlap = sorted(set(curated) & set(deferred))
+    declared = set(curated) | set(deferred)
+    unclassified = sorted(discovered - declared)
+    missing = sorted(declared - discovered)
+
+    if duplicate_curated:
+        errors.append(f"duplicate curated suites: {', '.join(duplicate_curated)}")
+    if duplicate_deferred:
+        errors.append(f"duplicate deferred suites: {', '.join(duplicate_deferred)}")
+    if reasonless_groups:
+        errors.append("deferred suite groups require a reason: " + ", ".join(str(index) for index in reasonless_groups))
+    if overlap:
+        errors.append(f"suites cannot be both curated and deferred: {', '.join(overlap)}")
+    if unclassified:
+        errors.append("unclassified E2E suites (execute or defer each one explicitly): " + ", ".join(unclassified))
+    if missing:
+        errors.append(f"manifest entries without a matching suite file: {', '.join(missing)}")
+    return tuple(errors)
+
+
+def check_suite_manifest(repo_root: Path) -> int:
+    errors = validate_suite_manifest(repo_root)
+    if errors:
+        for error in errors:
+            print(f"E2E suite manifest error: {error}", file=sys.stderr)
+        return 1
+
+    deferred_count = sum(len(group.suites) for group in DEFERRED_SUITE_GROUPS)
+    print(f"E2E suite manifest OK: {len(CURATED_SUITES)} curated, {deferred_count} explicitly deferred")
+    return 0
+
+
 def run_suite(name: str, repo_root: Path, env: dict[str, str] | None = None) -> SuiteResult:
     suite_path = repo_root / "backend" / "tests" / name
     if not suite_path.is_file():
@@ -109,6 +285,9 @@ def _tail(text: str, lines: int = 80) -> str:
 
 
 def run_curated(repo_root: Path, env: dict[str, str] | None = None) -> int:
+    if check_suite_manifest(repo_root) != 0:
+        return 1
+
     total_pass = 0
     total_fail = 0
     failed_suites: list[str] = []
@@ -130,8 +309,7 @@ def run_curated(repo_root: Path, env: dict[str, str] | None = None) -> int:
         total_fail += result.failed
         print("::endgroup::", flush=True)
         print(
-            f"▸ {suite}: {result.passed} passed, {result.failed} failed "
-            f"(rc={result.returncode})",
+            f"▸ {suite}: {result.passed} passed, {result.failed} failed (rc={result.returncode})",
             flush=True,
         )
         completion_event: dict[str, object] = {
@@ -195,8 +373,16 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=Path(__file__).resolve().parents[3],
     )
+    parser.add_argument(
+        "--check-manifest",
+        action="store_true",
+        help=("validate that every backend/tests/*_e2e.sh suite is curated or explicitly deferred"),
+    )
     args = parser.parse_args(argv)
-    return run_curated(args.repo_root.resolve())
+    repo_root = args.repo_root.resolve()
+    if args.check_manifest:
+        return check_suite_manifest(repo_root)
+    return run_curated(repo_root)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_agent_sessions_e2e.sh
+++ b/backend/tests/test_agent_sessions_e2e.sh
@@ -375,8 +375,7 @@ B_MV=$(curl -sk -X POST "$BASE_URL/api/v1/agent-sessions/collide-b-${TS}" \
 # ── Summary ────────────────────────────────────────────────
 echo ""
 echo "════════════════════════════════════════════════"
-echo "  Passed: $PASS"
-echo "  Failed: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 echo "════════════════════════════════════════════════"
 if [ "$FAIL" -ne 0 ]; then
   for e in "${ERRORS[@]}"; do echo "  — $e"; done

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -33,8 +33,11 @@ from e2e_gate_observability import (  # noqa: E402
 import e2e_suite_runner  # noqa: E402
 from e2e_suite_runner import (  # noqa: E402
     CURATED_SUITES,
+    DEFERRED_SUITE_GROUPS,
+    DeferredSuiteGroup,
     SuiteResult,
     parse_assertion_summary,
+    validate_suite_manifest,
 )
 from fixture_control import create_app  # noqa: E402
 
@@ -43,6 +46,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_FILE = CI_DIR / "dependency-compose.yaml"
 BOOTSTRAP = CI_DIR / "ubuntu_e2e_bootstrap.sh"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "e2e.yml"
+LOCAL_CANONICAL_RUNNER = REPO_ROOT / "scripts" / "run_canonical_e2e.sh"
 
 
 def make_config(tmp_path: Path, *, mode: str = "serve") -> RuntimeConfig:
@@ -217,7 +221,58 @@ def test_suite_summary_uses_last_complete_line_and_fails_closed():
     assert SuiteResult("suite.sh", 0, 0, 0, None, "").gate_failed
     assert SuiteResult("suite.sh", 0, 2, 0, "Results: 2 passed, 0 failed", "").gate_failed is False
     assert SuiteResult("suite.sh", -4, 0, 0, None, "").signal == 4
-    assert len(CURATED_SUITES) == 15
+    assert len(CURATED_SUITES) == 25
+
+
+def test_shell_e2e_manifest_classifies_every_suite_exactly_once():
+    assert validate_suite_manifest(REPO_ROOT) == ()
+    discovered = {
+        path.name for path in (REPO_ROOT / "backend" / "tests").glob("*_e2e.sh")
+    }
+    deferred = {
+        suite for group in DEFERRED_SUITE_GROUPS for suite in group.suites
+    }
+    assert discovered == set(CURATED_SUITES) | deferred
+    assert set(CURATED_SUITES).isdisjoint(deferred)
+
+
+def test_shell_e2e_manifest_reports_unclassified_overlap_and_missing(
+    tmp_path, monkeypatch
+):
+    tests_dir = tmp_path / "backend" / "tests"
+    tests_dir.mkdir(parents=True)
+    for name in ("test_run_e2e.sh", "test_defer_e2e.sh", "test_new_e2e.sh"):
+        (tests_dir / name).touch()
+
+    monkeypatch.setattr(
+        e2e_suite_runner,
+        "CURATED_SUITES",
+        ("test_run_e2e.sh", "test_overlap_e2e.sh"),
+    )
+    monkeypatch.setattr(
+        e2e_suite_runner,
+        "DEFERRED_SUITE_GROUPS",
+        (
+            DeferredSuiteGroup(
+                reason="fixture",
+                suites=("test_defer_e2e.sh", "test_overlap_e2e.sh"),
+            ),
+        ),
+    )
+
+    errors = validate_suite_manifest(tmp_path)
+    assert any(
+        "unclassified E2E suites" in error and "test_new_e2e.sh" in error
+        for error in errors
+    )
+    assert any(
+        "both curated and deferred" in error and "test_overlap_e2e.sh" in error
+        for error in errors
+    )
+    assert any(
+        "without a matching suite file" in error and "test_overlap_e2e.sh" in error
+        for error in errors
+    )
 
 
 def test_gate_events_are_safe_and_shell_signal_aware(capsys):
@@ -247,6 +302,7 @@ def test_gate_events_are_safe_and_shell_signal_aware(capsys):
 
 def test_suite_runner_emits_suite_and_gate_events(monkeypatch, capsys):
     monkeypatch.setattr(e2e_suite_runner, "CURATED_SUITES", ("test_fake.sh",))
+    monkeypatch.setattr(e2e_suite_runner, "check_suite_manifest", lambda _repo_root: 0)
     monkeypatch.setattr(
         e2e_suite_runner,
         "run_suite",
@@ -460,6 +516,10 @@ def test_compose_and_hosted_workflow_preserve_the_live_topology():
     for suite in CURATED_SUITES:
         assert suite not in workflow
     assert "akb-e2e-runtime-logs" in workflow
+
+    local_runner = LOCAL_CANONICAL_RUNNER.read_text()
+    assert "backend/scripts/ci/e2e_suite_runner.py" in local_runner
+    assert "SUITES=(" not in local_runner
 
 
 def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():

--- a/backend/tests/test_events_emit_e2e.sh
+++ b/backend/tests/test_events_emit_e2e.sh
@@ -112,7 +112,7 @@ curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" \
 
 echo ""
 echo "═══════════════════════════════════════════"
-echo "  Passed: $PASS   Failed: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 if [ $FAIL -gt 0 ]; then
   echo "  Failures:"
   printf '    - %s\n' "${ERRORS[@]}"

--- a/backend/tests/test_resource_hash_e2e.sh
+++ b/backend/tests/test_resource_hash_e2e.sh
@@ -151,7 +151,7 @@ DL_HASH=$(echo "$DL" | json_get "d['content_hash']")
 rm -f "$TMP_FILE"
 
 echo ""
-echo "Passed: $PASS  Failed: $FAIL"
+echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
   printf ' - %s\n' "${ERRORS[@]}"
   exit 1

--- a/backend/tests/test_s3_delete_outbox_e2e.sh
+++ b/backend/tests/test_s3_delete_outbox_e2e.sh
@@ -110,7 +110,7 @@ curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" \
 
 echo ""
 echo "═══════════════════════════════════════════"
-echo "  Passed: $PASS   Failed: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 if [ $FAIL -gt 0 ]; then
   echo "  Failures:"
   printf '    - %s\n' "${ERRORS[@]}"

--- a/backend/tests/test_vault_scope_e2e.sh
+++ b/backend/tests/test_vault_scope_e2e.sh
@@ -139,7 +139,7 @@ mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_delete_vault" "{\"vault\":\"$NONGDN_VAULT\"
 # ── Summary ──────────────────────────────────────────────────
 echo ""
 echo "════════════════════════════════════════════"
-echo "  PASS: $PASS    FAIL: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
   printf '  %s\n' "${ERRORS[@]}"
   exit 1

--- a/backend/tests/test_vault_scope_sql_e2e.sh
+++ b/backend/tests/test_vault_scope_sql_e2e.sh
@@ -161,7 +161,7 @@ mcp_as "$UNSCOPED_PAT" "$SID_U" "akb_delete_vault" "{\"vault\":\"$NONGDN_VAULT\"
 # ── Summary ──────────────────────────────────────────────────
 echo ""
 echo "════════════════════════════════════════════════"
-echo "  PASS: $PASS    FAIL: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
   printf '  %s\n' "${ERRORS[@]}"
   exit 1

--- a/backend/tests/test_vault_write_policy_e2e.sh
+++ b/backend/tests/test_vault_write_policy_e2e.sh
@@ -217,7 +217,7 @@ curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$OTHER_VAULT" -H "Authorization: Bea
 
 echo ""
 echo "═══════════════════════════════════════════"
-echo "  Passed: $PASS   Failed: $FAIL"
+echo "  Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
   echo "  Failures:"
   printf '    - %s\n' "${ERRORS[@]}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -12,6 +12,12 @@ cd "${REPO_ROOT}"
 
 step() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
 
+# ─── E2E suite manifest ───────────────────────────────────────────
+# Fails fast when a new shell E2E suite is neither run by the hosted gate nor
+# deliberately deferred with a reviewed reason.
+step "E2E suite manifest"
+python backend/scripts/ci/e2e_suite_runner.py --check-manifest --repo-root "${REPO_ROOT}"
+
 # ─── backend: ruff (lint) ──────────────────────────────────────────
 step "ruff (backend)"
 ruff check backend/

--- a/scripts/run_canonical_e2e.sh
+++ b/scripts/run_canonical_e2e.sh
@@ -1,45 +1,6 @@
 #!/usr/bin/env bash
-# Run the canonical E2E suites listed in CLAUDE.md, plus the repro suite.
-set -uo pipefail
-cd "$(dirname "$0")/.."
+# Run the same curated E2E manifest used by hosted CI.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 export AKB_URL="${AKB_URL:-http://localhost:8001}"
-
-SUITES=(
-  test_mcp_e2e.sh
-  test_edit_e2e.sh
-  test_security_edge_e2e.sh
-  test_graph_replace_e2e.sh
-  test_defensive_e2e.sh
-  test_probes_e2e.sh
-  test_stdio_files_e2e.sh
-  test_put_file_param_e2e.sh
-  test_concurrency_repro_e2e.sh
-  test_jwt_revocation_e2e.sh
-)
-
-LINES=()
-TOTAL_PASS=0
-TOTAL_FAIL=0
-for s in "${SUITES[@]}"; do
-  echo "═══ $s ═══"
-  OUT=$(bash "backend/tests/$s" 2>&1)
-  # Same summary pattern as .github/workflows/e2e.yml — both counts are
-  # required so a partial summary reports 0 rather than a silent zero
-  # for the failed count.
-  SUMMARY=$(echo "$OUT" | grep -E 'Results: *[0-9]+ passed, *[0-9]+ failed' | tail -1)
-  echo "  $SUMMARY"
-  P=$(echo "$SUMMARY" | grep -oE '[0-9]+ passed' | head -1 | grep -oE '^[0-9]+')
-  F=$(echo "$SUMMARY" | grep -oE '[0-9]+ failed' | head -1 | grep -oE '^[0-9]+')
-  P=${P:-0}; F=${F:-0}
-  LINES+=("$(printf '  %-45s %s passed, %s failed' "$s" "$P" "$F")")
-  TOTAL_PASS=$((TOTAL_PASS + P))
-  TOTAL_FAIL=$((TOTAL_FAIL + F))
-done
-
-echo ""
-echo "═════════════════════════════════════════"
-echo "Per-suite breakdown:"
-for l in "${LINES[@]}"; do echo "$l"; done
-echo ""
-echo "TOTAL across canonical suites: $TOTAL_PASS passed, $TOTAL_FAIL failed"
-echo "═════════════════════════════════════════"
+exec python3 "$REPO_ROOT/backend/scripts/ci/e2e_suite_runner.py" --repo-root "$REPO_ROOT"


### PR DESCRIPTION
## Summary

- add a fail-closed manifest that requires every `backend/tests/*_e2e.sh` file to be either executed by the hosted gate or explicitly deferred with a reviewed reason
- make the hosted workflow, repository-owned runtime, and `scripts/run_canonical_e2e.sh` use the same curated runner
- expand the hosted gate from 15 to 25 suites and normalize result summaries for the newly admitted suites
- run manifest validation in the static check so an unclassified suite fails before the live E2E job

## Validation

- `bash scripts/check.sh`
- `uv run --locked --extra dev --project backend python -m pytest backend/tests/test_e2e_runtime_unit.py -q` — 17 passed
- repository-owned isolated E2E runtime — 25 suites, 810 passed, 0 failed

## Security and privacy

This changes CI classification and test execution only; application authentication, authorization, and runtime behavior are unchanged. Deferred-suite reasons describe dependency classes without embedding environment-specific endpoints or credentials, and no secrets are added.

Closes #291
