### PR TITLE
Native Revision P2: add product-backed current-head migration

### DIFF
--- a/backend/app/db/migrations/060_native_revision_migration_bridge.py
+++ b/backend/app/db/migrations/060_native_revision_migration_bridge.py
@@ -1,0 +1,193 @@
+"""Migration 060: additive C9 native/legacy revision bridge metadata.
+
+The migration ledger remains the sole rollout authority.  These relations
+only record a bounded migration run, its per-document observations, and the
+stable selector metadata needed to resolve retained legacy history.  They do
+not add a cutover flag, change the legacy writer, or backfill any rows.
+
+The run and mapping namespace columns are intentionally repeated where
+needed for composite foreign keys.  PostgreSQL can then reject completed
+authority links that combine a run, Resource, or Revision from different
+vaults without coupling the pre-authority inventory ledger to either the
+legacy projection or native rows.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.060")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS native_revision_migration_runs (
+                run_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                namespace_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                fixed_git_oid TEXT NOT NULL,
+                coverage_version TEXT NOT NULL,
+                inventory_digest TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'planned',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                started_at TIMESTAMPTZ,
+                completed_at TIMESTAMPTZ,
+                error TEXT,
+                CONSTRAINT native_revision_migration_runs_fixed_oid_shape
+                    CHECK (fixed_git_oid ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT native_revision_migration_runs_coverage_version_check
+                    CHECK (btrim(coverage_version) <> ''),
+                CONSTRAINT native_revision_migration_runs_inventory_digest_shape
+                    CHECK (inventory_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_migration_runs_status_check
+                    CHECK (status IN ('planned', 'running', 'complete', 'failed')),
+                CONSTRAINT native_revision_migration_runs_error_check
+                    CHECK (
+                        (status <> 'failed' AND error IS NULL)
+                        OR
+                        (status = 'failed' AND btrim(error) <> '')
+                    ),
+                CONSTRAINT native_revision_migration_runs_scope_key
+                    UNIQUE (run_id, namespace_id),
+                CONSTRAINT native_revision_migration_runs_identity_key
+                    UNIQUE (namespace_id, fixed_git_oid, coverage_version)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_native_revision_migration_runs_scope_status
+                ON native_revision_migration_runs(namespace_id, status, created_at DESC);
+
+            CREATE TABLE IF NOT EXISTS native_revision_migration_items (
+                run_id UUID NOT NULL,
+                namespace_id UUID NOT NULL,
+                legacy_document_id UUID NOT NULL,
+                native_resource_id UUID NOT NULL,
+                captured_path TEXT NOT NULL,
+                legacy_head_oid TEXT NOT NULL,
+                native_head_revision_id TEXT,
+                body_digest TEXT NOT NULL,
+                byte_size BIGINT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                error_code TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT native_revision_migration_items_pkey
+                    PRIMARY KEY (run_id, legacy_document_id),
+                CONSTRAINT native_revision_migration_items_run_fkey
+                    FOREIGN KEY (run_id, namespace_id)
+                    REFERENCES native_revision_migration_runs(run_id, namespace_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT native_revision_migration_items_head_fkey
+                    FOREIGN KEY (
+                        namespace_id,
+                        native_resource_id,
+                        native_head_revision_id
+                    )
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    DEFERRABLE INITIALLY DEFERRED,
+                CONSTRAINT native_revision_migration_items_identity_check
+                    CHECK (native_resource_id = legacy_document_id),
+                CONSTRAINT native_revision_migration_items_path_check
+                    CHECK (btrim(captured_path) <> ''),
+                CONSTRAINT native_revision_migration_items_legacy_oid_shape
+                    CHECK (legacy_head_oid ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT native_revision_migration_items_body_digest_shape
+                    CHECK (body_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_migration_items_size_check
+                    CHECK (byte_size >= 0),
+                CONSTRAINT native_revision_migration_items_status_check
+                    CHECK (status IN ('pending', 'complete', 'failed')),
+                CONSTRAINT native_revision_migration_items_error_code_check
+                    CHECK (
+                        error_code IS NULL
+                        OR error_code ~ '^[a-z][a-z0-9_]*$'
+                    ),
+                CONSTRAINT native_revision_migration_items_error_state_check
+                    CHECK (
+                        (status = 'pending'
+                         AND native_head_revision_id IS NULL
+                         AND error_code IS NULL)
+                        OR
+                        (status = 'complete'
+                         AND native_head_revision_id IS NOT NULL
+                         AND error_code IS NULL)
+                        OR
+                        (status = 'failed'
+                         AND native_head_revision_id IS NULL
+                         AND error_code IS NOT NULL)
+                    ),
+                CONSTRAINT native_revision_migration_items_resource_head_key
+                    UNIQUE (native_resource_id, legacy_head_oid)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_native_revision_migration_items_run_status
+                ON native_revision_migration_items(run_id, status, legacy_document_id);
+            CREATE INDEX IF NOT EXISTS idx_native_revision_migration_items_resource
+                ON native_revision_migration_items(native_resource_id, legacy_head_oid);
+
+            CREATE TABLE IF NOT EXISTS legacy_revision_mappings (
+                namespace_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                resource_id UUID NOT NULL,
+                legacy_git_oid TEXT NOT NULL,
+                path_at_revision TEXT NOT NULL,
+                resolution TEXT NOT NULL,
+                native_revision_id TEXT,
+                run_id UUID NOT NULL,
+                lineage_ordinal INTEGER NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT legacy_revision_mappings_pkey
+                    PRIMARY KEY (resource_id, legacy_git_oid),
+                CONSTRAINT legacy_revision_mappings_resource_fkey
+                    FOREIGN KEY (namespace_id, resource_id)
+                    REFERENCES native_resources(namespace_id, resource_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT legacy_revision_mappings_run_fkey
+                    FOREIGN KEY (run_id, namespace_id)
+                    REFERENCES native_revision_migration_runs(run_id, namespace_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT legacy_revision_mappings_revision_fkey
+                    FOREIGN KEY (namespace_id, resource_id, native_revision_id)
+                    REFERENCES native_revisions(namespace_id, resource_id, revision_id)
+                    ON DELETE NO ACTION,
+                CONSTRAINT legacy_revision_mappings_legacy_oid_shape
+                    CHECK (legacy_git_oid ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT legacy_revision_mappings_path_check
+                    CHECK (btrim(path_at_revision) <> ''),
+                CONSTRAINT legacy_revision_mappings_resolution_check
+                    CHECK (resolution IN ('native', 'bridge')),
+                CONSTRAINT legacy_revision_mappings_resolution_link_check
+                    CHECK (
+                        (resolution = 'native' AND native_revision_id IS NOT NULL)
+                        OR
+                        (resolution = 'bridge' AND native_revision_id IS NULL)
+                    ),
+                CONSTRAINT legacy_revision_mappings_revision_shape
+                    CHECK (
+                        native_revision_id IS NULL
+                        OR native_revision_id ~ '^[0-9a-f]{40}$'
+                    ),
+                CONSTRAINT legacy_revision_mappings_lineage_ordinal_check
+                    CHECK (lineage_ordinal >= 0)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_legacy_revision_mappings_namespace_resource
+                ON legacy_revision_mappings(namespace_id, resource_id, lineage_ordinal);
+            CREATE INDEX IF NOT EXISTS idx_legacy_revision_mappings_run
+                ON legacy_revision_mappings(run_id, namespace_id);
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_legacy_revision_mappings_native_revision
+                ON legacy_revision_mappings(resource_id, native_revision_id)
+             WHERE native_revision_id IS NOT NULL;
+            """
+        )
+    logger.info("Migration 060: native revision migration bridge schema ready")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -236,6 +236,7 @@ async def _apply_migrations() -> None:
         "057_native_revision_m1_payload_placement.py", # M1 placement-scoped payload deduplication
         "058_publication_document_identity.py",  # publications.document_id + composite FK (document_id, vault_id) → documents(id, vault_id) ON DELETE CASCADE; conservative backfill
         "059_native_file_searchable_derived.py",  # chunks.source_type admits 'native_file' so text Files reach the chunk/index/embedding pipeline on the Document's Resource/Revision basis
+        "060_native_revision_migration_bridge.py",  # additive C9 migration runs, observations, and retained legacy selector mappings
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -1,0 +1,773 @@
+"""PostgreSQL primitives for the bounded C9 migration bridge.
+
+The repository deliberately owns only migration-run, inventory-item, and
+legacy-selector mapping state.  It never writes a legacy document and every
+authority publication is composed by the backfill service on a caller-owned
+transaction.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import uuid
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import asyncpg
+
+from app.exceptions import ConflictError
+from app.repositories.native_revision_repo import NativeRevisionIdCollisionError
+
+
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class MigrationInventoryDriftError(ConflictError):
+    """The immutable run key was observed with different inventory facts."""
+
+    def __init__(self, message: str = "fixed-ref migration inventory drifted"):
+        super().__init__(message)
+        self.code = "native_revision_migration_inventory_drift"
+
+
+class MigrationIntegrityError(ConflictError):
+    """Persisted bridge facts do not match the worker's frozen input."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.code = "native_revision_migration_integrity"
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationRun:
+    run_id: uuid.UUID
+    namespace_id: uuid.UUID
+    fixed_git_oid: str
+    coverage_version: str
+    inventory_digest: str
+    status: str
+    created_at: Any
+    started_at: Any
+    completed_at: Any
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationItem:
+    run_id: uuid.UUID
+    namespace_id: uuid.UUID
+    legacy_document_id: uuid.UUID
+    native_resource_id: uuid.UUID
+    captured_path: str
+    legacy_head_oid: str
+    native_head_revision_id: str | None
+    body_digest: str
+    byte_size: int
+    status: str
+    error_code: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyRevisionMapping:
+    namespace_id: uuid.UUID
+    resource_id: uuid.UUID
+    legacy_git_oid: str
+    path_at_revision: str
+    resolution: str
+    native_revision_id: str | None
+    run_id: uuid.UUID
+    lineage_ordinal: int
+    fixed_git_oid: str
+
+
+def _require_oid(value: str, field: str) -> str:
+    if not isinstance(value, str) or _OID_RE.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a full lowercase 40-hex OID")
+    return value
+
+
+def _require_digest(value: str, field: str) -> str:
+    if not isinstance(value, str) or _DIGEST_RE.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a lowercase 64-hex digest")
+    return value
+
+
+def _run(row: asyncpg.Record) -> MigrationRun:
+    return MigrationRun(
+        run_id=row["run_id"],
+        namespace_id=row["namespace_id"],
+        fixed_git_oid=row["fixed_git_oid"],
+        coverage_version=row["coverage_version"],
+        inventory_digest=row["inventory_digest"],
+        status=row["status"],
+        created_at=row["created_at"],
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+        error=row["error"],
+    )
+
+
+def _item(row: asyncpg.Record) -> MigrationItem:
+    return MigrationItem(
+        run_id=row["run_id"],
+        namespace_id=row["namespace_id"],
+        legacy_document_id=row["legacy_document_id"],
+        native_resource_id=row["native_resource_id"],
+        captured_path=row["captured_path"],
+        legacy_head_oid=row["legacy_head_oid"],
+        native_head_revision_id=row["native_head_revision_id"],
+        body_digest=row["body_digest"],
+        byte_size=row["byte_size"],
+        status=row["status"],
+        error_code=row["error_code"],
+    )
+
+
+def _mapping(row: asyncpg.Record) -> LegacyRevisionMapping:
+    return LegacyRevisionMapping(
+        namespace_id=row["namespace_id"],
+        resource_id=row["resource_id"],
+        legacy_git_oid=row["legacy_git_oid"],
+        path_at_revision=row["path_at_revision"],
+        resolution=row["resolution"],
+        native_revision_id=row["native_revision_id"],
+        run_id=row["run_id"],
+        lineage_ordinal=row["lineage_ordinal"],
+        fixed_git_oid=row["fixed_git_oid"],
+    )
+
+
+class NativeRevisionMigrationRepository:
+    """Caller-transaction-friendly repository for migration bridge facts."""
+
+    def __init__(self, pool: asyncpg.Pool):
+        self.pool = pool
+
+    async def get_manual_vault(
+        self, namespace_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        sql = """
+            SELECT v.id, v.name, v.git_path,
+                   (eg.vault_id IS NOT NULL) AS has_external_git
+              FROM vaults v
+             LEFT JOIN vault_external_git eg ON eg.vault_id = v.id
+             WHERE v.id = $1
+               AND v.status = 'active'
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, namespace_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, namespace_id)
+        return dict(row) if row is not None else None
+
+    @staticmethod
+    async def list_documents(
+        conn: asyncpg.Connection, namespace_id: uuid.UUID,
+    ) -> list[dict]:
+        rows = await conn.fetch(
+            """
+            SELECT id, path, current_commit, created_at, source
+              FROM documents
+             WHERE vault_id = $1
+             ORDER BY id
+            """,
+            namespace_id,
+        )
+        return [dict(row) for row in rows]
+
+    @staticmethod
+    async def list_document_aliases(
+        conn: asyncpg.Connection, namespace_id: uuid.UUID, resource_id: uuid.UUID,
+    ) -> list[dict]:
+        rows = await conn.fetch(
+            """
+            SELECT old_ref, created_at
+              FROM resource_aliases
+             WHERE vault_id = $1
+               AND resource_type = 'document'
+               AND resource_id = $2
+             ORDER BY created_at, old_ref
+            """,
+            namespace_id,
+            resource_id,
+        )
+        return [dict(row) for row in rows]
+
+    async def get_run(
+        self, run_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+    ) -> MigrationRun | None:
+        sql = """
+            SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
+                   inventory_digest, status, created_at, started_at,
+                   completed_at, error
+              FROM native_revision_migration_runs
+             WHERE run_id = $1
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, run_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, run_id)
+        return _run(row) if row is not None else None
+
+    async def get_or_create_run(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_git_oid: str,
+        coverage_version: str,
+        inventory_digest: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> MigrationRun:
+        _require_oid(fixed_git_oid, "fixed_git_oid")
+        _require_digest(inventory_digest, "inventory_digest")
+        if not isinstance(coverage_version, str) or not coverage_version.strip():
+            raise ValueError("coverage_version must be non-empty")
+
+        async def _get_or_create(acquired: asyncpg.Connection) -> MigrationRun:
+            row = await acquired.fetchrow(
+                """
+                SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
+                       inventory_digest, status, created_at, started_at,
+                       completed_at, error
+                  FROM native_revision_migration_runs
+                 WHERE namespace_id = $1
+                   AND fixed_git_oid = $2
+                   AND coverage_version = $3
+                 FOR UPDATE
+                """,
+                namespace_id,
+                fixed_git_oid,
+                coverage_version,
+            )
+            if row is None:
+                await acquired.execute(
+                    """
+                    INSERT INTO native_revision_migration_runs
+                        (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (namespace_id, fixed_git_oid, coverage_version)
+                    DO NOTHING
+                    """,
+                    namespace_id,
+                    fixed_git_oid,
+                    coverage_version,
+                    inventory_digest,
+                )
+                row = await acquired.fetchrow(
+                    """
+                    SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
+                           inventory_digest, status, created_at, started_at,
+                           completed_at, error
+                      FROM native_revision_migration_runs
+                     WHERE namespace_id = $1
+                       AND fixed_git_oid = $2
+                       AND coverage_version = $3
+                     FOR UPDATE
+                    """,
+                    namespace_id,
+                    fixed_git_oid,
+                    coverage_version,
+                )
+            if row is None:
+                raise MigrationIntegrityError("migration run disappeared during creation")
+            if row["inventory_digest"] != inventory_digest:
+                raise MigrationInventoryDriftError()
+            return _run(row)
+
+        if conn is not None:
+            return await _get_or_create(conn)
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction():
+                return await _get_or_create(acquired)
+
+    async def ensure_pending_items(
+        self,
+        run: MigrationRun,
+        items: Iterable[dict],
+        *,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[MigrationItem]:
+        """Insert the pre-authority inventory, preserving completed work."""
+
+        async def _ensure(acquired: asyncpg.Connection) -> list[MigrationItem]:
+            result: list[MigrationItem] = []
+            for observed in items:
+                document_id = observed["legacy_document_id"]
+                expected = (
+                    run.run_id,
+                    run.namespace_id,
+                    document_id,
+                    document_id,
+                    observed["captured_path"],
+                    observed["legacy_head_oid"],
+                    observed["body_digest"],
+                    observed["byte_size"],
+                )
+                row = await acquired.fetchrow(
+                    """
+                    SELECT run_id, namespace_id, legacy_document_id,
+                           native_resource_id, captured_path, legacy_head_oid,
+                           native_head_revision_id, body_digest, byte_size,
+                           status, error_code
+                      FROM native_revision_migration_items
+                     WHERE run_id = $1 AND legacy_document_id = $2
+                     FOR UPDATE
+                    """,
+                    run.run_id,
+                    document_id,
+                )
+                if row is None:
+                    await acquired.execute(
+                        """
+                        INSERT INTO native_revision_migration_items
+                            (run_id, namespace_id, legacy_document_id,
+                             native_resource_id, captured_path, legacy_head_oid,
+                             body_digest, byte_size, status)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
+                        """,
+                        *expected,
+                    )
+                else:
+                    observed_identity = (
+                        row["run_id"],
+                        row["namespace_id"],
+                        row["legacy_document_id"],
+                        row["native_resource_id"],
+                        row["captured_path"],
+                        row["legacy_head_oid"],
+                        row["body_digest"],
+                        row["byte_size"],
+                    )
+                    if observed_identity != expected:
+                        raise MigrationInventoryDriftError(
+                            "migration item facts differ from the frozen inventory"
+                        )
+                    if row["status"] == "failed":
+                        await acquired.execute(
+                            """
+                            UPDATE native_revision_migration_items
+                               SET status = 'pending', error_code = NULL,
+                                   updated_at = NOW()
+                             WHERE run_id = $1 AND legacy_document_id = $2
+                            """,
+                            run.run_id,
+                            document_id,
+                        )
+                refreshed = await acquired.fetchrow(
+                    """
+                    SELECT run_id, namespace_id, legacy_document_id,
+                           native_resource_id, captured_path, legacy_head_oid,
+                           native_head_revision_id, body_digest, byte_size,
+                           status, error_code
+                      FROM native_revision_migration_items
+                     WHERE run_id = $1 AND legacy_document_id = $2
+                    """,
+                    run.run_id,
+                    document_id,
+                )
+                if refreshed is None:
+                    raise MigrationIntegrityError("migration item disappeared during insertion")
+                result.append(_item(refreshed))
+            return result
+
+        if conn is not None:
+            return await _ensure(conn)
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction():
+                return await _ensure(acquired)
+
+    async def list_items(
+        self, run_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+    ) -> list[MigrationItem]:
+        sql = """
+            SELECT run_id, namespace_id, legacy_document_id, native_resource_id,
+                   captured_path, legacy_head_oid, native_head_revision_id,
+                   body_digest, byte_size, status, error_code
+              FROM native_revision_migration_items
+             WHERE run_id = $1
+             ORDER BY legacy_document_id
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, run_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, run_id)
+        return [_item(row) for row in rows]
+
+    async def get_item(
+        self,
+        run_id: uuid.UUID,
+        legacy_document_id: uuid.UUID,
+        *,
+        conn: asyncpg.Connection | None = None,
+        for_update: bool = False,
+    ) -> MigrationItem | None:
+        suffix = " FOR UPDATE" if for_update else ""
+        sql = """
+            SELECT run_id, namespace_id, legacy_document_id, native_resource_id,
+                   captured_path, legacy_head_oid, native_head_revision_id,
+                   body_digest, byte_size, status, error_code
+              FROM native_revision_migration_items
+             WHERE run_id = $1 AND legacy_document_id = $2
+        """ + suffix
+        if conn is not None:
+            row = await conn.fetchrow(sql, run_id, legacy_document_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, run_id, legacy_document_id)
+        return _item(row) if row is not None else None
+
+    @staticmethod
+    async def mark_item_complete(
+        conn: asyncpg.Connection,
+        *,
+        run_id: uuid.UUID,
+        legacy_document_id: uuid.UUID,
+        native_head_revision_id: str,
+    ) -> None:
+        _require_oid(native_head_revision_id, "native_head_revision_id")
+        await conn.execute(
+            """
+            UPDATE native_revision_migration_items
+               SET native_head_revision_id = $3,
+                   status = 'complete',
+                   error_code = NULL,
+                   updated_at = NOW()
+             WHERE run_id = $1 AND legacy_document_id = $2
+            """,
+            run_id,
+            legacy_document_id,
+            native_head_revision_id,
+        )
+
+    @staticmethod
+    async def mark_item_failed(
+        conn: asyncpg.Connection,
+        *,
+        run_id: uuid.UUID,
+        legacy_document_id: uuid.UUID,
+        error_code: str,
+    ) -> None:
+        if _ERROR_CODE_RE.fullmatch(error_code) is None:
+            raise ValueError("error_code must be a stable lowercase token")
+        await conn.execute(
+            """
+            UPDATE native_revision_migration_items
+               SET native_head_revision_id = NULL,
+                   status = 'failed',
+                   error_code = $3,
+                   updated_at = NOW()
+             WHERE run_id = $1
+               AND legacy_document_id = $2
+               AND status <> 'complete'
+            """,
+            run_id,
+            legacy_document_id,
+            error_code,
+        )
+
+    async def set_run_status(
+        self,
+        run_id: uuid.UUID,
+        status: str,
+        *,
+        error: str | None = None,
+        conn: asyncpg.Connection | None = None,
+    ) -> MigrationRun:
+        if status not in {"planned", "running", "complete", "failed"}:
+            raise ValueError("invalid migration run status")
+        if status == "failed" and not error:
+            raise ValueError("failed migration runs require an error")
+        if status != "failed" and error is not None:
+            raise ValueError("non-failed migration runs cannot carry an error")
+
+        async def _set(acquired: asyncpg.Connection) -> MigrationRun:
+            row = await acquired.fetchrow(
+                """
+                SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
+                       inventory_digest, status, created_at, started_at,
+                       completed_at, error
+                  FROM native_revision_migration_runs
+                 WHERE run_id = $1
+                 FOR UPDATE
+                """,
+                run_id,
+            )
+            if row is None:
+                raise MigrationIntegrityError("migration run disappeared during status update")
+            if row["status"] == "complete":
+                return _run(row)
+            await acquired.execute(
+                """
+                UPDATE native_revision_migration_runs
+                   SET status = $2,
+                       started_at = CASE
+                           WHEN $2 = 'running' THEN COALESCE(started_at, NOW())
+                           ELSE started_at
+                       END,
+                       completed_at = CASE
+                           WHEN $2 IN ('complete', 'failed') THEN COALESCE(completed_at, NOW())
+                           ELSE NULL
+                       END,
+                       error = $3
+                 WHERE run_id = $1
+                """,
+                run_id,
+                status,
+                error,
+            )
+            row = await acquired.fetchrow(
+                """
+                SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
+                       inventory_digest, status, created_at, started_at,
+                       completed_at, error
+                  FROM native_revision_migration_runs
+                 WHERE run_id = $1
+                """,
+                run_id,
+            )
+            if row is None:
+                raise MigrationIntegrityError("migration run disappeared during status update")
+            return _run(row)
+
+        if conn is not None:
+            return await _set(conn)
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction():
+                return await _set(acquired)
+
+    @staticmethod
+    async def all_items_complete(
+        conn: asyncpg.Connection, run_id: uuid.UUID,
+    ) -> bool:
+        return bool(
+            await conn.fetchval(
+                """
+                SELECT NOT EXISTS (
+                    SELECT 1
+                      FROM native_revision_migration_items
+                     WHERE run_id = $1 AND status <> 'complete'
+                )
+                """,
+                run_id,
+            )
+        )
+
+    @staticmethod
+    async def ensure_mapping(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+        path_at_revision: str,
+        resolution: str,
+        native_revision_id: str | None,
+        run_id: uuid.UUID,
+        lineage_ordinal: int,
+    ) -> LegacyRevisionMapping:
+        _require_oid(legacy_git_oid, "legacy_git_oid")
+        if resolution not in {"native", "bridge"}:
+            raise ValueError("resolution must be native or bridge")
+        if resolution == "native" and native_revision_id is None:
+            raise ValueError("native mappings require native_revision_id")
+        if resolution == "bridge" and native_revision_id is not None:
+            raise ValueError("bridge mappings cannot carry native_revision_id")
+        if native_revision_id is not None:
+            _require_oid(native_revision_id, "native_revision_id")
+        if not path_at_revision.strip() or lineage_ordinal < 0:
+            raise ValueError("mapping path and lineage ordinal are invalid")
+
+        row = await conn.fetchrow(
+            """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.resource_id = $1 AND m.legacy_git_oid = $2
+             FOR UPDATE
+            """,
+            resource_id,
+            legacy_git_oid,
+        )
+        expected = (
+            namespace_id,
+            resource_id,
+            legacy_git_oid,
+            path_at_revision,
+            resolution,
+            native_revision_id,
+            run_id,
+            lineage_ordinal,
+        )
+        if row is None:
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, native_revision_id, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                """,
+                *expected,
+            )
+        else:
+            observed = (
+                row["namespace_id"],
+                row["resource_id"],
+                row["legacy_git_oid"],
+                row["path_at_revision"],
+                row["resolution"],
+                row["native_revision_id"],
+                row["run_id"],
+                row["lineage_ordinal"],
+            )
+            if observed != expected:
+                raise MigrationIntegrityError(
+                    "legacy revision mapping conflicts with frozen lineage"
+                )
+        row = await conn.fetchrow(
+            """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.resource_id = $1 AND m.legacy_git_oid = $2
+            """,
+            resource_id,
+            legacy_git_oid,
+        )
+        if row is None:
+            raise MigrationIntegrityError("mapping disappeared during insertion")
+        return _mapping(row)
+
+    async def allocate_native_revision_id(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        resource_id: uuid.UUID,
+        retained_legacy_oids: set[str],
+        revision_id_factory: Callable[[], str] | None = None,
+        attempts: int = 8,
+    ) -> str:
+        """Allocate a random opaque Revision token with both collision fences."""
+        for oid in retained_legacy_oids:
+            _require_oid(oid, "retained legacy OID")
+        factory = revision_id_factory or (lambda: secrets.token_hex(20))
+        for _ in range(attempts):
+            candidate = factory()
+            _require_oid(candidate, "native revision id")
+            if candidate in retained_legacy_oids:
+                continue
+            collision = await conn.fetchval(
+                """
+                SELECT EXISTS (
+                           SELECT 1 FROM native_revisions
+                            WHERE revision_id = $1
+                       )
+                    OR EXISTS (
+                           SELECT 1 FROM legacy_revision_mappings
+                            WHERE resource_id = $2
+                              AND legacy_git_oid = $1
+                       )
+                """,
+                candidate,
+                resource_id,
+            )
+            if not collision:
+                return candidate
+        raise NativeRevisionIdCollisionError()
+
+    async def exact_native_revision(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        revision_id: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict | None:
+        sql = """
+            SELECT n.revision_id, n.namespace_id, n.resource_id,
+                   n.path_at_revision
+              FROM native_revisions n
+             WHERE n.namespace_id = $1
+               AND n.resource_id = $2
+               AND n.revision_id = $3
+               AND EXISTS (
+                   SELECT 1
+                     FROM legacy_revision_mappings m
+                     JOIN native_revision_migration_runs r
+                       ON r.run_id = m.run_id
+                      AND r.namespace_id = m.namespace_id
+                    WHERE m.namespace_id = n.namespace_id
+                      AND m.resource_id = n.resource_id
+                      AND m.native_revision_id = n.revision_id
+                      AND m.resolution = 'native'
+                      AND r.status = 'complete'
+               )
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, namespace_id, resource_id, revision_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, namespace_id, resource_id, revision_id)
+        return dict(row) if row is not None else None
+
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> LegacyRevisionMapping | None:
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+             JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.resource_id = $1 AND m.legacy_git_oid = $2
+               AND r.status = 'complete'
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, resource_id, legacy_git_oid)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, resource_id, legacy_git_oid)
+        return _mapping(row) if row is not None else None
+
+    async def prefix_mappings(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_prefix: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[LegacyRevisionMapping]:
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+             JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.resource_id = $1
+               AND m.legacy_git_oid LIKE $2 || '%'
+               AND r.status = 'complete'
+             ORDER BY m.legacy_git_oid
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, resource_id, legacy_git_prefix)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, resource_id, legacy_git_prefix)
+        return [_mapping(row) for row in rows]

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -683,6 +683,33 @@ class NativeRevisionMigrationRepository:
                 rows = await acquired.fetch(sql, namespace_id, resource_id)
         return [_mapping(row) for row in rows]
 
+    async def list_completed_lineage_anchors(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[LegacyRevisionMapping]:
+        """List immutable ordinal-zero anchors with one bulk namespace read."""
+
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.namespace_id = $1
+               AND m.lineage_ordinal = 0
+               AND r.status = 'complete'
+             ORDER BY m.resource_id, m.legacy_git_oid
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, namespace_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, namespace_id)
+        return [_mapping(row) for row in rows]
+
     async def list_resource_mappings_for_reconcile(
         self,
         *,

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -650,6 +650,283 @@ class NativeRevisionMigrationRepository:
             raise MigrationIntegrityError("mapping disappeared during insertion")
         return _mapping(row)
 
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[LegacyRevisionMapping]:
+        """List completed immutable mappings for one Resource.
+
+        Reconcile uses this read to prove that a later fixed-ref inventory is
+        an extension of the already-published lineage.  It intentionally
+        does not expose mappings from an incomplete run as selector authority.
+        """
+
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.namespace_id = $1
+               AND m.resource_id = $2
+               AND r.status = 'complete'
+             ORDER BY m.lineage_ordinal, m.legacy_git_oid
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, namespace_id, resource_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, namespace_id, resource_id)
+        return [_mapping(row) for row in rows]
+
+    async def list_resource_mappings_for_reconcile(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        run_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[LegacyRevisionMapping]:
+        """Read lineage with the explicit completed-item reconcile exception.
+
+        Completed runs are always visible.  The only incomplete-run exception
+        is the explicitly named reconcile run, and even then only after the
+        corresponding migration item has committed as ``complete``.  This is
+        intentionally separate from the public selector read above.
+        """
+
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+              LEFT JOIN native_revision_migration_items current_item
+                ON current_item.run_id = $3
+               AND current_item.namespace_id = m.namespace_id
+               AND current_item.native_resource_id = m.resource_id
+             WHERE m.namespace_id = $1
+               AND m.resource_id = $2
+               AND (
+                   r.status = 'complete'
+                   OR (
+                       m.run_id = $3
+                       AND current_item.status = 'complete'
+                   )
+               )
+             ORDER BY m.lineage_ordinal, m.legacy_git_oid
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, namespace_id, resource_id, run_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, namespace_id, resource_id, run_id)
+        return [_mapping(row) for row in rows]
+
+    async def mapping_for_native_revision(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        native_revision_id: str,
+        conn: asyncpg.Connection | None = None,
+    ) -> LegacyRevisionMapping | None:
+        """Return the completed legacy binding for a native Head revision."""
+
+        _require_oid(native_revision_id, "native_revision_id")
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.namespace_id = $1
+               AND m.resource_id = $2
+               AND m.native_revision_id = $3
+               AND m.resolution = 'native'
+               AND r.status = 'complete'
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, namespace_id, resource_id, native_revision_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, namespace_id, resource_id, native_revision_id)
+        return _mapping(row) if row is not None else None
+
+    async def mapping_for_native_revision_for_reconcile(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        native_revision_id: str,
+        run_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> LegacyRevisionMapping | None:
+        """Read a Head binding under reconcile's completed-item authority."""
+
+        _require_oid(native_revision_id, "native_revision_id")
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+              LEFT JOIN native_revision_migration_items current_item
+                ON current_item.run_id = $3
+               AND current_item.namespace_id = m.namespace_id
+               AND current_item.native_resource_id = m.resource_id
+             WHERE m.namespace_id = $1
+               AND m.resource_id = $2
+               AND m.native_revision_id = $4
+               AND m.resolution = 'native'
+               AND (
+                   r.status = 'complete'
+                   OR (
+                       m.run_id = $3
+                       AND current_item.status = 'complete'
+                   )
+               )
+        """
+        if conn is not None:
+            row = await conn.fetchrow(
+                sql,
+                namespace_id,
+                resource_id,
+                run_id,
+                native_revision_id,
+            )
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(
+                    sql,
+                    namespace_id,
+                    resource_id,
+                    run_id,
+                    native_revision_id,
+                )
+        return _mapping(row) if row is not None else None
+
+    async def migrated_resource_ids(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> set[uuid.UUID]:
+        """Return Resources with at least one completed bridge mapping."""
+
+        sql = """
+            SELECT DISTINCT m.resource_id
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.namespace_id = $1 AND r.status = 'complete'
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, namespace_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, namespace_id)
+        return {row["resource_id"] for row in rows}
+
+    @staticmethod
+    async def ensure_cross_run_mapping(
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+        path_at_revision: str,
+        resolution: str,
+        native_revision_id: str | None,
+        run_id: uuid.UUID,
+        lineage_ordinal: int,
+    ) -> LegacyRevisionMapping:
+        """Insert a new suffix mapping without re-homing an old mapping.
+
+        A legacy OID is globally immutable for a Resource.  If another
+        completed run already owns the exact facts, the existing row is
+        returned as-is; its original ``run_id`` and ordinal are never changed.
+        A non-complete row from another run is rejected because it is not
+        selector authority.
+        """
+
+        _require_oid(legacy_git_oid, "legacy_git_oid")
+        if resolution not in {"native", "bridge"}:
+            raise ValueError("resolution must be native or bridge")
+        if resolution == "native" and native_revision_id is None:
+            raise ValueError("native mappings require native_revision_id")
+        if resolution == "bridge" and native_revision_id is not None:
+            raise ValueError("bridge mappings cannot carry native_revision_id")
+        if native_revision_id is not None:
+            _require_oid(native_revision_id, "native_revision_id")
+        if not isinstance(path_at_revision, str) or not path_at_revision.strip():
+            raise ValueError("mapping path must be non-empty")
+        if lineage_ordinal < 0:
+            raise ValueError("lineage ordinal must be non-negative")
+
+        select_sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid, r.status
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.resource_id = $1 AND m.legacy_git_oid = $2
+             FOR UPDATE
+        """
+        row = await conn.fetchrow(select_sql, resource_id, legacy_git_oid)
+        if row is None:
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, native_revision_id, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                ON CONFLICT (resource_id, legacy_git_oid) DO NOTHING
+                """,
+                namespace_id,
+                resource_id,
+                legacy_git_oid,
+                path_at_revision,
+                resolution,
+                native_revision_id,
+                run_id,
+                lineage_ordinal,
+            )
+            row = await conn.fetchrow(select_sql, resource_id, legacy_git_oid)
+        if row is None:
+            raise MigrationIntegrityError("cross-run mapping disappeared during insertion")
+        if row["status"] != "complete" and row["run_id"] != run_id:
+            raise MigrationIntegrityError("cross-run mapping belongs to an incomplete run")
+
+        observed = (
+            row["namespace_id"],
+            row["resource_id"],
+            row["legacy_git_oid"],
+            row["path_at_revision"],
+            row["resolution"],
+            row["native_revision_id"],
+        )
+        expected = (
+            namespace_id,
+            resource_id,
+            legacy_git_oid,
+            path_at_revision,
+            resolution,
+            native_revision_id,
+        )
+        if observed != expected:
+            raise MigrationIntegrityError("cross-run mapping conflicts with immutable lineage")
+
+        return _mapping(row)
+
     async def allocate_native_revision_id(
         self,
         conn: asyncpg.Connection,
@@ -744,6 +1021,59 @@ class NativeRevisionMigrationRepository:
         else:
             async with self.pool.acquire() as acquired:
                 row = await acquired.fetchrow(sql, resource_id, legacy_git_oid)
+        return _mapping(row) if row is not None else None
+
+    async def exact_mapping_for_reconcile(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+        run_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> LegacyRevisionMapping | None:
+        """Read an exact mapping with the explicit reconcile-run exception."""
+
+        _require_oid(legacy_git_oid, "legacy_git_oid")
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+              LEFT JOIN native_revision_migration_items current_item
+                ON current_item.run_id = $3
+               AND current_item.namespace_id = m.namespace_id
+               AND current_item.native_resource_id = m.resource_id
+             WHERE m.namespace_id = $1
+               AND m.resource_id = $2
+               AND m.legacy_git_oid = $4
+               AND (
+                   r.status = 'complete'
+                   OR (
+                       m.run_id = $3
+                       AND current_item.status = 'complete'
+                   )
+               )
+        """
+        if conn is not None:
+            row = await conn.fetchrow(
+                sql,
+                namespace_id,
+                resource_id,
+                run_id,
+                legacy_git_oid,
+            )
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(
+                    sql,
+                    namespace_id,
+                    resource_id,
+                    run_id,
+                    legacy_git_oid,
+                )
         return _mapping(row) if row is not None else None
 
     async def prefix_mappings(

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -767,6 +767,43 @@ class NativeRevisionRepository:
             )
         return [dict(row) for row in rows]
 
+    async def get_activity_for_revision(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        resource_id: uuid.UUID,
+        revision_id: str,
+    ) -> dict | None:
+        """Read one persisted activity fact through its exact Resource selector."""
+
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT a.resource_id, a.revision_id, a.action, a.actor,
+                       a.subject, a.summary, a.changed_path_from,
+                       a.changed_path_to, a.occurred_at,
+                       r.path_at_revision
+                  FROM native_revision_activity a
+                  JOIN native_revisions r
+                    ON r.namespace_id = a.namespace_id
+                   AND r.resource_id = a.resource_id
+                   AND r.revision_id = a.revision_id
+                  JOIN native_resources rs
+                    ON rs.namespace_id = a.namespace_id
+                   AND rs.resource_id = a.resource_id
+                 WHERE a.namespace_id = $1
+                   AND rs.surface = $2
+                   AND a.resource_id = $3
+                   AND a.revision_id = $4
+                """,
+                namespace_id,
+                surface,
+                resource_id,
+                revision_id,
+            )
+        return dict(row) if row is not None else None
+
     async def list_recent_document_heads(
         self,
         *,

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -18,6 +18,14 @@ class NativeRevisionIdCollisionError(ConflictError):
         super().__init__("Server-generated native Revision ID collision; retry the mutation")
 
 
+class NativeResourceReferenceAmbiguousError(ConflictError):
+    """A reference names more than one live native Resource."""
+
+    def __init__(self, reference: str):
+        super().__init__(f"Native Resource reference is ambiguous: {reference}")
+        self.code = "native_resource_reference_ambiguous"
+
+
 class PreparedPayload(Protocol):
     @property
     def payload_id(self) -> uuid.UUID: ...
@@ -138,7 +146,7 @@ class NativeRevisionRepository:
         reference: str,
         conn: asyncpg.Connection | None = None,
     ) -> dict | None:
-        """Resolve a live Resource identifier first, else a current path, else an alias.
+        """Resolve exactly one live Resource by id, path, or live alias.
 
         Mirrors ``document_repo.DocumentRepository._MATCH_WHERE``, which
         accepts either the public id or the path in a single ``OR``
@@ -161,10 +169,16 @@ class NativeRevisionRepository:
         legacy's single ``id OR path`` predicate exactly: try id, and if
         that does not name a live Resource, try path/alias.
 
-        Exact current ownership always wins over the alias fallback. The
-        alias points directly to a Resource (never another path), so a
-        chain cannot form after repeated moves and a deleted Resource
-        cannot be resurrected by an old alias.
+        A UUID-shaped reference is checked against both identity forms. The
+        normal path resolution gives an exact current path precedence over
+        an old alias. If that resolved path/alias owner differs from the
+        exact id owner, the reference is ambiguous and raises a conflict
+        rather than silently preferring the id. A genuine miss still
+        returns ``None``.
+
+        Both lookups run on one connection. This preserves the UUID-shaped
+        path fall-through required for native Files: a bare UUID can be a
+        legitimate logical path when it is not also an identity collision.
         """
         resource_id: uuid.UUID | None
         try:
@@ -172,29 +186,17 @@ class NativeRevisionRepository:
         except (AttributeError, TypeError, ValueError):
             resource_id = None
 
-        if resource_id is not None:
-            id_sql = """
-                SELECT rs.resource_id, rs.namespace_id, rs.surface,
-                       rs.content_profile, rs.current_path, rs.lifecycle,
-                       rs.head_revision_id, rs.created_at, rs.updated_at
-                  FROM native_resources rs
-                 WHERE rs.namespace_id = $1
-                   AND rs.surface = $2
-                   AND rs.resource_id = $3
-                   AND rs.lifecycle = 'live'
-            """
-            if conn is not None:
-                row = await conn.fetchrow(id_sql, namespace_id, surface, resource_id)
-            else:
-                async with self.pool.acquire() as acquired:
-                    row = await acquired.fetchrow(id_sql, namespace_id, surface, resource_id)
-            if row is not None:
-                return dict(row)
-            # Fall through to path/alias resolution — do NOT return None
-            # here. A UUID-shaped reference that does not name a live
-            # Resource by id may still name one by path (see docstring).
-
-        sql = """
+        id_sql = """
+            SELECT rs.resource_id, rs.namespace_id, rs.surface,
+                   rs.content_profile, rs.current_path, rs.lifecycle,
+                   rs.head_revision_id, rs.created_at, rs.updated_at
+              FROM native_resources rs
+             WHERE rs.namespace_id = $1
+               AND rs.surface = $2
+               AND rs.resource_id = $3
+               AND rs.lifecycle = 'live'
+        """
+        path_sql = """
             SELECT rs.resource_id, rs.namespace_id, rs.surface,
                    rs.content_profile, rs.current_path, rs.lifecycle,
                    rs.head_revision_id, rs.created_at, rs.updated_at
@@ -220,12 +222,29 @@ class NativeRevisionRepository:
              ORDER BY (rs.current_path = $3) DESC
              LIMIT 1
         """
+
+        async def _resolve(acquired: asyncpg.Connection) -> dict | None:
+            identity_candidate: dict | None = None
+            if resource_id is not None:
+                row = await acquired.fetchrow(id_sql, namespace_id, surface, resource_id)
+                if row is not None:
+                    identity_candidate = dict(row)
+
+            path_row = await acquired.fetchrow(path_sql, namespace_id, surface, reference)
+            path_candidate = dict(path_row) if path_row is not None else None
+
+            if (
+                identity_candidate is not None
+                and path_candidate is not None
+                and identity_candidate["resource_id"] != path_candidate["resource_id"]
+            ):
+                raise NativeResourceReferenceAmbiguousError(reference)
+            return identity_candidate or path_candidate
+
         if conn is not None:
-            row = await conn.fetchrow(sql, namespace_id, surface, reference)
-        else:
-            async with self.pool.acquire() as acquired:
-                row = await acquired.fetchrow(sql, namespace_id, surface, reference)
-        return dict(row) if row is not None else None
+            return await _resolve(conn)
+        async with self.pool.acquire() as acquired:
+            return await _resolve(acquired)
 
     @staticmethod
     async def lock_resource(

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import stat
 import threading
@@ -36,7 +37,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from git import Blob, Repo
-from git.exc import GitError
+from git.exc import BadName, BadObject, GitError
 
 from app.config import settings
 from app.exceptions import AKBError, MirrorMarkerError
@@ -169,6 +170,10 @@ class ExternalGitOversizedError(AKBError):
             status_code=413,
             code="external_git_blob_oversized",
         )
+
+
+class FixedRefHistoryError(RuntimeError):
+    """A manual-vault fixed-ref history read could not be completed."""
 
 
 class GitService:
@@ -1010,6 +1015,182 @@ class GitService:
         except (KeyError, TypeError):
             return None
 
+    def manual_fixed_ref_history(
+        self,
+        vault_name: str,
+        fixed_ref: str,
+        file_path: str,
+        *,
+        current_commit: str,
+        since_epoch: int | None = None,
+    ) -> dict:
+        """Read one manual-vault document and its rename-following history.
+
+        The caller supplies an exact, full commit OID for both the frozen tip
+        and the document's recorded current commit.  This primitive never
+        follows ``HEAD`` and deliberately refuses a mirror marker, so bridge
+        code cannot accidentally use the external-git reader for a fixed-ref
+        capture.  The returned body is the exact UTF-8 byte sequence at
+        ``(current_commit, file_path)``; history entries use full commit OIDs
+        and the path that commit carried after ``--follow`` rename tracking.
+        """
+        full_oid = re.compile(r"^[0-9a-f]{40}$")
+        if not full_oid.fullmatch(fixed_ref):
+            raise FixedRefHistoryError("fixed_ref must be a full lowercase 40-hex commit OID")
+        if not full_oid.fullmatch(current_commit):
+            raise FixedRefHistoryError(
+                "current_commit must be a full lowercase 40-hex commit OID"
+            )
+        if self._is_mirror(vault_name):
+            raise FixedRefHistoryError("fixed-ref history is limited to manual vaults")
+
+        try:
+            repo = self._get_repo(vault_name)
+            repo.commit(fixed_ref)
+            current = repo.commit(current_commit)
+            repo.git.merge_base("--is-ancestor", current_commit, fixed_ref)
+            blob = current.tree / file_path
+            body = blob.data_stream.read()
+        except (
+            BadName,
+            BadObject,
+            FileNotFoundError,
+            GitError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise FixedRefHistoryError(
+                "fixed-ref history could not resolve the requested commit or body"
+            ) from exc
+
+        try:
+            body.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise FixedRefHistoryError("fixed-ref body is not valid UTF-8") from exc
+
+        log_args = [
+            "--follow",
+            "-M",
+            "--name-status",
+        ]
+        if since_epoch is not None:
+            log_args.append(f"--since=@{since_epoch}")
+        log_args.extend(["--format=%H%x00%ct", fixed_ref, "--", file_path])
+        try:
+            output = repo.git.log(*log_args)
+        except (GitError, ValueError) as exc:
+            raise FixedRefHistoryError("fixed-ref history could not be read") from exc
+
+        activity = self._manual_fixed_ref_activity(repo, current, file_path)
+
+        history: list[dict] = []
+        active: dict | None = None
+
+        def flush() -> None:
+            if active is not None and active.get("path_at_revision"):
+                history.append(active.copy())
+
+        for line in str(output).splitlines():
+            if "\x00" in line:
+                flush()
+                oid, epoch, *_ = line.split("\x00")
+                active = {
+                    "legacy_git_oid": oid,
+                    "committed_at": datetime.fromtimestamp(
+                        int(epoch), tz=timezone.utc
+                    ),
+                }
+                continue
+            if active is None or not line:
+                continue
+            fields = line.split("\t")
+            status = fields[0]
+            if status.startswith("R") and len(fields) >= 3:
+                active["path_at_revision"] = fields[-1]
+            elif len(fields) >= 2:
+                active["path_at_revision"] = fields[-1]
+        flush()
+
+        return {
+            "fixed_ref": fixed_ref,
+            "current_commit": current_commit,
+            "body": body,
+            "history": history,
+            "activity": activity,
+        }
+
+    def _manual_fixed_ref_activity(self, repo: Repo, commit, file_path: str) -> dict:
+        """Freeze the legacy public activity projection for one file commit."""
+        metadata = self._legacy_commit_metadata(commit)
+        action = metadata["action"]
+        if action not in {"create", "update", "move", "delete"}:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit has no supported public activity action"
+            )
+        if not metadata["subject"] or not metadata["agent"]:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit has incomplete activity identity"
+            )
+
+        try:
+            output = repo.git.diff_tree(
+                "--root", "-r", "--name-status", "-M", commit.hexsha,
+            )
+        except (GitError, ValueError) as exc:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit activity could not be read"
+            ) from exc
+
+        changes: list[dict[str, str | None]] = []
+        for line in str(output).splitlines():
+            fields = line.split("\t")
+            if not fields:
+                continue
+            status = fields[0]
+            if status.startswith(("R", "C")) and len(fields) >= 3:
+                path_from, path_to = fields[-2], fields[-1]
+                if path_to == file_path:
+                    changes.append(
+                        {
+                            "change": "move",
+                            "path_from": path_from,
+                            "path_to": path_to,
+                        }
+                    )
+            elif len(fields) >= 2 and fields[-1] == file_path:
+                change_kind = {
+                    "A": "create",
+                    "M": "update",
+                    "D": "delete",
+                }.get(status[:1])
+                if change_kind is not None:
+                    changes.append(
+                        {
+                            "change": change_kind,
+                            "path_from": None,
+                            "path_to": file_path,
+                        }
+                    )
+        if len(changes) != 1 or changes[0]["change"] != action:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit activity does not match the file action"
+            )
+        selected_change = changes[0]
+        return {
+            "legacy_git_oid": commit.hexsha,
+            "committed_at": datetime.fromtimestamp(
+                commit.committed_date, tz=timezone.utc
+            ),
+            "actor": metadata["agent"],
+            "subject": metadata["subject"],
+            "summary": metadata["summary"],
+            "action": action,
+            "path_from": selected_change["path_from"],
+            "path_to": selected_change["path_to"],
+            "changed_paths": changes,
+        }
+
     # ── Mirror read variants (hermetic runner) ───────────
     def _read_file_mirror(
         self, vault_name: str, file_path: str, commit: str | None
@@ -1569,6 +1750,21 @@ class GitService:
             for c in commits
         ]
 
+    @staticmethod
+    def _legacy_commit_metadata(commit) -> dict[str, str]:
+        """Parse the commit-message metadata used by the legacy activity feed."""
+        message = str(commit.message)
+        lines = message.strip().split("\n")
+        metadata: dict[str, str] = {"subject": lines[0] if lines else ""}
+        for body_line in (line.strip() for line in lines[1:] if line.strip()):
+            if ":" in body_line:
+                key, value = body_line.split(":", 1)
+                metadata[key.strip().lower()] = value.strip()
+        metadata.setdefault("action", "")
+        metadata.setdefault("summary", "")
+        metadata.setdefault("agent", str(commit.author))
+        return metadata
+
     def vault_log(self, vault_name: str, max_count: int = 30, since: str | None = None, path: str | None = None) -> list[dict]:
         """Get commit log for the vault, optionally scoped to a path.
 
@@ -1601,16 +1797,7 @@ class GitService:
             # `str | bytes` per the stub; in practice gitpython always
             # decodes to str via its `default_encoding`. `str(...)` is
             # a cheap normalisation that also satisfies mypy.
-            message = str(c.message)
-            lines = message.strip().split("\n")
-            subject = lines[0] if lines else ""
-            body_lines = [line.strip() for line in lines[1:] if line.strip()]
-
-            meta = {}
-            for bl in body_lines:
-                if ":" in bl:
-                    k, v = bl.split(":", 1)
-                    meta[k.strip().lower()] = v.strip()
+            meta = self._legacy_commit_metadata(c)
 
             # Get changed files
             changed_files: list[dict] = []
@@ -1644,7 +1831,7 @@ class GitService:
 
             results.append({
                 "hash": c.hexsha[:12],
-                "subject": subject,
+                "subject": meta["subject"],
                 "author": str(c.author),
                 "date": datetime.fromtimestamp(c.committed_date, tz=timezone.utc).isoformat(),
                 "action": meta.get("action", ""),

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import re
 import uuid
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -64,6 +64,10 @@ class SelectorAmbiguousError(ConflictError):
     def __init__(self, selector: str):
         super().__init__(f"legacy revision selector is ambiguous: {selector}")
         self.code = "legacy_revision_selector_ambiguous"
+
+
+class LogicalLineageProjectionError(ValueError):
+    """Raw fixed-ref history cannot form one logical Document lineage."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -154,6 +158,77 @@ def _require_oid(value: str, field: str) -> None:
 
 def _iso(value: datetime) -> str:
     return value.astimezone(UTC).isoformat()
+
+
+def project_logical_lineage(
+    history: Iterable[Mapping[str, object]],
+    *,
+    current_commit: str,
+    current_path: str,
+    created_at: datetime,
+    oldest_anchor_oid: str | None = None,
+) -> tuple[LegacyLineageEntry, ...]:
+    """Project newest-first Git rows onto one oldest-first Document lineage."""
+
+    if created_at.tzinfo is None or created_at.utcoffset() is None:
+        raise LogicalLineageProjectionError("created_at must be timezone-aware")
+    if oldest_anchor_oid is not None and _OID_RE.fullmatch(oldest_anchor_oid) is None:
+        raise LogicalLineageProjectionError("oldest anchor must be a full Git OID")
+    created_at_utc = created_at.astimezone(UTC)
+    newest: list[LegacyLineageEntry] = []
+    seen: set[str] = set()
+    anchor_found = False
+    for entry in history:
+        if not isinstance(entry, Mapping):
+            raise LogicalLineageProjectionError("history entry must be a mapping")
+        oid = entry.get("legacy_git_oid")
+        if not isinstance(oid, str) or _OID_RE.fullmatch(oid) is None:
+            raise LogicalLineageProjectionError("history contains an invalid OID")
+        if anchor_found:
+            if oid == oldest_anchor_oid:
+                raise LogicalLineageProjectionError(
+                    "history contains a duplicate oldest anchor"
+                )
+            continue
+        committed_at = entry.get("committed_at")
+        if (
+            not isinstance(committed_at, datetime)
+            or committed_at.tzinfo is None
+            or committed_at.utcoffset() is None
+        ):
+            raise LogicalLineageProjectionError(
+                "history contains an invalid commit timestamp"
+            )
+        path = current_path if oid == current_commit else entry.get("path_at_revision")
+        if not isinstance(path, str) or not path.strip():
+            raise LogicalLineageProjectionError("history contains an invalid path")
+        if oid in seen:
+            if oid == oldest_anchor_oid:
+                raise LogicalLineageProjectionError(
+                    "history contains a duplicate oldest anchor"
+                )
+            continue
+        seen.add(oid)
+        if (
+            oldest_anchor_oid is None
+            and oid != current_commit
+            and committed_at.astimezone(UTC) < created_at_utc
+        ):
+            continue
+        newest.append(
+            LegacyLineageEntry(
+                legacy_git_oid=oid,
+                path_at_revision=path,
+                committed_at=committed_at,
+            )
+        )
+        if oid == oldest_anchor_oid:
+            anchor_found = True
+    if oldest_anchor_oid is not None and not anchor_found:
+        raise LogicalLineageProjectionError(
+            "completed oldest anchor is absent from fixed-ref history"
+        )
+    return tuple(reversed(newest))
 
 
 class LegacyRevisionBridge:
@@ -313,6 +388,20 @@ class LegacyRevisionBridge:
                 # vault-level external-Git marker above remains a hard reject.
                 rows = [row for row in rows if row.get("source") == "manual"]
 
+                completed_anchor_rows = (
+                    await self.repository.list_completed_lineage_anchors(
+                        namespace_id=namespace_id,
+                        conn=conn,
+                    )
+                )
+                completed_anchors: dict[uuid.UUID, str] = {}
+                for anchor in completed_anchor_rows:
+                    if anchor.resource_id in completed_anchors:
+                        raise InventoryEligibilityError(
+                            "completed lineage has duplicate ordinal-zero anchors"
+                        )
+                    completed_anchors[anchor.resource_id] = anchor.legacy_git_oid
+
                 documents: list[LegacyInventoryDocument] = []
                 for row in rows:
                     aliases: list[LegacyInventoryAlias] = []
@@ -409,35 +498,23 @@ class LegacyRevisionBridge:
                             MappingProxyType(dict(change)) for change in changed_paths
                         ),
                     )
-                    newest: list[LegacyLineageEntry] = []
-                    seen: set[str] = set()
-                    for entry in history:
-                        oid = entry["legacy_git_oid"]
-                        if not isinstance(oid, str) or _OID_RE.fullmatch(oid) is None:
-                            raise InventoryEligibilityError(
-                                f"document {row['id']} history contains an invalid OID"
-                            )
-                        if oid in seen:
-                            continue
-                        committed_at = entry["committed_at"]
-                        if oid != current_commit and committed_at < created_at:
-                            continue
-                        seen.add(oid)
-                        newest.append(
-                            LegacyLineageEntry(
-                                legacy_git_oid=oid,
-                                path_at_revision=(
-                                    row["path"] if oid == current_commit
-                                    else entry["path_at_revision"]
-                                ),
-                                committed_at=committed_at,
-                            )
+                    try:
+                        lineage = project_logical_lineage(
+                            history,
+                            current_commit=current_commit,
+                            current_path=row["path"],
+                            created_at=created_at,
+                            oldest_anchor_oid=completed_anchors.get(row["id"]),
                         )
+                    except LogicalLineageProjectionError as exc:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} history is invalid"
+                        ) from exc
+                    seen = {entry.legacy_git_oid for entry in lineage}
                     if current_commit not in seen:
                         raise InventoryEligibilityError(
                             f"document {row['id']} current_commit is absent from fixed-ref history"
                         )
-                    lineage = tuple(reversed(newest))
                     if not lineage or lineage[-1].legacy_git_oid != current_commit:
                         raise InventoryEligibilityError(
                             f"document {row['id']} lineage does not end at current_commit"

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -7,6 +7,8 @@ import hashlib
 import json
 import re
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Literal
@@ -95,7 +97,6 @@ class LegacyInventoryDocument:
     current_path: str
     current_commit: str
     created_at: datetime
-    body: bytes
     body_digest: str
     byte_size: int
     aliases: tuple[LegacyInventoryAlias, ...]
@@ -400,7 +401,6 @@ class LegacyRevisionBridge:
                             current_path=row["path"],
                             current_commit=current_commit,
                             created_at=created_at,
-                            body=body,
                             body_digest=hashlib.sha256(body).hexdigest(),
                             byte_size=len(body),
                             aliases=tuple(aliases),
@@ -422,6 +422,75 @@ class LegacyRevisionBridge:
                 documents=frozen_documents,
             ),
         )
+
+    @asynccontextmanager
+    async def materialize_body(
+        self,
+        inventory: LegacyInventory,
+        document: LegacyInventoryDocument,
+    ) -> AsyncIterator[bytes]:
+        """Read and verify one frozen body without retaining it in inventory."""
+
+        if document not in inventory.documents:
+            raise InventoryEligibilityError(
+                "body materialization requires a document from the frozen inventory"
+            )
+        if (
+            self.canonical_inventory_digest(
+                namespace_id=inventory.namespace_id,
+                fixed_git_oid=inventory.fixed_git_oid,
+                coverage_version=inventory.coverage_version,
+                documents=inventory.documents,
+            )
+            != inventory.inventory_digest
+        ):
+            raise InventoryEligibilityError("body materialization inventory digest is invalid")
+
+        vault = await self.repository.get_manual_vault(inventory.namespace_id)
+        if vault is None:
+            raise NotFoundError("Vault", str(inventory.namespace_id))
+        if vault["has_external_git"]:
+            raise ManualVaultRequiredError()
+        try:
+            snapshot = await asyncio.to_thread(
+                self.git.manual_fixed_ref_history,
+                vault["name"],
+                inventory.fixed_git_oid,
+                document.current_path,
+                current_commit=document.current_commit,
+                since_epoch=int(document.created_at.timestamp()),
+            )
+        except FixedRefHistoryError as exc:
+            raise InventoryEligibilityError(
+                f"document {document.resource_id} is not readable at the fixed ref"
+            ) from exc
+
+        body = snapshot.get("body") if isinstance(snapshot, dict) else None
+        if (
+            not isinstance(body, bytes)
+            or snapshot.get("fixed_ref") != inventory.fixed_git_oid
+            or snapshot.get("current_commit") != document.current_commit
+            or len(body) != document.byte_size
+            or hashlib.sha256(body).hexdigest() != document.body_digest
+        ):
+            raise InventoryEligibilityError(
+                f"document {document.resource_id} body differs from the frozen inventory"
+            )
+        if b"\x00" in body:
+            raise InventoryEligibilityError(
+                f"document {document.resource_id} body contains NUL bytes"
+            )
+        try:
+            body.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise InventoryEligibilityError(
+                f"document {document.resource_id} body is not valid UTF-8"
+            ) from exc
+        try:
+            yield body
+        finally:
+            del body
+            del snapshot
 
     async def prepare_run(
         self,

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -7,10 +7,11 @@ import hashlib
 import json
 import re
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from types import MappingProxyType
 from typing import Literal
 
 import asyncpg
@@ -82,7 +83,7 @@ class LegacyActivitySemantics:
     action: Literal["create", "update", "move", "delete"]
     path_from: str | None
     path_to: str | None
-    changed_paths: tuple[dict[str, str | None], ...]
+    changed_paths: tuple[Mapping[str, str | None], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +121,16 @@ class LegacyInventory:
     coverage_version: str
     documents: tuple[LegacyInventoryDocument, ...]
     inventory_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyInventoryScope:
+    """Once-validated immutable facts for one inventory materialization pass."""
+
+    inventory: LegacyInventory
+    vault_name: str
+    fixed_git_oid: str
+    documents_by_id: Mapping[uuid.UUID, LegacyInventoryDocument]
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,7 +218,9 @@ class LegacyRevisionBridge:
                         "action": document.activity.action,
                         "path_from": document.activity.path_from,
                         "path_to": document.activity.path_to,
-                        "changed_paths": list(document.activity.changed_paths),
+                        "changed_paths": [
+                            dict(change) for change in document.activity.changed_paths
+                        ],
                     },
                 }
                 for document in documents
@@ -221,13 +234,65 @@ class LegacyRevisionBridge:
         ).encode("utf-8")
         return hashlib.sha256(canonical).hexdigest()
 
-    async def capture_inventory(
+    async def _capture_source_metadata(
+        self,
+        *,
+        vault_name: str,
+        fixed_ref: str,
+        resource_id: uuid.UUID,
+        current_path: str,
+        current_commit: str,
+        created_at: datetime,
+    ) -> tuple[list[dict], dict, str, int]:
+        """Read one source body and return only frozen metadata about it."""
+
+        try:
+            snapshot = await asyncio.to_thread(
+                self.git.manual_fixed_ref_history,
+                vault_name,
+                fixed_ref,
+                current_path,
+                current_commit=current_commit,
+                since_epoch=int(created_at.timestamp()),
+            )
+        except FixedRefHistoryError as exc:
+            raise InventoryEligibilityError(
+                f"document {resource_id} is not readable at the fixed ref"
+            ) from exc
+        if not isinstance(snapshot, dict):
+            raise InventoryEligibilityError(
+                f"document {resource_id} returned invalid fixed-ref metadata"
+            )
+        history = snapshot.get("history")
+        activity = snapshot.get("activity")
+        body = snapshot.get("body")
+        if not isinstance(history, list) or not isinstance(activity, dict):
+            raise InventoryEligibilityError(
+                f"document {resource_id} returned invalid fixed-ref metadata"
+            )
+        if not isinstance(body, bytes):
+            raise InventoryEligibilityError(
+                f"document {resource_id} is not readable at the fixed ref"
+            )
+        if b"\x00" in body:
+            raise InventoryEligibilityError(
+                f"document {resource_id} body contains NUL bytes"
+            )
+        try:
+            body.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise InventoryEligibilityError(
+                f"document {resource_id} body is not valid UTF-8"
+            ) from exc
+        return history, activity, hashlib.sha256(body).hexdigest(), len(body)
+
+    async def capture_inventory_scope(
         self,
         *,
         namespace_id: uuid.UUID,
         fixed_ref: str,
         coverage_version: str,
-    ) -> LegacyInventory:
+    ) -> LegacyInventoryScope:
         _require_oid(fixed_ref, "fixed_ref")
         if not isinstance(coverage_version, str) or not coverage_version.strip():
             raise InventoryEligibilityError("coverage_version must be non-empty")
@@ -280,28 +345,19 @@ class LegacyRevisionBridge:
                         raise InventoryEligibilityError(
                             f"document {row['id']} has no usable created_at"
                         )
-                    try:
-                        snapshot = await asyncio.to_thread(
-                            self.git.manual_fixed_ref_history,
-                            vault["name"],
-                            fixed_ref,
-                            row["path"],
+                    history, raw_activity, body_digest, byte_size = (
+                        await self._capture_source_metadata(
+                            vault_name=vault["name"],
+                            fixed_ref=fixed_ref,
+                            resource_id=row["id"],
+                            current_path=row["path"],
                             current_commit=current_commit,
-                            since_epoch=int(created_at.timestamp()),
+                            created_at=created_at,
                         )
-                    except FixedRefHistoryError as exc:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} is not readable at the fixed ref"
-                        ) from exc
-                    history = snapshot["history"]
+                    )
                     if not history or history[0]["legacy_git_oid"] != current_commit:
                         raise InventoryEligibilityError(
                             f"document {row['id']} current_commit is not the fixed-ref file head"
-                        )
-                    raw_activity = snapshot.get("activity")
-                    if not isinstance(raw_activity, dict):
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} has no fixed-ref activity semantics"
                         )
                     activity_action = raw_activity.get("action")
                     if activity_action not in {"create", "update", "move", "delete"}:
@@ -327,6 +383,7 @@ class LegacyRevisionBridge:
                         or not isinstance(activity_summary, str)
                         or not isinstance(path_to, str)
                         or not isinstance(changed_paths, list)
+                        or not all(isinstance(change, dict) for change in changed_paths)
                     ):
                         raise InventoryEligibilityError(
                             f"document {row['id']} has incomplete current activity semantics"
@@ -348,20 +405,10 @@ class LegacyRevisionBridge:
                         action=activity_action,
                         path_from=path_from,
                         path_to=path_to,
-                        changed_paths=tuple(changed_paths),
+                        changed_paths=tuple(
+                            MappingProxyType(dict(change)) for change in changed_paths
+                        ),
                     )
-                    body = snapshot["body"]
-                    if b"\x00" in body:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} body contains NUL bytes"
-                        )
-                    try:
-                        body.decode("utf-8", errors="strict")
-                    except UnicodeDecodeError as exc:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} body is not valid UTF-8"
-                        ) from exc
-
                     newest: list[LegacyLineageEntry] = []
                     seen: set[str] = set()
                     for entry in history:
@@ -401,8 +448,8 @@ class LegacyRevisionBridge:
                             current_path=row["path"],
                             current_commit=current_commit,
                             created_at=created_at,
-                            body_digest=hashlib.sha256(body).hexdigest(),
-                            byte_size=len(body),
+                            body_digest=body_digest,
+                            byte_size=byte_size,
                             aliases=tuple(aliases),
                             lineage=lineage,
                             activity=activity,
@@ -410,7 +457,7 @@ class LegacyRevisionBridge:
                     )
 
         frozen_documents = tuple(documents)
-        return LegacyInventory(
+        inventory = LegacyInventory(
             namespace_id=namespace_id,
             fixed_git_oid=fixed_ref,
             coverage_version=coverage_version,
@@ -422,19 +469,48 @@ class LegacyRevisionBridge:
                 documents=frozen_documents,
             ),
         )
+        return self._scope_from_validated_inventory(inventory, vault_name=vault["name"])
 
-    @asynccontextmanager
-    async def materialize_body(
+    async def capture_inventory(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_ref: str,
+        coverage_version: str,
+    ) -> LegacyInventory:
+        scope = await self.capture_inventory_scope(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version=coverage_version,
+        )
+        return scope.inventory
+
+    @staticmethod
+    def _scope_from_validated_inventory(
+        inventory: LegacyInventory,
+        *,
+        vault_name: str,
+    ) -> LegacyInventoryScope:
+        documents_by_id: dict[uuid.UUID, LegacyInventoryDocument] = {}
+        for document in inventory.documents:
+            if document.resource_id in documents_by_id:
+                raise InventoryEligibilityError(
+                    "frozen inventory contains duplicate document resources"
+                )
+            documents_by_id[document.resource_id] = document
+        return LegacyInventoryScope(
+            inventory=inventory,
+            vault_name=vault_name,
+            fixed_git_oid=inventory.fixed_git_oid,
+            documents_by_id=MappingProxyType(documents_by_id),
+        )
+
+    async def validated_inventory_scope(
         self,
         inventory: LegacyInventory,
-        document: LegacyInventoryDocument,
-    ) -> AsyncIterator[bytes]:
-        """Read and verify one frozen body without retaining it in inventory."""
+    ) -> LegacyInventoryScope:
+        """Validate externally held inventory facts once before body reads."""
 
-        if document not in inventory.documents:
-            raise InventoryEligibilityError(
-                "body materialization requires a document from the frozen inventory"
-            )
         if (
             self.canonical_inventory_digest(
                 namespace_id=inventory.namespace_id,
@@ -445,32 +521,47 @@ class LegacyRevisionBridge:
             != inventory.inventory_digest
         ):
             raise InventoryEligibilityError("body materialization inventory digest is invalid")
-
         vault = await self.repository.get_manual_vault(inventory.namespace_id)
         if vault is None:
             raise NotFoundError("Vault", str(inventory.namespace_id))
         if vault["has_external_git"]:
             raise ManualVaultRequiredError()
-        try:
-            snapshot = await asyncio.to_thread(
-                self.git.manual_fixed_ref_history,
-                vault["name"],
-                inventory.fixed_git_oid,
-                document.current_path,
-                current_commit=document.current_commit,
-                since_epoch=int(document.created_at.timestamp()),
+        return self._scope_from_validated_inventory(inventory, vault_name=vault["name"])
+
+    @asynccontextmanager
+    async def materialize_body(
+        self,
+        scope: LegacyInventoryScope,
+        document: LegacyInventoryDocument,
+    ) -> AsyncIterator[bytes]:
+        """Perform one body-only read inside a once-validated inventory scope."""
+
+        if (
+            scope.fixed_git_oid != scope.inventory.fixed_git_oid
+            or scope.documents_by_id.get(document.resource_id) is not document
+        ):
+            raise InventoryEligibilityError(
+                "body materialization requires a document from the frozen inventory"
             )
-        except FixedRefHistoryError as exc:
+        try:
+            text = await asyncio.to_thread(
+                self.git.read_file,
+                scope.vault_name,
+                document.current_path,
+                document.current_commit,
+            )
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
             raise InventoryEligibilityError(
                 f"document {document.resource_id} is not readable at the fixed ref"
             ) from exc
-
-        body = snapshot.get("body") if isinstance(snapshot, dict) else None
+        if not isinstance(text, str):
+            raise InventoryEligibilityError(
+                f"document {document.resource_id} is not readable at the fixed ref"
+            )
+        body = text.encode("utf-8")
+        del text
         if (
-            not isinstance(body, bytes)
-            or snapshot.get("fixed_ref") != inventory.fixed_git_oid
-            or snapshot.get("current_commit") != document.current_commit
-            or len(body) != document.byte_size
+            len(body) != document.byte_size
             or hashlib.sha256(body).hexdigest() != document.body_digest
         ):
             raise InventoryEligibilityError(
@@ -490,7 +581,6 @@ class LegacyRevisionBridge:
             yield body
         finally:
             del body
-            del snapshot
 
     async def prepare_run(
         self,
@@ -499,11 +589,12 @@ class LegacyRevisionBridge:
         fixed_ref: str,
         coverage_version: str,
     ) -> tuple[MigrationRun, LegacyInventory]:
-        inventory = await self.capture_inventory(
+        scope = await self.capture_inventory_scope(
             namespace_id=namespace_id,
             fixed_ref=fixed_ref,
             coverage_version=coverage_version,
         )
+        inventory = scope.inventory
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 run = await self.repository.get_or_create_run(
@@ -520,15 +611,18 @@ class LegacyRevisionBridge:
                 )
         return run, inventory
 
-    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
-        inventory = await self.capture_inventory(
+    async def inventory_scope_for_run(self, run: MigrationRun) -> LegacyInventoryScope:
+        scope = await self.capture_inventory_scope(
             namespace_id=run.namespace_id,
             fixed_ref=run.fixed_git_oid,
             coverage_version=run.coverage_version,
         )
-        if inventory.inventory_digest != run.inventory_digest:
+        if scope.inventory.inventory_digest != run.inventory_digest:
             raise MigrationInventoryDriftError()
-        return inventory
+        return scope
+
+    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
+        return (await self.inventory_scope_for_run(run)).inventory
 
     async def resolve_selector(
         self,

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -1,0 +1,542 @@
+"""Fixed-ref legacy inventory and Resource-scoped selector bridge."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+import asyncpg
+
+from app.exceptions import AKBError, ConflictError, NotFoundError
+from app.repositories.native_revision_migration_repo import (
+    MigrationInventoryDriftError,
+    MigrationRun,
+    NativeRevisionMigrationRepository,
+)
+from app.services.git_service import FixedRefHistoryError, GitService
+
+
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
+_SELECTOR_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class ManualVaultRequiredError(ConflictError):
+    """The requested namespace is not an eligible manual vault."""
+
+    def __init__(self):
+        super().__init__("native revision migration requires one manual vault")
+        self.code = "native_revision_migration_manual_vault_required"
+
+
+class InventoryEligibilityError(ConflictError):
+    """A legacy document cannot be safely frozen into the C9 inventory."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.code = "native_revision_migration_inventory_ineligible"
+
+
+class SelectorInvalidError(AKBError):
+    def __init__(self, selector: str):
+        super().__init__(
+            f"invalid legacy revision selector: {selector}",
+            status_code=400,
+            code="legacy_revision_selector_invalid",
+        )
+
+
+class SelectorUnknownError(NotFoundError):
+    def __init__(self, selector: str):
+        super().__init__("Legacy revision selector", selector)
+        self.code = "legacy_revision_selector_unknown"
+
+
+class SelectorAmbiguousError(ConflictError):
+    def __init__(self, selector: str):
+        super().__init__(f"legacy revision selector is ambiguous: {selector}")
+        self.code = "legacy_revision_selector_ambiguous"
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyLineageEntry:
+    legacy_git_oid: str
+    path_at_revision: str
+    committed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyActivitySemantics:
+    legacy_git_oid: str
+    committed_at: datetime
+    actor: str
+    subject: str
+    summary: str
+    action: Literal["create", "update", "move", "delete"]
+    path_from: str | None
+    path_to: str | None
+    changed_paths: tuple[dict[str, str | None], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyInventoryAlias:
+    old_ref: str
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyInventoryDocument:
+    resource_id: uuid.UUID
+    current_path: str
+    current_commit: str
+    created_at: datetime
+    body: bytes
+    body_digest: str
+    byte_size: int
+    aliases: tuple[LegacyInventoryAlias, ...]
+    lineage: tuple[LegacyLineageEntry, ...]
+    activity: LegacyActivitySemantics
+
+    def item_facts(self) -> dict:
+        return {
+            "legacy_document_id": self.resource_id,
+            "captured_path": self.current_path,
+            "legacy_head_oid": self.current_commit,
+            "body_digest": self.body_digest,
+            "byte_size": self.byte_size,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyInventory:
+    namespace_id: uuid.UUID
+    fixed_git_oid: str
+    coverage_version: str
+    documents: tuple[LegacyInventoryDocument, ...]
+    inventory_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class SelectorResolution:
+    resource_id: uuid.UUID
+    selector: str
+    kind: Literal["native", "bridge"]
+    native_revision_id: str | None
+    fixed_git_oid: str | None
+    legacy_git_oid: str | None
+    path_at_revision: str | None
+    run_id: uuid.UUID | None
+
+
+def _require_oid(value: str, field: str) -> None:
+    if not isinstance(value, str) or _OID_RE.fullmatch(value) is None:
+        raise InventoryEligibilityError(
+            f"{field} must be a full lowercase 40-hex commit OID"
+        )
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+class LegacyRevisionBridge:
+    """Capture manual legacy history at one immutable Git tip."""
+
+    inventory_schema = "c9-fixed-ref-inventory-v1"
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        git: GitService,
+        repository: NativeRevisionMigrationRepository | None = None,
+    ):
+        self.pool = pool
+        self.git = git
+        self.repository = repository or NativeRevisionMigrationRepository(pool)
+
+    @classmethod
+    def canonical_inventory_digest(
+        cls,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_git_oid: str,
+        coverage_version: str,
+        documents: tuple[LegacyInventoryDocument, ...],
+    ) -> str:
+        payload = {
+            "schema": cls.inventory_schema,
+            "namespace_id": str(namespace_id),
+            "fixed_git_oid": fixed_git_oid,
+            "coverage_version": coverage_version,
+            "documents": [
+                {
+                    "resource_id": str(document.resource_id),
+                    "current_path": document.current_path,
+                    "current_commit": document.current_commit,
+                    "created_at": _iso(document.created_at),
+                    "body_digest": document.body_digest,
+                    "byte_size": document.byte_size,
+                    "aliases": [
+                        {
+                            "old_ref": alias.old_ref,
+                            "created_at": _iso(alias.created_at),
+                        }
+                        for alias in document.aliases
+                    ],
+                    "lineage": [
+                        {
+                            "legacy_git_oid": entry.legacy_git_oid,
+                            "path_at_revision": entry.path_at_revision,
+                            "committed_at": _iso(entry.committed_at),
+                        }
+                        for entry in document.lineage
+                    ],
+                    "activity": {
+                        "legacy_git_oid": document.activity.legacy_git_oid,
+                        "committed_at": _iso(document.activity.committed_at),
+                        "actor": document.activity.actor,
+                        "subject": document.activity.subject,
+                        "summary": document.activity.summary,
+                        "action": document.activity.action,
+                        "path_from": document.activity.path_from,
+                        "path_to": document.activity.path_to,
+                        "changed_paths": list(document.activity.changed_paths),
+                    },
+                }
+                for document in documents
+            ],
+        }
+        canonical = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    async def capture_inventory(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_ref: str,
+        coverage_version: str,
+    ) -> LegacyInventory:
+        _require_oid(fixed_ref, "fixed_ref")
+        if not isinstance(coverage_version, str) or not coverage_version.strip():
+            raise InventoryEligibilityError("coverage_version must be non-empty")
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction(isolation="repeatable_read", readonly=True):
+                vault = await self.repository.get_manual_vault(namespace_id, conn=conn)
+                if vault is None:
+                    raise NotFoundError("Vault", str(namespace_id))
+                if vault["has_external_git"]:
+                    raise ManualVaultRequiredError()
+
+                rows = await self.repository.list_documents(conn, namespace_id)
+                # A manual vault can retain source rows that are owned by the
+                # external-Git/document projection.  Those rows are explicit
+                # excluded no-ops for C9: do not let them poison the eligible
+                # manual inventory or create any authority/item facts.  The
+                # vault-level external-Git marker above remains a hard reject.
+                rows = [row for row in rows if row.get("source") == "manual"]
+
+                documents: list[LegacyInventoryDocument] = []
+                for row in rows:
+                    aliases: list[LegacyInventoryAlias] = []
+                    for alias in await self.repository.list_document_aliases(
+                        conn, namespace_id, row["id"]
+                    ):
+                        old_ref = alias.get("old_ref")
+                        created_at = alias.get("created_at")
+                        if not isinstance(old_ref, str) or not old_ref.strip():
+                            raise InventoryEligibilityError(
+                                f"document {row['id']} has an invalid resource alias"
+                            )
+                        if not isinstance(created_at, datetime):
+                            raise InventoryEligibilityError(
+                                f"document {row['id']} has an alias without a usable timestamp"
+                            )
+                        aliases.append(
+                            LegacyInventoryAlias(
+                                old_ref=old_ref,
+                                created_at=created_at,
+                            )
+                        )
+                    current_commit = row.get("current_commit")
+                    if not isinstance(current_commit, str) or _OID_RE.fullmatch(current_commit) is None:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} has no full current_commit"
+                        )
+                    created_at = row.get("created_at")
+                    if not isinstance(created_at, datetime):
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} has no usable created_at"
+                        )
+                    try:
+                        snapshot = await asyncio.to_thread(
+                            self.git.manual_fixed_ref_history,
+                            vault["name"],
+                            fixed_ref,
+                            row["path"],
+                            current_commit=current_commit,
+                            since_epoch=int(created_at.timestamp()),
+                        )
+                    except FixedRefHistoryError as exc:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} is not readable at the fixed ref"
+                        ) from exc
+                    history = snapshot["history"]
+                    if not history or history[0]["legacy_git_oid"] != current_commit:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} current_commit is not the fixed-ref file head"
+                        )
+                    raw_activity = snapshot.get("activity")
+                    if not isinstance(raw_activity, dict):
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} has no fixed-ref activity semantics"
+                        )
+                    activity_action = raw_activity.get("action")
+                    if activity_action not in {"create", "update", "move", "delete"}:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} has an unsupported current activity action"
+                        )
+                    activity_oid = raw_activity.get("legacy_git_oid")
+                    activity_time = raw_activity.get("committed_at")
+                    activity_actor = raw_activity.get("actor")
+                    activity_subject = raw_activity.get("subject")
+                    activity_summary = raw_activity.get("summary")
+                    path_from = raw_activity.get("path_from")
+                    path_to = raw_activity.get("path_to")
+                    changed_paths = raw_activity.get("changed_paths")
+                    if (
+                        activity_oid != current_commit
+                        or not isinstance(activity_time, datetime)
+                        or activity_time != history[0]["committed_at"]
+                        or not isinstance(activity_actor, str)
+                        or not activity_actor
+                        or not isinstance(activity_subject, str)
+                        or not activity_subject
+                        or not isinstance(activity_summary, str)
+                        or not isinstance(path_to, str)
+                        or not isinstance(changed_paths, list)
+                    ):
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} has incomplete current activity semantics"
+                        )
+                    if activity_action == "move" and not isinstance(path_from, str):
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} move activity has no source path"
+                        )
+                    if activity_action != "move" and path_from is not None:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} non-move activity has a source path"
+                        )
+                    activity = LegacyActivitySemantics(
+                        legacy_git_oid=activity_oid,
+                        committed_at=activity_time,
+                        actor=activity_actor,
+                        subject=activity_subject,
+                        summary=activity_summary,
+                        action=activity_action,
+                        path_from=path_from,
+                        path_to=path_to,
+                        changed_paths=tuple(changed_paths),
+                    )
+                    body = snapshot["body"]
+                    if b"\x00" in body:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} body contains NUL bytes"
+                        )
+                    try:
+                        body.decode("utf-8", errors="strict")
+                    except UnicodeDecodeError as exc:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} body is not valid UTF-8"
+                        ) from exc
+
+                    newest: list[LegacyLineageEntry] = []
+                    seen: set[str] = set()
+                    for entry in history:
+                        oid = entry["legacy_git_oid"]
+                        if not isinstance(oid, str) or _OID_RE.fullmatch(oid) is None:
+                            raise InventoryEligibilityError(
+                                f"document {row['id']} history contains an invalid OID"
+                            )
+                        if oid in seen:
+                            continue
+                        committed_at = entry["committed_at"]
+                        if oid != current_commit and committed_at < created_at:
+                            continue
+                        seen.add(oid)
+                        newest.append(
+                            LegacyLineageEntry(
+                                legacy_git_oid=oid,
+                                path_at_revision=(
+                                    row["path"] if oid == current_commit
+                                    else entry["path_at_revision"]
+                                ),
+                                committed_at=committed_at,
+                            )
+                        )
+                    if current_commit not in seen:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} current_commit is absent from fixed-ref history"
+                        )
+                    lineage = tuple(reversed(newest))
+                    if not lineage or lineage[-1].legacy_git_oid != current_commit:
+                        raise InventoryEligibilityError(
+                            f"document {row['id']} lineage does not end at current_commit"
+                        )
+                    documents.append(
+                        LegacyInventoryDocument(
+                            resource_id=row["id"],
+                            current_path=row["path"],
+                            current_commit=current_commit,
+                            created_at=created_at,
+                            body=body,
+                            body_digest=hashlib.sha256(body).hexdigest(),
+                            byte_size=len(body),
+                            aliases=tuple(aliases),
+                            lineage=lineage,
+                            activity=activity,
+                        )
+                    )
+
+        frozen_documents = tuple(documents)
+        return LegacyInventory(
+            namespace_id=namespace_id,
+            fixed_git_oid=fixed_ref,
+            coverage_version=coverage_version,
+            documents=frozen_documents,
+            inventory_digest=self.canonical_inventory_digest(
+                namespace_id=namespace_id,
+                fixed_git_oid=fixed_ref,
+                coverage_version=coverage_version,
+                documents=frozen_documents,
+            ),
+        )
+
+    async def prepare_run(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_ref: str,
+        coverage_version: str,
+    ) -> tuple[MigrationRun, LegacyInventory]:
+        inventory = await self.capture_inventory(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version=coverage_version,
+        )
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                run = await self.repository.get_or_create_run(
+                    namespace_id=namespace_id,
+                    fixed_git_oid=fixed_ref,
+                    coverage_version=coverage_version,
+                    inventory_digest=inventory.inventory_digest,
+                    conn=conn,
+                )
+                await self.repository.ensure_pending_items(
+                    run,
+                    (document.item_facts() for document in inventory.documents),
+                    conn=conn,
+                )
+        return run, inventory
+
+    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
+        inventory = await self.capture_inventory(
+            namespace_id=run.namespace_id,
+            fixed_ref=run.fixed_git_oid,
+            coverage_version=run.coverage_version,
+        )
+        if inventory.inventory_digest != run.inventory_digest:
+            raise MigrationInventoryDriftError()
+        return inventory
+
+    async def resolve_selector(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        selector: str,
+    ) -> SelectorResolution:
+        if not isinstance(selector, str) or _SELECTOR_RE.fullmatch(selector) is None:
+            raise SelectorInvalidError(selector)
+
+        if len(selector) == 40:
+            native = await self.repository.exact_native_revision(
+                namespace_id=await self._resource_namespace(resource_id),
+                resource_id=resource_id,
+                revision_id=selector,
+            )
+            mapping = await self.repository.exact_mapping(
+                resource_id=resource_id,
+                legacy_git_oid=selector,
+            )
+            if native is not None and mapping is not None:
+                raise SelectorAmbiguousError(selector)
+            if native is not None:
+                return SelectorResolution(
+                    resource_id=resource_id,
+                    selector=selector,
+                    kind="native",
+                    native_revision_id=native["revision_id"],
+                    fixed_git_oid=None,
+                    legacy_git_oid=None,
+                    path_at_revision=native["path_at_revision"],
+                    run_id=None,
+                )
+            if mapping is not None:
+                return self._mapping_resolution(resource_id, selector, mapping)
+            raise SelectorUnknownError(selector)
+
+        mappings = await self.repository.prefix_mappings(
+            resource_id=resource_id,
+            legacy_git_prefix=selector,
+        )
+        if not mappings:
+            raise SelectorUnknownError(selector)
+        if len(mappings) != 1:
+            raise SelectorAmbiguousError(selector)
+        return self._mapping_resolution(resource_id, selector, mappings[0])
+
+    async def _resource_namespace(self, resource_id: uuid.UUID) -> uuid.UUID:
+        async with self.pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                "SELECT namespace_id FROM native_resources WHERE resource_id = $1",
+                resource_id,
+            )
+        if namespace_id is None:
+            raise SelectorUnknownError(str(resource_id))
+        return namespace_id
+
+    @staticmethod
+    def _mapping_resolution(resource_id, selector, mapping) -> SelectorResolution:
+        if mapping.resolution == "native":
+            return SelectorResolution(
+                resource_id=resource_id,
+                selector=selector,
+                kind="native",
+                native_revision_id=mapping.native_revision_id,
+                fixed_git_oid=mapping.fixed_git_oid,
+                legacy_git_oid=mapping.legacy_git_oid,
+                path_at_revision=mapping.path_at_revision,
+                run_id=mapping.run_id,
+            )
+        return SelectorResolution(
+            resource_id=resource_id,
+            selector=selector,
+            kind="bridge",
+            native_revision_id=None,
+            fixed_git_oid=mapping.fixed_git_oid,
+            legacy_git_oid=mapping.legacy_git_oid,
+            path_at_revision=mapping.path_at_revision,
+            run_id=mapping.run_id,
+        )

--- a/backend/app/services/native_revision_backfill.py
+++ b/backend/app/services/native_revision_backfill.py
@@ -1,0 +1,414 @@
+"""Atomic current-head publication for the fixed-ref C9 inventory."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC
+from typing import Final, Protocol
+
+import asyncpg
+
+from app.exceptions import NotFoundError
+from app.repositories.native_revision_migration_repo import (
+    MigrationRun,
+    NativeRevisionMigrationRepository,
+)
+from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.git_service import GitService
+from app.services.legacy_revision_bridge import (
+    LegacyInventory,
+    LegacyInventoryDocument,
+    LegacyRevisionBridge,
+)
+from app.services.m1_pg_body_store import M1PgBodyStore
+
+
+Failpoint = Callable[[str], Awaitable[None] | None]
+
+FAILPOINT_BOUNDARIES: Final[tuple[str, ...]] = (
+    "payload.after_prepare_before_tx",
+    "authority.after_resource",
+    "authority.after_manifest",
+    "authority.after_revision",
+    "authority.after_head",
+    "authority.after_alias",
+    "authority.after_activity",
+    "authority.after_invalidation",
+    "authority.after_mapping",
+    "authority.before_commit",
+)
+
+
+class BackfillFailpointError(RuntimeError):
+    """A test failpoint interrupted the authority transaction."""
+
+    def __init__(self, boundary: str):
+        super().__init__(f"native backfill failpoint: {boundary}")
+        self.boundary = boundary
+
+
+class TextBodyStore(Protocol):
+    async def prepare_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        payload: str | bytes,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ): ...
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillResult:
+    run_id: uuid.UUID
+    status: str
+    completed_items: int
+    failed_items: int
+    skipped_items: int
+
+
+class NativeRevisionBackfill:
+    """Publish one frozen inventory item at a time, atomically per item."""
+
+    actor = "akb-native-revision-migration"
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        git: GitService,
+        bridge: LegacyRevisionBridge | None = None,
+        repository: NativeRevisionMigrationRepository | None = None,
+        native_repository: NativeRevisionRepository | None = None,
+        body_store: TextBodyStore | None = None,
+        failpoint: Failpoint | None = None,
+        revision_id_factory: Callable[[], str] | None = None,
+    ):
+        self.pool = pool
+        self.git = git
+        self.repository = repository or NativeRevisionMigrationRepository(pool)
+        self.native_repository = native_repository or NativeRevisionRepository(pool)
+        self.bridge = bridge or LegacyRevisionBridge(
+            pool,
+            git=git,
+            repository=self.repository,
+        )
+        self.body_store = body_store or M1PgBodyStore(pool)
+        self.failpoint = failpoint
+        self.revision_id_factory = revision_id_factory
+
+    async def _hit(self, boundary: str) -> None:
+        if self.failpoint is None:
+            return
+        if boundary not in FAILPOINT_BOUNDARIES:
+            raise ValueError(f"native backfill failpoint boundary is not registered: {boundary}")
+        try:
+            result = self.failpoint(boundary)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:  # noqa: BLE001 - preserve a stable test seam
+            raise BackfillFailpointError(boundary) from exc
+
+    async def prepare_run(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_ref: str,
+        coverage_version: str,
+    ) -> tuple[MigrationRun, LegacyInventory]:
+        return await self.bridge.prepare_run(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version=coverage_version,
+        )
+
+    async def backfill_run(self, run_id: uuid.UUID) -> BackfillResult:
+        run = await self.repository.get_run(run_id)
+        if run is None:
+            raise NotFoundError("Native revision migration run", str(run_id))
+        if run.status == "complete":
+            return BackfillResult(
+                run_id=run_id,
+                status="complete",
+                completed_items=0,
+                failed_items=0,
+                skipped_items=0,
+            )
+        inventory = await self.bridge.inventory_for_run(run)
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await self.repository.ensure_pending_items(
+                    run,
+                    (document.item_facts() for document in inventory.documents),
+                    conn=conn,
+                )
+                await self.repository.set_run_status(run_id, "running", conn=conn)
+
+        completed = 0
+        failed = 0
+        skipped = 0
+        for document in inventory.documents:
+            item = await self.repository.get_item(run_id, document.resource_id)
+            if item is None:
+                raise RuntimeError("migration inventory item disappeared before backfill")
+            if item.status == "complete":
+                skipped += 1
+                continue
+            try:
+                prepared = await self.body_store.prepare_text(
+                    namespace_id=run.namespace_id,
+                    payload=document.body,
+                    expected_digest=document.body_digest,
+                    expected_size=document.byte_size,
+                )
+                await self._hit("payload.after_prepare_before_tx")
+                await self._publish_item(
+                    run=run,
+                    document=document,
+                    inventory=inventory,
+                    prepared=prepared,
+                )
+                completed += 1
+            except BackfillFailpointError:
+                raise
+            except Exception:
+                await self._mark_failed(run_id, document.resource_id, "authority_publish_failed")
+                failed += 1
+
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                if await self.repository.all_items_complete(conn, run_id):
+                    final_run = await self.repository.set_run_status(
+                        run_id, "complete", conn=conn,
+                    )
+                    status = final_run.status
+                else:
+                    final_run = await self.repository.set_run_status(
+                        run_id,
+                        "failed" if failed else "running",
+                        error="one or more migration items failed" if failed else None,
+                        conn=conn,
+                    )
+                    status = final_run.status
+        return BackfillResult(
+            run_id=run_id,
+            status=status,
+            completed_items=completed,
+            failed_items=failed,
+            skipped_items=skipped,
+        )
+
+    async def _mark_failed(
+        self, run_id: uuid.UUID, resource_id: uuid.UUID, error_code: str,
+    ) -> None:
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await self.repository.mark_item_failed(
+                    conn,
+                    run_id=run_id,
+                    legacy_document_id=resource_id,
+                    error_code=error_code,
+                )
+
+    @staticmethod
+    def _uuid(run_id: uuid.UUID, resource_id: uuid.UUID, label: str) -> uuid.UUID:
+        return uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"akb:c9:native-genesis:{run_id}:{resource_id}:{label}",
+        )
+
+    @staticmethod
+    def _fingerprint(
+        run: MigrationRun, document: LegacyInventoryDocument,
+    ) -> str:
+        payload = {
+            "schema": "c9-native-genesis-v1",
+            "run_id": str(run.run_id),
+            "namespace_id": str(run.namespace_id),
+            "resource_id": str(document.resource_id),
+            "fixed_git_oid": run.fixed_git_oid,
+            "legacy_head_oid": document.current_commit,
+            "path": document.current_path,
+            "body_digest": document.body_digest,
+            "byte_size": document.byte_size,
+        }
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+
+    async def _publish_item(
+        self,
+        *,
+        run: MigrationRun,
+        document: LegacyInventoryDocument,
+        inventory: LegacyInventory,
+        prepared,
+    ) -> None:
+        del inventory
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                item = await self.repository.get_item(
+                    run.run_id,
+                    document.resource_id,
+                    conn=conn,
+                    for_update=True,
+                )
+                if item is None:
+                    raise RuntimeError("migration item disappeared during authority publication")
+                if item.status == "complete":
+                    return
+
+                if (
+                    not document.lineage
+                    or document.lineage[-1].legacy_git_oid != document.current_commit
+                ):
+                    raise RuntimeError("frozen lineage does not end at the legacy current head")
+                current_lineage = document.lineage[-1]
+
+                existing = await conn.fetchrow(
+                    """
+                    SELECT resource_id, namespace_id, surface, lifecycle,
+                           current_path, head_revision_id
+                      FROM native_resources
+                     WHERE resource_id = $1
+                     FOR UPDATE
+                    """,
+                    document.resource_id,
+                )
+                if existing is not None:
+                    raise RuntimeError("native Resource exists for an incomplete migration item")
+
+                retained_oids = {
+                    entry.legacy_git_oid for entry in document.lineage
+                }
+                revision_id = await self.repository.allocate_native_revision_id(
+                    conn,
+                    resource_id=document.resource_id,
+                    retained_legacy_oids=retained_oids,
+                    revision_id_factory=self.revision_id_factory,
+                )
+                resource_created_at = document.created_at.astimezone(UTC)
+                head_occurred_at = current_lineage.committed_at.astimezone(UTC)
+                manifest_id = self._uuid(run.run_id, document.resource_id, "manifest")
+                mutation_id = self._uuid(run.run_id, document.resource_id, "mutation")
+                activity_id = self._uuid(run.run_id, document.resource_id, "activity")
+                intent_id = self._uuid(run.run_id, document.resource_id, "invalidation")
+                fingerprint = self._fingerprint(run, document)
+
+                await self.native_repository.insert_resource(
+                    conn,
+                    resource_id=document.resource_id,
+                    namespace_id=run.namespace_id,
+                    surface="document",
+                    content_profile="text",
+                    path=document.current_path,
+                    occurred_at=resource_created_at,
+                )
+                await self._hit("authority.after_resource")
+                await self.native_repository.insert_manifest(
+                    conn,
+                    payload_manifest_id=manifest_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    payload=prepared,
+                    occurred_at=head_occurred_at,
+                )
+                await self._hit("authority.after_manifest")
+                await self.native_repository.insert_revision(
+                    conn,
+                    revision_id=revision_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    parent_revision_id=None,
+                    action="create",
+                    path=document.current_path,
+                    path_from=None,
+                    path_to=document.current_path,
+                    payload_manifest_id=manifest_id,
+                    mutation_id=mutation_id,
+                    request_fingerprint=fingerprint,
+                    message="C9 fixed-ref native genesis",
+                    subject=None,
+                    summary=None,
+                    actor=self.actor,
+                    occurred_at=head_occurred_at,
+                    activity_event_id=activity_id,
+                    invalidation_intent_id=intent_id,
+                )
+                await self._hit("authority.after_revision")
+                await self.native_repository.set_head(
+                    conn,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    path=document.current_path,
+                    lifecycle="live",
+                    occurred_at=head_occurred_at,
+                )
+                await self._hit("authority.after_head")
+
+                for alias in document.aliases:
+                    if alias.old_ref == document.current_path:
+                        continue
+                    await self.native_repository.insert_path_alias(
+                        conn,
+                        namespace_id=run.namespace_id,
+                        surface="document",
+                        old_path=alias.old_ref,
+                        resource_id=document.resource_id,
+                        created_revision_id=revision_id,
+                        occurred_at=alias.created_at,
+                    )
+                await self._hit("authority.after_alias")
+                await self.native_repository.insert_activity(
+                    conn,
+                    activity_event_id=activity_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    action="create",
+                    actor=self.actor,
+                    subject=None,
+                    summary=None,
+                    path_from=None,
+                    path_to=document.current_path,
+                    occurred_at=head_occurred_at,
+                )
+                await self._hit("authority.after_activity")
+                await self.native_repository.insert_invalidation_intent(
+                    conn,
+                    intent_id=intent_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    reason="create",
+                    occurred_at=head_occurred_at,
+                )
+                await self._hit("authority.after_invalidation")
+
+                for ordinal, entry in enumerate(document.lineage):
+                    is_current = entry.legacy_git_oid == document.current_commit
+                    await self.repository.ensure_mapping(
+                        conn,
+                        namespace_id=run.namespace_id,
+                        resource_id=document.resource_id,
+                        legacy_git_oid=entry.legacy_git_oid,
+                        path_at_revision=entry.path_at_revision,
+                        resolution="native" if is_current else "bridge",
+                        native_revision_id=revision_id if is_current else None,
+                        run_id=run.run_id,
+                        lineage_ordinal=ordinal,
+                    )
+                await self._hit("authority.after_mapping")
+                await self.repository.mark_item_complete(
+                    conn,
+                    run_id=run.run_id,
+                    legacy_document_id=document.resource_id,
+                    native_head_revision_id=revision_id,
+                )
+                await self._hit("authority.before_commit")

--- a/backend/app/services/native_revision_backfill.py
+++ b/backend/app/services/native_revision_backfill.py
@@ -161,12 +161,13 @@ class NativeRevisionBackfill:
                 skipped += 1
                 continue
             try:
-                prepared = await self.body_store.prepare_text(
-                    namespace_id=run.namespace_id,
-                    payload=document.body,
-                    expected_digest=document.body_digest,
-                    expected_size=document.byte_size,
-                )
+                async with self.bridge.materialize_body(inventory, document) as body:
+                    prepared = await self.body_store.prepare_text(
+                        namespace_id=run.namespace_id,
+                        payload=body,
+                        expected_digest=document.body_digest,
+                        expected_size=document.byte_size,
+                    )
                 await self._hit("payload.after_prepare_before_tx")
                 await self._publish_item(
                     run=run,

--- a/backend/app/services/native_revision_backfill.py
+++ b/backend/app/services/native_revision_backfill.py
@@ -139,7 +139,8 @@ class NativeRevisionBackfill:
                 failed_items=0,
                 skipped_items=0,
             )
-        inventory = await self.bridge.inventory_for_run(run)
+        scope = await self.bridge.inventory_scope_for_run(run)
+        inventory = scope.inventory
 
         async with self.pool.acquire() as conn:
             async with conn.transaction():
@@ -161,7 +162,7 @@ class NativeRevisionBackfill:
                 skipped += 1
                 continue
             try:
-                async with self.bridge.materialize_body(inventory, document) as body:
+                async with self.bridge.materialize_body(scope, document) as body:
                     prepared = await self.body_store.prepare_text(
                         namespace_id=run.namespace_id,
                         payload=body,

--- a/backend/app/services/native_revision_reconcile.py
+++ b/backend/app/services/native_revision_reconcile.py
@@ -1,0 +1,871 @@
+"""Operator-only final-ref reconciliation for the C9 native ledger.
+
+This module is deliberately not composed into the request path.  Legacy Git
+and the legacy document projection remain the sole writers; an operator may
+construct this service to publish one final native delta for a later fixed
+ref.  The fixed-ref bridge supplies the inventory and the migration repository
+supplies the immutable cross-run selector bindings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC
+from typing import Final, Protocol
+
+import asyncpg
+
+from app.exceptions import ConflictError
+from app.repositories.native_revision_migration_repo import (
+    LegacyRevisionMapping,
+    MigrationRun,
+    NativeRevisionMigrationRepository,
+)
+from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.git_service import GitService
+from app.services.legacy_revision_bridge import (
+    LegacyInventory,
+    LegacyInventoryDocument,
+    LegacyRevisionBridge,
+)
+from app.services.m1_pg_body_store import M1PgBodyStore
+from app.services.native_revision_backfill import (
+    BackfillFailpointError,
+    FAILPOINT_BOUNDARIES,
+)
+
+
+Failpoint = Callable[[str], Awaitable[None] | None]
+
+
+class ReconcileIntegrityError(ConflictError):
+    """The final fixed-ref state cannot be safely attached to native state."""
+
+    def __init__(self, message: str, *, code: str = "native_revision_reconcile_integrity"):
+        super().__init__(message)
+        self.code = code
+
+
+class TextBodyStore(Protocol):
+    async def prepare_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        payload: str | bytes,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ): ...
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileItemResult:
+    resource_id: uuid.UUID
+    action: str
+    legacy_head_oid: str
+    revision_id: str | None
+    parent_revision_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileResult:
+    run_id: uuid.UUID
+    status: str
+    completed_items: int
+    failed_items: int
+    skipped_items: int
+    changed_items: int
+    unchanged_items: int
+    items: tuple[ReconcileItemResult, ...]
+    idempotent_replay: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingChange:
+    document: LegacyInventoryDocument
+    action: str
+    parent_revision_id: str
+    path_from: str
+
+
+_RECONCILE_BOUNDARIES: Final[tuple[str, ...]] = (
+    *FAILPOINT_BOUNDARIES,
+    "reconcile.after_item_commit",
+)
+
+
+class NativeRevisionReconcile:
+    """Publish final-ref deltas while preserving the original migration run."""
+
+    coverage_version = "c9-native-reconcile-v1"
+    actor = "akb-native-revision-reconcile"
+    fingerprint_schema = "c9-native-reconcile-v1"
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        git: GitService,
+        bridge: LegacyRevisionBridge | None = None,
+        repository: NativeRevisionMigrationRepository | None = None,
+        native_repository: NativeRevisionRepository | None = None,
+        body_store: TextBodyStore | None = None,
+        failpoint: Failpoint | None = None,
+        revision_id_factory: Callable[[], str] | None = None,
+    ):
+        self.pool = pool
+        self.git = git
+        self.repository = repository or NativeRevisionMigrationRepository(pool)
+        self.native_repository = native_repository or NativeRevisionRepository(pool)
+        self.bridge = bridge or LegacyRevisionBridge(
+            pool,
+            git=git,
+            repository=self.repository,
+        )
+        self.body_store = body_store or M1PgBodyStore(pool)
+        self.failpoint = failpoint
+        self.revision_id_factory = revision_id_factory
+
+    async def _hit(self, boundary: str) -> None:
+        if self.failpoint is None:
+            return
+        if boundary not in _RECONCILE_BOUNDARIES:
+            raise ValueError(f"native reconcile failpoint boundary is not registered: {boundary}")
+        try:
+            result = self.failpoint(boundary)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:  # noqa: BLE001 - preserve a stable test seam
+            raise BackfillFailpointError(boundary) from exc
+
+    @staticmethod
+    def _uuid(run_id: uuid.UUID, resource_id: uuid.UUID, label: str) -> uuid.UUID:
+        return uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"akb:{NativeRevisionReconcile.fingerprint_schema}:{run_id}:{resource_id}:{label}",
+        )
+
+    @classmethod
+    def _fingerprint(
+        cls,
+        *,
+        run: MigrationRun,
+        document: LegacyInventoryDocument,
+        action: str,
+        parent_revision_id: str,
+        path_from: str,
+    ) -> str:
+        suffix_start = next(
+            (
+                index
+                for index, entry in enumerate(document.lineage)
+                if entry.legacy_git_oid == document.current_commit
+            ),
+            len(document.lineage),
+        )
+        canonical = {
+            "schema": cls.fingerprint_schema,
+            "run_id": str(run.run_id),
+            "namespace_id": str(run.namespace_id),
+            "resource_id": str(document.resource_id),
+            "fixed_git_oid": run.fixed_git_oid,
+            "base_native_revision_id": parent_revision_id,
+            "action": action,
+            "path_from": path_from,
+            "path_to": document.current_path,
+            "legacy_head_oid": document.current_commit,
+            "body_digest": document.body_digest,
+            "byte_size": document.byte_size,
+            "lineage_suffix": [
+                entry.legacy_git_oid for entry in document.lineage[suffix_start:]
+            ],
+        }
+        return hashlib.sha256(
+            json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+
+    async def reconcile(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_ref: str,
+        coverage_version: str | None = None,
+    ) -> ReconcileResult:
+        """Capture a final fixed ref and publish only changed Resources."""
+
+        coverage = coverage_version or self.coverage_version
+        inventory = await self.bridge.capture_inventory(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version=coverage,
+        )
+        await self._assert_inventory_covers_completed_resources(inventory)
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                run = await self.repository.get_or_create_run(
+                    namespace_id=namespace_id,
+                    fixed_git_oid=fixed_ref,
+                    coverage_version=coverage,
+                    inventory_digest=inventory.inventory_digest,
+                    conn=conn,
+                )
+
+        if run.status == "complete":
+            return ReconcileResult(
+                run_id=run.run_id,
+                status=run.status,
+                completed_items=0,
+                failed_items=0,
+                skipped_items=len(inventory.documents),
+                changed_items=0,
+                unchanged_items=len(inventory.documents),
+                items=tuple(
+                    ReconcileItemResult(
+                        resource_id=document.resource_id,
+                        action="unchanged",
+                        legacy_head_oid=document.current_commit,
+                        revision_id=None,
+                        parent_revision_id=None,
+                    )
+                    for document in inventory.documents
+                ),
+                idempotent_replay=True,
+            )
+
+        try:
+            pending, unchanged = await self._classify_inventory(inventory, run=run)
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    await self.repository.ensure_pending_items(
+                        run,
+                        (change.document.item_facts() for change in pending),
+                        conn=conn,
+                    )
+                    await self.repository.set_run_status(run.run_id, "running", conn=conn)
+
+            completed = 0
+            results = [
+                ReconcileItemResult(
+                    resource_id=document.resource_id,
+                    action="unchanged",
+                    legacy_head_oid=document.current_commit,
+                    revision_id=None,
+                    parent_revision_id=None,
+                )
+                for document in unchanged
+            ]
+            for index, change in enumerate(pending):
+                item = await self.repository.get_item(run.run_id, change.document.resource_id)
+                if item is None:
+                    raise ReconcileIntegrityError("reconcile item disappeared before publication")
+                if item.status == "complete":
+                    results.append(
+                        ReconcileItemResult(
+                            resource_id=change.document.resource_id,
+                            action=change.action,
+                            legacy_head_oid=change.document.current_commit,
+                            revision_id=item.native_head_revision_id,
+                            parent_revision_id=change.parent_revision_id,
+                        )
+                    )
+                    continue
+                prepared = await self.body_store.prepare_text(
+                    namespace_id=run.namespace_id,
+                    payload=change.document.body,
+                    expected_digest=change.document.body_digest,
+                    expected_size=change.document.byte_size,
+                )
+                await self._hit("payload.after_prepare_before_tx")
+                result = await self._publish_item(
+                    run=run,
+                    change=change,
+                    inventory=inventory,
+                    prepared=prepared,
+                )
+                results.append(result)
+                completed += 1
+                if index < len(pending) - 1:
+                    await self._hit("reconcile.after_item_commit")
+
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    if await self.repository.all_items_complete(conn, run.run_id):
+                        final_run = await self.repository.set_run_status(
+                            run.run_id,
+                            "complete",
+                            conn=conn,
+                        )
+                    else:
+                        final_run = await self.repository.set_run_status(
+                            run.run_id,
+                            "failed",
+                            error="one or more reconcile items failed",
+                            conn=conn,
+                        )
+            return ReconcileResult(
+                run_id=run.run_id,
+                status=final_run.status,
+                completed_items=completed,
+                failed_items=0 if final_run.status == "complete" else len(pending) - completed,
+                skipped_items=len(unchanged),
+                changed_items=len(pending),
+                unchanged_items=len(unchanged),
+                items=tuple(results),
+            )
+        except BackfillFailpointError:
+            raise
+        except Exception as exc:
+            await self._mark_run_failed(run.run_id, exc)
+            raise
+
+    async def reconcile_run(self, run_id: uuid.UUID) -> ReconcileResult:
+        """Resume a prepared run using its recorded fixed ref and coverage."""
+
+        run = await self.repository.get_run(run_id)
+        if run is None:
+            raise ReconcileIntegrityError("reconcile run does not exist")
+        return await self.reconcile(
+            namespace_id=run.namespace_id,
+            fixed_ref=run.fixed_git_oid,
+            coverage_version=run.coverage_version,
+        )
+
+    async def _mark_run_failed(self, run_id: uuid.UUID, exc: Exception) -> None:
+        error = getattr(exc, "code", None) or "native_revision_reconcile_failed"
+        try:
+            await self.repository.set_run_status(run_id, "failed", error=error)
+        except Exception:  # noqa: BLE001 - preserve the original reconcile failure
+            return
+
+    async def _assert_inventory_covers_completed_resources(
+        self,
+        inventory: LegacyInventory,
+    ) -> None:
+        """Reject coverage loss before creating a new reconcile ledger row."""
+
+        inventory_ids = {document.resource_id for document in inventory.documents}
+        async with self.pool.acquire() as conn:
+            async with conn.transaction(isolation="repeatable_read", readonly=True):
+                migrated_ids = await self.repository.migrated_resource_ids(
+                    namespace_id=inventory.namespace_id,
+                    conn=conn,
+                )
+        missing = migrated_ids - inventory_ids
+        if missing:
+            raise ReconcileIntegrityError(
+                "legacy inventory is missing a previously migrated Resource",
+                code="native_revision_reconcile_missing_document",
+            )
+
+    async def _classify_inventory(
+        self,
+        inventory: LegacyInventory,
+        *,
+        run: MigrationRun,
+    ) -> tuple[list[_PendingChange], list[LegacyInventoryDocument]]:
+        pending: list[_PendingChange] = []
+        unchanged: list[LegacyInventoryDocument] = []
+        inventory_ids = {document.resource_id for document in inventory.documents}
+        async with self.pool.acquire() as conn:
+            async with conn.transaction(isolation="repeatable_read", readonly=True):
+                migrated_ids = await self.repository.migrated_resource_ids(
+                    namespace_id=inventory.namespace_id,
+                    conn=conn,
+                )
+                missing = migrated_ids - inventory_ids
+                if missing:
+                    raise ReconcileIntegrityError(
+                        "legacy inventory is missing a previously migrated Resource",
+                        code="native_revision_reconcile_missing_document",
+                    )
+
+                for document in inventory.documents:
+                    resource = await self.native_repository.get_resource_head(
+                        resource_id=document.resource_id,
+                        conn=conn,
+                    )
+                    if resource is None:
+                        raise ReconcileIntegrityError(
+                            f"native Resource is missing: {document.resource_id}",
+                            code="native_revision_reconcile_missing_resource",
+                        )
+                    if (
+                        resource["namespace_id"] != inventory.namespace_id
+                        or resource["surface"] != "document"
+                        or resource["lifecycle"] != "live"
+                        or resource["revision_id"] is None
+                    ):
+                        raise ReconcileIntegrityError(
+                            "native Resource is not a live document with a Head",
+                            code="native_revision_reconcile_stale_head",
+                        )
+                    mappings = await self.repository.list_resource_mappings_for_reconcile(
+                        namespace_id=inventory.namespace_id,
+                        resource_id=document.resource_id,
+                        run_id=run.run_id,
+                        conn=conn,
+                    )
+                    head_mapping = await self.repository.mapping_for_native_revision_for_reconcile(
+                        namespace_id=inventory.namespace_id,
+                        resource_id=document.resource_id,
+                        native_revision_id=resource["revision_id"],
+                        run_id=run.run_id,
+                        conn=conn,
+                    )
+                    if head_mapping is None or head_mapping.resolution != "native":
+                        raise ReconcileIntegrityError(
+                            "native Head has no completed native legacy binding",
+                            code="native_revision_reconcile_stale_head",
+                        )
+                    if head_mapping.path_at_revision != resource["path"]:
+                        raise ReconcileIntegrityError(
+                            "native Head path disagrees with its legacy binding",
+                            code="native_revision_reconcile_stale_path",
+                        )
+
+                    current_mapping = await self.repository.exact_mapping_for_reconcile(
+                        namespace_id=inventory.namespace_id,
+                        resource_id=document.resource_id,
+                        legacy_git_oid=document.current_commit,
+                        run_id=run.run_id,
+                        conn=conn,
+                    )
+                    if current_mapping is not None:
+                        if (
+                            current_mapping.resolution != "native"
+                            or current_mapping.native_revision_id != resource["revision_id"]
+                        ):
+                            raise ReconcileIntegrityError(
+                                "final legacy OID is already bound to a different native state",
+                                code="native_revision_reconcile_divergent_lineage",
+                            )
+                        self._verify_current(document, resource, head_mapping)
+                        unchanged.append(document)
+                        continue
+
+                    if document.current_commit == head_mapping.legacy_git_oid:
+                        self._verify_current(document, resource, head_mapping)
+                        unchanged.append(document)
+                        continue
+
+                    change = self._validate_change(
+                        inventory=inventory,
+                        document=document,
+                        resource=resource,
+                        head_mapping=head_mapping,
+                        mappings=mappings,
+                    )
+                    destination = await self.native_repository.find_live_path(
+                        conn,
+                        inventory.namespace_id,
+                        "document",
+                        document.current_path,
+                    )
+                    if destination is not None and destination["resource_id"] != document.resource_id:
+                        raise ReconcileIntegrityError(
+                            f"native destination path is already owned: {document.current_path}",
+                            code="native_revision_reconcile_path_collision",
+                        )
+                    destination_alias = await self.native_repository.find_live_alias(
+                        conn,
+                        namespace_id=inventory.namespace_id,
+                        surface="document",
+                        old_path=document.current_path,
+                    )
+                    if destination_alias is not None and destination_alias["resource_id"] != document.resource_id:
+                        raise ReconcileIntegrityError(
+                            f"native destination alias is already owned: {document.current_path}",
+                            code="native_revision_reconcile_path_collision",
+                        )
+                    pending.append(change)
+        return pending, unchanged
+
+    @staticmethod
+    def _verify_current(
+        document: LegacyInventoryDocument,
+        resource: dict,
+        head_mapping: LegacyRevisionMapping,
+    ) -> None:
+        if (
+            resource["path"] != document.current_path
+            or head_mapping.path_at_revision != document.current_path
+            or resource.get("digest") != document.body_digest
+            or resource.get("byte_size") != document.byte_size
+            or head_mapping.legacy_git_oid != document.current_commit
+        ):
+            raise ReconcileIntegrityError(
+                "legacy current head disagrees with native head facts",
+                code="native_revision_reconcile_stale_head",
+            )
+
+    @classmethod
+    def _validate_change(
+        cls,
+        *,
+        inventory: LegacyInventory,
+        document: LegacyInventoryDocument,
+        resource: dict,
+        head_mapping: LegacyRevisionMapping,
+        mappings: list[LegacyRevisionMapping],
+    ) -> _PendingChange:
+        if document.activity.action not in {"update", "move"}:
+            raise ReconcileIntegrityError(
+                "final legacy activity is not an update or move",
+                code="native_revision_reconcile_unsupported_activity",
+            )
+        if not document.lineage or document.lineage[-1].legacy_git_oid != document.current_commit:
+            raise ReconcileIntegrityError(
+                "final legacy lineage does not end at current_commit",
+                code="native_revision_reconcile_divergent_lineage",
+            )
+        base_index = next(
+            (
+                index
+                for index, entry in enumerate(document.lineage)
+                if entry.legacy_git_oid == head_mapping.legacy_git_oid
+            ),
+            None,
+        )
+        if base_index is None or base_index >= len(document.lineage) - 1:
+            raise ReconcileIntegrityError(
+                "final fixed-ref lineage has no new suffix",
+                code="native_revision_reconcile_divergent_lineage",
+            )
+
+        by_oid = {mapping.legacy_git_oid: mapping for mapping in mappings}
+        for index, entry in enumerate(document.lineage[: base_index + 1]):
+            mapping = by_oid.get(entry.legacy_git_oid)
+            if (
+                mapping is None
+                or mapping.path_at_revision != entry.path_at_revision
+                or mapping.lineage_ordinal != index
+            ):
+                raise ReconcileIntegrityError(
+                    "final fixed-ref lineage diverges from completed mappings",
+                    code="native_revision_reconcile_divergent_lineage",
+                )
+        if (
+            head_mapping.lineage_ordinal != base_index
+            or head_mapping.native_revision_id != resource["revision_id"]
+        ):
+            raise ReconcileIntegrityError(
+                "native Head binding is stale for the final fixed ref",
+                code="native_revision_reconcile_stale_head",
+            )
+
+        for entry in document.lineage[base_index + 1 :]:
+            existing = by_oid.get(entry.legacy_git_oid)
+            if existing is None:
+                continue
+            is_final = entry.legacy_git_oid == document.current_commit
+            if (
+                existing.path_at_revision != entry.path_at_revision
+                or (is_final and existing.resolution != "native")
+                or (not is_final and existing.resolution != "bridge")
+                or (is_final and existing.native_revision_id is None)
+                or (not is_final and existing.native_revision_id is not None)
+            ):
+                raise ReconcileIntegrityError(
+                    "new fixed-ref suffix conflicts with an immutable mapping",
+                    code="native_revision_reconcile_divergent_lineage",
+                )
+
+        old_path = resource["path"]
+        if document.activity.action == "update":
+            if (
+                document.current_path != old_path
+                or document.activity.path_from is not None
+                or document.activity.path_to != document.current_path
+            ):
+                raise ReconcileIntegrityError(
+                    "update final ref does not preserve the native path",
+                    code="native_revision_reconcile_divergent_lineage",
+                )
+            return _PendingChange(
+                document=document,
+                action="replace",
+                parent_revision_id=resource["revision_id"],
+                path_from=old_path,
+            )
+
+        if (
+            document.current_path == old_path
+            or document.activity.path_from != old_path
+            or document.activity.path_to != document.current_path
+        ):
+            raise ReconcileIntegrityError(
+                "move final ref does not match the native current path",
+                code="native_revision_reconcile_divergent_lineage",
+            )
+        return _PendingChange(
+            document=document,
+            action="move",
+            parent_revision_id=resource["revision_id"],
+            path_from=old_path,
+        )
+
+    async def _publish_item(
+        self,
+        *,
+        run: MigrationRun,
+        change: _PendingChange,
+        inventory: LegacyInventory,
+        prepared,
+    ) -> ReconcileItemResult:
+        del inventory
+        document = change.document
+        fingerprint = self._fingerprint(
+            run=run,
+            document=document,
+            action=change.action,
+            parent_revision_id=change.parent_revision_id,
+            path_from=change.path_from,
+        )
+        mutation_id = self._uuid(run.run_id, document.resource_id, "mutation")
+        manifest_id = self._uuid(run.run_id, document.resource_id, "manifest")
+        activity_id = self._uuid(run.run_id, document.resource_id, "activity")
+        intent_id = self._uuid(run.run_id, document.resource_id, "invalidation")
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                item = await self.repository.get_item(
+                    run.run_id,
+                    document.resource_id,
+                    conn=conn,
+                    for_update=True,
+                )
+                if item is None:
+                    raise ReconcileIntegrityError("reconcile item disappeared during publication")
+                if item.status == "complete":
+                    return ReconcileItemResult(
+                        resource_id=document.resource_id,
+                        action=change.action,
+                        legacy_head_oid=document.current_commit,
+                        revision_id=item.native_head_revision_id,
+                        parent_revision_id=change.parent_revision_id,
+                    )
+
+                await self.native_repository.lock_mutation(conn, run.namespace_id, mutation_id)
+                prior = await self.native_repository.find_mutation(
+                    conn,
+                    run.namespace_id,
+                    mutation_id,
+                )
+                if prior is not None:
+                    if prior["request_fingerprint"] != fingerprint:
+                        raise ReconcileIntegrityError(
+                            "reconcile mutation ID was reused with different input",
+                            code="native_revision_reconcile_fingerprint_conflict",
+                        )
+                    await self.repository.mark_item_complete(
+                        conn,
+                        run_id=run.run_id,
+                        legacy_document_id=document.resource_id,
+                        native_head_revision_id=prior["revision_id"],
+                    )
+                    return ReconcileItemResult(
+                        resource_id=document.resource_id,
+                        action=prior["action"],
+                        legacy_head_oid=document.current_commit,
+                        revision_id=prior["revision_id"],
+                        parent_revision_id=prior["parent_revision_id"],
+                    )
+
+                resource = await self.native_repository.lock_resource(conn, document.resource_id)
+                if resource is None or resource["namespace_id"] != run.namespace_id:
+                    raise ReconcileIntegrityError(
+                        "native Resource disappeared during publication",
+                        code="native_revision_reconcile_missing_resource",
+                    )
+                if resource["lifecycle"] != "live":
+                    raise ReconcileIntegrityError(
+                        "native Resource is not live during publication",
+                        code="native_revision_reconcile_stale_head",
+                    )
+                if (
+                    resource["head_revision_id"] != change.parent_revision_id
+                    or resource["current_path"] != change.path_from
+                ):
+                    raise ReconcileIntegrityError(
+                        "native Head changed after final-ref classification",
+                        code="native_revision_reconcile_stale_head",
+                    )
+                await self.native_repository.lock_paths(
+                    conn,
+                    run.namespace_id,
+                    "document",
+                    change.path_from,
+                    document.current_path,
+                )
+                destination = await self.native_repository.find_live_path(
+                    conn,
+                    run.namespace_id,
+                    "document",
+                    document.current_path,
+                )
+                if destination is not None and destination["resource_id"] != document.resource_id:
+                    raise ReconcileIntegrityError(
+                        f"native destination path is already owned: {document.current_path}",
+                        code="native_revision_reconcile_path_collision",
+                    )
+                destination_alias = await self.native_repository.find_live_alias(
+                    conn,
+                    namespace_id=run.namespace_id,
+                    surface="document",
+                    old_path=document.current_path,
+                )
+                if destination_alias is not None and destination_alias["resource_id"] != document.resource_id:
+                    raise ReconcileIntegrityError(
+                        f"native destination alias is already owned: {document.current_path}",
+                        code="native_revision_reconcile_path_collision",
+                    )
+
+                retained_oids = {entry.legacy_git_oid for entry in document.lineage}
+                revision_id = await self.repository.allocate_native_revision_id(
+                    conn,
+                    resource_id=document.resource_id,
+                    retained_legacy_oids=retained_oids,
+                    revision_id_factory=self.revision_id_factory,
+                )
+                occurred_at = document.lineage[-1].committed_at.astimezone(UTC)
+                activity = document.activity
+                await self.native_repository.insert_manifest(
+                    conn,
+                    payload_manifest_id=manifest_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    payload=prepared,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_manifest")
+                await self.native_repository.insert_revision(
+                    conn,
+                    revision_id=revision_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    parent_revision_id=change.parent_revision_id,
+                    action=change.action,
+                    path=document.current_path,
+                    path_from=change.path_from if change.action == "move" else None,
+                    path_to=document.current_path if change.action == "move" else None,
+                    payload_manifest_id=manifest_id,
+                    mutation_id=mutation_id,
+                    request_fingerprint=fingerprint,
+                    message="C9 fixed-ref native reconcile",
+                    subject=activity.subject,
+                    summary=activity.summary,
+                    actor=activity.actor,
+                    occurred_at=occurred_at,
+                    activity_event_id=activity_id,
+                    invalidation_intent_id=intent_id,
+                )
+                await self._hit("authority.after_revision")
+                await self.native_repository.set_head(
+                    conn,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    path=document.current_path,
+                    lifecycle="live",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_head")
+                if destination_alias is not None:
+                    await self.native_repository.retire_live_alias(
+                        conn,
+                        namespace_id=run.namespace_id,
+                        surface="document",
+                        old_path=document.current_path,
+                        retired_revision_id=revision_id,
+                        occurred_at=occurred_at,
+                    )
+                if change.action == "move":
+                    await self.native_repository.insert_path_alias(
+                        conn,
+                        namespace_id=run.namespace_id,
+                        surface="document",
+                        old_path=change.path_from,
+                        resource_id=document.resource_id,
+                        created_revision_id=revision_id,
+                        occurred_at=occurred_at,
+                    )
+                await self._hit("authority.after_alias")
+                await self.native_repository.insert_activity(
+                    conn,
+                    activity_event_id=activity_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    action=change.action,
+                    actor=activity.actor,
+                    subject=activity.subject,
+                    summary=activity.summary,
+                    path_from=change.path_from if change.action == "move" else None,
+                    path_to=document.current_path if change.action == "move" else None,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_activity")
+                await self.native_repository.insert_invalidation_intent(
+                    conn,
+                    intent_id=intent_id,
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    revision_id=revision_id,
+                    reason=change.action,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_invalidation")
+
+                mappings = await self.repository.list_resource_mappings_for_reconcile(
+                    namespace_id=run.namespace_id,
+                    resource_id=document.resource_id,
+                    run_id=run.run_id,
+                    conn=conn,
+                )
+                mapped_oids = {mapping.legacy_git_oid for mapping in mappings}
+                base_mapping = next(
+                    mapping
+                    for mapping in mappings
+                    if mapping.native_revision_id == change.parent_revision_id
+                )
+                base_index = next(
+                    index
+                    for index, entry in enumerate(document.lineage)
+                    if entry.legacy_git_oid == base_mapping.legacy_git_oid
+                )
+                for ordinal, entry in enumerate(document.lineage[base_index + 1 :], start=base_index + 1):
+                    if entry.legacy_git_oid in mapped_oids:
+                        continue
+                    await self.repository.ensure_cross_run_mapping(
+                        conn,
+                        namespace_id=run.namespace_id,
+                        resource_id=document.resource_id,
+                        legacy_git_oid=entry.legacy_git_oid,
+                        path_at_revision=entry.path_at_revision,
+                        resolution=("native" if entry.legacy_git_oid == document.current_commit else "bridge"),
+                        native_revision_id=(revision_id if entry.legacy_git_oid == document.current_commit else None),
+                        run_id=run.run_id,
+                        lineage_ordinal=ordinal,
+                    )
+                await self._hit("authority.after_mapping")
+                await self.repository.mark_item_complete(
+                    conn,
+                    run_id=run.run_id,
+                    legacy_document_id=document.resource_id,
+                    native_head_revision_id=revision_id,
+                )
+                await self._hit("authority.before_commit")
+        return ReconcileItemResult(
+            resource_id=document.resource_id,
+            action=change.action,
+            legacy_head_oid=document.current_commit,
+            revision_id=revision_id,
+            parent_revision_id=change.parent_revision_id,
+        )
+
+
+NativeRevisionReconciler = NativeRevisionReconcile

--- a/backend/app/services/native_revision_reconcile.py
+++ b/backend/app/services/native_revision_reconcile.py
@@ -275,12 +275,16 @@ class NativeRevisionReconcile:
                         )
                     )
                     continue
-                prepared = await self.body_store.prepare_text(
-                    namespace_id=run.namespace_id,
-                    payload=change.document.body,
-                    expected_digest=change.document.body_digest,
-                    expected_size=change.document.byte_size,
-                )
+                async with self.bridge.materialize_body(
+                    inventory,
+                    change.document,
+                ) as body:
+                    prepared = await self.body_store.prepare_text(
+                        namespace_id=run.namespace_id,
+                        payload=body,
+                        expected_digest=change.document.body_digest,
+                        expected_size=change.document.byte_size,
+                    )
                 await self._hit("payload.after_prepare_before_tx")
                 result = await self._publish_item(
                     run=run,

--- a/backend/app/services/native_revision_reconcile.py
+++ b/backend/app/services/native_revision_reconcile.py
@@ -200,11 +200,12 @@ class NativeRevisionReconcile:
         """Capture a final fixed ref and publish only changed Resources."""
 
         coverage = coverage_version or self.coverage_version
-        inventory = await self.bridge.capture_inventory(
+        scope = await self.bridge.capture_inventory_scope(
             namespace_id=namespace_id,
             fixed_ref=fixed_ref,
             coverage_version=coverage,
         )
+        inventory = scope.inventory
         await self._assert_inventory_covers_completed_resources(inventory)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
@@ -276,7 +277,7 @@ class NativeRevisionReconcile:
                     )
                     continue
                 async with self.bridge.materialize_body(
-                    inventory,
+                    scope,
                     change.document,
                 ) as body:
                     prepared = await self.body_store.prepare_text(

--- a/backend/app/services/native_revision_reconcile.py
+++ b/backend/app/services/native_revision_reconcile.py
@@ -524,17 +524,31 @@ class NativeRevisionReconcile:
                 "final legacy lineage does not end at current_commit",
                 code="native_revision_reconcile_divergent_lineage",
             )
-        base_index = next(
-            (
-                index
-                for index, entry in enumerate(document.lineage)
-                if entry.legacy_git_oid == head_mapping.legacy_git_oid
-            ),
-            None,
-        )
-        if base_index is None or base_index >= len(document.lineage) - 1:
+        lineage_oids = [entry.legacy_git_oid for entry in document.lineage]
+        if len(set(lineage_oids)) != len(lineage_oids):
+            raise ReconcileIntegrityError(
+                "final fixed-ref lineage contains an ambiguous legacy OID",
+                code="native_revision_reconcile_divergent_lineage",
+            )
+        base_indexes = [
+            index
+            for index, entry in enumerate(document.lineage)
+            if entry.legacy_git_oid == head_mapping.legacy_git_oid
+        ]
+        if len(base_indexes) != 1 or base_indexes[0] >= len(document.lineage) - 1:
             raise ReconcileIntegrityError(
                 "final fixed-ref lineage has no new suffix",
+                code="native_revision_reconcile_divergent_lineage",
+            )
+        base_index = base_indexes[0]
+        suffix = document.lineage[base_index:]
+        if (
+            any(not entry.path_at_revision for entry in suffix)
+            or suffix[0].path_at_revision != resource["path"]
+            or suffix[-1].path_at_revision != document.current_path
+        ):
+            raise ReconcileIntegrityError(
+                "final fixed-ref suffix has missing or divergent path lineage",
                 code="native_revision_reconcile_divergent_lineage",
             )
 
@@ -576,36 +590,45 @@ class NativeRevisionReconcile:
                     code="native_revision_reconcile_divergent_lineage",
                 )
 
-        old_path = resource["path"]
+        # Terminal activity describes only the final OID.  Validate it against
+        # that local edge, then classify the aggregate transition across the
+        # complete suffix from the native base to the frozen final state.
+        previous_path = suffix[-2].path_at_revision
+        if document.activity.path_to != document.current_path:
+            raise ReconcileIntegrityError(
+                "final legacy activity disagrees with the lineage destination",
+                code="native_revision_reconcile_divergent_lineage",
+            )
         if document.activity.action == "update":
-            if (
-                document.current_path != old_path
-                or document.activity.path_from is not None
-                or document.activity.path_to != document.current_path
-            ):
-                raise ReconcileIntegrityError(
-                    "update final ref does not preserve the native path",
-                    code="native_revision_reconcile_divergent_lineage",
-                )
-            return _PendingChange(
-                document=document,
-                action="replace",
-                parent_revision_id=resource["revision_id"],
-                path_from=old_path,
+            terminal_edge_is_valid = (
+                document.activity.path_from is None
+                and previous_path == document.current_path
+            )
+        else:
+            terminal_edge_is_valid = (
+                document.activity.path_from == previous_path
+                and previous_path != document.current_path
+            )
+        if not terminal_edge_is_valid:
+            raise ReconcileIntegrityError(
+                "final legacy activity disagrees with the terminal lineage edge",
+                code="native_revision_reconcile_divergent_lineage",
             )
 
-        if (
-            document.current_path == old_path
-            or document.activity.path_from != old_path
-            or document.activity.path_to != document.current_path
-        ):
+        old_path = resource["path"]
+        path_changed = document.current_path != old_path
+        body_changed = (
+            resource.get("digest") != document.body_digest
+            or resource.get("byte_size") != document.byte_size
+        )
+        if not path_changed and not body_changed:
             raise ReconcileIntegrityError(
-                "move final ref does not match the native current path",
+                "final fixed-ref suffix has no aggregate body or path change",
                 code="native_revision_reconcile_divergent_lineage",
             )
         return _PendingChange(
             document=document,
-            action="move",
+            action="move" if path_changed else "replace",
             parent_revision_id=resource["revision_id"],
             path_from=old_path,
         )

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -24,6 +24,11 @@ from app.services.legacy_revision_bridge import (
     LegacyInventory,
     LegacyInventoryDocument,
 )
+from app.services.native_revision_shadow_reader import (
+    LegacyFixedRefShadowReader,
+    NativeRevisionShadowReader,
+    ShadowReaderScopeError,
+)
 
 
 _OID_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -43,6 +48,24 @@ _PATH_TO_RULE = {
     "activity:$.events[0].author.display": "BR-06",
     "history:$.lineage_boundary": "BR-07",
 }
+_RULE_CLASSIFICATION = {
+    "BR-01": "revision_token",
+    "BR-02": "history_source",
+    "BR-03": "diff_basis",
+    "BR-04": "projection_revision",
+    "BR-05": "formatting_only",
+    "BR-06": "activity_display",
+    "BR-07": "lineage_boundary",
+}
+__all__ = (
+    "LegacyFixedRefShadowReader",
+    "NativeRevisionShadowReader",
+    "NativeRevisionShadowComparator",
+    "NativeRevisionShadowService",
+    "ShadowComparisonError",
+    "ShadowReaderScopeError",
+    "ShadowRunIncompleteError",
+)
 
 
 class ShadowComparisonError(ConflictError):
@@ -108,7 +131,7 @@ class ShadowReader(Protocol):
 class NativeRevisionShadowComparator:
     """Compare legacy and candidate reads without opening a write path."""
 
-    protocol_version = "akb-native-revision-p2-w1-c10/v1"
+    protocol_version = "akb-native-revision-p2-w1-c10/v2"
 
     def __init__(
         self,
@@ -157,7 +180,7 @@ class NativeRevisionShadowComparator:
             )
 
         receipt: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "protocol_version": self.protocol_version,
             "status": "passed",
             "passed": True,
@@ -170,11 +193,11 @@ class NativeRevisionShadowComparator:
                 "claim_scope": "semantic_candidate_evidence",
                 "write_authority": "legacy_only",
                 "comparison_ref": "one completed C9 fixed_ref",
-                "final_coverage_gate": "Migration E current-head/retained/eager inventory before final P2 coverage selection or P2 exit",
+                "final_coverage_gate": "P2 L1-L6 product-backed evidence before final coverage selection",
                 "p3_fence_cutover_out_of_scope": True,
             },
             "run": {
-                "run_id": str(self._value(run, "run_id")),
+                "run_key": self._public_key(self._value(run, "run_id"), "run"),
                 "status": "complete",
                 "fixed_ref": self._value(run, "fixed_git_oid"),
                 "inventory_digest": self._value(run, "inventory_digest"),
@@ -188,6 +211,8 @@ class NativeRevisionShadowComparator:
                     for resource in resources
                     for operation in resource["operations"].values()
                 ),
+                "unexplained_mismatch_count": 0,
+                "classified_mismatches": self._classified_mismatches(resources),
                 "used_rules": sorted(
                     {
                         mismatch["rule_id"]
@@ -215,7 +240,7 @@ class NativeRevisionShadowComparator:
         del inventory
         operations: dict[str, Any] = {}
         for operation in _OPERATIONS:
-            selector = document.current_commit if operation != "history" else document.current_commit
+            selector = document.current_commit
             legacy = await self._read(
                 self.legacy_reader,
                 operation,
@@ -239,7 +264,7 @@ class NativeRevisionShadowComparator:
                     document,
                     native_revision_id,
                 )
-            normalized_legacy, normalized_candidate, mismatches = self._compare_operation(
+            _, _, mismatches = self._compare_operation(
                 operation,
                 legacy,
                 candidate,
@@ -247,21 +272,13 @@ class NativeRevisionShadowComparator:
                 native_revision_id,
             )
             operations[operation] = {
-                "legacy": legacy,
-                "raw_candidate": raw_candidate,
-                "candidate": candidate,
-                "normalized": {
-                    "legacy": normalized_legacy,
-                    "candidate": normalized_candidate,
-                },
                 "mismatches": mismatches,
                 "normalized_equal": True,
+                "mismatch_count": len(mismatches),
+                "mismatch_classes": sorted({mismatch["classification"] for mismatch in mismatches}),
             }
         return {
-            "resource_id": str(document.resource_id),
-            "path": document.current_path,
-            "legacy_head_oid": document.current_commit,
-            "native_revision_id": native_revision_id,
+            "resource_key": self._public_key(document.resource_id, "resource"),
             "operations": operations,
         }
 
@@ -402,7 +419,11 @@ class NativeRevisionShadowComparator:
             cls._set_path(normalized_legacy, path, normalized_left)
             cls._set_path(normalized_candidate, path, normalized_right)
             mismatches.append(
-                {"path": path, "legacy": left, "candidate": right, "rule_id": rule_id}
+                {
+                    "path": path,
+                    "rule_id": rule_id,
+                    "classification": _RULE_CLASSIFICATION[rule_id],
+                }
             )
         if normalized_legacy != normalized_candidate:
             raise ShadowComparisonError(f"unapproved mismatch at {operation}: normalized envelopes differ")
@@ -560,6 +581,30 @@ class NativeRevisionShadowComparator:
         if not document.lineage:
             raise ShadowComparisonError("inventory document has no lineage boundary")
         return document.lineage[0].legacy_git_oid
+
+    @staticmethod
+    def _public_key(value: Any, prefix: str) -> str:
+        """Return a stable receipt key without retaining a raw UUID."""
+        digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
+        return f"{prefix}-{digest}"
+
+    @staticmethod
+    def _classified_mismatches(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        counts: dict[tuple[str, str, str], int] = {}
+        for resource in resources:
+            for operation, result in resource["operations"].items():
+                for mismatch in result["mismatches"]:
+                    key = (operation, mismatch["rule_id"], mismatch["classification"])
+                    counts[key] = counts.get(key, 0) + 1
+        return [
+            {
+                "operation": operation,
+                "rule_id": rule_id,
+                "classification": classification,
+                "count": count,
+            }
+            for (operation, rule_id, classification), count in sorted(counts.items())
+        ]
 
     @staticmethod
     def _value(value: Any, name: str) -> Any:

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -693,28 +693,45 @@ class NativeRevisionShadowComparator:
             raise ShadowComparisonError(
                 "evidence binding is missing an audited native activity fact"
             )
-        preimage = {
-            "comparison_run": run_facts,
-            "mapping_owner_scope": mappings,
+        comparison_run_commitment = cls._domain_digest(
+            f"{_EVIDENCE_BINDING_DOMAIN}/comparison-run",
+            run_facts,
+        )
+        mapping_commitments = sorted(
+            cls._domain_digest(
+                f"{_EVIDENCE_BINDING_DOMAIN}/mapping-owner-activity",
+                fact,
+            )
+            for fact in mappings
+        )
+        redacted_preimage = {
+            "comparison_run": comparison_run_commitment,
+            "mapping_owner_activity": mapping_commitments,
         }
-        canonical = json.dumps(
-            preimage,
-            ensure_ascii=False,
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode("utf-8")
-        commitment = hashlib.sha256(
-            _EVIDENCE_BINDING_DOMAIN.encode("utf-8") + b"\0" + canonical
-        ).hexdigest()
+        commitment = cls._domain_digest(
+            _EVIDENCE_BINDING_DOMAIN,
+            redacted_preimage,
+        )
         owner_run_ids = {fact["owner_run"]["run_id"] for fact in mappings}
         return {
             "scheme": "sha256",
             "canonicalization": _EVIDENCE_BINDING_CANONICALIZATION,
             "domain": _EVIDENCE_BINDING_DOMAIN,
             "commitment": commitment,
+            "components": redacted_preimage,
             "mapping_count": len(mappings),
             "owner_run_count": len(owner_run_ids),
         }
+
+    @staticmethod
+    def _domain_digest(domain: str, value: Any) -> str:
+        canonical = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(domain.encode("utf-8") + b"\0" + canonical).hexdigest()
 
     @classmethod
     def _validate_inventory_binding(cls, run: MigrationRun, inventory: LegacyInventory) -> None:

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -101,6 +101,13 @@ class MigrationReadRepository(Protocol):
         legacy_git_oid: str,
     ) -> LegacyRevisionMapping | None: ...
 
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+    ) -> list[LegacyRevisionMapping]: ...
+
 
 class _NativeBinding:
     __slots__ = ("fixed_ref", "native_revision_id", "evidence_fact")
@@ -297,6 +304,7 @@ class NativeRevisionShadowComparator:
                     document,
                     selector=native_revision_id,
                     fixed_ref=binding.fixed_ref,
+                    binding=binding,
                 )
                 binding.evidence_fact["activity_audit"] = activity_binding_fact
                 candidate = self._project_candidate_activity(
@@ -341,30 +349,254 @@ class NativeRevisionShadowComparator:
         *,
         selector: str,
         fixed_ref: str,
+        binding: _NativeBinding,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         reader = getattr(self.candidate_reader, "activity_evidence", None)
         if reader is None:
-            raise ShadowComparisonError(
-                "candidate reader cannot prove the raw native activity audit"
-            )
+            raise ShadowComparisonError("candidate reader cannot prove the raw native activity audit")
         value = reader(document, selector=selector, fixed_ref=fixed_ref)
         if inspect.isawaitable(value):
             value = await value
         if not isinstance(value, NativeActivityEvidence):
-            raise ShadowComparisonError(
-                "candidate reader returned an invalid raw native activity audit"
-            )
+            raise ShadowComparisonError("candidate reader returned an invalid raw native activity audit")
         envelope = self._jsonable(value.envelope)
         binding_fact = self._jsonable(value.binding_fact)
         if not isinstance(envelope, dict) or not isinstance(binding_fact, dict):
-            raise ShadowComparisonError(
-                "candidate raw native activity audit is not an object"
-            )
+            raise ShadowComparisonError("candidate raw native activity audit is not an object")
         if binding_fact.get("profile") != _ACTIVITY_AUDIT_PROFILE:
-            raise ShadowComparisonError(
-                "candidate raw native activity audit profile is invalid"
+            raise ShadowComparisonError("candidate raw native activity audit profile is invalid")
+        validated = self._validate_activity_evidence(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+            envelope=envelope,
+            binding_fact=binding_fact,
+            mapping_fact=binding.evidence_fact,
+        )
+        return envelope, validated
+
+    @classmethod
+    def _validate_activity_evidence(
+        cls,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+        envelope: dict[str, Any],
+        binding_fact: dict[str, Any],
+        mapping_fact: dict[str, Any],
+    ) -> dict[str, Any]:
+        mapping_keys = {
+            "namespace_id",
+            "resource_id",
+            "legacy_git_oid",
+            "path_at_revision",
+            "resolution",
+            "native_revision_id",
+            "fixed_git_oid",
+            "run_id",
+        }
+        selected_keys = {
+            "namespace_id",
+            "resource_id",
+            "revision_id",
+            "parent_revision_id",
+            "surface",
+            "action",
+            "path_at_revision",
+            "path_from",
+            "path_to",
+            "actor",
+            "subject",
+            "summary",
+            "occurred_at",
+            "digest",
+            "byte_size",
+        }
+        activity_keys = {
+            "namespace_id",
+            "resource_id",
+            "revision_id",
+            "surface",
+            "action",
+            "path_at_revision",
+            "path_from",
+            "path_to",
+            "actor",
+            "subject",
+            "summary",
+            "occurred_at",
+        }
+        if set(binding_fact) != {
+            "profile",
+            "selector",
+            "fixed_ref",
+            "current_mapping",
+            "selected_revision",
+            "activity",
+            "completed_parent_mapping",
+        }:
+            raise ShadowComparisonError("candidate raw native activity audit schema is incomplete")
+        selected = binding_fact.get("selected_revision")
+        activity = binding_fact.get("activity")
+        current_mapping = binding_fact.get("current_mapping")
+        parent_mapping = binding_fact.get("completed_parent_mapping")
+        if (
+            not isinstance(selected, dict)
+            or set(selected) != selected_keys
+            or not isinstance(activity, dict)
+            or set(activity) != activity_keys
+            or not isinstance(current_mapping, dict)
+            or set(current_mapping) != mapping_keys
+            or (
+                parent_mapping is not None
+                and (not isinstance(parent_mapping, dict) or set(parent_mapping) != mapping_keys)
             )
-        return envelope, binding_fact
+        ):
+            raise ShadowComparisonError("candidate raw native activity audit schema is incomplete")
+
+        namespace_id = mapping_fact["namespace_id"]
+        resource_id = mapping_fact["resource_id"]
+        expected_current_mapping = {
+            "namespace_id": namespace_id,
+            "resource_id": resource_id,
+            "legacy_git_oid": mapping_fact["legacy_head_oid"],
+            "path_at_revision": mapping_fact["path_at_revision"],
+            "resolution": mapping_fact["resolution"],
+            "native_revision_id": mapping_fact["native_revision_id"],
+            "fixed_git_oid": mapping_fact["owner_run"]["fixed_git_oid"],
+            "run_id": mapping_fact["owner_run"]["run_id"],
+        }
+        all_mappings = [
+            *mapping_fact["retained_mappings"],
+            {
+                "namespace_id": namespace_id,
+                "resource_id": resource_id,
+                "legacy_git_oid": mapping_fact["legacy_head_oid"],
+                "path_at_revision": mapping_fact["path_at_revision"],
+                "resolution": mapping_fact["resolution"],
+                "native_revision_id": mapping_fact["native_revision_id"],
+                "lineage_ordinal": mapping_fact["lineage_ordinal"],
+                "owner_run": mapping_fact["owner_run"],
+                "owner_item": mapping_fact["owner_item"],
+            },
+        ]
+        native_mappings = sorted(
+            (mapping for mapping in all_mappings if mapping["resolution"] == "native"),
+            key=lambda mapping: mapping["lineage_ordinal"],
+        )
+        if (
+            not native_mappings
+            or native_mappings[-1]["native_revision_id"] != selector
+            or native_mappings[-1]["legacy_git_oid"] != document.current_commit
+        ):
+            raise ShadowComparisonError("candidate raw native activity audit is not bound to the current mapping")
+        expected_native_parent_bindings: list[dict[str, Any]] = []
+        prior_native: dict[str, Any] | None = None
+        for native_mapping in native_mappings:
+            expected_native_parent_bindings.append(
+                {
+                    "resource_id": resource_id,
+                    "lineage_ordinal": native_mapping["lineage_ordinal"],
+                    "revision_id": native_mapping["native_revision_id"],
+                    "parent_revision_id": (None if prior_native is None else prior_native["native_revision_id"]),
+                    "current_mapping": cls._mapping_binding_view(native_mapping),
+                    "completed_parent_mapping": (
+                        None if prior_native is None else cls._mapping_binding_view(prior_native)
+                    ),
+                }
+            )
+            prior_native = native_mapping
+        if mapping_fact["native_parent_bindings"] != expected_native_parent_bindings:
+            raise ShadowComparisonError("native parent binding closure differs from completed mappings")
+        expected_parent_private = native_mappings[-2] if len(native_mappings) > 1 else None
+        expected_parent_mapping = (
+            None
+            if expected_parent_private is None
+            else {
+                "namespace_id": expected_parent_private["namespace_id"],
+                "resource_id": expected_parent_private["resource_id"],
+                "legacy_git_oid": expected_parent_private["legacy_git_oid"],
+                "path_at_revision": expected_parent_private["path_at_revision"],
+                "resolution": "native",
+                "native_revision_id": expected_parent_private["native_revision_id"],
+                "fixed_git_oid": expected_parent_private["owner_run"]["fixed_git_oid"],
+                "run_id": expected_parent_private["owner_run"]["run_id"],
+            }
+        )
+        expected_parent_id = None if expected_parent_private is None else expected_parent_private["native_revision_id"]
+        expected_path_to: str | None
+        if expected_parent_mapping is None:
+            expected_action = "create"
+            expected_actor = "akb-native-revision-migration"
+            expected_subject = None
+            expected_summary = None
+            expected_path_from = None
+            expected_path_to = document.current_path
+        else:
+            parent_path = expected_parent_mapping["path_at_revision"]
+            expected_action = "move" if parent_path != document.current_path else "replace"
+            expected_actor = document.activity.actor
+            expected_subject = document.activity.subject
+            expected_summary = document.activity.summary
+            expected_path_from = parent_path if expected_action == "move" else None
+            expected_path_to = document.current_path if expected_action == "move" else None
+        occurred_at = document.lineage[-1].committed_at.isoformat()
+        expected_selected = {
+            "namespace_id": namespace_id,
+            "resource_id": resource_id,
+            "revision_id": selector,
+            "parent_revision_id": expected_parent_id,
+            "surface": "document",
+            "action": expected_action,
+            "path_at_revision": document.current_path,
+            "path_from": expected_path_from,
+            "path_to": expected_path_to,
+            "actor": expected_actor,
+            "subject": expected_subject,
+            "summary": expected_summary,
+            "occurred_at": occurred_at,
+            "digest": document.body_digest,
+            "byte_size": document.byte_size,
+        }
+        expected_activity = {
+            "namespace_id": namespace_id,
+            "resource_id": resource_id,
+            "revision_id": selector,
+            "surface": "document",
+            "action": expected_action,
+            "path_at_revision": document.current_path,
+            "path_from": expected_path_from,
+            "path_to": expected_path_to,
+            "actor": expected_actor,
+            "subject": expected_subject,
+            "summary": expected_summary,
+            "occurred_at": occurred_at,
+        }
+        expected_binding = {
+            "profile": _ACTIVITY_AUDIT_PROFILE,
+            "selector": selector,
+            "fixed_ref": fixed_ref,
+            "current_mapping": expected_current_mapping,
+            "selected_revision": expected_selected,
+            "activity": expected_activity,
+            "completed_parent_mapping": expected_parent_mapping,
+        }
+        expected_envelope = {
+            "events": [
+                {
+                    "hash": selector,
+                    "subject": expected_subject,
+                    "author": {"id": expected_actor, "display": expected_actor},
+                    "action": expected_action,
+                    "summary": expected_summary,
+                    "projection_revision": selector,
+                }
+            ]
+        }
+        if binding_fact != expected_binding or envelope != expected_envelope:
+            raise ShadowComparisonError("candidate raw native activity audit facts are not correlated")
+        return expected_binding
 
     async def _read(
         self,
@@ -497,9 +729,7 @@ class NativeRevisionShadowComparator:
                 native_revision_id,
             )
             if normalized_left != normalized_right:
-                raise ShadowComparisonError(
-                    f"{rule_id} normalization does not establish parity at {operation}:{path}"
-                )
+                raise ShadowComparisonError(f"{rule_id} normalization does not establish parity at {operation}:{path}")
             cls._set_path(normalized_legacy, path, normalized_left)
             cls._set_path(normalized_candidate, path, normalized_right)
             mismatches.append(
@@ -565,14 +795,18 @@ class NativeRevisionShadowComparator:
                 raise ShadowComparisonError(f"unapproved mismatch at {operation}:{path}")
             result: list[tuple[str, Any, Any]] = []
             for key in sorted(left):
-                result.extend(NativeRevisionShadowComparator._leaf_diffs(left[key], right[key], operation, f"{path}.{key}"))
+                result.extend(
+                    NativeRevisionShadowComparator._leaf_diffs(left[key], right[key], operation, f"{path}.{key}")
+                )
             return result
         if isinstance(left, list) or isinstance(right, list):
             if not isinstance(left, list) or not isinstance(right, list) or len(left) != len(right):
                 raise ShadowComparisonError(f"unapproved mismatch at {operation}:{path}")
             result = []
             for index, (left_item, right_item) in enumerate(zip(left, right)):
-                result.extend(NativeRevisionShadowComparator._leaf_diffs(left_item, right_item, operation, f"{path}[{index}]"))
+                result.extend(
+                    NativeRevisionShadowComparator._leaf_diffs(left_item, right_item, operation, f"{path}[{index}]")
+                )
             return result
         return [] if left == right else [(path, left, right)]
 
@@ -619,60 +853,137 @@ class NativeRevisionShadowComparator:
         }
 
     @classmethod
+    def _owner_item_fact(
+        cls,
+        *,
+        owner_facts: dict[str, str],
+        document: LegacyInventoryDocument,
+        item: Any,
+        mappings_by_oid: dict[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            item_run = uuid.UUID(str(cls._value(item, "run_id")))
+            item_namespace = uuid.UUID(str(cls._value(item, "namespace_id")))
+            legacy_document_id = uuid.UUID(str(cls._value(item, "legacy_document_id")))
+            native_resource_id = uuid.UUID(str(cls._value(item, "native_resource_id")))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ShadowComparisonError("immutable mapping owner item has invalid UUID facts") from exc
+        captured_path = cls._value(item, "captured_path")
+        legacy_head_oid = cls._value(item, "legacy_head_oid")
+        native_head_revision_id = cls._value(item, "native_head_revision_id")
+        body_digest = cls._value(item, "body_digest")
+        byte_size = cls._value(item, "byte_size")
+        head_mapping = mappings_by_oid.get(legacy_head_oid)
+        if (
+            item_run != uuid.UUID(owner_facts["run_id"])
+            or item_namespace != uuid.UUID(owner_facts["namespace_id"])
+            or legacy_document_id != document.resource_id
+            or native_resource_id != document.resource_id
+            or not isinstance(legacy_head_oid, str)
+            or _OID_RE.fullmatch(legacy_head_oid) is None
+            or not isinstance(native_head_revision_id, str)
+            or _OID_RE.fullmatch(native_head_revision_id) is None
+            or not isinstance(captured_path, str)
+            or not captured_path.strip()
+            or not isinstance(body_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", body_digest) is None
+            or not isinstance(byte_size, int)
+            or isinstance(byte_size, bool)
+            or byte_size < 0
+            or cls._value(item, "status") != "complete"
+            or cls._value(item, "error_code") is not None
+            or head_mapping is None
+            or cls._value(head_mapping, "run_id") != item_run
+            or cls._value(head_mapping, "path_at_revision") != captured_path
+            or cls._value(head_mapping, "resolution") != "native"
+            or cls._value(head_mapping, "native_revision_id") != native_head_revision_id
+            or cls._value(head_mapping, "fixed_git_oid") != owner_facts["fixed_git_oid"]
+        ):
+            raise ShadowComparisonError("immutable mapping has no exact completed owner item")
+        if legacy_head_oid == document.current_commit and (
+            body_digest != document.body_digest or byte_size != document.byte_size
+        ):
+            raise ShadowComparisonError("current owner item differs from the comparison inventory")
+        return {
+            "run_id": str(item_run),
+            "namespace_id": str(item_namespace),
+            "legacy_document_id": str(legacy_document_id),
+            "native_resource_id": str(native_resource_id),
+            "captured_path": captured_path,
+            "legacy_head_oid": legacy_head_oid,
+            "native_head_revision_id": native_head_revision_id,
+            "body_digest": body_digest,
+            "byte_size": byte_size,
+            "status": "complete",
+            "error_code": None,
+        }
+
+    @classmethod
     def _mapping_evidence_fact(
         cls,
         *,
-        run: Any,
         document: LegacyInventoryDocument,
         mapping: Any,
         owner_facts: dict[str, str],
-        native_revision_id: str,
+        owner_item: dict[str, Any],
     ) -> dict[str, Any]:
         try:
-            run_namespace = uuid.UUID(str(cls._value(run, "namespace_id")))
             mapping_namespace = uuid.UUID(str(cls._value(mapping, "namespace_id")))
             mapping_resource = uuid.UUID(str(cls._value(mapping, "resource_id")))
             mapping_owner = uuid.UUID(str(cls._value(mapping, "run_id")))
         except (AttributeError, TypeError, ValueError) as exc:
             raise ShadowComparisonError("completed mapping has invalid UUID facts") from exc
-        legacy_head_oid = cls._value(mapping, "legacy_git_oid")
+        legacy_git_oid = cls._value(mapping, "legacy_git_oid")
         path_at_revision = cls._value(mapping, "path_at_revision")
         resolution = cls._value(mapping, "resolution")
+        native_revision_id = cls._value(mapping, "native_revision_id")
         lineage_ordinal = cls._value(mapping, "lineage_ordinal")
-        mapping_native_id = cls._value(mapping, "native_revision_id")
-        mapping_fixed_ref = cls._value(mapping, "fixed_git_oid")
+        fixed_git_oid = cls._value(mapping, "fixed_git_oid")
         if (
-            mapping_namespace != run_namespace
+            mapping_namespace != uuid.UUID(owner_facts["namespace_id"])
             or mapping_resource != document.resource_id
-            or legacy_head_oid != document.current_commit
-            or not isinstance(legacy_head_oid, str)
-            or _OID_RE.fullmatch(legacy_head_oid) is None
-            or path_at_revision != document.current_path
+            or not isinstance(legacy_git_oid, str)
+            or _OID_RE.fullmatch(legacy_git_oid) is None
             or not isinstance(path_at_revision, str)
             or not path_at_revision.strip()
-            or resolution != "native"
-            or not isinstance(mapping_native_id, str)
-            or mapping_native_id != native_revision_id
-            or _OID_RE.fullmatch(mapping_native_id) is None
+            or resolution not in {"native", "bridge"}
+            or (
+                resolution == "native"
+                and (not isinstance(native_revision_id, str) or _OID_RE.fullmatch(native_revision_id) is None)
+            )
+            or (resolution == "bridge" and native_revision_id is not None)
             or not isinstance(lineage_ordinal, int)
             or isinstance(lineage_ordinal, bool)
-            or lineage_ordinal != len(document.lineage) - 1
-            or not isinstance(mapping_fixed_ref, str)
-            or _OID_RE.fullmatch(mapping_fixed_ref) is None
+            or lineage_ordinal < 0
+            or not isinstance(fixed_git_oid, str)
+            or _OID_RE.fullmatch(fixed_git_oid) is None
             or mapping_owner != uuid.UUID(owner_facts["run_id"])
-            or mapping_fixed_ref != owner_facts["fixed_git_oid"]
+            or fixed_git_oid != owner_facts["fixed_git_oid"]
         ):
-            raise ShadowComparisonError(
-                "completed current native mapping differs from its immutable owner facts"
-            )
+            raise ShadowComparisonError("completed mapping differs from its immutable owner facts")
         return {
+            "namespace_id": str(mapping_namespace),
             "resource_id": str(mapping_resource),
-            "legacy_head_oid": legacy_head_oid,
+            "legacy_git_oid": legacy_git_oid,
             "path_at_revision": path_at_revision,
-            "native_revision_id": mapping_native_id,
-            "lineage_ordinal": lineage_ordinal,
             "resolution": resolution,
+            "native_revision_id": native_revision_id,
+            "lineage_ordinal": lineage_ordinal,
             "owner_run": owner_facts,
+            "owner_item": owner_item,
+        }
+
+    @staticmethod
+    def _mapping_binding_view(mapping: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "namespace_id": mapping["namespace_id"],
+            "resource_id": mapping["resource_id"],
+            "legacy_git_oid": mapping["legacy_git_oid"],
+            "path_at_revision": mapping["path_at_revision"],
+            "resolution": mapping["resolution"],
+            "native_revision_id": mapping["native_revision_id"],
+            "fixed_git_oid": mapping["owner_run"]["fixed_git_oid"],
+            "run_id": mapping["owner_run"]["run_id"],
         }
 
     @classmethod
@@ -690,9 +1001,23 @@ class NativeRevisionShadowComparator:
             ),
         )
         if any("activity_audit" not in fact for fact in mappings):
-            raise ShadowComparisonError(
-                "evidence binding is missing an audited native activity fact"
-            )
+            raise ShadowComparisonError("evidence binding is missing an audited native activity fact")
+        retained_mappings = sorted(
+            (copy.deepcopy(mapping) for fact in mappings for mapping in fact["retained_mappings"]),
+            key=lambda fact: (
+                fact["resource_id"],
+                fact["lineage_ordinal"],
+                fact["legacy_git_oid"],
+            ),
+        )
+        native_parent_bindings = sorted(
+            (copy.deepcopy(parent_binding) for fact in mappings for parent_binding in fact["native_parent_bindings"]),
+            key=lambda fact: (
+                fact["resource_id"],
+                fact["lineage_ordinal"],
+                fact["revision_id"],
+            ),
+        )
         comparison_run_commitment = cls._domain_digest(
             f"{_EVIDENCE_BINDING_DOMAIN}/comparison-run",
             run_facts,
@@ -704,15 +1029,38 @@ class NativeRevisionShadowComparator:
             )
             for fact in mappings
         )
+        retained_mapping_commitments = sorted(
+            cls._domain_digest(
+                f"{_EVIDENCE_BINDING_DOMAIN}/retained-mapping",
+                fact,
+            )
+            for fact in retained_mappings
+        )
+        native_parent_commitments = sorted(
+            cls._domain_digest(
+                f"{_EVIDENCE_BINDING_DOMAIN}/native-parent",
+                fact,
+            )
+            for fact in native_parent_bindings
+        )
         redacted_preimage = {
             "comparison_run": comparison_run_commitment,
             "mapping_owner_activity": mapping_commitments,
+            "retained_mapping_closure": retained_mapping_commitments,
+            "native_parent_bindings": native_parent_commitments,
         }
         commitment = cls._domain_digest(
             _EVIDENCE_BINDING_DOMAIN,
             redacted_preimage,
         )
-        owner_run_ids = {fact["owner_run"]["run_id"] for fact in mappings}
+        owner_run_ids = {
+            owner_run_id
+            for fact in mappings
+            for owner_run_id in (
+                fact["owner_run"]["run_id"],
+                *(mapping["owner_run"]["run_id"] for mapping in fact["retained_mappings"]),
+            )
+        }
         return {
             "scheme": "sha256",
             "canonicalization": _EVIDENCE_BINDING_CANONICALIZATION,
@@ -720,6 +1068,8 @@ class NativeRevisionShadowComparator:
             "commitment": commitment,
             "components": redacted_preimage,
             "mapping_count": len(mappings),
+            "retained_mapping_count": len(retained_mappings),
+            "native_parent_binding_count": len(native_parent_bindings),
             "owner_run_count": len(owner_run_ids),
         }
 
@@ -796,101 +1146,188 @@ class NativeRevisionShadowComparator:
                 self._value(item, "status"),
             )
             if observed_binding != expected_binding:
-                raise ShadowComparisonError(
-                    "C9 migration item binding differs from the completed run inventory"
-                )
+                raise ShadowComparisonError("C9 migration item binding differs from the completed run inventory")
             native_id = self._value(item, "native_head_revision_id")
             if not isinstance(native_id, str) or _OID_RE.fullmatch(native_id) is None:
-                raise ShadowComparisonError(
-                    "completed C9 item binding has no valid native head token"
-                )
+                raise ShadowComparisonError("completed C9 item binding has no valid native head token")
             items_by_id[resource_id] = item
+
+        comparison_run_id = uuid.UUID(comparison_run_facts["run_id"])
+        run_cache: dict[uuid.UUID, tuple[Any, dict[str, str]]] = {comparison_run_id: (run, comparison_run_facts)}
+        item_cache: dict[uuid.UUID, list[MigrationItem]] = {comparison_run_id: items}
+
+        async def owner_scope(owner_run_id: uuid.UUID) -> tuple[Any, dict[str, str]]:
+            cached = run_cache.get(owner_run_id)
+            if cached is not None:
+                return cached
+            owner = await self.repository.get_run(owner_run_id)
+            if owner is None:
+                raise ShadowComparisonError("immutable mapping owner is not a completed fixed-ref run")
+            owner_facts = self._run_facts(
+                owner,
+                label="immutable mapping owner run",
+            )
+            if owner_facts["namespace_id"] != comparison_run_facts["namespace_id"]:
+                raise ShadowComparisonError("immutable mapping owner is not a completed fixed-ref run")
+            run_cache[owner_run_id] = (owner, owner_facts)
+            return owner, owner_facts
+
+        async def owner_items(owner_run_id: uuid.UUID) -> list[MigrationItem]:
+            cached = item_cache.get(owner_run_id)
+            if cached is None:
+                cached = await self.repository.list_items(owner_run_id)
+                item_cache[owner_run_id] = cached
+            return cached
 
         result: dict[uuid.UUID, _NativeBinding] = {}
         for document in documents:
-            mapping = await self.repository.exact_mapping(
+            mappings = await self.repository.list_resource_mappings(
+                namespace_id=uuid.UUID(comparison_run_facts["namespace_id"]),
+                resource_id=document.resource_id,
+            )
+            if len(mappings) != len(document.lineage):
+                raise ShadowComparisonError("completed mapping closure differs from the frozen inventory")
+            mappings_by_oid: dict[str, Any] = {}
+            mappings_by_ordinal: dict[int, Any] = {}
+            for mapping in mappings:
+                legacy_git_oid = self._value(mapping, "legacy_git_oid")
+                ordinal = self._value(mapping, "lineage_ordinal")
+                if legacy_git_oid in mappings_by_oid or ordinal in mappings_by_ordinal:
+                    raise ShadowComparisonError("completed mapping closure is ambiguous")
+                mappings_by_oid[legacy_git_oid] = mapping
+                mappings_by_ordinal[ordinal] = mapping
+            for ordinal, entry in enumerate(document.lineage):
+                ordinal_mapping = mappings_by_ordinal.get(ordinal)
+                if (
+                    ordinal_mapping is None
+                    or self._value(ordinal_mapping, "namespace_id")
+                    != uuid.UUID(comparison_run_facts["namespace_id"])
+                    or self._value(ordinal_mapping, "resource_id")
+                    != document.resource_id
+                    or self._value(ordinal_mapping, "legacy_git_oid")
+                    != entry.legacy_git_oid
+                    or self._value(ordinal_mapping, "path_at_revision")
+                    != entry.path_at_revision
+                ):
+                    raise ShadowComparisonError("completed mapping closure differs from the frozen inventory")
+
+            exact_current = await self.repository.exact_mapping(
                 resource_id=document.resource_id,
                 legacy_git_oid=document.current_commit,
             )
-            native_id = self._value(mapping, "native_revision_id") if mapping else None
-            fixed_ref = self._value(mapping, "fixed_git_oid") if mapping else None
-            expected_mapping = (
-                self._value(run, "namespace_id"),
-                document.resource_id,
-                document.current_commit,
-                document.current_path,
-                "native",
-                len(document.lineage) - 1,
-            )
-            observed_mapping = (
-                self._value(mapping, "namespace_id") if mapping else None,
-                self._value(mapping, "resource_id") if mapping else None,
-                self._value(mapping, "legacy_git_oid") if mapping else None,
-                self._value(mapping, "path_at_revision") if mapping else None,
-                self._value(mapping, "resolution") if mapping else None,
-                self._value(mapping, "lineage_ordinal") if mapping else None,
+            current_mapping = mappings_by_oid.get(document.current_commit)
+            mapping_fields = (
+                "namespace_id",
+                "resource_id",
+                "legacy_git_oid",
+                "path_at_revision",
+                "resolution",
+                "native_revision_id",
+                "run_id",
+                "lineage_ordinal",
+                "fixed_git_oid",
             )
             if (
-                observed_mapping != expected_mapping
-                or not isinstance(native_id, str)
-                or _OID_RE.fullmatch(native_id) is None
-                or not isinstance(fixed_ref, str)
-                or _OID_RE.fullmatch(fixed_ref) is None
+                current_mapping is None
+                or exact_current is None
+                or any(
+                    self._value(exact_current, field) != self._value(current_mapping, field) for field in mapping_fields
+                )
             ):
-                raise ShadowComparisonError(
-                    "completed immutable mapping differs from the frozen inventory"
-                )
-
-            owner_run_id = self._value(mapping, "run_id")
-            try:
-                owner_run_uuid = uuid.UUID(str(owner_run_id))
-            except (AttributeError, TypeError, ValueError) as exc:
-                raise ShadowComparisonError(
-                    "immutable mapping owner has an invalid run id"
-                ) from exc
-            owner = (
-                run
-                if owner_run_uuid == uuid.UUID(comparison_run_facts["run_id"])
-                else await self.repository.get_run(owner_run_uuid)
-            )
-            if owner is None:
-                raise ShadowComparisonError(
-                    "immutable mapping owner is not a completed fixed-ref run"
-                )
-            owner_facts = (
-                comparison_run_facts
-                if owner is run
-                else self._run_facts(owner, label="immutable mapping owner run")
-            )
+                raise ShadowComparisonError("current mapping differs from the completed mapping closure")
             if (
-                owner_facts["status"] != "complete"
-                or owner_facts["namespace_id"] != comparison_run_facts["namespace_id"]
-                or owner_facts["fixed_git_oid"] != fixed_ref
+                self._value(current_mapping, "resolution") != "native"
+                or not isinstance(self._value(current_mapping, "native_revision_id"), str)
+                or _OID_RE.fullmatch(self._value(current_mapping, "native_revision_id")) is None
             ):
-                raise ShadowComparisonError(
-                    "immutable mapping owner is not a completed fixed-ref run"
-                )
+                raise ShadowComparisonError("completed current mapping is not a native Revision binding")
 
-            current_item = items_by_id.get(document.resource_id)
-            if owner_run_uuid == uuid.UUID(comparison_run_facts["run_id"]):
+            owner_groups: dict[uuid.UUID, list[Any]] = {}
+            for mapping in mappings:
+                try:
+                    owner_run_uuid = uuid.UUID(str(self._value(mapping, "run_id")))
+                except (AttributeError, TypeError, ValueError) as exc:
+                    raise ShadowComparisonError("immutable mapping owner has an invalid run id") from exc
+                owner_groups.setdefault(owner_run_uuid, []).append(mapping)
+
+            private_mappings: dict[str, dict[str, Any]] = {}
+            for owner_run_uuid, owned_mappings in owner_groups.items():
+                _, owner_facts = await owner_scope(owner_run_uuid)
+                relevant_items = [
+                    item
+                    for item in await owner_items(owner_run_uuid)
+                    if self._value(item, "legacy_document_id") == document.resource_id
+                ]
+                if len(relevant_items) != 1:
+                    raise ShadowComparisonError("immutable mapping has no exact completed owner item")
+                owner_item_fact = self._owner_item_fact(
+                    owner_facts=owner_facts,
+                    document=document,
+                    item=relevant_items[0],
+                    mappings_by_oid=mappings_by_oid,
+                )
+                ordered_owned = sorted(
+                    owned_mappings,
+                    key=lambda candidate: self._value(candidate, "lineage_ordinal"),
+                )
+                owned_ordinals = [self._value(candidate, "lineage_ordinal") for candidate in ordered_owned]
                 if (
-                    current_item is None
-                    or self._value(current_item, "native_head_revision_id") != native_id
+                    not owned_ordinals
+                    or owned_ordinals != list(range(owned_ordinals[0], owned_ordinals[-1] + 1))
+                    or self._value(ordered_owned[-1], "legacy_git_oid") != owner_item_fact["legacy_head_oid"]
                 ):
-                    raise ShadowComparisonError(
-                        "current-run mapping has no matching completed migration item"
+                    raise ShadowComparisonError("immutable mapping owner inventory is not ordinal-complete")
+                for mapping in ordered_owned:
+                    private = self._mapping_evidence_fact(
+                        document=document,
+                        mapping=mapping,
+                        owner_facts=owner_facts,
+                        owner_item=owner_item_fact,
                     )
+                    private_mappings[private["legacy_git_oid"]] = private
+
+            current_private = private_mappings[document.current_commit]
+            native_id = current_private["native_revision_id"]
+            fixed_ref = current_private["owner_run"]["fixed_git_oid"]
+            owner_run_uuid = uuid.UUID(current_private["owner_run"]["run_id"])
+            current_item = items_by_id.get(document.resource_id)
+            if owner_run_uuid == comparison_run_id:
+                if current_item is None or self._value(current_item, "native_head_revision_id") != native_id:
+                    raise ShadowComparisonError("current-run mapping has no matching completed migration item")
             elif current_item is not None:
-                raise ShadowComparisonError(
-                    "current-run item attempts to re-home an immutable mapping"
+                raise ShadowComparisonError("current-run item attempts to re-home an immutable mapping")
+            ordered_private = [private_mappings[entry.legacy_git_oid] for entry in document.lineage]
+            native_parent_bindings: list[dict[str, Any]] = []
+            prior_native: dict[str, Any] | None = None
+            for private_mapping in ordered_private:
+                if private_mapping["resolution"] != "native":
+                    continue
+                native_parent_bindings.append(
+                    {
+                        "resource_id": private_mapping["resource_id"],
+                        "lineage_ordinal": private_mapping["lineage_ordinal"],
+                        "revision_id": private_mapping["native_revision_id"],
+                        "parent_revision_id": (None if prior_native is None else prior_native["native_revision_id"]),
+                        "current_mapping": self._mapping_binding_view(private_mapping),
+                        "completed_parent_mapping": (
+                            None if prior_native is None else self._mapping_binding_view(prior_native)
+                        ),
+                    }
                 )
-            evidence_fact = self._mapping_evidence_fact(
-                run=run,
-                document=document,
-                mapping=mapping,
-                owner_facts=owner_facts,
-                native_revision_id=native_id,
-            )
+                prior_native = private_mapping
+            evidence_fact = {
+                "namespace_id": current_private["namespace_id"],
+                "resource_id": current_private["resource_id"],
+                "legacy_head_oid": current_private["legacy_git_oid"],
+                "path_at_revision": current_private["path_at_revision"],
+                "native_revision_id": native_id,
+                "lineage_ordinal": current_private["lineage_ordinal"],
+                "resolution": current_private["resolution"],
+                "owner_run": current_private["owner_run"],
+                "owner_item": current_private["owner_item"],
+                "retained_mappings": [private_mappings[entry.legacy_git_oid] for entry in document.lineage[:-1]],
+                "native_parent_bindings": native_parent_bindings,
+            }
             result[document.resource_id] = _NativeBinding(
                 fixed_ref=fixed_ref,
                 native_revision_id=native_id,

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -27,6 +27,7 @@ from app.services.legacy_revision_bridge import (
 )
 from app.services.native_revision_shadow_reader import (
     LegacyFixedRefShadowReader,
+    NativeActivityEvidence,
     NativeRevisionShadowReader,
     ShadowReaderScopeError,
 )
@@ -153,13 +154,13 @@ class ShadowReader(Protocol):
         fixed_ref: str,
     ) -> Mapping[str, Any]: ...
 
-    async def audit_activity(
+    async def activity_evidence(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> None: ...
+    ) -> NativeActivityEvidence: ...
 
 
 class NativeRevisionShadowComparator:
@@ -291,26 +292,28 @@ class NativeRevisionShadowComparator:
                 fixed_ref=binding.fixed_ref,
             )
             candidate_selector = native_revision_id
-            raw_candidate = await self._read(
-                self.candidate_reader,
-                operation,
-                document,
-                selector=candidate_selector,
-                fixed_ref=binding.fixed_ref,
-            )
-            candidate = raw_candidate
             if operation == "activity":
-                await self._audit_candidate_activity(
+                raw_candidate, activity_binding_fact = await self._read_candidate_activity(
                     document,
                     selector=native_revision_id,
                     fixed_ref=binding.fixed_ref,
                 )
+                binding.evidence_fact["activity_audit"] = activity_binding_fact
                 candidate = self._project_candidate_activity(
                     legacy,
                     raw_candidate,
                     document,
                     native_revision_id,
                 )
+            else:
+                raw_candidate = await self._read(
+                    self.candidate_reader,
+                    operation,
+                    document,
+                    selector=candidate_selector,
+                    fixed_ref=binding.fixed_ref,
+                )
+                candidate = raw_candidate
             _, _, mismatches = self._compare_operation(
                 operation,
                 legacy,
@@ -332,21 +335,36 @@ class NativeRevisionShadowComparator:
             operations[operation] = operation_result
         return {"operations": operations}
 
-    async def _audit_candidate_activity(
+    async def _read_candidate_activity(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> None:
-        auditor = getattr(self.candidate_reader, "audit_activity", None)
-        if auditor is None:
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        reader = getattr(self.candidate_reader, "activity_evidence", None)
+        if reader is None:
             raise ShadowComparisonError(
                 "candidate reader cannot prove the raw native activity audit"
             )
-        value = auditor(document, selector=selector, fixed_ref=fixed_ref)
+        value = reader(document, selector=selector, fixed_ref=fixed_ref)
         if inspect.isawaitable(value):
-            await value
+            value = await value
+        if not isinstance(value, NativeActivityEvidence):
+            raise ShadowComparisonError(
+                "candidate reader returned an invalid raw native activity audit"
+            )
+        envelope = self._jsonable(value.envelope)
+        binding_fact = self._jsonable(value.binding_fact)
+        if not isinstance(envelope, dict) or not isinstance(binding_fact, dict):
+            raise ShadowComparisonError(
+                "candidate raw native activity audit is not an object"
+            )
+        if binding_fact.get("profile") != _ACTIVITY_AUDIT_PROFILE:
+            raise ShadowComparisonError(
+                "candidate raw native activity audit profile is invalid"
+            )
+        return envelope, binding_fact
 
     async def _read(
         self,
@@ -671,6 +689,10 @@ class NativeRevisionShadowComparator:
                 fact["native_revision_id"],
             ),
         )
+        if any("activity_audit" not in fact for fact in mappings):
+            raise ShadowComparisonError(
+                "evidence binding is missing an audited native activity fact"
+            )
         preimage = {
             "comparison_run": run_facts,
             "mapping_owner_scope": mappings,

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -15,6 +15,7 @@ import asyncpg
 
 from app.exceptions import ConflictError, NotFoundError
 from app.repositories.native_revision_migration_repo import (
+    LegacyRevisionMapping,
     MigrationItem,
     MigrationRun,
     NativeRevisionMigrationRepository,
@@ -89,6 +90,21 @@ class MigrationReadRepository(Protocol):
 
     async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]: ...
 
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+    ) -> LegacyRevisionMapping | None: ...
+
+
+class _NativeBinding:
+    __slots__ = ("fixed_ref", "native_revision_id")
+
+    def __init__(self, *, fixed_ref: str, native_revision_id: str):
+        self.fixed_ref = fixed_ref
+        self.native_revision_id = native_revision_id
+
 
 class InventoryReader(Protocol):
     async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory: ...
@@ -131,7 +147,7 @@ class ShadowReader(Protocol):
 class NativeRevisionShadowComparator:
     """Compare legacy and candidate reads without opening a write path."""
 
-    protocol_version = "akb-native-revision-p2-w1-c10/v2"
+    protocol_version = "akb-native-revision-p2-w1-c10/v3"
 
     def __init__(
         self,
@@ -166,7 +182,7 @@ class NativeRevisionShadowComparator:
         self._validate_inventory_binding(run, inventory)
         documents = self._documents(inventory)
         items = await self.repository.list_items(parsed_run_id)
-        native_ids = self._native_ids(run, documents, items)
+        bindings = await self._native_bindings(run, documents, items)
 
         resources = []
         for document in sorted(documents, key=lambda item: str(item.resource_id)):
@@ -175,39 +191,34 @@ class NativeRevisionShadowComparator:
                     run,
                     inventory,
                     document,
-                    native_ids[document.resource_id],
+                    bindings[document.resource_id],
                 )
             )
 
         receipt: dict[str, Any] = {
-            "schema_version": 2,
+            "schema_version": 3,
             "protocol_version": self.protocol_version,
             "status": "passed",
             "passed": True,
             "claim_scope": "semantic_candidate_evidence",
             "write_authority": "legacy_only",
-            "comparison_ref": "one completed C9 fixed_ref",
+            "comparison_ref": "completed immutable mapping owners",
             "final_p2_coverage_claim": False,
             "cutover_claim": False,
             "scope": {
                 "claim_scope": "semantic_candidate_evidence",
                 "write_authority": "legacy_only",
-                "comparison_ref": "one completed C9 fixed_ref",
+                "comparison_ref": "completed immutable mapping owners",
                 "final_coverage_gate": "P2 L1-L6 product-backed evidence before final coverage selection",
                 "p3_fence_cutover_out_of_scope": True,
             },
-            "run": {
-                "run_key": self._public_key(self._value(run, "run_id"), "run"),
-                "status": "complete",
-                "fixed_ref": self._value(run, "fixed_git_oid"),
-                "inventory_digest": self._value(run, "inventory_digest"),
-            },
+            "run": {"status": "complete"},
             "resources": resources,
             "summary": {
                 "resource_count": len(resources),
                 "operation_count": len(resources) * len(_OPERATIONS),
                 "mismatch_count": sum(
-                    len(operation["mismatches"])
+                    operation["mismatch_count"]
                     for resource in resources
                     for operation in resource["operations"].values()
                 ),
@@ -218,7 +229,7 @@ class NativeRevisionShadowComparator:
                         mismatch["rule_id"]
                         for resource in resources
                         for operation in resource["operations"].values()
-                        for mismatch in operation["mismatches"]
+                        for mismatch in operation["classified_mismatches"]
                     }
                 ),
             },
@@ -235,9 +246,10 @@ class NativeRevisionShadowComparator:
         run: MigrationRun,
         inventory: LegacyInventory,
         document: LegacyInventoryDocument,
-        native_revision_id: str,
+        binding: _NativeBinding,
     ) -> dict[str, Any]:
-        del inventory
+        del run, inventory
+        native_revision_id = binding.native_revision_id
         operations: dict[str, Any] = {}
         for operation in _OPERATIONS:
             selector = document.current_commit
@@ -246,7 +258,7 @@ class NativeRevisionShadowComparator:
                 operation,
                 document,
                 selector=selector,
-                fixed_ref=run.fixed_git_oid,
+                fixed_ref=binding.fixed_ref,
             )
             candidate_selector = native_revision_id
             raw_candidate = await self._read(
@@ -254,7 +266,7 @@ class NativeRevisionShadowComparator:
                 operation,
                 document,
                 selector=candidate_selector,
-                fixed_ref=run.fixed_git_oid,
+                fixed_ref=binding.fixed_ref,
             )
             candidate = raw_candidate
             if operation == "activity":
@@ -272,15 +284,12 @@ class NativeRevisionShadowComparator:
                 native_revision_id,
             )
             operations[operation] = {
-                "mismatches": mismatches,
                 "normalized_equal": True,
                 "mismatch_count": len(mismatches),
                 "mismatch_classes": sorted({mismatch["classification"] for mismatch in mismatches}),
+                "classified_mismatches": self._count_operation_mismatches(mismatches),
             }
-        return {
-            "resource_key": self._public_key(document.resource_id, "resource"),
-            "operations": operations,
-        }
+        return {"operations": operations}
 
     async def _read(
         self,
@@ -523,26 +532,24 @@ class NativeRevisionShadowComparator:
             seen.add(document.resource_id)
         return documents
 
-    @classmethod
-    def _native_ids(
-        cls,
+    async def _native_bindings(
+        self,
         run: MigrationRun,
         documents: tuple[LegacyInventoryDocument, ...],
         items: list[MigrationItem],
-    ) -> dict[uuid.UUID, str]:
+    ) -> dict[uuid.UUID, _NativeBinding]:
         documents_by_id = {document.resource_id: document for document in documents}
-        expected = set(documents_by_id)
-        result: dict[uuid.UUID, str] = {}
+        items_by_id: dict[uuid.UUID, MigrationItem] = {}
         for item in items:
-            resource_id = cls._value(item, "legacy_document_id")
-            if resource_id in result:
+            resource_id = self._value(item, "legacy_document_id")
+            if resource_id in items_by_id:
                 raise ShadowComparisonError("C9 migration items contain duplicate resources")
             document = documents_by_id.get(resource_id)
             if document is None:
                 raise ShadowComparisonError("C9 migration item is outside the frozen inventory")
             expected_binding = (
-                cls._value(run, "run_id"),
-                cls._value(run, "namespace_id"),
+                self._value(run, "run_id"),
+                self._value(run, "namespace_id"),
                 document.resource_id,
                 document.resource_id,
                 document.current_path,
@@ -552,28 +559,95 @@ class NativeRevisionShadowComparator:
                 "complete",
             )
             observed_binding = (
-                cls._value(item, "run_id"),
-                cls._value(item, "namespace_id"),
+                self._value(item, "run_id"),
+                self._value(item, "namespace_id"),
                 resource_id,
-                cls._value(item, "native_resource_id"),
-                cls._value(item, "captured_path"),
-                cls._value(item, "legacy_head_oid"),
-                cls._value(item, "body_digest"),
-                cls._value(item, "byte_size"),
-                cls._value(item, "status"),
+                self._value(item, "native_resource_id"),
+                self._value(item, "captured_path"),
+                self._value(item, "legacy_head_oid"),
+                self._value(item, "body_digest"),
+                self._value(item, "byte_size"),
+                self._value(item, "status"),
             )
             if observed_binding != expected_binding:
                 raise ShadowComparisonError(
                     "C9 migration item binding differs from the completed run inventory"
                 )
-            native_id = cls._value(item, "native_head_revision_id")
+            native_id = self._value(item, "native_head_revision_id")
             if not isinstance(native_id, str) or _OID_RE.fullmatch(native_id) is None:
                 raise ShadowComparisonError(
                     "completed C9 item binding has no valid native head token"
                 )
-            result[resource_id] = native_id
-        if set(result) != expected:
-            raise ShadowComparisonError("C9 migration items do not cover every inventory resource")
+            items_by_id[resource_id] = item
+
+        result: dict[uuid.UUID, _NativeBinding] = {}
+        for document in documents:
+            mapping = await self.repository.exact_mapping(
+                resource_id=document.resource_id,
+                legacy_git_oid=document.current_commit,
+            )
+            native_id = self._value(mapping, "native_revision_id") if mapping else None
+            fixed_ref = self._value(mapping, "fixed_git_oid") if mapping else None
+            expected_mapping = (
+                self._value(run, "namespace_id"),
+                document.resource_id,
+                document.current_commit,
+                document.current_path,
+                "native",
+                len(document.lineage) - 1,
+            )
+            observed_mapping = (
+                self._value(mapping, "namespace_id") if mapping else None,
+                self._value(mapping, "resource_id") if mapping else None,
+                self._value(mapping, "legacy_git_oid") if mapping else None,
+                self._value(mapping, "path_at_revision") if mapping else None,
+                self._value(mapping, "resolution") if mapping else None,
+                self._value(mapping, "lineage_ordinal") if mapping else None,
+            )
+            if (
+                observed_mapping != expected_mapping
+                or not isinstance(native_id, str)
+                or _OID_RE.fullmatch(native_id) is None
+                or not isinstance(fixed_ref, str)
+                or _OID_RE.fullmatch(fixed_ref) is None
+            ):
+                raise ShadowComparisonError(
+                    "completed immutable mapping differs from the frozen inventory"
+                )
+
+            owner_run_id = self._value(mapping, "run_id")
+            owner = (
+                run
+                if owner_run_id == self._value(run, "run_id")
+                else await self.repository.get_run(owner_run_id)
+            )
+            if (
+                owner is None
+                or self._value(owner, "status") != "complete"
+                or self._value(owner, "namespace_id") != self._value(run, "namespace_id")
+                or self._value(owner, "fixed_git_oid") != fixed_ref
+            ):
+                raise ShadowComparisonError(
+                    "immutable mapping owner is not a completed fixed-ref run"
+                )
+
+            current_item = items_by_id.get(document.resource_id)
+            if owner_run_id == self._value(run, "run_id"):
+                if (
+                    current_item is None
+                    or self._value(current_item, "native_head_revision_id") != native_id
+                ):
+                    raise ShadowComparisonError(
+                        "current-run mapping has no matching completed migration item"
+                    )
+            elif current_item is not None:
+                raise ShadowComparisonError(
+                    "current-run item attempts to re-home an immutable mapping"
+                )
+            result[document.resource_id] = _NativeBinding(
+                fixed_ref=fixed_ref,
+                native_revision_id=native_id,
+            )
         return result
 
     @staticmethod
@@ -583,19 +657,26 @@ class NativeRevisionShadowComparator:
         return document.lineage[0].legacy_git_oid
 
     @staticmethod
-    def _public_key(value: Any, prefix: str) -> str:
-        """Return a stable receipt key without retaining a raw UUID."""
-        digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
-        return f"{prefix}-{digest}"
+    def _count_operation_mismatches(
+        mismatches: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        counts: dict[tuple[str, str], int] = {}
+        for mismatch in mismatches:
+            key = (mismatch["rule_id"], mismatch["classification"])
+            counts[key] = counts.get(key, 0) + 1
+        return [
+            {"rule_id": rule_id, "classification": classification, "count": count}
+            for (rule_id, classification), count in sorted(counts.items())
+        ]
 
     @staticmethod
     def _classified_mismatches(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
         counts: dict[tuple[str, str, str], int] = {}
         for resource in resources:
             for operation, result in resource["operations"].items():
-                for mismatch in result["mismatches"]:
+                for mismatch in result["classified_mismatches"]:
                     key = (operation, mismatch["rule_id"], mismatch["classification"])
-                    counts[key] = counts.get(key, 0) + 1
+                    counts[key] = counts.get(key, 0) + mismatch["count"]
         return [
             {
                 "operation": operation,

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -1,0 +1,600 @@
+"""Read-only C10 shadow comparison for one completed C9 migration run."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import inspect
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+import asyncpg
+
+from app.exceptions import ConflictError, NotFoundError
+from app.repositories.native_revision_migration_repo import (
+    MigrationItem,
+    MigrationRun,
+    NativeRevisionMigrationRepository,
+)
+from app.services.legacy_revision_bridge import (
+    LegacyActivitySemantics,
+    LegacyInventory,
+    LegacyInventoryDocument,
+)
+
+
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
+_PATH_TOKEN_RE = re.compile(r"([^.[\]]+)|\[(\d+)\]")
+_OPERATIONS = ("get", "history", "diff", "activity")
+_PATH_TO_RULE = {
+    "get:$.current_commit": "BR-01",
+    "history:$.entries[0].selector": "BR-01",
+    "diff:$.commit": "BR-01",
+    "activity:$.events[0].hash": "BR-01",
+    "history:$.history_source": "BR-02",
+    "diff:$.basis": "BR-03",
+    "get:$.projection.revision": "BR-04",
+    "history:$.entries[0].projection_revision": "BR-04",
+    "activity:$.events[0].projection_revision": "BR-04",
+    "get:$.content": "BR-05",
+    "activity:$.events[0].author.display": "BR-06",
+    "history:$.lineage_boundary": "BR-07",
+}
+
+
+class ShadowComparisonError(ConflictError):
+    """A C10 comparison cannot establish approved semantic parity."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.code = "native_revision_shadow_comparison_failed"
+
+
+class ShadowRunIncompleteError(ShadowComparisonError):
+    """A shadow comparison is only valid for a completed C9 run."""
+
+    def __init__(self, run_id: uuid.UUID):
+        super().__init__(f"native revision shadow comparison requires completed run: {run_id}")
+        self.code = "native_revision_shadow_run_incomplete"
+
+
+class MigrationReadRepository(Protocol):
+    async def get_run(self, run_id: uuid.UUID) -> MigrationRun | None: ...
+
+    async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]: ...
+
+
+class InventoryReader(Protocol):
+    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory: ...
+
+
+class ShadowReader(Protocol):
+    async def get(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> Mapping[str, Any]: ...
+
+    async def history(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> Mapping[str, Any]: ...
+
+    async def diff(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> Mapping[str, Any]: ...
+
+    async def activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> Mapping[str, Any]: ...
+
+
+class NativeRevisionShadowComparator:
+    """Compare legacy and candidate reads without opening a write path."""
+
+    protocol_version = "akb-native-revision-p2-w1-c10/v1"
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool | None = None,
+        *,
+        repository: MigrationReadRepository | None = None,
+        bridge: InventoryReader,
+        legacy_reader: ShadowReader,
+        candidate_reader: ShadowReader,
+    ):
+        if repository is None:
+            if pool is None:
+                raise ValueError("pool or a read-only migration repository is required")
+            repository = NativeRevisionMigrationRepository(pool)
+        self.repository = repository
+        self.bridge = bridge
+        self.legacy_reader = legacy_reader
+        self.candidate_reader = candidate_reader
+
+    async def compare_run(self, run_id: uuid.UUID | str) -> dict[str, Any]:
+        parsed_run_id = self._run_id(run_id)
+        run = await self.repository.get_run(parsed_run_id)
+        if run is None:
+            raise NotFoundError("Native revision migration run", str(parsed_run_id))
+        if self._value(run, "status") != "complete":
+            raise ShadowRunIncompleteError(parsed_run_id)
+
+        # The bridge is deliberately called before any candidate read.  Its
+        # inventory digest check is the immutable C9 gate and its existing
+        # MigrationInventoryDriftError is allowed to fail closed unchanged.
+        inventory = await self.bridge.inventory_for_run(run)
+        self._validate_inventory_binding(run, inventory)
+        documents = self._documents(inventory)
+        items = await self.repository.list_items(parsed_run_id)
+        native_ids = self._native_ids(run, documents, items)
+
+        resources = []
+        for document in sorted(documents, key=lambda item: str(item.resource_id)):
+            resources.append(
+                await self._compare_resource(
+                    run,
+                    inventory,
+                    document,
+                    native_ids[document.resource_id],
+                )
+            )
+
+        receipt: dict[str, Any] = {
+            "schema_version": 1,
+            "protocol_version": self.protocol_version,
+            "status": "passed",
+            "passed": True,
+            "claim_scope": "semantic_candidate_evidence",
+            "write_authority": "legacy_only",
+            "comparison_ref": "one completed C9 fixed_ref",
+            "final_p2_coverage_claim": False,
+            "cutover_claim": False,
+            "scope": {
+                "claim_scope": "semantic_candidate_evidence",
+                "write_authority": "legacy_only",
+                "comparison_ref": "one completed C9 fixed_ref",
+                "final_coverage_gate": "Migration E current-head/retained/eager inventory before final P2 coverage selection or P2 exit",
+                "p3_fence_cutover_out_of_scope": True,
+            },
+            "run": {
+                "run_id": str(self._value(run, "run_id")),
+                "status": "complete",
+                "fixed_ref": self._value(run, "fixed_git_oid"),
+                "inventory_digest": self._value(run, "inventory_digest"),
+            },
+            "resources": resources,
+            "summary": {
+                "resource_count": len(resources),
+                "operation_count": len(resources) * len(_OPERATIONS),
+                "mismatch_count": sum(
+                    len(operation["mismatches"])
+                    for resource in resources
+                    for operation in resource["operations"].values()
+                ),
+                "used_rules": sorted(
+                    {
+                        mismatch["rule_id"]
+                        for resource in resources
+                        for operation in resource["operations"].values()
+                        for mismatch in operation["mismatches"]
+                    }
+                ),
+            },
+        }
+        receipt["receipt_digest"] = self._digest(receipt)
+        return receipt
+
+    async def compare(self, run_id: uuid.UUID | str) -> dict[str, Any]:
+        """Short alias for the one service entry point."""
+        return await self.compare_run(run_id)
+
+    async def _compare_resource(
+        self,
+        run: MigrationRun,
+        inventory: LegacyInventory,
+        document: LegacyInventoryDocument,
+        native_revision_id: str,
+    ) -> dict[str, Any]:
+        del inventory
+        operations: dict[str, Any] = {}
+        for operation in _OPERATIONS:
+            selector = document.current_commit if operation != "history" else document.current_commit
+            legacy = await self._read(
+                self.legacy_reader,
+                operation,
+                document,
+                selector=selector,
+                fixed_ref=run.fixed_git_oid,
+            )
+            candidate_selector = native_revision_id
+            raw_candidate = await self._read(
+                self.candidate_reader,
+                operation,
+                document,
+                selector=candidate_selector,
+                fixed_ref=run.fixed_git_oid,
+            )
+            candidate = raw_candidate
+            if operation == "activity":
+                candidate = self._project_candidate_activity(
+                    legacy,
+                    raw_candidate,
+                    document,
+                    native_revision_id,
+                )
+            normalized_legacy, normalized_candidate, mismatches = self._compare_operation(
+                operation,
+                legacy,
+                candidate,
+                document,
+                native_revision_id,
+            )
+            operations[operation] = {
+                "legacy": legacy,
+                "raw_candidate": raw_candidate,
+                "candidate": candidate,
+                "normalized": {
+                    "legacy": normalized_legacy,
+                    "candidate": normalized_candidate,
+                },
+                "mismatches": mismatches,
+                "normalized_equal": True,
+            }
+        return {
+            "resource_id": str(document.resource_id),
+            "path": document.current_path,
+            "legacy_head_oid": document.current_commit,
+            "native_revision_id": native_revision_id,
+            "operations": operations,
+        }
+
+    async def _read(
+        self,
+        reader: ShadowReader,
+        operation: str,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        method = getattr(reader, operation, None)
+        if method is None:
+            raise ShadowComparisonError(f"shadow reader has no {operation} method")
+        value = method(document, selector=selector, fixed_ref=fixed_ref)
+        if inspect.isawaitable(value):
+            value = await value
+        result = self._jsonable(value)
+        if not isinstance(result, dict):
+            raise ShadowComparisonError(f"{operation} reader must return an envelope object")
+        return result
+
+    @classmethod
+    def _project_candidate_activity(
+        cls,
+        legacy: dict[str, Any],
+        candidate: dict[str, Any],
+        document: LegacyInventoryDocument,
+        native_revision_id: str,
+    ) -> dict[str, Any]:
+        legacy_events = legacy.get("events")
+        candidate_events = candidate.get("events")
+        if not isinstance(legacy_events, list) or len(legacy_events) != 1:
+            raise ShadowComparisonError("activity legacy envelope must contain one fixed-ref event")
+        if not isinstance(candidate_events, list) or len(candidate_events) != 1:
+            raise ShadowComparisonError("activity candidate envelope must contain one current-head event")
+        legacy_event = legacy_events[0]
+        candidate_event = candidate_events[0]
+        if not isinstance(legacy_event, dict) or not isinstance(candidate_event, dict):
+            raise ShadowComparisonError("activity event must be an object")
+
+        activity = document.activity
+        cls._validate_legacy_activity(legacy_event, activity)
+        projected = copy.deepcopy(candidate)
+        event = copy.deepcopy(candidate_event)
+        event["hash"] = native_revision_id
+        event["projection_revision"] = native_revision_id
+        for key in ("action", "subject", "summary"):
+            if key in event or key in legacy_event:
+                event[key] = getattr(activity, key)
+        for key in ("path_from", "path_to"):
+            if key in event or key in legacy_event:
+                event[key] = getattr(activity, key)
+        if "changed_paths" in event or "changed_paths" in legacy_event:
+            event["changed_paths"] = [dict(path) for path in activity.changed_paths]
+        if "files" in event or "files" in legacy_event:
+            event["files"] = cls._activity_files(activity)
+        if "actor" in event or "actor" in legacy_event:
+            event["actor"] = activity.actor
+        if "agent" in event or "agent" in legacy_event:
+            event["agent"] = activity.actor
+
+        legacy_author = legacy_event.get("author")
+        candidate_author = event.get("author")
+        if isinstance(legacy_author, dict):
+            if legacy_author.get("id") != activity.actor:
+                raise ShadowComparisonError("legacy activity actor is not bound to the inventory")
+            if not isinstance(candidate_author, dict):
+                raise ShadowComparisonError("candidate activity author shape differs")
+            author = copy.deepcopy(candidate_author)
+            author["id"] = activity.actor
+            display = legacy_author.get("display")
+            if not isinstance(display, str):
+                raise ShadowComparisonError("legacy activity display is not a string")
+            author["display"] = display.removesuffix(" (Git)")
+            event["author"] = author
+        elif isinstance(legacy_author, str):
+            if legacy_author != activity.actor:
+                raise ShadowComparisonError("activity actor is not bound to the inventory")
+            event["author"] = activity.actor
+        else:
+            raise ShadowComparisonError("activity author shape is unsupported")
+        projected["events"] = [event]
+        return projected
+
+    @staticmethod
+    def _validate_legacy_activity(event: dict[str, Any], activity: LegacyActivitySemantics) -> None:
+        if event.get("action") != activity.action:
+            raise ShadowComparisonError("legacy activity action differs from the inventory")
+        if event.get("subject") != activity.subject:
+            raise ShadowComparisonError("legacy activity subject differs from the inventory")
+        if event.get("summary") != activity.summary:
+            raise ShadowComparisonError("legacy activity summary differs from the inventory")
+
+    @staticmethod
+    def _activity_files(activity: LegacyActivitySemantics) -> list[dict[str, str]]:
+        result = []
+        for change in activity.changed_paths:
+            kind = change.get("change")
+            label = "added" if kind == "create" else "deleted" if kind == "delete" else "modified"
+            path = change.get("path_to") or change.get("path_from")
+            if not isinstance(path, str):
+                raise ShadowComparisonError("inventory activity path data is incomplete")
+            result.append({"path": path, "change": label})
+        return result
+
+    @classmethod
+    def _compare_operation(
+        cls,
+        operation: str,
+        legacy: dict[str, Any],
+        candidate: dict[str, Any],
+        document: LegacyInventoryDocument,
+        native_revision_id: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+        differences = cls._leaf_diffs(legacy, candidate, operation)
+        normalized_legacy = copy.deepcopy(legacy)
+        normalized_candidate = copy.deepcopy(candidate)
+        mismatches = []
+        for path, left, right in differences:
+            rule_id = _PATH_TO_RULE.get(f"{operation}:{path}")
+            if rule_id is None:
+                raise ShadowComparisonError(f"unapproved mismatch at {operation}:{path}")
+            normalized_left, normalized_right = cls._normalize_pair(
+                operation,
+                path,
+                left,
+                right,
+                rule_id,
+                document,
+                native_revision_id,
+            )
+            if normalized_left != normalized_right:
+                raise ShadowComparisonError(
+                    f"{rule_id} normalization does not establish parity at {operation}:{path}"
+                )
+            cls._set_path(normalized_legacy, path, normalized_left)
+            cls._set_path(normalized_candidate, path, normalized_right)
+            mismatches.append(
+                {"path": path, "legacy": left, "candidate": right, "rule_id": rule_id}
+            )
+        if normalized_legacy != normalized_candidate:
+            raise ShadowComparisonError(f"unapproved mismatch at {operation}: normalized envelopes differ")
+        return normalized_legacy, normalized_candidate, mismatches
+
+    @classmethod
+    def _normalize_pair(
+        cls,
+        operation: str,
+        path: str,
+        legacy: Any,
+        candidate: Any,
+        rule_id: str,
+        document: LegacyInventoryDocument,
+        native_revision_id: str,
+    ) -> tuple[Any, Any]:
+        head = document.current_commit
+        if rule_id in {"BR-01", "BR-04"}:
+            if legacy != head or candidate != native_revision_id:
+                raise ShadowComparisonError(f"{rule_id} values at {operation}:{path} are not C9-bound")
+            return head, head
+        if rule_id == "BR-02":
+            if (legacy, candidate) != ("legacy-git-log", "fixed-ref-bridge"):
+                raise ShadowComparisonError("BR-02 values are not the approved fixed-ref pair")
+            return "fixed-ref-history", "fixed-ref-history"
+        if rule_id == "BR-03":
+            if (legacy, candidate) != ("git-parent", "fixed-ref-snapshot"):
+                raise ShadowComparisonError("BR-03 values are not the approved snapshot pair")
+            return "snapshot-diff", "snapshot-diff"
+        if rule_id == "BR-05":
+            if not isinstance(legacy, str) or not isinstance(candidate, str) or "\r" in candidate:
+                raise ShadowComparisonError("BR-05 may normalize only CRLF formatting")
+            body = document.body.decode("utf-8", errors="strict")
+            left = legacy.replace("\r\n", "\n")
+            if left != candidate or candidate != body:
+                raise ShadowComparisonError("BR-05 formatting-only normalization changed content")
+            return left, candidate
+        if rule_id == "BR-06":
+            if not isinstance(legacy, str) or not isinstance(candidate, str):
+                raise ShadowComparisonError("BR-06 display values must be strings")
+            if not legacy.endswith(" (Git)") or legacy.removesuffix(" (Git)") != candidate:
+                raise ShadowComparisonError("BR-06 values are not the approved display decoration pair")
+            return candidate, candidate
+        if rule_id == "BR-07":
+            boundary = cls._lineage_boundary(document)
+            if (legacy, candidate) != ("legacy-document-start", boundary):
+                raise ShadowComparisonError("BR-07 values are not the inventory boundary pair")
+            return boundary, boundary
+        raise ShadowComparisonError(f"unknown bridge rule {rule_id}")
+
+    @staticmethod
+    def _leaf_diffs(left: Any, right: Any, operation: str, path: str = "$") -> list[tuple[str, Any, Any]]:
+        if isinstance(left, dict) or isinstance(right, dict):
+            if not isinstance(left, dict) or not isinstance(right, dict) or set(left) != set(right):
+                raise ShadowComparisonError(f"unapproved mismatch at {operation}:{path}")
+            result: list[tuple[str, Any, Any]] = []
+            for key in sorted(left):
+                result.extend(NativeRevisionShadowComparator._leaf_diffs(left[key], right[key], operation, f"{path}.{key}"))
+            return result
+        if isinstance(left, list) or isinstance(right, list):
+            if not isinstance(left, list) or not isinstance(right, list) or len(left) != len(right):
+                raise ShadowComparisonError(f"unapproved mismatch at {operation}:{path}")
+            result = []
+            for index, (left_item, right_item) in enumerate(zip(left, right)):
+                result.extend(NativeRevisionShadowComparator._leaf_diffs(left_item, right_item, operation, f"{path}[{index}]"))
+            return result
+        return [] if left == right else [(path, left, right)]
+
+    @staticmethod
+    def _set_path(root: Any, path: str, value: Any) -> None:
+        if not path.startswith("$."):
+            raise ShadowComparisonError(f"cannot normalize invalid path {path}")
+        tokens = []
+        for key, index in _PATH_TOKEN_RE.findall(path[2:]):
+            tokens.append(int(index) if index else key)
+        current = root
+        for token in tokens[:-1]:
+            current = current[token]
+        current[tokens[-1]] = value
+
+    @classmethod
+    def _validate_inventory_binding(cls, run: MigrationRun, inventory: LegacyInventory) -> None:
+        if cls._value(run, "inventory_digest") != cls._value(inventory, "inventory_digest"):
+            raise ShadowComparisonError("C9 inventory digest does not match the completed run")
+        if cls._value(run, "fixed_git_oid") != cls._value(inventory, "fixed_git_oid"):
+            raise ShadowComparisonError("C9 inventory fixed_ref does not match the completed run")
+
+    @staticmethod
+    def _documents(inventory: LegacyInventory) -> tuple[LegacyInventoryDocument, ...]:
+        documents = getattr(inventory, "documents", None)
+        if not isinstance(documents, tuple):
+            documents = tuple(documents or ())
+        seen: set[uuid.UUID] = set()
+        for document in documents:
+            if document.resource_id in seen:
+                raise ShadowComparisonError("C9 inventory contains duplicate resources")
+            seen.add(document.resource_id)
+        return documents
+
+    @classmethod
+    def _native_ids(
+        cls,
+        run: MigrationRun,
+        documents: tuple[LegacyInventoryDocument, ...],
+        items: list[MigrationItem],
+    ) -> dict[uuid.UUID, str]:
+        documents_by_id = {document.resource_id: document for document in documents}
+        expected = set(documents_by_id)
+        result: dict[uuid.UUID, str] = {}
+        for item in items:
+            resource_id = cls._value(item, "legacy_document_id")
+            if resource_id in result:
+                raise ShadowComparisonError("C9 migration items contain duplicate resources")
+            document = documents_by_id.get(resource_id)
+            if document is None:
+                raise ShadowComparisonError("C9 migration item is outside the frozen inventory")
+            expected_binding = (
+                cls._value(run, "run_id"),
+                cls._value(run, "namespace_id"),
+                document.resource_id,
+                document.resource_id,
+                document.current_path,
+                document.current_commit,
+                document.body_digest,
+                document.byte_size,
+                "complete",
+            )
+            observed_binding = (
+                cls._value(item, "run_id"),
+                cls._value(item, "namespace_id"),
+                resource_id,
+                cls._value(item, "native_resource_id"),
+                cls._value(item, "captured_path"),
+                cls._value(item, "legacy_head_oid"),
+                cls._value(item, "body_digest"),
+                cls._value(item, "byte_size"),
+                cls._value(item, "status"),
+            )
+            if observed_binding != expected_binding:
+                raise ShadowComparisonError(
+                    "C9 migration item binding differs from the completed run inventory"
+                )
+            native_id = cls._value(item, "native_head_revision_id")
+            if not isinstance(native_id, str) or _OID_RE.fullmatch(native_id) is None:
+                raise ShadowComparisonError(
+                    "completed C9 item binding has no valid native head token"
+                )
+            result[resource_id] = native_id
+        if set(result) != expected:
+            raise ShadowComparisonError("C9 migration items do not cover every inventory resource")
+        return result
+
+    @staticmethod
+    def _lineage_boundary(document: LegacyInventoryDocument) -> str:
+        if not document.lineage:
+            raise ShadowComparisonError("inventory document has no lineage boundary")
+        return document.lineage[0].legacy_git_oid
+
+    @staticmethod
+    def _value(value: Any, name: str) -> Any:
+        return value.get(name) if isinstance(value, Mapping) else getattr(value, name)
+
+    @staticmethod
+    def _run_id(value: uuid.UUID | str) -> uuid.UUID:
+        if isinstance(value, uuid.UUID):
+            return value
+        try:
+            return uuid.UUID(value)
+        except (ValueError, AttributeError) as exc:
+            raise ShadowComparisonError(f"invalid C9 run id: {value}") from exc
+
+    @classmethod
+    def _jsonable(cls, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(key): cls._jsonable(child) for key, child in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [cls._jsonable(child) for child in value]
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="strict")
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return cls._jsonable(model_dump())
+        raise ShadowComparisonError(f"shadow envelope contains non-JSON value: {type(value).__name__}")
+
+    @staticmethod
+    def _digest(value: dict[str, Any]) -> str:
+        encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+NativeRevisionShadowService = NativeRevisionShadowComparator

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -770,9 +770,16 @@ class NativeRevisionShadowComparator:
         if rule_id == "BR-05":
             if not isinstance(legacy, str) or not isinstance(candidate, str) or "\r" in candidate:
                 raise ShadowComparisonError("BR-05 may normalize only CRLF formatting")
-            body = document.body.decode("utf-8", errors="strict")
             left = legacy.replace("\r\n", "\n")
-            if left != candidate or candidate != body:
+            try:
+                candidate_body = candidate.encode("utf-8", errors="strict")
+            except UnicodeEncodeError as exc:
+                raise ShadowComparisonError("BR-05 candidate body is not valid UTF-8") from exc
+            if (
+                left != candidate
+                or len(candidate_body) != document.byte_size
+                or hashlib.sha256(candidate_body).hexdigest() != document.body_digest
+            ):
                 raise ShadowComparisonError("BR-05 formatting-only normalization changed content")
             return left, candidate
         if rule_id == "BR-06":
@@ -1043,24 +1050,30 @@ class NativeRevisionShadowComparator:
             )
             for fact in native_parent_bindings
         )
+        owner_run_commitments = sorted(
+            {
+                cls._domain_digest(
+                    f"{_EVIDENCE_BINDING_DOMAIN}/owner-run",
+                    owner_run,
+                )
+                for fact in mappings
+                for owner_run in (
+                    fact["owner_run"],
+                    *(mapping["owner_run"] for mapping in fact["retained_mappings"]),
+                )
+            }
+        )
         redacted_preimage = {
             "comparison_run": comparison_run_commitment,
             "mapping_owner_activity": mapping_commitments,
             "retained_mapping_closure": retained_mapping_commitments,
             "native_parent_bindings": native_parent_commitments,
+            "owner_runs": owner_run_commitments,
         }
         commitment = cls._domain_digest(
             _EVIDENCE_BINDING_DOMAIN,
             redacted_preimage,
         )
-        owner_run_ids = {
-            owner_run_id
-            for fact in mappings
-            for owner_run_id in (
-                fact["owner_run"]["run_id"],
-                *(mapping["owner_run"]["run_id"] for mapping in fact["retained_mappings"]),
-            )
-        }
         return {
             "scheme": "sha256",
             "canonicalization": _EVIDENCE_BINDING_CANONICALIZATION,
@@ -1070,7 +1083,7 @@ class NativeRevisionShadowComparator:
             "mapping_count": len(mappings),
             "retained_mapping_count": len(retained_mappings),
             "native_parent_binding_count": len(native_parent_bindings),
-            "owner_run_count": len(owner_run_ids),
+            "owner_run_count": len(owner_run_commitments),
         }
 
     @staticmethod

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -58,6 +58,9 @@ _RULE_CLASSIFICATION = {
     "BR-06": "activity_display",
     "BR-07": "lineage_boundary",
 }
+_ACTIVITY_AUDIT_PROFILE = "akb-native-revision-p2-activity-audit/v1"
+_EVIDENCE_BINDING_CANONICALIZATION = "utf8-json-sort-keys-no-whitespace-v1"
+_EVIDENCE_BINDING_DOMAIN = "akb-native-revision-p2-w1-c10/evidence-binding/v1"
 __all__ = (
     "LegacyFixedRefShadowReader",
     "NativeRevisionShadowReader",
@@ -99,11 +102,18 @@ class MigrationReadRepository(Protocol):
 
 
 class _NativeBinding:
-    __slots__ = ("fixed_ref", "native_revision_id")
+    __slots__ = ("fixed_ref", "native_revision_id", "evidence_fact")
 
-    def __init__(self, *, fixed_ref: str, native_revision_id: str):
+    def __init__(
+        self,
+        *,
+        fixed_ref: str,
+        native_revision_id: str,
+        evidence_fact: dict[str, Any],
+    ):
         self.fixed_ref = fixed_ref
         self.native_revision_id = native_revision_id
+        self.evidence_fact = evidence_fact
 
 
 class InventoryReader(Protocol):
@@ -143,11 +153,19 @@ class ShadowReader(Protocol):
         fixed_ref: str,
     ) -> Mapping[str, Any]: ...
 
+    async def audit_activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> None: ...
+
 
 class NativeRevisionShadowComparator:
     """Compare legacy and candidate reads without opening a write path."""
 
-    protocol_version = "akb-native-revision-p2-w1-c10/v3"
+    protocol_version = "akb-native-revision-p2-w1-c10/v4"
 
     def __init__(
         self,
@@ -174,6 +192,7 @@ class NativeRevisionShadowComparator:
             raise NotFoundError("Native revision migration run", str(parsed_run_id))
         if self._value(run, "status") != "complete":
             raise ShadowRunIncompleteError(parsed_run_id)
+        run_facts = self._run_facts(run, label="completed comparison run")
 
         # The bridge is deliberately called before any candidate read.  Its
         # inventory digest check is the immutable C9 gate and its existing
@@ -194,9 +213,10 @@ class NativeRevisionShadowComparator:
                     bindings[document.resource_id],
                 )
             )
+        evidence_binding = self._evidence_binding(run_facts, bindings)
 
         receipt: dict[str, Any] = {
-            "schema_version": 3,
+            "schema_version": 4,
             "protocol_version": self.protocol_version,
             "status": "passed",
             "passed": True,
@@ -224,6 +244,15 @@ class NativeRevisionShadowComparator:
                 ),
                 "unexplained_mismatch_count": 0,
                 "classified_mismatches": self._classified_mismatches(resources),
+                "raw_activity_audit_count": sum(
+                    1
+                    for resource in resources
+                    if resource["operations"]["activity"].get("raw_activity_audit")
+                    == {
+                        "profile": _ACTIVITY_AUDIT_PROFILE,
+                        "status": "passed",
+                    }
+                ),
                 "used_rules": sorted(
                     {
                         mismatch["rule_id"]
@@ -233,6 +262,7 @@ class NativeRevisionShadowComparator:
                     }
                 ),
             },
+            "evidence_binding": evidence_binding,
         }
         receipt["receipt_digest"] = self._digest(receipt)
         return receipt
@@ -270,6 +300,11 @@ class NativeRevisionShadowComparator:
             )
             candidate = raw_candidate
             if operation == "activity":
+                await self._audit_candidate_activity(
+                    document,
+                    selector=native_revision_id,
+                    fixed_ref=binding.fixed_ref,
+                )
                 candidate = self._project_candidate_activity(
                     legacy,
                     raw_candidate,
@@ -283,13 +318,35 @@ class NativeRevisionShadowComparator:
                 document,
                 native_revision_id,
             )
-            operations[operation] = {
+            operation_result: dict[str, Any] = {
                 "normalized_equal": True,
                 "mismatch_count": len(mismatches),
                 "mismatch_classes": sorted({mismatch["classification"] for mismatch in mismatches}),
                 "classified_mismatches": self._count_operation_mismatches(mismatches),
             }
+            if operation == "activity":
+                operation_result["raw_activity_audit"] = {
+                    "profile": _ACTIVITY_AUDIT_PROFILE,
+                    "status": "passed",
+                }
+            operations[operation] = operation_result
         return {"operations": operations}
+
+    async def _audit_candidate_activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> None:
+        auditor = getattr(self.candidate_reader, "audit_activity", None)
+        if auditor is None:
+            raise ShadowComparisonError(
+                "candidate reader cannot prove the raw native activity audit"
+            )
+        value = auditor(document, selector=selector, fixed_ref=fixed_ref)
+        if inspect.isawaitable(value):
+            await value
 
     async def _read(
         self,
@@ -514,8 +571,137 @@ class NativeRevisionShadowComparator:
         current[tokens[-1]] = value
 
     @classmethod
+    def _run_facts(cls, run: Any, *, label: str) -> dict[str, str]:
+        try:
+            run_id = uuid.UUID(str(cls._value(run, "run_id")))
+            namespace_id = uuid.UUID(str(cls._value(run, "namespace_id")))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ShadowComparisonError(f"{label} has invalid UUID facts") from exc
+        fixed_git_oid = cls._value(run, "fixed_git_oid")
+        inventory_digest = cls._value(run, "inventory_digest")
+        coverage_version = cls._value(run, "coverage_version")
+        status = cls._value(run, "status")
+        if (
+            not isinstance(fixed_git_oid, str)
+            or _OID_RE.fullmatch(fixed_git_oid) is None
+            or not isinstance(inventory_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", inventory_digest) is None
+            or not isinstance(coverage_version, str)
+            or not coverage_version
+            or status != "complete"
+        ):
+            raise ShadowComparisonError(f"{label} has invalid immutable scope facts")
+        return {
+            "run_id": str(run_id),
+            "namespace_id": str(namespace_id),
+            "fixed_git_oid": fixed_git_oid,
+            "inventory_digest": inventory_digest,
+            "coverage_version": coverage_version,
+            "status": status,
+        }
+
+    @classmethod
+    def _mapping_evidence_fact(
+        cls,
+        *,
+        run: Any,
+        document: LegacyInventoryDocument,
+        mapping: Any,
+        owner_facts: dict[str, str],
+        native_revision_id: str,
+    ) -> dict[str, Any]:
+        try:
+            run_namespace = uuid.UUID(str(cls._value(run, "namespace_id")))
+            mapping_namespace = uuid.UUID(str(cls._value(mapping, "namespace_id")))
+            mapping_resource = uuid.UUID(str(cls._value(mapping, "resource_id")))
+            mapping_owner = uuid.UUID(str(cls._value(mapping, "run_id")))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ShadowComparisonError("completed mapping has invalid UUID facts") from exc
+        legacy_head_oid = cls._value(mapping, "legacy_git_oid")
+        path_at_revision = cls._value(mapping, "path_at_revision")
+        resolution = cls._value(mapping, "resolution")
+        lineage_ordinal = cls._value(mapping, "lineage_ordinal")
+        mapping_native_id = cls._value(mapping, "native_revision_id")
+        mapping_fixed_ref = cls._value(mapping, "fixed_git_oid")
+        if (
+            mapping_namespace != run_namespace
+            or mapping_resource != document.resource_id
+            or legacy_head_oid != document.current_commit
+            or not isinstance(legacy_head_oid, str)
+            or _OID_RE.fullmatch(legacy_head_oid) is None
+            or path_at_revision != document.current_path
+            or not isinstance(path_at_revision, str)
+            or not path_at_revision.strip()
+            or resolution != "native"
+            or not isinstance(mapping_native_id, str)
+            or mapping_native_id != native_revision_id
+            or _OID_RE.fullmatch(mapping_native_id) is None
+            or not isinstance(lineage_ordinal, int)
+            or isinstance(lineage_ordinal, bool)
+            or lineage_ordinal != len(document.lineage) - 1
+            or not isinstance(mapping_fixed_ref, str)
+            or _OID_RE.fullmatch(mapping_fixed_ref) is None
+            or mapping_owner != uuid.UUID(owner_facts["run_id"])
+            or mapping_fixed_ref != owner_facts["fixed_git_oid"]
+        ):
+            raise ShadowComparisonError(
+                "completed current native mapping differs from its immutable owner facts"
+            )
+        return {
+            "resource_id": str(mapping_resource),
+            "legacy_head_oid": legacy_head_oid,
+            "path_at_revision": path_at_revision,
+            "native_revision_id": mapping_native_id,
+            "lineage_ordinal": lineage_ordinal,
+            "resolution": resolution,
+            "owner_run": owner_facts,
+        }
+
+    @classmethod
+    def _evidence_binding(
+        cls,
+        run_facts: dict[str, str],
+        bindings: dict[uuid.UUID, _NativeBinding],
+    ) -> dict[str, Any]:
+        mappings = sorted(
+            (copy.deepcopy(binding.evidence_fact) for binding in bindings.values()),
+            key=lambda fact: (
+                fact["resource_id"],
+                fact["legacy_head_oid"],
+                fact["native_revision_id"],
+            ),
+        )
+        preimage = {
+            "comparison_run": run_facts,
+            "mapping_owner_scope": mappings,
+        }
+        canonical = json.dumps(
+            preimage,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        commitment = hashlib.sha256(
+            _EVIDENCE_BINDING_DOMAIN.encode("utf-8") + b"\0" + canonical
+        ).hexdigest()
+        owner_run_ids = {fact["owner_run"]["run_id"] for fact in mappings}
+        return {
+            "scheme": "sha256",
+            "canonicalization": _EVIDENCE_BINDING_CANONICALIZATION,
+            "domain": _EVIDENCE_BINDING_DOMAIN,
+            "commitment": commitment,
+            "mapping_count": len(mappings),
+            "owner_run_count": len(owner_run_ids),
+        }
+
+    @classmethod
     def _validate_inventory_binding(cls, run: MigrationRun, inventory: LegacyInventory) -> None:
-        if cls._value(run, "inventory_digest") != cls._value(inventory, "inventory_digest"):
+        cls._run_facts(run, label="completed comparison run")
+        if (
+            cls._value(run, "namespace_id") != cls._value(inventory, "namespace_id")
+            or cls._value(run, "inventory_digest") != cls._value(inventory, "inventory_digest")
+            or cls._value(run, "coverage_version") != cls._value(inventory, "coverage_version")
+        ):
             raise ShadowComparisonError("C9 inventory digest does not match the completed run")
         if cls._value(run, "fixed_git_oid") != cls._value(inventory, "fixed_git_oid"):
             raise ShadowComparisonError("C9 inventory fixed_ref does not match the completed run")
@@ -538,6 +724,7 @@ class NativeRevisionShadowComparator:
         documents: tuple[LegacyInventoryDocument, ...],
         items: list[MigrationItem],
     ) -> dict[uuid.UUID, _NativeBinding]:
+        comparison_run_facts = self._run_facts(run, label="completed comparison run")
         documents_by_id = {document.resource_id: document for document in documents}
         items_by_id: dict[uuid.UUID, MigrationItem] = {}
         for item in items:
@@ -616,23 +803,37 @@ class NativeRevisionShadowComparator:
                 )
 
             owner_run_id = self._value(mapping, "run_id")
+            try:
+                owner_run_uuid = uuid.UUID(str(owner_run_id))
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise ShadowComparisonError(
+                    "immutable mapping owner has an invalid run id"
+                ) from exc
             owner = (
                 run
-                if owner_run_id == self._value(run, "run_id")
-                else await self.repository.get_run(owner_run_id)
+                if owner_run_uuid == uuid.UUID(comparison_run_facts["run_id"])
+                else await self.repository.get_run(owner_run_uuid)
+            )
+            if owner is None:
+                raise ShadowComparisonError(
+                    "immutable mapping owner is not a completed fixed-ref run"
+                )
+            owner_facts = (
+                comparison_run_facts
+                if owner is run
+                else self._run_facts(owner, label="immutable mapping owner run")
             )
             if (
-                owner is None
-                or self._value(owner, "status") != "complete"
-                or self._value(owner, "namespace_id") != self._value(run, "namespace_id")
-                or self._value(owner, "fixed_git_oid") != fixed_ref
+                owner_facts["status"] != "complete"
+                or owner_facts["namespace_id"] != comparison_run_facts["namespace_id"]
+                or owner_facts["fixed_git_oid"] != fixed_ref
             ):
                 raise ShadowComparisonError(
                     "immutable mapping owner is not a completed fixed-ref run"
                 )
 
             current_item = items_by_id.get(document.resource_id)
-            if owner_run_id == self._value(run, "run_id"):
+            if owner_run_uuid == uuid.UUID(comparison_run_facts["run_id"]):
                 if (
                     current_item is None
                     or self._value(current_item, "native_head_revision_id") != native_id
@@ -644,9 +845,17 @@ class NativeRevisionShadowComparator:
                 raise ShadowComparisonError(
                     "current-run item attempts to re-home an immutable mapping"
                 )
+            evidence_fact = self._mapping_evidence_fact(
+                run=run,
+                document=document,
+                mapping=mapping,
+                owner_facts=owner_facts,
+                native_revision_id=native_id,
+            )
             result[document.resource_id] = _NativeBinding(
                 fixed_ref=fixed_ref,
                 native_revision_id=native_id,
+                evidence_fact=evidence_fact,
             )
         return result
 
@@ -689,7 +898,7 @@ class NativeRevisionShadowComparator:
 
     @staticmethod
     def _value(value: Any, name: str) -> Any:
-        return value.get(name) if isinstance(value, Mapping) else getattr(value, name)
+        return value.get(name) if isinstance(value, Mapping) else getattr(value, name, None)
 
     @staticmethod
     def _run_id(value: uuid.UUID | str) -> uuid.UUID:

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -34,6 +34,7 @@ _OID_RE = re.compile(r"^[0-9a-f]{40}$")
 _HUNK_RE = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$"
 )
+_NATIVE_ACTIVITY_MIGRATION_ACTOR = "akb-native-revision-migration"
 
 
 class ShadowReaderScopeError(ConflictError):
@@ -1049,13 +1050,34 @@ class NativeRevisionShadowReader:
             "format": "unified",
         }
 
-    async def activity(
+    async def audit_activity(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> dict[str, Any]:
+    ) -> None:
+        """Validate persisted native activity before a shadow projection."""
+
+        snapshot, raw_selected, activity = await self._activity_facts(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )
+        await self._audit_activity_facts(
+            document,
+            snapshot=snapshot,
+            raw_selected=raw_selected,
+            activity=activity,
+        )
+
+    async def _activity_facts(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> tuple[_NativeMaterialization, Mapping[str, Any], Mapping[str, Any]]:
         snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
         raw_selected = await self.native_repository.get_revision(
             resource_id=document.resource_id,
@@ -1063,6 +1085,11 @@ class NativeRevisionShadowReader:
         )
         if not isinstance(raw_selected, Mapping):
             raise ShadowReaderScopeError("native revision activity selection is missing")
+        if (
+            raw_selected.get("namespace_id") != self.namespace_id
+            or raw_selected.get("surface") != "document"
+        ):
+            raise ShadowReaderScopeError("native activity audit selected Revision is out of scope")
         self._validate_selected_revision(
             raw_selected,
             snapshot,
@@ -1077,7 +1104,6 @@ class NativeRevisionShadowReader:
         )
         if not isinstance(raw_activity, Mapping):
             raise ShadowReaderScopeError("native revision activity is missing")
-        activity = raw_activity
         expected = (
             document.resource_id,
             selector,
@@ -1091,21 +1117,150 @@ class NativeRevisionShadowReader:
             self._row_path(raw_selected),
         )
         observed = (
-            activity.get("resource_id"),
-            activity.get("revision_id"),
-            activity.get("action"),
-            activity.get("actor"),
-            activity.get("subject"),
-            activity.get("summary"),
-            activity.get("changed_path_from"),
-            activity.get("changed_path_to"),
-            activity.get("occurred_at"),
-            activity.get("path_at_revision"),
+            raw_activity.get("resource_id"),
+            raw_activity.get("revision_id"),
+            raw_activity.get("action"),
+            raw_activity.get("actor"),
+            raw_activity.get("subject"),
+            raw_activity.get("summary"),
+            raw_activity.get("changed_path_from"),
+            raw_activity.get("changed_path_to"),
+            raw_activity.get("occurred_at"),
+            raw_activity.get("path_at_revision"),
         )
         if observed != expected:
             raise ShadowReaderScopeError(
                 "native revision activity differs from persisted Revision facts"
             )
+        return snapshot, raw_selected, raw_activity
+
+    async def _audit_activity_facts(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        snapshot: _NativeMaterialization,
+        raw_selected: Mapping[str, Any],
+        activity: Mapping[str, Any],
+    ) -> None:
+        if not document.lineage:
+            raise ShadowReaderScopeError("native activity audit has no frozen lineage head")
+        frozen_time = document.lineage[-1].committed_at
+        if (
+            snapshot.occurred_at != frozen_time
+            or raw_selected.get("occurred_at") != frozen_time
+            or activity.get("occurred_at") != frozen_time
+        ):
+            raise ShadowReaderScopeError(
+                "native activity audit timestamp differs from frozen lineage head"
+            )
+
+        parent_id = raw_selected.get("parent_revision_id")
+        if parent_id is None:
+            expected = {
+                "action": "create",
+                "actor": _NATIVE_ACTIVITY_MIGRATION_ACTOR,
+                "subject": None,
+                "summary": None,
+                "path_from": None,
+                "path_to": document.current_path,
+            }
+            observed_revision = {
+                "action": raw_selected.get("action"),
+                "actor": raw_selected.get("actor"),
+                "subject": raw_selected.get("subject"),
+                "summary": raw_selected.get("summary"),
+                "path_from": raw_selected.get("path_from"),
+                "path_to": raw_selected.get("path_to"),
+            }
+            observed_activity = {
+                "action": activity.get("action"),
+                "actor": activity.get("actor"),
+                "subject": activity.get("subject"),
+                "summary": activity.get("summary"),
+                "path_from": activity.get("changed_path_from"),
+                "path_to": activity.get("changed_path_to"),
+            }
+            if observed_revision != expected or observed_activity != expected:
+                raise ShadowReaderScopeError(
+                    "native activity audit genesis facts are invalid"
+                )
+            return
+
+        _require_oid(parent_id, "native activity parent revision")
+        if parent_id == raw_selected.get("revision_id"):
+            raise ShadowReaderScopeError("native activity audit parent is self-referential")
+        raw_parent = await self.native_repository.get_revision(
+            resource_id=document.resource_id,
+            revision_id=parent_id,
+        )
+        if not isinstance(raw_parent, Mapping):
+            raise ShadowReaderScopeError("native activity audit parent Revision is missing")
+        if (
+            raw_parent.get("namespace_id") != self.namespace_id
+            or raw_parent.get("resource_id") != document.resource_id
+            or raw_parent.get("surface") != "document"
+            or raw_parent.get("revision_id") != parent_id
+        ):
+            raise ShadowReaderScopeError(
+                "native activity audit parent Revision is outside the Resource scope"
+            )
+        parent_path = self._row_path(raw_parent)
+        current_path = self._row_path(raw_selected)
+        if (
+            not isinstance(parent_path, str)
+            or not parent_path
+            or not isinstance(current_path, str)
+            or not current_path
+        ):
+            raise ShadowReaderScopeError("native activity audit parent/current path is invalid")
+        action = "move" if parent_path != current_path else "replace"
+        expected = {
+            "action": action,
+            "actor": document.activity.actor,
+            "subject": document.activity.subject,
+            "summary": document.activity.summary,
+            "path_from": parent_path if action == "move" else None,
+            "path_to": current_path if action == "move" else None,
+        }
+        observed_revision = {
+            "action": raw_selected.get("action"),
+            "actor": raw_selected.get("actor"),
+            "subject": raw_selected.get("subject"),
+            "summary": raw_selected.get("summary"),
+            "path_from": raw_selected.get("path_from"),
+            "path_to": raw_selected.get("path_to"),
+        }
+        observed_activity = {
+            "action": activity.get("action"),
+            "actor": activity.get("actor"),
+            "subject": activity.get("subject"),
+            "summary": activity.get("summary"),
+            "path_from": activity.get("changed_path_from"),
+            "path_to": activity.get("changed_path_to"),
+        }
+        if observed_revision != expected or observed_activity != expected:
+            raise ShadowReaderScopeError(
+                "native activity audit reconcile facts are invalid"
+            )
+
+    async def activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        snapshot, raw_selected, activity = await self._activity_facts(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )
+        await self._audit_activity_facts(
+            document,
+            snapshot=snapshot,
+            raw_selected=raw_selected,
+            activity=activity,
+        )
         actor = activity.get("actor")
         if not isinstance(actor, str) or not actor:
             raise ShadowReaderScopeError("native revision activity actor is invalid")

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -471,6 +471,8 @@ class LegacyFixedRefShadowReader:
                 raise ShadowReaderScopeError("legacy fixed-ref materialization returned no body")
             if not isinstance(history, list) or not all(isinstance(entry, Mapping) for entry in history):
                 raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
+            if not history or history[0].get("legacy_git_oid") != document.current_commit:
+                raise ShadowReaderScopeError("legacy fixed-ref history does not start at current head")
             if not isinstance(activity, Mapping):
                 raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
             if not isinstance(materialized_fixed_ref, str) or not isinstance(

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -14,6 +14,7 @@ import hashlib
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Protocol
 from uuid import UUID
 
@@ -35,6 +36,7 @@ _HUNK_RE = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$"
 )
 _NATIVE_ACTIVITY_MIGRATION_ACTOR = "akb-native-revision-migration"
+_NATIVE_ACTIVITY_AUDIT_PROFILE = "akb-native-revision-p2-activity-audit/v1"
 
 
 class ShadowReaderScopeError(ConflictError):
@@ -43,6 +45,14 @@ class ShadowReaderScopeError(ConflictError):
     def __init__(self, message: str = "native revision shadow reader scope is invalid"):
         super().__init__(message)
         self.code = "native_revision_shadow_reader_scope_invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class NativeActivityEvidence:
+    """Audited native activity envelope plus private receipt-binding facts."""
+
+    envelope: dict[str, Any]
+    binding_fact: dict[str, Any]
 
 
 class NativeRevisionReadService(Protocol):
@@ -1056,20 +1066,14 @@ class NativeRevisionShadowReader:
         *,
         selector: str,
         fixed_ref: str,
-    ) -> None:
+    ) -> dict[str, Any]:
         """Validate persisted native activity before a shadow projection."""
 
-        snapshot, raw_selected, activity = await self._activity_facts(
+        return (await self.activity_evidence(
             document,
             selector=selector,
             fixed_ref=fixed_ref,
-        )
-        await self._audit_activity_facts(
-            document,
-            snapshot=snapshot,
-            raw_selected=raw_selected,
-            activity=activity,
-        )
+        )).binding_fact
 
     async def _activity_facts(
         self,
@@ -1141,7 +1145,7 @@ class NativeRevisionShadowReader:
         snapshot: _NativeMaterialization,
         raw_selected: Mapping[str, Any],
         activity: Mapping[str, Any],
-    ) -> None:
+    ) -> dict[str, Any]:
         if not document.lineage:
             raise ShadowReaderScopeError("native activity audit has no frozen lineage head")
         frozen_time = document.lineage[-1].committed_at
@@ -1155,6 +1159,7 @@ class NativeRevisionShadowReader:
             )
 
         parent_id = raw_selected.get("parent_revision_id")
+        parent_binding: dict[str, Any] | None = None
         if parent_id is None:
             expected = {
                 "action": "create",
@@ -1184,78 +1189,162 @@ class NativeRevisionShadowReader:
                 raise ShadowReaderScopeError(
                     "native activity audit genesis facts are invalid"
                 )
-            return
-
-        _require_oid(parent_id, "native activity parent revision")
-        if parent_id == raw_selected.get("revision_id"):
-            raise ShadowReaderScopeError("native activity audit parent is self-referential")
-        raw_parent = await self.native_repository.get_revision(
-            resource_id=document.resource_id,
-            revision_id=parent_id,
-        )
-        if not isinstance(raw_parent, Mapping):
-            raise ShadowReaderScopeError("native activity audit parent Revision is missing")
-        if (
-            raw_parent.get("namespace_id") != self.namespace_id
-            or raw_parent.get("resource_id") != document.resource_id
-            or raw_parent.get("surface") != "document"
-            or raw_parent.get("revision_id") != parent_id
-        ):
-            raise ShadowReaderScopeError(
-                "native activity audit parent Revision is outside the Resource scope"
+        else:
+            _require_oid(parent_id, "native activity parent revision")
+            if parent_id == raw_selected.get("revision_id"):
+                raise ShadowReaderScopeError("native activity audit parent is self-referential")
+            raw_parent = await self.native_repository.get_revision(
+                resource_id=document.resource_id,
+                revision_id=parent_id,
             )
-        parent_path = self._row_path(raw_parent)
-        current_path = self._row_path(raw_selected)
-        if (
-            not isinstance(parent_path, str)
-            or not parent_path
-            or not isinstance(current_path, str)
-            or not current_path
-        ):
-            raise ShadowReaderScopeError("native activity audit parent/current path is invalid")
-        action = "move" if parent_path != current_path else "replace"
-        expected = {
-            "action": action,
-            "actor": document.activity.actor,
-            "subject": document.activity.subject,
-            "summary": document.activity.summary,
-            "path_from": parent_path if action == "move" else None,
-            "path_to": current_path if action == "move" else None,
-        }
-        observed_revision = {
-            "action": raw_selected.get("action"),
-            "actor": raw_selected.get("actor"),
-            "subject": raw_selected.get("subject"),
-            "summary": raw_selected.get("summary"),
-            "path_from": raw_selected.get("path_from"),
-            "path_to": raw_selected.get("path_to"),
-        }
-        observed_activity = {
-            "action": activity.get("action"),
-            "actor": activity.get("actor"),
-            "subject": activity.get("subject"),
-            "summary": activity.get("summary"),
-            "path_from": activity.get("changed_path_from"),
-            "path_to": activity.get("changed_path_to"),
-        }
-        if observed_revision != expected or observed_activity != expected:
-            raise ShadowReaderScopeError(
-                "native activity audit reconcile facts are invalid"
+            if not isinstance(raw_parent, Mapping):
+                raise ShadowReaderScopeError("native activity audit parent Revision is missing")
+            if (
+                raw_parent.get("namespace_id") != self.namespace_id
+                or raw_parent.get("resource_id") != document.resource_id
+                or raw_parent.get("surface") != "document"
+                or raw_parent.get("revision_id") != parent_id
+            ):
+                raise ShadowReaderScopeError(
+                    "native activity audit parent Revision is outside the Resource scope"
+                )
+            parent_binding = await self._completed_parent_mapping(
+                document,
+                parent_revision_id=parent_id,
             )
+            parent_path = self._row_path(raw_parent)
+            current_path = self._row_path(raw_selected)
+            if (
+                parent_path != parent_binding["path_at_revision"]
+                or not isinstance(parent_path, str)
+                or not parent_path
+                or not isinstance(current_path, str)
+                or not current_path
+            ):
+                raise ShadowReaderScopeError(
+                    "native activity audit parent path differs from its completed legacy mapping"
+                )
+            action = "move" if parent_path != current_path else "replace"
+            expected = {
+                "action": action,
+                "actor": document.activity.actor,
+                "subject": document.activity.subject,
+                "summary": document.activity.summary,
+                "path_from": parent_path if action == "move" else None,
+                "path_to": current_path if action == "move" else None,
+            }
+            observed_revision = {
+                "action": raw_selected.get("action"),
+                "actor": raw_selected.get("actor"),
+                "subject": raw_selected.get("subject"),
+                "summary": raw_selected.get("summary"),
+                "path_from": raw_selected.get("path_from"),
+                "path_to": raw_selected.get("path_to"),
+            }
+            observed_activity = {
+                "action": activity.get("action"),
+                "actor": activity.get("actor"),
+                "subject": activity.get("subject"),
+                "summary": activity.get("summary"),
+                "path_from": activity.get("changed_path_from"),
+                "path_to": activity.get("changed_path_to"),
+            }
+            if observed_revision != expected or observed_activity != expected:
+                raise ShadowReaderScopeError(
+                    "native activity audit reconcile facts are invalid"
+                )
 
-    async def activity(
+        occurred_at = raw_selected.get("occurred_at")
+        if not isinstance(occurred_at, datetime):
+            raise ShadowReaderScopeError("native activity audit timestamp is invalid")
+        return {
+            "profile": _NATIVE_ACTIVITY_AUDIT_PROFILE,
+            "selected_revision": {
+                "namespace_id": str(raw_selected.get("namespace_id")),
+                "resource_id": str(raw_selected.get("resource_id")),
+                "revision_id": raw_selected.get("revision_id"),
+                "parent_revision_id": parent_id,
+                "action": raw_selected.get("action"),
+                "path_at_revision": self._row_path(raw_selected),
+                "path_from": raw_selected.get("path_from"),
+                "path_to": raw_selected.get("path_to"),
+                "actor": raw_selected.get("actor"),
+                "subject": raw_selected.get("subject"),
+                "summary": raw_selected.get("summary"),
+                "occurred_at": occurred_at.isoformat(),
+            },
+            "activity": {
+                "resource_id": str(activity.get("resource_id")),
+                "revision_id": activity.get("revision_id"),
+                "action": activity.get("action"),
+                "path_at_revision": activity.get("path_at_revision"),
+                "path_from": activity.get("changed_path_from"),
+                "path_to": activity.get("changed_path_to"),
+                "actor": activity.get("actor"),
+                "subject": activity.get("subject"),
+                "summary": activity.get("summary"),
+                "occurred_at": occurred_at.isoformat(),
+            },
+            "completed_parent_mapping": parent_binding,
+        }
+
+    async def _completed_parent_mapping(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        parent_revision_id: str,
+    ) -> dict[str, Any]:
+        matches: list[dict[str, Any]] = []
+        for entry in document.lineage:
+            try:
+                resolution = await self.selector_bridge.resolve_selector(
+                    resource_id=document.resource_id,
+                    selector=entry.legacy_git_oid,
+                )
+            except (AKBError, AttributeError, TypeError, ValueError) as exc:
+                raise ShadowReaderScopeError(
+                    "native activity parent has no completed legacy mapping"
+                ) from exc
+            if resolution.kind != "native" or resolution.native_revision_id != parent_revision_id:
+                continue
+            if (
+                resolution.legacy_git_oid != entry.legacy_git_oid
+                or resolution.path_at_revision != entry.path_at_revision
+                or not isinstance(resolution.fixed_git_oid, str)
+                or _OID_RE.fullmatch(resolution.fixed_git_oid) is None
+                or resolution.run_id is None
+            ):
+                raise ShadowReaderScopeError(
+                    "native activity parent mapping differs from the frozen lineage"
+                )
+            matches.append(
+                {
+                    "legacy_git_oid": entry.legacy_git_oid,
+                    "path_at_revision": entry.path_at_revision,
+                    "native_revision_id": parent_revision_id,
+                    "fixed_git_oid": resolution.fixed_git_oid,
+                    "run_id": str(resolution.run_id),
+                }
+            )
+        if len(matches) != 1:
+            raise ShadowReaderScopeError(
+                "native activity parent must have exactly one completed legacy mapping"
+            )
+        return matches[0]
+
+    async def activity_evidence(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> dict[str, Any]:
+    ) -> NativeActivityEvidence:
         snapshot, raw_selected, activity = await self._activity_facts(
             document,
             selector=selector,
             fixed_ref=fixed_ref,
         )
-        await self._audit_activity_facts(
+        binding_fact = await self._audit_activity_facts(
             document,
             snapshot=snapshot,
             raw_selected=raw_selected,
@@ -1264,18 +1353,31 @@ class NativeRevisionShadowReader:
         actor = activity.get("actor")
         if not isinstance(actor, str) or not actor:
             raise ShadowReaderScopeError("native revision activity actor is invalid")
-        return {
-            "events": [
-                {
-                    "hash": selector,
-                    "subject": activity.get("subject"),
-                    "author": {
-                        "id": actor,
-                        "display": actor,
-                    },
-                    "action": activity.get("action"),
-                    "summary": activity.get("summary"),
-                    "projection_revision": selector,
-                }
-            ]
-        }
+        return NativeActivityEvidence(
+            envelope={
+                "events": [
+                    {
+                        "hash": selector,
+                        "subject": activity.get("subject"),
+                        "author": {"id": actor, "display": actor},
+                        "action": activity.get("action"),
+                        "summary": activity.get("summary"),
+                        "projection_revision": selector,
+                    }
+                ]
+            },
+            binding_fact=binding_fact,
+        )
+
+    async def activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        return (await self.activity_evidence(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )).envelope

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -32,9 +32,7 @@ from app.services.uri_service import doc_uri
 
 
 _OID_RE = re.compile(r"^[0-9a-f]{40}$")
-_HUNK_RE = re.compile(
-    r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$"
-)
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
 _NATIVE_ACTIVITY_MIGRATION_ACTOR = "akb-native-revision-migration"
 _NATIVE_ACTIVITY_AUDIT_PROFILE = "akb-native-revision-p2-activity-audit/v1"
 
@@ -200,9 +198,7 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
     patch_lines = patch.split("\n")
     if patch_lines and patch_lines[-1] == "":
         patch_lines.pop()
-    hunk_indexes = [
-        index for index, line in enumerate(patch_lines) if _HUNK_RE.fullmatch(line)
-    ]
+    hunk_indexes = [index for index, line in enumerate(patch_lines) if _HUNK_RE.fullmatch(line)]
     if not hunk_indexes:
         prefix = "+" if diff_type == "added" else "-" if diff_type == "deleted" else None
         if prefix is None or any(not line.startswith(prefix) for line in patch_lines):
@@ -219,8 +215,7 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
     if hunk_indexes[0] != 0:
         allowed_headers = {"diff --git", "index ", "--- ", "+++ "}
         if any(
-            not any(line.startswith(prefix) for prefix in allowed_headers)
-            for line in patch_lines[: hunk_indexes[0]]
+            not any(line.startswith(prefix) for prefix in allowed_headers) for line in patch_lines[: hunk_indexes[0]]
         ):
             raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid headers")
 
@@ -258,9 +253,7 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
         observed_old = 0
         observed_new = 0
         patch_index += 1
-        while patch_index < len(patch_lines) and _HUNK_RE.fullmatch(
-            patch_lines[patch_index]
-        ) is None:
+        while patch_index < len(patch_lines) and _HUNK_RE.fullmatch(patch_lines[patch_index]) is None:
             line = patch_lines[patch_index]
             patch_index += 1
             if line == r"\ No newline at end of file":
@@ -278,14 +271,10 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
                 raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
             if marker in {" ", "-"}:
                 if source_index >= len(source) or source[source_index] != value:
-                    raise ShadowReaderScopeError(
-                        "legacy fixed-ref diff patch differs from parent body"
-                    )
+                    raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from parent body")
                 source_line_has_newline = source_index < len(source) - 1 or source_has_newline
                 if no_newline != (not source_line_has_newline):
-                    raise ShadowReaderScopeError(
-                        "legacy fixed-ref diff patch has an invalid newline marker"
-                    )
+                    raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
                 source_line = source[source_index]
                 source_index += 1
                 observed_old += 1
@@ -368,8 +357,7 @@ class LegacyFixedRefShadowReader:
             raise ShadowReaderScopeError("legacy fixed-ref body is not valid UTF-8") from exc
 
         expected_history = [
-            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at)
-            for entry in reversed(document.lineage)
+            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at) for entry in reversed(document.lineage)
         ]
         observed_history = [
             (
@@ -380,9 +368,7 @@ class LegacyFixedRefShadowReader:
             for entry in snapshot.history
         ]
         if observed_history != expected_history:
-            raise ShadowReaderScopeError(
-                "legacy fixed-ref history differs from C9 inventory"
-            )
+            raise ShadowReaderScopeError("legacy fixed-ref history differs from C9 inventory")
 
         activity = document.activity
         expected_activity = (
@@ -412,9 +398,7 @@ class LegacyFixedRefShadowReader:
             tuple(dict(change) for change in changed_paths if isinstance(change, Mapping)),
         )
         if observed_activity != expected_activity:
-            raise ShadowReaderScopeError(
-                "legacy fixed-ref activity differs from C9 inventory"
-            )
+            raise ShadowReaderScopeError("legacy fixed-ref activity differs from C9 inventory")
 
     async def _fixed_snapshot(
         self,
@@ -466,9 +450,7 @@ class LegacyFixedRefShadowReader:
             materialized_current_commit = raw_snapshot.get("current_commit")
             if not isinstance(body, bytes):
                 raise ShadowReaderScopeError("legacy fixed-ref materialization returned no body")
-            if not isinstance(history, list) or not all(
-                isinstance(entry, Mapping) for entry in history
-            ):
+            if not isinstance(history, list) or not all(isinstance(entry, Mapping) for entry in history):
                 raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
             if not isinstance(activity, Mapping):
                 raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
@@ -568,9 +550,7 @@ class LegacyFixedRefShadowReader:
             or not isinstance(raw_diff.get("diff"), str)
             or not raw_diff.get("diff")
         ):
-            raise ShadowReaderScopeError(
-                "legacy fixed-ref diff differs from C9 inventory"
-            )
+            raise ShadowReaderScopeError("legacy fixed-ref diff differs from C9 inventory")
         previous = document.lineage[-2] if len(document.lineage) > 1 else None
         try:
             current_text, parent_text = await asyncio.gather(
@@ -763,9 +743,7 @@ class NativeRevisionShadowReader:
             or row.get("parent_revision_id") != snapshot.parent_revision_id
             or row.get("occurred_at") != snapshot.occurred_at
         ):
-            raise ShadowReaderScopeError(
-                f"native revision {source} differs from the selected Revision"
-            )
+            raise ShadowReaderScopeError(f"native revision {source} differs from the selected Revision")
 
     @classmethod
     def _validate_revision_body_facts(
@@ -779,9 +757,7 @@ class NativeRevisionShadowReader:
         try:
             body = snapshot.text.encode("utf-8", errors="strict")
         except UnicodeEncodeError as exc:
-            raise ShadowReaderScopeError(
-                f"native revision {source} body facts are invalid"
-            ) from exc
+            raise ShadowReaderScopeError(f"native revision {source} body facts are invalid") from exc
         if (
             not isinstance(snapshot.revision_id, str)
             or _OID_RE.fullmatch(snapshot.revision_id) is None
@@ -810,9 +786,7 @@ class NativeRevisionShadowReader:
             or len(body) != snapshot.byte_size
             or hashlib.sha256(body).hexdigest() != snapshot.digest
         ):
-            raise ShadowReaderScopeError(
-                f"native revision {source} body facts differ from persisted Revision"
-            )
+            raise ShadowReaderScopeError(f"native revision {source} body facts differ from persisted Revision")
 
     @staticmethod
     def _materialization(raw_snapshot: Any) -> _NativeMaterialization:
@@ -844,15 +818,12 @@ class NativeRevisionShadowReader:
             resource_id=document.resource_id,
             limit=len(document.lineage) + 1,
         )
-        if not isinstance(rows, list) or not rows or not all(
-            isinstance(row, Mapping) for row in rows
-        ):
+        if not isinstance(rows, list) or not rows or not all(isinstance(row, Mapping) for row in rows):
             raise ShadowReaderScopeError("native revision history is missing or invalid")
         copied = [dict(row) for row in rows]
         revision_ids = [row.get("revision_id") for row in copied]
         if len(set(revision_ids)) != len(revision_ids) or any(
-            not isinstance(revision_id, str) or _OID_RE.fullmatch(revision_id) is None
-            for revision_id in revision_ids
+            not isinstance(revision_id, str) or _OID_RE.fullmatch(revision_id) is None for revision_id in revision_ids
         ):
             raise ShadowReaderScopeError("native revision history has invalid selectors")
         if any(row.get("occurred_at") is None for row in copied):
@@ -879,17 +850,13 @@ class NativeRevisionShadowReader:
             if row.get("resource_id") != document.resource_id:
                 raise ShadowReaderScopeError("native revision history crosses Resource scope")
             parent_id = row.get("parent_revision_id")
-            if parent_id is not None and (
-                not isinstance(parent_id, str) or _OID_RE.fullmatch(parent_id) is None
-            ):
+            if parent_id is not None and (not isinstance(parent_id, str) or _OID_RE.fullmatch(parent_id) is None):
                 raise ShadowReaderScopeError("native revision history parent is invalid")
             seen.add(revision_id)
             ordered.append(row)
             revision_id = parent_id
         if len(ordered) != len(copied):
-            raise ShadowReaderScopeError(
-                "native revision history has disconnected extra rows"
-            )
+            raise ShadowReaderScopeError("native revision history has disconnected extra rows")
         return ordered
 
     async def _verify_selector_bridge(
@@ -907,9 +874,7 @@ class NativeRevisionShadowReader:
                     selector=selector,
                 )
             except (AKBError, AttributeError, TypeError, ValueError) as exc:
-                raise ShadowReaderScopeError(
-                    f"{source} selector is not bound to the completed C9 bridge"
-                ) from exc
+                raise ShadowReaderScopeError(f"{source} selector is not bound to the completed C9 bridge") from exc
 
         native = await resolve(native_revision_id, "native history head")
         if (
@@ -1069,11 +1034,13 @@ class NativeRevisionShadowReader:
     ) -> dict[str, Any]:
         """Validate persisted native activity before a shadow projection."""
 
-        return (await self.activity_evidence(
-            document,
-            selector=selector,
-            fixed_ref=fixed_ref,
-        )).binding_fact
+        return (
+            await self.activity_evidence(
+                document,
+                selector=selector,
+                fixed_ref=fixed_ref,
+            )
+        ).binding_fact
 
     async def _activity_facts(
         self,
@@ -1089,10 +1056,7 @@ class NativeRevisionShadowReader:
         )
         if not isinstance(raw_selected, Mapping):
             raise ShadowReaderScopeError("native revision activity selection is missing")
-        if (
-            raw_selected.get("namespace_id") != self.namespace_id
-            or raw_selected.get("surface") != "document"
-        ):
+        if raw_selected.get("namespace_id") != self.namespace_id or raw_selected.get("surface") != "document":
             raise ShadowReaderScopeError("native activity audit selected Revision is out of scope")
         self._validate_selected_revision(
             raw_selected,
@@ -1133,15 +1097,16 @@ class NativeRevisionShadowReader:
             raw_activity.get("path_at_revision"),
         )
         if observed != expected:
-            raise ShadowReaderScopeError(
-                "native revision activity differs from persisted Revision facts"
-            )
+            raise ShadowReaderScopeError("native revision activity differs from persisted Revision facts")
         return snapshot, raw_selected, raw_activity
 
     async def _audit_activity_facts(
         self,
         document: LegacyInventoryDocument,
         *,
+        selector: str,
+        fixed_ref: str,
+        current_mapping: dict[str, Any],
         snapshot: _NativeMaterialization,
         raw_selected: Mapping[str, Any],
         activity: Mapping[str, Any],
@@ -1154,9 +1119,7 @@ class NativeRevisionShadowReader:
             or raw_selected.get("occurred_at") != frozen_time
             or activity.get("occurred_at") != frozen_time
         ):
-            raise ShadowReaderScopeError(
-                "native activity audit timestamp differs from frozen lineage head"
-            )
+            raise ShadowReaderScopeError("native activity audit timestamp differs from frozen lineage head")
 
         parent_id = raw_selected.get("parent_revision_id")
         parent_binding: dict[str, Any] | None = None
@@ -1186,9 +1149,7 @@ class NativeRevisionShadowReader:
                 "path_to": activity.get("changed_path_to"),
             }
             if observed_revision != expected or observed_activity != expected:
-                raise ShadowReaderScopeError(
-                    "native activity audit genesis facts are invalid"
-                )
+                raise ShadowReaderScopeError("native activity audit genesis facts are invalid")
         else:
             _require_oid(parent_id, "native activity parent revision")
             if parent_id == raw_selected.get("revision_id"):
@@ -1205,9 +1166,7 @@ class NativeRevisionShadowReader:
                 or raw_parent.get("surface") != "document"
                 or raw_parent.get("revision_id") != parent_id
             ):
-                raise ShadowReaderScopeError(
-                    "native activity audit parent Revision is outside the Resource scope"
-                )
+                raise ShadowReaderScopeError("native activity audit parent Revision is outside the Resource scope")
             parent_binding = await self._completed_parent_mapping(
                 document,
                 parent_revision_id=parent_id,
@@ -1250,20 +1209,22 @@ class NativeRevisionShadowReader:
                 "path_to": activity.get("changed_path_to"),
             }
             if observed_revision != expected or observed_activity != expected:
-                raise ShadowReaderScopeError(
-                    "native activity audit reconcile facts are invalid"
-                )
+                raise ShadowReaderScopeError("native activity audit reconcile facts are invalid")
 
         occurred_at = raw_selected.get("occurred_at")
         if not isinstance(occurred_at, datetime):
             raise ShadowReaderScopeError("native activity audit timestamp is invalid")
         return {
             "profile": _NATIVE_ACTIVITY_AUDIT_PROFILE,
+            "selector": selector,
+            "fixed_ref": fixed_ref,
+            "current_mapping": current_mapping,
             "selected_revision": {
                 "namespace_id": str(raw_selected.get("namespace_id")),
                 "resource_id": str(raw_selected.get("resource_id")),
                 "revision_id": raw_selected.get("revision_id"),
                 "parent_revision_id": parent_id,
+                "surface": raw_selected.get("surface"),
                 "action": raw_selected.get("action"),
                 "path_at_revision": self._row_path(raw_selected),
                 "path_from": raw_selected.get("path_from"),
@@ -1272,10 +1233,14 @@ class NativeRevisionShadowReader:
                 "subject": raw_selected.get("subject"),
                 "summary": raw_selected.get("summary"),
                 "occurred_at": occurred_at.isoformat(),
+                "digest": raw_selected.get("digest"),
+                "byte_size": raw_selected.get("byte_size"),
             },
             "activity": {
+                "namespace_id": str(self.namespace_id),
                 "resource_id": str(activity.get("resource_id")),
                 "revision_id": activity.get("revision_id"),
+                "surface": "document",
                 "action": activity.get("action"),
                 "path_at_revision": activity.get("path_at_revision"),
                 "path_from": activity.get("changed_path_from"),
@@ -1286,6 +1251,42 @@ class NativeRevisionShadowReader:
                 "occurred_at": occurred_at.isoformat(),
             },
             "completed_parent_mapping": parent_binding,
+        }
+
+    async def _completed_current_mapping(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        try:
+            resolution = await self.selector_bridge.resolve_selector(
+                resource_id=document.resource_id,
+                selector=document.current_commit,
+            )
+        except (AKBError, AttributeError, TypeError, ValueError) as exc:
+            raise ShadowReaderScopeError("native activity current selector has no completed legacy mapping") from exc
+        if (
+            resolution.resource_id != document.resource_id
+            or resolution.selector != document.current_commit
+            or resolution.kind != "native"
+            or resolution.native_revision_id != selector
+            or resolution.legacy_git_oid != document.current_commit
+            or resolution.path_at_revision != document.current_path
+            or resolution.fixed_git_oid != fixed_ref
+            or resolution.run_id is None
+        ):
+            raise ShadowReaderScopeError("native activity current mapping differs from the selected fixed-ref scope")
+        return {
+            "namespace_id": str(self.namespace_id),
+            "resource_id": str(document.resource_id),
+            "legacy_git_oid": document.current_commit,
+            "path_at_revision": document.current_path,
+            "resolution": "native",
+            "native_revision_id": selector,
+            "fixed_git_oid": fixed_ref,
+            "run_id": str(resolution.run_id),
         }
 
     async def _completed_parent_mapping(
@@ -1302,9 +1303,7 @@ class NativeRevisionShadowReader:
                     selector=entry.legacy_git_oid,
                 )
             except (AKBError, AttributeError, TypeError, ValueError) as exc:
-                raise ShadowReaderScopeError(
-                    "native activity parent has no completed legacy mapping"
-                ) from exc
+                raise ShadowReaderScopeError("native activity parent has no completed legacy mapping") from exc
             if resolution.kind != "native" or resolution.native_revision_id != parent_revision_id:
                 continue
             if (
@@ -1314,22 +1313,21 @@ class NativeRevisionShadowReader:
                 or _OID_RE.fullmatch(resolution.fixed_git_oid) is None
                 or resolution.run_id is None
             ):
-                raise ShadowReaderScopeError(
-                    "native activity parent mapping differs from the frozen lineage"
-                )
+                raise ShadowReaderScopeError("native activity parent mapping differs from the frozen lineage")
             matches.append(
                 {
+                    "namespace_id": str(self.namespace_id),
+                    "resource_id": str(document.resource_id),
                     "legacy_git_oid": entry.legacy_git_oid,
                     "path_at_revision": entry.path_at_revision,
+                    "resolution": "native",
                     "native_revision_id": parent_revision_id,
                     "fixed_git_oid": resolution.fixed_git_oid,
                     "run_id": str(resolution.run_id),
                 }
             )
         if len(matches) != 1:
-            raise ShadowReaderScopeError(
-                "native activity parent must have exactly one completed legacy mapping"
-            )
+            raise ShadowReaderScopeError("native activity parent must have exactly one completed legacy mapping")
         return matches[0]
 
     async def activity_evidence(
@@ -1344,8 +1342,16 @@ class NativeRevisionShadowReader:
             selector=selector,
             fixed_ref=fixed_ref,
         )
+        current_mapping = await self._completed_current_mapping(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )
         binding_fact = await self._audit_activity_facts(
             document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+            current_mapping=current_mapping,
             snapshot=snapshot,
             raw_selected=raw_selected,
             activity=activity,
@@ -1376,8 +1382,10 @@ class NativeRevisionShadowReader:
         selector: str,
         fixed_ref: str,
     ) -> dict[str, Any]:
-        return (await self.activity_evidence(
-            document,
-            selector=selector,
-            fixed_ref=fixed_ref,
-        )).envelope
+        return (
+            await self.activity_evidence(
+                document,
+                selector=selector,
+                fixed_ref=fixed_ref,
+            )
+        ).envelope

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -26,6 +26,8 @@ from app.services.document_service import _parse_markdown
 from app.services.git_service import FixedRefHistoryError, GitService
 from app.services.legacy_revision_bridge import (
     LegacyInventoryDocument,
+    LogicalLineageProjectionError,
+    project_logical_lineage,
 )
 from app.services.native_revision_service import NativeRevisionService
 from app.services.uri_service import doc_uri
@@ -359,33 +361,20 @@ class LegacyFixedRefShadowReader:
         expected_history = [
             (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at) for entry in reversed(document.lineage)
         ]
-        observed_history = []
-        seen: set[str] = set()
-        for entry in snapshot.history:
-            oid = entry.get("legacy_git_oid")
-            committed_at = entry.get("committed_at")
-            if (
-                not isinstance(oid, str)
-                or _OID_RE.fullmatch(oid) is None
-                or not isinstance(committed_at, datetime)
-            ):
-                raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
-            if oid in seen:
-                continue
-            if oid != document.current_commit and committed_at < document.created_at:
-                continue
-            seen.add(oid)
-            observed_history.append(
-                (
-                    oid,
-                    (
-                        document.current_path
-                        if oid == document.current_commit
-                        else entry.get("path_at_revision")
-                    ),
-                    committed_at,
-                )
+        try:
+            projected = project_logical_lineage(
+                snapshot.history,
+                current_commit=document.current_commit,
+                current_path=document.current_path,
+                created_at=document.created_at,
+                oldest_anchor_oid=document.lineage[0].legacy_git_oid,
             )
+        except LogicalLineageProjectionError as exc:
+            raise ShadowReaderScopeError("legacy fixed-ref history is invalid") from exc
+        observed_history = [
+            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at)
+            for entry in reversed(projected)
+        ]
         if observed_history != expected_history:
             raise ShadowReaderScopeError("legacy fixed-ref history differs from C9 inventory")
 

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -9,6 +9,7 @@ the Resource identity and the native genesis Revision published by C9.
 from __future__ import annotations
 
 import asyncio
+import difflib
 import hashlib
 import re
 from collections.abc import Mapping
@@ -18,19 +19,21 @@ from uuid import UUID
 
 import asyncpg
 
-from app.exceptions import ConflictError, NotFoundError
+from app.exceptions import AKBError, ConflictError, NotFoundError
 from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.document_service import _parse_markdown
 from app.services.git_service import FixedRefHistoryError, GitService
 from app.services.legacy_revision_bridge import (
     LegacyInventoryDocument,
-    LegacyRevisionBridge,
 )
 from app.services.native_revision_service import NativeRevisionService
 from app.services.uri_service import doc_uri
 
 
 _OID_RE = re.compile(r"^[0-9a-f]{40}$")
+_HUNK_RE = re.compile(
+    r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$"
+)
 
 
 class ShadowReaderScopeError(ConflictError):
@@ -75,6 +78,15 @@ class NativeRevisionReadRepository(Protocol):
         resource_id,
         revision_id: str,
     ) -> dict[str, Any] | None: ...
+
+
+class SelectorBridge(Protocol):
+    async def resolve_selector(
+        self,
+        *,
+        resource_id,
+        selector: str,
+    ): ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,18 +161,99 @@ def _validate_lineage(document: LegacyInventoryDocument) -> None:
 
 
 def _snapshot_diff(text: str) -> str:
-    """Render one deterministic content snapshot for both read models.
-
-    C10 compares a Git parent-based diff with the native fixed-ref snapshot
-    basis.  The basis is the approved semantic difference; the selected
-    current body must still be the same.  This deliberately avoids making the
-    native genesis pretend it has a legacy parent.
-    """
+    """Render the shared final-state form after a verified transition."""
     normalized = text.replace("\r\n", "\n")
     lines = normalized.splitlines()
     if not lines:
         return "@@ snapshot @@\n"
     return "@@ snapshot @@\n" + "\n".join(f" {line}" for line in lines)
+
+
+def _canonical_transition(parent_text: str, current_text: str) -> str:
+    """Derive the parity envelope through both immutable transition bodies."""
+    delta = tuple(
+        difflib.ndiff(
+            parent_text.splitlines(keepends=True),
+            current_text.splitlines(keepends=True),
+        )
+    )
+    rebuilt = "".join(difflib.restore(delta, 2))
+    if rebuilt != current_text:
+        raise ShadowReaderScopeError("shadow reader transition could not reproduce current body")
+    _, body = _parsed_body(rebuilt)
+    return _snapshot_diff(body)
+
+
+def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
+    """Apply the exact Git patch to an independently read parent body."""
+    patch_lines = patch.splitlines()
+    hunk_indexes = [
+        index for index, line in enumerate(patch_lines) if _HUNK_RE.fullmatch(line)
+    ]
+    if not hunk_indexes:
+        prefix = "+" if diff_type == "added" else "-" if diff_type == "deleted" else None
+        if prefix is None or any(not line.startswith(prefix) for line in patch_lines):
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch is not canonical unified data")
+        materialized = "\n".join(line[1:] for line in patch_lines)
+        if diff_type == "deleted":
+            if materialized != parent_text:
+                raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from parent body")
+            return ""
+        if parent_text:
+            raise ShadowReaderScopeError("legacy fixed-ref added patch has a non-empty parent")
+        return materialized
+
+    if hunk_indexes[0] != 0:
+        allowed_headers = {"diff --git", "index ", "--- ", "+++ "}
+        if any(
+            not any(line.startswith(prefix) for prefix in allowed_headers)
+            for line in patch_lines[: hunk_indexes[0]]
+        ):
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid headers")
+
+    source = parent_text.split("\n")
+    output: list[str] = []
+    source_index = 0
+    patch_index = hunk_indexes[0]
+    while patch_index < len(patch_lines):
+        header = _HUNK_RE.fullmatch(patch_lines[patch_index])
+        if header is None:
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has trailing data")
+        old_start = int(header.group(1))
+        old_count = int(header.group(2) or "1")
+        new_count = int(header.group(4) or "1")
+        hunk_source = 0 if old_start == 0 else old_start - 1
+        if hunk_source < source_index or hunk_source > len(source):
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid parent range")
+        output.extend(source[source_index:hunk_source])
+        source_index = hunk_source
+        observed_old = 0
+        observed_new = 0
+        patch_index += 1
+        while patch_index < len(patch_lines) and _HUNK_RE.fullmatch(
+            patch_lines[patch_index]
+        ) is None:
+            line = patch_lines[patch_index]
+            patch_index += 1
+            if line == r"\ No newline at end of file":
+                continue
+            if not line or line[0] not in {" ", "+", "-"}:
+                raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk data")
+            marker, value = line[0], line[1:]
+            if marker in {" ", "-"}:
+                if source_index >= len(source) or source[source_index] != value:
+                    raise ShadowReaderScopeError(
+                        "legacy fixed-ref diff patch differs from parent body"
+                    )
+                source_index += 1
+                observed_old += 1
+            if marker in {" ", "+"}:
+                output.append(value)
+                observed_new += 1
+        if (observed_old, observed_new) != (old_count, new_count):
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk counts")
+    output.extend(source[source_index:])
+    return "\n".join(output)
 
 
 def _history_entries(
@@ -417,12 +510,40 @@ class LegacyFixedRefShadowReader:
             raise ShadowReaderScopeError(
                 "legacy fixed-ref diff differs from C9 inventory"
             )
-        _, body = _parsed_body(snapshot.body.decode("utf-8"))
+        previous = document.lineage[-2] if len(document.lineage) > 1 else None
+        try:
+            current_text, parent_text = await asyncio.gather(
+                asyncio.to_thread(
+                    self.git.read_file,
+                    self.vault_name,
+                    document.current_path,
+                    commit=selector,
+                ),
+                asyncio.to_thread(
+                    self.git.read_file,
+                    self.vault_name,
+                    previous.path_at_revision,
+                    commit=previous.legacy_git_oid,
+                )
+                if previous is not None
+                else asyncio.sleep(0, result=""),
+            )
+        except (OSError, ValueError) as exc:
+            raise ShadowReaderScopeError("legacy fixed-ref diff body reads failed") from exc
+        if not isinstance(current_text, str) or not isinstance(parent_text, str):
+            raise ShadowReaderScopeError("legacy fixed-ref diff body facts are missing")
+        snapshot_text = snapshot.body.decode("utf-8")
+        if current_text != snapshot_text:
+            raise ShadowReaderScopeError("legacy fixed-ref diff current body differs from C9 facts")
+        patch_parent = "" if diff_type == "added" else parent_text
+        applied = _apply_unified_patch(patch_parent, raw_diff["diff"], diff_type)
+        if applied != current_text:
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from current body")
         return {
             "file": document.current_path,
             "commit": selector,
             "basis": "git-parent",
-            "text": _snapshot_diff(body),
+            "text": _canonical_transition(parent_text, applied),
             "format": "unified",
         }
 
@@ -465,12 +586,14 @@ class NativeRevisionShadowReader:
         vault_name: str,
         native_service: NativeRevisionReadService | None = None,
         native_repository: NativeRevisionReadRepository | None = None,
-        selector_bridge: LegacyRevisionBridge | None = None,
+        selector_bridge: SelectorBridge | None = None,
     ):
         if native_service is None and pool is None:
             raise ValueError("pool or native_service is required")
         if not isinstance(vault_name, str) or not vault_name.strip():
             raise ValueError("vault_name must be non-empty")
+        if selector_bridge is None:
+            raise ValueError("selector_bridge is required for product shadow evidence")
         self.pool = pool
         self.namespace_id = namespace_id
         self.vault_name = vault_name
@@ -553,22 +676,7 @@ class NativeRevisionShadowReader:
                 )
             except NotFoundError as exc:
                 raise ShadowReaderScopeError("native revision is outside the C9 Resource scope") from exc
-            text = _value(raw_snapshot, "text")
-            if not isinstance(text, str):
-                raise ShadowReaderScopeError("native revision materialization returned no text")
-            action = _value(raw_snapshot, "action")
-            snapshot = _NativeMaterialization(
-                resource_id=_value(raw_snapshot, "resource_id"),
-                revision_id=_value(raw_snapshot, "revision_id"),
-                surface=_value(raw_snapshot, "surface"),
-                path=_value(raw_snapshot, "path"),
-                text=text,
-                digest=_value(raw_snapshot, "digest"),
-                byte_size=_value(raw_snapshot, "byte_size"),
-                action=action if isinstance(action, str) and action else "create",
-                parent_revision_id=_value(raw_snapshot, "parent_revision_id"),
-                occurred_at=_value(raw_snapshot, "occurred_at"),
-            )
+            snapshot = self._materialization(raw_snapshot)
             self._validate_materialization(snapshot, document, selector=selector)
             self._snapshot_cache = (key, snapshot)
             return snapshot
@@ -598,6 +706,74 @@ class NativeRevisionShadowReader:
                 f"native revision {source} differs from the selected Revision"
             )
 
+    @classmethod
+    def _validate_revision_body_facts(
+        cls,
+        row: Mapping[str, Any],
+        snapshot: _NativeMaterialization,
+        *,
+        namespace_id: Any,
+        source: str,
+    ) -> None:
+        try:
+            body = snapshot.text.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise ShadowReaderScopeError(
+                f"native revision {source} body facts are invalid"
+            ) from exc
+        if (
+            not isinstance(snapshot.revision_id, str)
+            or _OID_RE.fullmatch(snapshot.revision_id) is None
+            or snapshot.surface != "document"
+            or not isinstance(snapshot.path, str)
+            or not snapshot.path
+            or snapshot.action not in {"create", "replace", "move"}
+            or snapshot.occurred_at is None
+            or (
+                snapshot.parent_revision_id is not None
+                and (
+                    not isinstance(snapshot.parent_revision_id, str)
+                    or _OID_RE.fullmatch(snapshot.parent_revision_id) is None
+                )
+            )
+            or row.get("namespace_id") != namespace_id
+            or row.get("resource_id") != snapshot.resource_id
+            or row.get("revision_id") != snapshot.revision_id
+            or row.get("surface") != snapshot.surface
+            or cls._row_path(row) != snapshot.path
+            or row.get("action") != snapshot.action
+            or row.get("parent_revision_id") != snapshot.parent_revision_id
+            or row.get("occurred_at") != snapshot.occurred_at
+            or row.get("digest") != snapshot.digest
+            or row.get("byte_size") != snapshot.byte_size
+            or len(body) != snapshot.byte_size
+            or hashlib.sha256(body).hexdigest() != snapshot.digest
+        ):
+            raise ShadowReaderScopeError(
+                f"native revision {source} body facts differ from persisted Revision"
+            )
+
+    @staticmethod
+    def _materialization(raw_snapshot: Any) -> _NativeMaterialization:
+        text = _value(raw_snapshot, "text")
+        if not isinstance(text, str):
+            raise ShadowReaderScopeError("native revision materialization returned no text")
+        action = _value(raw_snapshot, "action")
+        if not isinstance(action, str) or not action:
+            raise ShadowReaderScopeError("native revision materialization returned no action")
+        return _NativeMaterialization(
+            resource_id=_value(raw_snapshot, "resource_id"),
+            revision_id=_value(raw_snapshot, "revision_id"),
+            surface=_value(raw_snapshot, "surface"),
+            path=_value(raw_snapshot, "path"),
+            text=text,
+            digest=_value(raw_snapshot, "digest"),
+            byte_size=_value(raw_snapshot, "byte_size"),
+            action=action,
+            parent_revision_id=_value(raw_snapshot, "parent_revision_id"),
+            occurred_at=_value(raw_snapshot, "occurred_at"),
+        )
+
     async def _native_history_rows(
         self,
         document: LegacyInventoryDocument,
@@ -612,12 +788,6 @@ class NativeRevisionShadowReader:
         ):
             raise ShadowReaderScopeError("native revision history is missing or invalid")
         copied = [dict(row) for row in rows]
-        self._validate_selected_revision(
-            copied[0],
-            snapshot,
-            document,
-            source="history",
-        )
         revision_ids = [row.get("revision_id") for row in copied]
         if len(set(revision_ids)) != len(revision_ids) or any(
             not isinstance(revision_id, str) or _OID_RE.fullmatch(revision_id) is None
@@ -626,22 +796,40 @@ class NativeRevisionShadowReader:
             raise ShadowReaderScopeError("native revision history has invalid selectors")
         if any(row.get("occurred_at") is None for row in copied):
             raise ShadowReaderScopeError("native revision history has missing chronology")
-        ordered = sorted(
-            copied,
-            key=lambda row: (row["occurred_at"], row["revision_id"]),
-            reverse=True,
+        rows_by_id = {row["revision_id"]: row for row in copied}
+        selected = rows_by_id.get(snapshot.revision_id)
+        if selected is None:
+            raise ShadowReaderScopeError("native revision history has no selected head")
+        self._validate_selected_revision(
+            selected,
+            snapshot,
+            document,
+            source="history",
         )
-        if [row["revision_id"] for row in copied] != [
-            row["revision_id"] for row in ordered
-        ]:
-            raise ShadowReaderScopeError("native revision history order is invalid")
-        for index, row in enumerate(copied):
-            expected_parent = (
-                copied[index + 1]["revision_id"] if index + 1 < len(copied) else None
+        ordered: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        revision_id: str | None = snapshot.revision_id
+        while revision_id is not None:
+            if revision_id in seen:
+                raise ShadowReaderScopeError("native revision history parent cycle is invalid")
+            row = rows_by_id.get(revision_id)
+            if row is None:
+                raise ShadowReaderScopeError("native revision history parent is missing")
+            if row.get("resource_id") != document.resource_id:
+                raise ShadowReaderScopeError("native revision history crosses Resource scope")
+            parent_id = row.get("parent_revision_id")
+            if parent_id is not None and (
+                not isinstance(parent_id, str) or _OID_RE.fullmatch(parent_id) is None
+            ):
+                raise ShadowReaderScopeError("native revision history parent is invalid")
+            seen.add(revision_id)
+            ordered.append(row)
+            revision_id = parent_id
+        if len(ordered) != len(copied):
+            raise ShadowReaderScopeError(
+                "native revision history has disconnected extra rows"
             )
-            if row.get("parent_revision_id") != expected_parent:
-                raise ShadowReaderScopeError("native revision history parent chain is invalid")
-        return copied
+        return ordered
 
     async def _verify_selector_bridge(
         self,
@@ -651,12 +839,18 @@ class NativeRevisionShadowReader:
         fixed_ref: str,
         history_rows: list[dict[str, Any]],
     ) -> None:
-        if self.selector_bridge is None:
-            return
-        native = await self.selector_bridge.resolve_selector(
-            resource_id=document.resource_id,
-            selector=native_revision_id,
-        )
+        async def resolve(selector: str, source: str):
+            try:
+                return await self.selector_bridge.resolve_selector(
+                    resource_id=document.resource_id,
+                    selector=selector,
+                )
+            except (AKBError, AttributeError, TypeError, ValueError) as exc:
+                raise ShadowReaderScopeError(
+                    f"{source} selector is not bound to the completed C9 bridge"
+                ) from exc
+
+        native = await resolve(native_revision_id, "native history head")
         if (
             native.kind != "native"
             or native.native_revision_id != native_revision_id
@@ -665,10 +859,7 @@ class NativeRevisionShadowReader:
             raise ShadowReaderScopeError("native history head is not bound to the C9 selector")
         native_lineage: list[str] = []
         for entry in document.lineage:
-            resolution = await self.selector_bridge.resolve_selector(
-                resource_id=document.resource_id,
-                selector=entry.legacy_git_oid,
-            )
+            resolution = await resolve(entry.legacy_git_oid, "retained")
             if (
                 resolution.kind not in {"native", "bridge"}
                 or resolution.legacy_git_oid != entry.legacy_git_oid
@@ -684,10 +875,7 @@ class NativeRevisionShadowReader:
                 ):
                     raise ShadowReaderScopeError("native history mapping has no Revision token")
                 native_lineage.append(resolution.native_revision_id)
-        current = await self.selector_bridge.resolve_selector(
-            resource_id=document.resource_id,
-            selector=document.current_commit,
-        )
+        current = await resolve(document.current_commit, "current retained")
         if (
             current.kind != "native"
             or current.native_revision_id != native_revision_id
@@ -765,14 +953,27 @@ class NativeRevisionShadowReader:
             document,
             source="diff",
         )
+        self._validate_revision_body_facts(
+            raw_selected,
+            snapshot,
+            namespace_id=self.namespace_id,
+            source="selected",
+        )
+        parent_text = ""
         if snapshot.action == "create":
             if snapshot.parent_revision_id is not None:
                 raise ShadowReaderScopeError("native revision diff has an invalid create parent")
         elif snapshot.action in {"replace", "move"}:
             if snapshot.parent_revision_id is None:
                 raise ShadowReaderScopeError("native revision diff has no parent")
+            raw_parent = await self.native_repository.get_revision(
+                resource_id=document.resource_id,
+                revision_id=snapshot.parent_revision_id,
+            )
+            if not isinstance(raw_parent, Mapping):
+                raise ShadowReaderScopeError("native revision diff parent row is missing")
             try:
-                parent = await self.native_service.get_resource_revision(
+                raw_parent_snapshot = await self.native_service.get_resource_revision(
                     namespace_id=self.namespace_id,
                     surface="document",
                     resource_id=document.resource_id,
@@ -780,20 +981,21 @@ class NativeRevisionShadowReader:
                 )
             except NotFoundError as exc:
                 raise ShadowReaderScopeError("native revision diff parent is missing") from exc
-            if (
-                _value(parent, "resource_id") != document.resource_id
-                or _value(parent, "revision_id") != snapshot.parent_revision_id
-                or not isinstance(_value(parent, "text"), str)
-            ):
-                raise ShadowReaderScopeError("native revision diff parent is invalid")
+            parent_snapshot = self._materialization(raw_parent_snapshot)
+            self._validate_revision_body_facts(
+                raw_parent,
+                parent_snapshot,
+                namespace_id=self.namespace_id,
+                source="parent",
+            )
+            parent_text = parent_snapshot.text
         else:
             raise ShadowReaderScopeError("native revision diff action is unsupported")
-        _, body = _parsed_body(snapshot.text)
         return {
             "file": document.current_path,
             "commit": selector,
             "basis": "fixed-ref-snapshot",
-            "text": _snapshot_diff(body),
+            "text": _canonical_transition(parent_text, snapshot.text),
             "format": "unified",
         }
 

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -597,15 +597,20 @@ class LegacyFixedRefShadowReader:
         snapshot_text = snapshot.body.decode("utf-8")
         if current_text != snapshot_text:
             raise ShadowReaderScopeError("legacy fixed-ref diff current body differs from C9 facts")
-        patch_parent = "" if diff_type == "added" else parent_text
-        applied = _apply_unified_patch(patch_parent, raw_diff["diff"], diff_type)
+        if previous is None and diff_type == "modified":
+            transition_parent = ""
+            applied = current_text
+        else:
+            patch_parent = "" if diff_type == "added" else parent_text
+            transition_parent = parent_text
+            applied = _apply_unified_patch(patch_parent, raw_diff["diff"], diff_type)
         if applied != current_text:
             raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from current body")
         return {
             "file": document.current_path,
             "commit": selector,
             "basis": "git-parent",
-            "text": _canonical_transition(parent_text, applied),
+            "text": _canonical_transition(transition_parent, applied),
             "format": "unified",
         }
 

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -19,6 +19,7 @@ from uuid import UUID
 import asyncpg
 
 from app.exceptions import ConflictError, NotFoundError
+from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.document_service import _parse_markdown
 from app.services.git_service import FixedRefHistoryError, GitService
 from app.services.legacy_revision_bridge import (
@@ -51,6 +52,31 @@ class NativeRevisionReadService(Protocol):
     ): ...
 
 
+class NativeRevisionReadRepository(Protocol):
+    async def get_revision(
+        self,
+        *,
+        resource_id,
+        revision_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def list_history(
+        self,
+        *,
+        resource_id,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]: ...
+
+    async def get_activity_for_revision(
+        self,
+        *,
+        namespace_id,
+        surface: str,
+        resource_id,
+        revision_id: str,
+    ) -> dict[str, Any] | None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class _LegacySnapshotKey:
     resource_id: UUID
@@ -66,6 +92,8 @@ class _LegacyMaterialization:
     fixed_ref: str
     current_commit: str
     body: bytes
+    history: tuple[dict[str, Any], ...]
+    activity: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,6 +116,8 @@ class _NativeMaterialization:
     digest: str
     byte_size: int
     action: str
+    parent_revision_id: str | None
+    occurred_at: Any
 
 
 def _require_oid(value: str, field: str) -> None:
@@ -183,6 +213,55 @@ class LegacyFixedRefShadowReader:
         except UnicodeDecodeError as exc:
             raise ShadowReaderScopeError("legacy fixed-ref body is not valid UTF-8") from exc
 
+        expected_history = [
+            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at)
+            for entry in reversed(document.lineage)
+        ]
+        observed_history = [
+            (
+                entry.get("legacy_git_oid"),
+                entry.get("path_at_revision"),
+                entry.get("committed_at"),
+            )
+            for entry in snapshot.history
+        ]
+        if observed_history != expected_history:
+            raise ShadowReaderScopeError(
+                "legacy fixed-ref history differs from C9 inventory"
+            )
+
+        activity = document.activity
+        expected_activity = (
+            activity.legacy_git_oid,
+            activity.committed_at,
+            activity.actor,
+            activity.subject,
+            activity.summary,
+            activity.action,
+            activity.path_from,
+            activity.path_to,
+            tuple(dict(change) for change in activity.changed_paths),
+        )
+        raw_activity = snapshot.activity
+        changed_paths = raw_activity.get("changed_paths")
+        if not isinstance(changed_paths, (list, tuple)):
+            raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
+        observed_activity = (
+            raw_activity.get("legacy_git_oid"),
+            raw_activity.get("committed_at"),
+            raw_activity.get("actor"),
+            raw_activity.get("subject"),
+            raw_activity.get("summary"),
+            raw_activity.get("action"),
+            raw_activity.get("path_from"),
+            raw_activity.get("path_to"),
+            tuple(dict(change) for change in changed_paths if isinstance(change, Mapping)),
+        )
+        if observed_activity != expected_activity:
+            raise ShadowReaderScopeError(
+                "legacy fixed-ref activity differs from C9 inventory"
+            )
+
     async def _fixed_snapshot(
         self,
         document: LegacyInventoryDocument,
@@ -227,10 +306,18 @@ class LegacyFixedRefShadowReader:
             if not isinstance(raw_snapshot, Mapping):
                 raise ShadowReaderScopeError("legacy fixed-ref materialization is invalid")
             body = raw_snapshot.get("body")
+            history = raw_snapshot.get("history")
+            activity = raw_snapshot.get("activity")
             materialized_fixed_ref = raw_snapshot.get("fixed_ref")
             materialized_current_commit = raw_snapshot.get("current_commit")
             if not isinstance(body, bytes):
                 raise ShadowReaderScopeError("legacy fixed-ref materialization returned no body")
+            if not isinstance(history, list) or not all(
+                isinstance(entry, Mapping) for entry in history
+            ):
+                raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
+            if not isinstance(activity, Mapping):
+                raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
             if not isinstance(materialized_fixed_ref, str) or not isinstance(
                 materialized_current_commit,
                 str,
@@ -240,6 +327,8 @@ class LegacyFixedRefShadowReader:
                 fixed_ref=materialized_fixed_ref,
                 current_commit=materialized_current_commit,
                 body=bytes(body),
+                history=tuple(dict(entry) for entry in history),
+                activity=dict(activity),
             )
             self._validate_materialization(snapshot, document, fixed_ref=fixed_ref)
             self._snapshot_cache = (key, snapshot)
@@ -300,6 +389,34 @@ class LegacyFixedRefShadowReader:
         if selector != document.current_commit:
             raise ShadowReaderScopeError("legacy diff selector is outside the frozen current head")
         snapshot = await self._fixed_snapshot(document, fixed_ref=fixed_ref)
+        try:
+            raw_diff = await asyncio.to_thread(
+                self.git.file_diff,
+                self.vault_name,
+                document.current_path,
+                selector,
+            )
+        except (OSError, ValueError) as exc:
+            raise ShadowReaderScopeError("legacy fixed-ref diff failed") from exc
+        if not isinstance(raw_diff, Mapping):
+            raise ShadowReaderScopeError("legacy fixed-ref diff is invalid")
+        diff_type = raw_diff.get("type")
+        allowed_types = {
+            "create": {"added"},
+            "update": {"modified"},
+            "move": {"added", "modified"},
+            "delete": {"deleted"},
+        }[document.activity.action]
+        if (
+            raw_diff.get("file") != document.current_path
+            or raw_diff.get("commit") != selector
+            or diff_type not in allowed_types
+            or not isinstance(raw_diff.get("diff"), str)
+            or not raw_diff.get("diff")
+        ):
+            raise ShadowReaderScopeError(
+                "legacy fixed-ref diff differs from C9 inventory"
+            )
         _, body = _parsed_body(snapshot.body.decode("utf-8"))
         return {
             "file": document.current_path,
@@ -347,6 +464,7 @@ class NativeRevisionShadowReader:
         namespace_id,
         vault_name: str,
         native_service: NativeRevisionReadService | None = None,
+        native_repository: NativeRevisionReadRepository | None = None,
         selector_bridge: LegacyRevisionBridge | None = None,
     ):
         if native_service is None and pool is None:
@@ -357,6 +475,15 @@ class NativeRevisionShadowReader:
         self.namespace_id = namespace_id
         self.vault_name = vault_name
         self.native_service = native_service or NativeRevisionService(pool)  # type: ignore[arg-type]
+        if native_repository is None:
+            if pool is not None:
+                native_repository = NativeRevisionRepository(pool)
+            else:
+                candidate = getattr(self.native_service, "repository", None)
+                if candidate is None:
+                    raise ValueError("pool or native_repository is required")
+                native_repository = candidate
+        self.native_repository = native_repository
         self.selector_bridge = selector_bridge
         self._snapshot_lock = asyncio.Lock()
         self._snapshot_cache: tuple[_NativeSnapshotKey, _NativeMaterialization] | None = None
@@ -377,6 +504,10 @@ class NativeRevisionShadowReader:
             or snapshot.byte_size != document.byte_size
         ):
             raise ShadowReaderScopeError("native revision facts differ from C9 inventory")
+        if snapshot.parent_revision_id is not None:
+            _require_oid(snapshot.parent_revision_id, "native parent revision")
+        if snapshot.occurred_at is None:
+            raise ShadowReaderScopeError("native revision chronology is missing")
         try:
             body = snapshot.text.encode("utf-8", errors="strict")
         except UnicodeEncodeError as exc:
@@ -435,10 +566,82 @@ class NativeRevisionShadowReader:
                 digest=_value(raw_snapshot, "digest"),
                 byte_size=_value(raw_snapshot, "byte_size"),
                 action=action if isinstance(action, str) and action else "create",
+                parent_revision_id=_value(raw_snapshot, "parent_revision_id"),
+                occurred_at=_value(raw_snapshot, "occurred_at"),
             )
             self._validate_materialization(snapshot, document, selector=selector)
             self._snapshot_cache = (key, snapshot)
             return snapshot
+
+    @staticmethod
+    def _row_path(row: Mapping[str, Any]) -> Any:
+        return row.get("path_at_revision", row.get("path"))
+
+    @classmethod
+    def _validate_selected_revision(
+        cls,
+        row: Mapping[str, Any],
+        snapshot: _NativeMaterialization,
+        document: LegacyInventoryDocument,
+        *,
+        source: str,
+    ) -> None:
+        if (
+            row.get("resource_id") != document.resource_id
+            or row.get("revision_id") != snapshot.revision_id
+            or cls._row_path(row) != document.current_path
+            or row.get("action") != snapshot.action
+            or row.get("parent_revision_id") != snapshot.parent_revision_id
+            or row.get("occurred_at") != snapshot.occurred_at
+        ):
+            raise ShadowReaderScopeError(
+                f"native revision {source} differs from the selected Revision"
+            )
+
+    async def _native_history_rows(
+        self,
+        document: LegacyInventoryDocument,
+        snapshot: _NativeMaterialization,
+    ) -> list[dict[str, Any]]:
+        rows = await self.native_repository.list_history(
+            resource_id=document.resource_id,
+            limit=len(document.lineage) + 1,
+        )
+        if not isinstance(rows, list) or not rows or not all(
+            isinstance(row, Mapping) for row in rows
+        ):
+            raise ShadowReaderScopeError("native revision history is missing or invalid")
+        copied = [dict(row) for row in rows]
+        self._validate_selected_revision(
+            copied[0],
+            snapshot,
+            document,
+            source="history",
+        )
+        revision_ids = [row.get("revision_id") for row in copied]
+        if len(set(revision_ids)) != len(revision_ids) or any(
+            not isinstance(revision_id, str) or _OID_RE.fullmatch(revision_id) is None
+            for revision_id in revision_ids
+        ):
+            raise ShadowReaderScopeError("native revision history has invalid selectors")
+        if any(row.get("occurred_at") is None for row in copied):
+            raise ShadowReaderScopeError("native revision history has missing chronology")
+        ordered = sorted(
+            copied,
+            key=lambda row: (row["occurred_at"], row["revision_id"]),
+            reverse=True,
+        )
+        if [row["revision_id"] for row in copied] != [
+            row["revision_id"] for row in ordered
+        ]:
+            raise ShadowReaderScopeError("native revision history order is invalid")
+        for index, row in enumerate(copied):
+            expected_parent = (
+                copied[index + 1]["revision_id"] if index + 1 < len(copied) else None
+            )
+            if row.get("parent_revision_id") != expected_parent:
+                raise ShadowReaderScopeError("native revision history parent chain is invalid")
+        return copied
 
     async def _verify_selector_bridge(
         self,
@@ -446,6 +649,7 @@ class NativeRevisionShadowReader:
         *,
         native_revision_id: str,
         fixed_ref: str,
+        history_rows: list[dict[str, Any]],
     ) -> None:
         if self.selector_bridge is None:
             return
@@ -453,20 +657,45 @@ class NativeRevisionShadowReader:
             resource_id=document.resource_id,
             selector=native_revision_id,
         )
-        if native.kind != "native" or native.native_revision_id != native_revision_id:
+        if (
+            native.kind != "native"
+            or native.native_revision_id != native_revision_id
+            or native.path_at_revision != document.current_path
+        ):
             raise ShadowReaderScopeError("native history head is not bound to the C9 selector")
-        for entry in document.lineage[:-1]:
+        native_lineage: list[str] = []
+        for entry in document.lineage:
             resolution = await self.selector_bridge.resolve_selector(
                 resource_id=document.resource_id,
                 selector=entry.legacy_git_oid,
             )
             if (
-                resolution.kind != "bridge"
-                or resolution.fixed_git_oid != fixed_ref
+                resolution.kind not in {"native", "bridge"}
                 or resolution.legacy_git_oid != entry.legacy_git_oid
                 or resolution.path_at_revision != entry.path_at_revision
+                or not isinstance(resolution.fixed_git_oid, str)
+                or _OID_RE.fullmatch(resolution.fixed_git_oid) is None
             ):
                 raise ShadowReaderScopeError("retained selector is not bound to the C9 fixed-ref bridge")
+            if resolution.kind == "native":
+                if (
+                    not isinstance(resolution.native_revision_id, str)
+                    or _OID_RE.fullmatch(resolution.native_revision_id) is None
+                ):
+                    raise ShadowReaderScopeError("native history mapping has no Revision token")
+                native_lineage.append(resolution.native_revision_id)
+        current = await self.selector_bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.current_commit,
+        )
+        if (
+            current.kind != "native"
+            or current.native_revision_id != native_revision_id
+            or current.fixed_git_oid != fixed_ref
+        ):
+            raise ShadowReaderScopeError("native history head has the wrong owning fixed ref")
+        if [row["revision_id"] for row in history_rows] != list(reversed(native_lineage)):
+            raise ShadowReaderScopeError("native revision history differs from completed mappings")
 
     async def get(
         self,
@@ -502,11 +731,13 @@ class NativeRevisionShadowReader:
         selector: str,
         fixed_ref: str,
     ) -> dict[str, Any]:
-        await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        history_rows = await self._native_history_rows(document, snapshot)
         await self._verify_selector_bridge(
             document,
             native_revision_id=selector,
             fixed_ref=fixed_ref,
+            history_rows=history_rows,
         )
         return {
             "history_source": "fixed-ref-bridge",
@@ -522,6 +753,41 @@ class NativeRevisionShadowReader:
         fixed_ref: str,
     ) -> dict[str, Any]:
         snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        raw_selected = await self.native_repository.get_revision(
+            resource_id=document.resource_id,
+            revision_id=selector,
+        )
+        if not isinstance(raw_selected, Mapping):
+            raise ShadowReaderScopeError("native revision diff selection is missing")
+        self._validate_selected_revision(
+            raw_selected,
+            snapshot,
+            document,
+            source="diff",
+        )
+        if snapshot.action == "create":
+            if snapshot.parent_revision_id is not None:
+                raise ShadowReaderScopeError("native revision diff has an invalid create parent")
+        elif snapshot.action in {"replace", "move"}:
+            if snapshot.parent_revision_id is None:
+                raise ShadowReaderScopeError("native revision diff has no parent")
+            try:
+                parent = await self.native_service.get_resource_revision(
+                    namespace_id=self.namespace_id,
+                    surface="document",
+                    resource_id=document.resource_id,
+                    revision_id=snapshot.parent_revision_id,
+                )
+            except NotFoundError as exc:
+                raise ShadowReaderScopeError("native revision diff parent is missing") from exc
+            if (
+                _value(parent, "resource_id") != document.resource_id
+                or _value(parent, "revision_id") != snapshot.parent_revision_id
+                or not isinstance(_value(parent, "text"), str)
+            ):
+                raise ShadowReaderScopeError("native revision diff parent is invalid")
+        else:
+            raise ShadowReaderScopeError("native revision diff action is unsupported")
         _, body = _parsed_body(snapshot.text)
         return {
             "file": document.current_path,
@@ -539,17 +805,69 @@ class NativeRevisionShadowReader:
         fixed_ref: str,
     ) -> dict[str, Any]:
         snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        raw_selected = await self.native_repository.get_revision(
+            resource_id=document.resource_id,
+            revision_id=selector,
+        )
+        if not isinstance(raw_selected, Mapping):
+            raise ShadowReaderScopeError("native revision activity selection is missing")
+        self._validate_selected_revision(
+            raw_selected,
+            snapshot,
+            document,
+            source="activity",
+        )
+        raw_activity = await self.native_repository.get_activity_for_revision(
+            namespace_id=self.namespace_id,
+            surface="document",
+            resource_id=document.resource_id,
+            revision_id=selector,
+        )
+        if not isinstance(raw_activity, Mapping):
+            raise ShadowReaderScopeError("native revision activity is missing")
+        activity = raw_activity
+        expected = (
+            document.resource_id,
+            selector,
+            raw_selected.get("action"),
+            raw_selected.get("actor"),
+            raw_selected.get("subject"),
+            raw_selected.get("summary"),
+            raw_selected.get("path_from"),
+            raw_selected.get("path_to"),
+            raw_selected.get("occurred_at"),
+            self._row_path(raw_selected),
+        )
+        observed = (
+            activity.get("resource_id"),
+            activity.get("revision_id"),
+            activity.get("action"),
+            activity.get("actor"),
+            activity.get("subject"),
+            activity.get("summary"),
+            activity.get("changed_path_from"),
+            activity.get("changed_path_to"),
+            activity.get("occurred_at"),
+            activity.get("path_at_revision"),
+        )
+        if observed != expected:
+            raise ShadowReaderScopeError(
+                "native revision activity differs from persisted Revision facts"
+            )
+        actor = activity.get("actor")
+        if not isinstance(actor, str) or not actor:
+            raise ShadowReaderScopeError("native revision activity actor is invalid")
         return {
             "events": [
                 {
                     "hash": selector,
-                    "subject": None,
+                    "subject": activity.get("subject"),
                     "author": {
-                        "id": "akb-native-revision-migration",
-                        "display": "Migration",
+                        "id": actor,
+                        "display": actor,
                     },
-                    "action": snapshot.action,
-                    "summary": "C9 fixed-ref native genesis",
+                    "action": activity.get("action"),
+                    "summary": activity.get("summary"),
                     "projection_revision": selector,
                 }
             ]

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -1,0 +1,556 @@
+"""Product-owned, read-only readers for the P2 shadow comparison.
+
+The readers deliberately expose the small C10 envelopes rather than calling a
+public route or registering a second request path.  The legacy reader is
+bounded by the immutable fixed-ref inventory; the native reader is bounded by
+the Resource identity and the native genesis Revision published by C9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+from uuid import UUID
+
+import asyncpg
+
+from app.exceptions import ConflictError, NotFoundError
+from app.services.document_service import _parse_markdown
+from app.services.git_service import FixedRefHistoryError, GitService
+from app.services.legacy_revision_bridge import (
+    LegacyInventoryDocument,
+    LegacyRevisionBridge,
+)
+from app.services.native_revision_service import NativeRevisionService
+from app.services.uri_service import doc_uri
+
+
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ShadowReaderScopeError(ConflictError):
+    """A product shadow read was not bound to its frozen C9 scope."""
+
+    def __init__(self, message: str = "native revision shadow reader scope is invalid"):
+        super().__init__(message)
+        self.code = "native_revision_shadow_reader_scope_invalid"
+
+
+class NativeRevisionReadService(Protocol):
+    async def get_resource_revision(
+        self,
+        *,
+        namespace_id,
+        surface: str,
+        resource_id,
+        revision_id: str,
+    ): ...
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacySnapshotKey:
+    resource_id: UUID
+    current_commit: str
+    fixed_ref: str
+    path: str
+    body_digest: str
+    byte_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyMaterialization:
+    fixed_ref: str
+    current_commit: str
+    body: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _NativeSnapshotKey:
+    resource_id: UUID
+    selector: str
+    fixed_ref: str
+    path: str
+    body_digest: str
+    byte_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class _NativeMaterialization:
+    resource_id: UUID
+    revision_id: str
+    surface: str
+    path: str
+    text: str
+    digest: str
+    byte_size: int
+    action: str
+
+
+def _require_oid(value: str, field: str) -> None:
+    if not isinstance(value, str) or _OID_RE.fullmatch(value) is None:
+        raise ShadowReaderScopeError(f"shadow reader {field} is not a full revision token")
+
+
+def _value(value: Any, field: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(field)
+    return getattr(value, field, None)
+
+
+def _parsed_body(text: str) -> tuple[dict[str, Any], str]:
+    try:
+        metadata, body = _parse_markdown(text)
+    except Exception as exc:  # noqa: BLE001 - a shadow read must fail closed
+        raise ShadowReaderScopeError("shadow reader payload is not valid markdown") from exc
+    return metadata, body
+
+
+def _validate_lineage(document: LegacyInventoryDocument) -> None:
+    if not document.lineage or document.lineage[-1].legacy_git_oid != document.current_commit:
+        raise ShadowReaderScopeError("shadow reader inventory lineage has no current-head boundary")
+    for entry in document.lineage:
+        _require_oid(entry.legacy_git_oid, "lineage selector")
+        if not isinstance(entry.path_at_revision, str) or not entry.path_at_revision.strip():
+            raise ShadowReaderScopeError("shadow reader inventory lineage has an invalid path")
+
+
+def _snapshot_diff(text: str) -> str:
+    """Render one deterministic content snapshot for both read models.
+
+    C10 compares a Git parent-based diff with the native fixed-ref snapshot
+    basis.  The basis is the approved semantic difference; the selected
+    current body must still be the same.  This deliberately avoids making the
+    native genesis pretend it has a legacy parent.
+    """
+    normalized = text.replace("\r\n", "\n")
+    lines = normalized.splitlines()
+    if not lines:
+        return "@@ snapshot @@\n"
+    return "@@ snapshot @@\n" + "\n".join(f" {line}" for line in lines)
+
+
+def _history_entries(
+    document: LegacyInventoryDocument,
+    *,
+    native_revision_id: str | None,
+) -> list[dict[str, Any]]:
+    entries = []
+    for index, lineage in enumerate(reversed(document.lineage)):
+        selector = native_revision_id if native_revision_id is not None and index == 0 else lineage.legacy_git_oid
+        entries.append(
+            {
+                "selector": selector,
+                "payload_sha256": hashlib.sha256(lineage.legacy_git_oid.encode()).hexdigest(),
+                "projection_revision": selector if index == 0 else None,
+                "summary": document.activity.summary if index == 0 else "retained history",
+            }
+        )
+    return entries
+
+
+class LegacyFixedRefShadowReader:
+    """Read one frozen legacy Document through the C9 fixed-ref Git seam."""
+
+    def __init__(self, *, git: GitService, vault_name: str):
+        if not isinstance(vault_name, str) or not vault_name.strip():
+            raise ValueError("vault_name must be non-empty")
+        self.git = git
+        self.vault_name = vault_name
+        self._snapshot_lock = asyncio.Lock()
+        self._snapshot_cache: tuple[_LegacySnapshotKey, _LegacyMaterialization] | None = None
+
+    @staticmethod
+    def _validate_materialization(
+        snapshot: _LegacyMaterialization,
+        document: LegacyInventoryDocument,
+        *,
+        fixed_ref: str,
+    ) -> None:
+        body = snapshot.body
+        if (
+            snapshot.fixed_ref != fixed_ref
+            or snapshot.current_commit != document.current_commit
+            or len(body) != document.byte_size
+            or hashlib.sha256(body).hexdigest() != document.body_digest
+        ):
+            raise ShadowReaderScopeError("legacy fixed-ref materialization differs from C9 inventory")
+        try:
+            body.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise ShadowReaderScopeError("legacy fixed-ref body is not valid UTF-8") from exc
+
+    async def _fixed_snapshot(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        fixed_ref: str,
+    ) -> _LegacyMaterialization:
+        _validate_lineage(document)
+        _require_oid(fixed_ref, "fixed_ref")
+        _require_oid(document.current_commit, "legacy current revision")
+        key = _LegacySnapshotKey(
+            resource_id=document.resource_id,
+            current_commit=document.current_commit,
+            fixed_ref=fixed_ref,
+            path=document.current_path,
+            body_digest=document.body_digest,
+            byte_size=document.byte_size,
+        )
+        async with self._snapshot_lock:
+            if self._snapshot_cache is not None and self._snapshot_cache[0] == key:
+                cached = self._snapshot_cache[1]
+                try:
+                    self._validate_materialization(cached, document, fixed_ref=fixed_ref)
+                except ShadowReaderScopeError:
+                    self._snapshot_cache = None
+                    raise
+                return cached
+
+            # A miss evicts before I/O: a failed replacement cannot expose the
+            # prior Resource's body through a later cache hit.
+            self._snapshot_cache = None
+            try:
+                raw_snapshot = await asyncio.to_thread(
+                    self.git.manual_fixed_ref_history,
+                    self.vault_name,
+                    fixed_ref,
+                    document.current_path,
+                    current_commit=document.current_commit,
+                    since_epoch=int(document.created_at.timestamp()),
+                )
+            except (FixedRefHistoryError, OSError, ValueError) as exc:
+                raise ShadowReaderScopeError("legacy fixed-ref materialization failed") from exc
+            if not isinstance(raw_snapshot, Mapping):
+                raise ShadowReaderScopeError("legacy fixed-ref materialization is invalid")
+            body = raw_snapshot.get("body")
+            materialized_fixed_ref = raw_snapshot.get("fixed_ref")
+            materialized_current_commit = raw_snapshot.get("current_commit")
+            if not isinstance(body, bytes):
+                raise ShadowReaderScopeError("legacy fixed-ref materialization returned no body")
+            if not isinstance(materialized_fixed_ref, str) or not isinstance(
+                materialized_current_commit,
+                str,
+            ):
+                raise ShadowReaderScopeError("legacy fixed-ref materialization has invalid scope")
+            snapshot = _LegacyMaterialization(
+                fixed_ref=materialized_fixed_ref,
+                current_commit=materialized_current_commit,
+                body=bytes(body),
+            )
+            self._validate_materialization(snapshot, document, fixed_ref=fixed_ref)
+            self._snapshot_cache = (key, snapshot)
+            return snapshot
+
+    async def get(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        if selector != document.current_commit:
+            raise ShadowReaderScopeError("legacy get selector is outside the frozen current head")
+        snapshot = await self._fixed_snapshot(document, fixed_ref=fixed_ref)
+        metadata, body = _parsed_body(snapshot.body.decode("utf-8"))
+        title = metadata.get("title")
+        if not isinstance(title, str) or not title:
+            title = document.current_path.rsplit("/", 1)[-1]
+        return {
+            "kind": "document",
+            "uri": doc_uri(self.vault_name, document.current_path),
+            "vault": self.vault_name,
+            "path": document.current_path,
+            "title": title,
+            "current_commit": selector,
+            "content": body,
+            "projection": {"revision": selector, "authoritative": False},
+            "actor": {
+                "id": document.activity.actor,
+                "display": document.activity.actor,
+            },
+        }
+
+    async def history(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        if selector != document.current_commit:
+            raise ShadowReaderScopeError("legacy history selector is outside the frozen current head")
+        await self._fixed_snapshot(document, fixed_ref=fixed_ref)
+        return {
+            "history_source": "legacy-git-log",
+            "lineage_boundary": "legacy-document-start",
+            "entries": _history_entries(document, native_revision_id=None),
+        }
+
+    async def diff(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        if selector != document.current_commit:
+            raise ShadowReaderScopeError("legacy diff selector is outside the frozen current head")
+        snapshot = await self._fixed_snapshot(document, fixed_ref=fixed_ref)
+        _, body = _parsed_body(snapshot.body.decode("utf-8"))
+        return {
+            "file": document.current_path,
+            "commit": selector,
+            "basis": "git-parent",
+            "text": _snapshot_diff(body),
+            "format": "unified",
+        }
+
+    async def activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        if selector != document.current_commit:
+            raise ShadowReaderScopeError("legacy activity selector is outside the frozen current head")
+        await self._fixed_snapshot(document, fixed_ref=fixed_ref)
+        activity = document.activity
+        return {
+            "events": [
+                {
+                    "hash": selector,
+                    "subject": activity.subject,
+                    "author": {
+                        "id": activity.actor,
+                        "display": f"{activity.actor} (Git)",
+                    },
+                    "action": activity.action,
+                    "summary": activity.summary,
+                    "projection_revision": selector,
+                }
+            ]
+        }
+
+
+class NativeRevisionShadowReader:
+    """Read one C9 native genesis through the PostgreSQL Revision service."""
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool | None,
+        *,
+        namespace_id,
+        vault_name: str,
+        native_service: NativeRevisionReadService | None = None,
+        selector_bridge: LegacyRevisionBridge | None = None,
+    ):
+        if native_service is None and pool is None:
+            raise ValueError("pool or native_service is required")
+        if not isinstance(vault_name, str) or not vault_name.strip():
+            raise ValueError("vault_name must be non-empty")
+        self.pool = pool
+        self.namespace_id = namespace_id
+        self.vault_name = vault_name
+        self.native_service = native_service or NativeRevisionService(pool)  # type: ignore[arg-type]
+        self.selector_bridge = selector_bridge
+        self._snapshot_lock = asyncio.Lock()
+        self._snapshot_cache: tuple[_NativeSnapshotKey, _NativeMaterialization] | None = None
+
+    @staticmethod
+    def _validate_materialization(
+        snapshot: _NativeMaterialization,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+    ) -> None:
+        if (
+            snapshot.resource_id != document.resource_id
+            or snapshot.revision_id != selector
+            or snapshot.surface != "document"
+            or snapshot.path != document.current_path
+            or snapshot.digest != document.body_digest
+            or snapshot.byte_size != document.byte_size
+        ):
+            raise ShadowReaderScopeError("native revision facts differ from C9 inventory")
+        try:
+            body = snapshot.text.encode("utf-8", errors="strict")
+        except UnicodeEncodeError as exc:
+            raise ShadowReaderScopeError("native revision materialization is not valid UTF-8") from exc
+        if len(body) != document.byte_size or hashlib.sha256(body).hexdigest() != document.body_digest:
+            raise ShadowReaderScopeError("native revision body differs from C9 inventory")
+
+    async def _native_snapshot(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> _NativeMaterialization:
+        _validate_lineage(document)
+        _require_oid(fixed_ref, "fixed_ref")
+        _require_oid(selector, "native revision")
+        key = _NativeSnapshotKey(
+            resource_id=document.resource_id,
+            selector=selector,
+            fixed_ref=fixed_ref,
+            path=document.current_path,
+            body_digest=document.body_digest,
+            byte_size=document.byte_size,
+        )
+        async with self._snapshot_lock:
+            if self._snapshot_cache is not None and self._snapshot_cache[0] == key:
+                cached = self._snapshot_cache[1]
+                try:
+                    self._validate_materialization(cached, document, selector=selector)
+                except ShadowReaderScopeError:
+                    self._snapshot_cache = None
+                    raise
+                return cached
+
+            self._snapshot_cache = None
+            try:
+                raw_snapshot = await self.native_service.get_resource_revision(
+                    namespace_id=self.namespace_id,
+                    surface="document",
+                    resource_id=document.resource_id,
+                    revision_id=selector,
+                )
+            except NotFoundError as exc:
+                raise ShadowReaderScopeError("native revision is outside the C9 Resource scope") from exc
+            text = _value(raw_snapshot, "text")
+            if not isinstance(text, str):
+                raise ShadowReaderScopeError("native revision materialization returned no text")
+            action = _value(raw_snapshot, "action")
+            snapshot = _NativeMaterialization(
+                resource_id=_value(raw_snapshot, "resource_id"),
+                revision_id=_value(raw_snapshot, "revision_id"),
+                surface=_value(raw_snapshot, "surface"),
+                path=_value(raw_snapshot, "path"),
+                text=text,
+                digest=_value(raw_snapshot, "digest"),
+                byte_size=_value(raw_snapshot, "byte_size"),
+                action=action if isinstance(action, str) and action else "create",
+            )
+            self._validate_materialization(snapshot, document, selector=selector)
+            self._snapshot_cache = (key, snapshot)
+            return snapshot
+
+    async def _verify_selector_bridge(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        native_revision_id: str,
+        fixed_ref: str,
+    ) -> None:
+        if self.selector_bridge is None:
+            return
+        native = await self.selector_bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=native_revision_id,
+        )
+        if native.kind != "native" or native.native_revision_id != native_revision_id:
+            raise ShadowReaderScopeError("native history head is not bound to the C9 selector")
+        for entry in document.lineage[:-1]:
+            resolution = await self.selector_bridge.resolve_selector(
+                resource_id=document.resource_id,
+                selector=entry.legacy_git_oid,
+            )
+            if (
+                resolution.kind != "bridge"
+                or resolution.fixed_git_oid != fixed_ref
+                or resolution.legacy_git_oid != entry.legacy_git_oid
+                or resolution.path_at_revision != entry.path_at_revision
+            ):
+                raise ShadowReaderScopeError("retained selector is not bound to the C9 fixed-ref bridge")
+
+    async def get(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        metadata, body = _parsed_body(snapshot.text)
+        title = metadata.get("title")
+        if not isinstance(title, str) or not title:
+            title = document.current_path.rsplit("/", 1)[-1]
+        return {
+            "kind": "document",
+            "uri": doc_uri(self.vault_name, document.current_path),
+            "vault": self.vault_name,
+            "path": document.current_path,
+            "title": title,
+            "current_commit": selector,
+            "content": body,
+            "projection": {"revision": selector, "authoritative": False},
+            "actor": {
+                "id": document.activity.actor,
+                "display": document.activity.actor,
+            },
+        }
+
+    async def history(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        await self._verify_selector_bridge(
+            document,
+            native_revision_id=selector,
+            fixed_ref=fixed_ref,
+        )
+        return {
+            "history_source": "fixed-ref-bridge",
+            "lineage_boundary": document.lineage[0].legacy_git_oid,
+            "entries": _history_entries(document, native_revision_id=selector),
+        }
+
+    async def diff(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        _, body = _parsed_body(snapshot.text)
+        return {
+            "file": document.current_path,
+            "commit": selector,
+            "basis": "fixed-ref-snapshot",
+            "text": _snapshot_diff(body),
+            "format": "unified",
+        }
+
+    async def activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> dict[str, Any]:
+        snapshot = await self._native_snapshot(document, selector=selector, fixed_ref=fixed_ref)
+        return {
+            "events": [
+                {
+                    "hash": selector,
+                    "subject": None,
+                    "author": {
+                        "id": "akb-native-revision-migration",
+                        "display": "Migration",
+                    },
+                    "action": snapshot.action,
+                    "summary": "C9 fixed-ref native genesis",
+                    "projection_revision": selector,
+                }
+            ]
+        }

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -359,14 +359,33 @@ class LegacyFixedRefShadowReader:
         expected_history = [
             (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at) for entry in reversed(document.lineage)
         ]
-        observed_history = [
-            (
-                entry.get("legacy_git_oid"),
-                entry.get("path_at_revision"),
-                entry.get("committed_at"),
+        observed_history = []
+        seen: set[str] = set()
+        for entry in snapshot.history:
+            oid = entry.get("legacy_git_oid")
+            committed_at = entry.get("committed_at")
+            if (
+                not isinstance(oid, str)
+                or _OID_RE.fullmatch(oid) is None
+                or not isinstance(committed_at, datetime)
+            ):
+                raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
+            if oid in seen:
+                continue
+            if oid != document.current_commit and committed_at < document.created_at:
+                continue
+            seen.add(oid)
+            observed_history.append(
+                (
+                    oid,
+                    (
+                        document.current_path
+                        if oid == document.current_commit
+                        else entry.get("path_at_revision")
+                    ),
+                    committed_at,
+                )
             )
-            for entry in snapshot.history
-        ]
         if observed_history != expected_history:
             raise ShadowReaderScopeError("legacy fixed-ref history differs from C9 inventory")
 

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -186,7 +186,9 @@ def _canonical_transition(parent_text: str, current_text: str) -> str:
 
 def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
     """Apply the exact Git patch to an independently read parent body."""
-    patch_lines = patch.splitlines()
+    patch_lines = patch.split("\n")
+    if patch_lines and patch_lines[-1] == "":
+        patch_lines.pop()
     hunk_indexes = [
         index for index, line in enumerate(patch_lines) if _HUNK_RE.fullmatch(line)
     ]
@@ -211,21 +213,36 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
         ):
             raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid headers")
 
-    source = parent_text.split("\n")
-    output: list[str] = []
+    source = parent_text.split("\n") if parent_text else []
+    source_has_newline = parent_text.endswith("\n")
+    if source_has_newline:
+        source.pop()
+    output: list[tuple[str, bool]] = []
     source_index = 0
     patch_index = hunk_indexes[0]
+    old_terminal_closed = False
+    new_terminal_closed = False
     while patch_index < len(patch_lines):
         header = _HUNK_RE.fullmatch(patch_lines[patch_index])
         if header is None:
             raise ShadowReaderScopeError("legacy fixed-ref diff patch has trailing data")
         old_start = int(header.group(1))
-        old_count = int(header.group(2) or "1")
-        new_count = int(header.group(4) or "1")
+        old_count = int(header.group(2)) if header.group(2) is not None else 1
+        new_count = int(header.group(4)) if header.group(4) is not None else 1
         hunk_source = 0 if old_start == 0 else old_start - 1
         if hunk_source < source_index or hunk_source > len(source):
             raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid parent range")
-        output.extend(source[source_index:hunk_source])
+        if old_terminal_closed and hunk_source > source_index:
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
+        if new_terminal_closed and hunk_source > source_index:
+            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
+        output.extend(
+            (
+                source[index],
+                index < len(source) - 1 or source_has_newline,
+            )
+            for index in range(source_index, hunk_source)
+        )
         source_index = hunk_source
         observed_old = 0
         observed_new = 0
@@ -236,24 +253,57 @@ def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
             line = patch_lines[patch_index]
             patch_index += 1
             if line == r"\ No newline at end of file":
-                continue
+                raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
             if not line or line[0] not in {" ", "+", "-"}:
                 raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk data")
             marker, value = line[0], line[1:]
+            no_newline = False
+            if patch_index < len(patch_lines) and patch_lines[patch_index] == r"\ No newline at end of file":
+                no_newline = True
+                patch_index += 1
+            old_line = marker in {" ", "-"}
+            new_line = marker in {" ", "+"}
+            if old_line and old_terminal_closed or new_line and new_terminal_closed:
+                raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
             if marker in {" ", "-"}:
                 if source_index >= len(source) or source[source_index] != value:
                     raise ShadowReaderScopeError(
                         "legacy fixed-ref diff patch differs from parent body"
                     )
+                source_line_has_newline = source_index < len(source) - 1 or source_has_newline
+                if no_newline != (not source_line_has_newline):
+                    raise ShadowReaderScopeError(
+                        "legacy fixed-ref diff patch has an invalid newline marker"
+                    )
+                source_line = source[source_index]
                 source_index += 1
                 observed_old += 1
+                if no_newline:
+                    old_terminal_closed = True
+            else:
+                source_line = ""
             if marker in {" ", "+"}:
-                output.append(value)
+                if marker == " ":
+                    output.append((source_line, not no_newline))
+                else:
+                    output.append((value, not no_newline))
                 observed_new += 1
+                if no_newline:
+                    new_terminal_closed = True
         if (observed_old, observed_new) != (old_count, new_count):
             raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk counts")
-    output.extend(source[source_index:])
-    return "\n".join(output)
+    if old_terminal_closed and source_index != len(source):
+        raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
+    if new_terminal_closed and source_index != len(source):
+        raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
+    output.extend(
+        (
+            source[index],
+            index < len(source) - 1 or source_has_newline,
+        )
+        for index in range(source_index, len(source))
+    )
+    return "".join(value + ("\n" if has_newline else "") for value, has_newline in output)
 
 
 def _history_entries(

--- a/backend/tests/test_migration_060_native_revision_bridge_unit.py
+++ b/backend/tests/test_migration_060_native_revision_bridge_unit.py
@@ -1,0 +1,549 @@
+"""PostgreSQL contract tests for migration 060's additive C9 substrate."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.services.native_revision_service import NativeRevisionService
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load(filename: str):
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"migration_060_test_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_schema():
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_native_revision_bridge_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        dsn = _database_dsn(name)
+        conn = await asyncpg.connect(dsn)
+        await conn.execute(_INIT_SQL)
+        await _load("048_native_revision_core.py").migrate(conn=conn)
+        migration = _load("060_native_revision_migration_bridge.py")
+        await migration.migrate(conn=conn)
+        await migration.migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def test_fresh_and_reapplied_schema_enforces_c9_keys_fks_and_cascades():
+    async with _fresh_schema() as pool:
+        async with pool.acquire() as conn:
+            tables = await conn.fetch(
+                """
+                SELECT table_name
+                  FROM information_schema.tables
+                 WHERE table_schema = 'public'
+                   AND table_name = ANY($1::text[])
+                 ORDER BY table_name
+                """,
+                [
+                    "native_revision_migration_runs",
+                    "native_revision_migration_items",
+                    "legacy_revision_mappings",
+                ],
+            )
+            assert [row["table_name"] for row in tables] == [
+                "legacy_revision_mappings",
+                "native_revision_migration_items",
+                "native_revision_migration_runs",
+            ]
+
+            constraint_counts = await conn.fetch(
+                """
+                SELECT conname, count(*)::int AS copies
+                  FROM pg_constraint
+                 WHERE conname LIKE ANY($1::text[])
+                 GROUP BY conname
+                 ORDER BY conname
+                """,
+                [
+                    "native_revision_migration_%",
+                    "legacy_revision_mappings_%",
+                ],
+            )
+            assert all(row["copies"] == 1 for row in constraint_counts)
+            assert await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM pg_indexes
+                 WHERE schemaname = 'public'
+                   AND indexname = 'uq_legacy_revision_mappings_native_revision'
+                """
+            ) == 1
+
+            namespace_one = await conn.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+                f"bridge-one-{uuid.uuid4().hex}",
+                "/tmp/bridge-one-unused.git",
+            )
+            namespace_two = await conn.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+                f"bridge-two-{uuid.uuid4().hex}",
+                "/tmp/bridge-two-unused.git",
+            )
+            document_one = await conn.fetchval(
+                """
+                INSERT INTO documents (vault_id, path, title)
+                VALUES ($1, 'one.md', 'one')
+                RETURNING id
+                """,
+                namespace_one,
+            )
+            document_two = await conn.fetchval(
+                """
+                INSERT INTO documents (vault_id, path, title)
+                VALUES ($1, 'two.md', 'two')
+                RETURNING id
+                """,
+                namespace_two,
+            )
+
+        async with pool.acquire() as conn:
+            run_one = await conn.fetchval(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                VALUES ($1, $2, 'c9-v1', $3)
+                RETURNING run_id
+                """,
+                namespace_one,
+                "a" * 40,
+                "b" * 64,
+            )
+            await conn.execute(
+                """
+                INSERT INTO native_revision_migration_items
+                    (run_id, namespace_id, legacy_document_id, native_resource_id,
+                     captured_path, legacy_head_oid, body_digest, byte_size, status)
+                VALUES ($1, $2, $3, $3, 'one.md', $4, $5, 9, 'pending')
+                """,
+                run_one,
+                namespace_one,
+                document_one,
+                "c" * 40,
+                "d" * 64,
+            )
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE resource_id = $1",
+                document_one,
+            ) == 0
+
+        service = NativeRevisionService(pool)
+        native_one = await service.create_text(
+            namespace_id=namespace_one,
+            surface="document",
+            path="one.md",
+            payload="one body\n",
+            actor="bridge-test",
+            mutation_id=uuid.uuid4(),
+            resource_id=document_one,
+        )
+        native_two = await service.create_text(
+            namespace_id=namespace_two,
+            surface="document",
+            path="two.md",
+            payload="two body\n",
+            actor="bridge-test",
+            mutation_id=uuid.uuid4(),
+            resource_id=document_two,
+        )
+
+        async with pool.acquire() as conn:
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_runs
+                        (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                    VALUES ($1, 'not-an-oid', 'c9-v1', $2)
+                    """,
+                    namespace_one,
+                    "b" * 64,
+                )
+
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, body_digest, byte_size,
+                         status)
+                    VALUES ($1, $2, $3, $3, 'one.md', $4, $5, -1, 'pending')
+                    """,
+                    run_one,
+                    namespace_one,
+                    document_one,
+                    "c" * 40,
+                    "d" * 64,
+                )
+            with pytest.raises(asyncpg.UniqueViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, body_digest, byte_size, status)
+                    VALUES ($1, $2, $3, $3, 'one.md', $4, $5, 9, 'pending')
+                    """,
+                    run_one,
+                    namespace_one,
+                    document_one,
+                    "c" * 40,
+                    "d" * 64,
+                )
+
+            run_two = await conn.fetchval(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                VALUES ($1, $2, 'c9-v2', $3)
+                RETURNING run_id
+                """,
+                namespace_one,
+                "e" * 40,
+                "f" * 64,
+            )
+            with pytest.raises(asyncpg.UniqueViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, body_digest, byte_size, status)
+                    VALUES ($1, $2, $3, $3, 'one.md', $4, $5, 9, 'pending')
+                    """,
+                    run_two,
+                    namespace_one,
+                    document_one,
+                    "c" * 40,
+                    "d" * 64,
+                )
+
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, body_digest, byte_size, status)
+                    VALUES ($1, $2, $3, $3, 'two.md', $4, $5, 9, 'pending')
+                    """,
+                    run_one,
+                    namespace_two,
+                    document_two,
+                    "1" * 40,
+                    "2" * 64,
+                )
+
+            run_three = await conn.fetchval(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                VALUES ($1, $2, 'c9-v3', $3)
+                RETURNING run_id
+                """,
+                namespace_one,
+                "6" * 40,
+                "7" * 64,
+            )
+            await conn.execute(
+                """
+                INSERT INTO native_revision_migration_items
+                    (run_id, namespace_id, legacy_document_id, native_resource_id,
+                     captured_path, legacy_head_oid, native_head_revision_id,
+                     body_digest, byte_size, status)
+                VALUES ($1, $2, $3, $3, 'one.md', $4, $5, $6, 9, 'complete')
+                """,
+                run_three,
+                namespace_one,
+                document_one,
+                "8" * 40,
+                native_one.revision_id,
+                "9" * 64,
+            )
+
+            run_four = await conn.fetchval(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                VALUES ($1, $2, 'c9-v4', $3)
+                RETURNING run_id
+                """,
+                namespace_one,
+                "a" * 40,
+                "b" * 64,
+            )
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, native_head_revision_id,
+                         body_digest, byte_size, status)
+                    VALUES ($1, $2, $3, $3, 'one.md', $4, $5, $6, 9, 'complete')
+                    """,
+                    run_four,
+                    namespace_one,
+                    document_one,
+                    "0" * 40,
+                    native_two.revision_id,
+                    "1" * 64,
+                )
+
+            run_five = await conn.fetchval(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (namespace_id, fixed_git_oid, coverage_version, inventory_digest)
+                VALUES ($1, $2, 'c9-v5', $3)
+                RETURNING run_id
+                """,
+                namespace_two,
+                "c" * 40,
+                "d" * 64,
+            )
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO native_revision_migration_items
+                        (run_id, namespace_id, legacy_document_id, native_resource_id,
+                         captured_path, legacy_head_oid, native_head_revision_id,
+                         body_digest, byte_size, status)
+                    VALUES ($1, $2, $3, $3, 'two.md', $4, $5, $6, 9, 'complete')
+                    """,
+                    run_five,
+                    namespace_two,
+                    document_two,
+                    "e" * 40,
+                    native_one.revision_id,
+                    "f" * 64,
+                )
+
+            failed_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO native_revision_migration_items
+                    (run_id, namespace_id, legacy_document_id, native_resource_id,
+                     captured_path, legacy_head_oid, body_digest, byte_size,
+                     status, error_code)
+                VALUES ($1, $2, $3, $3, 'one.md', $4, $5, 9, 'failed', $6)
+                """,
+                run_two,
+                namespace_one,
+                failed_id,
+                "9" * 40,
+                "a" * 64,
+                "body_unavailable",
+            )
+
+            invalid_states = (
+                (
+                    "pending_with_head",
+                    "b" * 40,
+                    native_one.revision_id,
+                    None,
+                    "pending",
+                ),
+                ("complete_without_head", "c" * 40, None, None, "complete"),
+                (
+                    "failed_with_head",
+                    "d" * 40,
+                    native_one.revision_id,
+                    "body_unavailable",
+                    "failed",
+                ),
+                ("failed_without_error", "e" * 40, None, None, "failed"),
+            )
+            for label, oid, head, error_code, status in invalid_states:
+                invalid_id = uuid.uuid5(uuid.NAMESPACE_URL, label)
+                with pytest.raises(asyncpg.CheckViolationError):
+                    await conn.execute(
+                        """
+                        INSERT INTO native_revision_migration_items
+                            (run_id, namespace_id, legacy_document_id, native_resource_id,
+                             captured_path, legacy_head_oid, native_head_revision_id,
+                             body_digest, byte_size, status, error_code)
+                        VALUES ($1, $2, $3, $3, 'one.md', $4, $5, $6, 9, $7, $8)
+                        """,
+                        run_two,
+                        namespace_one,
+                        invalid_id,
+                        oid,
+                        head,
+                        "f" * 64,
+                        status,
+                        error_code,
+                    )
+
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, 'one.md', 'bridge', $4, 0)
+                """,
+                namespace_one,
+                document_one,
+                "1" * 40,
+                run_one,
+            )
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, native_revision_id, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, 'one.md', 'native', $4, $5, 1)
+                """,
+                namespace_one,
+                document_one,
+                "2" * 40,
+                native_one.revision_id,
+                run_one,
+            )
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO legacy_revision_mappings
+                        (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                         resolution, native_revision_id, run_id, lineage_ordinal)
+                    VALUES ($1, $2, $3, 'one.md', 'native', NULL, $4, 2)
+                    """,
+                    namespace_one,
+                    document_one,
+                    "3" * 40,
+                    run_one,
+                )
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO legacy_revision_mappings
+                        (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                         resolution, native_revision_id, run_id, lineage_ordinal)
+                    VALUES ($1, $2, $3, 'one.md', 'bridge', $4, $5, 2)
+                    """,
+                    namespace_one,
+                    document_one,
+                    "4" * 40,
+                    native_one.revision_id,
+                    run_one,
+                )
+            with pytest.raises(asyncpg.UniqueViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO legacy_revision_mappings
+                        (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                         resolution, native_revision_id, run_id, lineage_ordinal)
+                    VALUES ($1, $2, $3, 'one.md', 'native', $4, $5, 2)
+                    """,
+                    namespace_one,
+                    document_one,
+                    "7" * 40,
+                    native_one.revision_id,
+                    run_one,
+                )
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO legacy_revision_mappings
+                        (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                         resolution, native_revision_id, run_id, lineage_ordinal)
+                    VALUES ($1, $2, $3, 'two.md', 'native', $4, $5, 2)
+                    """,
+                    namespace_one,
+                    document_one,
+                    "5" * 40,
+                    native_two.revision_id,
+                    run_one,
+                )
+
+            await conn.execute("DELETE FROM documents WHERE id = $1", document_one)
+            assert await conn.fetchval(
+                "SELECT count(*) FROM documents WHERE id = $1",
+                document_one,
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
+                run_one,
+            ) == 1
+
+            assert await conn.fetchval(
+                "SELECT count(*) FROM legacy_revision_mappings WHERE run_id = $1",
+                run_one,
+            ) == 2
+            await conn.execute(
+                "DELETE FROM native_revision_migration_runs WHERE run_id = $1",
+                run_one,
+            )
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
+                run_one,
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT count(*) FROM legacy_revision_mappings WHERE run_id = $1",
+                run_one,
+            ) == 0
+
+            # A different namespace cannot reuse the first run's key even if
+            # the UUIDs and selector values are otherwise valid.
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO legacy_revision_mappings
+                        (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                         resolution, native_revision_id, run_id, lineage_ordinal)
+                    VALUES ($1, $2, $3, 'two.md', 'native', $4, $5, 0)
+                    """,
+                    namespace_two,
+                    document_two,
+                    "6" * 40,
+                    native_two.revision_id,
+                    run_two,
+                )

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -1,0 +1,1203 @@
+"""Focused manual-Git/disposable-PG checks for C9 A3+A4."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from pathlib import Path
+
+import asyncpg
+import pytest
+from git import Repo
+
+from app.exceptions import NotFoundError
+from app.repositories.native_revision_migration_repo import (
+    MigrationInventoryDriftError,
+    NativeRevisionMigrationRepository,
+)
+from app.repositories.native_revision_repo import NativeRevisionIdCollisionError
+from app.services.git_service import FixedRefHistoryError, GitService
+from app.services.legacy_revision_bridge import (
+    InventoryEligibilityError,
+    LegacyRevisionBridge,
+    ManualVaultRequiredError,
+    SelectorAmbiguousError,
+    SelectorInvalidError,
+    SelectorUnknownError,
+)
+from app.services.m1_pg_body_store import M1PgBodyStore
+from app.services.native_revision_backfill import (
+    BackfillFailpointError,
+    FAILPOINT_BOUNDARIES,
+    NativeRevisionBackfill,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load(filename: str):
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"migration_c9_test_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_schema(tmp_path: Path):
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_c9_bridge_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        dsn = _database_dsn(name)
+        conn = await asyncpg.connect(dsn)
+        await conn.execute(_INIT_SQL)
+        for filename in (
+            "010_external_git_mirror.py",
+            "048_native_revision_core.py",
+            "053_native_revision_m1_pg_body.py",
+            "060_native_revision_migration_bridge.py",
+        ):
+            await _load(filename).migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _make_fixture(pool, tmp_path: Path) -> dict:
+    git = GitService(storage_path=str(tmp_path / "git"))
+    vault_name = f"c9-{uuid.uuid4().hex}"
+    git.init_vault(vault_name)
+
+    old_oid = git.commit_file(vault_name, "same.md", "old resource\n", "old")
+    await asyncio.sleep(1.05)
+    initial_oid = git.commit_file(
+        vault_name,
+        "same.md",
+        "new v1\n",
+        "[create] same.md\n\nagent: legacy-writer\naction: create\nsummary: create same document",
+    )
+    initial_dt = Repo(str(git._bare_path(vault_name))).commit(initial_oid).committed_datetime
+    created_at = initial_dt - timedelta(milliseconds=100)
+    await asyncio.sleep(1.05)
+    move_oid = git.move_file(
+        vault_name,
+        "same.md",
+        "renamed.md",
+        "[move] same.md -> renamed.md\n\nagent: legacy-writer\naction: move\nsummary: move same document",
+    )
+    await asyncio.sleep(1.05)
+    current_oid = git.commit_file(
+        vault_name,
+        "renamed.md",
+        "new v2\n",
+        "[update] renamed.md\n\nagent: legacy-writer\naction: update\nsummary: update renamed document",
+    )
+    current_dt = Repo(str(git._bare_path(vault_name))).commit(current_oid).committed_datetime
+    await asyncio.sleep(1.05)
+    other_oid = git.commit_file(
+        vault_name,
+        "other.md",
+        "other\n",
+        "[create] other.md\n\nagent: legacy-writer\naction: create\nsummary: create other document",
+    )
+    other_dt = Repo(str(git._bare_path(vault_name))).commit(other_oid).committed_datetime
+    await asyncio.sleep(1.05)
+    unrelated_tip = git.commit_file(vault_name, "unrelated.md", "tip\n", "unrelated")
+    await asyncio.sleep(1.05)
+    later_file_tip = git.commit_file(vault_name, "renamed.md", "post-head\n", "later file")
+
+    async with pool.acquire() as conn:
+        namespace_id = await conn.fetchval(
+            """
+            INSERT INTO vaults (name, git_path, status)
+            VALUES ($1, $2, 'active')
+            RETURNING id
+            """,
+            vault_name,
+            str(git._bare_path(vault_name)),
+        )
+        document_one = uuid.uuid4()
+        document_two = uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO documents
+                (id, vault_id, path, title, created_at, updated_at, current_commit, source)
+            VALUES ($1, $2, 'renamed.md', 'renamed', $3, $3, $4, 'manual')
+            """,
+            document_one,
+            namespace_id,
+            created_at,
+            current_oid,
+        )
+        await conn.execute(
+            """
+            INSERT INTO documents
+                (id, vault_id, path, title, created_at, updated_at, current_commit, source)
+            VALUES ($1, $2, 'other.md', 'other', $3, $3, $4, 'manual')
+            """,
+            document_two,
+            namespace_id,
+            other_dt - timedelta(milliseconds=100),
+            other_oid,
+        )
+        await conn.execute(
+            """
+            INSERT INTO resource_aliases (vault_id, resource_type, old_ref, resource_id)
+            VALUES ($1, 'document', 'same.md', $2)
+            """,
+            namespace_id,
+            document_one,
+        )
+
+    return {
+        "pool": pool,
+        "git": git,
+        "vault_name": vault_name,
+        "namespace_id": namespace_id,
+        "document_one": document_one,
+        "document_two": document_two,
+        "old_oid": old_oid,
+        "initial_oid": initial_oid,
+        "move_oid": move_oid,
+        "current_oid": current_oid,
+        "current_dt": current_dt,
+        "other_oid": other_oid,
+        "unrelated_tip": unrelated_tip,
+        "later_file_tip": later_file_tip,
+        "created_at": created_at,
+    }
+
+
+async def _make_compact_failpoint_fixtures(pool, tmp_path: Path) -> tuple[
+    GitService, list[dict]
+]:
+    """Build one short manual-vault case per registered failpoint.
+
+    The loop intentionally avoids the multi-second chronology fixture above:
+    each case has one current file commit and one unrelated fixed-ref tip, so
+    the table exercises every atomic boundary without repeating six sleeps.
+    """
+    git = GitService(storage_path=str(tmp_path / "git-failpoints"))
+    fixtures: list[dict] = []
+    async with pool.acquire() as conn:
+        for index, boundary in enumerate(FAILPOINT_BOUNDARIES):
+            vault_name = f"c9-fp-{index}-{uuid.uuid4().hex}"
+            git.init_vault(vault_name)
+            current_oid = git.commit_file(
+                vault_name,
+                "current.md",
+                f"body-{index}\n",
+                f"[create] current-{index}.md\n\nagent: legacy-writer\naction: create\nsummary: create current-{index}",
+            )
+            fixed_ref = git.commit_file(
+                vault_name,
+                f"tip-{index}.md",
+                "unrelated\n",
+                "unrelated fixed-ref tip",
+            )
+            current_dt = Repo(str(git._bare_path(vault_name))).commit(
+                current_oid
+            ).committed_datetime
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active')
+                RETURNING id
+                """,
+                vault_name,
+                str(git._bare_path(vault_name)),
+            )
+            document_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, 'current.md', $3, $4, $4, $5, 'manual')
+                """,
+                document_id,
+                namespace_id,
+                f"current-{index}",
+                current_dt - timedelta(seconds=1),
+                current_oid,
+            )
+            await conn.execute(
+                """
+                INSERT INTO resource_aliases (vault_id, resource_type, old_ref, resource_id)
+                VALUES ($1, 'document', $2, $3)
+                """,
+                namespace_id,
+                f"legacy-{index}.md",
+                document_id,
+            )
+            fixtures.append(
+                {
+                    "boundary": boundary,
+                    "namespace_id": namespace_id,
+                    "document_id": document_id,
+                    "fixed_ref": fixed_ref,
+                    "current_oid": current_oid,
+                    "alias": f"legacy-{index}.md",
+                }
+            )
+    return git, fixtures
+
+
+async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        bridge = LegacyRevisionBridge(
+            pool,
+            git=fixture["git"],
+        )
+
+        inventory = await bridge.capture_inventory(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-v1",
+        )
+        doc = next(
+            item for item in inventory.documents
+            if item.resource_id == fixture["document_one"]
+        )
+        assert doc.current_path == "renamed.md"
+        assert doc.current_commit == fixture["current_oid"]
+        assert doc.body == b"new v2\n"
+        assert doc.byte_size == len(doc.body)
+        assert doc.lineage[-1].legacy_git_oid == fixture["current_oid"]
+        assert [entry.path_at_revision for entry in doc.lineage] == [
+            "same.md", "renamed.md", "renamed.md",
+        ]
+        assert fixture["old_oid"] not in {entry.legacy_git_oid for entry in doc.lineage}
+        assert fixture["unrelated_tip"] not in {entry.legacy_git_oid for entry in doc.lineage}
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET current_commit = $2 WHERE id = $1",
+                fixture["document_one"],
+                fixture["unrelated_tip"],
+            )
+        with pytest.raises(InventoryEligibilityError):
+            await bridge.capture_inventory(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["unrelated_tip"],
+                coverage_version="c9-v2",
+            )
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET current_commit = $2 WHERE id = $1",
+                fixture["document_one"],
+                fixture["current_oid"],
+            )
+        with pytest.raises(InventoryEligibilityError):
+            await bridge.capture_inventory(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["later_file_tip"],
+                coverage_version="c9-v3",
+            )
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET source = 'external_git' WHERE id = $1",
+                fixture["document_one"],
+            )
+        mixed_inventory = await bridge.capture_inventory(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-v4",
+        )
+        assert [item.resource_id for item in mixed_inventory.documents] == [
+            fixture["document_two"]
+        ]
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET source = 'manual' WHERE id = $1",
+                fixture["document_one"],
+            )
+            await conn.execute(
+                "UPDATE vaults SET status = 'archived' WHERE id = $1",
+                fixture["namespace_id"],
+            )
+        with pytest.raises(NotFoundError):
+            await bridge.capture_inventory(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["unrelated_tip"],
+                coverage_version="c9-v5",
+            )
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE vaults SET status = 'active' WHERE id = $1",
+                fixture["namespace_id"],
+            )
+            await conn.execute(
+                """
+                INSERT INTO vault_external_git (vault_id, remote_url)
+                VALUES ($1, 'https://example.invalid/repo.git')
+                """,
+                fixture["namespace_id"],
+            )
+        with pytest.raises(ManualVaultRequiredError):
+            await bridge.capture_inventory(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["unrelated_tip"],
+                coverage_version="c9-v6",
+            )
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 0
+
+
+async def test_every_backfill_failpoint_rolls_back_then_retries_once(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git, fixtures = await _make_compact_failpoint_fixtures(pool, tmp_path)
+
+        for fixture in fixtures:
+            bridge = LegacyRevisionBridge(pool, git=git)
+            backfill = NativeRevisionBackfill(pool, git=git, bridge=bridge)
+            run, inventory = await backfill.prepare_run(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["fixed_ref"],
+                coverage_version=f"c9-failpoint-{fixture['boundary']}",
+            )
+            assert len(inventory.documents) == 1
+
+            async def failpoint(name: str, expected=fixture["boundary"]):
+                if name == expected:
+                    raise RuntimeError("rollback this boundary")
+
+            failing = NativeRevisionBackfill(
+                pool,
+                git=git,
+                bridge=bridge,
+                failpoint=failpoint,
+            )
+            with pytest.raises(BackfillFailpointError) as failure:
+                await failing.backfill_run(run.run_id)
+            assert failure.value.boundary == fixture["boundary"]
+
+            async with pool.acquire() as conn:
+                rolled_back = await conn.fetchrow(
+                    """
+                    SELECT
+                        (SELECT count(*) FROM native_resources
+                          WHERE namespace_id = $1) AS resources,
+                        (SELECT count(*) FROM native_revisions
+                          WHERE namespace_id = $1) AS revisions,
+                        (SELECT count(*) FROM native_payload_manifests
+                          WHERE namespace_id = $1) AS manifests,
+                        (SELECT count(*) FROM native_resource_path_aliases
+                          WHERE namespace_id = $1) AS aliases,
+                        (SELECT count(*) FROM native_revision_activity
+                          WHERE namespace_id = $1) AS activities,
+                        (SELECT count(*) FROM native_invalidation_intents
+                          WHERE namespace_id = $1) AS invalidations,
+                        (SELECT count(*) FROM legacy_revision_mappings
+                          WHERE namespace_id = $1) AS mappings,
+                        (SELECT count(*) FROM native_revision_migration_items
+                          WHERE run_id = $2 AND status = 'complete') AS completed_items,
+                        (SELECT count(*) FROM m1_reference_payloads
+                          WHERE namespace_id = $1) AS prepared_payloads,
+                        (SELECT status FROM native_revision_migration_items
+                          WHERE run_id = $2) AS item_status
+                    """,
+                    fixture["namespace_id"],
+                    run.run_id,
+                )
+            assert dict(rolled_back) == {
+                "resources": 0,
+                "revisions": 0,
+                "manifests": 0,
+                "aliases": 0,
+                "activities": 0,
+                "invalidations": 0,
+                "mappings": 0,
+                "completed_items": 0,
+                "prepared_payloads": 1,
+                "item_status": "pending",
+            }
+
+            clean = NativeRevisionBackfill(pool, git=git, bridge=bridge)
+            result = await clean.backfill_run(run.run_id)
+            assert result.status == "complete"
+            async with pool.acquire() as conn:
+                published = await conn.fetchrow(
+                    """
+                    SELECT
+                        (SELECT count(*) FROM native_resources
+                          WHERE namespace_id = $1) AS resources,
+                        (SELECT count(*) FROM native_revisions
+                          WHERE namespace_id = $1) AS revisions,
+                        (SELECT count(*) FROM native_payload_manifests
+                          WHERE namespace_id = $1) AS manifests,
+                        (SELECT count(*) FROM native_resource_path_aliases
+                          WHERE namespace_id = $1) AS aliases,
+                        (SELECT count(*) FROM native_revision_activity
+                          WHERE namespace_id = $1) AS activities,
+                        (SELECT count(*) FROM native_invalidation_intents
+                          WHERE namespace_id = $1) AS invalidations,
+                        (SELECT count(*) FROM legacy_revision_mappings
+                          WHERE namespace_id = $1) AS mappings,
+                        (SELECT count(*) FROM native_revision_migration_items
+                          WHERE run_id = $2 AND status = 'complete') AS completed_items,
+                        (SELECT count(*) FROM m1_reference_payloads
+                          WHERE namespace_id = $1) AS prepared_payloads,
+                        (SELECT status FROM native_revision_migration_items
+                          WHERE run_id = $2) AS item_status,
+                        (SELECT old_path FROM native_resource_path_aliases
+                          WHERE namespace_id = $1 AND resource_id = $3) AS alias_path
+                    """,
+                    fixture["namespace_id"],
+                    run.run_id,
+                    fixture["document_id"],
+                )
+            assert dict(published) == {
+                "resources": 1,
+                "revisions": 1,
+                "manifests": 1,
+                "aliases": 1,
+                "activities": 1,
+                "invalidations": 1,
+                "mappings": 1,
+                "completed_items": 1,
+                "prepared_payloads": 1,
+                "item_status": "complete",
+                "alias_path": fixture["alias"],
+            }
+
+            repeated = await clean.backfill_run(run.run_id)
+            assert repeated.status == "complete"
+            async with pool.acquire() as conn:
+                assert await conn.fetchval(
+                    """
+                    SELECT count(*)
+                      FROM native_resources
+                     WHERE namespace_id = $1
+                    """,
+                    fixture["namespace_id"],
+                ) == 1
+                assert await conn.fetchval(
+                    """
+                    SELECT count(*)
+                      FROM legacy_revision_mappings
+                     WHERE namespace_id = $1
+                    """,
+                    fixture["namespace_id"],
+                ) == 1
+
+
+async def test_mixed_manual_and_external_documents_exclude_external_noop(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET source = 'external_git' WHERE id = $1",
+                fixture["document_two"],
+            )
+
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"])
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-mixed-source",
+        )
+        assert [item.resource_id for item in inventory.documents] == [
+            fixture["document_one"]
+        ]
+
+        result = await backfill.backfill_run(run.run_id)
+        assert result.status == "complete"
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
+                run.run_id,
+            ) == 1
+            assert await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM native_revision_migration_items
+                 WHERE run_id = $1 AND legacy_document_id = $2
+                """,
+                run.run_id,
+                fixture["document_two"],
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 1
+            assert await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM native_resources
+                 WHERE namespace_id = $1 AND resource_id = $2
+                """,
+                fixture["namespace_id"],
+                fixture["document_two"],
+            ) == 0
+            assert await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM legacy_revision_mappings
+                 WHERE namespace_id = $1 AND resource_id = $2
+                """,
+                fixture["namespace_id"],
+                fixture["document_two"],
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT source FROM documents WHERE id = $1",
+                fixture["document_two"],
+            ) == "external_git"
+
+
+async def test_current_move_activity_semantics_are_preserved(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git = GitService(storage_path=str(tmp_path / "git-current-move"))
+        vault_name = f"c9-move-{uuid.uuid4().hex}"
+        git.init_vault(vault_name)
+        initial_oid = git.commit_file(
+            vault_name,
+            "same.md",
+            "move body\n",
+            "[create] same.md\n\nagent: legacy-writer\naction: create\nsummary: create same",
+        )
+        initial_dt = Repo(str(git._bare_path(vault_name))).commit(
+            initial_oid
+        ).committed_datetime
+        move_oid = git.move_file(
+            vault_name,
+            "same.md",
+            "renamed.md",
+            "[move] same.md -> renamed.md\n\nagent: legacy-writer\naction: move\nsummary: move same document",
+        )
+        fixed_ref = git.commit_file(
+            vault_name,
+            "unrelated.md",
+            "tip\n",
+            "unrelated fixed-ref tip",
+        )
+        async with pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active')
+                RETURNING id
+                """,
+                vault_name,
+                str(git._bare_path(vault_name)),
+            )
+            document_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, 'renamed.md', 'renamed.md', $3, $3, $4, 'manual')
+                """,
+                document_id,
+                namespace_id,
+                initial_dt - timedelta(seconds=1),
+                move_oid,
+            )
+
+        backfill = NativeRevisionBackfill(pool, git=git)
+        run, inventory = await backfill.prepare_run(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version="c9-current-move",
+        )
+        document = inventory.documents[0]
+        assert document.activity.action == "move"
+        assert document.activity.path_from == "same.md"
+        assert document.activity.path_to == "renamed.md"
+        body_store = M1PgBodyStore(pool)
+        await body_store.prepare_text(
+            namespace_id=namespace_id,
+            payload=document.body,
+            expected_digest=document.body_digest,
+            expected_size=document.byte_size,
+        )
+        result = await backfill.backfill_run(run.run_id)
+        async with pool.acquire() as conn:
+            item_error = await conn.fetchval(
+                "SELECT error_code FROM native_revision_migration_items WHERE run_id = $1",
+                run.run_id,
+            )
+            activity = await conn.fetchrow(
+                """
+                SELECT action, actor, subject, summary,
+                       changed_path_from, changed_path_to
+                  FROM native_revision_activity
+                 WHERE namespace_id = $1 AND resource_id = $2
+                """,
+                namespace_id,
+                document_id,
+            )
+        assert result.status == "complete", item_error
+        assert dict(activity) == {
+            "action": "create",
+            "actor": "akb-native-revision-migration",
+            "subject": None,
+            "summary": None,
+            "changed_path_from": None,
+            "changed_path_to": "renamed.md",
+        }
+
+
+async def test_selector_is_hidden_until_run_complete(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"])
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-selector",
+        )
+        document = next(
+            item for item in inventory.documents
+            if item.resource_id == fixture["document_one"]
+        )
+        body_store = M1PgBodyStore(pool)
+        prepared = await body_store.prepare_text(
+            namespace_id=fixture["namespace_id"],
+            payload=document.body,
+            expected_digest=document.body_digest,
+            expected_size=document.byte_size,
+        )
+        await backfill._publish_item(
+            run=run,
+            document=document,
+            inventory=inventory,
+            prepared=prepared,
+        )
+        bridge = backfill.bridge
+        with pytest.raises(SelectorUnknownError):
+            await bridge.resolve_selector(
+                resource_id=document.resource_id,
+                selector=document.current_commit,
+            )
+        with pytest.raises(SelectorUnknownError):
+            await bridge.resolve_selector(
+                resource_id=document.resource_id,
+                selector=document.lineage[0].legacy_git_oid[:7],
+            )
+
+        other = next(item for item in inventory.documents if item.resource_id != document.resource_id)
+        other_prepared = await body_store.prepare_text(
+            namespace_id=fixture["namespace_id"],
+            payload=other.body,
+            expected_digest=other.body_digest,
+            expected_size=other.byte_size,
+        )
+        await backfill._publish_item(
+            run=run,
+            document=other,
+            inventory=inventory,
+            prepared=other_prepared,
+        )
+        repository = NativeRevisionMigrationRepository(pool)
+        async with pool.acquire() as conn:
+            await repository.set_run_status(run.run_id, "complete", conn=conn)
+
+        current = await bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.current_commit,
+        )
+        assert current.kind == "native"
+        old = await bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.lineage[0].legacy_git_oid,
+        )
+        assert old.kind == "bridge"
+        assert old.fixed_git_oid == fixture["unrelated_tip"]
+        old_prefix = await bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.lineage[0].legacy_git_oid[:7],
+        )
+        assert old_prefix.kind == "bridge"
+        with pytest.raises(SelectorUnknownError):
+            await bridge.resolve_selector(
+                resource_id=document.resource_id,
+                selector=fixture["unrelated_tip"],
+            )
+
+
+async def test_atomic_retry_chronology_selector_shapes_and_legacy_unchanged(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        bridge = LegacyRevisionBridge(pool, git=fixture["git"])
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"], bridge=bridge)
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-backfill",
+        )
+        async with pool.acquire() as conn:
+            legacy_before = await conn.fetchrow(
+                """
+                SELECT path, current_commit, source, created_at
+                  FROM documents
+                 WHERE id = $1
+                """,
+                fixture["document_one"],
+            )
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 0
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET created_at = $2 WHERE id = $1",
+                fixture["document_one"],
+                fixture["created_at"] + timedelta(seconds=1),
+            )
+        with pytest.raises(MigrationInventoryDriftError):
+            await bridge.prepare_run(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["unrelated_tip"],
+                coverage_version="c9-backfill",
+            )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET created_at = $2 WHERE id = $1",
+                fixture["document_one"],
+                fixture["created_at"],
+            )
+
+        async def fail_before_commit(name: str):
+            if name == "authority.before_commit":
+                raise RuntimeError("rollback")
+
+        failing = NativeRevisionBackfill(
+            pool,
+            git=fixture["git"],
+            bridge=bridge,
+            failpoint=fail_before_commit,
+        )
+        with pytest.raises(BackfillFailpointError):
+            await failing.backfill_run(run.run_id)
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT count(*) FROM legacy_revision_mappings"
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT count(*) FROM m1_reference_payloads WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 1
+            assert await conn.fetchval(
+                "SELECT status FROM native_revision_migration_items WHERE run_id = $1 AND legacy_document_id = $2",
+                run.run_id,
+                fixture["document_one"],
+            ) == "pending"
+
+        result = await backfill.backfill_run(run.run_id)
+        assert result.status == "complete"
+        async with pool.acquire() as conn:
+            counts_before = await conn.fetch(
+                """
+                SELECT 'resource' AS kind, count(*)::int AS n FROM native_resources
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'revision', count(*)::int FROM native_revisions
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'manifest', count(*)::int FROM native_payload_manifests
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'mapping', count(*)::int FROM legacy_revision_mappings
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'item', count(*)::int FROM native_revision_migration_items
+                 WHERE namespace_id = $1
+                ORDER BY kind
+                """,
+                fixture["namespace_id"],
+            )
+            chronology = await conn.fetchrow(
+                """
+                SELECT rs.created_at AS resource_created,
+                       rs.updated_at AS resource_updated,
+                       rv.occurred_at AS revision_occurred,
+                       a.occurred_at AS activity_occurred,
+                       a.action AS activity_action,
+                       a.actor AS activity_actor,
+                       a.subject AS activity_subject,
+                       a.summary AS activity_summary,
+                       a.changed_path_from AS activity_path_from,
+                       a.changed_path_to AS activity_path_to,
+                       i.occurred_at AS invalidation_occurred
+                  FROM native_resources rs
+                  JOIN native_revisions rv
+                    ON rv.resource_id = rs.resource_id
+                   AND rv.revision_id = rs.head_revision_id
+                  JOIN native_revision_activity a
+                    ON a.revision_id = rv.revision_id
+                  JOIN native_invalidation_intents i
+                    ON i.revision_id = rv.revision_id
+                 WHERE rs.resource_id = $1
+                """,
+                fixture["document_one"],
+            )
+            revision_id = await conn.fetchval(
+                "SELECT head_revision_id FROM native_resources WHERE resource_id = $1",
+                fixture["document_one"],
+            )
+            copied_alias = await conn.fetchrow(
+                """
+                SELECT old_path, created_revision_id
+                  FROM native_resource_path_aliases
+                 WHERE namespace_id = $1 AND resource_id = $2
+                """,
+                fixture["namespace_id"],
+                fixture["document_one"],
+            )
+        assert chronology["resource_created"] == legacy_before["created_at"]
+        assert chronology["resource_updated"] == fixture["current_dt"]
+        assert chronology["revision_occurred"] == fixture["current_dt"]
+        assert chronology["activity_occurred"] == fixture["current_dt"]
+        assert chronology["invalidation_occurred"] == fixture["current_dt"]
+        assert chronology["activity_action"] == "create"
+        assert chronology["activity_actor"] == "akb-native-revision-migration"
+        assert chronology["activity_subject"] is None
+        assert chronology["activity_summary"] is None
+        assert chronology["activity_path_from"] is None
+        assert chronology["activity_path_to"] == "renamed.md"
+        assert copied_alias["old_path"] == "same.md"
+        assert copied_alias["created_revision_id"] == revision_id
+
+        repeated = await backfill.backfill_run(run.run_id)
+        assert repeated.status == "complete"
+        async with pool.acquire() as conn:
+            counts_after = await conn.fetch(
+                """
+                SELECT 'resource' AS kind, count(*)::int AS n FROM native_resources
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'revision', count(*)::int FROM native_revisions
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'manifest', count(*)::int FROM native_payload_manifests
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'mapping', count(*)::int FROM legacy_revision_mappings
+                 WHERE namespace_id = $1
+                UNION ALL SELECT 'item', count(*)::int FROM native_revision_migration_items
+                 WHERE namespace_id = $1
+                ORDER BY kind
+                """,
+                fixture["namespace_id"],
+            )
+            legacy_after = await conn.fetchrow(
+                "SELECT path, current_commit, source, created_at FROM documents WHERE id = $1",
+                fixture["document_one"],
+            )
+        assert counts_after == counts_before
+        assert legacy_after == legacy_before
+
+        current = await bridge.resolve_selector(
+            resource_id=fixture["document_one"],
+            selector=fixture["current_oid"],
+        )
+        assert current.kind == "native"
+        assert current.native_revision_id == revision_id
+        document_one_inventory = next(
+            item for item in inventory.documents
+            if item.resource_id == fixture["document_one"]
+        )
+        old_oid = document_one_inventory.lineage[0].legacy_git_oid
+        old = await bridge.resolve_selector(
+            resource_id=fixture["document_one"],
+            selector=old_oid,
+        )
+        assert old.kind == "bridge"
+        assert old.path_at_revision == "same.md"
+        unique_prefix = await bridge.resolve_selector(
+            resource_id=fixture["document_one"],
+            selector=old_oid[:7],
+        )
+        assert unique_prefix.kind == "bridge"
+        unique_long_prefix = await bridge.resolve_selector(
+            resource_id=fixture["document_one"],
+            selector=old_oid[:39],
+        )
+        assert unique_long_prefix.kind == "bridge"
+        for invalid_selector in (revision_id[:7], revision_id[:39]):
+            with pytest.raises(SelectorUnknownError):
+                await bridge.resolve_selector(
+                    resource_id=fixture["document_one"],
+                    selector=invalid_selector,
+                )
+        for invalid_selector in ("123456", "ABCDEF0"):
+            with pytest.raises(SelectorInvalidError):
+                await bridge.resolve_selector(
+                    resource_id=fixture["document_one"],
+                    selector=invalid_selector,
+                )
+        with pytest.raises(SelectorUnknownError):
+            await bridge.resolve_selector(
+                resource_id=fixture["document_one"],
+                selector=fixture["other_oid"],
+            )
+        with pytest.raises(SelectorInvalidError):
+            await bridge.resolve_selector(
+                resource_id=fixture["document_one"],
+                selector="not-hex",
+            )
+        with pytest.raises(SelectorUnknownError):
+            await bridge.resolve_selector(
+                resource_id=fixture["document_two"],
+                selector=fixture["current_oid"],
+            )
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, 'synthetic-a.md', 'bridge', $4, 100),
+                       ($1, $2, $5, 'synthetic-b.md', 'bridge', $4, 101)
+                """,
+                fixture["namespace_id"],
+                fixture["document_one"],
+                "abc1234" + "1" * 33,
+                run.run_id,
+                "abc1234" + "2" * 33,
+            )
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, 'collision.md', 'bridge', $4, 102)
+                """,
+                fixture["namespace_id"],
+                fixture["document_one"],
+                revision_id,
+                run.run_id,
+            )
+        with pytest.raises(SelectorAmbiguousError):
+            await bridge.resolve_selector(
+                resource_id=fixture["document_one"],
+                selector="abc1234",
+            )
+        with pytest.raises(SelectorAmbiguousError):
+            await bridge.resolve_selector(
+                resource_id=fixture["document_one"],
+                selector=revision_id,
+            )
+
+        repository = NativeRevisionMigrationRepository(pool)
+        async with pool.acquire() as conn:
+            with pytest.raises(NativeRevisionIdCollisionError):
+                await repository.allocate_native_revision_id(
+                    conn,
+                    resource_id=fixture["document_one"],
+                    retained_legacy_oids=set(),
+                    revision_id_factory=lambda: old_oid,
+                    attempts=1,
+                )
+
+
+async def test_completed_item_is_not_demoted_by_a_queued_failure(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git, fixtures = await _make_compact_failpoint_fixtures(pool, tmp_path)
+        fixture = fixtures[0]
+        repository = NativeRevisionMigrationRepository(pool)
+        bridge = LegacyRevisionBridge(pool, git=git, repository=repository)
+        backfill = NativeRevisionBackfill(
+            pool,
+            git=git,
+            bridge=bridge,
+            repository=repository,
+        )
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_ref"],
+            coverage_version="c9-concurrency",
+        )
+        document = inventory.documents[0]
+        result = await backfill.backfill_run(run.run_id)
+        assert result.status == "complete"
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                item = await repository.get_item(
+                    run.run_id,
+                    document.resource_id,
+                    conn=conn,
+                    for_update=True,
+                )
+                assert item is not None and item.status == "complete"
+                failure = asyncio.create_task(
+                    backfill._mark_failed(
+                        run.run_id,
+                        document.resource_id,
+                        "authority_publish_failed",
+                    )
+                )
+                await asyncio.sleep(0)
+
+        await failure
+        item = await repository.get_item(run.run_id, document.resource_id)
+        assert item is not None
+        assert item.status == "complete"
+        assert item.native_head_revision_id is not None
+        assert item.error_code is None
+
+
+async def test_completed_run_replay_preserves_terminal_state_and_selector(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git, fixtures = await _make_compact_failpoint_fixtures(pool, tmp_path)
+        fixture = fixtures[0]
+        repository = NativeRevisionMigrationRepository(pool)
+        bridge = LegacyRevisionBridge(pool, git=git, repository=repository)
+        backfill = NativeRevisionBackfill(
+            pool,
+            git=git,
+            bridge=bridge,
+            repository=repository,
+        )
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_ref"],
+            coverage_version="c9-replay",
+        )
+        document = inventory.documents[0]
+        first = await backfill.backfill_run(run.run_id)
+        assert first.status == "complete"
+        before = await repository.get_run(run.run_id)
+        assert before is not None
+        assert before.status == "complete"
+        assert before.completed_at is not None
+        visible_before = await bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.current_commit,
+        )
+        assert visible_before.kind == "native"
+
+        await asyncio.sleep(0.01)
+        replay = await backfill.backfill_run(run.run_id)
+        assert replay.status == "complete"
+        after = await repository.get_run(run.run_id)
+        assert after is not None
+        assert (
+            after.status,
+            after.created_at,
+            after.started_at,
+            after.completed_at,
+            after.error,
+        ) == (
+            before.status,
+            before.created_at,
+            before.started_at,
+            before.completed_at,
+            before.error,
+        )
+        visible_after = await bridge.resolve_selector(
+            resource_id=document.resource_id,
+            selector=document.current_commit,
+        )
+        assert visible_after.kind == "native"
+
+
+async def test_alias_mutation_after_prepare_fails_closed_before_publication(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git, fixtures = await _make_compact_failpoint_fixtures(pool, tmp_path)
+        fixture = fixtures[0]
+        repository = NativeRevisionMigrationRepository(pool)
+        bridge = LegacyRevisionBridge(pool, git=git, repository=repository)
+        backfill = NativeRevisionBackfill(
+            pool,
+            git=git,
+            bridge=bridge,
+            repository=repository,
+        )
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_ref"],
+            coverage_version="c9-alias-freeze",
+        )
+        document = inventory.documents[0]
+        assert [alias.old_ref for alias in document.aliases] == [fixture["alias"]]
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO resource_aliases (vault_id, resource_type, old_ref, resource_id)
+                VALUES ($1, 'document', 'post-freeze.md', $2)
+                """,
+                fixture["namespace_id"],
+                document.resource_id,
+            )
+
+        with pytest.raises(MigrationInventoryDriftError):
+            await backfill.backfill_run(run.run_id)
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE resource_id = $1",
+                document.resource_id,
+            ) == 0
+            assert await conn.fetchval(
+                """
+                SELECT count(*)
+                  FROM native_resource_path_aliases
+                 WHERE resource_id = $1
+                   AND old_path = 'post-freeze.md'
+                """,
+                document.resource_id,
+            ) == 0
+
+
+async def test_manual_fixed_ref_history_missing_repo_is_stable_error(tmp_path):
+    git = GitService(storage_path=str(tmp_path / "missing-git"))
+    with pytest.raises(FixedRefHistoryError):
+        git.manual_fixed_ref_history(
+            "missing-vault",
+            "a" * 40,
+            "missing.md",
+            current_commit="b" * 40,
+        )

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -7,7 +7,7 @@ import importlib.util
 import os
 import uuid
 from contextlib import asynccontextmanager
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import asyncpg
@@ -292,11 +292,12 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
             git=fixture["git"],
         )
 
-        inventory = await bridge.capture_inventory(
+        scope = await bridge.capture_inventory_scope(
             namespace_id=fixture["namespace_id"],
             fixed_ref=fixture["unrelated_tip"],
             coverage_version="c9-v1",
         )
+        inventory = scope.inventory
         doc = next(
             item for item in inventory.documents
             if item.resource_id == fixture["document_one"]
@@ -304,7 +305,7 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
         assert doc.current_path == "renamed.md"
         assert doc.current_commit == fixture["current_oid"]
         assert not hasattr(doc, "body")
-        async with bridge.materialize_body(inventory, doc) as body:
+        async with bridge.materialize_body(scope, doc) as body:
             assert body == b"new v2\n"
             assert doc.byte_size == len(body)
         assert doc.lineage[-1].legacy_git_oid == fixture["current_oid"]
@@ -405,8 +406,8 @@ async def test_backfill_inventory_is_metadata_only_and_materializes_one_body_at_
             self.max_active_bodies = 0
 
         @asynccontextmanager
-        async def materialize_body(self, inventory, document):
-            async with super().materialize_body(inventory, document) as body:
+        async def materialize_body(self, scope, document):
+            async with super().materialize_body(scope, document) as body:
                 self.active_bodies += 1
                 self.max_active_bodies = max(
                     self.max_active_bodies,
@@ -435,6 +436,197 @@ async def test_backfill_inventory_is_metadata_only_and_materializes_one_body_at_
         assert result.status == "complete"
         assert bridge.max_active_bodies == 1
         assert bridge.active_bodies == 0
+
+
+async def test_capture_releases_each_source_body_before_reading_the_next(tmp_path):
+    class LiveBody(bytes):
+        active = 0
+        max_active = 0
+
+        def __new__(cls, value):
+            instance = super().__new__(cls, value)
+            cls.active += 1
+            cls.max_active = max(cls.max_active, cls.active)
+            return instance
+
+        def __del__(self):
+            type(self).active -= 1
+
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        original_history = fixture["git"].manual_fixed_ref_history
+
+        def tracked_history(*args, **kwargs):
+            snapshot = original_history(*args, **kwargs)
+            snapshot["body"] = LiveBody(snapshot["body"])
+            return snapshot
+
+        fixture["git"].manual_fixed_ref_history = tracked_history
+        bridge = LegacyRevisionBridge(pool, git=fixture["git"])
+
+        inventory = await bridge.capture_inventory(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-capture-max-live-body",
+        )
+
+        assert len(inventory.documents) == 2
+        assert LiveBody.max_active == 1
+        assert LiveBody.active == 0
+
+
+async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item(
+    tmp_path,
+    monkeypatch,
+):
+    document_count = 95
+    fixed_ref = "f" * 40
+    committed_at = datetime(2026, 1, 1, tzinfo=UTC)
+
+    class CountingGit:
+        def __init__(self):
+            self.bodies: dict[str, bytes] = {}
+            self.commits: dict[str, str] = {}
+            self.history_calls = 0
+            self.body_read_calls = 0
+
+        def manual_fixed_ref_history(
+            self,
+            vault_name,
+            observed_fixed_ref,
+            file_path,
+            *,
+            current_commit,
+            since_epoch=None,
+        ):
+            del vault_name, since_epoch
+            self.history_calls += 1
+            assert observed_fixed_ref == fixed_ref
+            assert current_commit == self.commits[file_path]
+            return {
+                "fixed_ref": observed_fixed_ref,
+                "current_commit": current_commit,
+                "body": self.bodies[file_path],
+                "history": [
+                    {
+                        "legacy_git_oid": current_commit,
+                        "path_at_revision": file_path,
+                        "committed_at": committed_at,
+                    }
+                ],
+                "activity": {
+                    "legacy_git_oid": current_commit,
+                    "committed_at": committed_at,
+                    "actor": "legacy-writer",
+                    "subject": file_path,
+                    "summary": f"create {file_path}",
+                    "action": "create",
+                    "path_from": None,
+                    "path_to": file_path,
+                    "changed_paths": [
+                        {"status": "A", "path_from": None, "path_to": file_path}
+                    ],
+                },
+            }
+
+        def read_file(self, vault_name, file_path, commit=None):
+            del vault_name
+            self.body_read_calls += 1
+            assert commit == self.commits[file_path]
+            return self.bodies[file_path].decode("utf-8")
+
+    class CountingRepository(NativeRevisionMigrationRepository):
+        def __init__(self, pool):
+            super().__init__(pool)
+            self.manual_vault_queries = 0
+
+        async def get_manual_vault(self, namespace_id, *, conn=None):
+            self.manual_vault_queries += 1
+            return await super().get_manual_vault(namespace_id, conn=conn)
+
+    class CountingBridge(LegacyRevisionBridge):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.run_scope_validations = 0
+
+        async def inventory_scope_for_run(self, run):
+            self.run_scope_validations += 1
+            return await super().inventory_scope_for_run(run)
+
+    canonical_calls = 0
+    canonical_digest = LegacyRevisionBridge.canonical_inventory_digest.__func__
+
+    def counted_canonical_digest(cls, **kwargs):
+        nonlocal canonical_calls
+        canonical_calls += 1
+        return canonical_digest(cls, **kwargs)
+
+    monkeypatch.setattr(
+        LegacyRevisionBridge,
+        "canonical_inventory_digest",
+        classmethod(counted_canonical_digest),
+    )
+
+    async with _fresh_schema(tmp_path) as pool:
+        git = CountingGit()
+        vault_name = f"c9-p95-{uuid.uuid4().hex}"
+        async with pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, '/unused/p95.git', 'active')
+                RETURNING id
+                """,
+                vault_name,
+            )
+            rows = []
+            for index in range(document_count):
+                path = f"p95/{index:03d}.md"
+                current_commit = f"{index + 1:040x}"
+                git.bodies[path] = f"body-{index}\n".encode()
+                git.commits[path] = current_commit
+                rows.append(
+                    (
+                        uuid.uuid4(),
+                        namespace_id,
+                        path,
+                        committed_at - timedelta(seconds=1),
+                        current_commit,
+                    )
+                )
+            await conn.executemany(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, $3, $3, $4, $4, $5, 'manual')
+                """,
+                rows,
+            )
+
+        repository = CountingRepository(pool)
+        bridge = CountingBridge(pool, git=git, repository=repository)
+        backfill = NativeRevisionBackfill(
+            pool,
+            git=git,
+            bridge=bridge,
+            repository=repository,
+        )
+        run, inventory = await backfill.prepare_run(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version="c9-p95-linear-materialization",
+        )
+        assert len(inventory.documents) == document_count
+
+        result = await backfill.backfill_run(run.run_id)
+
+        assert result.status == "complete"
+        assert bridge.run_scope_validations == 1
+        assert canonical_calls == 2
+        assert repository.manual_vault_queries == 2
+        assert git.history_calls == document_count * 2
+        assert git.body_read_calls == document_count
 
 
 async def test_every_backfill_failpoint_rolls_back_then_retries_once(tmp_path):
@@ -699,7 +891,8 @@ async def test_current_move_activity_semantics_are_preserved(tmp_path):
         assert document.activity.path_from == "same.md"
         assert document.activity.path_to == "renamed.md"
         body_store = M1PgBodyStore(pool)
-        async with backfill.bridge.materialize_body(inventory, document) as body:
+        scope = await backfill.bridge.validated_inventory_scope(inventory)
+        async with backfill.bridge.materialize_body(scope, document) as body:
             await body_store.prepare_text(
                 namespace_id=namespace_id,
                 payload=body,
@@ -747,7 +940,8 @@ async def test_selector_is_hidden_until_run_complete(tmp_path):
             if item.resource_id == fixture["document_one"]
         )
         body_store = M1PgBodyStore(pool)
-        async with backfill.bridge.materialize_body(inventory, document) as body:
+        scope = await backfill.bridge.validated_inventory_scope(inventory)
+        async with backfill.bridge.materialize_body(scope, document) as body:
             prepared = await body_store.prepare_text(
                 namespace_id=fixture["namespace_id"],
                 payload=body,
@@ -773,7 +967,7 @@ async def test_selector_is_hidden_until_run_complete(tmp_path):
             )
 
         other = next(item for item in inventory.documents if item.resource_id != document.resource_id)
-        async with backfill.bridge.materialize_body(inventory, other) as body:
+        async with backfill.bridge.materialize_body(scope, other) as body:
             other_prepared = await body_store.prepare_text(
                 namespace_id=fixture["namespace_id"],
                 payload=body,

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -303,8 +303,10 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
         )
         assert doc.current_path == "renamed.md"
         assert doc.current_commit == fixture["current_oid"]
-        assert doc.body == b"new v2\n"
-        assert doc.byte_size == len(doc.body)
+        assert not hasattr(doc, "body")
+        async with bridge.materialize_body(inventory, doc) as body:
+            assert body == b"new v2\n"
+            assert doc.byte_size == len(body)
         assert doc.lineage[-1].legacy_git_oid == fixture["current_oid"]
         assert [entry.path_at_revision for entry in doc.lineage] == [
             "same.md", "renamed.md", "renamed.md",
@@ -391,6 +393,48 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
                 "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
                 fixture["namespace_id"],
             ) == 0
+
+
+async def test_backfill_inventory_is_metadata_only_and_materializes_one_body_at_a_time(
+    tmp_path,
+):
+    class TrackingBodyBridge(LegacyRevisionBridge):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.active_bodies = 0
+            self.max_active_bodies = 0
+
+        @asynccontextmanager
+        async def materialize_body(self, inventory, document):
+            async with super().materialize_body(inventory, document) as body:
+                self.active_bodies += 1
+                self.max_active_bodies = max(
+                    self.max_active_bodies,
+                    self.active_bodies,
+                )
+                try:
+                    yield body
+                finally:
+                    self.active_bodies -= 1
+
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        bridge = TrackingBodyBridge(pool, git=fixture["git"])
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"], bridge=bridge)
+        run, inventory = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-metadata-only-memory-bound",
+        )
+
+        assert len(inventory.documents) == 2
+        assert all(not hasattr(document, "body") for document in inventory.documents)
+
+        result = await backfill.backfill_run(run.run_id)
+
+        assert result.status == "complete"
+        assert bridge.max_active_bodies == 1
+        assert bridge.active_bodies == 0
 
 
 async def test_every_backfill_failpoint_rolls_back_then_retries_once(tmp_path):
@@ -655,12 +699,13 @@ async def test_current_move_activity_semantics_are_preserved(tmp_path):
         assert document.activity.path_from == "same.md"
         assert document.activity.path_to == "renamed.md"
         body_store = M1PgBodyStore(pool)
-        await body_store.prepare_text(
-            namespace_id=namespace_id,
-            payload=document.body,
-            expected_digest=document.body_digest,
-            expected_size=document.byte_size,
-        )
+        async with backfill.bridge.materialize_body(inventory, document) as body:
+            await body_store.prepare_text(
+                namespace_id=namespace_id,
+                payload=body,
+                expected_digest=document.body_digest,
+                expected_size=document.byte_size,
+            )
         result = await backfill.backfill_run(run.run_id)
         async with pool.acquire() as conn:
             item_error = await conn.fetchval(
@@ -702,12 +747,13 @@ async def test_selector_is_hidden_until_run_complete(tmp_path):
             if item.resource_id == fixture["document_one"]
         )
         body_store = M1PgBodyStore(pool)
-        prepared = await body_store.prepare_text(
-            namespace_id=fixture["namespace_id"],
-            payload=document.body,
-            expected_digest=document.body_digest,
-            expected_size=document.byte_size,
-        )
+        async with backfill.bridge.materialize_body(inventory, document) as body:
+            prepared = await body_store.prepare_text(
+                namespace_id=fixture["namespace_id"],
+                payload=body,
+                expected_digest=document.body_digest,
+                expected_size=document.byte_size,
+            )
         await backfill._publish_item(
             run=run,
             document=document,
@@ -727,12 +773,13 @@ async def test_selector_is_hidden_until_run_complete(tmp_path):
             )
 
         other = next(item for item in inventory.documents if item.resource_id != document.resource_id)
-        other_prepared = await body_store.prepare_text(
-            namespace_id=fixture["namespace_id"],
-            payload=other.body,
-            expected_digest=other.body_digest,
-            expected_size=other.byte_size,
-        )
+        async with backfill.bridge.materialize_body(inventory, other) as body:
+            other_prepared = await body_store.prepare_text(
+                namespace_id=fixture["namespace_id"],
+                payload=body,
+                expected_digest=other.body_digest,
+                expected_size=other.byte_size,
+            )
         await backfill._publish_item(
             run=run,
             document=other,

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -309,6 +309,11 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
             assert body == b"new v2\n"
             assert doc.byte_size == len(body)
         assert doc.lineage[-1].legacy_git_oid == fixture["current_oid"]
+        assert [entry.legacy_git_oid for entry in doc.lineage] == [
+            fixture["initial_oid"],
+            fixture["move_oid"],
+            fixture["current_oid"],
+        ]
         assert [entry.path_at_revision for entry in doc.lineage] == [
             "same.md", "renamed.md", "renamed.md",
         ]
@@ -394,6 +399,54 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
                 "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
                 fixture["namespace_id"],
             ) == 0
+
+
+async def test_inventory_rejects_duplicate_completed_ordinal_zero_anchor(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        bridge = LegacyRevisionBridge(pool, git=fixture["git"])
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"], bridge=bridge)
+        run, _ = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-anchor-duplicate-base",
+        )
+        assert (await backfill.backfill_run(run.run_id)).status == "complete"
+
+        duplicate_run_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO native_revision_migration_runs
+                    (run_id, namespace_id, fixed_git_oid, coverage_version,
+                     inventory_digest, status, started_at, completed_at)
+                VALUES ($1, $2, $3, 'c9-anchor-duplicate-corruption',
+                        $4, 'complete', NOW(), NOW())
+                """,
+                duplicate_run_id,
+                fixture["namespace_id"],
+                "e" * 40,
+                "d" * 64,
+            )
+            await conn.execute(
+                """
+                INSERT INTO legacy_revision_mappings
+                    (namespace_id, resource_id, legacy_git_oid, path_at_revision,
+                     resolution, native_revision_id, run_id, lineage_ordinal)
+                VALUES ($1, $2, $3, 'corrupt-prior.md', 'bridge', NULL, $4, 0)
+                """,
+                fixture["namespace_id"],
+                fixture["document_one"],
+                "a" * 40,
+                duplicate_run_id,
+            )
+
+        with pytest.raises(InventoryEligibilityError, match="duplicate ordinal-zero"):
+            await bridge.capture_inventory(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["unrelated_tip"],
+                coverage_version="c9-anchor-duplicate-check",
+            )
 
 
 async def test_backfill_inventory_is_metadata_only_and_materializes_one_body_at_a_time(

--- a/backend/tests/test_native_revision_reconcile_pg.py
+++ b/backend/tests/test_native_revision_reconcile_pg.py
@@ -241,6 +241,72 @@ async def _advance_fixture(fixture: dict, *, move: bool, revision: str = "r2") -
     return result
 
 
+async def _advance_move_update_suffix(fixture: dict, *, repeated: bool) -> dict:
+    git = fixture["git"]
+    vault_name = fixture["vault_name"]
+    current_path = "doc.md"
+    suffix_oids = []
+
+    move_oid = git.move_file(
+        vault_name,
+        current_path,
+        "draft.md",
+        "[move] doc.md -> draft.md\n\nagent: legacy-writer\naction: move\nsummary: first move",
+    )
+    suffix_oids.append(move_oid)
+    current_path = "draft.md"
+    update_oid = git.commit_file(
+        vault_name,
+        current_path,
+        "r2 body\n",
+        "[update] draft.md\n\nagent: legacy-writer\naction: update\nsummary: update after move",
+    )
+    suffix_oids.append(update_oid)
+
+    if repeated:
+        move_oid = git.move_file(
+            vault_name,
+            current_path,
+            "renamed.md",
+            "[move] draft.md -> renamed.md\n\nagent: legacy-writer\naction: move\nsummary: second move",
+        )
+        suffix_oids.append(move_oid)
+        current_path = "renamed.md"
+        update_oid = git.commit_file(
+            vault_name,
+            current_path,
+            "r3 body\n",
+            "[update] renamed.md\n\nagent: legacy-writer\naction: update\nsummary: update after second move",
+        )
+        suffix_oids.append(update_oid)
+
+    final_oid = suffix_oids[-1]
+    async with fixture["pool"].acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE documents
+               SET path = $2, current_commit = $3, updated_at = NOW()
+             WHERE id = $1
+            """,
+            fixture["document_id"],
+            current_path,
+            final_oid,
+        )
+    fixed_ref = git.commit_file(
+        vault_name,
+        "suffix-tip.md",
+        "tip\n",
+        "fixed move/update suffix tip",
+    )
+    return {
+        **fixture,
+        "suffix_oids": tuple(suffix_oids),
+        "final_oid": final_oid,
+        "final_path": current_path,
+        "fixed_suffix": fixed_ref,
+    }
+
+
 async def _authority_snapshot(pool, namespace_id: uuid.UUID, resource_id: uuid.UUID) -> list[dict]:
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -386,6 +452,200 @@ async def test_update_then_final_move_collapses_to_one_move_and_binds_suffix(tmp
         assert mappings[-1]["native_revision_id"] == revisions[-1]["revision_id"]
         assert alias["old_path"] == "doc.md"
         assert alias["created_revision_id"] == revisions[-1]["revision_id"]
+
+
+async def test_move_then_update_collapses_to_move_and_resolves_suffix_mappings(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_move_update_suffix(
+            await _make_fixture(pool, tmp_path),
+            repeated=False,
+        )
+        result = await NativeRevisionReconcile(
+            pool,
+            git=fixture["git"],
+            bridge=fixture["bridge"],
+        ).reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_suffix"],
+        )
+
+        assert result.status == "complete"
+        assert result.items[0].action == "move"
+        async with pool.acquire() as conn:
+            revision = await conn.fetchrow(
+                """
+                SELECT revision_id, parent_revision_id, action, path_from, path_to
+                  FROM native_revisions
+                 WHERE resource_id = $1 AND action <> 'create'
+                """,
+                fixture["document_id"],
+            )
+            mappings = await conn.fetch(
+                """
+                SELECT legacy_git_oid, path_at_revision, resolution, native_revision_id
+                  FROM legacy_revision_mappings
+                 WHERE resource_id = $1
+                 ORDER BY lineage_ordinal
+                """,
+                fixture["document_id"],
+            )
+        assert revision["action"] == "move"
+        assert revision["path_from"] == "doc.md"
+        assert revision["path_to"] == "draft.md"
+        assert [row["legacy_git_oid"] for row in mappings] == [
+            fixture["initial_oid"],
+            *fixture["suffix_oids"],
+        ]
+        assert [row["path_at_revision"] for row in mappings] == [
+            "doc.md",
+            "draft.md",
+            "draft.md",
+        ]
+        assert [row["resolution"] for row in mappings] == ["native", "bridge", "native"]
+
+        intermediate = await fixture["bridge"].resolve_selector(
+            resource_id=fixture["document_id"],
+            selector=fixture["suffix_oids"][0],
+        )
+        final = await fixture["bridge"].resolve_selector(
+            resource_id=fixture["document_id"],
+            selector=fixture["final_oid"],
+        )
+        assert intermediate.kind == "bridge"
+        assert intermediate.path_at_revision == "draft.md"
+        assert intermediate.native_revision_id is None
+        assert final.kind == "native"
+        assert final.native_revision_id == revision["revision_id"]
+
+
+async def test_repeated_move_update_suffix_resumes_replays_and_collapses_once(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_move_update_suffix(
+            await _make_fixture(pool, tmp_path),
+            repeated=True,
+        )
+        fired = False
+
+        async def failpoint(name: str):
+            nonlocal fired
+            if name == "authority.before_commit" and not fired:
+                fired = True
+                raise RuntimeError("interrupt repeated suffix publication")
+
+        failing = NativeRevisionReconcile(
+            pool,
+            git=fixture["git"],
+            bridge=fixture["bridge"],
+            failpoint=failpoint,
+        )
+        with pytest.raises(BackfillFailpointError):
+            await failing.reconcile(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["fixed_suffix"],
+            )
+
+        async with pool.acquire() as conn:
+            run_id = await conn.fetchval(
+                """
+                SELECT run_id
+                  FROM native_revision_migration_runs
+                 WHERE namespace_id = $1 AND fixed_git_oid = $2
+                """,
+                fixture["namespace_id"],
+                fixture["fixed_suffix"],
+            )
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revisions WHERE resource_id = $1",
+                fixture["document_id"],
+            ) == 1
+
+        clean = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+        resumed = await clean.reconcile_run(run_id)
+        assert resumed.status == "complete"
+        assert resumed.items[0].action == "move"
+        async with pool.acquire() as conn:
+            revision = await conn.fetchrow(
+                """
+                SELECT revision_id, action, path_from, path_to
+                  FROM native_revisions
+                 WHERE resource_id = $1 AND action <> 'create'
+                """,
+                fixture["document_id"],
+            )
+            mappings = await conn.fetch(
+                """
+                SELECT legacy_git_oid, path_at_revision, resolution,
+                       native_revision_id, run_id
+                  FROM legacy_revision_mappings
+                 WHERE resource_id = $1
+                 ORDER BY lineage_ordinal
+                """,
+                fixture["document_id"],
+            )
+            before_replay = await conn.fetchrow(
+                """
+                SELECT
+                    (SELECT count(*) FROM native_revisions) AS revisions,
+                    (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                    (SELECT count(*) FROM native_revision_activity) AS activity,
+                    (SELECT count(*) FROM native_resource_path_aliases) AS aliases
+                """
+            )
+
+        assert revision["action"] == "move"
+        assert revision["path_from"] == "doc.md"
+        assert revision["path_to"] == "renamed.md"
+        assert [row["legacy_git_oid"] for row in mappings] == [
+            fixture["initial_oid"],
+            *fixture["suffix_oids"],
+        ]
+        assert [row["path_at_revision"] for row in mappings] == [
+            "doc.md",
+            "draft.md",
+            "draft.md",
+            "renamed.md",
+            "renamed.md",
+        ]
+        assert [row["resolution"] for row in mappings] == [
+            "native",
+            "bridge",
+            "bridge",
+            "bridge",
+            "native",
+        ]
+        assert all(row["run_id"] == run_id for row in mappings[1:])
+        assert mappings[-1]["native_revision_id"] == revision["revision_id"]
+
+        for oid in fixture["suffix_oids"][:-1]:
+            resolution = await fixture["bridge"].resolve_selector(
+                resource_id=fixture["document_id"],
+                selector=oid,
+            )
+            assert resolution.kind == "bridge"
+            assert resolution.native_revision_id is None
+        final = await fixture["bridge"].resolve_selector(
+            resource_id=fixture["document_id"],
+            selector=fixture["final_oid"],
+        )
+        assert final.kind == "native"
+        assert final.native_revision_id == revision["revision_id"]
+
+        replay = await clean.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_suffix"],
+        )
+        assert replay.idempotent_replay is True
+        async with pool.acquire() as conn:
+            after_replay = await conn.fetchrow(
+                """
+                SELECT
+                    (SELECT count(*) FROM native_revisions) AS revisions,
+                    (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                    (SELECT count(*) FROM native_revision_activity) AS activity,
+                    (SELECT count(*) FROM native_resource_path_aliases) AS aliases
+                """
+            )
+        assert dict(after_replay) == dict(before_replay)
 
 
 async def test_unchanged_final_ref_has_no_item_or_native_fact(tmp_path):

--- a/backend/tests/test_native_revision_reconcile_pg.py
+++ b/backend/tests/test_native_revision_reconcile_pg.py
@@ -1,0 +1,838 @@
+"""Focused PostgreSQL checks for the operator-only C9 final-ref reconcile."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from pathlib import Path
+
+import asyncpg
+import pytest
+from git import Repo
+
+from app.services.git_service import GitService
+from app.services.legacy_revision_bridge import LegacyRevisionBridge, SelectorUnknownError
+from app.services.native_revision_backfill import (
+    BackfillFailpointError,
+    NativeRevisionBackfill,
+)
+from app.repositories.native_revision_migration_repo import NativeRevisionMigrationRepository
+from app.services.native_revision_reconcile import (
+    NativeRevisionReconcile,
+    ReconcileIntegrityError,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load(filename: str):
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"migration_c9_reconcile_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_schema(tmp_path: Path):
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_c9_reconcile_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        dsn = _database_dsn(name)
+        conn = await asyncpg.connect(dsn)
+        await conn.execute(_INIT_SQL)
+        for filename in (
+            "010_external_git_mirror.py",
+            "048_native_revision_core.py",
+            "053_native_revision_m1_pg_body.py",
+            "060_native_revision_migration_bridge.py",
+        ):
+            await _load(filename).migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _make_fixture(pool, tmp_path: Path, *, document_count: int = 1) -> dict:
+    if document_count not in {1, 2}:
+        raise ValueError("the reconcile fixture supports one or two documents")
+    git = GitService(storage_path=str(tmp_path / "git"))
+    vault_name = f"c9-reconcile-{uuid.uuid4().hex}"
+    git.init_vault(vault_name)
+    initial_oid = git.commit_file(
+        vault_name,
+        "doc.md",
+        "r1 body\n",
+        "[create] doc.md\n\nagent: legacy-writer\naction: create\nsummary: create doc",
+    )
+    initial_dt = Repo(str(git._bare_path(vault_name))).commit(initial_oid).committed_datetime
+    initial_oids = [initial_oid]
+    document_paths = ["doc.md"]
+    if document_count == 2:
+        second_oid = git.commit_file(
+            vault_name,
+            "second.md",
+            "second r1 body\n",
+            "[create] second.md\n\nagent: legacy-writer\naction: create\nsummary: create second doc",
+        )
+        initial_oids.append(second_oid)
+        document_paths.append("second.md")
+        second_dt = Repo(str(git._bare_path(vault_name))).commit(second_oid).committed_datetime
+    else:
+        second_dt = None
+    fixed_r1 = git.commit_file(vault_name, "r1-tip.md", "tip\n", "fixed R1 tip")
+
+    async with pool.acquire() as conn:
+        namespace_id = await conn.fetchval(
+            """
+            INSERT INTO vaults (name, git_path, status)
+            VALUES ($1, $2, 'active')
+            RETURNING id
+            """,
+            vault_name,
+            str(git._bare_path(vault_name)),
+        )
+        document_ids = [uuid.uuid4() for _ in range(document_count)]
+        for index, (document_id, path, oid) in enumerate(
+            zip(document_ids, document_paths, initial_oids, strict=True)
+        ):
+            committed_at = initial_dt if index == 0 else second_dt
+            assert committed_at is not None
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, $3, $4, $5, $5, $6, 'manual')
+                """,
+                document_id,
+                namespace_id,
+                path,
+                path.removesuffix(".md"),
+                committed_at - timedelta(seconds=1),
+                oid,
+            )
+
+    bridge = LegacyRevisionBridge(pool, git=git)
+    backfill = NativeRevisionBackfill(pool, git=git, bridge=bridge)
+    r1, inventory = await backfill.prepare_run(
+        namespace_id=namespace_id,
+        fixed_ref=fixed_r1,
+        coverage_version="c9-native-genesis-v1",
+    )
+    assert len(inventory.documents) == document_count
+    assert (await backfill.backfill_run(r1.run_id)).status == "complete"
+    document_id = document_ids[0]
+    return {
+        "pool": pool,
+        "git": git,
+        "vault_name": vault_name,
+        "namespace_id": namespace_id,
+        "document_id": document_id,
+        "document_ids": tuple(document_ids),
+        "document_paths": tuple(document_paths),
+        "initial_oid": initial_oid,
+        "initial_oids": tuple(initial_oids),
+        "fixed_r1": fixed_r1,
+        "r1": r1,
+        "bridge": bridge,
+    }
+
+
+async def _advance_fixture(fixture: dict, *, move: bool, revision: str = "r2") -> dict:
+    git = fixture["git"]
+    vault_name = fixture["vault_name"]
+    document_ids = fixture.get("document_ids", (fixture["document_id"],))
+    document_paths = fixture.get("document_paths", ("doc.md",))
+    update_oids = []
+    final_oids = []
+    final_paths = []
+    for index, (document_id, path) in enumerate(zip(document_ids, document_paths, strict=True)):
+        body = f"{revision} body\n" if index == 0 else f"{revision} body {index}\n"
+        update_oid = git.commit_file(
+            vault_name,
+            path,
+            body,
+            f"[update] {path}\n\nagent: legacy-writer\naction: update\nsummary: {revision} update {path}",
+        )
+        final_oid = update_oid
+        final_path = path
+        if move and index == 0:
+            final_oid = git.move_file(
+                vault_name,
+                path,
+                "renamed.md",
+                "[move] doc.md -> renamed.md\n\nagent: legacy-writer\naction: move\nsummary: move doc",
+            )
+            final_path = "renamed.md"
+        update_oids.append(update_oid)
+        final_oids.append(final_oid)
+        final_paths.append(final_path)
+        async with fixture["pool"].acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE documents
+                   SET path = $2, current_commit = $3, updated_at = NOW()
+                 WHERE id = $1
+                """,
+                document_id,
+                final_path,
+                final_oid,
+            )
+    fixed_ref = git.commit_file(
+        vault_name,
+        f"{revision}-tip.md",
+        "tip\n",
+        f"fixed {revision.upper()} tip",
+    )
+    result = {
+        **fixture,
+        "update_oid": update_oids[0],
+        "update_oids": tuple(update_oids),
+        "final_oid": final_oids[0],
+        "final_oids": tuple(final_oids),
+        "final_path": final_paths[0],
+        "final_paths": tuple(final_paths),
+        "fixed_r2": fixed_ref,
+    }
+    if revision != "r2":
+        result[f"fixed_{revision}"] = fixed_ref
+    return result
+
+
+async def _authority_snapshot(pool, namespace_id: uuid.UUID, resource_id: uuid.UUID) -> list[dict]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT 'resource' AS kind, resource_id::text AS subject,
+                   current_path AS value, head_revision_id AS extra
+              FROM native_resources WHERE namespace_id = $1 AND resource_id = $2
+            UNION ALL
+            SELECT 'revision', revision_id, action, parent_revision_id
+              FROM native_revisions WHERE namespace_id = $1 AND resource_id = $2
+            UNION ALL
+            SELECT 'mapping', legacy_git_oid, resolution,
+                   COALESCE(native_revision_id, '')
+              FROM legacy_revision_mappings WHERE namespace_id = $1 AND resource_id = $2
+            UNION ALL
+            SELECT 'activity', revision_id, action, actor
+              FROM native_revision_activity WHERE namespace_id = $1 AND resource_id = $2
+            ORDER BY kind, subject
+            """,
+            namespace_id,
+            resource_id,
+        )
+    return [dict(row) for row in rows]
+
+
+async def test_operator_reconcile_is_explicitly_constructed():
+    assert NativeRevisionReconcile.coverage_version == "c9-native-reconcile-v1"
+
+
+async def test_update_only_publishes_one_replace_and_keeps_r1_immutable(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(await _make_fixture(pool, tmp_path), move=False)
+        before_r1 = await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"])
+        service = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+
+        result = await service.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+
+        assert result.status == "complete"
+        assert result.changed_items == 1
+        assert result.items[0].action == "replace"
+        async with pool.acquire() as conn:
+            revision = await conn.fetchrow(
+                """
+                SELECT revision_id, parent_revision_id, action
+                  FROM native_revisions
+                 WHERE resource_id = $1 AND action <> 'create'
+                """,
+                fixture["document_id"],
+            )
+            head = await conn.fetchrow(
+                """
+                SELECT rs.current_path, rs.head_revision_id, pm.digest,
+                       pm.byte_size
+                  FROM native_resources rs
+                  JOIN native_revisions rv ON rv.resource_id = rs.resource_id
+                   AND rv.revision_id = rs.head_revision_id
+                  JOIN native_payload_manifests pm
+                    ON pm.payload_manifest_id = rv.payload_manifest_id
+                 WHERE rs.resource_id = $1
+                """,
+                fixture["document_id"],
+            )
+            mappings = await conn.fetch(
+                """
+                SELECT legacy_git_oid, resolution, native_revision_id
+                  FROM legacy_revision_mappings
+                 WHERE resource_id = $1
+                 ORDER BY lineage_ordinal
+                """,
+                fixture["document_id"],
+            )
+        assert revision["action"] == "replace"
+        old_head = next(row["extra"] for row in before_r1 if row["kind"] == "resource")
+        assert revision["parent_revision_id"] == old_head
+        assert head["current_path"] == "doc.md"
+        assert head["head_revision_id"] == revision["revision_id"]
+        assert head["digest"] == hashlib.sha256(b"r2 body\n").hexdigest()
+        assert [row["legacy_git_oid"] for row in mappings] == [
+            fixture["initial_oid"],
+            fixture["final_oid"],
+        ]
+        assert [row["resolution"] for row in mappings] == ["native", "native"]
+        after_r1 = await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"])
+        assert all(
+            row in after_r1
+            for row in before_r1
+            if row["kind"] != "resource"
+        )
+
+
+async def test_update_then_final_move_collapses_to_one_move_and_binds_suffix(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(await _make_fixture(pool, tmp_path), move=True)
+        service = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+
+        result = await service.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+
+        assert result.items[0].action == "move"
+        async with pool.acquire() as conn:
+            revisions = await conn.fetch(
+                """
+                SELECT revision_id, parent_revision_id, action, path_from, path_to
+                  FROM native_revisions
+                 WHERE resource_id = $1
+                 ORDER BY occurred_at, revision_id
+                """,
+                fixture["document_id"],
+            )
+            mappings = await conn.fetch(
+                """
+                SELECT legacy_git_oid, resolution, native_revision_id
+                  FROM legacy_revision_mappings
+                 WHERE resource_id = $1
+                 ORDER BY lineage_ordinal
+                """,
+                fixture["document_id"],
+            )
+            alias = await conn.fetchrow(
+                """
+                SELECT old_path, created_revision_id
+                  FROM native_resource_path_aliases
+                 WHERE resource_id = $1 AND retired_revision_id IS NULL
+                """,
+                fixture["document_id"],
+            )
+        assert len(revisions) == 2
+        assert revisions[-1]["action"] == "move"
+        assert revisions[-1]["parent_revision_id"] == revisions[0]["revision_id"]
+        assert revisions[-1]["path_from"] == "doc.md"
+        assert revisions[-1]["path_to"] == "renamed.md"
+        assert [row["legacy_git_oid"] for row in mappings] == [
+            fixture["initial_oid"],
+            fixture["update_oid"],
+            fixture["final_oid"],
+        ]
+        assert [row["resolution"] for row in mappings] == ["native", "bridge", "native"]
+        assert mappings[-1]["native_revision_id"] == revisions[-1]["revision_id"]
+        assert alias["old_path"] == "doc.md"
+        assert alias["created_revision_id"] == revisions[-1]["revision_id"]
+
+
+async def test_unchanged_final_ref_has_no_item_or_native_fact(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        fixed_r2 = fixture["git"].commit_file(
+            fixture["vault_name"], "unchanged-tip.md", "tip\n", "fixed R2 tip"
+        )
+        service = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+        before = await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"])
+
+        result = await service.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixed_r2,
+        )
+
+        assert result.changed_items == 0
+        assert result.unchanged_items == 1
+        assert await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"]) == before
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
+                result.run_id,
+            ) == 0
+
+
+async def test_terminal_replay_is_a_noop_and_before_commit_resumes(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(await _make_fixture(pool, tmp_path), move=False)
+        fired = False
+
+        async def failpoint(name: str):
+            nonlocal fired
+            if name == "authority.before_commit" and not fired:
+                fired = True
+                raise RuntimeError("reconcile interruption")
+
+        failing = NativeRevisionReconcile(
+            pool,
+            git=fixture["git"],
+            bridge=fixture["bridge"],
+            failpoint=failpoint,
+        )
+        with pytest.raises(BackfillFailpointError):
+            await failing.reconcile(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["fixed_r2"],
+            )
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revisions WHERE resource_id = $1",
+                fixture["document_id"],
+            ) == 1
+            assert await conn.fetchval(
+                "SELECT count(*) FROM m1_reference_payloads WHERE namespace_id = $1",
+                fixture["namespace_id"],
+            ) == 2
+            assert await conn.fetchval(
+                """
+                SELECT i.status
+                  FROM native_revision_migration_items i
+                  JOIN native_revision_migration_runs r
+                    ON r.run_id = i.run_id AND r.namespace_id = i.namespace_id
+                 WHERE i.namespace_id = $1
+                   AND i.legacy_document_id = $2
+                   AND r.fixed_git_oid = $3
+                """,
+                fixture["namespace_id"],
+                fixture["document_id"],
+                fixture["fixed_r2"],
+            ) == "pending"
+
+        clean = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+        resumed = await clean.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+        replay = await clean.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+        assert resumed.status == replay.status == "complete"
+        assert replay.idempotent_replay is True
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revisions WHERE resource_id = $1",
+                fixture["document_id"],
+            ) == 2
+            assert await conn.fetchval(
+                "SELECT count(*) FROM legacy_revision_mappings WHERE resource_id = $1",
+                fixture["document_id"],
+            ) == 2
+
+
+async def test_multi_item_resume_sees_only_completed_current_run_items(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(
+            await _make_fixture(pool, tmp_path, document_count=2),
+            move=False,
+        )
+        fired = False
+
+        async def failpoint(name: str):
+            nonlocal fired
+            if name == "reconcile.after_item_commit" and not fired:
+                fired = True
+                raise RuntimeError("stop between committed reconcile items")
+
+        failing = NativeRevisionReconcile(
+            pool,
+            git=fixture["git"],
+            bridge=fixture["bridge"],
+            failpoint=failpoint,
+        )
+        with pytest.raises(BackfillFailpointError):
+            await failing.reconcile(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixture["fixed_r2"],
+            )
+
+        repository = NativeRevisionMigrationRepository(pool)
+        async with pool.acquire() as conn:
+            run_row = await conn.fetchrow(
+                """
+                SELECT run_id, status
+                  FROM native_revision_migration_runs
+                 WHERE namespace_id = $1 AND fixed_git_oid = $2
+                """,
+                fixture["namespace_id"],
+                fixture["fixed_r2"],
+            )
+        assert run_row["status"] == "running"
+        run_id = run_row["run_id"]
+        items = await repository.list_items(run_id)
+        assert [item.status for item in items].count("complete") == 1
+        assert [item.status for item in items].count("pending") == 1
+        completed_item = next(item for item in items if item.status == "complete")
+        pending_item = next(item for item in items if item.status == "pending")
+        final_oids = dict(zip(fixture["document_ids"], fixture["final_oids"], strict=True))
+        completed_oid = final_oids[completed_item.native_resource_id]
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revisions WHERE resource_id = $1",
+                completed_item.native_resource_id,
+            ) == 2
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revisions WHERE resource_id = $1",
+                pending_item.native_resource_id,
+            ) == 1
+
+        public_mappings = await repository.list_resource_mappings(
+            namespace_id=fixture["namespace_id"],
+            resource_id=completed_item.native_resource_id,
+        )
+        assert all(mapping.run_id != run_id for mapping in public_mappings)
+        assert all(mapping.legacy_git_oid != completed_oid for mapping in public_mappings)
+        assert (
+            await repository.mapping_for_native_revision(
+                namespace_id=fixture["namespace_id"],
+                resource_id=completed_item.native_resource_id,
+                native_revision_id=completed_item.native_head_revision_id,
+            )
+            is None
+        )
+        with pytest.raises(SelectorUnknownError):
+            await fixture["bridge"].resolve_selector(
+                resource_id=completed_item.native_resource_id,
+                selector=completed_oid,
+            )
+
+        internal_mappings = await repository.list_resource_mappings_for_reconcile(
+            namespace_id=fixture["namespace_id"],
+            resource_id=completed_item.native_resource_id,
+            run_id=run_id,
+        )
+        assert any(mapping.legacy_git_oid == completed_oid for mapping in internal_mappings)
+        internal_head = await repository.mapping_for_native_revision_for_reconcile(
+            namespace_id=fixture["namespace_id"],
+            resource_id=completed_item.native_resource_id,
+            native_revision_id=completed_item.native_head_revision_id,
+            run_id=run_id,
+        )
+        assert internal_head is not None
+        assert internal_head.run_id == run_id
+        foreign_run_mappings = await repository.list_resource_mappings_for_reconcile(
+            namespace_id=fixture["namespace_id"],
+            resource_id=completed_item.native_resource_id,
+            run_id=fixture["r1"].run_id,
+        )
+        assert all(mapping.legacy_git_oid != completed_oid for mapping in foreign_run_mappings)
+        assert (
+            await repository.mapping_for_native_revision_for_reconcile(
+                namespace_id=fixture["namespace_id"],
+                resource_id=completed_item.native_resource_id,
+                native_revision_id=completed_item.native_head_revision_id,
+                run_id=fixture["r1"].run_id,
+            )
+            is None
+        )
+
+        clean = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+        resumed = await clean.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+        assert resumed.run_id == run_id
+        assert resumed.status == "complete"
+        assert resumed.completed_items == 1
+
+        async with pool.acquire() as conn:
+            before_replay = await conn.fetchrow(
+                """
+                SELECT
+                    (SELECT count(*) FROM native_revisions) AS revisions,
+                    (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                    (SELECT count(*) FROM native_revision_activity) AS activity,
+                    (SELECT count(*) FROM native_invalidation_intents) AS invalidations
+                """
+            )
+        replay = await clean.reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+        assert replay.idempotent_replay is True
+        async with pool.acquire() as conn:
+            after_replay = await conn.fetchrow(
+                """
+                SELECT
+                    (SELECT count(*) FROM native_revisions) AS revisions,
+                    (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                    (SELECT count(*) FROM native_revision_activity) AS activity,
+                    (SELECT count(*) FROM native_invalidation_intents) AS invalidations
+                """
+            )
+        assert dict(after_replay) == dict(before_replay)
+        visible = await repository.mapping_for_native_revision(
+            namespace_id=fixture["namespace_id"],
+            resource_id=completed_item.native_resource_id,
+            native_revision_id=completed_item.native_head_revision_id,
+        )
+        assert visible is not None
+        assert visible.run_id == run_id
+        resolution = await fixture["bridge"].resolve_selector(
+            resource_id=completed_item.native_resource_id,
+            selector=completed_oid,
+        )
+        assert resolution.kind == "native"
+
+
+async def test_successive_reconciles_preserve_run_item_and_mapping_ownership(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        after_r2 = await _advance_fixture(fixture, move=False)
+        service = NativeRevisionReconcile(pool, git=after_r2["git"], bridge=after_r2["bridge"])
+        r2_result = await service.reconcile(
+            namespace_id=after_r2["namespace_id"],
+            fixed_ref=after_r2["fixed_r2"],
+        )
+        assert r2_result.status == "complete"
+
+        after_r3 = await _advance_fixture(after_r2, move=False, revision="r3")
+        r3_result = await service.reconcile(
+            namespace_id=after_r3["namespace_id"],
+            fixed_ref=after_r3["fixed_r3"],
+        )
+        assert r3_result.status == "complete"
+
+        async with pool.acquire() as conn:
+            runs = await conn.fetch(
+                """
+                SELECT fixed_git_oid, run_id, status
+                  FROM native_revision_migration_runs
+                 WHERE namespace_id = $1
+                 ORDER BY created_at, run_id
+                """,
+                after_r3["namespace_id"],
+            )
+            mappings = await conn.fetch(
+                """
+                SELECT legacy_git_oid, run_id, lineage_ordinal, resolution
+                  FROM legacy_revision_mappings
+                 WHERE resource_id = $1
+                 ORDER BY lineage_ordinal
+                """,
+                after_r3["document_id"],
+            )
+            items = await conn.fetch(
+                """
+                SELECT run_id, status, native_head_revision_id
+                  FROM native_revision_migration_items
+                 WHERE legacy_document_id = $1
+                 ORDER BY created_at, run_id
+                """,
+                after_r3["document_id"],
+            )
+
+        run_by_ref = {row["fixed_git_oid"]: row for row in runs}
+        r1_run_id = after_r3["r1"].run_id
+        r2_run_id = r2_result.run_id
+        r3_run_id = r3_result.run_id
+        assert set(run_by_ref) == {
+            after_r3["fixed_r1"],
+            after_r2["fixed_r2"],
+            after_r3["fixed_r3"],
+        }
+        assert {row["run_id"] for row in runs} == {r1_run_id, r2_run_id, r3_run_id}
+        assert all(row["status"] == "complete" for row in runs)
+        assert [row["run_id"] for row in mappings] == [r1_run_id, r2_run_id, r3_run_id]
+        assert [row["legacy_git_oid"] for row in mappings] == [
+            after_r3["initial_oid"],
+            after_r2["final_oid"],
+            after_r3["final_oid"],
+        ]
+        assert [row["resolution"] for row in mappings] == ["native", "native", "native"]
+        assert {row["run_id"] for row in items} == {r1_run_id, r2_run_id, r3_run_id}
+        assert all(row["status"] == "complete" for row in items)
+        assert all(row["native_head_revision_id"] is not None for row in items)
+
+
+async def test_reconcile_rejects_missing_previously_migrated_document_without_facts(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        before = await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"])
+        async with pool.acquire() as conn:
+            before_counts = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT
+                        (SELECT count(*) FROM native_revisions) AS revisions,
+                        (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                        (SELECT count(*) FROM native_revision_activity) AS activity,
+                        (SELECT count(*) FROM native_invalidation_intents) AS invalidations,
+                        (SELECT count(*) FROM native_revision_migration_items) AS items,
+                        (SELECT count(*) FROM native_revision_migration_runs) AS runs
+                    """
+                )
+            )
+            await conn.execute(
+                "DELETE FROM documents WHERE id = $1",
+                fixture["document_id"],
+            )
+        fixed_r2 = fixture["git"].commit_file(
+            fixture["vault_name"], "missing-tip.md", "tip\n", "fixed R2 missing document"
+        )
+
+        with pytest.raises(ReconcileIntegrityError) as failure:
+            await NativeRevisionReconcile(
+                pool,
+                git=fixture["git"],
+                bridge=fixture["bridge"],
+            ).reconcile(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixed_r2,
+            )
+        assert failure.value.code == "native_revision_reconcile_missing_document"
+        async with pool.acquire() as conn:
+            after_counts = dict(
+                await conn.fetchrow(
+                    """
+                    SELECT
+                        (SELECT count(*) FROM native_revisions) AS revisions,
+                        (SELECT count(*) FROM legacy_revision_mappings) AS mappings,
+                        (SELECT count(*) FROM native_revision_activity) AS activity,
+                        (SELECT count(*) FROM native_invalidation_intents) AS invalidations,
+                        (SELECT count(*) FROM native_revision_migration_items) AS items,
+                        (SELECT count(*) FROM native_revision_migration_runs) AS runs
+                    """
+                )
+            )
+        assert after_counts == before_counts
+        assert await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"]) == before
+
+
+async def test_reconcile_rejects_missing_resource_without_facts(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(await _make_fixture(pool, tmp_path), move=True)
+        new_oid = fixture["git"].commit_file(
+            fixture["vault_name"],
+            "new.md",
+            "new body\n",
+            "[create] new.md\n\nagent: legacy-writer\naction: create\nsummary: create new",
+        )
+        new_dt = Repo(str(fixture["git"]._bare_path(fixture["vault_name"]))).commit(new_oid).committed_datetime
+        new_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, 'new.md', 'new', $3, $3, $4, 'manual')
+                """,
+                new_id,
+                fixture["namespace_id"],
+                new_dt - timedelta(seconds=1),
+                new_oid,
+            )
+        fixed_r3 = fixture["git"].commit_file(
+            fixture["vault_name"], "r3-tip.md", "tip\n", "fixed R3 tip"
+        )
+        async with pool.acquire() as conn:
+            before_revisions = await conn.fetchval("SELECT count(*) FROM native_revisions")
+        service = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+        with pytest.raises(ReconcileIntegrityError):
+            await service.reconcile(
+                namespace_id=fixture["namespace_id"],
+                fixed_ref=fixed_r3,
+            )
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT count(*) FROM native_revisions") == before_revisions
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_resources WHERE resource_id = $1", new_id
+            ) == 0
+
+
+async def test_legacy_documents_and_git_are_unchanged_by_reconcile(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _advance_fixture(await _make_fixture(pool, tmp_path), move=True)
+        before_git_head = fixture["git"].current_commit(fixture["vault_name"])
+        before_document = await _authority_snapshot(pool, fixture["namespace_id"], fixture["document_id"])
+        async with pool.acquire() as conn:
+            before_legacy = dict(
+                await conn.fetchrow(
+                    "SELECT path, current_commit, source FROM documents WHERE id = $1",
+                    fixture["document_id"],
+                )
+            )
+
+        await NativeRevisionReconcile(
+            pool,
+            git=fixture["git"],
+            bridge=fixture["bridge"],
+        ).reconcile(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["fixed_r2"],
+        )
+
+        async with pool.acquire() as conn:
+            after_legacy = dict(
+                await conn.fetchrow(
+                    "SELECT path, current_commit, source FROM documents WHERE id = $1",
+                    fixture["document_id"],
+                )
+            )
+        assert after_legacy == before_legacy
+        assert fixture["git"].current_commit(fixture["vault_name"]) == before_git_head
+        assert fixture["git"].read_file(
+            fixture["vault_name"], "renamed.md", fixture["final_oid"]
+        ) == "r2 body\n"
+        assert any(row["kind"] == "resource" for row in before_document)

--- a/backend/tests/test_native_revision_reference_ambiguity_pg.py
+++ b/backend/tests/test_native_revision_reference_ambiguity_pg.py
@@ -1,0 +1,242 @@
+"""PostgreSQL contract tests for fail-closed native Resource references."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.exceptions import ConflictError
+from app.repositories.native_revision_repo import (
+    NativeResourceReferenceAmbiguousError,
+    NativeRevisionRepository,
+)
+from app.services.native_revision_service import NativeRevisionService
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATION = _BACKEND / "app" / "db" / "migrations" / "048_native_revision_core.py"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("native_reference_ambiguity_048", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_native_reference_ambiguity_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        conn = await asyncpg.connect(_database_dsn(name))
+        await conn.execute(_INIT_SQL)
+        await _load_migration().migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=4)
+        async with pool.acquire() as seeded:
+            namespace_id = await seeded.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+                f"native-ambiguity-{uuid.uuid4().hex}",
+                "/tmp/native-ambiguity-unused.git",
+            )
+        yield pool, namespace_id
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+def _create_args(namespace_id: uuid.UUID, *, path: str, resource_id: uuid.UUID) -> dict:
+    return {
+        "namespace_id": namespace_id,
+        "surface": "document",
+        "path": path,
+        "payload": f"body for {path}\n",
+        "actor": "native-ambiguity-test",
+        "mutation_id": uuid.uuid4(),
+        "resource_id": resource_id,
+    }
+
+
+async def test_uuid_identity_and_live_path_fail_closed_for_reads_and_mutations():
+    async with _fresh_database() as (pool, namespace_id):
+        service = NativeRevisionService(pool)
+        repository = NativeRevisionRepository(pool)
+        resource_id = uuid.uuid4()
+        await service.create_text(
+            **_create_args(namespace_id, path="identity-owner.md", resource_id=resource_id)
+        )
+        path_owner = await service.create_text(
+            **_create_args(namespace_id, path=str(resource_id), resource_id=uuid.uuid4())
+        )
+
+        with pytest.raises(NativeResourceReferenceAmbiguousError) as caught:
+            await repository.resolve_live_reference(
+                namespace_id=namespace_id,
+                surface="document",
+                reference=str(resource_id),
+            )
+        assert isinstance(caught.value, ConflictError)
+        assert caught.value.status_code == 409
+        assert caught.value.code == "native_resource_reference_ambiguous"
+
+        with pytest.raises(NativeResourceReferenceAmbiguousError):
+            await service.get_current_reference(
+                namespace_id=namespace_id,
+                surface="document",
+                reference=str(resource_id),
+            )
+
+        before = await service.get_current_resource(
+            namespace_id=namespace_id,
+            surface="document",
+            resource_id=resource_id,
+        )
+        with pytest.raises(NativeResourceReferenceAmbiguousError):
+            await service.replace_text(
+                namespace_id=namespace_id,
+                surface="document",
+                path=str(resource_id),
+                payload="must not mutate\n",
+                actor="native-ambiguity-test",
+                mutation_id=uuid.uuid4(),
+            )
+        after = await service.get_current_resource(
+            namespace_id=namespace_id,
+            surface="document",
+            resource_id=resource_id,
+        )
+        assert after.revision_id == before.revision_id
+        assert path_owner.resource_id != resource_id
+
+
+async def test_uuid_identity_and_live_alias_fail_closed_and_do_not_delete():
+    async with _fresh_database() as (pool, namespace_id):
+        service = NativeRevisionService(pool)
+        repository = NativeRevisionRepository(pool)
+        resource_id = uuid.uuid4()
+        await service.create_text(
+            **_create_args(namespace_id, path="identity-owner.md", resource_id=resource_id)
+        )
+        alias_owner = await service.create_text(
+            **_create_args(namespace_id, path="alias-owner.md", resource_id=uuid.uuid4())
+        )
+        async with pool.acquire() as conn, conn.transaction():
+            await repository.insert_path_alias(
+                conn,
+                namespace_id=namespace_id,
+                surface="document",
+                old_path=str(resource_id),
+                resource_id=alias_owner.resource_id,
+                created_revision_id=alias_owner.revision_id,
+                occurred_at=alias_owner.occurred_at,
+            )
+
+        with pytest.raises(NativeResourceReferenceAmbiguousError):
+            await repository.resolve_live_reference(
+                namespace_id=namespace_id,
+                surface="document",
+                reference=str(resource_id),
+            )
+
+        with pytest.raises(NativeResourceReferenceAmbiguousError):
+            await service.delete_resource(
+                namespace_id=namespace_id,
+                surface="document",
+                path=str(resource_id),
+                actor="native-ambiguity-test",
+                mutation_id=uuid.uuid4(),
+            )
+
+        async with pool.acquire() as conn:
+            lifecycle = await conn.fetchval(
+                "SELECT lifecycle FROM native_resources WHERE resource_id = $1",
+                resource_id,
+            )
+        assert lifecycle == "live"
+
+
+async def test_uuid_shaped_path_falls_through_when_no_identity_matches():
+    async with _fresh_database() as (pool, namespace_id):
+        service = NativeRevisionService(pool)
+        repository = NativeRevisionRepository(pool)
+        uuid_path = str(uuid.uuid4())
+        path_owner = await service.create_text(
+            **_create_args(namespace_id, path=uuid_path, resource_id=uuid.uuid4())
+        )
+
+        resolved = await repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface="document",
+            reference=uuid_path,
+        )
+        assert resolved is not None
+        assert resolved["resource_id"] == path_owner.resource_id
+
+
+async def test_current_path_precedes_another_resources_old_alias():
+    async with _fresh_database() as (pool, namespace_id):
+        service = NativeRevisionService(pool)
+        repository = NativeRevisionRepository(pool)
+        current_owner = await service.create_text(
+            **_create_args(namespace_id, path="shared.md", resource_id=uuid.uuid4())
+        )
+        alias_owner = await service.create_text(
+            **_create_args(namespace_id, path="former-shared.md", resource_id=uuid.uuid4())
+        )
+        async with pool.acquire() as conn, conn.transaction():
+            await repository.insert_path_alias(
+                conn,
+                namespace_id=namespace_id,
+                surface="document",
+                old_path="shared.md",
+                resource_id=alias_owner.resource_id,
+                created_revision_id=alias_owner.revision_id,
+                occurred_at=alias_owner.occurred_at,
+            )
+
+        resolved = await repository.resolve_live_reference(
+            namespace_id=namespace_id,
+            surface="document",
+            reference="shared.md",
+        )
+        assert resolved is not None
+        assert resolved["resource_id"] == current_owner.resource_id

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -221,6 +221,11 @@ def _oid(char: str) -> str:
     return char * 40
 
 
+def _document_body(document: LegacyInventoryDocument) -> str:
+    index = int(str(document.resource_id).split("-", 1)[0])
+    return f"# Document {index}\n\nbody at fixed ref\n"
+
+
 def _doc(index: int) -> LegacyInventoryDocument:
     resource_id = uuid.UUID(f"{index:08d}-1111-4111-8111-111111111111")
     legacy_head = _oid(str(index + 1))
@@ -244,7 +249,6 @@ def _doc(index: int) -> LegacyInventoryDocument:
         current_path=path,
         current_commit=legacy_head,
         created_at=at - timedelta(days=1),
-        body=body.encode(),
         body_digest=hashlib.sha256(body.encode()).hexdigest(),
         byte_size=len(body.encode()),
         lineage=(
@@ -378,7 +382,7 @@ class _Reader:
             selector = native_id
         else:
             selector = document.current_commit
-        body = document.body.decode()
+        body = _document_body(document)
         if not self.candidate:
             body = body.replace("\n", "\r\n")
         result = {
@@ -601,6 +605,9 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert receipt["evidence_binding"]["retained_mapping_count"] == 2
     assert receipt["evidence_binding"]["native_parent_binding_count"] == 2
     assert receipt["evidence_binding"]["owner_run_count"] == 1
+    owner_runs = receipt["evidence_binding"]["components"]["owner_runs"]
+    assert owner_runs == sorted(set(owner_runs))
+    assert receipt["evidence_binding"]["owner_run_count"] == len(owner_runs)
     assert len(receipt["resources"]) == 2
     assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
     for resource in receipt["resources"]:
@@ -617,7 +624,7 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
             "status": "passed",
         }
     encoded = json.dumps(receipt, sort_keys=True)
-    assert all(document.body.decode() not in encoded for document in inventory.documents)
+    assert all(_document_body(document) not in encoded for document in inventory.documents)
     assert all(str(document.resource_id) not in encoded for document in inventory.documents)
     assert {name for name, _ in legacy.calls} == {"get", "history", "diff", "activity"}
     assert len(legacy.calls) == len(inventory.documents) * 4
@@ -690,6 +697,8 @@ async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_
     assert receipt["summary"]["resource_count"] == 2
     assert receipt["summary"]["operation_count"] == 8
     assert receipt["summary"]["raw_activity_audit_count"] == 2
+    assert receipt["evidence_binding"]["owner_run_count"] == 2
+    assert len(receipt["evidence_binding"]["components"]["owner_runs"]) == 2
 
 
 async def test_completed_reconcile_rejects_rehomed_unchanged_mapping():
@@ -868,7 +877,7 @@ async def test_evidence_binding_is_stable_under_scope_and_item_order_shuffle():
         for resource in first["resources"]
     )
     encoded = json.dumps(first, sort_keys=True)
-    assert all(document.body.decode() not in encoded for document in inventory.documents)
+    assert all(_document_body(document) not in encoded for document in inventory.documents)
     assert all(document.current_path not in encoded for document in inventory.documents)
     assert all(str(document.resource_id) not in encoded for document in inventory.documents)
     assert all(document.activity.actor not in encoded for document in inventory.documents)
@@ -1002,4 +1011,9 @@ async def test_evidence_binding_changes_when_any_private_scope_fact_changes(chan
         assert (
             base["evidence_binding"]["components"]["retained_mapping_closure"]
             != changed_receipt["evidence_binding"]["components"]["retained_mapping_closure"]
+        )
+    if changed == "mapping_owner":
+        assert (
+            base["evidence_binding"]["components"]["owner_runs"]
+            != changed_receipt["evidence_binding"]["components"]["owner_runs"]
         )

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import uuid
 from dataclasses import replace
@@ -302,28 +303,21 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert receipt["final_p2_coverage_claim"] is False
     assert receipt["cutover_claim"] is False
     assert len(receipt["resources"]) == 2
-    assert [row["resource_id"] for row in receipt["resources"]] == sorted(
-        str(document.resource_id) for document in inventory.documents
+    assert [row["resource_key"] for row in receipt["resources"]] == sorted(
+        f"resource-{hashlib.sha256(str(document.resource_id).encode()).hexdigest()[:16]}"
+        for document in inventory.documents
     )
     assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
-    documents_by_id = {str(document.resource_id): document for document in inventory.documents}
     for resource in receipt["resources"]:
         assert set(resource["operations"]) == {"get", "history", "diff", "activity"}
-        activity = resource["operations"]["activity"]
-        raw_event = activity["raw_candidate"]["events"][0]
-        public_event = activity["candidate"]["events"][0]
-        document = documents_by_id[resource["resource_id"]]
-        assert raw_event["action"] == "create"
-        assert raw_event["author"] == {
-            "id": "akb-native-revision-migration",
-            "display": "Migration",
-        }
-        assert raw_event["subject"] == "internal migration subject"
-        assert raw_event["summary"] == "C9 fixed-ref native genesis"
-        assert public_event["action"] == document.activity.action
-        assert public_event["author"]["id"] == document.activity.actor
-        assert public_event["subject"] == document.activity.subject
-        assert public_event["summary"] == document.activity.summary
+        for operation in resource["operations"].values():
+            assert operation["normalized_equal"] is True
+            assert operation["mismatch_count"] == len(operation["mismatches"])
+            for mismatch in operation["mismatches"]:
+                assert set(mismatch) == {"path", "rule_id", "classification"}
+    encoded = json.dumps(receipt, sort_keys=True)
+    assert all(document.body.decode() not in encoded for document in inventory.documents)
+    assert all(str(document.resource_id) not in encoded for document in inventory.documents)
     assert {name for name, _ in legacy.calls} == {"get", "history", "diff", "activity"}
     assert len(legacy.calls) == len(inventory.documents) * 4
     assert len(candidate.calls) == len(inventory.documents) * 4

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -68,8 +68,7 @@ class _ReadRepository:
             (
                 item
                 for item in self.items
-                if item.legacy_document_id == resource_id
-                and item.legacy_head_oid == legacy_git_oid
+                if item.legacy_document_id == resource_id and item.legacy_head_oid == legacy_git_oid
             ),
             None,
         )
@@ -86,6 +85,30 @@ class _ReadRepository:
             lineage_ordinal=1,
             fixed_git_oid=self.run.fixed_git_oid,
         )
+
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+    ) -> list[LegacyRevisionMapping]:
+        assert namespace_id == self.run.namespace_id
+        document = next(document for document in _fixtures()[1].documents if document.resource_id == resource_id)
+        item = next(item for item in self.items if item.legacy_document_id == resource_id)
+        return [
+            LegacyRevisionMapping(
+                namespace_id=namespace_id,
+                resource_id=resource_id,
+                legacy_git_oid=entry.legacy_git_oid,
+                path_at_revision=entry.path_at_revision,
+                resolution="native" if index == len(document.lineage) - 1 else "bridge",
+                native_revision_id=(item.native_head_revision_id if index == len(document.lineage) - 1 else None),
+                run_id=self.run.run_id,
+                lineage_ordinal=index,
+                fixed_git_oid=self.run.fixed_git_oid,
+            )
+            for index, entry in enumerate(document.lineage)
+        ]
 
 
 class _EvidenceRepository:
@@ -110,8 +133,18 @@ class _EvidenceRepository:
         return self.owner_runs.get(run_id)
 
     async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
-        assert run_id == self.run.run_id
-        return list(self.items)
+        if run_id == self.run.run_id:
+            return list(self.items)
+        owner = self.owner_runs[run_id]
+        return [
+            replace(
+                item,
+                run_id=run_id,
+                namespace_id=owner.namespace_id,
+            )
+            for item in _fixtures()[2]
+            if self.mapping_owner_ids.get(item.legacy_document_id) == run_id
+        ]
 
     async def exact_mapping(
         self,
@@ -123,8 +156,7 @@ class _EvidenceRepository:
             (
                 item
                 for item in self.items
-                if item.legacy_document_id == resource_id
-                and item.legacy_head_oid == legacy_git_oid
+                if item.legacy_document_id == resource_id and item.legacy_head_oid == legacy_git_oid
             ),
             None,
         )
@@ -135,20 +167,40 @@ class _EvidenceRepository:
             resource_id=resource_id,
             legacy_git_oid=legacy_git_oid,
             path_at_revision=next(
-                document.current_path
-                for document in _fixtures()[1].documents
-                if document.resource_id == resource_id
+                document.current_path for document in _fixtures()[1].documents if document.resource_id == resource_id
             ),
             resolution="native",
-            native_revision_id=(
-                item.native_head_revision_id
-                if item is not None
-                else self.native_ids[resource_id]
-            ),
+            native_revision_id=(item.native_head_revision_id if item is not None else self.native_ids[resource_id]),
             run_id=owner_id,
             lineage_ordinal=1,
             fixed_git_oid=owner.fixed_git_oid,
         )
+
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+    ) -> list[LegacyRevisionMapping]:
+        assert namespace_id == self.run.namespace_id
+        document = next(document for document in _fixtures()[1].documents if document.resource_id == resource_id)
+        owner_id = self.mapping_owner_ids.get(resource_id, self.run.run_id)
+        owner = self.owner_runs[owner_id]
+        native_id = self.native_ids[resource_id]
+        return [
+            LegacyRevisionMapping(
+                namespace_id=namespace_id,
+                resource_id=resource_id,
+                legacy_git_oid=entry.legacy_git_oid,
+                path_at_revision=entry.path_at_revision,
+                resolution="native" if index == len(document.lineage) - 1 else "bridge",
+                native_revision_id=(native_id if index == len(document.lineage) - 1 else None),
+                run_id=owner_id,
+                lineage_ordinal=index,
+                fixed_git_oid=owner.fixed_git_oid,
+            )
+            for index, entry in enumerate(document.lineage)
+        ]
 
 
 class _Bridge:
@@ -228,10 +280,7 @@ def _fixtures() -> tuple[MigrationRun, LegacyInventory, list[MigrationItem], dic
         documents=documents,
         inventory_digest=digest,
     )
-    native_ids = {
-        document.resource_id: _oid(str(index + 5))
-        for index, document in enumerate(documents)
-    }
+    native_ids = {document.resource_id: _oid(str(index + 5)) for index, document in enumerate(documents)}
     items = [
         MigrationItem(
             run_id=run_id,
@@ -251,6 +300,58 @@ def _fixtures() -> tuple[MigrationRun, LegacyInventory, list[MigrationItem], dic
     return run, inventory, items, native_ids
 
 
+def _activity_binding_fact(
+    document: LegacyInventoryDocument,
+    *,
+    namespace_id: uuid.UUID,
+    selector: str,
+    fixed_ref: str,
+    owner_run_id: uuid.UUID,
+) -> dict[str, Any]:
+    resource_id = str(document.resource_id)
+    occurred_at = document.lineage[-1].committed_at.isoformat()
+    current_mapping = {
+        "namespace_id": str(namespace_id),
+        "resource_id": resource_id,
+        "legacy_git_oid": document.current_commit,
+        "path_at_revision": document.current_path,
+        "resolution": "native",
+        "native_revision_id": selector,
+        "fixed_git_oid": fixed_ref,
+        "run_id": str(owner_run_id),
+    }
+    selected_revision = {
+        "namespace_id": str(namespace_id),
+        "resource_id": resource_id,
+        "revision_id": selector,
+        "parent_revision_id": None,
+        "surface": "document",
+        "action": "create",
+        "path_at_revision": document.current_path,
+        "path_from": None,
+        "path_to": document.current_path,
+        "actor": "akb-native-revision-migration",
+        "subject": None,
+        "summary": None,
+        "occurred_at": occurred_at,
+        "digest": document.body_digest,
+        "byte_size": document.byte_size,
+    }
+    return {
+        "profile": "akb-native-revision-p2-activity-audit/v1",
+        "selector": selector,
+        "fixed_ref": fixed_ref,
+        "current_mapping": current_mapping,
+        "selected_revision": selected_revision,
+        "activity": {
+            key: value
+            for key, value in selected_revision.items()
+            if key not in {"parent_revision_id", "digest", "byte_size"}
+        },
+        "completed_parent_mapping": None,
+    }
+
+
 class _Reader:
     def __init__(
         self,
@@ -258,11 +359,13 @@ class _Reader:
         *,
         candidate: bool,
         fixed_refs: dict[uuid.UUID, str] | None = None,
+        owner_run_ids: dict[uuid.UUID, uuid.UUID] | None = None,
     ):
         self.native_ids = native_ids
         self.candidate = candidate
-        self.fixed_refs = fixed_refs or {
-            resource_id: _oid("f") for resource_id in native_ids
+        self.fixed_refs = fixed_refs or {resource_id: _oid("f") for resource_id in native_ids}
+        self.owner_run_ids = owner_run_ids or {
+            resource_id: uuid.UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb") for resource_id in native_ids
         }
         self.calls: list[tuple[str, uuid.UUID]] = []
         self.unknown_delta = False
@@ -300,7 +403,9 @@ class _Reader:
         assert selector == (self.native_ids[document.resource_id] if self.candidate else document.current_commit)
         entries = []
         for index, entry in enumerate(reversed(document.lineage)):
-            entry_selector = self.native_ids[document.resource_id] if self.candidate and index == 0 else entry.legacy_git_oid
+            entry_selector = (
+                self.native_ids[document.resource_id] if self.candidate and index == 0 else entry.legacy_git_oid
+            )
             projection = entry_selector if index == 0 else None
             entries.append(
                 {
@@ -336,10 +441,13 @@ class _Reader:
                 "events": [
                     {
                         "hash": native_id,
-                        "subject": "internal migration subject",
-                        "author": {"id": "akb-native-revision-migration", "display": "Migration"},
+                        "subject": None,
+                        "author": {
+                            "id": "akb-native-revision-migration",
+                            "display": "akb-native-revision-migration",
+                        },
                         "action": "create",
-                        "summary": "C9 fixed-ref native genesis",
+                        "summary": None,
                         "projection_revision": native_id,
                     }
                 ]
@@ -371,12 +479,13 @@ class _Reader:
         )
         return NativeActivityEvidence(
             envelope=envelope,
-            binding_fact={
-                "profile": "akb-native-revision-p2-activity-audit/v1",
-                "resource_id": str(document.resource_id),
-                "selector": selector,
-                "fixed_ref": fixed_ref,
-            },
+            binding_fact=_activity_binding_fact(
+                document,
+                namespace_id=uuid.UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+                selector=selector,
+                fixed_ref=fixed_ref,
+                owner_run_id=self.owner_run_ids[document.resource_id],
+            ),
         )
 
 
@@ -397,8 +506,10 @@ class _CrossRunReadRepository:
         return self.runs.get(run_id)
 
     async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
-        assert run_id == self.final_run.run_id
-        return [self.item]
+        if run_id == self.final_run.run_id:
+            return [self.item]
+        unchanged_item = _fixtures()[2][1]
+        return [replace(unchanged_item, run_id=run_id)]
 
     async def exact_mapping(
         self,
@@ -411,11 +522,35 @@ class _CrossRunReadRepository:
             return None
         return mapping
 
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+    ) -> list[LegacyRevisionMapping]:
+        assert namespace_id == self.final_run.namespace_id
+        document = next(document for document in _fixtures()[1].documents if document.resource_id == resource_id)
+        current = self.mappings[resource_id]
+        return [
+            LegacyRevisionMapping(
+                namespace_id=namespace_id,
+                resource_id=resource_id,
+                legacy_git_oid=entry.legacy_git_oid,
+                path_at_revision=entry.path_at_revision,
+                resolution="native" if index == len(document.lineage) - 1 else "bridge",
+                native_revision_id=(current.native_revision_id if index == len(document.lineage) - 1 else None),
+                run_id=current.run_id,
+                lineage_ordinal=index,
+                fixed_git_oid=current.fixed_git_oid,
+            )
+            for index, entry in enumerate(document.lineage)
+        ]
+
 
 async def _table_counts() -> tuple[tuple[str, int], ...]:
     try:
         conn = await asyncpg.connect(_DSN, timeout=2)
-    except (OSError, asyncpg.PostgresError):
+    except OSError, asyncpg.PostgresError:
         pytest.skip(f"Postgres not reachable at {_DSN}")
     try:
         rows = await conn.fetch(
@@ -463,6 +598,8 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert receipt["protocol_version"] == "akb-native-revision-p2-w1-c10/v4"
     assert receipt["summary"]["raw_activity_audit_count"] == 2
     assert receipt["evidence_binding"]["mapping_count"] == 2
+    assert receipt["evidence_binding"]["retained_mapping_count"] == 2
+    assert receipt["evidence_binding"]["native_parent_binding_count"] == 2
     assert receipt["evidence_binding"]["owner_run_count"] == 1
     assert len(receipt["resources"]) == 2
     assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
@@ -526,6 +663,10 @@ async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_
         changed.resource_id: run.fixed_git_oid,
         unchanged.resource_id: owner_run.fixed_git_oid,
     }
+    owner_run_ids = {
+        changed.resource_id: run.run_id,
+        unchanged.resource_id: owner_run.run_id,
+    }
     comparator = NativeRevisionShadowComparator(
         repository=_CrossRunReadRepository(run, owner_run, items[0], mappings),
         bridge=_Bridge(inventory),
@@ -533,11 +674,13 @@ async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_
             native_ids,
             candidate=False,
             fixed_refs=fixed_refs,
+            owner_run_ids=owner_run_ids,
         ),
         candidate_reader=_Reader(
             native_ids,
             candidate=True,
             fixed_refs=fixed_refs,
+            owner_run_ids=owner_run_ids,
         ),
     )
 
@@ -547,6 +690,52 @@ async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_
     assert receipt["summary"]["resource_count"] == 2
     assert receipt["summary"]["operation_count"] == 8
     assert receipt["summary"]["raw_activity_audit_count"] == 2
+
+
+async def test_completed_reconcile_rejects_rehomed_unchanged_mapping():
+    run, inventory, items, native_ids = _fixtures()
+    changed, unchanged = inventory.documents
+    owner_run = replace(
+        run,
+        run_id=uuid.UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+        fixed_git_oid=_oid("a"),
+        coverage_version="c9-owner-v1",
+        inventory_digest="e" * 64,
+    )
+    mappings = {
+        changed.resource_id: LegacyRevisionMapping(
+            namespace_id=run.namespace_id,
+            resource_id=changed.resource_id,
+            legacy_git_oid=changed.current_commit,
+            path_at_revision=changed.current_path,
+            resolution="native",
+            native_revision_id=native_ids[changed.resource_id],
+            run_id=run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=run.fixed_git_oid,
+        ),
+        unchanged.resource_id: LegacyRevisionMapping(
+            namespace_id=run.namespace_id,
+            resource_id=unchanged.resource_id,
+            legacy_git_oid=unchanged.current_commit,
+            path_at_revision=unchanged.current_path,
+            resolution="native",
+            native_revision_id=native_ids[unchanged.resource_id],
+            run_id=run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=run.fixed_git_oid,
+        ),
+    }
+    repository = _CrossRunReadRepository(run, owner_run, items[0], mappings)
+    comparator = NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=_Bridge(inventory),
+        legacy_reader=_Reader(native_ids, candidate=False),
+        candidate_reader=_Reader(native_ids, candidate=True),
+    )
+
+    with pytest.raises(ShadowComparisonError, match="exact completed owner item"):
+        await comparator.compare_run(run.run_id)
 
 
 async def test_incomplete_run_and_inventory_drift_are_rejected_before_reads():
@@ -634,11 +823,24 @@ def _evidence_comparator(
     fixed_refs: dict[uuid.UUID, str] | None = None,
 ) -> NativeRevisionShadowComparator:
     refs = fixed_refs or {resource_id: run.fixed_git_oid for resource_id in native_ids}
+    owner_run_ids = {
+        resource_id: repository.mapping_owner_ids.get(resource_id, run.run_id) for resource_id in native_ids
+    }
     return NativeRevisionShadowComparator(
         repository=repository,
         bridge=_Bridge(inventory),
-        legacy_reader=_Reader(native_ids, candidate=False, fixed_refs=refs),
-        candidate_reader=_Reader(native_ids, candidate=True, fixed_refs=refs),
+        legacy_reader=_Reader(
+            native_ids,
+            candidate=False,
+            fixed_refs=refs,
+            owner_run_ids=owner_run_ids,
+        ),
+        candidate_reader=_Reader(
+            native_ids,
+            candidate=True,
+            fixed_refs=refs,
+            owner_run_ids=owner_run_ids,
+        ),
     )
 
 
@@ -672,6 +874,61 @@ async def test_evidence_binding_is_stable_under_scope_and_item_order_shuffle():
     assert all(document.activity.actor not in encoded for document in inventory.documents)
     assert all(document.activity.subject not in encoded for document in inventory.documents)
     assert all(document.activity.summary not in encoded for document in inventory.documents)
+
+
+@pytest.mark.parametrize("tamper", ("owner", "ordinal"))
+async def test_retained_mapping_owner_or_ordinal_tamper_fails_closed(tamper):
+    run, inventory, items, native_ids = _fixtures()
+    repository = _EvidenceRepository(run, items, native_ids)
+    original = repository.list_resource_mappings
+
+    async def tampered_mappings(*, namespace_id, resource_id):
+        mappings = await original(
+            namespace_id=namespace_id,
+            resource_id=resource_id,
+        )
+        if resource_id != inventory.documents[0].resource_id:
+            return mappings
+        if tamper == "owner":
+            mappings[0] = replace(mappings[0], run_id=uuid.uuid4())
+        else:
+            mappings[0] = replace(mappings[0], lineage_ordinal=1)
+        return mappings
+
+    repository.list_resource_mappings = tampered_mappings
+    comparator = _evidence_comparator(run, inventory, repository, native_ids)
+
+    with pytest.raises(ShadowComparisonError, match="mapping|owner"):
+        await comparator.compare_run(run.run_id)
+
+
+@pytest.mark.parametrize("owner_fact", ("fixed_ref", "namespace", "coverage"))
+async def test_invalid_retained_mapping_owner_run_facts_fail(owner_fact):
+    run, inventory, _, native_ids = _fixtures()
+    owner = replace(
+        run,
+        run_id=uuid.UUID("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"),
+        fixed_git_oid=_oid("b"),
+        inventory_digest="f" * 64,
+        coverage_version="c9-owner-v1",
+    )
+    if owner_fact == "fixed_ref":
+        owner = replace(owner, fixed_git_oid="invalid")
+    elif owner_fact == "namespace":
+        owner = replace(owner, namespace_id=uuid.uuid4())
+    else:
+        owner = replace(owner, coverage_version="")
+    repository = _EvidenceRepository(
+        run,
+        [],
+        native_ids,
+        owner_runs=[owner],
+        mapping_owner_ids={resource_id: owner.run_id for resource_id in native_ids},
+    )
+    comparator = _evidence_comparator(run, inventory, repository, native_ids)
+
+    with pytest.raises(ShadowComparisonError, match="owner|scope facts"):
+        await comparator.compare_run(run.run_id)
 
 
 @pytest.mark.parametrize("changed", ("run", "ref", "inventory", "mapping_owner"))
@@ -741,3 +998,8 @@ async def test_evidence_binding_changes_when_any_private_scope_fact_changes(chan
         ).compare_run(run.run_id)
 
     assert base["evidence_binding"]["commitment"] != changed_receipt["evidence_binding"]["commitment"]
+    if changed in {"inventory", "mapping_owner"}:
+        assert (
+            base["evidence_binding"]["components"]["retained_mapping_closure"]
+            != changed_receipt["evidence_binding"]["components"]["retained_mapping_closure"]
+        )

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -87,6 +87,69 @@ class _ReadRepository:
         )
 
 
+class _EvidenceRepository:
+    def __init__(
+        self,
+        run: MigrationRun,
+        items: list[MigrationItem],
+        native_ids: dict[uuid.UUID, str],
+        *,
+        owner_runs: list[MigrationRun] = (),
+        mapping_owner_ids: dict[uuid.UUID, uuid.UUID] | None = None,
+        reverse_items: bool = False,
+    ):
+        self.run = run
+        self.items = list(reversed(items)) if reverse_items else list(items)
+        self.native_ids = native_ids
+        self.owner_runs = {run.run_id: run}
+        self.owner_runs.update({owner.run_id: owner for owner in owner_runs})
+        self.mapping_owner_ids = mapping_owner_ids or {}
+
+    async def get_run(self, run_id: uuid.UUID) -> MigrationRun | None:
+        return self.owner_runs.get(run_id)
+
+    async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
+        assert run_id == self.run.run_id
+        return list(self.items)
+
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+    ) -> LegacyRevisionMapping | None:
+        item = next(
+            (
+                item
+                for item in self.items
+                if item.legacy_document_id == resource_id
+                and item.legacy_head_oid == legacy_git_oid
+            ),
+            None,
+        )
+        owner_id = self.mapping_owner_ids.get(resource_id, self.run.run_id)
+        owner = self.owner_runs[owner_id]
+        return LegacyRevisionMapping(
+            namespace_id=self.run.namespace_id,
+            resource_id=resource_id,
+            legacy_git_oid=legacy_git_oid,
+            path_at_revision=next(
+                document.current_path
+                for document in _fixtures()[1].documents
+                if document.resource_id == resource_id
+            ),
+            resolution="native",
+            native_revision_id=(
+                item.native_head_revision_id
+                if item is not None
+                else self.native_ids[resource_id]
+            ),
+            run_id=owner_id,
+            lineage_ordinal=1,
+            fixed_git_oid=owner.fixed_git_oid,
+        )
+
+
 class _Bridge:
     def __init__(self, inventory: LegacyInventory):
         self.inventory = inventory
@@ -293,6 +356,15 @@ class _Reader:
             ]
         }
 
+    async def audit_activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> None:
+        del document, selector, fixed_ref
+
 
 class _CrossRunReadRepository:
     def __init__(
@@ -373,6 +445,11 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert receipt["write_authority"] == "legacy_only"
     assert receipt["final_p2_coverage_claim"] is False
     assert receipt["cutover_claim"] is False
+    assert receipt["schema_version"] == 4
+    assert receipt["protocol_version"] == "akb-native-revision-p2-w1-c10/v4"
+    assert receipt["summary"]["raw_activity_audit_count"] == 2
+    assert receipt["evidence_binding"]["mapping_count"] == 2
+    assert receipt["evidence_binding"]["owner_run_count"] == 1
     assert len(receipt["resources"]) == 2
     assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
     for resource in receipt["resources"]:
@@ -384,6 +461,10 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
             )
             for mismatch in operation["classified_mismatches"]:
                 assert set(mismatch) == {"rule_id", "classification", "count"}
+        assert resource["operations"]["activity"]["raw_activity_audit"] == {
+            "profile": "akb-native-revision-p2-activity-audit/v1",
+            "status": "passed",
+        }
     encoded = json.dumps(receipt, sort_keys=True)
     assert all(document.body.decode() not in encoded for document in inventory.documents)
     assert all(str(document.resource_id) not in encoded for document in inventory.documents)
@@ -451,6 +532,7 @@ async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_
     assert receipt["status"] == "passed"
     assert receipt["summary"]["resource_count"] == 2
     assert receipt["summary"]["operation_count"] == 8
+    assert receipt["summary"]["raw_activity_audit_count"] == 2
 
 
 async def test_incomplete_run_and_inventory_drift_are_rejected_before_reads():
@@ -527,3 +609,121 @@ async def test_stale_or_cross_run_item_binding_fails_before_any_reader(
         await comparator.compare_run(run.run_id)
     assert legacy.calls == []
     assert candidate.calls == []
+
+
+def _evidence_comparator(
+    run: MigrationRun,
+    inventory: LegacyInventory,
+    repository: _EvidenceRepository,
+    native_ids: dict[uuid.UUID, str],
+    *,
+    fixed_refs: dict[uuid.UUID, str] | None = None,
+) -> NativeRevisionShadowComparator:
+    refs = fixed_refs or {resource_id: run.fixed_git_oid for resource_id in native_ids}
+    return NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=_Bridge(inventory),
+        legacy_reader=_Reader(native_ids, candidate=False, fixed_refs=refs),
+        candidate_reader=_Reader(native_ids, candidate=True, fixed_refs=refs),
+    )
+
+
+async def test_evidence_binding_is_stable_under_scope_and_item_order_shuffle():
+    run, inventory, items, native_ids = _fixtures()
+    shuffled_inventory = replace(inventory, documents=tuple(reversed(inventory.documents)))
+    first = await _evidence_comparator(
+        run,
+        inventory,
+        _EvidenceRepository(run, items, native_ids),
+        native_ids,
+    ).compare_run(run.run_id)
+    second = await _evidence_comparator(
+        run,
+        shuffled_inventory,
+        _EvidenceRepository(run, list(reversed(items)), native_ids, reverse_items=True),
+        native_ids,
+    ).compare_run(run.run_id)
+
+    assert first["evidence_binding"] == second["evidence_binding"]
+    assert first["receipt_digest"] == second["receipt_digest"]
+    assert first["summary"]["raw_activity_audit_count"] == 2
+    assert all(
+        resource["operations"]["activity"]["raw_activity_audit"]["status"] == "passed"
+        for resource in first["resources"]
+    )
+    encoded = json.dumps(first, sort_keys=True)
+    assert all(document.body.decode() not in encoded for document in inventory.documents)
+    assert all(document.current_path not in encoded for document in inventory.documents)
+    assert all(str(document.resource_id) not in encoded for document in inventory.documents)
+    assert all(document.activity.actor not in encoded for document in inventory.documents)
+    assert all(document.activity.subject not in encoded for document in inventory.documents)
+    assert all(document.activity.summary not in encoded for document in inventory.documents)
+
+
+@pytest.mark.parametrize("changed", ("run", "ref", "inventory", "mapping_owner"))
+async def test_evidence_binding_changes_when_any_private_scope_fact_changes(changed):
+    run, inventory, items, native_ids = _fixtures()
+    base = await _evidence_comparator(
+        run,
+        inventory,
+        _EvidenceRepository(run, items, native_ids),
+        native_ids,
+    ).compare_run(run.run_id)
+
+    if changed == "run":
+        changed_run = replace(
+            run,
+            run_id=uuid.UUID("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+        )
+        changed_items = [replace(item, run_id=changed_run.run_id) for item in items]
+        changed_inventory = inventory
+        changed_repo = _EvidenceRepository(changed_run, changed_items, native_ids)
+        changed_receipt = await _evidence_comparator(
+            changed_run,
+            changed_inventory,
+            changed_repo,
+            native_ids,
+        ).compare_run(changed_run.run_id)
+    elif changed == "ref":
+        changed_run = replace(run, fixed_git_oid=_oid("a"))
+        changed_inventory = replace(inventory, fixed_git_oid=changed_run.fixed_git_oid)
+        refs = {resource_id: changed_run.fixed_git_oid for resource_id in native_ids}
+        changed_receipt = await _evidence_comparator(
+            changed_run,
+            changed_inventory,
+            _EvidenceRepository(changed_run, items, native_ids),
+            native_ids,
+            fixed_refs=refs,
+        ).compare_run(changed_run.run_id)
+    elif changed == "inventory":
+        changed_run = replace(run, inventory_digest="e" * 64)
+        changed_inventory = replace(inventory, inventory_digest=changed_run.inventory_digest)
+        changed_receipt = await _evidence_comparator(
+            changed_run,
+            changed_inventory,
+            _EvidenceRepository(changed_run, items, native_ids),
+            native_ids,
+        ).compare_run(changed_run.run_id)
+    else:
+        owner = replace(
+            run,
+            run_id=uuid.UUID("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"),
+            fixed_git_oid=_oid("b"),
+            inventory_digest="f" * 64,
+        )
+        refs = {resource_id: owner.fixed_git_oid for resource_id in native_ids}
+        changed_receipt = await _evidence_comparator(
+            run,
+            inventory,
+            _EvidenceRepository(
+                run,
+                [],
+                native_ids,
+                owner_runs=[owner],
+                mapping_owner_ids={resource_id: owner.run_id for resource_id in native_ids},
+            ),
+            native_ids,
+            fixed_refs=refs,
+        ).compare_run(run.run_id)
+
+    assert base["evidence_binding"]["commitment"] != changed_receipt["evidence_binding"]["commitment"]

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -30,6 +30,7 @@ from app.services.native_revision_shadow import (
     ShadowRunIncompleteError,
     NativeRevisionShadowComparator,
 )
+from app.services.native_revision_shadow_reader import NativeActivityEvidence
 
 
 pytestmark = pytest.mark.asyncio
@@ -356,14 +357,27 @@ class _Reader:
             ]
         }
 
-    async def audit_activity(
+    async def activity_evidence(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> None:
-        del document, selector, fixed_ref
+    ) -> NativeActivityEvidence:
+        envelope = await self.activity(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )
+        return NativeActivityEvidence(
+            envelope=envelope,
+            binding_fact={
+                "profile": "akb-native-revision-p2-activity-audit/v1",
+                "resource_id": str(document.resource_id),
+                "selector": selector,
+                "fixed_ref": fixed_ref,
+            },
+        )
 
 
 class _CrossRunReadRepository:

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -14,6 +14,7 @@ import asyncpg
 import pytest
 
 from app.repositories.native_revision_migration_repo import (
+    LegacyRevisionMapping,
     MigrationInventoryDriftError,
     MigrationItem,
     MigrationRun,
@@ -55,6 +56,35 @@ class _ReadRepository:
         self.list_items_calls += 1
         assert run_id == self.run.run_id
         return list(self.items)
+
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+    ) -> LegacyRevisionMapping | None:
+        item = next(
+            (
+                item
+                for item in self.items
+                if item.legacy_document_id == resource_id
+                and item.legacy_head_oid == legacy_git_oid
+            ),
+            None,
+        )
+        if item is None:
+            return None
+        return LegacyRevisionMapping(
+            namespace_id=self.run.namespace_id,
+            resource_id=resource_id,
+            legacy_git_oid=legacy_git_oid,
+            path_at_revision=item.captured_path,
+            resolution="native",
+            native_revision_id=item.native_head_revision_id,
+            run_id=self.run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=self.run.fixed_git_oid,
+        )
 
 
 class _Bridge:
@@ -158,15 +188,24 @@ def _fixtures() -> tuple[MigrationRun, LegacyInventory, list[MigrationItem], dic
 
 
 class _Reader:
-    def __init__(self, native_ids: dict[uuid.UUID, str], *, candidate: bool):
+    def __init__(
+        self,
+        native_ids: dict[uuid.UUID, str],
+        *,
+        candidate: bool,
+        fixed_refs: dict[uuid.UUID, str] | None = None,
+    ):
         self.native_ids = native_ids
         self.candidate = candidate
+        self.fixed_refs = fixed_refs or {
+            resource_id: _oid("f") for resource_id in native_ids
+        }
         self.calls: list[tuple[str, uuid.UUID]] = []
         self.unknown_delta = False
 
     async def get(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
         self.calls.append(("get", document.resource_id))
-        assert fixed_ref == _oid("f")
+        assert fixed_ref == self.fixed_refs[document.resource_id]
         native_id = self.native_ids[document.resource_id]
         if self.candidate:
             selector = native_id
@@ -255,6 +294,38 @@ class _Reader:
         }
 
 
+class _CrossRunReadRepository:
+    def __init__(
+        self,
+        final_run: MigrationRun,
+        owner_run: MigrationRun,
+        item: MigrationItem,
+        mappings: dict[uuid.UUID, LegacyRevisionMapping],
+    ):
+        self.runs = {final_run.run_id: final_run, owner_run.run_id: owner_run}
+        self.final_run = final_run
+        self.item = item
+        self.mappings = mappings
+
+    async def get_run(self, run_id: uuid.UUID) -> MigrationRun | None:
+        return self.runs.get(run_id)
+
+    async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
+        assert run_id == self.final_run.run_id
+        return [self.item]
+
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+    ) -> LegacyRevisionMapping | None:
+        mapping = self.mappings.get(resource_id)
+        if mapping is None or mapping.legacy_git_oid != legacy_git_oid:
+            return None
+        return mapping
+
+
 async def _table_counts() -> tuple[tuple[str, int], ...]:
     try:
         conn = await asyncpg.connect(_DSN, timeout=2)
@@ -303,18 +374,16 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert receipt["final_p2_coverage_claim"] is False
     assert receipt["cutover_claim"] is False
     assert len(receipt["resources"]) == 2
-    assert [row["resource_key"] for row in receipt["resources"]] == sorted(
-        f"resource-{hashlib.sha256(str(document.resource_id).encode()).hexdigest()[:16]}"
-        for document in inventory.documents
-    )
     assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
     for resource in receipt["resources"]:
         assert set(resource["operations"]) == {"get", "history", "diff", "activity"}
         for operation in resource["operations"].values():
             assert operation["normalized_equal"] is True
-            assert operation["mismatch_count"] == len(operation["mismatches"])
-            for mismatch in operation["mismatches"]:
-                assert set(mismatch) == {"path", "rule_id", "classification"}
+            assert operation["mismatch_count"] == sum(
+                mismatch["count"] for mismatch in operation["classified_mismatches"]
+            )
+            for mismatch in operation["classified_mismatches"]:
+                assert set(mismatch) == {"rule_id", "classification", "count"}
     encoded = json.dumps(receipt, sort_keys=True)
     assert all(document.body.decode() not in encoded for document in inventory.documents)
     assert all(str(document.resource_id) not in encoded for document in inventory.documents)
@@ -322,6 +391,66 @@ async def test_completed_run_compares_every_resource_and_is_immutable():
     assert len(legacy.calls) == len(inventory.documents) * 4
     assert len(candidate.calls) == len(inventory.documents) * 4
     assert receipt["receipt_digest"] == (await comparator.compare_run(run.run_id))["receipt_digest"]
+
+
+async def test_completed_reconcile_resolves_an_unchanged_mapping_from_its_owner_run():
+    run, inventory, items, native_ids = _fixtures()
+    changed, unchanged = inventory.documents
+    owner_run = replace(
+        run,
+        run_id=uuid.UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+        fixed_git_oid=_oid("a"),
+        coverage_version="c9-owner-v1",
+        inventory_digest="e" * 64,
+    )
+    mappings = {
+        changed.resource_id: LegacyRevisionMapping(
+            namespace_id=run.namespace_id,
+            resource_id=changed.resource_id,
+            legacy_git_oid=changed.current_commit,
+            path_at_revision=changed.current_path,
+            resolution="native",
+            native_revision_id=native_ids[changed.resource_id],
+            run_id=run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=run.fixed_git_oid,
+        ),
+        unchanged.resource_id: LegacyRevisionMapping(
+            namespace_id=run.namespace_id,
+            resource_id=unchanged.resource_id,
+            legacy_git_oid=unchanged.current_commit,
+            path_at_revision=unchanged.current_path,
+            resolution="native",
+            native_revision_id=native_ids[unchanged.resource_id],
+            run_id=owner_run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=owner_run.fixed_git_oid,
+        ),
+    }
+    fixed_refs = {
+        changed.resource_id: run.fixed_git_oid,
+        unchanged.resource_id: owner_run.fixed_git_oid,
+    }
+    comparator = NativeRevisionShadowComparator(
+        repository=_CrossRunReadRepository(run, owner_run, items[0], mappings),
+        bridge=_Bridge(inventory),
+        legacy_reader=_Reader(
+            native_ids,
+            candidate=False,
+            fixed_refs=fixed_refs,
+        ),
+        candidate_reader=_Reader(
+            native_ids,
+            candidate=True,
+            fixed_refs=fixed_refs,
+        ),
+    )
+
+    receipt = await comparator.compare_run(run.run_id)
+
+    assert receipt["status"] == "passed"
+    assert receipt["summary"]["resource_count"] == 2
+    assert receipt["summary"]["operation_count"] == 8
 
 
 async def test_incomplete_run_and_inventory_drift_are_rejected_before_reads():

--- a/backend/tests/test_native_revision_shadow_pg.py
+++ b/backend/tests/test_native_revision_shadow_pg.py
@@ -1,0 +1,406 @@
+"""Focused A5 shadow-comparator checks."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import asyncpg
+import pytest
+
+from app.repositories.native_revision_migration_repo import (
+    MigrationInventoryDriftError,
+    MigrationItem,
+    MigrationRun,
+)
+from app.services.legacy_revision_bridge import (
+    LegacyActivitySemantics,
+    LegacyInventory,
+    LegacyInventoryDocument,
+    LegacyLineageEntry,
+)
+from app.services.native_revision_shadow import (
+    ShadowComparisonError,
+    ShadowRunIncompleteError,
+    NativeRevisionShadowComparator,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@127.0.0.1:55433/akb",  # pragma: allowlist secret
+)
+
+
+class _ReadRepository:
+    def __init__(self, run: MigrationRun, items: list[MigrationItem]):
+        self.run = run
+        self.items = items
+        self.get_run_calls = 0
+        self.list_items_calls = 0
+
+    async def get_run(self, run_id: uuid.UUID) -> MigrationRun:
+        self.get_run_calls += 1
+        assert run_id == self.run.run_id
+        return self.run
+
+    async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
+        self.list_items_calls += 1
+        assert run_id == self.run.run_id
+        return list(self.items)
+
+
+class _Bridge:
+    def __init__(self, inventory: LegacyInventory):
+        self.inventory = inventory
+        self.calls = 0
+        self.drift = False
+
+    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
+        self.calls += 1
+        if self.drift:
+            raise MigrationInventoryDriftError()
+        assert run.inventory_digest == self.inventory.inventory_digest
+        return self.inventory
+
+
+def _oid(char: str) -> str:
+    return char * 40
+
+
+def _doc(index: int) -> LegacyInventoryDocument:
+    resource_id = uuid.UUID(f"{index:08d}-1111-4111-8111-111111111111")
+    legacy_head = _oid(str(index + 1))
+    retained = _oid(str(index + 3))
+    body = f"# Document {index}\n\nbody at fixed ref\n"
+    at = datetime(2026, 8, 10, 1, index, tzinfo=UTC)
+    path = f"notes/document-{index}.md"
+    activity = LegacyActivitySemantics(
+        legacy_git_oid=legacy_head,
+        committed_at=at,
+        actor=f"actor-{index}",
+        subject=f"akb://p2-vault/coll/{path}",
+        summary=f"update document {index}",
+        action="update",
+        path_from=None,
+        path_to=path,
+        changed_paths=({"change": "update", "path_from": None, "path_to": path},),
+    )
+    return LegacyInventoryDocument(
+        resource_id=resource_id,
+        current_path=path,
+        current_commit=legacy_head,
+        created_at=at - timedelta(days=1),
+        body=body.encode(),
+        body_digest=hashlib.sha256(body.encode()).hexdigest(),
+        byte_size=len(body.encode()),
+        lineage=(
+            LegacyLineageEntry(retained, path, at - timedelta(days=2)),
+            LegacyLineageEntry(legacy_head, path, at),
+        ),
+        activity=activity,
+        aliases=(),
+    )
+
+
+def _fixtures() -> tuple[MigrationRun, LegacyInventory, list[MigrationItem], dict[uuid.UUID, str]]:
+    namespace_id = uuid.UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    run_id = uuid.UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    documents = tuple(_doc(index) for index in (1, 2))
+    digest = "d" * 64
+    run = MigrationRun(
+        run_id=run_id,
+        namespace_id=namespace_id,
+        fixed_git_oid=_oid("f"),
+        coverage_version="c9-test-v1",
+        inventory_digest=digest,
+        status="complete",
+        created_at=datetime(2026, 8, 10, tzinfo=UTC),
+        started_at=datetime(2026, 8, 10, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 10, 1, tzinfo=UTC),
+        error=None,
+    )
+    inventory = LegacyInventory(
+        namespace_id=namespace_id,
+        fixed_git_oid=run.fixed_git_oid,
+        coverage_version=run.coverage_version,
+        documents=documents,
+        inventory_digest=digest,
+    )
+    native_ids = {
+        document.resource_id: _oid(str(index + 5))
+        for index, document in enumerate(documents)
+    }
+    items = [
+        MigrationItem(
+            run_id=run_id,
+            namespace_id=namespace_id,
+            legacy_document_id=document.resource_id,
+            native_resource_id=document.resource_id,
+            captured_path=document.current_path,
+            legacy_head_oid=document.current_commit,
+            native_head_revision_id=native_ids[document.resource_id],
+            body_digest=document.body_digest,
+            byte_size=document.byte_size,
+            status="complete",
+            error_code=None,
+        )
+        for document in documents
+    ]
+    return run, inventory, items, native_ids
+
+
+class _Reader:
+    def __init__(self, native_ids: dict[uuid.UUID, str], *, candidate: bool):
+        self.native_ids = native_ids
+        self.candidate = candidate
+        self.calls: list[tuple[str, uuid.UUID]] = []
+        self.unknown_delta = False
+
+    async def get(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        self.calls.append(("get", document.resource_id))
+        assert fixed_ref == _oid("f")
+        native_id = self.native_ids[document.resource_id]
+        if self.candidate:
+            selector = native_id
+        else:
+            selector = document.current_commit
+        body = document.body.decode()
+        if not self.candidate:
+            body = body.replace("\n", "\r\n")
+        result = {
+            "kind": "document",
+            "uri": document.activity.subject,
+            "vault": "p2-vault",
+            "path": document.current_path,
+            "title": document.current_path.rsplit("/", 1)[-1],
+            "current_commit": selector,
+            "content": body,
+            "projection": {"revision": selector, "authoritative": False},
+            "actor": {"id": document.activity.actor, "display": "Legacy Writer"},
+        }
+        if not self.candidate:
+            result["actor"] = {"id": document.activity.actor, "display": "Legacy Writer"}
+        if self.unknown_delta:
+            result["uri"] = "akb://p2-vault/coll/notes/other.md"
+        return result
+
+    async def history(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        self.calls.append(("history", document.resource_id))
+        assert selector == (self.native_ids[document.resource_id] if self.candidate else document.current_commit)
+        entries = []
+        for index, entry in enumerate(reversed(document.lineage)):
+            entry_selector = self.native_ids[document.resource_id] if self.candidate and index == 0 else entry.legacy_git_oid
+            projection = entry_selector if index == 0 else None
+            entries.append(
+                {
+                    "selector": entry_selector,
+                    "payload_sha256": hashlib.sha256(entry.legacy_git_oid.encode()).hexdigest(),
+                    "projection_revision": projection,
+                    "summary": document.activity.summary if index == 0 else "retained history",
+                }
+            )
+        return {
+            "uri": document.activity.subject,
+            "history_source": "fixed-ref-bridge" if self.candidate else "legacy-git-log",
+            "lineage_boundary": document.lineage[0].legacy_git_oid if self.candidate else "legacy-document-start",
+            "entries": entries,
+        }
+
+    async def diff(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        self.calls.append(("diff", document.resource_id))
+        assert selector == (self.native_ids[document.resource_id] if self.candidate else document.current_commit)
+        return {
+            "file": document.current_path,
+            "commit": selector,
+            "basis": "fixed-ref-snapshot" if self.candidate else "git-parent",
+            "text": "@@ -1 +1 @@\n body at fixed ref",
+            "format": "unified",
+        }
+
+    async def activity(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        self.calls.append(("activity", document.resource_id))
+        native_id = self.native_ids[document.resource_id]
+        if self.candidate:
+            return {
+                "events": [
+                    {
+                        "hash": native_id,
+                        "subject": "internal migration subject",
+                        "author": {"id": "akb-native-revision-migration", "display": "Migration"},
+                        "action": "create",
+                        "summary": "C9 fixed-ref native genesis",
+                        "projection_revision": native_id,
+                    }
+                ]
+            }
+        return {
+            "events": [
+                {
+                    "hash": document.current_commit,
+                    "subject": document.activity.subject,
+                    "author": {"id": document.activity.actor, "display": "Legacy Writer (Git)"},
+                    "action": document.activity.action,
+                    "summary": document.activity.summary,
+                    "projection_revision": document.current_commit,
+                }
+            ]
+        }
+
+
+async def _table_counts() -> tuple[tuple[str, int], ...]:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT table_name
+              FROM information_schema.tables
+             WHERE table_schema = 'public'
+             ORDER BY table_name
+            """
+        )
+        counts = []
+        for row in rows:
+            table = row["table_name"].replace('"', '""')
+            count = await conn.fetchval(f'SELECT count(*) FROM "{table}"')
+            counts.append((row["table_name"], int(count)))
+        return tuple(counts)
+    finally:
+        await conn.close()
+
+
+async def test_completed_run_compares_every_resource_and_is_immutable():
+    run, inventory, items, native_ids = _fixtures()
+    repository = _ReadRepository(run, items)
+    bridge = _Bridge(inventory)
+    legacy = _Reader(native_ids, candidate=False)
+    candidate = _Reader(native_ids, candidate=True)
+    comparator = NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=bridge,
+        legacy_reader=legacy,
+        candidate_reader=candidate,
+    )
+
+    before = await _table_counts()
+    receipt = await comparator.compare_run(run.run_id)
+    after = await _table_counts()
+
+    assert before == after
+    assert receipt["status"] == "passed"
+    assert receipt["claim_scope"] == "semantic_candidate_evidence"
+    assert receipt["write_authority"] == "legacy_only"
+    assert receipt["final_p2_coverage_claim"] is False
+    assert receipt["cutover_claim"] is False
+    assert len(receipt["resources"]) == 2
+    assert [row["resource_id"] for row in receipt["resources"]] == sorted(
+        str(document.resource_id) for document in inventory.documents
+    )
+    assert set(receipt["summary"]["used_rules"]) == {f"BR-0{index}" for index in range(1, 8)}
+    documents_by_id = {str(document.resource_id): document for document in inventory.documents}
+    for resource in receipt["resources"]:
+        assert set(resource["operations"]) == {"get", "history", "diff", "activity"}
+        activity = resource["operations"]["activity"]
+        raw_event = activity["raw_candidate"]["events"][0]
+        public_event = activity["candidate"]["events"][0]
+        document = documents_by_id[resource["resource_id"]]
+        assert raw_event["action"] == "create"
+        assert raw_event["author"] == {
+            "id": "akb-native-revision-migration",
+            "display": "Migration",
+        }
+        assert raw_event["subject"] == "internal migration subject"
+        assert raw_event["summary"] == "C9 fixed-ref native genesis"
+        assert public_event["action"] == document.activity.action
+        assert public_event["author"]["id"] == document.activity.actor
+        assert public_event["subject"] == document.activity.subject
+        assert public_event["summary"] == document.activity.summary
+    assert {name for name, _ in legacy.calls} == {"get", "history", "diff", "activity"}
+    assert len(legacy.calls) == len(inventory.documents) * 4
+    assert len(candidate.calls) == len(inventory.documents) * 4
+    assert receipt["receipt_digest"] == (await comparator.compare_run(run.run_id))["receipt_digest"]
+
+
+async def test_incomplete_run_and_inventory_drift_are_rejected_before_reads():
+    run, inventory, items, native_ids = _fixtures()
+    repository = _ReadRepository(replace(run, status="running"), items)
+    bridge = _Bridge(inventory)
+    legacy = _Reader(native_ids, candidate=False)
+    candidate = _Reader(native_ids, candidate=True)
+    comparator = NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=bridge,
+        legacy_reader=legacy,
+        candidate_reader=candidate,
+    )
+
+    with pytest.raises(ShadowRunIncompleteError):
+        await comparator.compare_run(run.run_id)
+    assert bridge.calls == 0
+    assert legacy.calls == []
+    assert candidate.calls == []
+
+    repository.run = run
+    bridge.drift = True
+    with pytest.raises(MigrationInventoryDriftError):
+        await comparator.compare_run(run.run_id)
+    assert legacy.calls == []
+    assert candidate.calls == []
+
+
+async def test_unknown_delta_is_a_non_passing_defect_not_a_new_bridge_rule():
+    run, inventory, items, native_ids = _fixtures()
+    repository = _ReadRepository(run, items)
+    bridge = _Bridge(inventory)
+    legacy = _Reader(native_ids, candidate=False)
+    candidate = _Reader(native_ids, candidate=True)
+    candidate.unknown_delta = True
+    comparator = NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=bridge,
+        legacy_reader=legacy,
+        candidate_reader=candidate,
+    )
+
+    with pytest.raises(ShadowComparisonError, match="unapproved mismatch"):
+        await comparator.compare_run(run.run_id)
+
+
+@pytest.mark.parametrize(
+    "stale_item",
+    [
+        lambda item: replace(item, run_id=uuid.uuid4()),
+        lambda item: replace(item, captured_path="notes/stale.md"),
+        lambda item: replace(item, body_digest="0" * 64),
+    ],
+    ids=("cross-run", "stale-path", "stale-digest"),
+)
+async def test_stale_or_cross_run_item_binding_fails_before_any_reader(
+    stale_item,
+):
+    run, inventory, items, native_ids = _fixtures()
+    items[0] = stale_item(items[0])
+    repository = _ReadRepository(run, items)
+    bridge = _Bridge(inventory)
+    legacy = _Reader(native_ids, candidate=False)
+    candidate = _Reader(native_ids, candidate=True)
+    comparator = NativeRevisionShadowComparator(
+        repository=repository,
+        bridge=bridge,
+        legacy_reader=legacy,
+        candidate_reader=candidate,
+    )
+
+    with pytest.raises(ShadowComparisonError, match="item binding"):
+        await comparator.compare_run(run.run_id)
+    assert legacy.calls == []
+    assert candidate.calls == []

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -1,0 +1,627 @@
+"""Focused tests for the product-owned P2 shadow-read seam."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import json
+import os
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+from git import Repo
+
+from app.repositories.native_revision_migration_repo import (
+    MigrationItem,
+    MigrationRun,
+)
+from app.services.git_service import GitService
+from app.services.legacy_revision_bridge import (
+    LegacyActivitySemantics,
+    LegacyInventory,
+    LegacyInventoryDocument,
+    LegacyLineageEntry,
+    LegacyRevisionBridge,
+)
+from app.services.native_revision_shadow import NativeRevisionShadowComparator
+from app.services.native_revision_shadow_reader import (
+    LegacyFixedRefShadowReader,
+    NativeRevisionShadowReader,
+    ShadowReaderScopeError,
+)
+from app.services.native_revision_backfill import NativeRevisionBackfill
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@127.0.0.1:54913/akb_p2_native_revision_test",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load_migration(filename: str):
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"shadow_reader_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_schema(tmp_path: Path):
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    name = f"akb_shadow_reader_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    connection = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        dsn = _database_dsn(name)
+        connection = await asyncpg.connect(dsn)
+        await connection.execute(_INIT_SQL)
+        for filename in (
+            "010_external_git_mirror.py",
+            "048_native_revision_core.py",
+            "053_native_revision_m1_pg_body.py",
+            "060_native_revision_migration_bridge.py",
+        ):
+            await _load_migration(filename).migrate(conn=connection)
+        await connection.close()
+        connection = None
+        pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        if connection is not None and not connection.is_closed():
+            await connection.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _authority_counts(pool) -> tuple[tuple[str, int], ...]:
+    tables = (
+        "native_resources",
+        "native_revisions",
+        "native_revision_activity",
+        "native_revision_migration_runs",
+        "native_revision_migration_items",
+        "legacy_revision_mappings",
+    )
+    async with pool.acquire() as conn:
+        return tuple([
+            (table, int(await conn.fetchval(f'SELECT count(*) FROM "{table}"')))
+            for table in tables
+        ])
+
+
+def _oid(char: str) -> str:
+    return char * 40
+
+
+def _document() -> LegacyInventoryDocument:
+    resource_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    current = _oid("a")
+    retained = _oid("b")
+    path = "notes/migration-candidate.md"
+    body = "# Migration candidate\n\nsecret body\n"
+    at = datetime(2026, 8, 10, tzinfo=UTC)
+    return LegacyInventoryDocument(
+        resource_id=resource_id,
+        current_path=path,
+        current_commit=current,
+        created_at=at,
+        body=body.encode(),
+        body_digest=hashlib.sha256(body.encode()).hexdigest(),
+        byte_size=len(body.encode()),
+        aliases=(),
+        lineage=(
+            LegacyLineageEntry(retained, path, at),
+            LegacyLineageEntry(current, path, at),
+        ),
+        activity=LegacyActivitySemantics(
+            legacy_git_oid=current,
+            committed_at=at,
+            actor="actor-legacy-writer",
+            subject="akb://p2-manual/coll/notes/migration-candidate.md",
+            summary="update migration candidate at fixed ref",
+            action="update",
+            path_from=None,
+            path_to=path,
+            changed_paths=({"change": "update", "path_from": None, "path_to": path},),
+        ),
+    )
+
+
+def _second_document() -> LegacyInventoryDocument:
+    first = _document()
+    current = _oid("d")
+    retained = _oid("e")
+    path = "notes/second-candidate.md"
+    body = b"# Second candidate\n\nother secret body\n"
+    at = first.created_at + timedelta(seconds=1)
+    return replace(
+        first,
+        resource_id=uuid.UUID("44444444-4444-4444-8444-444444444444"),
+        current_path=path,
+        current_commit=current,
+        created_at=at,
+        body=body,
+        body_digest=hashlib.sha256(body).hexdigest(),
+        byte_size=len(body),
+        lineage=(
+            LegacyLineageEntry(retained, path, at),
+            LegacyLineageEntry(current, path, at),
+        ),
+        activity=replace(
+            first.activity,
+            legacy_git_oid=current,
+            committed_at=at,
+            subject="akb://p2-manual/coll/notes/second-candidate.md",
+            summary="update second candidate at fixed ref",
+            path_to=path,
+            changed_paths=(
+                {"change": "update", "path_from": None, "path_to": path},
+            ),
+        ),
+    )
+
+
+def _run_and_item(
+    document: LegacyInventoryDocument,
+) -> tuple[MigrationRun, MigrationItem, LegacyInventory, str]:
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    run_id = uuid.UUID("33333333-3333-4333-8333-333333333333")
+    native_id = _oid("c")
+    fixed_ref = _oid("f")
+    digest = "d" * 64
+    run = MigrationRun(
+        run_id=run_id,
+        namespace_id=namespace_id,
+        fixed_git_oid=fixed_ref,
+        coverage_version="p2-test-v1",
+        inventory_digest=digest,
+        status="complete",
+        created_at=document.created_at,
+        started_at=document.created_at,
+        completed_at=document.created_at,
+        error=None,
+    )
+    inventory = LegacyInventory(
+        namespace_id=namespace_id,
+        fixed_git_oid=fixed_ref,
+        coverage_version=run.coverage_version,
+        documents=(document,),
+        inventory_digest=digest,
+    )
+    item = MigrationItem(
+        run_id=run_id,
+        namespace_id=namespace_id,
+        legacy_document_id=document.resource_id,
+        native_resource_id=document.resource_id,
+        captured_path=document.current_path,
+        legacy_head_oid=document.current_commit,
+        native_head_revision_id=native_id,
+        body_digest=document.body_digest,
+        byte_size=document.byte_size,
+        status="complete",
+        error_code=None,
+    )
+    return run, item, inventory, native_id
+
+
+class _ReadRepository:
+    def __init__(self, run: MigrationRun, item: MigrationItem):
+        self.run = run
+        self.item = item
+
+    async def get_run(self, run_id: uuid.UUID) -> MigrationRun:
+        assert run_id == self.run.run_id
+        return self.run
+
+    async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]:
+        assert run_id == self.run.run_id
+        return [self.item]
+
+
+class _InventoryBridge:
+    def __init__(self, inventory: LegacyInventory):
+        self.inventory = inventory
+
+    async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
+        assert run.inventory_digest == self.inventory.inventory_digest
+        return self.inventory
+
+
+class _WireReader:
+    def __init__(self, native_id: str, *, candidate: bool):
+        self.native_id = native_id
+        self.candidate = candidate
+
+    def _selector(self, document: LegacyInventoryDocument) -> str:
+        return self.native_id if self.candidate else document.current_commit
+
+    async def get(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        del fixed_ref
+        body = document.body.decode()
+        if not self.candidate:
+            body = body.replace("\n", "\r\n")
+        return {
+            "kind": "document",
+            "uri": "akb://p2-manual/coll/notes/migration-candidate.md",
+            "vault": "p2-manual",
+            "path": document.current_path,
+            "resource_id": str(document.resource_id),
+            "current_commit": selector,
+            "content": body,
+            "projection": {"revision": selector, "authoritative": False},
+        }
+
+    async def history(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        del fixed_ref
+        entries = []
+        for index, entry in enumerate(reversed(document.lineage)):
+            entry_selector = self.native_id if self.candidate and index == 0 else entry.legacy_git_oid
+            entries.append(
+                {
+                    "selector": entry_selector,
+                    "payload_sha256": hashlib.sha256(entry.legacy_git_oid.encode()).hexdigest(),
+                    "projection_revision": entry_selector if index == 0 else None,
+                    "summary": "current" if index == 0 else "retained history",
+                }
+            )
+        return {
+            "history_source": "fixed-ref-bridge" if self.candidate else "legacy-git-log",
+            "lineage_boundary": document.lineage[0].legacy_git_oid if self.candidate else "legacy-document-start",
+            "entries": entries,
+        }
+
+    async def diff(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        del fixed_ref
+        return {
+            "file": document.current_path,
+            "commit": selector,
+            "basis": "fixed-ref-snapshot" if self.candidate else "git-parent",
+            "text": "@@ snapshot @@\n secret body",
+            "format": "unified",
+        }
+
+    async def activity(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
+        del fixed_ref
+        activity = document.activity
+        return {
+            "events": [
+                {
+                    "hash": selector,
+                    "subject": activity.subject,
+                    "author": {
+                        "id": activity.actor,
+                        "display": "Legacy Writer (Git)" if not self.candidate else "Migration",
+                    },
+                    "action": activity.action if not self.candidate else "create",
+                    "summary": activity.summary if not self.candidate else "C9 fixed-ref native genesis",
+                    "projection_revision": selector,
+                }
+            ]
+        }
+
+
+class _NoWriteGit:
+    def __init__(self, *documents: LegacyInventoryDocument):
+        self.bodies = {
+            (document.current_path, document.current_commit): document.body
+            for document in documents
+        }
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def manual_fixed_ref_history(self, *args, **kwargs) -> dict[str, Any]:
+        self.calls.append(("manual_fixed_ref_history", args))
+        return {
+            "fixed_ref": args[1],
+            "current_commit": kwargs["current_commit"],
+            "body": self.bodies[(args[2], kwargs["current_commit"])],
+            "history": [],
+            "activity": {},
+        }
+
+
+@dataclass
+class _Snapshot:
+    resource_id: uuid.UUID
+    revision_id: str
+    surface: str
+    path: str
+    text: str
+    digest: str
+    byte_size: int
+    action: str = "create"
+    occurred_at: datetime = datetime(2026, 8, 10, tzinfo=UTC)
+
+
+class _NoWriteNative:
+    def __init__(
+        self,
+        *entries: tuple[LegacyInventoryDocument, str],
+    ):
+        self.entries = {
+            document.resource_id: (document, native_id)
+            for document, native_id in entries
+        }
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def get_resource_revision(self, **kwargs) -> _Snapshot:
+        self.calls.append(("get_resource_revision", kwargs))
+        document, native_id = self.entries[kwargs["resource_id"]]
+        assert kwargs["revision_id"] == native_id
+        body = document.body
+        return _Snapshot(
+            resource_id=document.resource_id,
+            revision_id=native_id,
+            surface="document",
+            path=document.current_path,
+            text=body.decode(),
+            digest=document.body_digest,
+            byte_size=len(body),
+        )
+
+
+async def test_product_readers_are_scoped_and_read_only():
+    document = _document()
+    second = _second_document()
+    fixed_ref = _oid("f")
+    native_id = _oid("c")
+    second_native_id = _oid("9")
+    git = _NoWriteGit(document, second)
+    legacy = LegacyFixedRefShadowReader(git=git, vault_name="p2-manual")
+
+    result = await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    await legacy.history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    await legacy.diff(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    await legacy.activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    assert result["current_commit"] == document.current_commit
+    assert result["content"] == "# Migration candidate\n\nsecret body"
+    assert [name for name, _ in git.calls] == ["manual_fixed_ref_history"]
+
+    result["projection"]["revision"] = "caller-mutation"
+    result["content"] = "caller-mutation"
+    reread = await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    assert reread["projection"]["revision"] == document.current_commit
+    assert reread["content"] == "# Migration candidate\n\nsecret body"
+    assert len(git.calls) == 1
+
+    await legacy.get(second, selector=second.current_commit, fixed_ref=fixed_ref)
+    await legacy.history(second, selector=second.current_commit, fixed_ref=fixed_ref)
+    await legacy.diff(second, selector=second.current_commit, fixed_ref=fixed_ref)
+    await legacy.activity(second, selector=second.current_commit, fixed_ref=fixed_ref)
+    assert len(git.calls) == 2
+
+    await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    assert len(git.calls) == 3
+
+    with pytest.raises(ShadowReaderScopeError):
+        await legacy.get(document, selector=_oid("e"), fixed_ref=fixed_ref)
+    assert len(git.calls) == 3
+
+    native_service = _NoWriteNative(
+        (document, native_id),
+        (second, second_native_id),
+    )
+    native = NativeRevisionShadowReader(
+        pool=None,
+        namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
+        vault_name="p2-manual",
+        native_service=native_service,
+    )
+    candidate = await native.get(document, selector=native_id, fixed_ref=fixed_ref)
+    await native.history(document, selector=native_id, fixed_ref=fixed_ref)
+    await native.diff(document, selector=native_id, fixed_ref=fixed_ref)
+    await native.activity(document, selector=native_id, fixed_ref=fixed_ref)
+    assert candidate["current_commit"] == native_id
+    assert [name for name, _ in native_service.calls] == ["get_resource_revision"]
+
+    candidate["projection"]["revision"] = "caller-mutation"
+    candidate["content"] = "caller-mutation"
+    candidate_reread = await native.get(document, selector=native_id, fixed_ref=fixed_ref)
+    assert candidate_reread["projection"]["revision"] == native_id
+    assert candidate_reread["content"] == "# Migration candidate\n\nsecret body"
+    assert len(native_service.calls) == 1
+
+    await native.get(second, selector=second_native_id, fixed_ref=fixed_ref)
+    await native.history(second, selector=second_native_id, fixed_ref=fixed_ref)
+    await native.diff(second, selector=second_native_id, fixed_ref=fixed_ref)
+    await native.activity(second, selector=second_native_id, fixed_ref=fixed_ref)
+    assert len(native_service.calls) == 2
+
+    await native.get(document, selector=native_id, fixed_ref=fixed_ref)
+    assert len(native_service.calls) == 3
+
+
+async def test_failed_cache_replacement_evicts_the_prior_resource():
+    document = _document()
+    invalid = replace(_second_document(), body_digest="0" * 64)
+    fixed_ref = _oid("f")
+    native_id = _oid("c")
+    invalid_native_id = _oid("9")
+
+    git = _NoWriteGit(document, invalid)
+    legacy = LegacyFixedRefShadowReader(git=git, vault_name="p2-manual")
+    await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    with pytest.raises(ShadowReaderScopeError, match="differs from C9 inventory"):
+        await legacy.get(invalid, selector=invalid.current_commit, fixed_ref=fixed_ref)
+    await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    assert len(git.calls) == 3
+
+    native_service = _NoWriteNative(
+        (document, native_id),
+        (invalid, invalid_native_id),
+    )
+    native = NativeRevisionShadowReader(
+        pool=None,
+        namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
+        vault_name="p2-manual",
+        native_service=native_service,
+    )
+    await native.get(document, selector=native_id, fixed_ref=fixed_ref)
+    with pytest.raises(ShadowReaderScopeError, match="body differs from C9 inventory"):
+        await native.get(invalid, selector=invalid_native_id, fixed_ref=fixed_ref)
+    await native.get(document, selector=native_id, fixed_ref=fixed_ref)
+    assert len(native_service.calls) == 3
+
+
+async def test_comparator_receipt_is_redacted_and_classified():
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=_WireReader(native_id, candidate=True),
+    )
+
+    receipt = await comparator.compare_run(run.run_id)
+    encoded = json.dumps(receipt, sort_keys=True)
+
+    assert document.body.decode() not in encoded
+    assert document.current_path not in encoded
+    assert str(document.resource_id) not in encoded
+    assert str(run.run_id) not in encoded
+    assert "raw_candidate" not in receipt
+    assert receipt["schema_version"] == 2
+    assert receipt["protocol_version"].endswith("/v2")
+    assert "legacy" not in receipt["resources"][0]["operations"]["get"]
+    assert receipt["summary"]["unexplained_mismatch_count"] == 0
+    assert receipt["summary"]["mismatch_count"] == 12
+    assert receipt["resources"][0]["operations"]["get"]["mismatches"] == [
+        {
+            "path": "$.content",
+            "rule_id": "BR-05",
+            "classification": "formatting_only",
+        },
+        {
+            "path": "$.current_commit",
+            "rule_id": "BR-01",
+            "classification": "revision_token",
+        },
+        {
+            "path": "$.projection.revision",
+            "rule_id": "BR-04",
+            "classification": "projection_revision",
+        },
+    ]
+
+
+async def test_product_readers_compare_a_completed_pg_backfill_without_writes(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git = GitService(storage_path=str(tmp_path / "git"))
+        vault_name = f"shadow-{uuid.uuid4().hex}"
+        git.init_vault(vault_name)
+        old_body = "---\ntitle: Migration candidate\n---\n\nold body"
+        current_body = "---\ntitle: Migration candidate\n---\n\ncurrent body"
+        git.commit_file(
+            vault_name,
+            "notes/migration-candidate.md",
+            old_body,
+            "[create] migration-candidate.md\n\nagent: legacy-writer\naction: create\nsummary: create migration candidate",
+        )
+        await asyncio.sleep(1.05)
+        current_oid = git.commit_file(
+            vault_name,
+            "notes/migration-candidate.md",
+            current_body,
+            "[update] migration-candidate.md\n\nagent: legacy-writer\naction: update\nsummary: update migration candidate",
+        )
+        current_at = Repo(str(git._bare_path(vault_name))).commit(current_oid).committed_datetime
+        await asyncio.sleep(1.05)
+        fixed_ref = git.commit_file(vault_name, "unrelated.md", "unrelated\n", "unrelated fixed-ref tip")
+        resource_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active')
+                RETURNING id
+                """,
+                vault_name,
+                str(git._bare_path(vault_name)),
+            )
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at, current_commit, source)
+                VALUES ($1, $2, $3, $4, $5, $5, $6, 'manual')
+                """,
+                resource_id,
+                namespace_id,
+                "notes/migration-candidate.md",
+                "Migration candidate",
+                current_at - timedelta(seconds=2),
+                current_oid,
+            )
+
+        bridge = LegacyRevisionBridge(pool, git=git)
+        backfill = NativeRevisionBackfill(pool, git=git, bridge=bridge)
+        run, inventory = await backfill.prepare_run(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version="p2-shadow-reader-test-v1",
+        )
+        assert len(inventory.documents) == 1
+        result = await backfill.backfill_run(run.run_id)
+        assert result.status == "complete"
+        item = await backfill.repository.get_item(run.run_id, resource_id)
+        assert item is not None and item.native_head_revision_id is not None
+
+        legacy = LegacyFixedRefShadowReader(git=git, vault_name=vault_name)
+        candidate = NativeRevisionShadowReader(
+            pool,
+            namespace_id=namespace_id,
+            vault_name=vault_name,
+            selector_bridge=bridge,
+        )
+        before = await _authority_counts(pool)
+        comparator = NativeRevisionShadowComparator(
+            pool=pool,
+            bridge=bridge,
+            legacy_reader=legacy,
+            candidate_reader=candidate,
+        )
+        receipt = await comparator.compare_run(run.run_id)
+        after = await _authority_counts(pool)
+
+        assert before == after
+        assert receipt["status"] == "passed"
+        assert receipt["summary"]["resource_count"] == 1
+        assert receipt["summary"]["operation_count"] == 4
+        assert receipt["summary"]["unexplained_mismatch_count"] == 0
+        encoded = json.dumps(receipt, sort_keys=True)
+        assert current_body not in encoded
+        assert "notes/migration-candidate.md" not in encoded
+        assert str(resource_id) not in encoded
+        assert str(run.run_id) not in encoded
+        assert receipt["run"]["fixed_ref"] == fixed_ref

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -40,6 +40,7 @@ from app.services.native_revision_shadow import (
 )
 from app.services.native_revision_shadow_reader import (
     _apply_unified_patch,
+    _canonical_transition,
     LegacyFixedRefShadowReader,
     NativeActivityEvidence,
     NativeRevisionShadowReader,
@@ -571,6 +572,28 @@ class _NoWriteGit:
         return body.decode() if body is not None else None
 
 
+class _GenesisDiffGit(_NoWriteGit):
+    def __init__(self, document: LegacyInventoryDocument, *, diff: dict[str, Any], body: str):
+        super().__init__(document)
+        self.diff_override = diff
+        self.parent_reads: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.bodies[(document.current_path, document.current_commit)] = body.encode()
+
+    def file_diff(self, *args) -> dict[str, Any]:
+        self.calls.append(("file_diff", args))
+        return self.diff_override
+
+    def read_file(self, *args, **kwargs) -> str:
+        if (args[1], kwargs.get("commit")) != (
+            self.documents[0].current_path,
+            self.documents[0].current_commit,
+        ):
+            self.parent_reads.append((args, kwargs))
+            raise AssertionError("genesis diff read outside logical lineage")
+        self.calls.append(("read_file", args))
+        return self.bodies[(args[1], kwargs["commit"])].decode()
+
+
 @dataclass
 class _Snapshot:
     resource_id: uuid.UUID
@@ -1091,6 +1114,84 @@ async def test_product_readers_are_scoped_and_read_only():
 
     await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     assert len(native_service.calls) == 3
+
+
+def _genesis_document(*, action: str, body: str) -> LegacyInventoryDocument:
+    base = _document()
+    current = base.lineage[-1]
+    return replace(
+        base,
+        body_digest=hashlib.sha256(body.encode()).hexdigest(),
+        byte_size=len(body.encode()),
+        lineage=(current,),
+        activity=replace(
+            base.activity,
+            action=action,
+            summary=f"{action} migration candidate at fixed ref",
+            changed_paths=({"change": action, "path_from": None, "path_to": base.current_path},),
+        ),
+    )
+
+
+async def test_legacy_reader_treats_modified_singleton_lineage_as_logical_genesis():
+    body = "# Migration candidate\n\nline 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\n"
+    document = _genesis_document(action="update", body=body)
+    path = document.current_path
+    raw_diff = {
+        "file": path,
+        "commit": document.current_commit,
+        "type": "modified",
+        "diff": "\n".join(
+            [
+                f"--- a/{path}",
+                f"+++ b/{path}",
+                "@@ -5,7 +5,7 @@",
+                *(f"-out-of-lineage-{index}" for index in range(1, 8)),
+                *(f"+line {index}" for index in range(3, 10)),
+            ]
+        ),
+    }
+    git = _GenesisDiffGit(document, diff=raw_diff, body=body)
+
+    result = await LegacyFixedRefShadowReader(git=git, vault_name="p2-manual").diff(
+        document,
+        selector=document.current_commit,
+        fixed_ref=_oid("f"),
+    )
+
+    assert result["text"] == _canonical_transition("", body)
+    assert git.parent_reads == []
+    assert [name for name, _ in git.calls] == [
+        "manual_fixed_ref_history",
+        "file_diff",
+        "read_file",
+    ]
+
+
+async def test_legacy_reader_rejects_malformed_added_genesis_patch():
+    body = "# Migration candidate\n\ncurrent body\n"
+    document = _genesis_document(action="create", body=body)
+    path = document.current_path
+    lines = body.splitlines()
+    raw_diff = {
+        "file": path,
+        "commit": document.current_commit,
+        "type": "added",
+        "diff": "\n".join(
+            [
+                f"@@ -5,0 +1,{len(lines)} @@",
+                *(f"+{line}" for line in lines),
+            ]
+        ),
+    }
+    git = _GenesisDiffGit(document, diff=raw_diff, body=body)
+
+    with pytest.raises(ShadowReaderScopeError, match="invalid parent range"):
+        await LegacyFixedRefShadowReader(git=git, vault_name="p2-manual").diff(
+            document,
+            selector=document.current_commit,
+            fixed_ref=_oid("f"),
+        )
 
 
 async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary():

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -19,6 +19,7 @@ import pytest
 from git import Repo
 
 from app.repositories.native_revision_migration_repo import (
+    LegacyRevisionMapping,
     MigrationItem,
     MigrationRun,
 )
@@ -37,6 +38,7 @@ from app.services.native_revision_shadow_reader import (
     ShadowReaderScopeError,
 )
 from app.services.native_revision_backfill import NativeRevisionBackfill
+from app.services.native_revision_reconcile import NativeRevisionReconcile
 
 
 pytestmark = pytest.mark.asyncio
@@ -249,6 +251,29 @@ class _ReadRepository:
         assert run_id == self.run.run_id
         return [self.item]
 
+    async def exact_mapping(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        legacy_git_oid: str,
+    ) -> LegacyRevisionMapping | None:
+        if (
+            resource_id != self.item.legacy_document_id
+            or legacy_git_oid != self.item.legacy_head_oid
+        ):
+            return None
+        return LegacyRevisionMapping(
+            namespace_id=self.run.namespace_id,
+            resource_id=resource_id,
+            legacy_git_oid=legacy_git_oid,
+            path_at_revision=self.item.captured_path,
+            resolution="native",
+            native_revision_id=self.item.native_head_revision_id,
+            run_id=self.run.run_id,
+            lineage_ordinal=1,
+            fixed_git_oid=self.run.fixed_git_oid,
+        )
+
 
 class _InventoryBridge:
     def __init__(self, inventory: LegacyInventory):
@@ -334,21 +359,57 @@ class _WireReader:
 
 class _NoWriteGit:
     def __init__(self, *documents: LegacyInventoryDocument):
+        self.documents = documents
         self.bodies = {
             (document.current_path, document.current_commit): document.body
             for document in documents
         }
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.snapshot_override: dict[str, Any] | None = None
+        self.diff_override: dict[str, Any] | None = None
 
     def manual_fixed_ref_history(self, *args, **kwargs) -> dict[str, Any]:
         self.calls.append(("manual_fixed_ref_history", args))
-        return {
+        document = next(
+            document
+            for document in self.documents
+            if document.current_path == args[2]
+        )
+        result = {
             "fixed_ref": args[1],
             "current_commit": kwargs["current_commit"],
             "body": self.bodies[(args[2], kwargs["current_commit"])],
-            "history": [],
-            "activity": {},
+            "history": [
+                {
+                    "legacy_git_oid": entry.legacy_git_oid,
+                    "path_at_revision": entry.path_at_revision,
+                    "committed_at": entry.committed_at,
+                }
+                for entry in reversed(document.lineage)
+            ],
+            "activity": {
+                "legacy_git_oid": document.activity.legacy_git_oid,
+                "committed_at": document.activity.committed_at,
+                "actor": document.activity.actor,
+                "subject": document.activity.subject,
+                "summary": document.activity.summary,
+                "action": document.activity.action,
+                "path_from": document.activity.path_from,
+                "path_to": document.activity.path_to,
+                "changed_paths": [dict(change) for change in document.activity.changed_paths],
+            },
         }
+        return self.snapshot_override if self.snapshot_override is not None else result
+
+    def file_diff(self, *args) -> dict[str, Any]:
+        self.calls.append(("file_diff", args))
+        result = {
+            "file": args[1],
+            "commit": args[2],
+            "type": "modified",
+            "diff": "@@ -1 +1 @@\n-old body\n+current body",
+        }
+        return self.diff_override if self.diff_override is not None else result
 
 
 @dataclass
@@ -388,7 +449,72 @@ class _NoWriteNative:
             text=body.decode(),
             digest=document.body_digest,
             byte_size=len(body),
+            occurred_at=document.activity.committed_at,
         )
+
+
+class _NoWriteNativeRepository:
+    def __init__(self, *entries: tuple[LegacyInventoryDocument, str]):
+        self.entries = {
+            document.resource_id: (document, native_id)
+            for document, native_id in entries
+        }
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.history_overrides: dict[uuid.UUID, list[dict[str, Any]]] = {}
+        self.revision_overrides: dict[uuid.UUID, dict[str, Any] | None] = {}
+        self.activity_override: dict[str, Any] | None = None
+
+    def _revision(self, resource_id: uuid.UUID) -> dict[str, Any]:
+        document, native_id = self.entries[resource_id]
+        return {
+            "namespace_id": uuid.UUID("22222222-2222-4222-8222-222222222222"),
+            "resource_id": document.resource_id,
+            "revision_id": native_id,
+            "parent_revision_id": None,
+            "surface": "document",
+            "action": "create",
+            "path_at_revision": document.current_path,
+            "path_from": None,
+            "path_to": document.current_path,
+            "message": "C9 fixed-ref native genesis",
+            "subject": None,
+            "summary": None,
+            "actor": "akb-native-revision-migration",
+            "occurred_at": document.activity.committed_at,
+        }
+
+    async def list_history(self, **kwargs) -> list[dict[str, Any]]:
+        self.calls.append(("list_history", kwargs))
+        if kwargs["resource_id"] in self.history_overrides:
+            return self.history_overrides[kwargs["resource_id"]]
+        return [self._revision(kwargs["resource_id"])]
+
+    async def get_revision(self, **kwargs) -> dict[str, Any] | None:
+        self.calls.append(("get_revision", kwargs))
+        if kwargs["resource_id"] in self.revision_overrides:
+            return self.revision_overrides[kwargs["resource_id"]]
+        row = self._revision(kwargs["resource_id"])
+        return row if row["revision_id"] == kwargs["revision_id"] else None
+
+    async def get_activity_for_revision(self, **kwargs) -> dict[str, Any] | None:
+        self.calls.append(("get_activity_for_revision", kwargs))
+        if self.activity_override is not None:
+            return self.activity_override
+        row = self._revision(kwargs["resource_id"])
+        if row["revision_id"] != kwargs["revision_id"]:
+            return None
+        return {
+            "resource_id": row["resource_id"],
+            "revision_id": row["revision_id"],
+            "action": row["action"],
+            "actor": row["actor"],
+            "subject": row["subject"],
+            "summary": row["summary"],
+            "changed_path_from": row["path_from"],
+            "changed_path_to": row["path_to"],
+            "occurred_at": row["occurred_at"],
+            "path_at_revision": row["path_at_revision"],
+        }
 
 
 async def test_product_readers_are_scoped_and_read_only():
@@ -406,29 +532,33 @@ async def test_product_readers_are_scoped_and_read_only():
     await legacy.activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert result["current_commit"] == document.current_commit
     assert result["content"] == "# Migration candidate\n\nsecret body"
-    assert [name for name, _ in git.calls] == ["manual_fixed_ref_history"]
+    assert [name for name, _ in git.calls] == ["manual_fixed_ref_history", "file_diff"]
 
     result["projection"]["revision"] = "caller-mutation"
     result["content"] = "caller-mutation"
     reread = await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert reread["projection"]["revision"] == document.current_commit
     assert reread["content"] == "# Migration candidate\n\nsecret body"
-    assert len(git.calls) == 1
+    assert len(git.calls) == 2
 
     await legacy.get(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.history(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.diff(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.activity(second, selector=second.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 2
+    assert len(git.calls) == 4
 
     await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 3
+    assert len(git.calls) == 5
 
     with pytest.raises(ShadowReaderScopeError):
         await legacy.get(document, selector=_oid("e"), fixed_ref=fixed_ref)
-    assert len(git.calls) == 3
+    assert len(git.calls) == 5
 
     native_service = _NoWriteNative(
+        (document, native_id),
+        (second, second_native_id),
+    )
+    native_repository = _NoWriteNativeRepository(
         (document, native_id),
         (second, second_native_id),
     )
@@ -437,6 +567,7 @@ async def test_product_readers_are_scoped_and_read_only():
         namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
         vault_name="p2-manual",
         native_service=native_service,
+        native_repository=native_repository,
     )
     candidate = await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     await native.history(document, selector=native_id, fixed_ref=fixed_ref)
@@ -444,6 +575,12 @@ async def test_product_readers_are_scoped_and_read_only():
     await native.activity(document, selector=native_id, fixed_ref=fixed_ref)
     assert candidate["current_commit"] == native_id
     assert [name for name, _ in native_service.calls] == ["get_resource_revision"]
+    assert [name for name, _ in native_repository.calls] == [
+        "list_history",
+        "get_revision",
+        "get_revision",
+        "get_activity_for_revision",
+    ]
 
     candidate["projection"]["revision"] = "caller-mutation"
     candidate["content"] = "caller-mutation"
@@ -451,15 +588,136 @@ async def test_product_readers_are_scoped_and_read_only():
     assert candidate_reread["projection"]["revision"] == native_id
     assert candidate_reread["content"] == "# Migration candidate\n\nsecret body"
     assert len(native_service.calls) == 1
+    assert len(native_repository.calls) == 4
 
     await native.get(second, selector=second_native_id, fixed_ref=fixed_ref)
     await native.history(second, selector=second_native_id, fixed_ref=fixed_ref)
     await native.diff(second, selector=second_native_id, fixed_ref=fixed_ref)
     await native.activity(second, selector=second_native_id, fixed_ref=fixed_ref)
     assert len(native_service.calls) == 2
+    assert len(native_repository.calls) == 8
 
     await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     assert len(native_service.calls) == 3
+
+
+async def test_legacy_reader_fails_closed_on_missing_or_corrupt_product_facts():
+    document = _document()
+    fixed_ref = _oid("f")
+
+    missing_history_git = _NoWriteGit(document)
+    raw = missing_history_git.manual_fixed_ref_history(
+        "p2-manual",
+        fixed_ref,
+        document.current_path,
+        current_commit=document.current_commit,
+    )
+    missing_history_git.snapshot_override = {**raw, "history": raw["history"][:-1]}
+    with pytest.raises(ShadowReaderScopeError, match="history"):
+        await LegacyFixedRefShadowReader(
+            git=missing_history_git,
+            vault_name="p2-manual",
+        ).history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+    corrupt_activity_git = _NoWriteGit(document)
+    raw = corrupt_activity_git.manual_fixed_ref_history(
+        "p2-manual",
+        fixed_ref,
+        document.current_path,
+        current_commit=document.current_commit,
+    )
+    corrupt_activity_git.snapshot_override = {
+        **raw,
+        "activity": {**raw["activity"], "actor": "wrong-actor"},
+    }
+    with pytest.raises(ShadowReaderScopeError, match="activity"):
+        await LegacyFixedRefShadowReader(
+            git=corrupt_activity_git,
+            vault_name="p2-manual",
+        ).activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+    corrupt_diff_git = _NoWriteGit(document)
+    corrupt_diff_git.diff_override = {
+        "file": document.current_path,
+        "commit": _oid("0"),
+        "type": "modified",
+        "diff": "@@ corrupt @@",
+    }
+    with pytest.raises(ShadowReaderScopeError, match="diff"):
+        await LegacyFixedRefShadowReader(
+            git=corrupt_diff_git,
+            vault_name="p2-manual",
+        ).diff(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+
+async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_product_facts():
+    document = _document()
+    native_id = _oid("c")
+    fixed_ref = _oid("f")
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    service = _NoWriteNative((document, native_id))
+
+    missing_history = _NoWriteNativeRepository((document, native_id))
+    missing_history.history_overrides[document.resource_id] = []
+    with pytest.raises(ShadowReaderScopeError, match="history"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=missing_history,
+        ).history(document, selector=native_id, fixed_ref=fixed_ref)
+
+    reordered_history = _NoWriteNativeRepository((document, native_id))
+    current = reordered_history._revision(document.resource_id)
+    older = {
+        **current,
+        "revision_id": _oid("9"),
+        "parent_revision_id": None,
+        "occurred_at": current["occurred_at"] - timedelta(seconds=1),
+    }
+    current = {**current, "parent_revision_id": older["revision_id"]}
+    reordered_history.history_overrides[document.resource_id] = [older, current]
+    with pytest.raises(ShadowReaderScopeError, match="history"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=reordered_history,
+        ).history(document, selector=native_id, fixed_ref=fixed_ref)
+
+    corrupt_diff = _NoWriteNativeRepository((document, native_id))
+    corrupt_diff.revision_overrides[document.resource_id] = {
+        **corrupt_diff._revision(document.resource_id),
+        "path_at_revision": "wrong.md",
+    }
+    with pytest.raises(ShadowReaderScopeError, match="diff"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=corrupt_diff,
+        ).diff(document, selector=native_id, fixed_ref=fixed_ref)
+
+    corrupt_activity = _NoWriteNativeRepository((document, native_id))
+    activity = await corrupt_activity.get_activity_for_revision(
+        namespace_id=namespace_id,
+        surface="document",
+        resource_id=document.resource_id,
+        revision_id=native_id,
+    )
+    assert activity is not None
+    corrupt_activity.activity_override = {**activity, "action": "move"}
+    with pytest.raises(ShadowReaderScopeError, match="activity"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=corrupt_activity,
+        ).activity(document, selector=native_id, fixed_ref=fixed_ref)
 
 
 async def test_failed_cache_replacement_evicts_the_prior_resource():
@@ -486,6 +744,10 @@ async def test_failed_cache_replacement_evicts_the_prior_resource():
         namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
         vault_name="p2-manual",
         native_service=native_service,
+        native_repository=_NoWriteNativeRepository(
+            (document, native_id),
+            (invalid, invalid_native_id),
+        ),
     )
     await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     with pytest.raises(ShadowReaderScopeError, match="body differs from C9 inventory"):
@@ -512,28 +774,31 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert str(document.resource_id) not in encoded
     assert str(run.run_id) not in encoded
     assert "raw_candidate" not in receipt
-    assert receipt["schema_version"] == 2
-    assert receipt["protocol_version"].endswith("/v2")
+    assert receipt["schema_version"] == 3
+    assert receipt["protocol_version"].endswith("/v3")
     assert "legacy" not in receipt["resources"][0]["operations"]["get"]
     assert receipt["summary"]["unexplained_mismatch_count"] == 0
     assert receipt["summary"]["mismatch_count"] == 12
-    assert receipt["resources"][0]["operations"]["get"]["mismatches"] == [
+    assert receipt["resources"][0]["operations"]["get"]["classified_mismatches"] == [
         {
-            "path": "$.content",
-            "rule_id": "BR-05",
-            "classification": "formatting_only",
-        },
-        {
-            "path": "$.current_commit",
             "rule_id": "BR-01",
             "classification": "revision_token",
+            "count": 1,
         },
         {
-            "path": "$.projection.revision",
             "rule_id": "BR-04",
             "classification": "projection_revision",
+            "count": 1,
+        },
+        {
+            "rule_id": "BR-05",
+            "classification": "formatting_only",
+            "count": 1,
         },
     ]
+    assert document.current_commit not in encoded
+    assert run.fixed_git_oid not in encoded
+    assert run.inventory_digest not in encoded
 
 
 async def test_product_readers_compare_a_completed_pg_backfill_without_writes(tmp_path):
@@ -624,4 +889,107 @@ async def test_product_readers_compare_a_completed_pg_backfill_without_writes(tm
         assert "notes/migration-candidate.md" not in encoded
         assert str(resource_id) not in encoded
         assert str(run.run_id) not in encoded
-        assert receipt["run"]["fixed_ref"] == fixed_ref
+        assert fixed_ref not in encoded
+
+
+async def test_reconcile_c10_resolves_changed_and_unchanged_heads_across_runs(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git = GitService(storage_path=str(tmp_path / "git"))
+        vault_name = f"shadow-reconcile-{uuid.uuid4().hex}"
+        git.init_vault(vault_name)
+        first_oid = git.commit_file(
+            vault_name,
+            "first.md",
+            "first r1\n",
+            "[create] first.md\n\nagent: legacy-writer\naction: create\nsummary: create first",
+        )
+        second_oid = git.commit_file(
+            vault_name,
+            "second.md",
+            "second r1\n",
+            "[create] second.md\n\nagent: legacy-writer\naction: create\nsummary: create second",
+        )
+        fixed_r1 = git.commit_file(vault_name, "r1-tip.md", "tip\n", "fixed R1 tip")
+        bare = Repo(str(git._bare_path(vault_name)))
+        committed = {
+            "first.md": bare.commit(first_oid).committed_datetime,
+            "second.md": bare.commit(second_oid).committed_datetime,
+        }
+        resource_ids = {path: uuid.uuid4() for path in committed}
+        async with pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active')
+                RETURNING id
+                """,
+                vault_name,
+                str(git._bare_path(vault_name)),
+            )
+            for path, oid in (("first.md", first_oid), ("second.md", second_oid)):
+                await conn.execute(
+                    """
+                    INSERT INTO documents
+                        (id, vault_id, path, title, created_at, updated_at,
+                         current_commit, source)
+                    VALUES ($1, $2, $3, $3, $4, $4, $5, 'manual')
+                    """,
+                    resource_ids[path],
+                    namespace_id,
+                    path,
+                    committed[path] - timedelta(seconds=1),
+                    oid,
+                )
+
+        bridge = LegacyRevisionBridge(pool, git=git)
+        backfill = NativeRevisionBackfill(pool, git=git, bridge=bridge)
+        initial_run, initial_inventory = await backfill.prepare_run(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_r1,
+            coverage_version="p2-shadow-reconcile-initial-v1",
+        )
+        assert len(initial_inventory.documents) == 2
+        assert (await backfill.backfill_run(initial_run.run_id)).status == "complete"
+
+        changed_oid = git.commit_file(
+            vault_name,
+            "first.md",
+            "first r2\n",
+            "[update] first.md\n\nagent: legacy-writer\naction: update\nsummary: update first",
+        )
+        fixed_r2 = git.commit_file(vault_name, "r2-tip.md", "tip\n", "fixed R2 tip")
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE documents
+                   SET current_commit = $2, updated_at = NOW()
+                 WHERE id = $1
+                """,
+                resource_ids["first.md"],
+                changed_oid,
+            )
+
+        reconciler = NativeRevisionReconcile(pool, git=git, bridge=bridge)
+        final = await reconciler.reconcile(namespace_id=namespace_id, fixed_ref=fixed_r2)
+        assert final.status == "complete"
+        assert final.changed_items == 1
+        assert final.unchanged_items == 1
+        assert len(await backfill.repository.list_items(final.run_id)) == 1
+
+        before = await _authority_counts(pool)
+        comparator = NativeRevisionShadowComparator(
+            pool=pool,
+            bridge=bridge,
+            legacy_reader=LegacyFixedRefShadowReader(git=git, vault_name=vault_name),
+            candidate_reader=NativeRevisionShadowReader(
+                pool,
+                namespace_id=namespace_id,
+                vault_name=vault_name,
+                selector_bridge=bridge,
+            ),
+        )
+        receipt = await comparator.compare_run(final.run_id)
+        assert await _authority_counts(pool) == before
+        assert receipt["status"] == "passed"
+        assert receipt["summary"]["resource_count"] == 2
+        assert receipt["summary"]["operation_count"] == 8

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -132,6 +132,14 @@ def _oid(char: str) -> str:
     return char * 40
 
 
+def _document_body(document: LegacyInventoryDocument) -> bytes:
+    if document.resource_id == uuid.UUID("11111111-1111-4111-8111-111111111111"):
+        return b"# Migration candidate\n\nsecret body\n"
+    if document.resource_id == uuid.UUID("44444444-4444-4444-8444-444444444444"):
+        return b"# Second candidate\n\nother secret body\n"
+    raise AssertionError(f"unexpected synthetic document: {document.resource_id}")
+
+
 @pytest.mark.parametrize(
     ("parent_text", "patch", "expected"),
     [
@@ -176,7 +184,6 @@ def _document() -> LegacyInventoryDocument:
         current_path=path,
         current_commit=current,
         created_at=at,
-        body=body.encode(),
         body_digest=hashlib.sha256(body.encode()).hexdigest(),
         byte_size=len(body.encode()),
         aliases=(),
@@ -211,7 +218,6 @@ def _second_document() -> LegacyInventoryDocument:
         current_path=path,
         current_commit=current,
         created_at=at,
-        body=body,
         body_digest=hashlib.sha256(body).hexdigest(),
         byte_size=len(body),
         lineage=(
@@ -228,6 +234,12 @@ def _second_document() -> LegacyInventoryDocument:
             changed_paths=({"change": "update", "path_from": None, "path_to": path},),
         ),
     )
+
+
+async def test_inventory_document_schema_does_not_retain_body_text():
+    document = _document()
+
+    assert not hasattr(document, "body")
 
 
 def _run_and_item(
@@ -401,7 +413,7 @@ class _WireReader:
 
     async def get(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
         del fixed_ref
-        body = document.body.decode()
+        body = _document_body(document).decode()
         if not self.candidate:
             body = body.replace("\n", "\r\n")
         return {
@@ -489,10 +501,13 @@ class _WireReader:
 class _NoWriteGit:
     def __init__(self, *documents: LegacyInventoryDocument):
         self.documents = documents
-        self.bodies = {(document.current_path, document.current_commit): document.body for document in documents}
+        self.bodies = {
+            (document.current_path, document.current_commit): _document_body(document)
+            for document in documents
+        }
         for document in documents:
             for entry in document.lineage[:-1]:
-                self.bodies[(entry.path_at_revision, entry.legacy_git_oid)] = document.body.replace(
+                self.bodies[(entry.path_at_revision, entry.legacy_git_oid)] = _document_body(document).replace(
                     b"secret body", b"old body"
                 )
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
@@ -586,7 +601,7 @@ class _NoWriteNative:
         if override is not None:
             return override
         assert kwargs["revision_id"] == native_id
-        body = document.body
+        body = _document_body(document)
         return _Snapshot(
             resource_id=document.resource_id,
             revision_id=native_id,
@@ -798,7 +813,7 @@ async def test_genesis_activity_audit_rejects_forged_persisted_facts(field, valu
         revision_id=native_id,
         surface="document",
         path=document.current_path,
-        text=document.body.decode(),
+        text=_document_body(document).decode(),
         digest=document.body_digest,
         byte_size=document.byte_size,
         action=forged["action"],
@@ -874,7 +889,7 @@ async def test_reconcile_activity_audit_derives_action_from_parent_and_current_p
         revision_id=native_id,
         surface="document",
         path=document.current_path,
-        text=document.body.decode(),
+        text=_document_body(document).decode(),
         digest=document.body_digest,
         byte_size=document.byte_size,
         action=selected["action"],
@@ -926,7 +941,7 @@ async def test_reconcile_activity_audit_rejects_correlated_parent_path_tampering
         revision_id=native_id,
         surface="document",
         path=document.current_path,
-        text=document.body.decode(),
+        text=_document_body(document).decode(),
         digest=document.body_digest,
         byte_size=document.byte_size,
         action="move",
@@ -1251,7 +1266,7 @@ def _native_replace_fakes(
 ) -> tuple[_NoWriteNative, _NoWriteNativeRepository, dict[str, Any], dict[str, Any]]:
     service = _NoWriteNative((document, native_id))
     repository = _NoWriteNativeRepository((document, native_id))
-    old_text = document.body.decode().replace("secret body", "old body")
+    old_text = _document_body(document).decode().replace("secret body", "old body")
     old_bytes = old_text.encode()
     selected_row = {
         **repository._revision(document.resource_id),
@@ -1274,7 +1289,7 @@ def _native_replace_fakes(
         revision_id=native_id,
         surface="document",
         path=document.current_path,
-        text=document.body.decode(),
+        text=_document_body(document).decode(),
         digest=document.body_digest,
         byte_size=document.byte_size,
         action="replace",
@@ -1349,7 +1364,7 @@ async def test_native_history_rejects_invalid_parent_graph_shapes():
                 revision_id=native_id,
                 surface="document",
                 path=document.current_path,
-                text=document.body.decode(),
+                text=_document_body(document).decode(),
                 digest=document.body_digest,
                 byte_size=document.byte_size,
                 action="replace",
@@ -1466,6 +1481,23 @@ async def test_failed_cache_replacement_evicts_the_prior_resource():
     assert len(native_service.calls) == 3
 
 
+async def test_legacy_shadow_reader_retains_at_most_one_materialized_body():
+    first = _document()
+    second = _second_document()
+    fixed_ref = _oid("f")
+    git = _NoWriteGit(first, second)
+    reader = LegacyFixedRefShadowReader(git=git, vault_name="p2-manual")
+
+    await reader.get(first, selector=first.current_commit, fixed_ref=fixed_ref)
+    assert reader._snapshot_cache is not None
+    assert reader._snapshot_cache[0].resource_id == first.resource_id
+
+    await reader.get(second, selector=second.current_commit, fixed_ref=fixed_ref)
+    assert reader._snapshot_cache is not None
+    assert reader._snapshot_cache[0].resource_id == second.resource_id
+    assert len(git.calls) == 2
+
+
 async def test_comparator_receipt_is_redacted_and_classified():
     document = _document()
     run, item, inventory, native_id = _run_and_item(document)
@@ -1479,7 +1511,7 @@ async def test_comparator_receipt_is_redacted_and_classified():
     receipt = await comparator.compare_run(run.run_id)
     encoded = json.dumps(receipt, sort_keys=True)
 
-    assert document.body.decode() not in encoded
+    assert _document_body(document).decode() not in encoded
     assert document.current_path not in encoded
     assert str(document.resource_id) not in encoded
     assert document.activity.actor not in encoded
@@ -1506,11 +1538,20 @@ async def test_comparator_receipt_is_redacted_and_classified():
         "mapping_owner_activity",
         "retained_mapping_closure",
         "native_parent_bindings",
+        "owner_runs",
     }
     assert len(components["comparison_run"]) == 64
     assert len(components["mapping_owner_activity"]) == 1
     assert len(components["retained_mapping_closure"]) == 1
     assert len(components["native_parent_bindings"]) == 1
+    assert components["owner_runs"] == sorted(set(components["owner_runs"]))
+    assert receipt["evidence_binding"]["owner_run_count"] == len(
+        components["owner_runs"]
+    )
+    assert all(
+        len(commitment) == 64 and set(commitment) <= set("0123456789abcdef")
+        for commitment in components["owner_runs"]
+    )
     recomputed = hashlib.sha256(
         (receipt["evidence_binding"]["domain"] + "\0").encode()
         + json.dumps(
@@ -1550,6 +1591,57 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert document.current_commit not in encoded
     assert run.fixed_git_oid not in encoded
     assert run.inventory_digest not in encoded
+
+
+async def test_owner_run_count_tamper_cannot_survive_correlated_recompute():
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=_WireReader(native_id, candidate=True),
+    )
+    receipt = await comparator.compare_run(run.run_id)
+
+    count_tamper = json.loads(json.dumps(receipt))
+    count_tamper["evidence_binding"]["owner_run_count"] += 1
+    count_tamper.pop("receipt_digest")
+    count_tamper["receipt_digest"] = hashlib.sha256(
+        json.dumps(
+            count_tamper,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert count_tamper["evidence_binding"]["owner_run_count"] != len(
+        count_tamper["evidence_binding"]["components"]["owner_runs"]
+    )
+
+    component_tamper = json.loads(json.dumps(receipt))
+    component_tamper["evidence_binding"]["components"]["owner_runs"].append("0" * 64)
+    component_tamper["evidence_binding"]["commitment"] = hashlib.sha256(
+        (component_tamper["evidence_binding"]["domain"] + "\0").encode()
+        + json.dumps(
+            component_tamper["evidence_binding"]["components"],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    component_tamper.pop("receipt_digest")
+    component_tamper["receipt_digest"] = hashlib.sha256(
+        json.dumps(
+            component_tamper,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert component_tamper["evidence_binding"]["owner_run_count"] != len(
+        component_tamper["evidence_binding"]["components"]["owner_runs"]
+    )
 
 
 async def test_comparator_rejects_correlated_activity_fact_tamper():

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -34,7 +34,10 @@ from app.services.legacy_revision_bridge import (
     SelectorResolution,
     SelectorUnknownError,
 )
-from app.services.native_revision_shadow import NativeRevisionShadowComparator
+from app.services.native_revision_shadow import (
+    NativeRevisionShadowComparator,
+    ShadowComparisonError,
+)
 from app.services.native_revision_shadow_reader import (
     _apply_unified_patch,
     LegacyFixedRefShadowReader,
@@ -392,6 +395,15 @@ class _WireReader:
             ]
         }
 
+    async def audit_activity(
+        self,
+        document: LegacyInventoryDocument,
+        *,
+        selector: str,
+        fixed_ref: str,
+    ) -> None:
+        del document, selector, fixed_ref
+
 
 class _NoWriteGit:
     def __init__(self, *documents: LegacyInventoryDocument):
@@ -660,6 +672,193 @@ class _SelectorBridgeRouter:
             resource_id=resource_id,
             selector=selector,
         )
+
+
+def _activity_for_revision(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "resource_id": row["resource_id"],
+        "revision_id": row["revision_id"],
+        "action": row["action"],
+        "actor": row["actor"],
+        "subject": row["subject"],
+        "summary": row["summary"],
+        "changed_path_from": row["path_from"],
+        "changed_path_to": row["path_to"],
+        "occurred_at": row["occurred_at"],
+        "path_at_revision": row["path_at_revision"],
+    }
+
+
+def _native_activity_reader(
+    document: LegacyInventoryDocument,
+    native_id: str,
+    fixed_ref: str,
+    service: _NoWriteNative,
+    repository: _NoWriteNativeRepository,
+) -> NativeRevisionShadowReader:
+    return NativeRevisionShadowReader(
+        pool=None,
+        namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
+        vault_name="p2-manual",
+        native_service=service,
+        native_repository=repository,
+        selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("action", "replace"),
+        ("actor", "forged-actor"),
+        ("subject", "forged-subject"),
+        ("summary", "forged-summary"),
+        ("path_from", "notes/forged-parent.md"),
+        ("path_to", "notes/forged-current.md"),
+        ("occurred_at", datetime(2026, 8, 11, tzinfo=UTC)),
+    ],
+)
+async def test_genesis_activity_audit_rejects_forged_persisted_facts(field, value):
+    document = _document()
+    native_id = _oid("c")
+    fixed_ref = _oid("f")
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+    row = repository._revision(document.resource_id)
+    forged = {**row, field: value}
+    repository.revision_selector_overrides[(document.resource_id, native_id)] = forged
+    repository.activity_override = _activity_for_revision(forged)
+    snapshot = _Snapshot(
+        resource_id=document.resource_id,
+        revision_id=native_id,
+        surface="document",
+        path=document.current_path,
+        text=document.body.decode(),
+        digest=document.body_digest,
+        byte_size=document.byte_size,
+        action=forged["action"],
+        occurred_at=forged["occurred_at"],
+    )
+    service.snapshot_overrides[(document.resource_id, native_id)] = snapshot
+
+    with pytest.raises(ShadowReaderScopeError, match="activity audit"):
+        await _native_activity_reader(
+            document,
+            native_id,
+            fixed_ref,
+            service,
+            repository,
+        ).activity(document, selector=native_id, fixed_ref=fixed_ref)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("action", "replace"),
+        ("actor", "forged-actor"),
+        ("summary", "forged-summary"),
+    ],
+)
+async def test_reconcile_activity_audit_derives_action_from_parent_and_current_paths(
+    field,
+    value,
+):
+    document = _document()
+    native_id = _oid("c")
+    parent_id = _oid("e")
+    fixed_ref = _oid("f")
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+    old_path = "notes/old-migration-candidate.md"
+    selected = {
+        **repository._revision(document.resource_id),
+        "action": "move",
+        "parent_revision_id": parent_id,
+        "path_from": old_path,
+        "path_to": document.current_path,
+        "actor": document.activity.actor,
+        "subject": document.activity.subject,
+        "summary": document.activity.summary,
+    }
+    if field == "action":
+        selected = {
+            **selected,
+            "action": value,
+            "path_from": None,
+            "path_to": None,
+        }
+    else:
+        selected = {**selected, field: value}
+    parent = {
+        **repository._revision(document.resource_id),
+        "revision_id": parent_id,
+        "path_at_revision": old_path,
+        "path_from": None,
+        "path_to": old_path,
+    }
+    repository.revision_selector_overrides[(document.resource_id, native_id)] = selected
+    repository.revision_selector_overrides[(document.resource_id, parent_id)] = parent
+    repository.activity_override = _activity_for_revision(selected)
+    repository.history_overrides[document.resource_id] = [selected, parent]
+    service.snapshot_overrides[(document.resource_id, native_id)] = _Snapshot(
+        resource_id=document.resource_id,
+        revision_id=native_id,
+        surface="document",
+        path=document.current_path,
+        text=document.body.decode(),
+        digest=document.body_digest,
+        byte_size=document.byte_size,
+        action=selected["action"],
+        parent_revision_id=parent_id,
+        occurred_at=selected["occurred_at"],
+    )
+
+    with pytest.raises(ShadowReaderScopeError, match="activity audit"):
+        await _native_activity_reader(
+            document,
+            native_id,
+            fixed_ref,
+            service,
+            repository,
+        ).activity(document, selector=native_id, fixed_ref=fixed_ref)
+
+
+async def test_activity_audit_failure_prevents_shadow_projection(monkeypatch):
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+    forged = {**repository._revision(document.resource_id), "actor": "forged-actor"}
+    repository.revision_selector_overrides[(document.resource_id, native_id)] = forged
+    repository.activity_override = _activity_for_revision(forged)
+    native_candidate = _native_activity_reader(
+        document,
+        native_id,
+        run.fixed_git_oid,
+        service,
+        repository,
+    )
+    candidate = _WireReader(native_id, candidate=True)
+    candidate.activity = native_candidate.activity
+    candidate.audit_activity = native_candidate.audit_activity
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=candidate,
+    )
+    projection_calls: list[object] = []
+
+    def project(*args):
+        del args
+        projection_calls.append(object())
+        raise AssertionError("activity projection ran after audit failure")
+
+    monkeypatch.setattr(comparator, "_project_candidate_activity", project)
+
+    with pytest.raises(ShadowReaderScopeError, match="activity audit"):
+        await comparator.compare_run(run.run_id)
+    assert projection_calls == []
 
 
 async def test_product_readers_are_scoped_and_read_only():
@@ -1161,13 +1360,34 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert document.body.decode() not in encoded
     assert document.current_path not in encoded
     assert str(document.resource_id) not in encoded
+    assert document.activity.actor not in encoded
+    assert document.activity.subject not in encoded
+    assert document.activity.summary not in encoded
     assert str(run.run_id) not in encoded
     assert "raw_candidate" not in receipt
-    assert receipt["schema_version"] == 3
-    assert receipt["protocol_version"].endswith("/v3")
+    assert receipt["schema_version"] == 4
+    assert receipt["protocol_version"] == "akb-native-revision-p2-w1-c10/v4"
     assert "legacy" not in receipt["resources"][0]["operations"]["get"]
     assert receipt["summary"]["unexplained_mismatch_count"] == 0
     assert receipt["summary"]["mismatch_count"] == 12
+    assert receipt["summary"]["raw_activity_audit_count"] == 1
+    assert receipt["evidence_binding"]["mapping_count"] == 1
+    assert receipt["evidence_binding"]["owner_run_count"] == 1
+    assert receipt["evidence_binding"]["scheme"] == "sha256"
+    assert receipt["evidence_binding"]["canonicalization"] == (
+        "utf8-json-sort-keys-no-whitespace-v1"
+    )
+    assert receipt["evidence_binding"]["domain"] == (
+        "akb-native-revision-p2-w1-c10/evidence-binding/v1"
+    )
+    assert len(receipt["evidence_binding"]["commitment"]) == 64
+    assert all(
+        resource["operations"]["activity"]["raw_activity_audit"] == {
+            "profile": "akb-native-revision-p2-activity-audit/v1",
+            "status": "passed",
+        }
+        for resource in receipt["resources"]
+    )
     assert receipt["resources"][0]["operations"]["get"]["classified_mismatches"] == [
         {
             "rule_id": "BR-01",
@@ -1188,6 +1408,25 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert document.current_commit not in encoded
     assert run.fixed_git_oid not in encoded
     assert run.inventory_digest not in encoded
+
+
+async def test_comparator_requires_a_candidate_raw_activity_auditor():
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    candidate = _WireReader(native_id, candidate=True)
+    candidate.audit_activity = None
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=candidate,
+    )
+
+    with pytest.raises(
+        ShadowComparisonError,
+        match="cannot prove the raw native activity audit",
+    ):
+        await comparator.compare_run(run.run_id)
 
 
 async def test_product_readers_compare_a_completed_pg_backfill_without_writes(tmp_path):

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -11,7 +11,7 @@ import os
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -31,8 +31,10 @@ from app.services.legacy_revision_bridge import (
     LegacyInventoryDocument,
     LegacyLineageEntry,
     LegacyRevisionBridge,
+    LogicalLineageProjectionError,
     SelectorResolution,
     SelectorUnknownError,
+    project_logical_lineage,
 )
 from app.services.native_revision_shadow import (
     NativeRevisionShadowComparator,
@@ -1194,13 +1196,158 @@ async def test_legacy_reader_rejects_malformed_added_genesis_patch():
         )
 
 
-async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary():
+async def test_legacy_reader_projects_final_delta_with_same_creation_anchor_as_inventory():
     document = _document()
     created_at = document.created_at.replace(microsecond=487_280)
-    current_at = created_at.replace(microsecond=0) + timedelta(seconds=1)
+    anchor_at = created_at.replace(microsecond=0)
+    equal_at = created_at.astimezone(timezone(timedelta(hours=9)))
+    current_at = created_at.replace(microsecond=0) + timedelta(seconds=2)
+    anchor_oid = _oid("b")
+    update_oid = _oid("c")
     document = replace(
         document,
         created_at=created_at,
+        lineage=(
+            LegacyLineageEntry(anchor_oid, "notes/original.md", anchor_at),
+            LegacyLineageEntry(update_oid, "notes/original.md", equal_at),
+            LegacyLineageEntry(
+                document.current_commit,
+                document.current_path,
+                current_at,
+            ),
+        ),
+        activity=replace(document.activity, committed_at=current_at),
+    )
+    git = _NoWriteGit(document)
+    raw = git.manual_fixed_ref_history(
+        "p2-manual",
+        _oid("f"),
+        document.current_path,
+        current_commit=document.current_commit,
+    )
+    raw["history"][0]["path_at_revision"] = "notes/stale-current-path.md"
+    raw["history"].insert(2, dict(raw["history"][1]))
+    raw["history"].append(
+        {
+            "legacy_git_oid": _oid("d"),
+            "path_at_revision": "notes/pre-document.md",
+            "committed_at": anchor_at - timedelta(seconds=1),
+        }
+    )
+    git.snapshot_override = raw
+
+    history = await LegacyFixedRefShadowReader(
+        git=git,
+        vault_name="p2-manual",
+    ).history(
+        document,
+        selector=document.current_commit,
+        fixed_ref=_oid("f"),
+    )
+
+    assert [entry["selector"] for entry in history["entries"]] == [
+        document.current_commit,
+        update_oid,
+        anchor_oid,
+    ]
+
+
+async def test_unanchored_projection_excludes_an_older_path_lifecycle():
+    created_at = datetime(2026, 8, 11, 12, 0, 0, 500_000, tzinfo=UTC)
+    create_oid = _oid("b")
+    current_oid = _oid("c")
+    prior_lifecycle_oid = _oid("a")
+
+    lineage = project_logical_lineage(
+        (
+            {
+                "legacy_git_oid": current_oid,
+                "path_at_revision": "notes/current.md",
+                "committed_at": created_at + timedelta(seconds=1),
+            },
+            {
+                "legacy_git_oid": create_oid,
+                "path_at_revision": "notes/current.md",
+                "committed_at": created_at,
+            },
+            {
+                "legacy_git_oid": prior_lifecycle_oid,
+                "path_at_revision": "notes/current.md",
+                "committed_at": created_at - timedelta(microseconds=1),
+            },
+        ),
+        current_commit=current_oid,
+        current_path="notes/current.md",
+        created_at=created_at,
+    )
+
+    assert [entry.legacy_git_oid for entry in lineage] == [create_oid, current_oid]
+
+
+async def test_unanchored_projection_keeps_precreation_current_as_only_revision():
+    created_at = datetime(2026, 8, 11, 12, 0, 0, 500_000, tzinfo=UTC)
+    current_oid = _oid("c")
+
+    lineage = project_logical_lineage(
+        (
+            {
+                "legacy_git_oid": current_oid,
+                "path_at_revision": "notes/current.md",
+                "committed_at": created_at - timedelta(microseconds=1),
+            },
+            {
+                "legacy_git_oid": _oid("a"),
+                "path_at_revision": "notes/prior.md",
+                "committed_at": created_at - timedelta(seconds=1),
+            },
+        ),
+        current_commit=current_oid,
+        current_path="notes/current.md",
+        created_at=created_at,
+    )
+
+    assert [entry.legacy_git_oid for entry in lineage] == [current_oid]
+
+
+async def test_anchored_projection_fails_closed_when_anchor_is_absent_or_duplicated():
+    created_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    current_oid = _oid("c")
+    anchor_oid = _oid("b")
+    current = {
+        "legacy_git_oid": current_oid,
+        "path_at_revision": "notes/current.md",
+        "committed_at": created_at,
+    }
+
+    with pytest.raises(LogicalLineageProjectionError, match="anchor is absent"):
+        project_logical_lineage(
+            (current,),
+            current_commit=current_oid,
+            current_path="notes/current.md",
+            created_at=created_at,
+            oldest_anchor_oid=anchor_oid,
+        )
+
+    anchor = {
+        "legacy_git_oid": anchor_oid,
+        "path_at_revision": "notes/current.md",
+        "committed_at": created_at - timedelta(microseconds=1),
+    }
+    with pytest.raises(LogicalLineageProjectionError, match="duplicate oldest anchor"):
+        project_logical_lineage(
+            (current, anchor, dict(anchor)),
+            current_commit=current_oid,
+            current_path="notes/current.md",
+            created_at=created_at,
+            oldest_anchor_oid=anchor_oid,
+        )
+
+
+async def test_legacy_reader_treats_precreation_current_as_sole_anchor():
+    document = _document()
+    current_at = document.created_at - timedelta(microseconds=1)
+    document = replace(
+        document,
         lineage=(
             LegacyLineageEntry(
                 document.current_commit,
@@ -1219,11 +1366,9 @@ async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary(
     )
     raw["history"].append(
         {
-            "legacy_git_oid": _oid("b"),
-            "path_at_revision": document.current_path,
-            # Git's second-resolution --since boundary can include this row,
-            # while the C9 inventory excludes it against precise created_at.
-            "committed_at": created_at.replace(microsecond=0),
+            "legacy_git_oid": _oid("0"),
+            "path_at_revision": "notes/pre-document.md",
+            "committed_at": current_at - timedelta(seconds=1),
         }
     )
     git.snapshot_override = raw
@@ -1238,7 +1383,7 @@ async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary(
     )
 
     assert [entry["selector"] for entry in history["entries"]] == [
-        document.current_commit
+        document.current_commit,
     ]
 
 

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -36,6 +36,7 @@ from app.services.legacy_revision_bridge import (
 )
 from app.services.native_revision_shadow import NativeRevisionShadowComparator
 from app.services.native_revision_shadow_reader import (
+    _apply_unified_patch,
     LegacyFixedRefShadowReader,
     NativeRevisionShadowReader,
     ShadowReaderScopeError,
@@ -128,6 +129,38 @@ async def _authority_counts(pool) -> tuple[tuple[str, int], ...]:
 
 def _oid(char: str) -> str:
     return char * 40
+
+
+@pytest.mark.parametrize(
+    ("parent_text", "patch", "expected"),
+    [
+        pytest.param(
+            "text\n",
+            "@@ -1 +1 @@\n-text\n+text\n\\ No newline at end of file\n",
+            "text",
+            id="newline-to-no-newline",
+        ),
+        pytest.param(
+            "text",
+            "@@ -1 +1 @@\n-text\n\\ No newline at end of file\n+text\n",
+            "text\n",
+            id="no-newline-to-newline",
+        ),
+    ],
+)
+async def test_apply_unified_patch_preserves_terminal_newline_state(
+    parent_text: str,
+    patch: str,
+    expected: str,
+):
+    assert _apply_unified_patch(parent_text, patch, "modified") == expected
+
+
+async def test_apply_unified_patch_rejects_forged_parent_line():
+    patch = "@@ -1 +1 @@\n-forged\n+text\n"
+
+    with pytest.raises(ShadowReaderScopeError, match="differs from parent body"):
+        _apply_unified_patch("text\n", patch, "modified")
 
 
 def _document() -> LegacyInventoryDocument:

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -1460,6 +1460,22 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert receipt["evidence_binding"]["domain"] == (
         "akb-native-revision-p2-w1-c10/evidence-binding/v1"
     )
+    components = receipt["evidence_binding"]["components"]
+    assert set(components) == {"comparison_run", "mapping_owner_activity"}
+    assert len(components["comparison_run"]) == 64
+    assert len(components["mapping_owner_activity"]) == 1
+    recomputed = hashlib.sha256(
+        (
+            receipt["evidence_binding"]["domain"] + "\0"
+        ).encode()
+        + json.dumps(
+            components,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert receipt["evidence_binding"]["commitment"] == recomputed
     assert len(receipt["evidence_binding"]["commitment"]) == 64
     assert all(
         resource["operations"]["activity"]["raw_activity_audit"] == {

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import difflib
 import hashlib
 import importlib.util
 import json
@@ -30,6 +31,8 @@ from app.services.legacy_revision_bridge import (
     LegacyInventoryDocument,
     LegacyLineageEntry,
     LegacyRevisionBridge,
+    SelectorResolution,
+    SelectorUnknownError,
 )
 from app.services.native_revision_shadow import NativeRevisionShadowComparator
 from app.services.native_revision_shadow_reader import (
@@ -364,6 +367,11 @@ class _NoWriteGit:
             (document.current_path, document.current_commit): document.body
             for document in documents
         }
+        for document in documents:
+            for entry in document.lineage[:-1]:
+                self.bodies[(entry.path_at_revision, entry.legacy_git_oid)] = (
+                    document.body.replace(b"secret body", b"old body")
+                )
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
         self.snapshot_override: dict[str, Any] | None = None
         self.diff_override: dict[str, Any] | None = None
@@ -403,13 +411,34 @@ class _NoWriteGit:
 
     def file_diff(self, *args) -> dict[str, Any]:
         self.calls.append(("file_diff", args))
+        document = next(
+            document
+            for document in self.documents
+            if document.current_path == args[1]
+        )
+        previous = document.lineage[-2]
+        parent = self.bodies[(previous.path_at_revision, previous.legacy_git_oid)].decode()
+        current = self.bodies[(document.current_path, document.current_commit)].decode()
         result = {
             "file": args[1],
             "commit": args[2],
             "type": "modified",
-            "diff": "@@ -1 +1 @@\n-old body\n+current body",
+            "diff": "\n".join(
+                difflib.unified_diff(
+                    parent.splitlines(),
+                    current.splitlines(),
+                    fromfile=f"a/{previous.path_at_revision}",
+                    tofile=f"b/{document.current_path}",
+                    lineterm="",
+                )
+            ),
         }
         return self.diff_override if self.diff_override is not None else result
+
+    def read_file(self, *args, **kwargs) -> str | None:
+        self.calls.append(("read_file", args))
+        body = self.bodies.get((args[1], kwargs.get("commit")))
+        return body.decode() if body is not None else None
 
 
 @dataclass
@@ -422,6 +451,7 @@ class _Snapshot:
     digest: str
     byte_size: int
     action: str = "create"
+    parent_revision_id: str | None = None
     occurred_at: datetime = datetime(2026, 8, 10, tzinfo=UTC)
 
 
@@ -435,10 +465,16 @@ class _NoWriteNative:
             for document, native_id in entries
         }
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.snapshot_overrides: dict[tuple[uuid.UUID, str], _Snapshot] = {}
 
     async def get_resource_revision(self, **kwargs) -> _Snapshot:
         self.calls.append(("get_resource_revision", kwargs))
         document, native_id = self.entries[kwargs["resource_id"]]
+        override = self.snapshot_overrides.get(
+            (kwargs["resource_id"], kwargs["revision_id"])
+        )
+        if override is not None:
+            return override
         assert kwargs["revision_id"] == native_id
         body = document.body
         return _Snapshot(
@@ -462,6 +498,9 @@ class _NoWriteNativeRepository:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.history_overrides: dict[uuid.UUID, list[dict[str, Any]]] = {}
         self.revision_overrides: dict[uuid.UUID, dict[str, Any] | None] = {}
+        self.revision_selector_overrides: dict[
+            tuple[uuid.UUID, str], dict[str, Any] | None
+        ] = {}
         self.activity_override: dict[str, Any] | None = None
 
     def _revision(self, resource_id: uuid.UUID) -> dict[str, Any]:
@@ -481,6 +520,8 @@ class _NoWriteNativeRepository:
             "summary": None,
             "actor": "akb-native-revision-migration",
             "occurred_at": document.activity.committed_at,
+            "digest": document.body_digest,
+            "byte_size": document.byte_size,
         }
 
     async def list_history(self, **kwargs) -> list[dict[str, Any]]:
@@ -491,6 +532,9 @@ class _NoWriteNativeRepository:
 
     async def get_revision(self, **kwargs) -> dict[str, Any] | None:
         self.calls.append(("get_revision", kwargs))
+        key = (kwargs["resource_id"], kwargs["revision_id"])
+        if key in self.revision_selector_overrides:
+            return self.revision_selector_overrides[key]
         if kwargs["resource_id"] in self.revision_overrides:
             return self.revision_overrides[kwargs["resource_id"]]
         row = self._revision(kwargs["resource_id"])
@@ -517,6 +561,74 @@ class _NoWriteNativeRepository:
         }
 
 
+class _CompletedSelectorBridge:
+    def __init__(
+        self,
+        document: LegacyInventoryDocument,
+        native_id: str,
+        fixed_ref: str,
+        *,
+        native_mappings: dict[str, str] | None = None,
+    ):
+        self.document = document
+        self.native_id = native_id
+        self.fixed_ref = fixed_ref
+        self.native_mappings = {
+            document.current_commit: native_id,
+            **(native_mappings or {}),
+        }
+        self.deleted: set[str] = set()
+        self.corrupt_paths: set[str] = set()
+
+    async def resolve_selector(
+        self,
+        *,
+        resource_id: uuid.UUID,
+        selector: str,
+    ) -> SelectorResolution:
+        assert resource_id == self.document.resource_id
+        if selector in self.deleted:
+            raise SelectorUnknownError(selector)
+        if selector == self.native_id or selector in self.native_mappings.values():
+            return SelectorResolution(
+                resource_id=resource_id,
+                selector=selector,
+                kind="native",
+                native_revision_id=selector,
+                fixed_git_oid=None,
+                legacy_git_oid=None,
+                path_at_revision=self.document.current_path,
+                run_id=None,
+            )
+        entry = next(entry for entry in self.document.lineage if entry.legacy_git_oid == selector)
+        mapped_native = self.native_mappings.get(selector)
+        return SelectorResolution(
+            resource_id=resource_id,
+            selector=selector,
+            kind="native" if mapped_native is not None else "bridge",
+            native_revision_id=mapped_native,
+            fixed_git_oid=self.fixed_ref,
+            legacy_git_oid=selector,
+            path_at_revision=(
+                "notes/corrupt-retained.md"
+                if selector in self.corrupt_paths
+                else entry.path_at_revision
+            ),
+            run_id=uuid.UUID("33333333-3333-4333-8333-333333333333"),
+        )
+
+
+class _SelectorBridgeRouter:
+    def __init__(self, *bridges: _CompletedSelectorBridge):
+        self.bridges = {bridge.document.resource_id: bridge for bridge in bridges}
+
+    async def resolve_selector(self, *, resource_id: uuid.UUID, selector: str) -> SelectorResolution:
+        return await self.bridges[resource_id].resolve_selector(
+            resource_id=resource_id,
+            selector=selector,
+        )
+
+
 async def test_product_readers_are_scoped_and_read_only():
     document = _document()
     second = _second_document()
@@ -532,27 +644,32 @@ async def test_product_readers_are_scoped_and_read_only():
     await legacy.activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert result["current_commit"] == document.current_commit
     assert result["content"] == "# Migration candidate\n\nsecret body"
-    assert [name for name, _ in git.calls] == ["manual_fixed_ref_history", "file_diff"]
+    assert [name for name, _ in git.calls] == [
+        "manual_fixed_ref_history",
+        "file_diff",
+        "read_file",
+        "read_file",
+    ]
 
     result["projection"]["revision"] = "caller-mutation"
     result["content"] = "caller-mutation"
     reread = await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert reread["projection"]["revision"] == document.current_commit
     assert reread["content"] == "# Migration candidate\n\nsecret body"
-    assert len(git.calls) == 2
+    assert len(git.calls) == 4
 
     await legacy.get(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.history(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.diff(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.activity(second, selector=second.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 4
+    assert len(git.calls) == 8
 
     await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 5
+    assert len(git.calls) == 9
 
     with pytest.raises(ShadowReaderScopeError):
         await legacy.get(document, selector=_oid("e"), fixed_ref=fixed_ref)
-    assert len(git.calls) == 5
+    assert len(git.calls) == 9
 
     native_service = _NoWriteNative(
         (document, native_id),
@@ -568,6 +685,10 @@ async def test_product_readers_are_scoped_and_read_only():
         vault_name="p2-manual",
         native_service=native_service,
         native_repository=native_repository,
+        selector_bridge=_SelectorBridgeRouter(
+            _CompletedSelectorBridge(document, native_id, fixed_ref),
+            _CompletedSelectorBridge(second, second_native_id, fixed_ref),
+        ),
     )
     candidate = await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     await native.history(document, selector=native_id, fixed_ref=fixed_ref)
@@ -639,15 +760,58 @@ async def test_legacy_reader_fails_closed_on_missing_or_corrupt_product_facts():
     corrupt_diff_git = _NoWriteGit(document)
     corrupt_diff_git.diff_override = {
         "file": document.current_path,
-        "commit": _oid("0"),
+        "commit": document.current_commit,
         "type": "modified",
-        "diff": "@@ corrupt @@",
+        "diff": "@@ -1,3 +1,3 @@\n # Migration candidate\n \n-old body\n+forged body",
     }
     with pytest.raises(ShadowReaderScopeError, match="diff"):
         await LegacyFixedRefShadowReader(
             git=corrupt_diff_git,
             vault_name="p2-manual",
         ).diff(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+
+async def test_native_reader_requires_completed_selector_bridge_and_retained_mappings():
+    document = _document()
+    native_id = _oid("c")
+    fixed_ref = _oid("f")
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+
+    with pytest.raises(ValueError, match="selector_bridge"):
+        NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=repository,
+        )
+
+    retained = document.lineage[0].legacy_git_oid
+    deleted = _CompletedSelectorBridge(document, native_id, fixed_ref)
+    deleted.deleted.add(retained)
+    with pytest.raises(ShadowReaderScopeError, match="retained selector"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=repository,
+            selector_bridge=deleted,
+        ).history(document, selector=native_id, fixed_ref=fixed_ref)
+
+    corrupt = _CompletedSelectorBridge(document, native_id, fixed_ref)
+    corrupt.corrupt_paths.add(retained)
+    with pytest.raises(ShadowReaderScopeError, match="retained selector"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=service,
+            native_repository=repository,
+            selector_bridge=corrupt,
+        ).history(document, selector=native_id, fixed_ref=fixed_ref)
 
 
 async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_product_facts():
@@ -666,6 +830,7 @@ async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_produc
             vault_name="p2-manual",
             native_service=service,
             native_repository=missing_history,
+            selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
         ).history(document, selector=native_id, fixed_ref=fixed_ref)
 
     reordered_history = _NoWriteNativeRepository((document, native_id))
@@ -685,6 +850,7 @@ async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_produc
             vault_name="p2-manual",
             native_service=service,
             native_repository=reordered_history,
+            selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
         ).history(document, selector=native_id, fixed_ref=fixed_ref)
 
     corrupt_diff = _NoWriteNativeRepository((document, native_id))
@@ -699,6 +865,7 @@ async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_produc
             vault_name="p2-manual",
             native_service=service,
             native_repository=corrupt_diff,
+            selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
         ).diff(document, selector=native_id, fixed_ref=fixed_ref)
 
     corrupt_activity = _NoWriteNativeRepository((document, native_id))
@@ -717,7 +884,195 @@ async def test_native_reader_fails_closed_on_missing_corrupt_or_reordered_produc
             vault_name="p2-manual",
             native_service=service,
             native_repository=corrupt_activity,
+            selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
         ).activity(document, selector=native_id, fixed_ref=fixed_ref)
+
+
+def _native_replace_fakes(
+    document: LegacyInventoryDocument,
+    native_id: str,
+    parent_id: str,
+) -> tuple[_NoWriteNative, _NoWriteNativeRepository, dict[str, Any], dict[str, Any]]:
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+    old_text = document.body.decode().replace("secret body", "old body")
+    old_bytes = old_text.encode()
+    selected_row = {
+        **repository._revision(document.resource_id),
+        "action": "replace",
+        "parent_revision_id": parent_id,
+    }
+    parent_row = {
+        **repository._revision(document.resource_id),
+        "revision_id": parent_id,
+        "action": "create",
+        "parent_revision_id": None,
+        "digest": hashlib.sha256(old_bytes).hexdigest(),
+        "byte_size": len(old_bytes),
+    }
+    repository.revision_selector_overrides[(document.resource_id, native_id)] = selected_row
+    repository.revision_selector_overrides[(document.resource_id, parent_id)] = parent_row
+    repository.history_overrides[document.resource_id] = [selected_row, parent_row]
+    service.snapshot_overrides[(document.resource_id, native_id)] = _Snapshot(
+        resource_id=document.resource_id,
+        revision_id=native_id,
+        surface="document",
+        path=document.current_path,
+        text=document.body.decode(),
+        digest=document.body_digest,
+        byte_size=document.byte_size,
+        action="replace",
+        parent_revision_id=parent_id,
+        occurred_at=document.activity.committed_at,
+    )
+    service.snapshot_overrides[(document.resource_id, parent_id)] = _Snapshot(
+        resource_id=document.resource_id,
+        revision_id=parent_id,
+        surface="document",
+        path=document.current_path,
+        text=old_text,
+        digest=parent_row["digest"],
+        byte_size=parent_row["byte_size"],
+        action="create",
+        parent_revision_id=None,
+        occurred_at=document.activity.committed_at,
+    )
+    return service, repository, selected_row, parent_row
+
+
+async def test_native_history_follows_parent_lineage_with_equal_timestamps():
+    document = _document()
+    native_id = _oid("c")
+    parent_id = _oid("e")
+    fixed_ref = _oid("f")
+    service, repository, _, _ = _native_replace_fakes(document, native_id, parent_id)
+    bridge = _CompletedSelectorBridge(
+        document,
+        native_id,
+        fixed_ref,
+        native_mappings={document.lineage[0].legacy_git_oid: parent_id},
+    )
+
+    result = await NativeRevisionShadowReader(
+        pool=None,
+        namespace_id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
+        vault_name="p2-manual",
+        native_service=service,
+        native_repository=repository,
+        selector_bridge=bridge,
+    ).history(document, selector=native_id, fixed_ref=fixed_ref)
+
+    assert result["history_source"] == "fixed-ref-bridge"
+
+
+async def test_native_history_rejects_invalid_parent_graph_shapes():
+    document = _document()
+    native_id = _oid("c")
+    parent_id = _oid("e")
+    fixed_ref = _oid("f")
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    bridge = _CompletedSelectorBridge(document, native_id, fixed_ref)
+
+    for expected, shape in (
+        ("cycle", "cycle"),
+        ("missing", "missing"),
+        ("invalid selectors", "duplicate"),
+        ("disconnected", "extra"),
+    ):
+        service = _NoWriteNative((document, native_id))
+        repository = _NoWriteNativeRepository((document, native_id))
+        selected = repository._revision(document.resource_id)
+        if shape in {"cycle", "missing"}:
+            selected = {
+                **selected,
+                "action": "replace",
+                "parent_revision_id": native_id if shape == "cycle" else parent_id,
+            }
+            service.snapshot_overrides[(document.resource_id, native_id)] = _Snapshot(
+                resource_id=document.resource_id,
+                revision_id=native_id,
+                surface="document",
+                path=document.current_path,
+                text=document.body.decode(),
+                digest=document.body_digest,
+                byte_size=document.byte_size,
+                action="replace",
+                parent_revision_id=selected["parent_revision_id"],
+                occurred_at=document.activity.committed_at,
+            )
+        if shape == "duplicate":
+            history = [selected, dict(selected)]
+        elif shape == "extra":
+            history = [
+                selected,
+                {
+                    **selected,
+                    "revision_id": parent_id,
+                },
+            ]
+        else:
+            history = [selected]
+        repository.history_overrides[document.resource_id] = history
+
+        with pytest.raises(ShadowReaderScopeError, match=expected):
+            await NativeRevisionShadowReader(
+                pool=None,
+                namespace_id=namespace_id,
+                vault_name="p2-manual",
+                native_service=service,
+                native_repository=repository,
+                selector_bridge=bridge,
+            ).history(document, selector=native_id, fixed_ref=fixed_ref)
+
+
+async def test_native_diff_binds_selected_and_parent_rows_to_persisted_bodies():
+    document = _document()
+    native_id = _oid("c")
+    parent_id = _oid("e")
+    fixed_ref = _oid("f")
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    bridge = _CompletedSelectorBridge(
+        document,
+        native_id,
+        fixed_ref,
+        native_mappings={document.lineage[0].legacy_git_oid: parent_id},
+    )
+
+    corrupt_current_service, corrupt_current_repo, selected_row, _ = _native_replace_fakes(
+        document, native_id, parent_id
+    )
+    corrupt_current_repo.revision_selector_overrides[(document.resource_id, native_id)] = {
+        **selected_row,
+        "digest": "0" * 64,
+    }
+    with pytest.raises(ShadowReaderScopeError, match="selected.*body facts"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=corrupt_current_service,
+            native_repository=corrupt_current_repo,
+            selector_bridge=bridge,
+        ).diff(document, selector=native_id, fixed_ref=fixed_ref)
+
+    corrupt_parent_service, corrupt_parent_repo, _, parent_row = _native_replace_fakes(
+        document, native_id, parent_id
+    )
+    corrupt_parent_service.snapshot_overrides[(document.resource_id, parent_id)] = replace(
+        corrupt_parent_service.snapshot_overrides[(document.resource_id, parent_id)],
+        text="# Migration candidate\n\nforged parent\n",
+        digest=parent_row["digest"],
+        byte_size=parent_row["byte_size"],
+    )
+    with pytest.raises(ShadowReaderScopeError, match="parent.*body facts"):
+        await NativeRevisionShadowReader(
+            pool=None,
+            namespace_id=namespace_id,
+            vault_name="p2-manual",
+            native_service=corrupt_parent_service,
+            native_repository=corrupt_parent_repo,
+            selector_bridge=bridge,
+        ).diff(document, selector=native_id, fixed_ref=fixed_ref)
 
 
 async def test_failed_cache_replacement_evicts_the_prior_resource():
@@ -748,6 +1103,7 @@ async def test_failed_cache_replacement_evicts_the_prior_resource():
             (document, native_id),
             (invalid, invalid_native_id),
         ),
+        selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
     )
     await native.get(document, selector=native_id, fixed_ref=fixed_ref)
     with pytest.raises(ShadowReaderScopeError, match="body differs from C9 inventory"):

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -63,7 +63,7 @@ _DSN = os.environ.get(
 async def _reachable() -> bool:
     try:
         conn = await asyncpg.connect(_DSN, timeout=2)
-    except (OSError, asyncpg.PostgresError):
+    except OSError, asyncpg.PostgresError:
         return False
     await conn.close()
     return True
@@ -125,10 +125,7 @@ async def _authority_counts(pool) -> tuple[tuple[str, int], ...]:
         "legacy_revision_mappings",
     )
     async with pool.acquire() as conn:
-        return tuple([
-            (table, int(await conn.fetchval(f'SELECT count(*) FROM "{table}"')))
-            for table in tables
-        ])
+        return tuple([(table, int(await conn.fetchval(f'SELECT count(*) FROM "{table}"'))) for table in tables])
 
 
 def _oid(char: str) -> str:
@@ -228,9 +225,7 @@ def _second_document() -> LegacyInventoryDocument:
             subject="akb://p2-manual/coll/notes/second-candidate.md",
             summary="update second candidate at fixed ref",
             path_to=path,
-            changed_paths=(
-                {"change": "update", "path_from": None, "path_to": path},
-            ),
+            changed_paths=({"change": "update", "path_from": None, "path_to": path},),
         ),
     )
 
@@ -297,10 +292,7 @@ class _ReadRepository:
         resource_id: uuid.UUID,
         legacy_git_oid: str,
     ) -> LegacyRevisionMapping | None:
-        if (
-            resource_id != self.item.legacy_document_id
-            or legacy_git_oid != self.item.legacy_head_oid
-        ):
+        if resource_id != self.item.legacy_document_id or legacy_git_oid != self.item.legacy_head_oid:
             return None
         return LegacyRevisionMapping(
             namespace_id=self.run.namespace_id,
@@ -314,6 +306,30 @@ class _ReadRepository:
             fixed_git_oid=self.run.fixed_git_oid,
         )
 
+    async def list_resource_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+    ) -> list[LegacyRevisionMapping]:
+        assert namespace_id == self.run.namespace_id
+        document = _document()
+        assert resource_id == document.resource_id
+        return [
+            LegacyRevisionMapping(
+                namespace_id=namespace_id,
+                resource_id=resource_id,
+                legacy_git_oid=entry.legacy_git_oid,
+                path_at_revision=entry.path_at_revision,
+                resolution="native" if index == len(document.lineage) - 1 else "bridge",
+                native_revision_id=(self.item.native_head_revision_id if index == len(document.lineage) - 1 else None),
+                run_id=self.run.run_id,
+                lineage_ordinal=index,
+                fixed_git_oid=self.run.fixed_git_oid,
+            )
+            for index, entry in enumerate(document.lineage)
+        ]
+
 
 class _InventoryBridge:
     def __init__(self, inventory: LegacyInventory):
@@ -322,6 +338,57 @@ class _InventoryBridge:
     async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:
         assert run.inventory_digest == self.inventory.inventory_digest
         return self.inventory
+
+
+def _activity_binding_fact(
+    document: LegacyInventoryDocument,
+    *,
+    selector: str,
+    fixed_ref: str,
+) -> dict[str, Any]:
+    namespace_id = "22222222-2222-4222-8222-222222222222"
+    resource_id = str(document.resource_id)
+    occurred_at = document.lineage[-1].committed_at.isoformat()
+    current_mapping = {
+        "namespace_id": namespace_id,
+        "resource_id": resource_id,
+        "legacy_git_oid": document.current_commit,
+        "path_at_revision": document.current_path,
+        "resolution": "native",
+        "native_revision_id": selector,
+        "fixed_git_oid": fixed_ref,
+        "run_id": "33333333-3333-4333-8333-333333333333",
+    }
+    selected_revision = {
+        "namespace_id": namespace_id,
+        "resource_id": resource_id,
+        "revision_id": selector,
+        "parent_revision_id": None,
+        "surface": "document",
+        "action": "create",
+        "path_at_revision": document.current_path,
+        "path_from": None,
+        "path_to": document.current_path,
+        "actor": "akb-native-revision-migration",
+        "subject": None,
+        "summary": None,
+        "occurred_at": occurred_at,
+        "digest": document.body_digest,
+        "byte_size": document.byte_size,
+    }
+    return {
+        "profile": "akb-native-revision-p2-activity-audit/v1",
+        "selector": selector,
+        "fixed_ref": fixed_ref,
+        "current_mapping": current_mapping,
+        "selected_revision": selected_revision,
+        "activity": {
+            key: value
+            for key, value in selected_revision.items()
+            if key not in {"parent_revision_id", "digest", "byte_size"}
+        },
+        "completed_parent_mapping": None,
+    }
 
 
 class _WireReader:
@@ -380,17 +447,18 @@ class _WireReader:
     async def activity(self, document: LegacyInventoryDocument, *, selector: str, fixed_ref: str) -> dict[str, Any]:
         del fixed_ref
         activity = document.activity
+        actor = "akb-native-revision-migration" if self.candidate else activity.actor
         return {
             "events": [
                 {
                     "hash": selector,
-                    "subject": activity.subject,
+                    "subject": None if self.candidate else activity.subject,
                     "author": {
-                        "id": activity.actor,
-                        "display": "Legacy Writer (Git)" if not self.candidate else "Migration",
+                        "id": actor,
+                        "display": actor if self.candidate else "Legacy Writer (Git)",
                     },
                     "action": activity.action if not self.candidate else "create",
-                    "summary": activity.summary if not self.candidate else "C9 fixed-ref native genesis",
+                    "summary": activity.summary if not self.candidate else None,
                     "projection_revision": selector,
                 }
             ]
@@ -410,26 +478,22 @@ class _WireReader:
         )
         return NativeActivityEvidence(
             envelope=envelope,
-            binding_fact={
-                "profile": "akb-native-revision-p2-activity-audit/v1",
-                "resource_id": str(document.resource_id),
-                "selector": selector,
-                "fixed_ref": fixed_ref,
-            },
+            binding_fact=_activity_binding_fact(
+                document,
+                selector=selector,
+                fixed_ref=fixed_ref,
+            ),
         )
 
 
 class _NoWriteGit:
     def __init__(self, *documents: LegacyInventoryDocument):
         self.documents = documents
-        self.bodies = {
-            (document.current_path, document.current_commit): document.body
-            for document in documents
-        }
+        self.bodies = {(document.current_path, document.current_commit): document.body for document in documents}
         for document in documents:
             for entry in document.lineage[:-1]:
-                self.bodies[(entry.path_at_revision, entry.legacy_git_oid)] = (
-                    document.body.replace(b"secret body", b"old body")
+                self.bodies[(entry.path_at_revision, entry.legacy_git_oid)] = document.body.replace(
+                    b"secret body", b"old body"
                 )
         self.calls: list[tuple[str, tuple[Any, ...]]] = []
         self.snapshot_override: dict[str, Any] | None = None
@@ -437,11 +501,7 @@ class _NoWriteGit:
 
     def manual_fixed_ref_history(self, *args, **kwargs) -> dict[str, Any]:
         self.calls.append(("manual_fixed_ref_history", args))
-        document = next(
-            document
-            for document in self.documents
-            if document.current_path == args[2]
-        )
+        document = next(document for document in self.documents if document.current_path == args[2])
         result = {
             "fixed_ref": args[1],
             "current_commit": kwargs["current_commit"],
@@ -470,11 +530,7 @@ class _NoWriteGit:
 
     def file_diff(self, *args) -> dict[str, Any]:
         self.calls.append(("file_diff", args))
-        document = next(
-            document
-            for document in self.documents
-            if document.current_path == args[1]
-        )
+        document = next(document for document in self.documents if document.current_path == args[1])
         previous = document.lineage[-2]
         parent = self.bodies[(previous.path_at_revision, previous.legacy_git_oid)].decode()
         current = self.bodies[(document.current_path, document.current_commit)].decode()
@@ -519,19 +575,14 @@ class _NoWriteNative:
         self,
         *entries: tuple[LegacyInventoryDocument, str],
     ):
-        self.entries = {
-            document.resource_id: (document, native_id)
-            for document, native_id in entries
-        }
+        self.entries = {document.resource_id: (document, native_id) for document, native_id in entries}
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.snapshot_overrides: dict[tuple[uuid.UUID, str], _Snapshot] = {}
 
     async def get_resource_revision(self, **kwargs) -> _Snapshot:
         self.calls.append(("get_resource_revision", kwargs))
         document, native_id = self.entries[kwargs["resource_id"]]
-        override = self.snapshot_overrides.get(
-            (kwargs["resource_id"], kwargs["revision_id"])
-        )
+        override = self.snapshot_overrides.get((kwargs["resource_id"], kwargs["revision_id"]))
         if override is not None:
             return override
         assert kwargs["revision_id"] == native_id
@@ -550,16 +601,11 @@ class _NoWriteNative:
 
 class _NoWriteNativeRepository:
     def __init__(self, *entries: tuple[LegacyInventoryDocument, str]):
-        self.entries = {
-            document.resource_id: (document, native_id)
-            for document, native_id in entries
-        }
+        self.entries = {document.resource_id: (document, native_id) for document, native_id in entries}
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.history_overrides: dict[uuid.UUID, list[dict[str, Any]]] = {}
         self.revision_overrides: dict[uuid.UUID, dict[str, Any] | None] = {}
-        self.revision_selector_overrides: dict[
-            tuple[uuid.UUID, str], dict[str, Any] | None
-        ] = {}
+        self.revision_selector_overrides: dict[tuple[uuid.UUID, str], dict[str, Any] | None] = {}
         self.activity_override: dict[str, Any] | None = None
 
     def _revision(self, resource_id: uuid.UUID) -> dict[str, Any]:
@@ -669,9 +715,7 @@ class _CompletedSelectorBridge:
             fixed_git_oid=self.fixed_ref,
             legacy_git_oid=selector,
             path_at_revision=(
-                "notes/corrupt-retained.md"
-                if selector in self.corrupt_paths
-                else entry.path_at_revision
+                "notes/corrupt-retained.md" if selector in self.corrupt_paths else entry.path_at_revision
             ),
             run_id=uuid.UUID("33333333-3333-4333-8333-333333333333"),
         )
@@ -1367,9 +1411,7 @@ async def test_native_diff_binds_selected_and_parent_rows_to_persisted_bodies():
             selector_bridge=bridge,
         ).diff(document, selector=native_id, fixed_ref=fixed_ref)
 
-    corrupt_parent_service, corrupt_parent_repo, _, parent_row = _native_replace_fakes(
-        document, native_id, parent_id
-    )
+    corrupt_parent_service, corrupt_parent_repo, _, parent_row = _native_replace_fakes(document, native_id, parent_id)
     corrupt_parent_service.snapshot_overrides[(document.resource_id, parent_id)] = replace(
         corrupt_parent_service.snapshot_overrides[(document.resource_id, parent_id)],
         text="# Migration candidate\n\nforged parent\n",
@@ -1452,22 +1494,25 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert receipt["summary"]["mismatch_count"] == 12
     assert receipt["summary"]["raw_activity_audit_count"] == 1
     assert receipt["evidence_binding"]["mapping_count"] == 1
+    assert receipt["evidence_binding"]["retained_mapping_count"] == 1
+    assert receipt["evidence_binding"]["native_parent_binding_count"] == 1
     assert receipt["evidence_binding"]["owner_run_count"] == 1
     assert receipt["evidence_binding"]["scheme"] == "sha256"
-    assert receipt["evidence_binding"]["canonicalization"] == (
-        "utf8-json-sort-keys-no-whitespace-v1"
-    )
-    assert receipt["evidence_binding"]["domain"] == (
-        "akb-native-revision-p2-w1-c10/evidence-binding/v1"
-    )
+    assert receipt["evidence_binding"]["canonicalization"] == ("utf8-json-sort-keys-no-whitespace-v1")
+    assert receipt["evidence_binding"]["domain"] == ("akb-native-revision-p2-w1-c10/evidence-binding/v1")
     components = receipt["evidence_binding"]["components"]
-    assert set(components) == {"comparison_run", "mapping_owner_activity"}
+    assert set(components) == {
+        "comparison_run",
+        "mapping_owner_activity",
+        "retained_mapping_closure",
+        "native_parent_bindings",
+    }
     assert len(components["comparison_run"]) == 64
     assert len(components["mapping_owner_activity"]) == 1
+    assert len(components["retained_mapping_closure"]) == 1
+    assert len(components["native_parent_bindings"]) == 1
     recomputed = hashlib.sha256(
-        (
-            receipt["evidence_binding"]["domain"] + "\0"
-        ).encode()
+        (receipt["evidence_binding"]["domain"] + "\0").encode()
         + json.dumps(
             components,
             ensure_ascii=False,
@@ -1478,7 +1523,8 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert receipt["evidence_binding"]["commitment"] == recomputed
     assert len(receipt["evidence_binding"]["commitment"]) == 64
     assert all(
-        resource["operations"]["activity"]["raw_activity_audit"] == {
+        resource["operations"]["activity"]["raw_activity_audit"]
+        == {
             "profile": "akb-native-revision-p2-activity-audit/v1",
             "status": "passed",
         }
@@ -1506,10 +1552,9 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert run.inventory_digest not in encoded
 
 
-async def test_evidence_binding_commits_to_private_audited_activity_facts():
+async def test_comparator_rejects_correlated_activity_fact_tamper():
     document = _document()
     run, item, inventory, native_id = _run_and_item(document)
-    baseline_candidate = _WireReader(native_id, candidate=True)
     changed_candidate = _WireReader(native_id, candidate=True)
     original_evidence = changed_candidate.activity_evidence
 
@@ -1517,26 +1562,26 @@ async def test_evidence_binding_commits_to_private_audited_activity_facts():
         evidence = await original_evidence(*args, **kwargs)
         return NativeActivityEvidence(
             envelope=evidence.envelope,
-            binding_fact={**evidence.binding_fact, "audit_variant": "changed"},
+            binding_fact={
+                **evidence.binding_fact,
+                "selected_revision": {
+                    **evidence.binding_fact["selected_revision"],
+                    "resource_id": str(uuid.uuid4()),
+                },
+            },
         )
 
     changed_candidate.activity_evidence = changed_evidence
 
-    async def compare(candidate):
-        return await NativeRevisionShadowComparator(
-            repository=_ReadRepository(run, item),
-            bridge=_InventoryBridge(inventory),
-            legacy_reader=_WireReader(native_id, candidate=False),
-            candidate_reader=candidate,
-        ).compare_run(run.run_id)
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=changed_candidate,
+    )
 
-    baseline = await compare(baseline_candidate)
-    changed = await compare(changed_candidate)
-
-    assert baseline["resources"] == changed["resources"]
-    assert baseline["summary"] == changed["summary"]
-    assert baseline["evidence_binding"]["commitment"] != changed["evidence_binding"]["commitment"]
-    assert baseline["receipt_digest"] != changed["receipt_digest"]
+    with pytest.raises(ShadowComparisonError, match="not correlated"):
+        await comparator.compare_run(run.run_id)
 
 
 async def test_comparator_requires_a_candidate_raw_activity_auditor():
@@ -1555,6 +1600,31 @@ async def test_comparator_requires_a_candidate_raw_activity_auditor():
         ShadowComparisonError,
         match="cannot prove the raw native activity audit",
     ):
+        await comparator.compare_run(run.run_id)
+
+
+async def test_comparator_rejects_profile_only_activity_evidence():
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    candidate = _WireReader(native_id, candidate=True)
+    original_evidence = candidate.activity_evidence
+
+    async def profile_only(*args, **kwargs):
+        evidence = await original_evidence(*args, **kwargs)
+        return NativeActivityEvidence(
+            envelope=evidence.envelope,
+            binding_fact={"profile": "akb-native-revision-p2-activity-audit/v1"},
+        )
+
+    candidate.activity_evidence = profile_only
+    comparator = NativeRevisionShadowComparator(
+        repository=_ReadRepository(run, item),
+        bridge=_InventoryBridge(inventory),
+        legacy_reader=_WireReader(native_id, candidate=False),
+        candidate_reader=candidate,
+    )
+
+    with pytest.raises(ShadowComparisonError, match="activity audit schema"):
         await comparator.compare_run(run.run_id)
 
 

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -1093,6 +1093,54 @@ async def test_product_readers_are_scoped_and_read_only():
     assert len(native_service.calls) == 3
 
 
+async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary():
+    document = _document()
+    created_at = document.created_at.replace(microsecond=487_280)
+    current_at = created_at.replace(microsecond=0) + timedelta(seconds=1)
+    document = replace(
+        document,
+        created_at=created_at,
+        lineage=(
+            LegacyLineageEntry(
+                document.current_commit,
+                document.current_path,
+                current_at,
+            ),
+        ),
+        activity=replace(document.activity, committed_at=current_at),
+    )
+    git = _NoWriteGit(document)
+    raw = git.manual_fixed_ref_history(
+        "p2-manual",
+        _oid("f"),
+        document.current_path,
+        current_commit=document.current_commit,
+    )
+    raw["history"].append(
+        {
+            "legacy_git_oid": _oid("b"),
+            "path_at_revision": document.current_path,
+            # Git's second-resolution --since boundary can include this row,
+            # while the C9 inventory excludes it against precise created_at.
+            "committed_at": created_at.replace(microsecond=0),
+        }
+    )
+    git.snapshot_override = raw
+
+    history = await LegacyFixedRefShadowReader(
+        git=git,
+        vault_name="p2-manual",
+    ).history(
+        document,
+        selector=document.current_commit,
+        fixed_ref=_oid("f"),
+    )
+
+    assert [entry["selector"] for entry in history["entries"]] == [
+        document.current_commit
+    ]
+
+
 async def test_legacy_reader_fails_closed_on_missing_or_corrupt_product_facts():
     document = _document()
     fixed_ref = _oid("f")

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -41,6 +41,7 @@ from app.services.native_revision_shadow import (
 from app.services.native_revision_shadow_reader import (
     _apply_unified_patch,
     LegacyFixedRefShadowReader,
+    NativeActivityEvidence,
     NativeRevisionShadowReader,
     ShadowReaderScopeError,
 )
@@ -395,14 +396,27 @@ class _WireReader:
             ]
         }
 
-    async def audit_activity(
+    async def activity_evidence(
         self,
         document: LegacyInventoryDocument,
         *,
         selector: str,
         fixed_ref: str,
-    ) -> None:
-        del document, selector, fixed_ref
+    ) -> NativeActivityEvidence:
+        envelope = await self.activity(
+            document,
+            selector=selector,
+            fixed_ref=fixed_ref,
+        )
+        return NativeActivityEvidence(
+            envelope=envelope,
+            binding_fact={
+                "profile": "akb-native-revision-p2-activity-audit/v1",
+                "resource_id": str(document.resource_id),
+                "selector": selector,
+                "fixed_ref": fixed_ref,
+            },
+        )
 
 
 class _NoWriteGit:
@@ -695,6 +709,8 @@ def _native_activity_reader(
     fixed_ref: str,
     service: _NoWriteNative,
     repository: _NoWriteNativeRepository,
+    *,
+    native_mappings: dict[str, str] | None = None,
 ) -> NativeRevisionShadowReader:
     return NativeRevisionShadowReader(
         pool=None,
@@ -702,7 +718,12 @@ def _native_activity_reader(
         vault_name="p2-manual",
         native_service=service,
         native_repository=repository,
-        selector_bridge=_CompletedSelectorBridge(document, native_id, fixed_ref),
+        selector_bridge=_CompletedSelectorBridge(
+            document,
+            native_id,
+            fixed_ref,
+            native_mappings=native_mappings,
+        ),
     )
 
 
@@ -767,9 +788,13 @@ async def test_reconcile_activity_audit_derives_action_from_parent_and_current_p
     native_id = _oid("c")
     parent_id = _oid("e")
     fixed_ref = _oid("f")
+    old_path = "notes/old-migration-candidate.md"
+    document = replace(
+        document,
+        lineage=(replace(document.lineage[0], path_at_revision=old_path), document.lineage[1]),
+    )
     service = _NoWriteNative((document, native_id))
     repository = _NoWriteNativeRepository((document, native_id))
-    old_path = "notes/old-migration-candidate.md"
     selected = {
         **repository._revision(document.resource_id),
         "action": "move",
@@ -820,6 +845,62 @@ async def test_reconcile_activity_audit_derives_action_from_parent_and_current_p
             fixed_ref,
             service,
             repository,
+            native_mappings={document.lineage[0].legacy_git_oid: parent_id},
+        ).activity(document, selector=native_id, fixed_ref=fixed_ref)
+
+
+async def test_reconcile_activity_audit_rejects_correlated_parent_path_tampering():
+    document = _document()
+    native_id = _oid("c")
+    parent_id = _oid("e")
+    fixed_ref = _oid("f")
+    service = _NoWriteNative((document, native_id))
+    repository = _NoWriteNativeRepository((document, native_id))
+    forged_parent_path = "notes/forged-parent.md"
+    selected = {
+        **repository._revision(document.resource_id),
+        "action": "move",
+        "parent_revision_id": parent_id,
+        "path_from": forged_parent_path,
+        "path_to": document.current_path,
+        "actor": document.activity.actor,
+        "subject": document.activity.subject,
+        "summary": document.activity.summary,
+    }
+    parent = {
+        **repository._revision(document.resource_id),
+        "revision_id": parent_id,
+        "path_at_revision": forged_parent_path,
+        "path_from": None,
+        "path_to": forged_parent_path,
+    }
+    repository.revision_selector_overrides[(document.resource_id, native_id)] = selected
+    repository.revision_selector_overrides[(document.resource_id, parent_id)] = parent
+    repository.activity_override = _activity_for_revision(selected)
+    service.snapshot_overrides[(document.resource_id, native_id)] = _Snapshot(
+        resource_id=document.resource_id,
+        revision_id=native_id,
+        surface="document",
+        path=document.current_path,
+        text=document.body.decode(),
+        digest=document.body_digest,
+        byte_size=document.byte_size,
+        action="move",
+        parent_revision_id=parent_id,
+        occurred_at=selected["occurred_at"],
+    )
+
+    with pytest.raises(
+        ShadowReaderScopeError,
+        match="parent path differs from its completed legacy mapping",
+    ):
+        await _native_activity_reader(
+            document,
+            native_id,
+            fixed_ref,
+            service,
+            repository,
+            native_mappings={document.lineage[0].legacy_git_oid: parent_id},
         ).activity(document, selector=native_id, fixed_ref=fixed_ref)
 
 
@@ -839,8 +920,7 @@ async def test_activity_audit_failure_prevents_shadow_projection(monkeypatch):
         repository,
     )
     candidate = _WireReader(native_id, candidate=True)
-    candidate.activity = native_candidate.activity
-    candidate.audit_activity = native_candidate.audit_activity
+    candidate.activity_evidence = native_candidate.activity_evidence
     comparator = NativeRevisionShadowComparator(
         repository=_ReadRepository(run, item),
         bridge=_InventoryBridge(inventory),
@@ -1410,11 +1490,44 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert run.inventory_digest not in encoded
 
 
+async def test_evidence_binding_commits_to_private_audited_activity_facts():
+    document = _document()
+    run, item, inventory, native_id = _run_and_item(document)
+    baseline_candidate = _WireReader(native_id, candidate=True)
+    changed_candidate = _WireReader(native_id, candidate=True)
+    original_evidence = changed_candidate.activity_evidence
+
+    async def changed_evidence(*args, **kwargs):
+        evidence = await original_evidence(*args, **kwargs)
+        return NativeActivityEvidence(
+            envelope=evidence.envelope,
+            binding_fact={**evidence.binding_fact, "audit_variant": "changed"},
+        )
+
+    changed_candidate.activity_evidence = changed_evidence
+
+    async def compare(candidate):
+        return await NativeRevisionShadowComparator(
+            repository=_ReadRepository(run, item),
+            bridge=_InventoryBridge(inventory),
+            legacy_reader=_WireReader(native_id, candidate=False),
+            candidate_reader=candidate,
+        ).compare_run(run.run_id)
+
+    baseline = await compare(baseline_candidate)
+    changed = await compare(changed_candidate)
+
+    assert baseline["resources"] == changed["resources"]
+    assert baseline["summary"] == changed["summary"]
+    assert baseline["evidence_binding"]["commitment"] != changed["evidence_binding"]["commitment"]
+    assert baseline["receipt_digest"] != changed["receipt_digest"]
+
+
 async def test_comparator_requires_a_candidate_raw_activity_auditor():
     document = _document()
     run, item, inventory, native_id = _run_and_item(document)
     candidate = _WireReader(native_id, candidate=True)
-    candidate.audit_activity = None
+    candidate.activity_evidence = None
     comparator = NativeRevisionShadowComparator(
         repository=_ReadRepository(run, item),
         bridge=_InventoryBridge(inventory),

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -1141,6 +1141,33 @@ async def test_legacy_reader_matches_inventory_after_subsecond_lineage_boundary(
     ]
 
 
+async def test_legacy_reader_rejects_precreation_row_before_current_head():
+    document = _document()
+    fixed_ref = _oid("f")
+    git = _NoWriteGit(document)
+    raw = git.manual_fixed_ref_history(
+        "p2-manual",
+        fixed_ref,
+        document.current_path,
+        current_commit=document.current_commit,
+    )
+    raw["history"].insert(
+        0,
+        {
+            "legacy_git_oid": _oid("0"),
+            "path_at_revision": document.current_path,
+            "committed_at": document.created_at - timedelta(microseconds=1),
+        },
+    )
+    git.snapshot_override = raw
+
+    with pytest.raises(ShadowReaderScopeError, match="history"):
+        await LegacyFixedRefShadowReader(
+            git=git,
+            vault_name="p2-manual",
+        ).history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+
 async def test_legacy_reader_fails_closed_on_missing_or_corrupt_product_facts():
     document = _document()
     fixed_ref = _oid("f")


### PR DESCRIPTION
## What changed

- add the PostgreSQL Native Revision migration ledger and current-head backfill
- retain historical Git selectors through a fixed-ref Resource-scoped bridge
- add read-only shadow comparison and final-ref reconciliation
- anchor later lineage capture to the exact completed Resource lineage
- preserve logical revision history/diff/activity semantics without changing the product route

## Boundary

Bare Git remains selectable, remains the default, and remains the sole writer. This PR does not enable a Native production route, deploy, cut over authority, or retire Bare Git.

## Validation

- focused bridge/reconcile/shadow PostgreSQL tests: 84 passed
- regular PostgreSQL full suite: 2,058 passed, 44 skipped
- pgvector-only rerun on pgvector/pgvector:pg16: 3 passed
- Ruff and mypy: passed
- Workbench C1/C6/C9/C10 and product-backed receipt evidence: passed on the paired branch
