### PR TITLE
feat: add stable PostgreSQL Native revision mode

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3357
+        "line_number": 3368
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T10:42:35Z"
+  "generated_at": "2026-08-12T02:08:30Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,17 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added an explicit PostgreSQL Native document revision mode
+
+AKB now accepts the stable process-scoped revision selectors `bare_git` and
+`postgres_native`, while keeping Bare Git as the default and retaining the old
+measurement selectors as compatibility aliases. PostgreSQL Native can start
+only after an explicit command claims a never-initialized AKB database and
+mints tenant/database/image-bound pending authority; first startup atomically
+turns that record into an immutable durable marker. Existing or merely empty
+legacy databases are rejected, and no existing tenant is converted by config.
+Readiness reports the canonical selected backend.
+
 ### Fixed scoped grep replacement completeness and recovery
 
 `akb_grep(replace=...)` now treats `limit` only as a response-preview bound and

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.14-slim
 
+ARG AKB_SOURCE_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/dnotitia/akb" \
+      org.opencontainers.image.revision="${AKB_SOURCE_REVISION}"
+
 # The hermetic external-git runner pins DNS resolution
 # via git's `http.curloptResolve`, documented since git 2.37 — a code-owned
 # security floor. Debian's packaged git is already well past 2.37, so we install

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -12,6 +12,7 @@ from app.services.access_service import (
 )
 from app.models.document import (
     DocumentDeleteResponse,
+    DocumentMoveRequest,
     DocumentPutRequest,
     DocumentPutResponse,
     DocumentResponse,
@@ -92,6 +93,29 @@ async def list_vaults(user: AuthenticatedUser = Depends(get_current_user)):
 async def put_document(req: DocumentPutRequest, user: AuthenticatedUser = Depends(get_current_user)):
     await check_vault_access(user.user_id, req.vault, required_role="writer")
     return await doc_service.put(req, agent_id=user.username)
+
+
+@router.post(
+    "/documents/{vault}/{doc_id:path}/move",
+    response_model=DocumentPutResponse,
+    summary="Move or rename a document",
+    operation_id="documentsMoveDocument",
+)
+async def move_document(
+    vault: str,
+    doc_id: str,
+    req: DocumentMoveRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    await check_vault_access(user.user_id, vault, required_role="writer")
+    return await doc_service.move(
+        vault,
+        doc_id,
+        collection=req.collection,
+        slug=req.slug,
+        message=req.message,
+        agent_id=user.username,
+    )
 
 
 @router.get(

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -13,6 +13,8 @@ Subcommands:
                                  Prints the temp password to stdout. Caller
                                  must share it with the user out-of-band.
     repair-resource-hashes      Backfill document/file content-hash projections.
+    initialize-postgres-native  Claim and initialize a never-used PostgreSQL
+                                database for the stable Native backend.
 """
 from __future__ import annotations
 
@@ -96,6 +98,27 @@ async def _repair_resource_hashes(args: list[str]) -> int:
     return 1 if report.get("errors") else 0
 
 
+async def _initialize_postgres_native(args: list[str]) -> int:
+    if args:
+        print("Usage: python -m app.cli initialize-postgres-native", file=sys.stderr)
+        return 2
+    from app.db.postgres import close_pool
+    from app.services.native_revision_authority import (
+        NativeAuthorityError,
+        bootstrap_postgres_native,
+    )
+
+    try:
+        report = await bootstrap_postgres_native()
+    except NativeAuthorityError as error:
+        print(f"{error.code}: {error}", file=sys.stderr)
+        return 1
+    finally:
+        await close_pool()
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
 def _okf_validate(args: list[str]) -> int:
     """`okf-validate <bundle-dir>` — check a directory against OKF v0.1."""
     from pathlib import Path
@@ -172,7 +195,8 @@ def main(argv: list[str] | None = None) -> int:
         print("Usage: python -m app.cli <subcommand> [args]", file=sys.stderr)
         print(
             "Subcommands: reset-password <username>, repair-resource-hashes, "
-            "okf-validate <dir>, okf-export --from-git <worktree> --vault <name> --out <dir>",
+            "initialize-postgres-native, okf-validate <dir>, "
+            "okf-export --from-git <worktree> --vault <name> --out <dir>",
             file=sys.stderr,
         )
         return 2
@@ -184,6 +208,8 @@ def main(argv: list[str] | None = None) -> int:
         return asyncio.run(_reset_password(argv[1]))
     if cmd == "repair-resource-hashes":
         return asyncio.run(_repair_resource_hashes(argv[1:]))
+    if cmd == "initialize-postgres-native":
+        return asyncio.run(_initialize_postgres_native(argv[1:]))
     if cmd == "okf-validate":
         return _okf_validate(argv[1:])
     if cmd == "okf-export":

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,8 @@ per deployment without re-rendering config files.
 """
 
 import ipaddress
+import re
+import uuid
 from pathlib import Path
 from typing import Literal
 
@@ -47,6 +49,20 @@ def parse_git_version(text: str) -> tuple[int, int, int] | None:
 
 
 NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME = "akb_revision_m1_measurement"
+
+_DNS1123_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+_NATIVE_RUNTIME_IMAGE_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def is_dns1123_namespace(value: str) -> bool:
+    """Return whether ``value`` is a DNS-1123 subdomain."""
+    if not value or len(value) > 253:
+        return False
+    labels = value.split(".")
+    return all(
+        1 <= len(label) <= 63 and _DNS1123_LABEL_RE.fullmatch(label) is not None
+        for label in labels
+    )
 
 
 class AuditSettings(BaseModel):
@@ -243,9 +259,18 @@ class Settings(BaseModel):
     # Git storage root (bare repos live here)
     git_storage_path: str = "/data/vaults"
 
-    # Native ledger selection is a dedicated M1 measurement path. Normal
-    # deployments retain the legacy bare-Git revision behavior by default.
-    document_revision_backend: Literal["bare_git_current", "native_ledger_m1"] = "bare_git_current"
+    # Stable document revision selector. ``bare_git`` is the default. The two
+    # legacy values remain accepted for receipt compatibility; they are not
+    # rendered by new deployment surfaces.
+    document_revision_backend: Literal[
+        "bare_git", "postgres_native", "bare_git_current", "native_ledger_m1"
+    ] = "bare_git"
+    # Positive new-database Native authority bootstrap identity. These values
+    # are deliberately YAML-only and are required only by postgres_native.
+    document_revision_tenant_id: str = ""
+    document_revision_namespace: str = ""
+    document_revision_database_id: uuid.UUID | None = None
+    document_revision_runtime_image_digest: str = ""
     native_revision_m1_measurement_only: bool = False
     # W4's public File measurement is an opt-in, dedicated-database-only
     # comparison.  ``s3_current`` leaves the normal File service completely
@@ -365,6 +390,40 @@ class Settings(BaseModel):
 
     @model_validator(mode="after")
     def validate_model_api_governance(self) -> "Settings":
+        if self.document_revision_backend == "postgres_native":
+            if not self.document_revision_tenant_id.strip():
+                raise ValueError(
+                    "postgres_native requires document_revision_tenant_id"
+                )
+            self.document_revision_tenant_id = self.document_revision_tenant_id.strip()
+            if not is_dns1123_namespace(self.document_revision_namespace):
+                raise ValueError(
+                    "postgres_native requires document_revision_namespace in DNS-1123 form"
+                )
+            if self.document_revision_database_id is None:
+                raise ValueError(
+                    "postgres_native requires document_revision_database_id"
+                )
+            if not _NATIVE_RUNTIME_IMAGE_DIGEST_RE.fullmatch(
+                self.document_revision_runtime_image_digest
+            ):
+                raise ValueError(
+                    "postgres_native requires document_revision_runtime_image_digest "
+                    "in sha256:<64 lowercase hex> form"
+                )
+            if self.db_name == NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME:
+                raise ValueError(
+                    "postgres_native rejects the reserved native measurement database"
+                )
+            if self.native_revision_m1_measurement_only:
+                raise ValueError(
+                    "postgres_native rejects native_revision_m1_measurement_only"
+                )
+            if self.native_revision_m1_file_driver != "s3_current":
+                raise ValueError(
+                    "postgres_native rejects non-s3_current native_revision_m1_file_driver"
+                )
+
         if self.document_revision_backend == "native_ledger_m1":
             if not self.native_revision_m1_measurement_only:
                 raise ValueError(

--- a/backend/app/db/migrations/061_native_revision_authority.py
+++ b/backend/app/db/migrations/061_native_revision_authority.py
@@ -1,0 +1,148 @@
+"""Migration 061: explicit PostgreSQL Native authority records."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.061")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS document_revision_bootstrap_claims (
+                claim_key BOOLEAN PRIMARY KEY DEFAULT TRUE,
+                claim_id UUID NOT NULL UNIQUE,
+                record_kind TEXT NOT NULL DEFAULT 'new_database',
+                tenant_id TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                database_id UUID NOT NULL,
+                current_database TEXT NOT NULL,
+                runtime_image_digest TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'claimed',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                minted_at TIMESTAMPTZ,
+                CONSTRAINT document_revision_bootstrap_claims_singleton_check CHECK (claim_key),
+                CONSTRAINT document_revision_bootstrap_claims_kind_check CHECK (record_kind = 'new_database'),
+                CONSTRAINT document_revision_bootstrap_claims_tenant_check CHECK (btrim(tenant_id) <> ''),
+                CONSTRAINT document_revision_bootstrap_claims_namespace_check CHECK (btrim(namespace) <> ''),
+                CONSTRAINT document_revision_bootstrap_claims_database_check CHECK (btrim(current_database) <> ''),
+                CONSTRAINT document_revision_bootstrap_claims_digest_check
+                    CHECK (runtime_image_digest ~ '^sha256:[0-9a-f]{64}$'),
+                CONSTRAINT document_revision_bootstrap_claims_status_check CHECK (status IN ('claimed', 'minted')),
+                CONSTRAINT document_revision_bootstrap_claims_minted_shape CHECK (
+                    (status = 'claimed' AND minted_at IS NULL)
+                    OR (status = 'minted' AND minted_at IS NOT NULL)
+                )
+            );
+
+            CREATE TABLE IF NOT EXISTS document_revision_authority_pending (
+                authority_id UUID PRIMARY KEY,
+                claim_id UUID NOT NULL UNIQUE REFERENCES document_revision_bootstrap_claims(claim_id),
+                record_kind TEXT NOT NULL DEFAULT 'new_database',
+                backend TEXT NOT NULL DEFAULT 'postgres_native',
+                tenant_id TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                database_id UUID NOT NULL,
+                current_database TEXT NOT NULL,
+                runtime_image_digest TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                consumed_at TIMESTAMPTZ,
+                CONSTRAINT document_revision_authority_pending_kind_check CHECK (record_kind = 'new_database'),
+                CONSTRAINT document_revision_authority_pending_backend_check CHECK (backend = 'postgres_native'),
+                CONSTRAINT document_revision_authority_pending_tenant_check CHECK (btrim(tenant_id) <> ''),
+                CONSTRAINT document_revision_authority_pending_namespace_check CHECK (btrim(namespace) <> ''),
+                CONSTRAINT document_revision_authority_pending_database_check CHECK (btrim(current_database) <> ''),
+                CONSTRAINT document_revision_authority_pending_digest_check
+                    CHECK (runtime_image_digest ~ '^sha256:[0-9a-f]{64}$'),
+                CONSTRAINT document_revision_authority_pending_status_check CHECK (status IN ('pending', 'consumed')),
+                CONSTRAINT document_revision_authority_pending_consumed_shape CHECK (
+                    (status = 'pending' AND consumed_at IS NULL)
+                    OR (status = 'consumed' AND consumed_at IS NOT NULL)
+                )
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_document_revision_authority_pending_active
+                ON document_revision_authority_pending ((TRUE)) WHERE status = 'pending';
+
+            CREATE TABLE IF NOT EXISTS document_revision_authority_marker (
+                marker_id BOOLEAN PRIMARY KEY DEFAULT TRUE,
+                authority_id UUID NOT NULL UNIQUE REFERENCES document_revision_authority_pending(authority_id),
+                claim_id UUID NOT NULL UNIQUE REFERENCES document_revision_bootstrap_claims(claim_id),
+                record_kind TEXT NOT NULL DEFAULT 'new_database',
+                backend TEXT NOT NULL DEFAULT 'postgres_native',
+                tenant_id TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                database_id UUID NOT NULL,
+                current_database TEXT NOT NULL,
+                runtime_image_digest TEXT NOT NULL,
+                initialized_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT document_revision_authority_marker_singleton_check CHECK (marker_id),
+                CONSTRAINT document_revision_authority_marker_kind_check CHECK (record_kind = 'new_database'),
+                CONSTRAINT document_revision_authority_marker_backend_check CHECK (backend = 'postgres_native'),
+                CONSTRAINT document_revision_authority_marker_tenant_check CHECK (btrim(tenant_id) <> ''),
+                CONSTRAINT document_revision_authority_marker_namespace_check CHECK (btrim(namespace) <> ''),
+                CONSTRAINT document_revision_authority_marker_database_check CHECK (btrim(current_database) <> ''),
+                CONSTRAINT document_revision_authority_marker_digest_check
+                    CHECK (runtime_image_digest ~ '^sha256:[0-9a-f]{64}$')
+            );
+
+            CREATE OR REPLACE FUNCTION guard_document_revision_authority_mutation()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $guard$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'document revision authority records cannot be deleted';
+                END IF;
+                IF TG_TABLE_NAME = 'document_revision_bootstrap_claims' THEN
+                    IF OLD.status <> 'claimed' OR NEW.status <> 'minted'
+                       OR (to_jsonb(OLD) - 'status' - 'minted_at')
+                          IS DISTINCT FROM (to_jsonb(NEW) - 'status' - 'minted_at') THEN
+                        RAISE EXCEPTION 'invalid document revision bootstrap claim mutation';
+                    END IF;
+                    RETURN NEW;
+                END IF;
+                IF TG_TABLE_NAME = 'document_revision_authority_pending' THEN
+                    IF OLD.status <> 'pending' OR NEW.status <> 'consumed'
+                       OR (to_jsonb(OLD) - 'status' - 'consumed_at')
+                          IS DISTINCT FROM (to_jsonb(NEW) - 'status' - 'consumed_at') THEN
+                        RAISE EXCEPTION 'invalid document revision pending mutation';
+                    END IF;
+                    RETURN NEW;
+                END IF;
+                RAISE EXCEPTION 'document revision authority marker is immutable';
+            END;
+            $guard$;
+
+            DROP TRIGGER IF EXISTS guard_document_revision_bootstrap_claims
+                ON document_revision_bootstrap_claims;
+            CREATE TRIGGER guard_document_revision_bootstrap_claims
+                BEFORE UPDATE OR DELETE ON document_revision_bootstrap_claims
+                FOR EACH ROW EXECUTE FUNCTION guard_document_revision_authority_mutation();
+
+            DROP TRIGGER IF EXISTS guard_document_revision_authority_pending
+                ON document_revision_authority_pending;
+            CREATE TRIGGER guard_document_revision_authority_pending
+                BEFORE UPDATE OR DELETE ON document_revision_authority_pending
+                FOR EACH ROW EXECUTE FUNCTION guard_document_revision_authority_mutation();
+
+            DROP TRIGGER IF EXISTS guard_document_revision_authority_marker
+                ON document_revision_authority_marker;
+            CREATE TRIGGER guard_document_revision_authority_marker
+                BEFORE UPDATE OR DELETE ON document_revision_authority_marker
+                FOR EACH ROW EXECUTE FUNCTION guard_document_revision_authority_mutation();
+            """
+        )
+    logger.info("Migration 061: PostgreSQL Native authority records ready")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -237,6 +237,7 @@ async def _apply_migrations() -> None:
         "058_publication_document_identity.py",  # publications.document_id + composite FK (document_id, vault_id) → documents(id, vault_id) ON DELETE CASCADE; conservative backfill
         "059_native_file_searchable_derived.py",  # chunks.source_type admits 'native_file' so text Files reach the chunk/index/embedding pipeline on the Document's Resource/Revision basis
         "060_native_revision_migration_bridge.py",  # additive C9 migration runs, observations, and retained legacy selector mappings
+        "061_native_revision_authority.py",       # explicit new-database Native authority claim/pending/marker records
     ):
         if filename in applied:
             continue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from app.services.auth_service import AuthenticatedUser
 from app.services.external_git_capability import check_external_git_capability
 from app.services.health import vault_health
 from app.services.lifecycle import init_storage, shutdown_storage, start_workers, stop_workers
+from app.services.revision_backend import selected_document_revision_backend
 from app.services.vector_store import get_vector_store
 from app.util.errors import CONFLICT, INTERNAL, INVALID_ARGUMENT, METHOD_NOT_ALLOWED, NOT_FOUND, PERMISSION_DENIED
 from mcp_server.http_app import mcp_app
@@ -330,7 +331,9 @@ async def _probe_ready() -> tuple[bool, dict]:
     on the configured driver would pull the pod from the Service and
     break login/auth/CRUD for ~30s.
     """
-    detail: dict = {}
+    detail: dict = {
+        "document_revision_backend": selected_document_revision_backend(),
+    }
     try:
         pool = await get_pool()
         await asyncio.wait_for(pool.fetchval("SELECT 1"), timeout=2.0)

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -86,6 +86,14 @@ class DocumentUpdateRequest(NFCModel):
     expected_content_hash: str | None = None
 
 
+class DocumentMoveRequest(NFCModel):
+    """Request body for moving or renaming a document."""
+
+    collection: str | None = None
+    slug: str | None = None
+    message: str | None = None
+
+
 class DocumentEditRequest(NFCModel):
     """Request body for akb_edit. Mirrors the MCP tool schema."""
 

--- a/backend/app/services/embed_worker.py
+++ b/backend/app/services/embed_worker.py
@@ -124,12 +124,18 @@ async def _process_once() -> int:
     # pipeline from durable native invalidation intents. This hook runs before
     # the normal claim so newly materialized chunks can be indexed in the same
     # pass; unguarded/default deployments never import or execute the consumer.
-    native_document_measurement = settings.document_revision_backend == "native_ledger_m1"
+    native_document_selected = settings.document_revision_backend in {
+        "postgres_native",
+        "native_ledger_m1",
+    }
     native_file_measurement = settings.native_revision_m1_file_driver != "s3_current"
     if (
-        (native_document_measurement or native_file_measurement)
-        and settings.native_revision_m1_measurement_only
-        and settings.db_name == NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME
+        native_document_selected
+        or (
+            native_file_measurement
+            and settings.native_revision_m1_measurement_only
+            and settings.db_name == NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME
+        )
     ):
         from app.services.native_derived_worker import NativeDerivedWorker
 

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -12,6 +12,11 @@ from app.config import settings
 from app.db.postgres import close_pool, get_pool, init_db
 from app.services import audit_log, delete_worker, embed_worker, events_publisher, external_git_poller, http_pool, m1_file_transfer_reaper, metadata_worker, s3_delete_worker, sparse_encoder, tool_usage, vault_backfill, write_lane
 from app.services.git_service import GitService
+from app.services.native_revision_authority import (
+    pre_migration_revision_authority_guard,
+    startup_revision_authority_preflight,
+)
+from app.services.revision_backend import canonical_document_revision_backend
 from app.services.role_sync import RoleSync, get_role_sync, set_role_sync
 from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
 from app.services.vector_store import get_vector_store
@@ -70,8 +75,15 @@ def _validate_required_settings() -> None:
 async def init_storage() -> None:
     """Initialize DB schema/migrations and eagerly construct vector-store driver."""
     _validate_required_settings()
+    await pre_migration_revision_authority_guard()
     await init_db()
     logger.info("Database initialized")
+    authority_status = await startup_revision_authority_preflight()
+    logger.info(
+        "Document revision authority ready: backend=%s status=%s",
+        canonical_document_revision_backend(settings.document_revision_backend),
+        authority_status,
+    )
     if settings.native_revision_m1_file_driver != "s3_current":
         # Text Files share the native ledger and PostgreSQL BodyStore with the
         # guarded M1 grep arm. Install only after 048 and 053-057 are durable; normal
@@ -84,12 +96,13 @@ async def init_storage() -> None:
     # Self-heal: clear stale git index.lock files left behind by a
     # crashed prior process. Without this, the affected vault's writes
     # fail silently until an operator removes the lock by hand.
-    try:
-        cleared = GitService().cleanup_stale_locks()
-        if cleared:
-            logger.info("Cleared %d stale git lock(s) at startup", cleared)
-    except Exception as e:  # noqa: BLE001 — never block startup on best-effort cleanup
-        logger.warning("Stale-lock self-heal failed (continuing): %s", e)
+    if settings.document_revision_backend != "postgres_native":
+        try:
+            cleared = GitService().cleanup_stale_locks()
+            if cleared:
+                logger.info("Cleared %d stale git lock(s) at startup", cleared)
+        except Exception as e:  # noqa: BLE001 — never block startup on best-effort cleanup
+            logger.warning("Stale-lock self-heal failed (continuing): %s", e)
     # Force-construct so a misconfigured vector-store URL/DSN fails at startup rather
     # than silently serving empty search results later.
     store = get_vector_store()

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -18,12 +18,15 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
 from app.models.document import (
     DOC_STATUSES,
+    BrowseItem,
     BrowseResponse,
     DocumentPutRequest,
     DocumentPutResponse,
     DocumentResponse,
     DocumentUpdateRequest,
 )
+from app.repositories import table_data_repo, table_registry_repo, vault_files_repo
+from app.repositories.document_repo import CollectionRepository
 from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.repositories.vault_repo import VaultRepository
 from app.services.document_service import (
@@ -45,15 +48,17 @@ from app.services.native_revision_service import (
 )
 from app.services.resource_hash import HASH_ALGORITHM
 from app.services.role_sync import get_role_sync
-from app.services.uri_service import doc_uri
+from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
 from app.util.text import (
     doc_path,
+    like_escape,
     normalize_collection_path,
     slugify,
     split_doc_path,
     strip_own_suffix,
     to_nfc,
 )
+from app.utils import ensure_list
 
 
 class NativeRevisionUnsupportedSurfaceError(AKBError):
@@ -716,8 +721,233 @@ class NativeDocumentService(DocumentService):
     def _unsupported(surface: str) -> NoReturn:
         raise NativeRevisionUnsupportedSurfaceError(surface)
 
-    async def browse(self, *args, **kwargs) -> BrowseResponse:
-        self._unsupported("document browse")
+    async def _browse_native_documents(
+        self,
+        vault: str,
+        vault_id: uuid.UUID,
+        *,
+        prefix: str,
+        max_depth: int,
+        include_hashes: bool,
+        include_archived: bool,
+    ) -> list[BrowseItem]:
+        """Read current Native document Heads for the public browse view.
+
+        The Native ledger owns document identity and body bytes.  Collections,
+        tables, and binary files intentionally remain catalog-backed legacy
+        surfaces during the selector rollout, but this query must never hydrate
+        the legacy ``documents`` projection or Git.
+        """
+        params: list[object] = [vault_id]
+        clauses = [
+            "rs.namespace_id = $1",
+            "rs.surface = 'document'",
+            "rs.lifecycle = 'live'",
+        ]
+        if prefix:
+            params.append(like_escape(prefix) + "/%")
+            clauses.append(f"rs.current_path LIKE ${len(params)} ESCAPE '\\'")
+            depth_offset = prefix.count("/") + 1
+        else:
+            depth_offset = 0
+        if max_depth >= 0:
+            params.append(max_depth + depth_offset)
+            clauses.append(
+                "(length(rs.current_path) - "
+                f"length(replace(rs.current_path, '/', ''))) <= ${len(params)}"
+            )
+
+        sql = """
+            SELECT rs.resource_id, rs.current_path AS path,
+                   rs.head_revision_id AS revision_id, rs.updated_at
+              FROM native_resources rs
+             WHERE """ + " AND ".join(clauses) + """
+             ORDER BY rs.updated_at DESC, rs.resource_id DESC
+        """
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(sql, *params)
+
+        native = await self._native()
+        items: list[BrowseItem] = []
+        for row in rows:
+            snapshot = await native.get_resource_revision(
+                namespace_id=vault_id,
+                surface="document",
+                resource_id=row["resource_id"],
+                revision_id=row["revision_id"],
+            )
+            frontmatter, body = _parse_markdown(snapshot.text)
+            status = frontmatter.get("status") or "draft"
+            if not include_archived and status == "archived":
+                continue
+            tags = frontmatter.get("tags") or []
+            if isinstance(tags, str):
+                tags = [tags]
+            path = snapshot.path
+            items.append(
+                BrowseItem(
+                    name=frontmatter.get("title") or path.rsplit("/", 1)[-1],
+                    path=path,
+                    type="document",
+                    uri=doc_uri(vault, path),
+                    summary=frontmatter.get("summary"),
+                    doc_type=frontmatter.get("type") or "note",
+                    status=status,
+                    tags=list(tags),
+                    last_updated=snapshot.resource_updated_at,
+                    current_commit=snapshot.revision_id if include_hashes else None,
+                    content_hash=_body_content_hash(body) if include_hashes else None,
+                    hash_algorithm=HASH_ALGORITHM if include_hashes else None,
+                )
+            )
+        return items
+
+    async def _browse_legacy_tables(
+        self,
+        vault: str,
+        vault_id: uuid.UUID,
+        *,
+        prefix: str,
+        max_depth: int,
+    ) -> list[BrowseItem]:
+        pool = await self._pool()
+        items: list[BrowseItem] = []
+        async with pool.acquire() as conn:
+            vault_name = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+            rows = await table_registry_repo.list_for_vault(
+                conn, vault_id, max_depth=max_depth, prefix=prefix,
+            )
+            for row in rows:
+                pg_name = table_data_repo.pg_table_name(vault_name, row["name"])
+                try:
+                    row_count = await conn.fetchval(f"SELECT COUNT(*) FROM {pg_name}")
+                except Exception:
+                    row_count = 0
+                columns = ensure_list(row["columns"]) if isinstance(row["columns"], str) else row["columns"]
+                items.append(
+                    BrowseItem(
+                        name=row["name"],
+                        path=row["name"],
+                        type="table",
+                        uri=table_uri(vault, row["name"], collection=row.get("collection")),
+                        summary=row["description"],
+                        row_count=row_count,
+                        columns=columns,
+                        sql_name=table_data_repo.pg_short_name(row["name"]),
+                        collection=row.get("collection"),
+                        last_updated=row["created_at"],
+                    )
+                )
+        return items
+
+    async def _browse_legacy_files(
+        self,
+        vault: str,
+        vault_id: uuid.UUID,
+        *,
+        prefix: str,
+        max_depth: int,
+        include_hashes: bool,
+    ) -> list[BrowseItem]:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            rows = await vault_files_repo.list_for_vault(
+                conn,
+                vault_id,
+                max_depth=max_depth,
+                prefix=prefix,
+                limit=10_000,
+            )
+        return [
+            BrowseItem(
+                name=row["name"],
+                path=(
+                    f"{row['collection']}/{row['name']}"
+                    if row.get("collection")
+                    else row["name"]
+                ),
+                type="file",
+                uri=file_uri(vault, str(row["id"]), collection=row.get("collection")),
+                mime_type=row["mime_type"],
+                size_bytes=row["size_bytes"],
+                summary=row["description"],
+                collection=row.get("collection"),
+                last_updated=row["created_at"],
+                content_hash=row.get("content_hash") if include_hashes else None,
+                hash_algorithm=row.get("hash_algorithm") if include_hashes else None,
+                etag=row.get("etag") if include_hashes else None,
+                storage_version=row.get("storage_version") if include_hashes else None,
+                version=(row.get("storage_version") or row.get("etag"))
+                if include_hashes
+                else None,
+            )
+            for row in rows
+        ]
+
+    async def browse(
+        self,
+        vault: str,
+        collection: str | None = None,
+        depth: int = 1,
+        content_type: str = "all",
+        include_hashes: bool = False,
+        include_archived: bool = False,
+    ) -> BrowseResponse:
+        """Return the legacy browse envelope with Native document Heads."""
+        prefix = normalize_collection_path(collection) if collection is not None else ""
+        vault_id = await self._vault_id(vault)
+        show_docs = content_type in ("all", "documents")
+        show_tables = content_type in ("all", "tables")
+        show_files = content_type in ("all", "files")
+
+        items: list[BrowseItem] = []
+        if show_docs:
+            pool = await self._pool()
+            for row in await CollectionRepository(pool).list_by_vault(vault_id):
+                if prefix and not row["path"].startswith(prefix + "/"):
+                    continue
+                items.append(
+                    BrowseItem(
+                        name=row["name"],
+                        path=row["path"],
+                        type="collection",
+                        uri=coll_uri(vault, row["path"]),
+                        summary=row["summary"],
+                        doc_count=row["doc_count"],
+                        last_updated=row["last_updated"],
+                    )
+                )
+            items.extend(
+                await self._browse_native_documents(
+                    vault,
+                    vault_id,
+                    prefix=prefix,
+                    max_depth=depth,
+                    include_hashes=include_hashes,
+                    include_archived=include_archived,
+                )
+            )
+        if show_tables:
+            items.extend(
+                await self._browse_legacy_tables(
+                    vault, vault_id, prefix=prefix, max_depth=depth,
+                )
+            )
+        if show_files:
+            items.extend(
+                await self._browse_legacy_files(
+                    vault,
+                    vault_id,
+                    prefix=prefix,
+                    max_depth=depth,
+                    include_hashes=include_hashes,
+                )
+            )
+
+        browse_path = prefix
+        hint = self._browse_hint(vault, prefix or None, items)
+        return BrowseResponse(vault=vault, path=browse_path, items=items, hint=hint)
 
     async def create_vault(
         self,

--- a/backend/app/services/native_revision_authority.py
+++ b/backend/app/services/native_revision_authority.py
@@ -1,0 +1,508 @@
+"""Crash-safe authority bootstrap and startup validation for PostgreSQL Native."""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+from app.config import Settings, settings
+
+
+AUTHORITY_BACKEND = "postgres_native"
+AUTHORITY_RECORD_KIND = "new_database"
+AUTHORITY_MARKER_KEY = True
+# A single, product-owned PostgreSQL advisory-lock namespace.  Bootstrap uses
+# the session form across init_db(); startup uses the transaction form.
+AUTHORITY_LOCK_KEY = 0x414B42524E415449
+
+_AKB_SENTINEL_TABLES = (
+    "schema_migrations",
+    "users",
+    "vaults",
+    "documents",
+    "native_resources",
+    "native_revisions",
+)
+_AUTHORITY_CONTENT_TABLES = (
+    "vaults",
+    "documents",
+    "vault_files",
+    "vault_tables",
+    "native_resources",
+    "native_revisions",
+    "native_revision_activity",
+    "native_invalidation_intents",
+    "native_revision_migration_runs",
+    "native_revision_migration_items",
+    "legacy_revision_mappings",
+)
+
+Failpoint = Callable[[str], Any]
+
+
+class NativeAuthorityError(RuntimeError):
+    """A Native authority preflight invariant failed."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class NativeAuthorityIdentity:
+    tenant_id: str
+    namespace: str
+    database_id: uuid.UUID
+    current_database: str
+    runtime_image_digest: str
+
+    @classmethod
+    def from_settings(cls, configured: Settings = settings) -> "NativeAuthorityIdentity":
+        if configured.document_revision_database_id is None:
+            raise NativeAuthorityError(
+                "native_authority_config_invalid",
+                "postgres_native requires document_revision_database_id",
+            )
+        return cls(
+            tenant_id=configured.document_revision_tenant_id,
+            namespace=configured.document_revision_namespace,
+            database_id=configured.document_revision_database_id,
+            current_database=configured.db_name,
+            runtime_image_digest=configured.document_revision_runtime_image_digest,
+        )
+
+    def params(self) -> tuple[Any, ...]:
+        return (
+            self.tenant_id,
+            self.namespace,
+            self.database_id,
+            self.current_database,
+            self.runtime_image_digest,
+        )
+
+
+def _binding_matches(row: asyncpg.Record | dict[str, Any], identity: NativeAuthorityIdentity) -> bool:
+    """Match durable deployment identity, excluding the initializing image.
+
+    The first image digest is immutable audit evidence.  A later AKB image may
+    restart the same database without pretending to initialize it again.
+    """
+    return all(
+        row[key] == value
+        for key, value in (
+            ("tenant_id", identity.tenant_id),
+            ("namespace", identity.namespace),
+            ("database_id", identity.database_id),
+            ("current_database", identity.current_database),
+        )
+    )
+
+
+def _initialization_matches(row: asyncpg.Record | dict[str, Any], identity: NativeAuthorityIdentity) -> bool:
+    return _binding_matches(row, identity) and row["runtime_image_digest"] == identity.runtime_image_digest
+
+
+async def _trip(failpoint: Failpoint | None, name: str) -> None:
+    if failpoint is None:
+        return
+    result = failpoint(name)
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _relation_exists(conn: asyncpg.Connection, relation: str) -> bool:
+    return await conn.fetchval("SELECT to_regclass($1) IS NOT NULL", f"public.{relation}")
+
+
+async def _existing_sentinels(conn: asyncpg.Connection) -> list[str]:
+    rows = await conn.fetch(
+        """
+        SELECT tablename
+          FROM pg_tables
+         WHERE schemaname = 'public'
+           AND tablename = ANY($1::text[])
+         ORDER BY tablename
+        """,
+        list(_AKB_SENTINEL_TABLES),
+    )
+    return [row["tablename"] for row in rows]
+
+
+async def _create_claim_table(conn: asyncpg.Connection) -> None:
+    # This is intentionally the only AKB schema object created before init_db.
+    # Migration 061 repeats the identical DDL with IF NOT EXISTS, then adds the
+    # pending/marker tables and mutation guards.
+    await conn.execute(
+        """
+        CREATE TABLE document_revision_bootstrap_claims (
+            claim_key BOOLEAN PRIMARY KEY DEFAULT TRUE,
+            claim_id UUID NOT NULL UNIQUE,
+            record_kind TEXT NOT NULL DEFAULT 'new_database',
+            tenant_id TEXT NOT NULL,
+            namespace TEXT NOT NULL,
+            database_id UUID NOT NULL,
+            current_database TEXT NOT NULL,
+            runtime_image_digest TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'claimed',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            minted_at TIMESTAMPTZ,
+            CONSTRAINT document_revision_bootstrap_claims_singleton_check CHECK (claim_key),
+            CONSTRAINT document_revision_bootstrap_claims_kind_check CHECK (record_kind = 'new_database'),
+            CONSTRAINT document_revision_bootstrap_claims_tenant_check CHECK (btrim(tenant_id) <> ''),
+            CONSTRAINT document_revision_bootstrap_claims_namespace_check CHECK (btrim(namespace) <> ''),
+            CONSTRAINT document_revision_bootstrap_claims_database_check CHECK (btrim(current_database) <> ''),
+            CONSTRAINT document_revision_bootstrap_claims_digest_check
+                CHECK (runtime_image_digest ~ '^sha256:[0-9a-f]{64}$'),
+            CONSTRAINT document_revision_bootstrap_claims_status_check CHECK (status IN ('claimed', 'minted')),
+            CONSTRAINT document_revision_bootstrap_claims_minted_shape CHECK (
+                (status = 'claimed' AND minted_at IS NULL)
+                OR (status = 'minted' AND minted_at IS NOT NULL)
+            )
+        )
+        """
+    )
+
+
+async def mint_new_database_claim(
+    conn: asyncpg.Connection,
+    *,
+    identity: NativeAuthorityIdentity,
+    claim_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Claim a never-initialized AKB database before migrations.
+
+    A matching claim can resume after interruption.  If no claim exists, any
+    AKB sentinel table proves that this is not a new database even when all
+    tenant rows were later deleted.
+    """
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        if await _relation_exists(conn, "document_revision_bootstrap_claims"):
+            rows = await conn.fetch("SELECT * FROM document_revision_bootstrap_claims FOR UPDATE")
+            if not rows:
+                raise NativeAuthorityError(
+                    "native_authority_database_not_new",
+                    "Native bootstrap cannot claim an AKB schema created without a pre-schema claim",
+                )
+            if len(rows) != 1:
+                raise NativeAuthorityError(
+                    "native_authority_claim_corrupt",
+                    "Native bootstrap claim table must contain exactly one singleton record",
+                )
+            existing = rows[0]
+            if (
+                not _initialization_matches(existing, identity)
+                or existing["record_kind"] != AUTHORITY_RECORD_KIND
+                or existing["claim_key"] is not True
+            ):
+                raise NativeAuthorityError(
+                    "native_authority_claim_mismatch",
+                    "Native bootstrap claim identity mismatch or copied-database replay",
+                )
+            return existing["claim_id"]
+
+        sentinels = await _existing_sentinels(conn)
+        if sentinels:
+            raise NativeAuthorityError(
+                "native_authority_database_not_new",
+                "Native bootstrap requires a never-initialized AKB database; "
+                f"found sentinel table(s): {', '.join(sentinels)}",
+            )
+
+        await _create_claim_table(conn)
+        claim_id = claim_id or uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO document_revision_bootstrap_claims (
+                claim_key, claim_id, tenant_id, namespace, database_id,
+                current_database, runtime_image_digest
+            ) VALUES (TRUE, $1, $2, $3, $4, $5, $6)
+            """,
+            claim_id,
+            *identity.params(),
+        )
+        return claim_id
+
+
+async def _content_inventory(conn: asyncpg.Connection) -> dict[str, int]:
+    inventory: dict[str, int] = {}
+    for table in _AUTHORITY_CONTENT_TABLES:
+        inventory[table] = int(await conn.fetchval(f'SELECT COUNT(*) FROM "{table}"'))
+    return inventory
+
+
+def git_authority_is_blank(root: str | Path) -> bool:
+    """Return True when no bare repository below ``root`` contains a ref."""
+    path = Path(root)
+    if not path.exists():
+        return True
+    for bare in path.rglob("*.git"):
+        refs = bare / "refs"
+        if refs.is_dir() and any(candidate.is_file() for candidate in refs.rglob("*")):
+            return False
+        packed_refs = bare / "packed-refs"
+        if packed_refs.is_file():
+            for line in packed_refs.read_text(errors="replace").splitlines():
+                if line and not line.startswith(("#", "^")):
+                    return False
+    return True
+
+
+async def mint_pending_authority(
+    conn: asyncpg.Connection,
+    *,
+    identity: NativeAuthorityIdentity,
+    claim_id: uuid.UUID,
+    git_storage_path: str | Path,
+    authority_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Mint pending authority after migrations and zero-authority checks."""
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        claim = await conn.fetchrow(
+            "SELECT * FROM document_revision_bootstrap_claims WHERE claim_key = TRUE FOR UPDATE"
+        )
+        if claim is None or claim["claim_id"] != claim_id or not _initialization_matches(claim, identity):
+            raise NativeAuthorityError(
+                "native_authority_claim_mismatch",
+                "Native pending authority claim does not match configured identity",
+            )
+
+        existing = await conn.fetchrow(
+            "SELECT * FROM document_revision_authority_pending WHERE claim_id = $1 FOR UPDATE",
+            claim_id,
+        )
+        if claim["status"] == "minted":
+            if existing is None or not _initialization_matches(existing, identity):
+                raise NativeAuthorityError(
+                    "native_authority_claim_corrupt",
+                    "Minted Native claim has no matching pending authority",
+                )
+            return existing["authority_id"]
+        if existing is not None:
+            raise NativeAuthorityError(
+                "native_authority_claim_corrupt",
+                "Claimed Native bootstrap record already has pending authority",
+            )
+
+        if not await _relation_exists(conn, "schema_migrations"):
+            raise NativeAuthorityError(
+                "native_authority_schema_not_initialized",
+                "Native pending authority requires completed AKB migrations",
+            )
+        inventory = await _content_inventory(conn)
+        occupied = {name: count for name, count in inventory.items() if count}
+        if occupied:
+            raise NativeAuthorityError(
+                "native_authority_inventory_not_empty",
+                f"Native pending authority requires zero legacy and Native facts: {occupied}",
+            )
+        if not git_authority_is_blank(git_storage_path):
+            raise NativeAuthorityError(
+                "native_authority_git_not_blank",
+                "Native pending authority requires Git storage with no repository refs",
+            )
+
+        authority_id = authority_id or uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO document_revision_authority_pending (
+                authority_id, claim_id, tenant_id, namespace, database_id,
+                current_database, runtime_image_digest
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            """,
+            authority_id,
+            claim_id,
+            *identity.params(),
+        )
+        await conn.execute(
+            """
+            UPDATE document_revision_bootstrap_claims
+               SET status = 'minted', minted_at = NOW()
+             WHERE claim_key = TRUE AND status = 'claimed'
+            """
+        )
+        return authority_id
+
+
+async def consume_or_validate_native_authority(
+    conn: asyncpg.Connection,
+    *,
+    identity: NativeAuthorityIdentity,
+    failpoint: Failpoint | None = None,
+) -> str:
+    """Consume pending authority or validate the immutable durable marker."""
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        await _trip(failpoint, "after_lock")
+        marker = await conn.fetchrow(
+            "SELECT * FROM document_revision_authority_marker WHERE marker_id = TRUE FOR UPDATE"
+        )
+        if marker is not None:
+            if not _binding_matches(marker, identity) or marker["backend"] != AUTHORITY_BACKEND:
+                raise NativeAuthorityError(
+                    "native_authority_marker_mismatch",
+                    "Native authority marker does not match configured deployment identity",
+                )
+            pending = await conn.fetchrow(
+                "SELECT status FROM document_revision_authority_pending WHERE authority_id = $1",
+                marker["authority_id"],
+            )
+            if pending is None or pending["status"] != "consumed":
+                raise NativeAuthorityError(
+                    "native_authority_marker_incomplete",
+                    "Native authority marker has no consumed pending record",
+                )
+            await _trip(failpoint, "validated_marker")
+            return "validated"
+
+        pending_rows = await conn.fetch(
+            "SELECT * FROM document_revision_authority_pending WHERE status = 'pending' FOR UPDATE"
+        )
+        if len(pending_rows) != 1:
+            raise NativeAuthorityError(
+                "native_authority_missing",
+                "postgres_native requires exactly one pending or initialized authority record",
+            )
+        pending = pending_rows[0]
+        if not _initialization_matches(pending, identity) or pending["backend"] != AUTHORITY_BACKEND:
+            raise NativeAuthorityError(
+                "native_authority_pending_mismatch",
+                "Native pending authority does not match configured tenant/database/image identity",
+            )
+        occupied = {name: count for name, count in (await _content_inventory(conn)).items() if count}
+        if occupied:
+            raise NativeAuthorityError(
+                "native_authority_inventory_not_empty",
+                f"First Native startup requires zero legacy and Native facts: {occupied}",
+            )
+        await _trip(failpoint, "before_marker")
+        await conn.execute(
+            """
+            INSERT INTO document_revision_authority_marker (
+                marker_id, authority_id, claim_id, tenant_id, namespace,
+                database_id, current_database, runtime_image_digest
+            ) VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7)
+            """,
+            pending["authority_id"],
+            pending["claim_id"],
+            *identity.params(),
+        )
+        await _trip(failpoint, "after_marker")
+        await conn.execute(
+            """
+            UPDATE document_revision_authority_pending
+               SET status = 'consumed', consumed_at = NOW()
+             WHERE authority_id = $1 AND status = 'pending'
+            """,
+            pending["authority_id"],
+        )
+        await _trip(failpoint, "after_consumed")
+        return "initialized"
+
+
+async def _reject_native_authority_for_non_product_mode(conn: asyncpg.Connection) -> None:
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        counts = await conn.fetchrow(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM document_revision_bootstrap_claims) AS claims,
+                (SELECT COUNT(*) FROM document_revision_authority_pending) AS pending,
+                (SELECT COUNT(*) FROM document_revision_authority_marker) AS markers
+            """
+        )
+        if any(int(counts[name]) for name in counts.keys()):
+            raise NativeAuthorityError(
+                "native_authority_mode_conflict",
+                "Bare Git and measurement modes reject a database claimed by postgres_native",
+            )
+
+
+async def startup_revision_authority_preflight(
+    configured: Settings = settings,
+    *,
+    failpoint: Failpoint | None = None,
+) -> str:
+    """Validate authority after migrations and before workers or requests."""
+    from app.db.postgres import get_pool
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        if configured.document_revision_backend == "postgres_native":
+            return await consume_or_validate_native_authority(
+                conn,
+                identity=NativeAuthorityIdentity.from_settings(configured),
+                failpoint=failpoint,
+            )
+        await _reject_native_authority_for_non_product_mode(conn)
+        return "not_applicable"
+
+
+async def pre_migration_revision_authority_guard(configured: Settings = settings) -> None:
+    """Reject an invalid mode before ordinary startup is allowed to run DDL."""
+    from app.db.postgres import get_pool
+
+    pool = await get_pool()
+    async with pool.acquire() as conn, conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        claim_table = await _relation_exists(conn, "document_revision_bootstrap_claims")
+        claim_count = (
+            int(await conn.fetchval("SELECT COUNT(*) FROM document_revision_bootstrap_claims"))
+            if claim_table
+            else 0
+        )
+        if configured.document_revision_backend == "postgres_native":
+            if claim_count != 1:
+                raise NativeAuthorityError(
+                    "native_authority_missing",
+                    "postgres_native startup requires a pre-schema bootstrap claim; "
+                    "run initialize-postgres-native before the first backend pod",
+                )
+        elif claim_count:
+            raise NativeAuthorityError(
+                "native_authority_mode_conflict",
+                "Bare Git and measurement modes reject a database claimed by postgres_native",
+            )
+
+
+async def bootstrap_postgres_native(configured: Settings = settings) -> dict[str, str]:
+    """Explicitly initialize a fresh database for stable postgres_native."""
+    if configured.document_revision_backend != "postgres_native":
+        raise NativeAuthorityError(
+            "native_authority_mode_invalid",
+            "initialize-postgres-native requires document_revision_backend=postgres_native",
+        )
+
+    from app.db.postgres import init_db
+
+    identity = NativeAuthorityIdentity.from_settings(configured)
+    conn = await asyncpg.connect(dsn=configured.asyncpg_dsn, command_timeout=30.0)
+    try:
+        await conn.execute("SELECT pg_advisory_lock($1)", AUTHORITY_LOCK_KEY)
+        claim_id = await mint_new_database_claim(conn, identity=identity)
+        await init_db()
+        authority_id = await mint_pending_authority(
+            conn,
+            identity=identity,
+            claim_id=claim_id,
+            git_storage_path=configured.git_storage_path,
+        )
+        return {
+            "status": "pending",
+            "backend": AUTHORITY_BACKEND,
+            "claim_id": str(claim_id),
+            "authority_id": str(authority_id),
+            "database_id": str(identity.database_id),
+        }
+    finally:
+        try:
+            await conn.execute("SELECT pg_advisory_unlock($1)", AUTHORITY_LOCK_KEY)
+        finally:
+            await conn.close()

--- a/backend/app/services/native_revision_authority.py
+++ b/backend/app/services/native_revision_authority.py
@@ -494,8 +494,28 @@ async def bootstrap_postgres_native(configured: Settings = settings) -> dict[str
             claim_id=claim_id,
             git_storage_path=configured.git_storage_path,
         )
+        marker = await conn.fetchrow(
+            "SELECT * FROM document_revision_authority_marker WHERE marker_id = TRUE"
+        )
+        status = "pending"
+        if marker is not None:
+            if not _binding_matches(marker, identity) or marker["backend"] != AUTHORITY_BACKEND:
+                raise NativeAuthorityError(
+                    "native_authority_marker_mismatch",
+                    "Native authority marker does not match configured deployment identity",
+                )
+            pending = await conn.fetchrow(
+                "SELECT status FROM document_revision_authority_pending WHERE authority_id = $1",
+                marker["authority_id"],
+            )
+            if pending is None or pending["status"] != "consumed":
+                raise NativeAuthorityError(
+                    "native_authority_marker_incomplete",
+                    "Native authority marker has no consumed pending record",
+                )
+            status = "initialized"
         return {
-            "status": "pending",
+            "status": status,
             "backend": AUTHORITY_BACKEND,
             "claim_id": str(claim_id),
             "authority_id": str(authority_id),

--- a/backend/app/services/revision_backend.py
+++ b/backend/app/services/revision_backend.py
@@ -1,9 +1,9 @@
 """Process-scoped selection of the document revision implementation.
 
-The legacy bare-Git document service remains the default. M1's native ledger
-path is measurement-only and must be registered by its implementation work.
-Selection happens once here, at a composition root, never from request or
-vault data.
+The stable bare-Git document service remains the default. Native is an
+explicit process-scoped choice, while the historical M1 selector remains a
+guarded compatibility path. Selection happens once at a composition root,
+never from request or vault data.
 """
 
 from __future__ import annotations
@@ -167,6 +167,19 @@ _selected_backend: str | None = None
 _native_revision_backend_factory: RevisionBackendFactory | None = None
 
 
+def canonical_document_revision_backend(backend: str) -> str:
+    """Return the public canonical name for a configured selector."""
+    if backend in {"bare_git", "bare_git_current"}:
+        return "bare_git"
+    if backend == "postgres_native":
+        return "postgres_native"
+    if backend == "native_ledger_m1":
+        # Diagnostics expose only the stable implementation family.  The raw
+        # measurement selector remains visible in configuration and receipts.
+        return "postgres_native"
+    raise RuntimeError(f"unsupported document revision backend: {backend!r}")
+
+
 def register_native_revision_backend(factory: RevisionBackendFactory) -> None:
     """Register the native facade before the process selects a backend.
 
@@ -203,7 +216,7 @@ def get_revision_backend() -> RevisionBackend:
 
         backend = settings.document_revision_backend
         revision_backend: RevisionBackend
-        if backend == "bare_git_current":
+        if backend in {"bare_git", "bare_git_current"}:
             revision_backend = LegacyRevisionBackend()
         elif backend == "native_ledger_m1":
             _assert_native_measurement_safety()
@@ -224,11 +237,24 @@ def get_revision_backend() -> RevisionBackend:
             native_factory = _native_revision_backend_factory
             assert native_factory is not None
             revision_backend = native_factory()
+        elif backend == "postgres_native":
+            if _native_revision_backend_factory is None:
+                from app.services.native_revision_backend import (
+                    native_revision_backend_factory,
+                )
+
+                _native_revision_backend_factory = cast(
+                    RevisionBackendFactory,
+                    native_revision_backend_factory,
+                )
+            native_factory = _native_revision_backend_factory
+            assert native_factory is not None
+            revision_backend = native_factory()
         else:  # Settings validates this, but fail closed for in-process mutation.
             raise RuntimeError(f"unsupported document revision backend: {backend!r}")
 
         _revision_backend = revision_backend
-        _selected_backend = backend
+        _selected_backend = canonical_document_revision_backend(backend)
         return revision_backend
 
 

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1126,7 +1126,8 @@ class SearchService:
             or document_source != NATIVE_DOCUMENT_SOURCE
         ):
             raise ValidationError(
-                "measurement_include_text_files requires the legacy native measurement selector"
+                "measurement_include_text_files requires the guarded native measurement "
+                "backend (native_ledger_m1)"
             )
         if document_source == NATIVE_DOCUMENT_SOURCE:
             from app.services.m1_native_grep_service import M1NativeGrepService

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -52,8 +52,14 @@ def active_document_source_type(
     database: str,
 ) -> str:
     """Select one Document authority; fail closed on a partial native guard."""
-    if backend == "bare_git_current":
+    if backend in {"bare_git", "bare_git_current"}:
         return LEGACY_DOCUMENT_SOURCE
+    if backend == "postgres_native":
+        if measurement_only:
+            raise RuntimeError("postgres_native rejects the measurement-only guard")
+        if database == NATIVE_MEASUREMENT_DATABASE:
+            raise RuntimeError("postgres_native rejects the reserved measurement database")
+        return NATIVE_DOCUMENT_SOURCE
     if backend != "native_ledger_m1":
         raise RuntimeError(f"unsupported document revision backend: {backend}")
     if not measurement_only:
@@ -1115,9 +1121,12 @@ class SearchService:
         limit = clamp_search_limit(limit)
 
         document_source = _configured_document_source_type()
-        if measurement_include_text_files and document_source != NATIVE_DOCUMENT_SOURCE:
+        if measurement_include_text_files and (
+            settings.document_revision_backend != "native_ledger_m1"
+            or document_source != NATIVE_DOCUMENT_SOURCE
+        ):
             raise ValidationError(
-                "measurement_include_text_files requires the guarded native measurement backend"
+                "measurement_include_text_files requires the legacy native measurement selector"
             )
         if document_source == NATIVE_DOCUMENT_SOURCE:
             from app.services.m1_native_grep_service import M1NativeGrepService

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -31,7 +31,6 @@ from app.services.m1_pg_body_store import M1PgBodyStore, PgBodyIntegrityError
 from app.services.m1_reference_payload_store import M1ReferencePayloadStore
 from app.services.native_document_service import (
     NativeDocumentService,
-    NativeRevisionUnsupportedSurfaceError,
 )
 from app.services.native_derived_worker import NativeDerivedWorker
 from app.services.native_revision_backend import NativeRevisionBackend
@@ -2913,8 +2912,99 @@ async def test_full_native_document_lifecycle_preserves_compatibility_without_gi
                 == 0
             )
 
-        with pytest.raises(NativeRevisionUnsupportedSurfaceError):
-            await document_service.browse(vault)
+        browsed = await document_service.browse(
+            vault,
+            collection="archive",
+            depth=0,
+            include_hashes=True,
+        )
+        assert browsed.path == "archive"
+        assert [(item.type, item.path) for item in browsed.items] == [
+            ("document", recreated.path),
+        ]
+        assert browsed.items[0].current_commit == recreated.commit_hash
+        assert browsed.items[0].content_hash
+
+
+async def test_native_browse_uses_native_heads_for_collection_root_and_depth():
+    async with _fresh_database() as (pool, vault_id):
+        async with pool.acquire() as conn:
+            vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
+            await conn.execute(
+                """
+                INSERT INTO collections (vault_id, path, name)
+                VALUES ($1, 'guides', 'guides'), ($1, 'guides/nested', 'nested')
+                """,
+                vault_id,
+            )
+
+        service = NativeDocumentService(pool=pool)
+        await service.put(
+            DocumentPutRequest(
+                vault=vault, collection="", slug="root", title="Root", content="root"
+            ),
+            agent_id="browse-writer",
+        )
+        await service.put(
+            DocumentPutRequest(
+                vault=vault, collection="guides", slug="direct", title="Direct", content="direct"
+            ),
+            agent_id="browse-writer",
+        )
+        await service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="guides/nested",
+                slug="deep",
+                title="Deep",
+                content="deep",
+            ),
+            agent_id="browse-writer",
+        )
+        await service.put(
+            DocumentPutRequest(
+                vault=vault,
+                collection="guides/nested",
+                slug="archived",
+                title="Archived",
+                content="archived",
+                status="archived",
+            ),
+            agent_id="browse-writer",
+        )
+
+        root = await service.browse(vault, depth=0)
+        assert {item.path for item in root.items if item.type == "document"} == {"root.md"}
+        assert {item.path for item in root.items if item.type == "collection"} == {
+            "guides",
+            "guides/nested",
+        }
+
+        collection_root = await service.browse(vault, collection="guides", depth=0)
+        assert {item.path for item in collection_root.items if item.type == "document"} == {
+            "guides/direct.md",
+        }
+        assert {item.path for item in collection_root.items if item.type == "collection"} == {
+            "guides/nested",
+        }
+
+        subtree = await service.browse(vault, collection="guides", depth=-1)
+        assert {item.path for item in subtree.items if item.type == "document"} == {
+            "guides/direct.md",
+            "guides/nested/deep.md",
+        }
+
+        archived = await service.browse(
+            vault,
+            collection="guides",
+            depth=-1,
+            include_archived=True,
+        )
+        assert {item.path for item in archived.items if item.type == "document"} == {
+            "guides/direct.md",
+            "guides/nested/deep.md",
+            "guides/nested/archived.md",
+        }
 
 
 async def test_vault_activity_and_recent_changes_are_scoped_to_the_document_surface():

--- a/backend/tests/test_document_move_routes_unit.py
+++ b/backend/tests/test_document_move_routes_unit.py
@@ -1,0 +1,73 @@
+"""REST move route and process-selected document-service boundary tests."""
+
+from __future__ import annotations
+
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-document-move-route-")
+
+from app.api.deps import get_current_user  # noqa: E402
+from app.api.routes import documents  # noqa: E402
+from app.models.document import DocumentPutResponse  # noqa: E402
+
+
+class _User:
+    user_id = "move-route-user"
+    username = "move-route-agent"
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(documents.router, prefix="/api/v1")
+    app.dependency_overrides[get_current_user] = lambda: _User()
+    return app
+
+
+def test_post_move_route_gates_writer_and_preserves_greedy_document_path(monkeypatch):
+    access_calls: list[tuple[str, str, str]] = []
+    move_calls: list[tuple[str, str, dict]] = []
+
+    async def _check_vault_access(user_id: str, vault: str, *, required_role: str):
+        access_calls.append((user_id, vault, required_role))
+
+    async def _move(vault: str, doc_ref: str, **kwargs):
+        move_calls.append((vault, doc_ref, kwargs))
+        return DocumentPutResponse(
+            uri=f"akb://{vault}/coll/archive/doc/moved.md",
+            vault=vault,
+            path="archive/moved.md",
+            commit_hash="a" * 40,
+            current_commit="a" * 40,
+            action="moved",
+            chunks_indexed=0,
+            entities_found=0,
+        )
+
+    monkeypatch.setattr(documents, "check_vault_access", _check_vault_access)
+    monkeypatch.setattr(documents.doc_service, "move", _move)
+
+    response = TestClient(_app()).post(
+        "/api/v1/documents/reef/guides/deep/source.md/move",
+        json={"collection": "archive", "slug": "moved", "message": "archive it"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["action"] == "moved"
+    assert access_calls == [("move-route-user", "reef", "writer")]
+    assert move_calls == [
+        (
+            "reef",
+            "guides/deep/source.md",
+            {
+                "collection": "archive",
+                "slug": "moved",
+                "message": "archive it",
+                "agent_id": "move-route-agent",
+            },
+        )
+    ]

--- a/backend/tests/test_native_revision_authority_postgres.py
+++ b/backend/tests/test_native_revision_authority_postgres.py
@@ -97,6 +97,11 @@ async def test_bootstrap_consume_restart_and_immutable_marker(tmp_path, monkeypa
             identity = NativeAuthorityIdentity.from_settings(configured)
             assert await consume_or_validate_native_authority(conn, identity=identity) == "initialized"
 
+            rerun = await bootstrap_postgres_native(configured)
+            assert rerun["status"] == "initialized"
+            assert rerun["claim_id"] == report["claim_id"]
+            assert rerun["authority_id"] == report["authority_id"]
+
             counts = await conn.fetchrow(
                 """
                 SELECT

--- a/backend/tests/test_native_revision_authority_postgres.py
+++ b/backend/tests/test_native_revision_authority_postgres.py
@@ -1,0 +1,205 @@
+"""Real-PostgreSQL proof for the stable Native authority state machine."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from urllib.parse import unquote, urlsplit
+
+import asyncpg
+import pytest
+
+from app.config import Settings
+from app.db import postgres
+from app.services.native_revision_authority import (
+    NativeAuthorityError,
+    NativeAuthorityIdentity,
+    bootstrap_postgres_native,
+    consume_or_validate_native_authority,
+    mint_new_database_claim,
+    pre_migration_revision_authority_guard,
+    startup_revision_authority_preflight,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_ADMIN_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_IMAGE = "sha256:" + "a" * 64
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_ADMIN_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _ADMIN_DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _settings(name: str, git_root, *, backend: str = "postgres_native") -> Settings:
+    parsed = urlsplit(_ADMIN_DSN)
+    values = {
+        "db_host": parsed.hostname or "localhost",
+        "db_port": parsed.port or 5432,
+        "db_name": name,
+        "db_user": unquote(parsed.username or "akb"),
+        "db_password": unquote(parsed.password or ""),
+        "git_storage_path": str(git_root),
+        "document_revision_backend": backend,
+    }
+    if backend == "postgres_native":
+        values.update(
+            document_revision_tenant_id="tenant-authority-proof",
+            document_revision_namespace="tenant-authority-proof",
+            document_revision_database_id=uuid.uuid4(),
+            document_revision_runtime_image_digest=_IMAGE,
+        )
+    return Settings(**values)
+
+
+@asynccontextmanager
+async def _fresh_database(tmp_path, monkeypatch, *, backend: str = "postgres_native"):
+    if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"Required PostgreSQL is not reachable at {_ADMIN_DSN}")
+        pytest.skip(f"PostgreSQL is not reachable at {_ADMIN_DSN}")
+    admin = await asyncpg.connect(_ADMIN_DSN)
+    name = f"akb_native_authority_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    configured = _settings(name, tmp_path / "git", backend=backend)
+    monkeypatch.setattr(postgres, "settings", configured)
+    await postgres.close_pool()
+    try:
+        yield configured, _database_dsn(name)
+    finally:
+        await postgres.close_pool()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def test_bootstrap_consume_restart_and_immutable_marker(tmp_path, monkeypatch):
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        report = await bootstrap_postgres_native(configured)
+        assert report["status"] == "pending"
+
+        conn = await asyncpg.connect(dsn)
+        try:
+            identity = NativeAuthorityIdentity.from_settings(configured)
+            assert await consume_or_validate_native_authority(conn, identity=identity) == "initialized"
+
+            counts = await conn.fetchrow(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM document_revision_bootstrap_claims) AS claims,
+                    (SELECT COUNT(*) FROM document_revision_authority_pending WHERE status = 'consumed') AS consumed,
+                    (SELECT COUNT(*) FROM document_revision_authority_marker) AS markers
+                """
+            )
+            assert tuple(counts.values()) == (1, 1, 1)
+
+            upgraded = replace(identity, runtime_image_digest="sha256:" + "b" * 64)
+            assert await consume_or_validate_native_authority(conn, identity=upgraded) == "validated"
+
+            with pytest.raises(asyncpg.RaiseError, match="cannot be deleted"):
+                await conn.execute("DELETE FROM document_revision_authority_marker")
+        finally:
+            await conn.close()
+
+
+async def test_failpoint_rolls_back_to_reusable_pending_authority(tmp_path, monkeypatch):
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        await bootstrap_postgres_native(configured)
+        conn = await asyncpg.connect(dsn)
+        identity = NativeAuthorityIdentity.from_settings(configured)
+
+        def failpoint(name: str) -> None:
+            if name == "after_marker":
+                raise RuntimeError("injected startup crash")
+
+        try:
+            with pytest.raises(RuntimeError, match="injected startup crash"):
+                await consume_or_validate_native_authority(
+                    conn,
+                    identity=identity,
+                    failpoint=failpoint,
+                )
+            assert await conn.fetchval("SELECT COUNT(*) FROM document_revision_authority_marker") == 0
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM document_revision_authority_pending WHERE status = 'pending'"
+                )
+                == 1
+            )
+            assert await consume_or_validate_native_authority(conn, identity=identity) == "initialized"
+        finally:
+            await conn.close()
+
+
+async def test_rejects_old_empty_schema_mismatch_and_bare_git_reuse(tmp_path, monkeypatch):
+    async with _fresh_database(tmp_path, monkeypatch, backend="bare_git") as (legacy, dsn):
+        await postgres.init_db()
+        native = _settings(legacy.db_name, legacy.git_storage_path)
+        conn = await asyncpg.connect(dsn)
+        try:
+            with pytest.raises(NativeAuthorityError) as rejected:
+                await mint_new_database_claim(
+                    conn,
+                    identity=NativeAuthorityIdentity.from_settings(native),
+                )
+            assert rejected.value.code == "native_authority_database_not_new"
+        finally:
+            await conn.close()
+
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        await bootstrap_postgres_native(configured)
+        conn = await asyncpg.connect(dsn)
+        try:
+            identity = NativeAuthorityIdentity.from_settings(configured)
+            mismatched = replace(identity, tenant_id="another-tenant")
+            with pytest.raises(NativeAuthorityError) as rejected:
+                await consume_or_validate_native_authority(conn, identity=mismatched)
+            assert rejected.value.code == "native_authority_pending_mismatch"
+        finally:
+            await conn.close()
+
+        bare = configured.model_copy(
+            update={
+                "document_revision_backend": "bare_git",
+                "document_revision_tenant_id": "",
+                "document_revision_namespace": "",
+                "document_revision_database_id": None,
+                "document_revision_runtime_image_digest": "",
+            }
+        )
+        with pytest.raises(NativeAuthorityError) as conflict:
+            await startup_revision_authority_preflight(bare)
+        assert conflict.value.code == "native_authority_mode_conflict"
+
+
+async def test_missing_claim_fails_before_ordinary_startup_creates_schema(tmp_path, monkeypatch):
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        with pytest.raises(NativeAuthorityError) as missing:
+            await pre_migration_revision_authority_guard(configured)
+        assert missing.value.code == "native_authority_missing"
+
+        conn = await asyncpg.connect(dsn)
+        try:
+            assert await conn.fetchval("SELECT to_regclass('public.schema_migrations')") is None
+            assert (
+                await conn.fetchval(
+                    "SELECT to_regclass('public.document_revision_bootstrap_claims')"
+                )
+                is None
+            )
+        finally:
+            await conn.close()

--- a/backend/tests/test_native_revision_r0_r1_unit.py
+++ b/backend/tests/test_native_revision_r0_r1_unit.py
@@ -89,6 +89,7 @@ def test_native_selector_constructs_the_native_facade_without_git(monkeypatch, t
     selected = revision_backend.get_revision_backend()
 
     assert isinstance(selected.document_service, NativeDocumentService)
+    assert selected.document_service.move.__func__ is NativeDocumentService.move
     assert revision_backend.selected_document_revision_backend() == "postgres_native"
 
 
@@ -113,6 +114,7 @@ def test_legacy_default_alias_still_builds_the_bare_git_service(monkeypatch, tmp
     selected = revision_backend.get_revision_backend()
 
     assert isinstance(selected.document_service, DocumentService)
+    assert selected.document_service.move.__func__ is DocumentService.move
     assert revision_backend.selected_document_revision_backend() == "bare_git"
 
 

--- a/backend/tests/test_native_revision_r0_r1_unit.py
+++ b/backend/tests/test_native_revision_r0_r1_unit.py
@@ -1,0 +1,132 @@
+"""R0/R1 stable selector and authority-configuration contract tests."""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+import pytest
+
+from app.config import NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME, Settings
+from app.services.document_service import DocumentService
+
+
+_DATABASE_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
+_IMAGE_DIGEST = "sha256:" + "a" * 64
+
+
+def _native_settings(tmp_path, **overrides) -> Settings:
+    values = {
+        "git_storage_path": str(tmp_path),
+        "document_revision_backend": "postgres_native",
+        "document_revision_tenant_id": "tenant-001",
+        "document_revision_namespace": "tenant-001",
+        "document_revision_database_id": _DATABASE_ID,
+        "document_revision_runtime_image_digest": _IMAGE_DIGEST,
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def test_omitted_selector_defaults_to_stable_bare_git(tmp_path):
+    from app.services.revision_backend import canonical_document_revision_backend
+
+    configured = Settings(git_storage_path=str(tmp_path))
+
+    assert configured.document_revision_backend == "bare_git"
+    assert canonical_document_revision_backend(configured.document_revision_backend) == "bare_git"
+
+
+@pytest.mark.parametrize(
+    ("selector", "canonical"),
+    [
+        ("bare_git", "bare_git"),
+        ("bare_git_current", "bare_git"),
+        ("postgres_native", "postgres_native"),
+        ("native_ledger_m1", "postgres_native"),
+    ],
+)
+def test_stable_selectors_and_legacy_bare_alias_have_canonical_names(selector, canonical):
+    from app.services.revision_backend import canonical_document_revision_backend
+
+    assert canonical_document_revision_backend(selector) == canonical
+
+
+def test_native_selector_requires_frozen_bootstrap_identity(tmp_path):
+    with pytest.raises(ValueError, match="document_revision_tenant_id"):
+        Settings(
+            git_storage_path=str(tmp_path),
+            document_revision_backend="postgres_native",
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"db_name": NATIVE_REVISION_M1_MEASUREMENT_DATABASE_NAME},
+        {"native_revision_m1_measurement_only": True},
+        {"native_revision_m1_file_driver": "fscas"},
+    ],
+)
+def test_native_selector_rejects_reserved_measurement_configuration(tmp_path, overrides):
+    with pytest.raises(ValueError, match="postgres_native"):
+        _native_settings(tmp_path, **overrides)
+
+
+def test_native_selector_constructs_the_native_facade_without_git(monkeypatch, tmp_path):
+    from app.services import git_service, revision_backend
+    from app.services.native_document_service import NativeDocumentService
+
+    configured = _native_settings(tmp_path)
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    monkeypatch.setattr(git_service, "settings", configured)
+
+    def fail_if_constructed(*_args, **_kwargs):
+        raise AssertionError("postgres_native composition must not construct GitService")
+
+    monkeypatch.setattr(revision_backend, "GitService", fail_if_constructed)
+
+    selected = revision_backend.get_revision_backend()
+
+    assert isinstance(selected.document_service, NativeDocumentService)
+    assert revision_backend.selected_document_revision_backend() == "postgres_native"
+
+
+def test_legacy_native_measurement_alias_remains_guarded(tmp_path):
+    with pytest.raises(ValueError, match="native_revision_m1_measurement_only"):
+        Settings(
+            git_storage_path=str(tmp_path),
+            document_revision_backend="native_ledger_m1",
+        )
+
+
+def test_legacy_default_alias_still_builds_the_bare_git_service(monkeypatch, tmp_path):
+    from app.services import git_service, revision_backend
+
+    configured = Settings(
+        git_storage_path=str(tmp_path),
+        document_revision_backend="bare_git_current",
+    )
+    monkeypatch.setattr(revision_backend, "settings", configured)
+    monkeypatch.setattr(git_service, "settings", configured)
+
+    selected = revision_backend.get_revision_backend()
+
+    assert isinstance(selected.document_service, DocumentService)
+    assert revision_backend.selected_document_revision_backend() == "bare_git"
+
+
+@pytest.fixture(autouse=True)
+def reset_revision_selection():
+    from app.services import revision_backend
+
+    revision_backend.reset_document_service_for_tests()
+    yield
+    revision_backend.reset_document_service_for_tests()
+    for module in (
+        "app.main",
+        "app.api.routes.activity",
+        "app.api.routes.documents",
+        "mcp_server.server",
+    ):
+        sys.modules.pop(module, None)

--- a/backend/tests/test_revision_backend_factory_unit.py
+++ b/backend/tests/test_revision_backend_factory_unit.py
@@ -50,7 +50,7 @@ def test_default_backend_is_legacy_document_service_once_per_process(monkeypatch
 
     assert isinstance(first, DocumentService)
     assert second is first
-    assert revision_backend.selected_document_revision_backend() == "bare_git_current"
+    assert revision_backend.selected_document_revision_backend() == "bare_git"
 
 
 def test_native_backend_requires_explicit_measurement_opt_in(tmp_path):
@@ -95,7 +95,7 @@ def test_native_backend_uses_registered_factory_once(monkeypatch, tmp_path):
     assert revision_backend.get_document_service() is native_service
     assert revision_backend.get_revision_backend() is native_backend
     assert factory_calls == 1
-    assert revision_backend.selected_document_revision_backend() == "native_ledger_m1"
+    assert revision_backend.selected_document_revision_backend() == "postgres_native"
 
 
 def test_native_backend_lazily_registers_real_facade_without_git(monkeypatch, tmp_path):

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -18,13 +18,21 @@ db_user: akb
 git_storage_path: /data/vaults
 
 # === Document revision backend ===
-# Default keeps the existing bare-Git implementation. native_ledger_m1 is
-# measurement-only: it requires native_revision_m1_measurement_only: true and
-# the exact dedicated database name below. Its native service must also be
-# registered before startup, so it cannot silently affect normal deployments.
-document_revision_backend: bare_git_current  # bare_git_current | native_ledger_m1
+# The stable choices are bare_git (default) and postgres_native. The Native
+# choice is only valid after an operator runs `python -m app.cli
+# initialize-postgres-native` against a never-used AKB database. It does not
+# convert an existing Bare Git tenant. The deployment must supply a stable
+# tenant/namespace identity, a provisioned database UUID, and this image's OCI
+# digest. `bare_git_current` remains an alias. `native_ledger_m1` remains a
+# deprecated, dedicated-database measurement alias for historical receipts.
+document_revision_backend: bare_git  # bare_git | postgres_native
+# document_revision_tenant_id: tenant-example
+# document_revision_namespace: tenant-example
+# document_revision_database_id: 11111111-1111-4111-8111-111111111111
+# document_revision_runtime_image_digest: sha256:<64 lowercase hex>
 native_revision_m1_measurement_only: false
-# Isolated M1 measurement runs must also set: db_name: akb_revision_m1_measurement
+# Historical M1 runs also set document_revision_backend: native_ledger_m1,
+# native_revision_m1_measurement_only: true, and db_name: akb_revision_m1_measurement.
 
 # === External-git mirror — network timeouts (seconds) ===
 external_git_lsremote_timeout: 30

--- a/docs/design/accepted/2026-08-12-postgres-native-revision-backend/README.md
+++ b/docs/design/accepted/2026-08-12-postgres-native-revision-backend/README.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+stage: applied
+created: 2026-08-12
+updated: 2026-08-12
+---
+
+# PostgreSQL Native Document Revision Backend
+
+## Decision
+
+AKB exposes two stable, process-scoped document revision backends:
+
+```yaml
+document_revision_backend: bare_git       # default
+# document_revision_backend: postgres_native
+```
+
+Both implementations ship in the same backend image and preserve the public
+AKB Document logical-revision contract. The unit of compatibility is an AKB
+revision—not a Git commit or object graph. Public history, historical get,
+message/actor/time/parent metadata, stable selectors, activity, and
+create/update/move/delete/recreate diffs remain available through REST and MCP.
+Diffs promise stable unified content and correct additions/removals; raw Git
+header byte identity is not part of the contract.
+
+`bare_git_current` remains a deprecated alias for `bare_git`.
+`native_ledger_m1` remains a guarded measurement alias, requiring its existing
+measurement flag and dedicated database name. New deployments must not render
+either old name.
+
+## Authority boundary
+
+Choosing `postgres_native` in configuration does not convert a tenant. A new
+Native deployment requires an explicit operator command before first startup:
+
+```text
+python -m app.cli initialize-postgres-native
+```
+
+The command is valid only for a database that has never contained an AKB
+schema. Before migrations it creates one singleton bootstrap claim bound to:
+
+- tenant identity;
+- deployment namespace;
+- provisioned database UUID and current database name;
+- initializing OCI image digest.
+
+The operation holds a PostgreSQL advisory lock across schema initialization,
+verifies zero Legacy and Native authority facts and no Git refs, then creates a
+single pending authority record. First backend startup consumes that record and
+creates the immutable durable marker in one transaction. An interrupted
+transaction leaves either reusable pending authority or the completed marker,
+never an authority gap. Later image versions validate the durable tenant and
+database binding; the original image digest remains audit evidence.
+
+An old-but-empty database is ineligible because its AKB sentinel schema exists
+without the pre-schema claim. Bare Git startup also rejects a database carrying
+any stable Native claim, pending record, or marker. A copied database presented
+with a different tenant, namespace, or database UUID is rejected. Detecting an
+identical-identity snapshot rollback requires an external provisioning attestor
+and is outside this backend contract.
+
+## Scope and non-goals
+
+- Bare Git remains the default.
+- Selection is immutable for the backend process; there is no request- or
+  Vault-level split and no dual canonical write.
+- Existing-tenant activation requires a later, separately approved fenced
+  migration record. This implementation mints only `new_database` authority.
+- No fleet default, tenant cutover, Bare Git retirement, or production-readiness
+  claim is implied by the selector.


### PR DESCRIPTION
## Summary
- add stable bare_git and postgres_native process selectors while keeping Bare Git as the default
- require an explicit pre-schema, tenant/database/image-bound bootstrap before PostgreSQL Native can start
- atomically consume pending authority into an immutable durable marker and expose the canonical mode in readiness
- retain guarded historical selector aliases and the existing Native service implementation

## Safety boundary
- configuration alone cannot convert an existing or old-but-empty AKB database
- no existing tenant activation, dual write, Native default, or Bare Git removal is included
- an existing-tenant transition still requires a later separately approved fenced activation record

## Verification
- 266 Native/P2 regression tests passed against real PostgreSQL
- 4 new authority state-machine tests passed against real PostgreSQL
- repo-native full check passed: ruff, mypy, bandit, frontend lint/type/tests, SDK build/type/tests/drift/packed proof, secret scan

Exact reviewed candidate: fa3298cf2fbdfd1ebb09aaf3eb646d4d1a1a29d5