### PR TITLE
fix: preserve logical revisions across backend moves

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3375
+        "line_number": 3378
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T03:54:25Z"
+  "generated_at": "2026-08-12T04:12:15Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3368
+        "line_number": 3375
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T02:08:30Z"
+  "generated_at": "2026-08-12T03:54:25Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -18,6 +18,13 @@ turns that record into an immutable durable marker. Existing or merely empty
 legacy databases are rejected, and no existing tenant is converted by config.
 Readiness reports the canonical selected backend.
 
+Public logical-revision reads now preserve the existing 7–40 character
+selector contract in PostgreSQL Native mode: short selectors resolve only
+when unique within the addressed Document, while unknown, cross-Document, and
+ambiguous selectors fail explicitly. Bare Git historical get, history, and
+diff also follow a Document across a move when addressed through its current
+URI, without changing the default backend or external-mirror history path.
+
 ### Fixed scoped grep replacement completeness and recovery
 
 `akb_grep(replace=...)` now treats `limit` only as a response-preview bound and

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -24,6 +24,9 @@ when unique within the addressed Document, while unknown, cross-Document, and
 ambiguous selectors fail explicitly. Bare Git historical get, history, and
 diff also follow a Document across a move when addressed through its current
 URI, without changing the default backend or external-mirror history path.
+The manual-vault rename lookup streams only through the requested revision and
+fails explicitly at bounded entry, output, or time limits instead of
+materializing an unbounded Git history.
 
 ### Fixed scoped grep replacement completeness and recovery
 

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -26,6 +26,14 @@ class NativeResourceReferenceAmbiguousError(ConflictError):
         self.code = "native_resource_reference_ambiguous"
 
 
+class NativeRevisionSelectorAmbiguousError(ConflictError):
+    """A revision selector names more than one Revision on one Resource."""
+
+    def __init__(self, selector: str):
+        super().__init__(f"Native Revision selector is ambiguous: {selector}")
+        self.code = "native_revision_selector_ambiguous"
+
+
 class PreparedPayload(Protocol):
     @property
     def payload_id(self) -> uuid.UUID: ...
@@ -663,7 +671,13 @@ class NativeRevisionRepository:
         revision_id: str,
         conn: asyncpg.Connection | None = None,
     ) -> dict | None:
-        sql = """
+        if len(revision_id) == 40 and all(ch in "0123456789abcdef" for ch in revision_id):
+            selector_sql = "rv.revision_id = $2"
+        elif 7 <= len(revision_id) < 40 and all(ch in "0123456789abcdef" for ch in revision_id):
+            selector_sql = "rv.revision_id LIKE $2 || '%'"
+        else:
+            return None
+        sql = f"""
             SELECT rv.*, rs.surface, rs.content_profile,
                    rs.created_at AS resource_created_at,
                    rs.updated_at AS resource_updated_at,
@@ -674,14 +688,17 @@ class NativeRevisionRepository:
               JOIN native_resources rs ON rs.resource_id = rv.resource_id
               LEFT JOIN native_payload_manifests pm
                 ON pm.payload_manifest_id = rv.payload_manifest_id
-             WHERE rv.resource_id = $1 AND rv.revision_id = $2
+             WHERE rv.resource_id = $1 AND {selector_sql}
+             LIMIT 2
         """
         if conn is not None:
-            row = await conn.fetchrow(sql, resource_id, revision_id)
+            rows = await conn.fetch(sql, resource_id, revision_id)
         else:
             async with self.pool.acquire() as acquired:
-                row = await acquired.fetchrow(sql, resource_id, revision_id)
-        return dict(row) if row is not None else None
+                rows = await acquired.fetch(sql, resource_id, revision_id)
+        if len(rows) > 1:
+            raise NativeRevisionSelectorAmbiguousError(revision_id)
+        return dict(rows[0]) if rows else None
 
     async def list_history(
         self,

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -9,6 +9,7 @@ from typing import Protocol
 import asyncpg
 
 from app.exceptions import ConflictError
+from app.util.errors import NATIVE_REVISION_SELECTOR_AMBIGUOUS
 
 
 class NativeRevisionIdCollisionError(ConflictError):
@@ -31,7 +32,7 @@ class NativeRevisionSelectorAmbiguousError(ConflictError):
 
     def __init__(self, selector: str):
         super().__init__(f"Native Revision selector is ambiguous: {selector}")
-        self.code = "native_revision_selector_ambiguous"
+        self.code = NATIVE_REVISION_SELECTOR_AMBIGUOUS
 
 
 class PreparedPayload(Protocol):

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 import logging
 import os
 import re
+import selectors
 import shutil
 import stat
+import subprocess
 import threading
 import time
 import uuid
@@ -78,6 +80,18 @@ _OUTPUT_MARGIN_BYTES = 64 * 1024
 # The per-image size checks refuse genuinely oversized content up front; this
 # streaming cap stays the backstop for a pathological many-hunk patch.
 _DIFF_OUTPUT_FACTOR = 4
+
+# ``path_at_revision`` only needs the prefix of a path-following walk through
+# the requested target.  Keep the prefix itself bounded as a backstop for a
+# target that is not in the path's history, and stream the command so a large
+# suffix is never materialized.  The timeout reuses the existing configured Git
+# command bound (the same setting used by the write lane); the entry/output
+# limits are code-owned safety floors because this internal lookup has no user
+# supplied page size.
+_PATH_AT_REVISION_MAX_ENTRIES = 10_000
+_PATH_AT_REVISION_MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+_PATH_AT_REVISION_READ_CHUNK_BYTES = 64 * 1024
+_PATH_AT_REVISION_DEFAULT_TIMEOUT_SECS = 30.0
 
 
 def _marker_state(marker: Path) -> str:
@@ -174,6 +188,34 @@ class ExternalGitOversizedError(AKBError):
 
 class FixedRefHistoryError(RuntimeError):
     """A manual-vault fixed-ref history read could not be completed."""
+
+
+class GitHistoryBoundError(AKBError, RuntimeError):
+    """A bounded manual-vault history lookup could not finish safely.
+
+    Unlike an unknown commit/path (which keeps the historical ``None`` result),
+    hitting a resource bound is explicit so callers cannot mistake a truncated
+    walk for a missing historical file.  The class is also a ``RuntimeError``
+    for legacy service callers that already classify Git history failures that
+    way, while ``AKBError`` gives public reads the normal error envelope.
+    """
+
+    def __init__(self, bound: str, limit: int | float):
+        if bound == "timeout":
+            message = f"git path history timed out after {limit:g}s"
+            status_code = 503
+            code = "git_history_timeout"
+        elif bound == "output":
+            message = f"git path history exceeded the {limit}-byte output cap"
+            status_code = 413
+            code = "git_history_output_capped"
+        else:
+            message = f"git path history exceeded the {limit}-entry cap"
+            status_code = 503
+            code = "git_history_entry_capped"
+        super().__init__(message, status_code=status_code, code=code)
+        self.bound = bound
+        self.limit = limit
 
 
 class GitService:
@@ -1077,6 +1119,167 @@ class GitService:
         log_args.extend(["--format=%H%x00%ct", fixed_ref, "--", file_path])
         return self._parse_follow_path_log(repo.git.log(*log_args[1:]))
 
+    @staticmethod
+    def _close_path_history_process(process, *, terminate: bool) -> None:
+        """Close a streamed GitPython process, killing it when still active."""
+        raw_process = getattr(process, "proc", None) or process
+        if terminate:
+            try:
+                if raw_process.poll() is None:
+                    raw_process.kill()
+            except (AttributeError, OSError):
+                pass
+            try:
+                raw_process.wait(timeout=5)
+            except (AttributeError, OSError, subprocess.TimeoutExpired):
+                pass
+        for stream_name in ("stdin", "stdout", "stderr"):
+            stream = getattr(raw_process, stream_name, None)
+            try:
+                if stream is not None:
+                    stream.close()
+            except (OSError, ValueError):
+                pass
+
+    def _stream_path_at_revision(
+        self,
+        repo: Repo,
+        fixed_ref: str,
+        file_path: str,
+        target: str,
+    ) -> str | None:
+        """Stream a rename-following log until ``target`` or a safe bound.
+
+        ``GitPython`` normally buffers ``git log`` before returning.  The
+        revision selector only needs the target commit's one status record, so
+        this reader owns a process and consumes stdout incrementally.  It asks
+        Git for one entry past the allowed prefix: that distinguishes an
+        ordinary short history from a walk truncated by the entry cap without
+        ever allowing an unbounded command or result.
+        """
+        max_entries = max(1, int(_PATH_AT_REVISION_MAX_ENTRIES))
+        max_output_bytes = max(1, int(_PATH_AT_REVISION_MAX_OUTPUT_BYTES))
+        try:
+            timeout_secs = float(
+                getattr(settings, "git_write_timeout_secs", _PATH_AT_REVISION_DEFAULT_TIMEOUT_SECS)
+            )
+        except (TypeError, ValueError):
+            timeout_secs = _PATH_AT_REVISION_DEFAULT_TIMEOUT_SECS
+        timeout_secs = max(0.001, timeout_secs)
+
+        log_args = [
+            "--follow",
+            "-M",
+            "--name-status",
+            f"--max-count={max_entries + 1}",
+            "--format=%H%x00%ct",
+            fixed_ref,
+            "--",
+            file_path,
+        ]
+        process = repo.git.log(*log_args, as_process=True)
+        raw_process = getattr(process, "proc", None) or process
+        stdout = getattr(raw_process, "stdout", None)
+        stderr = getattr(raw_process, "stderr", None)
+        stdout_fd = stdout.fileno() if stdout is not None else -1
+        selector = selectors.DefaultSelector()
+        pending = bytearray()
+        output_bytes = 0
+        entry_count = 0
+        active_oid: str | None = None
+        finished = False
+        deadline = time.monotonic() + timeout_secs
+
+        def consume_line(line: bytes) -> str | None:
+            nonlocal active_oid, entry_count
+            text = line.decode("utf-8", "replace").rstrip("\r")
+            if "\x00" in text:
+                entry_count += 1
+                if entry_count > max_entries:
+                    raise GitHistoryBoundError("entry", max_entries)
+                oid = text.split("\x00", 1)[0]
+                active_oid = oid if re.fullmatch(r"[0-9a-f]{40}", oid) else None
+                return None
+            if active_oid is None or not text:
+                return None
+            fields = text.split("\t")
+            if len(fields) >= 2 and active_oid == target:
+                return fields[-1]
+            return None
+
+        try:
+            for stream in (stdout, stderr):
+                if stream is not None:
+                    selector.register(stream, selectors.EVENT_READ)
+
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise GitHistoryBoundError("timeout", timeout_secs)
+                events = selector.select(remaining)
+                if not events:
+                    continue
+                for key, _mask in events:
+                    try:
+                        if key.fd == stdout_fd:
+                            available = max_output_bytes - output_bytes - len(pending)
+                            if available < 0:
+                                raise GitHistoryBoundError("output", max_output_bytes)
+                            read_size = min(
+                                _PATH_AT_REVISION_READ_CHUNK_BYTES,
+                                max(1, available + 1),
+                            )
+                        else:
+                            read_size = _PATH_AT_REVISION_READ_CHUNK_BYTES
+                        chunk = os.read(key.fd, read_size)
+                    except (OSError, ValueError):
+                        selector.unregister(key.fileobj)
+                        continue
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    if key.fd != stdout_fd:
+                        continue
+
+                    pending.extend(chunk)
+                    while True:
+                        newline = pending.find(b"\n")
+                        if newline < 0:
+                            break
+                        line = bytes(pending[:newline])
+                        del pending[: newline + 1]
+                        output_bytes += newline + 1
+                        if output_bytes > max_output_bytes:
+                            raise GitHistoryBoundError("output", max_output_bytes)
+                        path = consume_line(line)
+                        if path is not None:
+                            return path
+                    if output_bytes + len(pending) > max_output_bytes:
+                        raise GitHistoryBoundError("output", max_output_bytes)
+
+            if pending:
+                output_bytes += len(pending)
+                if output_bytes > max_output_bytes:
+                    raise GitHistoryBoundError("output", max_output_bytes)
+                path = consume_line(bytes(pending))
+                if path is not None:
+                    return path
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise GitHistoryBoundError("timeout", timeout_secs)
+            try:
+                status = raw_process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                raise GitHistoryBoundError("timeout", timeout_secs) from None
+            finished = True
+            if status != 0:
+                raise GitError("git path history command failed")
+            return None
+        finally:
+            selector.close()
+            self._close_path_history_process(process, terminate=not finished)
+
     def path_at_revision(
         self, vault_name: str, file_path: str, commit: str
     ) -> str | None:
@@ -1096,14 +1299,9 @@ class GitService:
             repo = self._get_repo(vault_name)
             target = repo.commit(commit).hexsha
             fixed_ref = repo.head.commit.hexsha
-            history = self._follow_path_history(repo, fixed_ref, file_path)
+            return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
         except (BadName, BadObject, GitError, FileNotFoundError, ValueError):
             return None
-
-        for entry in history:
-            if entry["legacy_git_oid"] == target:
-                return entry["path_at_revision"]
-        return None
 
     def manual_fixed_ref_history(
         self,

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1013,7 +1013,97 @@ class GitService:
             blob = ref.tree / file_path
             return blob.data_stream.read().decode("utf-8")
         except (KeyError, TypeError):
+            if commit is None:
+                return None
+            historical_path = self.path_at_revision(vault_name, file_path, commit)
+            if historical_path and historical_path != file_path:
+                try:
+                    blob = ref.tree / historical_path
+                    return blob.data_stream.read().decode("utf-8")
+                except (KeyError, TypeError):
+                    pass
             return None
+
+    @staticmethod
+    def _parse_follow_path_log(output: str) -> list[dict]:
+        """Parse ``git log --follow --name-status`` into revision/path pairs."""
+        history: list[dict] = []
+        active: dict | None = None
+
+        def flush() -> None:
+            if active is not None and active.get("path_at_revision"):
+                history.append(active.copy())
+
+        for line in str(output).splitlines():
+            if "\x00" in line:
+                flush()
+                oid, epoch, *_ = line.split("\x00")
+                if not re.fullmatch(r"[0-9a-f]{40}", oid):
+                    active = None
+                    continue
+                try:
+                    committed_at = datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+                except (TypeError, ValueError, OverflowError):
+                    active = None
+                    continue
+                active = {
+                    "legacy_git_oid": oid,
+                    "committed_at": committed_at,
+                }
+                continue
+            if active is None or not line:
+                continue
+            fields = line.split("\t")
+            if len(fields) >= 2:
+                active["path_at_revision"] = fields[-1]
+        flush()
+        return history
+
+    def _follow_path_history(
+        self,
+        repo: Repo,
+        fixed_ref: str,
+        file_path: str,
+        *,
+        max_count: int | None = None,
+        since_epoch: int | None = None,
+    ) -> list[dict]:
+        """Return newest-first rename-following revisions for ``file_path``."""
+        log_args = ["log", "--follow", "-M", "--name-status"]
+        if max_count is not None:
+            log_args.append(f"--max-count={max_count}")
+        if since_epoch is not None:
+            log_args.append(f"--since=@{since_epoch}")
+        log_args.extend(["--format=%H%x00%ct", fixed_ref, "--", file_path])
+        return self._parse_follow_path_log(repo.git.log(*log_args[1:]))
+
+    def path_at_revision(
+        self, vault_name: str, file_path: str, commit: str
+    ) -> str | None:
+        """Return the path carried by ``commit`` while following renames.
+
+        ``file_path`` is the document's current path.  The walk starts at the
+        current local tip, not at ``commit`` itself, so a pre-move selector can
+        be mapped back to the old path.  Manual vaults use GitPython; mirror
+        vaults remain on :class:`ExternalGitRunner`'s hermetic local boundary.
+        """
+        # External mirrors retain their existing fixed-path semantics. Their
+        # separate source-corpus history contract is deliberately out of this
+        # manual-vault logical revision change.
+        if self._use_mirror_reader(vault_name):
+            return None
+        try:
+            repo = self._get_repo(vault_name)
+            target = repo.commit(commit).hexsha
+            fixed_ref = repo.head.commit.hexsha
+            history = self._follow_path_history(repo, fixed_ref, file_path)
+        except (BadName, BadObject, GitError, FileNotFoundError, ValueError):
+            return None
+
+        for entry in history:
+            if entry["legacy_git_oid"] == target:
+                return entry["path_at_revision"]
+        return None
 
     def manual_fixed_ref_history(
         self,
@@ -1244,16 +1334,16 @@ class GitService:
         if not bare.exists():
             return []
         out: list[dict] = []
-        for e in self._ext_runner.log_for_path(bare, file_path, max_count):
-            if since_epoch is not None and e["committed_epoch"] < since_epoch:
+        for entry in self._ext_runner.log_for_path(bare, file_path, max_count):
+            if since_epoch is not None and entry["committed_epoch"] < since_epoch:
                 continue
             out.append(
                 {
-                    "hash": e["hash"][:12],
-                    "message": e["message"].strip(),
-                    "author": e["author"],
+                    "hash": entry["hash"][:12],
+                    "message": entry["message"].strip(),
+                    "author": entry["author"],
                     "date": datetime.fromtimestamp(
-                        e["committed_epoch"], tz=timezone.utc
+                        entry["committed_epoch"], tz=timezone.utc
                     ).isoformat(),
                 }
             )
@@ -1733,22 +1823,34 @@ class GitService:
             return self._file_log_mirror(vault_name, file_path, max_count, since_epoch)
         repo = self._get_repo(vault_name)
         try:
-            commits = list(repo.iter_commits(paths=file_path, max_count=max_count))
+            entries = self._follow_path_history(
+                repo,
+                repo.head.commit.hexsha,
+                file_path,
+                max_count=max_count,
+                since_epoch=since_epoch,
+            )
         except (ValueError, GitError):
             return []
 
-        if since_epoch is not None:
-            commits = [c for c in commits if c.committed_date >= since_epoch]
-
-        return [
-            {
-                "hash": c.hexsha[:12],
-                "message": c.message.strip(),
-                "author": str(c.author),
-                "date": datetime.fromtimestamp(c.committed_date, tz=timezone.utc).isoformat(),
-            }
-            for c in commits
-        ]
+        results: list[dict] = []
+        for entry in entries:
+            committed_at = entry["committed_at"]
+            if since_epoch is not None and int(committed_at.timestamp()) < since_epoch:
+                continue
+            try:
+                commit = repo.commit(entry["legacy_git_oid"])
+            except (BadName, BadObject, ValueError):
+                continue
+            results.append(
+                {
+                    "hash": commit.hexsha[:12],
+                    "message": commit.message.strip(),
+                    "author": str(commit.author),
+                    "date": committed_at.isoformat(),
+                }
+            )
+        return results
 
     @staticmethod
     def _legacy_commit_metadata(commit) -> dict[str, str]:
@@ -1857,6 +1959,9 @@ class GitService:
         if self._use_mirror_reader(vault_name):
             return self._file_diff_mirror(vault_name, file_path, commit_hash)
         from git.exc import BadName, BadObject
+        historical_path = self.path_at_revision(vault_name, file_path, commit_hash)
+        if historical_path:
+            file_path = historical_path
         repo = self._get_repo(vault_name)
         try:
             commit = repo.commit(commit_hash)

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -37,6 +37,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from git import Blob, Repo
 from git.exc import BadName, BadObject, GitError
@@ -45,6 +46,12 @@ from app.config import settings
 from app.exceptions import AKBError, MirrorMarkerError
 from app.services.external_git_runner import ExternalGitRunner
 from app.services.external_git_validation import validate_branch
+from app.util.errors import (
+    GIT_HISTORY_ENTRY_CAPPED,
+    GIT_HISTORY_FAILED,
+    GIT_HISTORY_OUTPUT_CAPPED,
+    GIT_HISTORY_TIMEOUT,
+)
 
 logger = logging.getLogger("akb.git")
 
@@ -204,18 +211,29 @@ class GitHistoryBoundError(AKBError, RuntimeError):
         if bound == "timeout":
             message = f"git path history timed out after {limit:g}s"
             status_code = 503
-            code = "git_history_timeout"
+            code = GIT_HISTORY_TIMEOUT
         elif bound == "output":
             message = f"git path history exceeded the {limit}-byte output cap"
             status_code = 413
-            code = "git_history_output_capped"
+            code = GIT_HISTORY_OUTPUT_CAPPED
         else:
             message = f"git path history exceeded the {limit}-entry cap"
             status_code = 503
-            code = "git_history_entry_capped"
+            code = GIT_HISTORY_ENTRY_CAPPED
         super().__init__(message, status_code=status_code, code=code)
         self.bound = bound
         self.limit = limit
+
+
+class GitHistoryCommandError(AKBError, RuntimeError):
+    """A streamed manual-vault history command exited unsuccessfully."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "git path history command failed",
+            status_code=503,
+            code=GIT_HISTORY_FAILED,
+        )
 
 
 class GitService:
@@ -1122,7 +1140,7 @@ class GitService:
     @staticmethod
     def _close_path_history_process(process, *, terminate: bool) -> None:
         """Close a streamed GitPython process, killing it when still active."""
-        raw_process = getattr(process, "proc", None) or process
+        raw_process: Any = getattr(process, "proc", None) or process
         if terminate:
             try:
                 if raw_process.poll() is None:
@@ -1177,8 +1195,11 @@ class GitService:
             "--",
             file_path,
         ]
-        process = repo.git.log(*log_args, as_process=True)
-        raw_process = getattr(process, "proc", None) or process
+        process = repo.git.execute(
+            ["git", "-c", "core.quotePath=false", "log", *log_args],
+            as_process=True,
+        )
+        raw_process: Any = getattr(process, "proc", None) or process
         stdout = getattr(raw_process, "stdout", None)
         stderr = getattr(raw_process, "stderr", None)
         stdout_fd = stdout.fileno() if stdout is not None else -1
@@ -1274,7 +1295,7 @@ class GitService:
                 raise GitHistoryBoundError("timeout", timeout_secs) from None
             finished = True
             if status != 0:
-                raise GitError("git path history command failed")
+                raise GitHistoryCommandError()
             return None
         finally:
             selector.close()
@@ -1299,9 +1320,9 @@ class GitService:
             repo = self._get_repo(vault_name)
             target = repo.commit(commit).hexsha
             fixed_ref = repo.head.commit.hexsha
-            return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
-        except (BadName, BadObject, GitError, FileNotFoundError, ValueError):
+        except (BadName, BadObject, FileNotFoundError, ValueError):
             return None
+        return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
 
     def manual_fixed_ref_history(
         self,
@@ -2158,8 +2179,7 @@ class GitService:
             return self._file_diff_mirror(vault_name, file_path, commit_hash)
         from git.exc import BadName, BadObject
         historical_path = self.path_at_revision(vault_name, file_path, commit_hash)
-        if historical_path:
-            file_path = historical_path
+        lookup_path = historical_path or file_path
         repo = self._get_repo(vault_name)
         try:
             commit = repo.commit(commit_hash)
@@ -2175,7 +2195,7 @@ class GitService:
         if not commit.parents:
             # Initial commit — show full content as addition
             try:
-                blob = commit.tree / file_path
+                blob = commit.tree / lookup_path
                 content = blob.data_stream.read().decode("utf-8")
                 return {
                     "file": file_path,
@@ -2187,7 +2207,7 @@ class GitService:
                 return {"file": file_path, "commit": commit_hash, "type": "unknown", "diff": ""}
 
         parent = commit.parents[0]
-        diffs = parent.diff(commit, paths=[file_path], create_patch=True)
+        diffs = parent.diff(commit, paths=[lookup_path], create_patch=True)
 
         for d in diffs:
             patch = d.diff

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1195,10 +1195,19 @@ class GitService:
             "--",
             file_path,
         ]
-        process = repo.git.execute(
-            ["git", "-c", "core.quotePath=false", "log", *log_args],
-            as_process=True,
-        )
+        try:
+            process = repo.git.execute(
+                [
+                    repo.git.GIT_PYTHON_GIT_EXECUTABLE,
+                    "-c",
+                    "core.quotePath=false",
+                    "log",
+                    *log_args,
+                ],
+                as_process=True,
+            )
+        except (GitError, OSError) as exc:
+            raise GitHistoryCommandError() from exc
         raw_process: Any = getattr(process, "proc", None) or process
         stdout = getattr(raw_process, "stdout", None)
         stderr = getattr(raw_process, "stderr", None)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -372,7 +372,10 @@ class NativeDocumentService(DocumentService):
         version: str,
     ) -> DocumentResponse:
         vault_id, current = await self._current(vault, doc_ref)
-        if len(version) != 40 or any(ch not in "0123456789abcdef" for ch in version):
+        # Public historical reads accept a full native Revision ID or a
+        # resource-scoped unique prefix. Write OCC pins remain exact-40 via
+        # NativeRevisionService._validate_expected_revision().
+        if not 7 <= len(version) <= 40 or any(ch not in "0123456789abcdef" for ch in version):
             raise NotFoundError("Document version", f"{current.path}@{version[:8]}")
         selected = await (await self._native()).get_revision(
             namespace_id=vault_id,

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -249,6 +249,7 @@ class NativeDocumentService(DocumentService):
         vault_id: uuid.UUID,
         current: NativeRevisionSnapshot,
         selected: NativeRevisionSnapshot | None = None,
+        public_selector: str | None = None,
     ) -> DocumentResponse:
         selected = selected or current
         current_fm, _ = _parse_markdown(current.text)
@@ -277,7 +278,9 @@ class NativeDocumentService(DocumentService):
             created_by_name=created_by_name,
             created_at=current_fm.get("created_at") or current.resource_created_at,
             updated_at=current.resource_updated_at,
-            current_commit=selected.revision_id,
+            current_commit=(
+                public_selector if public_selector is not None else selected.revision_id
+            ),
             content_hash=_body_content_hash(selected_body),
             hash_algorithm=HASH_ALGORITHM,
             tags=list(current_fm.get("tags") or []),
@@ -384,7 +387,11 @@ class NativeDocumentService(DocumentService):
             revision_id=version,
         )
         return await self._response(
-            vault=vault, vault_id=vault_id, current=current, selected=selected,
+            vault=vault,
+            vault_id=vault_id,
+            current=current,
+            selected=selected,
+            public_selector=version,
         )
 
     async def update(

--- a/backend/app/services/native_revision_backend.py
+++ b/backend/app/services/native_revision_backend.py
@@ -259,7 +259,7 @@ class NativeRevisionBackend:
         version: str,
     ) -> tuple[dict[str, Any], str] | None:
         current = await self.document_service.get(vault, doc_ref)
-        if len(version) != 40 or any(ch not in "0123456789abcdef" for ch in version):
+        if not 7 <= len(version) <= 40 or any(ch not in "0123456789abcdef" for ch in version):
             return None
         try:
             vault_id = await self._vault_id(vault)

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -241,6 +241,11 @@ class NativeRevisionService:
             raise ValidationError("Expected native Revision ID must be exactly 40 lowercase hex")
 
     @staticmethod
+    def _validate_revision_selector(revision_id: str) -> None:
+        if not 7 <= len(revision_id) <= 40 or any(ch not in "0123456789abcdef" for ch in revision_id):
+            raise ValidationError("Native Revision selector must be 7..40 lowercase hex")
+
+    @staticmethod
     def _from_row(row: dict, *, replay: bool) -> NativeMutationResult:
         return NativeMutationResult(
             resource_id=row["resource_id"],
@@ -1165,7 +1170,7 @@ class NativeRevisionService:
         reference: str,
         revision_id: str,
     ) -> NativeRevisionSnapshot:
-        self._validate_expected_revision(revision_id)
+        self._validate_revision_selector(revision_id)
         resource = await self.repository.resolve_live_reference(
             namespace_id=namespace_id,
             surface=surface,

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -75,6 +75,7 @@ INVALID_PATH = "invalid_path"              # collection / file path failure
 UNKNOWN_ARGUMENT = "unknown_argument"      # arg key not in tool schema (0.5.4)
 UNKNOWN_TOOL = "unknown_tool"
 CONFLICT = "conflict"                      # version / expected-state mismatch
+NATIVE_REVISION_SELECTOR_AMBIGUOUS = "native_revision_selector_ambiguous"
 WRITE_BUSY = "write_busy"                  # write-lane admission timed out — retry after backoff
 UNIQUE_VIOLATION = "unique_violation"      # PG 23505 — INSERT/UPDATE breaks a unique key
 EDIT_FAILED = "edit_failed"                # akb_edit: old_string match / uniqueness failure
@@ -158,7 +159,9 @@ def exception_envelope(e: Exception) -> dict:
     if isinstance(e, NotFoundError):
         return err(str(e), code=NOT_FOUND)
     if isinstance(e, ConflictError):
-        return err(str(e), code=e.code or CONFLICT)
+        if e.code == NATIVE_REVISION_SELECTOR_AMBIGUOUS:
+            return err(str(e), code=NATIVE_REVISION_SELECTOR_AMBIGUOUS)
+        return err(str(e), code=CONFLICT)
     if isinstance(e, InvalidColumnTypeError):
         return err(
             str(e),

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -158,7 +158,7 @@ def exception_envelope(e: Exception) -> dict:
     if isinstance(e, NotFoundError):
         return err(str(e), code=NOT_FOUND)
     if isinstance(e, ConflictError):
-        return err(str(e), code=CONFLICT)
+        return err(str(e), code=e.code or CONFLICT)
     if isinstance(e, InvalidColumnTypeError):
         return err(
             str(e),

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -111,6 +111,14 @@ SELF_LINK = "self_link"
 # storage write failure in akb_publication_snapshot).
 INTERNAL = "internal"
 
+# Manual-vault Git history resolution. These are deliberately catalogue
+# entries rather than values copied from an exception at dispatch time: the
+# MCP wire contract must remain statically auditable by the catalogue test.
+GIT_HISTORY_FAILED = "git_history_failed"
+GIT_HISTORY_TIMEOUT = "git_history_timeout"
+GIT_HISTORY_OUTPUT_CAPPED = "git_history_output_capped"
+GIT_HISTORY_ENTRY_CAPPED = "git_history_entry_capped"
+
 
 # ── Builder ───────────────────────────────────────────────────
 
@@ -175,6 +183,14 @@ def exception_envelope(e: Exception) -> dict:
             hint="The vault is under heavy write load. Wait a few seconds and retry; no partial write occurred.",
             retry_after_secs=e.retry_after_secs,
         )
+    if getattr(e, "code", None) == GIT_HISTORY_FAILED:
+        return err(str(e), code=GIT_HISTORY_FAILED)
+    if getattr(e, "code", None) == GIT_HISTORY_TIMEOUT:
+        return err(str(e), code=GIT_HISTORY_TIMEOUT)
+    if getattr(e, "code", None) == GIT_HISTORY_OUTPUT_CAPPED:
+        return err(str(e), code=GIT_HISTORY_OUTPUT_CAPPED)
+    if getattr(e, "code", None) == GIT_HISTORY_ENTRY_CAPPED:
+        return err(str(e), code=GIT_HISTORY_ENTRY_CAPPED)
     if isinstance(e, ValidationError):
         return err(str(e), code=INVALID_ARGUMENT)
     return err(str(e), code=INTERNAL)

--- a/backend/tests/test_errors_unit.py
+++ b/backend/tests/test_errors_unit.py
@@ -22,7 +22,12 @@ from pathlib import Path
 
 from app.util import errors as errors_mod
 from app.util.errors import (
+    GIT_HISTORY_ENTRY_CAPPED,
+    GIT_HISTORY_FAILED,
+    GIT_HISTORY_OUTPUT_CAPPED,
+    GIT_HISTORY_TIMEOUT,
     err,
+    exception_envelope,
     NOT_FOUND,
     PERMISSION_DENIED,
     UNKNOWN_ARGUMENT,
@@ -76,6 +81,20 @@ def test_code_field_is_always_set():
     out = err("oops", code="something")
     assert "code" in out
     assert out["code"] == "something"
+
+
+def test_git_history_failures_keep_explicit_mcp_codes():
+    from app.services.git_service import GitHistoryBoundError, GitHistoryCommandError
+
+    cases = (
+        (GitHistoryBoundError("timeout", 0.5), GIT_HISTORY_TIMEOUT),
+        (GitHistoryBoundError("output", 1024), GIT_HISTORY_OUTPUT_CAPPED),
+        (GitHistoryBoundError("entry", 10), GIT_HISTORY_ENTRY_CAPPED),
+        (GitHistoryCommandError(), GIT_HISTORY_FAILED),
+    )
+
+    for error, code in cases:
+        assert exception_envelope(error) == {"error": str(error), "code": code}
 
 
 # ── Catalogue enforcement ─────────────────────────────────────

--- a/backend/tests/test_legacy_move_history_contract.py
+++ b/backend/tests/test_legacy_move_history_contract.py
@@ -1,0 +1,87 @@
+"""Public bare-Git contract for document moves and historical selectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.services.git_service import GitService
+
+
+@dataclass(frozen=True)
+class _MovedDocument:
+    git: GitService
+    vault: str
+    old_path: str
+    new_path: str
+    created: str
+    updated: str
+    moved: str
+    latest: str
+
+
+@pytest.fixture
+def moved_document(tmp_path) -> _MovedDocument:
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    vault = "move-history"
+    old_path = "drafts/contract.md"
+    new_path = "published/contract.md"
+    git.init_vault(vault)
+
+    created = git.commit_file(
+        vault_name=vault,
+        file_path=old_path,
+        content="old body\n",
+        message="create",
+    )
+    updated = git.commit_file(
+        vault_name=vault,
+        file_path=old_path,
+        content="updated old body\n",
+        message="update",
+    )
+    moved = git.move_file(
+        vault_name=vault,
+        old_path=old_path,
+        new_path=new_path,
+        message="move",
+    )
+    latest = git.commit_file(
+        vault_name=vault,
+        file_path=new_path,
+        content="latest body\n",
+        message="update after move",
+    )
+    return _MovedDocument(
+        git=git,
+        vault=vault,
+        old_path=old_path,
+        new_path=new_path,
+        created=created,
+        updated=updated,
+        moved=moved,
+        latest=latest,
+    )
+
+
+def test_current_moved_path_preserves_bare_git_history_contract(
+    moved_document: _MovedDocument,
+) -> None:
+    doc = moved_document
+
+    assert doc.git.path_at_revision(doc.vault, doc.new_path, doc.updated[:7]) == doc.old_path
+    assert doc.git.read_file(doc.vault, doc.new_path, doc.updated[:7]) == "updated old body\n"
+
+    history = doc.git.file_log(doc.vault, doc.new_path, max_count=10)
+    assert [entry["hash"] for entry in history] == [
+        doc.latest[:12],
+        doc.moved[:12],
+        doc.updated[:12],
+        doc.created[:12],
+    ]
+    diff = doc.git.file_diff(doc.vault, doc.new_path, doc.updated[:7])
+    assert diff["file"] == doc.old_path
+    assert diff["type"] == "modified"
+    assert "-old body" in diff["diff"]
+    assert "+updated old body" in diff["diff"]

--- a/backend/tests/test_legacy_move_history_contract.py
+++ b/backend/tests/test_legacy_move_history_contract.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import dataclass
 
 import pytest
+from git import Repo
 
 from app.services.git_service import GitService
 
@@ -85,3 +88,109 @@ def test_current_moved_path_preserves_bare_git_history_contract(
     assert diff["type"] == "modified"
     assert "-old body" in diff["diff"]
     assert "+updated old body" in diff["diff"]
+
+
+def test_path_at_revision_stream_stops_after_target(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    doc = moved_document
+    repo = Repo(str(doc.git._bare_path(doc.vault)))
+    marker = tmp_path / "tail-consumed"
+    output = (
+        f"{doc.latest}\x000\nM\t{doc.new_path}\n"
+        f"{doc.updated}\x000\nM\t{doc.old_path}\n"
+    )
+    script = (
+        "import pathlib, sys, time; "
+        f"sys.stdout.write({output!r}); sys.stdout.flush(); "
+        "time.sleep(2); "
+        f"pathlib.Path({str(marker)!r}).write_text('tail consumed')"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    git_type = type(repo.git)
+    original_execute = git_type.execute
+
+    def fake_execute(self, command, *args, **kwargs):
+        if any(str(item) == "log" for item in command):
+            assert kwargs["as_process"] is True
+            return process
+        return original_execute(self, command, *args, **kwargs)
+
+    monkeypatch.setattr(doc.git, "_get_repo", lambda _vault: repo)
+    monkeypatch.setattr(git_type, "execute", fake_execute)
+
+    assert doc.git.path_at_revision(doc.vault, doc.new_path, doc.updated[:7]) == doc.old_path
+    assert not marker.exists()
+
+
+def test_path_at_revision_entry_cap_is_explicit(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import git_service as gs
+
+    monkeypatch.setattr(gs, "_PATH_AT_REVISION_MAX_ENTRIES", 1, raising=False)
+
+    with pytest.raises(RuntimeError, match="entry cap"):
+        moved_document.git.path_at_revision(
+            moved_document.vault,
+            moved_document.new_path,
+            moved_document.updated[:7],
+        )
+
+
+def test_path_at_revision_output_cap_is_explicit(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import git_service as gs
+
+    monkeypatch.setattr(gs, "_PATH_AT_REVISION_MAX_OUTPUT_BYTES", 1, raising=False)
+
+    with pytest.raises(RuntimeError, match="output cap"):
+        moved_document.git.path_at_revision(
+            moved_document.vault,
+            moved_document.new_path,
+            moved_document.updated[:7],
+        )
+
+
+def test_path_at_revision_timeout_is_explicit(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import git_service as gs
+
+    repo = Repo(str(moved_document.git._bare_path(moved_document.vault)))
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(2)"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    git_type = type(repo.git)
+    original_execute = git_type.execute
+
+    def fake_execute(self, command, *args, **kwargs):
+        if any(str(item) == "log" for item in command):
+            assert kwargs["as_process"] is True
+            return process
+        return original_execute(self, command, *args, **kwargs)
+
+    monkeypatch.setattr(moved_document.git, "_get_repo", lambda _vault: repo)
+    monkeypatch.setattr(git_type, "execute", fake_execute)
+    monkeypatch.setattr(gs.settings, "git_write_timeout_secs", 0.05)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        moved_document.git.path_at_revision(
+            moved_document.vault,
+            moved_document.new_path,
+            moved_document.updated[:7],
+        )

--- a/backend/tests/test_legacy_move_history_contract.py
+++ b/backend/tests/test_legacy_move_history_contract.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 import pytest
 from git import Repo
+from git.exc import GitCommandNotFound
 
 from app.services.git_service import (
     GitHistoryBoundError,
@@ -275,6 +276,38 @@ def test_path_at_revision_nonzero_exit_is_not_a_missing_path(
             moved_document.updated[:7],
         )
     assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "git_history_failed"
+
+
+def test_path_at_revision_uses_configured_git_and_maps_launch_failure(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = Repo(str(moved_document.git._bare_path(moved_document.vault)))
+    configured_git = "/configured/bin/git"
+    captured: dict[str, object] = {}
+    fixed_ref = repo.head.commit.hexsha
+    target = repo.commit(moved_document.updated[:7]).hexsha
+
+    def fail_execute(self, command, *args, **kwargs):
+        captured["command"] = command
+        raise GitCommandNotFound(command, "unavailable")
+
+    git_type = type(repo.git)
+    monkeypatch.setattr(git_type, "GIT_PYTHON_GIT_EXECUTABLE", configured_git)
+    monkeypatch.setattr(git_type, "execute", fail_execute)
+
+    with pytest.raises(GitHistoryCommandError) as exc_info:
+        moved_document.git._stream_path_at_revision(
+            repo,
+            fixed_ref,
+            moved_document.new_path,
+            target,
+        )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[0] == configured_git
     assert exc_info.value.code == "git_history_failed"
 
 

--- a/backend/tests/test_legacy_move_history_contract.py
+++ b/backend/tests/test_legacy_move_history_contract.py
@@ -9,7 +9,11 @@ from dataclasses import dataclass
 import pytest
 from git import Repo
 
-from app.services.git_service import GitService
+from app.services.git_service import (
+    GitHistoryBoundError,
+    GitHistoryCommandError,
+    GitService,
+)
 
 
 @dataclass(frozen=True)
@@ -84,10 +88,52 @@ def test_current_moved_path_preserves_bare_git_history_contract(
         doc.created[:12],
     ]
     diff = doc.git.file_diff(doc.vault, doc.new_path, doc.updated[:7])
-    assert diff["file"] == doc.old_path
+    assert diff["file"] == doc.new_path
     assert diff["type"] == "modified"
     assert "-old body" in diff["diff"]
     assert "+updated old body" in diff["diff"]
+
+
+def test_non_ascii_moved_paths_resolve_for_historical_get_and_diff(tmp_path) -> None:
+    git = GitService(storage_path=str(tmp_path / "vaults"))
+    vault = "unicode-move-history"
+    old_path = "초안/계약서.md"
+    new_path = "게시/계약서.md"
+    git.init_vault(vault)
+
+    created = git.commit_file(
+        vault_name=vault,
+        file_path=old_path,
+        content="초안\n",
+        message="create",
+    )
+    updated = git.commit_file(
+        vault_name=vault,
+        file_path=old_path,
+        content="수정된 초안\n",
+        message="update",
+    )
+    git.move_file(
+        vault_name=vault,
+        old_path=old_path,
+        new_path=new_path,
+        message="move",
+    )
+    git.commit_file(
+        vault_name=vault,
+        file_path=new_path,
+        content="최신 계약서\n",
+        message="update after move",
+    )
+
+    assert len(created) == 40
+    assert git.path_at_revision(vault, new_path, updated[:7]) == old_path
+    assert git.read_file(vault, new_path, updated[:7]) == "수정된 초안\n"
+    diff = git.file_diff(vault, new_path, updated[:7])
+    assert diff["file"] == new_path
+    assert diff["type"] == "modified"
+    assert "-초안" in diff["diff"]
+    assert "+수정된 초안" in diff["diff"]
 
 
 def test_path_at_revision_stream_stops_after_target(
@@ -138,12 +184,13 @@ def test_path_at_revision_entry_cap_is_explicit(
 
     monkeypatch.setattr(gs, "_PATH_AT_REVISION_MAX_ENTRIES", 1, raising=False)
 
-    with pytest.raises(RuntimeError, match="entry cap"):
+    with pytest.raises(GitHistoryBoundError, match="entry cap") as exc_info:
         moved_document.git.path_at_revision(
             moved_document.vault,
             moved_document.new_path,
             moved_document.updated[:7],
         )
+    assert exc_info.value.code == "git_history_entry_capped"
 
 
 def test_path_at_revision_output_cap_is_explicit(
@@ -154,12 +201,13 @@ def test_path_at_revision_output_cap_is_explicit(
 
     monkeypatch.setattr(gs, "_PATH_AT_REVISION_MAX_OUTPUT_BYTES", 1, raising=False)
 
-    with pytest.raises(RuntimeError, match="output cap"):
+    with pytest.raises(GitHistoryBoundError, match="output cap") as exc_info:
         moved_document.git.path_at_revision(
             moved_document.vault,
             moved_document.new_path,
             moved_document.updated[:7],
         )
+    assert exc_info.value.code == "git_history_output_capped"
 
 
 def test_path_at_revision_timeout_is_explicit(
@@ -188,9 +236,54 @@ def test_path_at_revision_timeout_is_explicit(
     monkeypatch.setattr(git_type, "execute", fake_execute)
     monkeypatch.setattr(gs.settings, "git_write_timeout_secs", 0.05)
 
-    with pytest.raises(RuntimeError, match="timed out"):
+    with pytest.raises(GitHistoryBoundError, match="timed out") as exc_info:
         moved_document.git.path_at_revision(
             moved_document.vault,
             moved_document.new_path,
             moved_document.updated[:7],
         )
+    assert exc_info.value.code == "git_history_timeout"
+
+
+def test_path_at_revision_nonzero_exit_is_not_a_missing_path(
+    moved_document: _MovedDocument,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = Repo(str(moved_document.git._bare_path(moved_document.vault)))
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.exit(2)"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    git_type = type(repo.git)
+    original_execute = git_type.execute
+
+    def fake_execute(self, command, *args, **kwargs):
+        if any(str(item) == "log" for item in command):
+            assert kwargs["as_process"] is True
+            return process
+        return original_execute(self, command, *args, **kwargs)
+
+    monkeypatch.setattr(moved_document.git, "_get_repo", lambda _vault: repo)
+    monkeypatch.setattr(git_type, "execute", fake_execute)
+
+    with pytest.raises(GitHistoryCommandError) as exc_info:
+        moved_document.git.path_at_revision(
+            moved_document.vault,
+            moved_document.new_path,
+            moved_document.updated[:7],
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "git_history_failed"
+
+
+def test_path_at_revision_unknown_selector_remains_none(moved_document: _MovedDocument) -> None:
+    assert (
+        moved_document.git.path_at_revision(
+            moved_document.vault,
+            moved_document.new_path,
+            "0" * 40,
+        )
+        is None
+    )

--- a/backend/tests/test_native_revision_mcp_selector_unit.py
+++ b/backend/tests/test_native_revision_mcp_selector_unit.py
@@ -1,0 +1,59 @@
+"""MCP wire contracts for Native Revision selector ambiguity."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.repositories.native_revision_repo import NativeRevisionSelectorAmbiguousError
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AmbiguousNativeBackend:
+    async def document_version(self, _vault: str, _doc_ref: str, version: str):
+        raise NativeRevisionSelectorAmbiguousError(version)
+
+    async def document_diff(self, _vault: str, _doc_ref: str, commit: str):
+        raise NativeRevisionSelectorAmbiguousError(commit)
+
+
+@pytest.mark.parametrize(
+    ("tool", "selector_key"),
+    (("akb_get", "version"), ("akb_diff", "commit")),
+)
+async def test_native_selector_ambiguity_survives_mcp_wire_envelope(
+    monkeypatch,
+    tmp_path,
+    tool: str,
+    selector_key: str,
+):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    from mcp_server import server
+
+    monkeypatch.setattr(server, "revision_backend", _AmbiguousNativeBackend())
+    monkeypatch.setattr(server, "split_uri", lambda *_args, **_kwargs: ("v", "doc.md"))
+
+    async def allow_access(*_args, **_kwargs):
+        return None
+
+    async def resolve_user():
+        return server._MCPUser()
+
+    monkeypatch.setattr(server, "check_vault_access", allow_access)
+    monkeypatch.setattr(server, "_get_user", resolve_user)
+    monkeypatch.setattr(server.audit_log, "record_tool", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server.tool_usage, "record", lambda *_args, **_kwargs: None)
+
+    response = await server.call_tool(
+        tool,
+        {"uri": "akb://v/doc/doc.md", selector_key: "abcdef0"},
+    )
+
+    envelope = json.loads(response[0].text)
+    assert envelope["code"] == "native_revision_selector_ambiguous"
+    assert envelope["code"] != "conflict"

--- a/backend/tests/test_native_revision_public_selector_pg.py
+++ b/backend/tests/test_native_revision_public_selector_pg.py
@@ -1,0 +1,153 @@
+"""PostgreSQL contract tests for public Native Revision selectors."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.exceptions import ConflictError
+from app.services.native_revision_backend import NativeRevisionBackend
+from app.services.native_revision_service import NativeRevisionService
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATION = _BACKEND / "app" / "db" / "migrations" / "048_native_revision_core.py"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("native_public_selector_048", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_native_public_selector_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        conn = await asyncpg.connect(_database_dsn(name))
+        await conn.execute(_INIT_SQL)
+        await _load_migration().migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=4)
+        vault_name = f"native-selector-{uuid.uuid4().hex}"
+        async with pool.acquire() as seeded:
+            namespace_id = await seeded.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+                vault_name,
+                "/tmp/native-selector-unused.git",
+            )
+        yield pool, namespace_id, vault_name
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def test_public_historical_selector_is_exact_or_resource_scoped_prefix(monkeypatch):
+    revision_ids = iter(
+        (
+            "abcdef0" + "1" * 33,
+            "abcdef0" + "2" * 33,
+            "1234567" + "3" * 33,
+        )
+    )
+    monkeypatch.setattr(
+        NativeRevisionService,
+        "_opaque_revision_id",
+        staticmethod(lambda: next(revision_ids)),
+    )
+
+    async with _fresh_database() as (pool, namespace_id, vault_name):
+        service = NativeRevisionService(pool)
+        first = await service.create_text(
+            namespace_id=namespace_id,
+            surface="document",
+            path="one.md",
+            payload="first\n",
+            actor="selector-test",
+            mutation_id=uuid.uuid4(),
+            resource_id=uuid.uuid4(),
+        )
+        await service.replace_text(
+            namespace_id=namespace_id,
+            surface="document",
+            path="one.md",
+            payload="second\n",
+            actor="selector-test",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=first.revision_id,
+        )
+        await service.create_text(
+            namespace_id=namespace_id,
+            surface="document",
+            path="two.md",
+            payload="other\n",
+            actor="selector-test",
+            mutation_id=uuid.uuid4(),
+            resource_id=uuid.uuid4(),
+        )
+
+        backend = NativeRevisionBackend(pool=pool)
+        exact = await backend.document_version(vault_name, "one.md", first.revision_id)
+        assert exact is not None
+        assert exact[1] == "first\n"
+
+        prefix = first.revision_id[:8]
+        selected = await backend.document_version(vault_name, "one.md", prefix)
+        assert selected is not None
+        assert selected[1] == "first\n"
+
+        assert await backend.document_version(vault_name, "one.md", "deadbee") is None
+        assert await backend.document_version(vault_name, "two.md", prefix) is None
+
+        diff = await backend.document_diff(vault_name, "one.md", prefix)
+        assert diff is not None
+        assert diff["type"] == "added"
+        assert "+first" in diff["diff"]
+
+        with pytest.raises(ConflictError) as caught:
+            await backend.document_version(vault_name, "one.md", first.revision_id[:7])
+        assert caught.value.code == "native_revision_selector_ambiguous"
+
+        with pytest.raises(ConflictError) as caught:
+            await backend.document_diff(vault_name, "one.md", first.revision_id[:7])
+        assert caught.value.code == "native_revision_selector_ambiguous"

--- a/backend/tests/test_native_revision_public_selector_pg.py
+++ b/backend/tests/test_native_revision_public_selector_pg.py
@@ -140,8 +140,10 @@ async def test_public_historical_selector_is_exact_or_resource_scoped_prefix(mon
         document_service = NativeDocumentService(pool=pool)
         rest_exact = await document_service.get_at_commit(vault_name, "one.md", first.revision_id)
         assert rest_exact.content == "first"
+        assert rest_exact.current_commit == first.revision_id
         rest_selected = await document_service.get_at_commit(vault_name, "one.md", first.revision_id[:8])
         assert rest_selected.content == "first"
+        assert rest_selected.current_commit == prefix
 
         NativeRevisionService._validate_expected_revision(first.revision_id)
         with pytest.raises(ValidationError):

--- a/backend/tests/test_native_revision_public_selector_pg.py
+++ b/backend/tests/test_native_revision_public_selector_pg.py
@@ -11,8 +11,9 @@ from pathlib import Path
 import asyncpg
 import pytest
 
-from app.exceptions import ConflictError
+from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.services.native_revision_backend import NativeRevisionBackend
+from app.services.native_document_service import NativeDocumentService
 from app.services.native_revision_service import NativeRevisionService
 
 
@@ -136,8 +137,23 @@ async def test_public_historical_selector_is_exact_or_resource_scoped_prefix(mon
         assert selected is not None
         assert selected[1] == "first\n"
 
+        document_service = NativeDocumentService(pool=pool)
+        rest_exact = await document_service.get_at_commit(vault_name, "one.md", first.revision_id)
+        assert rest_exact.content == "first"
+        rest_selected = await document_service.get_at_commit(vault_name, "one.md", first.revision_id[:8])
+        assert rest_selected.content == "first"
+
+        NativeRevisionService._validate_expected_revision(first.revision_id)
+        with pytest.raises(ValidationError):
+            NativeRevisionService._validate_expected_revision(first.revision_id[:8])
+
         assert await backend.document_version(vault_name, "one.md", "deadbee") is None
         assert await backend.document_version(vault_name, "two.md", prefix) is None
+
+        with pytest.raises(NotFoundError):
+            await document_service.get_at_commit(vault_name, "one.md", "deadbee")
+        with pytest.raises(NotFoundError):
+            await document_service.get_at_commit(vault_name, "two.md", prefix)
 
         diff = await backend.document_diff(vault_name, "one.md", prefix)
         assert diff is not None
@@ -150,4 +166,8 @@ async def test_public_historical_selector_is_exact_or_resource_scoped_prefix(mon
 
         with pytest.raises(ConflictError) as caught:
             await backend.document_diff(vault_name, "one.md", first.revision_id[:7])
+        assert caught.value.code == "native_revision_selector_ambiguous"
+
+        with pytest.raises(ConflictError) as caught:
+            await document_service.get_at_commit(vault_name, "one.md", first.revision_id[:7])
         assert caught.value.code == "native_revision_selector_ambiguous"


### PR DESCRIPTION
## Summary
- resolve PostgreSQL Native public selectors by exact or resource-scoped unique prefix
- follow Bare Git document history across moves for historical get/history/diff
- preserve Bare Git as the default and leave external mirror history unchanged

## Validation
- 76 focused tests passed with live PostgreSQL
- ruff and mypy passed on touched code

Draft until exact-head review, full CI, rebuilt image, and isolated development environment R4 rerun complete.