### PR TITLE
fix: seed postgres-native vault skill atomically

### DIFF
--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -165,6 +165,19 @@ def _create_lock(name: str) -> asyncio.Lock:
     return lock
 
 
+def build_vault_skill_seed_request(vault: str) -> DocumentPutRequest:
+    """Build the canonical seed request shared by every document backend."""
+    return DocumentPutRequest(
+        vault=vault,
+        collection="overview",
+        title=f"{vault} Guide",
+        slug="vault-skill",
+        content=VAULT_SKILL_SEED_TEMPLATE.replace("{vault}", vault),
+        type="skill",
+        tags=["akb:skill"],
+    )
+
+
 class EditError(AKBError):
     """Raised when an edit operation cannot be performed."""
 
@@ -1946,21 +1959,12 @@ class DocumentService:
             # the vault-skill seed writes BOTH git AND a documents row so akb_get /
             # akb_browse / akb_search can find it.
             if not external_git:  # mirror vaults are read-only
-                skill_body = VAULT_SKILL_SEED_TEMPLATE.replace("{vault}", name)
                 # Route through the canonical put() so chunks/BM25 indexing,
                 # frontmatter composition, collection-count increment, and the
                 # document.put event all run — fixing I1–I4.
                 # put() calls coll_repo.get_or_create internally, so no
                 # separate create_empty is needed.
-                seed_req = DocumentPutRequest(
-                    vault=name,
-                    collection="overview",
-                    title=f"{name} Guide",
-                    slug="vault-skill",
-                    content=skill_body,
-                    type="skill",
-                    tags=["akb:skill"],
-                )
+                seed_req = build_vault_skill_seed_request(name)
                 await self.put(seed_req, agent_id=str(owner_id) if owner_id else None)
         except BaseException:
             # run_compensation: the whole rollback runs to COMPLETION even

--- a/backend/app/services/m1_pg_body_store.py
+++ b/backend/app/services/m1_pg_body_store.py
@@ -109,44 +109,84 @@ class M1PgBodyStore:
             expected_size=expected_size,
         )
         async with self.pool.acquire() as conn:
+            return await self._prepare_verified_in_conn(
+                conn,
+                namespace_id=namespace_id,
+                canonical=canonical,
+                digest=digest,
+            )
+
+    async def prepare_text_in_conn(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        payload: str | bytes,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> PreparedReferencePayload:
+        """Prepare a body on the caller's active PostgreSQL transaction."""
+        if not conn.is_in_transaction():
+            raise ValidationError("Transaction-aware body preparation requires an active transaction")
+        canonical, digest = await asyncio.to_thread(
+            self._verified_bytes,
+            payload,
+            expected_digest=expected_digest,
+            expected_size=expected_size,
+        )
+        return await self._prepare_verified_in_conn(
+            conn,
+            namespace_id=namespace_id,
+            canonical=canonical,
+            digest=digest,
+        )
+
+    async def _prepare_verified_in_conn(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        canonical: bytes,
+        digest: str,
+    ) -> PreparedReferencePayload:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO m1_reference_payloads (
+                namespace_id, content_profile, digest, byte_size, encoding,
+                selected_placement, verification_profile, canonical_bytes
+            )
+            VALUES ($1, 'text', $2, $3, 'utf-8', $4, $5, $6)
+            ON CONFLICT DO NOTHING
+            RETURNING payload_id, namespace_id, content_profile, digest,
+                      byte_size, encoding, selected_placement,
+                      verification_profile, canonical_bytes
+            """,
+            namespace_id,
+            digest,
+            len(canonical),
+            self.selected_placement,
+            self.verification_profile,
+            canonical,
+        )
+        if row is None:
             row = await conn.fetchrow(
                 """
-                INSERT INTO m1_reference_payloads (
-                    namespace_id, content_profile, digest, byte_size, encoding,
-                    selected_placement, verification_profile, canonical_bytes
-                )
-                VALUES ($1, 'text', $2, $3, 'utf-8', $4, $5, $6)
-                ON CONFLICT DO NOTHING
-                RETURNING payload_id, namespace_id, content_profile, digest,
-                          byte_size, encoding, selected_placement,
-                          verification_profile, canonical_bytes
+                SELECT payload_id, namespace_id, content_profile, digest,
+                       byte_size, encoding, selected_placement,
+                       verification_profile, canonical_bytes
+                  FROM m1_reference_payloads
+                 WHERE namespace_id = $1
+                   AND digest = $2
+                   AND byte_size = $3
+                   AND selected_placement = $4
+                   AND verification_profile = $5
                 """,
                 namespace_id,
                 digest,
                 len(canonical),
                 self.selected_placement,
                 self.verification_profile,
-                canonical,
             )
-            if row is None:
-                row = await conn.fetchrow(
-                    """
-                    SELECT payload_id, namespace_id, content_profile, digest,
-                           byte_size, encoding, selected_placement,
-                           verification_profile, canonical_bytes
-                      FROM m1_reference_payloads
-                     WHERE namespace_id = $1
-                       AND digest = $2
-                       AND byte_size = $3
-                       AND selected_placement = $4
-                       AND verification_profile = $5
-                    """,
-                    namespace_id,
-                    digest,
-                    len(canonical),
-                    self.selected_placement,
-                    self.verification_profile,
-                )
         if row is None:
             raise PgBodyIntegrityError(
                 "PostgreSQL body disappeared during placement-scoped deduplication"

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -34,6 +34,7 @@ from app.services.document_service import (
     DocumentService,
     _body_content_hash,
     _build_frontmatter,
+    build_vault_skill_seed_request,
     _certified_content_hash,
     _compose_markdown,
     _parse_markdown,
@@ -727,6 +728,43 @@ class NativeDocumentService(DocumentService):
         ]
         return {"uri": doc_uri(vault, resource["current_path"]), "history": history}
 
+    async def _seed_native_vault_skill(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        vault_id: uuid.UUID,
+        vault_name: str,
+        owner_id: uuid.UUID | None,
+    ) -> None:
+        """Publish the canonical vault skill inside the vault-create TX."""
+        request = build_vault_skill_seed_request(vault_name)
+        now = datetime.now(UTC)
+        frontmatter = _build_frontmatter(request, now)
+        if owner_id is not None:
+            frontmatter["created_by"] = str(owner_id)
+        raw = _compose_markdown(frontmatter, request.content)
+        path = doc_path(
+            normalize_collection_path(request.collection),
+            slugify(request.slug or request.title),
+        )
+        actor = str(owner_id) if owner_id is not None else "unknown"
+        await (await self._native()).create_text_in_conn(
+            conn,
+            namespace_id=vault_id,
+            surface="document",
+            path=path,
+            payload=raw,
+            actor=actor,
+            mutation_id=uuid.uuid4(),
+            resource_id=uuid.uuid4(),
+            message=(
+                f"[put] {path}\n\nagent: {actor}\naction: create\n"
+                f"summary: {request.title}"
+            ),
+            subject=f"[put] {path}",
+            summary=request.title,
+        )
+
     @staticmethod
     def _unsupported(surface: str) -> NoReturn:
         raise NativeRevisionUnsupportedSurfaceError(surface)
@@ -1008,6 +1046,12 @@ class NativeDocumentService(DocumentService):
                     await role_sync.on_vault_create_in_conn(conn, vault_id, uid)
                     await role_sync.on_public_access_change_in_conn(
                         conn, vault_id, public_access,
+                    )
+                    await self._seed_native_vault_skill(
+                        conn,
+                        vault_id=vault_id,
+                        vault_name=name,
+                        owner_id=uid,
                     )
         except asyncpg.UniqueViolationError as exc:
             if exc.constraint_name == "vaults_name_key":

--- a/backend/app/services/native_revision_service.py
+++ b/backend/app/services/native_revision_service.py
@@ -12,9 +12,10 @@ import json
 import secrets
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Final, Protocol
+from typing import Final, Protocol, runtime_checkable
 
 import asyncpg
 
@@ -66,6 +67,21 @@ class TextPayloadStore(Protocol):
     ) -> PreparedReferencePayload: ...
 
     async def open_verified(self, payload_id: uuid.UUID) -> bytes: ...
+
+
+@runtime_checkable
+class TransactionAwareTextPayloadStore(TextPayloadStore, Protocol):
+    """Payload-store capability for publication in a caller-owned PG TX."""
+
+    async def prepare_text_in_conn(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        payload: str | bytes,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> PreparedReferencePayload: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -263,11 +279,17 @@ class NativeRevisionService:
         # P0 froze this at random 20 bytes rendered as 40 lowercase hex.
         return secrets.token_hex(20)
 
-    async def _allocate_revision_id(self) -> str:
+    async def _allocate_revision_id(self, conn: asyncpg.Connection | None = None) -> str:
         """Reject observed collisions and retry with a fresh server token."""
         for _ in range(3):
             candidate = self._opaque_revision_id()
-            async with self.pool.acquire() as conn:
+            if conn is None:
+                async with self.pool.acquire() as acquired:
+                    exists = await acquired.fetchval(
+                        "SELECT EXISTS(SELECT 1 FROM native_revisions WHERE revision_id = $1)",
+                        candidate,
+                    )
+            else:
                 exists = await conn.fetchval(
                     "SELECT EXISTS(SELECT 1 FROM native_revisions WHERE revision_id = $1)",
                     candidate,
@@ -275,6 +297,16 @@ class NativeRevisionService:
             if not exists:
                 return candidate
         raise ConflictError("Unable to allocate a unique native Revision ID after collisions")
+
+    @asynccontextmanager
+    async def _authority_transaction(self, conn: asyncpg.Connection | None):
+        """Use a caller-owned connection, or preserve ordinary create semantics."""
+        if conn is not None:
+            yield conn
+            return
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction():
+                yield acquired
 
     async def _lock_live_reference(
         self,
@@ -355,6 +387,83 @@ class NativeRevisionService:
             expected_digest=expected_digest,
             expected_size=expected_size,
         )
+        result = await self._create_prepared_text(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+            resource_id=resource_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            prepared=prepared,
+        )
+        await self._hit("authority.after_commit_before_response")
+        return result
+
+    async def create_text_in_conn(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        payload: str | bytes,
+        actor: str,
+        mutation_id: uuid.UUID,
+        resource_id: uuid.UUID | None = None,
+        message: str | None = None,
+        subject: str | None = None,
+        summary: str | None = None,
+        expected_digest: str | None = None,
+        expected_size: int | None = None,
+    ) -> NativeMutationResult:
+        """Create text within an existing caller-owned PostgreSQL transaction."""
+        if not conn.is_in_transaction():
+            raise ValidationError("Transaction-aware native publication requires an active transaction")
+        if not isinstance(self.payload_store, TransactionAwareTextPayloadStore):
+            raise TypeError("Native publication requires a transaction-aware payload store")
+        self._validate_common(surface=surface, path=path, actor=actor, mutation_id=mutation_id)
+        if resource_id is not None and not isinstance(resource_id, uuid.UUID):
+            raise ValidationError("Native Resource ID must be a UUID")
+        await self._hit("payload.before_prepare")
+        prepared = await self.payload_store.prepare_text_in_conn(
+            conn,
+            namespace_id=namespace_id,
+            payload=payload,
+            expected_digest=expected_digest,
+            expected_size=expected_size,
+        )
+        return await self._create_prepared_text(
+            namespace_id=namespace_id,
+            surface=surface,
+            path=path,
+            actor=actor,
+            mutation_id=mutation_id,
+            resource_id=resource_id,
+            message=message,
+            subject=subject,
+            summary=summary,
+            prepared=prepared,
+            conn=conn,
+        )
+
+    async def _create_prepared_text(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        surface: str,
+        path: str,
+        actor: str,
+        mutation_id: uuid.UUID,
+        resource_id: uuid.UUID | None,
+        message: str | None,
+        subject: str | None,
+        summary: str | None,
+        prepared: PreparedReferencePayload,
+        conn: asyncpg.Connection | None = None,
+    ) -> NativeMutationResult:
         await self._hit("payload.after_verified")
         fingerprint = self._fingerprint(
             action="create",
@@ -382,8 +491,8 @@ class NativeRevisionService:
             prepared=prepared,
             fingerprint=fingerprint,
             resource_id=resource_id,
+            conn=conn,
         )
-        await self._hit("authority.after_commit_before_response")
         return result
 
     async def _publish_create(
@@ -400,120 +509,120 @@ class NativeRevisionService:
         prepared: PreparedReferencePayload,
         fingerprint: str,
         resource_id: uuid.UUID | None,
+        conn: asyncpg.Connection | None = None,
     ) -> NativeMutationResult:
         resource_id = resource_id or uuid.uuid4()
-        revision_id = await self._allocate_revision_id()
+        revision_id = await self._allocate_revision_id(conn=conn)
         manifest_id = uuid.uuid4()
         activity_id = uuid.uuid4()
         intent_id = uuid.uuid4()
         try:
-            async with self.pool.acquire() as conn:
-                async with conn.transaction():
-                    await self.repository.lock_mutation(conn, namespace_id, mutation_id)
-                    prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
-                    if prior is not None:
-                        if prior["request_fingerprint"] != fingerprint:
-                            raise ConflictError("Native idempotency key was reused with different input")
-                        return self._from_row(prior, replay=True)
+            async with self._authority_transaction(conn) as conn:
+                await self.repository.lock_mutation(conn, namespace_id, mutation_id)
+                prior = await self.repository.find_mutation(conn, namespace_id, mutation_id)
+                if prior is not None:
+                    if prior["request_fingerprint"] != fingerprint:
+                        raise ConflictError("Native idempotency key was reused with different input")
+                    return self._from_row(prior, replay=True)
 
-                    await self.repository.lock_paths(conn, namespace_id, surface, path)
-                    if await self.repository.find_live_path(conn, namespace_id, surface, path) is not None:
-                        raise ConflictError(f"Native Resource already exists at path: {path}")
-                    reused_alias = await self.repository.find_live_alias(
+                await self.repository.lock_paths(conn, namespace_id, surface, path)
+                if await self.repository.find_live_path(conn, namespace_id, surface, path) is not None:
+                    raise ConflictError(f"Native Resource already exists at path: {path}")
+                reused_alias = await self.repository.find_live_alias(
+                    conn,
+                    namespace_id=namespace_id,
+                    surface=surface,
+                    old_path=path,
+                )
+
+                occurred_at = datetime.now(UTC)
+                await self.repository.insert_resource(
+                    conn,
+                    resource_id=resource_id,
+                    namespace_id=namespace_id,
+                    surface=surface,
+                    content_profile="text",
+                    path=path,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_resource")
+                await self.repository.insert_manifest(
+                    conn,
+                    payload_manifest_id=manifest_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    payload=prepared,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_manifest")
+                await self.repository.insert_revision(
+                    conn,
+                    revision_id=revision_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    parent_revision_id=None,
+                    action="create",
+                    path=path,
+                    path_from=None,
+                    path_to=path,
+                    payload_manifest_id=manifest_id,
+                    mutation_id=mutation_id,
+                    request_fingerprint=fingerprint,
+                    message=message,
+                    subject=subject,
+                    summary=summary,
+                    actor=actor,
+                    occurred_at=occurred_at,
+                    activity_event_id=activity_id,
+                    invalidation_intent_id=intent_id,
+                )
+                await self._hit("authority.after_revision")
+                await self.repository.set_head(
+                    conn,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    path=path,
+                    lifecycle="live",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_head")
+                await self._hit("authority.after_path")
+                if reused_alias is not None:
+                    await self.repository.retire_live_alias(
                         conn,
                         namespace_id=namespace_id,
                         surface=surface,
                         old_path=path,
-                    )
-
-                    occurred_at = datetime.now(UTC)
-                    await self.repository.insert_resource(
-                        conn,
-                        resource_id=resource_id,
-                        namespace_id=namespace_id,
-                        surface=surface,
-                        content_profile="text",
-                        path=path,
+                        retired_revision_id=revision_id,
                         occurred_at=occurred_at,
                     )
-                    await self._hit("authority.after_resource")
-                    await self.repository.insert_manifest(
-                        conn,
-                        payload_manifest_id=manifest_id,
-                        namespace_id=namespace_id,
-                        resource_id=resource_id,
-                        payload=prepared,
-                        occurred_at=occurred_at,
-                    )
-                    await self._hit("authority.after_manifest")
-                    await self.repository.insert_revision(
-                        conn,
-                        revision_id=revision_id,
-                        namespace_id=namespace_id,
-                        resource_id=resource_id,
-                        parent_revision_id=None,
-                        action="create",
-                        path=path,
-                        path_from=None,
-                        path_to=path,
-                        payload_manifest_id=manifest_id,
-                        mutation_id=mutation_id,
-                        request_fingerprint=fingerprint,
-                        message=message,
-                        subject=subject,
-                        summary=summary,
-                        actor=actor,
-                        occurred_at=occurred_at,
-                        activity_event_id=activity_id,
-                        invalidation_intent_id=intent_id,
-                    )
-                    await self._hit("authority.after_revision")
-                    await self.repository.set_head(
-                        conn,
-                        resource_id=resource_id,
-                        revision_id=revision_id,
-                        path=path,
-                        lifecycle="live",
-                        occurred_at=occurred_at,
-                    )
-                    await self._hit("authority.after_head")
-                    await self._hit("authority.after_path")
-                    if reused_alias is not None:
-                        await self.repository.retire_live_alias(
-                            conn,
-                            namespace_id=namespace_id,
-                            surface=surface,
-                            old_path=path,
-                            retired_revision_id=revision_id,
-                            occurred_at=occurred_at,
-                        )
-                    await self._hit("authority.after_alias")
-                    await self.repository.insert_activity(
-                        conn,
-                        activity_event_id=activity_id,
-                        namespace_id=namespace_id,
-                        resource_id=resource_id,
-                        revision_id=revision_id,
-                        action="create",
-                        actor=actor,
-                        subject=subject,
-                        summary=summary,
-                        path_from=None,
-                        path_to=path,
-                        occurred_at=occurred_at,
-                    )
-                    await self._hit("authority.after_activity")
-                    await self.repository.insert_invalidation_intent(
-                        conn,
-                        intent_id=intent_id,
-                        namespace_id=namespace_id,
-                        resource_id=resource_id,
-                        revision_id=revision_id,
-                        reason="create",
-                        occurred_at=occurred_at,
-                    )
-                    await self._hit("authority.after_invalidation")
-                    await self._hit("authority.before_commit")
+                await self._hit("authority.after_alias")
+                await self.repository.insert_activity(
+                    conn,
+                    activity_event_id=activity_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    action="create",
+                    actor=actor,
+                    subject=subject,
+                    summary=summary,
+                    path_from=None,
+                    path_to=path,
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_activity")
+                await self.repository.insert_invalidation_intent(
+                    conn,
+                    intent_id=intent_id,
+                    namespace_id=namespace_id,
+                    resource_id=resource_id,
+                    revision_id=revision_id,
+                    reason="create",
+                    occurred_at=occurred_at,
+                )
+                await self._hit("authority.after_invalidation")
+                await self._hit("authority.before_commit")
         except asyncpg.UniqueViolationError as exc:
             if exc.constraint_name == "uq_native_resources_live_path":
                 raise ConflictError(f"Native Resource already exists at path: {path}") from exc

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -9,17 +9,20 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib.util
+import inspect
 import os
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 import asyncpg
+import frontmatter
 import pytest
 
 from app.exceptions import ConflictError, NotFoundError, ValidationError
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.native_revision_repo import NativeRevisionRepository
+from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE
 from app.services.m1_file_measurement import (
     NativeTextDeleteRequest,
     NativeTextPublishRequest,
@@ -160,6 +163,97 @@ async def _authority_counts(pool: asyncpg.Pool) -> dict[str, int]:
     )
     async with pool.acquire() as conn:
         return {table: await conn.fetchval(f"SELECT count(*) FROM {table}") for table in tables}
+
+
+async def _assert_native_vault_creation_rolled_back(pool: asyncpg.Pool, vault_name: str) -> None:
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM vaults WHERE name = $1", vault_name) == 0
+        for table in (
+            "native_resources",
+            "native_revisions",
+            "native_payload_manifests",
+            "native_revision_activity",
+            "native_invalidation_intents",
+            "native_resource_path_aliases",
+            "m1_reference_payloads",
+            "documents",
+        ):
+            assert await conn.fetchval(f"SELECT COUNT(*) FROM {table}") == 0
+
+
+async def test_create_text_public_signature_does_not_expose_a_connection() -> None:
+    assert "conn" not in inspect.signature(NativeRevisionService.create_text).parameters
+
+
+async def test_create_text_in_conn_rejects_connection_outside_a_transaction() -> None:
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool, payload_store=M1PgBodyStore(pool))
+        async with pool.acquire() as conn:
+            with pytest.raises(ValidationError, match="active transaction"):
+                await service.create_text_in_conn(conn, **_create_args(vault_id))
+
+        assert await _authority_counts(pool) == {
+            "native_resources": 0,
+            "native_revisions": 0,
+            "native_payload_manifests": 0,
+            "native_revision_activity": 0,
+            "native_invalidation_intents": 0,
+        }
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT COUNT(*) FROM m1_reference_payloads") == 0
+
+
+async def test_create_text_in_conn_rejects_default_reference_payload_store() -> None:
+    async with _fresh_database() as (pool, vault_id):
+        service = NativeRevisionService(pool)
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                with pytest.raises(TypeError, match="transaction-aware payload store"):
+                    await service.create_text_in_conn(conn, **_create_args(vault_id))
+
+        assert await _authority_counts(pool) == {
+            "native_resources": 0,
+            "native_revisions": 0,
+            "native_payload_manifests": 0,
+            "native_revision_activity": 0,
+            "native_invalidation_intents": 0,
+        }
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT COUNT(*) FROM m1_reference_payloads") == 0
+
+
+async def test_create_text_in_conn_does_not_report_caller_transaction_as_committed() -> None:
+    async with _fresh_database() as (pool, vault_id):
+        seen: list[str] = []
+
+        async def record(name: str) -> None:
+            seen.append(name)
+
+        service = NativeRevisionService(
+            pool,
+            payload_store=M1PgBodyStore(pool),
+            failpoint=record,
+        )
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await service.create_text_in_conn(conn, **_create_args(vault_id))
+                assert conn.is_in_transaction()
+                assert "authority.after_commit_before_response" not in seen
+
+        assert seen == [
+            "payload.before_prepare",
+            "payload.after_verified",
+            "payload.after_prepare_before_tx",
+            "authority.after_resource",
+            "authority.after_manifest",
+            "authority.after_revision",
+            "authority.after_head",
+            "authority.after_path",
+            "authority.after_alias",
+            "authority.after_activity",
+            "authority.after_invalidation",
+            "authority.before_commit",
+        ]
 
 
 async def test_create_get_replace_are_native_atomic_and_leave_legacy_projection_untouched():
@@ -603,6 +697,109 @@ async def test_native_vault_create_is_postgres_only_and_wires_owner_and_public_a
         assert list(tmp_path.iterdir()) == []
 
 
+async def test_native_vault_create_seeds_exact_canonical_skill_in_one_pg_slot(tmp_path, monkeypatch):
+    async with _fresh_database(pool_max_size=1) as (pool, _):
+        from app.config import settings
+        from app.services import native_document_service as native_documents
+
+        class _RoleSync:
+            async def on_vault_create_in_conn(self, conn, vault_id, owner_id) -> None:
+                pass
+
+            async def on_public_access_change_in_conn(self, conn, vault_id, access) -> None:
+                pass
+
+        monkeypatch.setattr(native_documents, "get_role_sync", lambda: _RoleSync())
+        monkeypatch.setattr(settings, "git_storage_path", str(tmp_path))
+        vault_name = f"native-seed-{uuid.uuid4().hex}"
+        owner_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)",
+                owner_id,
+                f"owner-{owner_id.hex}",
+                f"{owner_id.hex}@example.test",
+                "test",
+            )
+        vault_id = uuid.UUID(
+            await NativeDocumentService(pool=pool).create_vault(
+                vault_name,
+                owner_id=str(owner_id),
+            )
+        )
+
+        expected_body = VAULT_SKILL_SEED_TEMPLATE.replace("{vault}", vault_name)
+        expected_path = "overview/vault-skill.md"
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT r.resource_id, r.current_path, r.lifecycle, r.head_revision_id,
+                       rv.parent_revision_id, rv.action, rv.path_at_revision,
+                       rv.path_from, rv.path_to, rv.actor, rv.subject, rv.summary,
+                       m.content_profile, m.digest, m.byte_size, m.encoding,
+                       m.selected_placement, m.verification_profile,
+                       p.canonical_bytes,
+                       a.action AS activity_action, a.actor AS activity_actor,
+                       a.subject AS activity_subject, a.summary AS activity_summary,
+                       a.changed_path_from, a.changed_path_to,
+                       i.reason AS invalidation_reason, i.selected_delivery,
+                       (SELECT COUNT(*) FROM documents d WHERE d.vault_id = r.namespace_id) AS legacy_documents
+                  FROM native_resources r
+                  JOIN native_revisions rv
+                    ON rv.resource_id = r.resource_id
+                   AND rv.revision_id = r.head_revision_id
+                  JOIN native_payload_manifests m
+                    ON m.payload_manifest_id = rv.payload_manifest_id
+                  JOIN m1_reference_payloads p
+                    ON p.payload_id = m.private_locator
+                  JOIN native_revision_activity a
+                    ON a.activity_event_id = rv.activity_event_id
+                  JOIN native_invalidation_intents i
+                    ON i.intent_id = rv.invalidation_intent_id
+                 WHERE r.namespace_id = $1
+                   AND r.surface = 'document'
+                """,
+                vault_id,
+            )
+
+        assert row is not None
+        assert row["current_path"] == row["path_at_revision"] == expected_path
+        assert row["lifecycle"] == "live"
+        assert row["parent_revision_id"] is None
+        assert row["action"] == "create"
+        assert row["path_from"] is None
+        assert row["path_to"] == expected_path
+        assert row["actor"] == row["activity_actor"] == str(owner_id)
+        assert row["subject"] == row["activity_subject"] == f"[put] {expected_path}"
+        assert row["summary"] == row["activity_summary"] == f"{vault_name} Guide"
+        assert row["activity_action"] == "create"
+        assert row["changed_path_from"] is None
+        assert row["changed_path_to"] == expected_path
+        assert row["invalidation_reason"] == "create"
+        assert row["selected_delivery"] is None
+        assert row["content_profile"] == "text"
+        assert row["encoding"] == "utf-8"
+        assert row["selected_placement"] == "pg-bodystore-v1"
+        assert row["verification_profile"] == "sha256-size-utf8-v1"
+
+        canonical = bytes(row["canonical_bytes"])
+        assert frontmatter.loads(canonical.decode("utf-8")).content == expected_body.strip()
+        metadata = frontmatter.loads(canonical.decode("utf-8")).metadata
+        assert metadata["title"] == f"{vault_name} Guide"
+        assert metadata["type"] == "skill"
+        assert metadata["status"] == "draft"
+        assert metadata["tags"] == ["akb:skill"]
+        assert metadata["created_by"] == str(owner_id)
+        assert metadata["summary"] == (
+            "> Edit this document to describe how agents should write into this vault."
+        )
+        assert metadata["created_at"] == metadata["updated_at"]
+        assert "id" not in metadata
+        assert row["byte_size"] == len(canonical)
+        assert row["legacy_documents"] == 0
+        assert list(tmp_path.iterdir()) == []
+
+
 async def test_native_vault_create_syncs_scoped_pat_inside_one_connection(monkeypatch):
     """A one-slot pool proves strict RoleSync never acquires a second slot."""
     async with _fresh_database(pool_max_size=1) as (pool, _):
@@ -743,7 +940,17 @@ async def test_native_vault_create_concurrent_same_name_returns_one_conflict(mon
         assert len([result for result in outcomes if isinstance(result, str)]) == 1
         assert len([result for result in outcomes if isinstance(result, ConflictError)]) == 1
         async with pool.acquire() as conn:
-            assert await conn.fetchval("SELECT COUNT(*) FROM vaults WHERE name = $1", vault_name) == 1
+            winner = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)
+            assert winner is not None
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM native_resources WHERE namespace_id = $1", winner["id"]
+            ) == 1
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM native_revisions WHERE namespace_id = $1", winner["id"]
+            ) == 1
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM m1_reference_payloads WHERE namespace_id = $1", winner["id"]
+            ) == 1
 
 
 async def test_public_delete_removes_native_vault_authority_and_derived_state(
@@ -803,11 +1010,13 @@ async def test_public_delete_removes_native_vault_authority_and_derived_state(
             ),
             agent_id=str(owner_id),
         )
-        assert await NativeDerivedWorker(pool).process_once() == 1
+        worker = NativeDerivedWorker(pool)
+        assert await worker.process_once() == 1  # canonical vault-skill seed
+        assert await worker.process_once() == 1  # user document
         async with pool.acquire() as conn:
             assert await conn.fetchval(
                 "SELECT COUNT(*) FROM native_derived_heads WHERE namespace_id = $1", vault_id
-            ) == 1
+            ) == 2
             assert await conn.fetchval(
                 "SELECT COUNT(*) FROM native_derived_chunks WHERE namespace_id = $1", vault_id
             ) > 0
@@ -926,7 +1135,9 @@ async def test_public_delete_tombstones_native_text_file_derived_chunks(
                 "main.py",
                 f"{vault_name}/src/main.py",
             )
-        assert await NativeDerivedWorker(pool).process_once() == 1
+        worker = NativeDerivedWorker(pool)
+        assert await worker.process_once() == 1  # canonical vault-skill seed
+        assert await worker.process_once() == 1  # native file
 
         async with pool.acquire() as conn:
             native_file_chunk_ids = {
@@ -939,6 +1150,9 @@ async def test_public_delete_tombstones_native_text_file_derived_chunks(
             assert native_file_chunk_ids
             assert await conn.fetchval(
                 "SELECT COUNT(*) FROM native_derived_heads WHERE namespace_id = $1", vault_id
+            ) == 2
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM native_derived_heads WHERE resource_id = $1", created.resource_id
             ) == 1
             assert await conn.fetchval(
                 "SELECT COUNT(*) FROM vector_delete_outbox"
@@ -964,7 +1178,7 @@ async def test_public_delete_tombstones_native_text_file_derived_chunks(
                 "SELECT COUNT(*) FROM chunks WHERE vault_id = $1", vault_id
             ) == 0
             assert await conn.fetchval(
-                "SELECT COUNT(*) FROM vector_delete_outbox"
+                "SELECT COUNT(*) FROM vector_delete_outbox WHERE source_type = 'native_file'"
             ) == len(native_file_chunk_ids)
             for table, where in (
                 ("vaults", "id"),
@@ -993,8 +1207,7 @@ async def test_native_vault_create_rolls_back_catalog_row_when_role_sync_raises(
         with pytest.raises(RuntimeError, match="role sync unavailable"):
             await NativeDocumentService(pool=pool).create_vault(vault_name)
 
-        async with pool.acquire() as conn:
-            assert await conn.fetchval("SELECT COUNT(*) FROM vaults WHERE name = $1", vault_name) == 0
+        await _assert_native_vault_creation_rolled_back(pool, vault_name)
 
 
 async def test_native_vault_create_rolls_back_catalog_row_when_strict_role_sync_is_cancelled(
@@ -1018,8 +1231,61 @@ async def test_native_vault_create_rolls_back_catalog_row_when_strict_role_sync_
         with pytest.raises(asyncio.CancelledError):
             await create_task
 
-        async with pool.acquire() as conn:
-            assert await conn.fetchval("SELECT COUNT(*) FROM vaults WHERE name = $1", vault_name) == 0
+        await _assert_native_vault_creation_rolled_back(pool, vault_name)
+
+
+async def test_native_vault_create_seed_failure_rolls_back_every_fact_and_payload(monkeypatch):
+    async with _fresh_database() as (pool, _):
+        from app.services import native_document_service as native_documents
+
+        class _RoleSync:
+            async def on_vault_create_in_conn(self, conn, vault_id, owner_id) -> None:
+                pass
+
+            async def on_public_access_change_in_conn(self, conn, vault_id, access) -> None:
+                pass
+
+        async def failpoint(name: str) -> None:
+            if name == "authority.after_activity":
+                raise RuntimeError("seed publication failed")
+
+        monkeypatch.setattr(native_documents, "get_role_sync", lambda: _RoleSync())
+        vault_name = f"native-seed-failure-{uuid.uuid4().hex}"
+        with pytest.raises(RuntimeError, match="seed publication failed"):
+            await NativeDocumentService(pool=pool, failpoint=failpoint).create_vault(vault_name)
+
+        await _assert_native_vault_creation_rolled_back(pool, vault_name)
+
+
+async def test_native_vault_create_seed_cancellation_rolls_back_every_fact_and_payload(monkeypatch):
+    async with _fresh_database(pool_max_size=1) as (pool, _):
+        from app.services import native_document_service as native_documents
+
+        class _RoleSync:
+            async def on_vault_create_in_conn(self, conn, vault_id, owner_id) -> None:
+                pass
+
+            async def on_public_access_change_in_conn(self, conn, vault_id, access) -> None:
+                pass
+
+        started = asyncio.Event()
+
+        async def failpoint(name: str) -> None:
+            if name == "authority.after_activity":
+                started.set()
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr(native_documents, "get_role_sync", lambda: _RoleSync())
+        vault_name = f"native-seed-cancel-{uuid.uuid4().hex}"
+        create_task = asyncio.create_task(
+            NativeDocumentService(pool=pool, failpoint=failpoint).create_vault(vault_name)
+        )
+        await started.wait()
+        create_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await create_task
+
+        await _assert_native_vault_creation_rolled_back(pool, vault_name)
 
 
 async def test_native_vault_create_cancellation_rolls_back_actual_role_sync_state(monkeypatch):

--- a/backend/tests/test_native_document_vault_creation_unit.py
+++ b/backend/tests/test_native_document_vault_creation_unit.py
@@ -66,6 +66,12 @@ async def test_create_vault_uses_postgres_repository_and_rbac_without_git(monkey
     monkeypatch.setattr(native_documents, "VaultRepository", _VaultRepository, raising=False)
     monkeypatch.setattr(native_documents, "get_role_sync", lambda: _RoleSync(), raising=False)
 
+    async def _seed(_service, conn, *, vault_id, vault_name, owner_id) -> None:
+        assert conn is connection
+        calls.append(("seed", vault_id, vault_name, owner_id))
+
+    monkeypatch.setattr(NativeDocumentService, "_seed_native_vault_skill", _seed)
+
     result = await NativeDocumentService(pool=pool_marker).create_vault(
         "native-create",
         "native description",
@@ -88,6 +94,7 @@ async def test_create_vault_uses_postgres_repository_and_rbac_without_git(monkey
         ),
         ("on_vault_create", vault_id, owner_id),
         ("on_public_access_change", vault_id, "reader"),
+        ("seed", vault_id, "native-create", owner_id),
     ]
 
 

--- a/backend/tests/test_vault_skill_seed_unit.py
+++ b/backend/tests/test_vault_skill_seed_unit.py
@@ -1,13 +1,34 @@
 """Unit test: create_vault seeds overview/vault-skill.md with type=skill."""
 import pytest
 
-from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE
+from app.services.document_service import (
+    VAULT_SKILL_SEED_TEMPLATE,
+    build_vault_skill_seed_request,
+)
 
 
 def test_seed_template_constant_exists():
     assert "Guide" in VAULT_SKILL_SEED_TEMPLATE
     assert "{vault}" in VAULT_SKILL_SEED_TEMPLATE  # substitutable
     assert "akb_put" not in VAULT_SKILL_SEED_TEMPLATE  # template is for owners to edit, not call-instructions
+
+
+def test_canonical_seed_request_preserves_legacy_fields_and_body():
+    vault = "parity-vault"
+    request = build_vault_skill_seed_request(vault)
+
+    assert request.model_dump(exclude_none=True) == {
+        "vault": vault,
+        "collection": "overview",
+        "title": "parity-vault Guide",
+        "type": "skill",
+        "slug": "vault-skill",
+        "tags": ["akb:skill"],
+        "content": VAULT_SKILL_SEED_TEMPLATE.replace("{vault}", vault),
+        "status": "draft",
+        "related_to": [],
+        "depends_on": [],
+    }
 
 
 def test_seed_template_secrets_placeholder_literal():


### PR DESCRIPTION
## Summary
- seed the canonical overview/vault-skill.md Document when postgres_native creates a vault
- keep vault catalog, role sync, BodyStore, logical revision, activity, and invalidation in one PostgreSQL transaction
- preserve ordinary create_text and Bare Git behavior while adding an explicit transaction-aware publication boundary

## Validation
- focused PostgreSQL/unit selection: 18 passed
- broader native revision/unit coverage before review adjustment: 73 passed, 2 skipped
- Ruff: passed
- targeted mypy: passed
- Sol xHigh review: 0 High / 0 Medium

R4 Live parity follow-up for the standalone Bare Git vs postgres_native isolated development environment pair.