### PR TITLE
fix: skip Git startup paths for PostgreSQL Native

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,27 +78,31 @@ async def lifespan(app: FastAPI):
     # Idempotent — already-covered handlers are skipped.
     install_secret_redaction()
     await init_storage()
-    # Stamp the external-mirror marker on any mirror whose
-    # bare repo predates it, so its reads route through the hermetic runner
-    # (fail-closed) rather than GitPython. Runs AFTER the DB is up (authoritative
-    # mirror list) and BEFORE workers/requests. UNCONDITIONAL — it runs even when
-    # external_git is disabled, because the marker is the fail-closed safety net
-    # that makes the read paths correctly REFUSE a disabled mirror (503) rather
-    # than serve it via GitPython; the kill-switch lives on the poller-start gate
-    # and the read paths, not here. FAIL-FAST: if a marker cannot be written onto
-    # an existing mirror bare (disk/permission), or the mirror list can't be
-    # read, this raises and startup ABORTS rather than serving mirrors that would
-    # fall open. No serving has begun yet, so the fail-open window is zero.
-    marked = await external_git_service.backfill_mirror_markers()
-    if marked:
-        logger.info("Backfilled external-git mirror marker on %d vault(s)", marked)
-    # When the mirror feature is enabled, prove at boot (in a
-    # thread; it runs a git subprocess + loopback socket) that this git build
-    # actually enforces the network controls the hermetic runner depends on
-    # (http.curloptResolve DNS-pin, proxy-off, --config-env) and meets the git
-    # >= 2.37 floor. Fast-fails the boot BEFORE workers/serving start if not; a
-    # no-op when external_git is disabled. No real network (uses a *.invalid host).
-    await asyncio.to_thread(check_external_git_capability, settings)
+    bare_git_selected = selected_document_revision_backend() == "bare_git"
+    if bare_git_selected:
+        # Stamp the external-mirror marker on any mirror whose
+        # bare repo predates it, so its reads route through the hermetic runner
+        # (fail-closed) rather than GitPython. Runs AFTER the DB is up (authoritative
+        # mirror list) and BEFORE workers/requests. This remains unconditional
+        # within Bare-Git mode, even when external_git is disabled, because the
+        # marker is the fail-closed safety net that makes the read paths correctly
+        # REFUSE a disabled mirror (503) rather than serve it via GitPython. The
+        # backfill is not composed for PostgreSQL Native, whose vault storage is
+        # PostgreSQL-only and may have no Git write authority. FAIL-FAST: if a
+        # marker cannot be written onto an existing mirror bare (disk/permission),
+        # or the mirror list can't be read, this raises and startup ABORTS rather
+        # than serving mirrors that would fall open. No serving has begun yet, so
+        # the fail-open window is zero.
+        marked = await external_git_service.backfill_mirror_markers()
+        if marked:
+            logger.info("Backfilled external-git mirror marker on %d vault(s)", marked)
+        # When the mirror feature is enabled, prove at boot (in a
+        # thread; it runs a git subprocess + loopback socket) that this git build
+        # actually enforces the network controls the hermetic runner depends on
+        # (http.curloptResolve DNS-pin, proxy-off, --config-env) and meets the git
+        # >= 2.37 floor. Fast-fails the boot BEFORE workers/serving start if not; a
+        # no-op when external_git is disabled. No real network (uses a *.invalid host).
+        await asyncio.to_thread(check_external_git_capability, settings)
     start_workers()
     yield
     await stop_workers()

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -17,7 +17,10 @@ from app.services.native_revision_authority import (
     pre_migration_revision_authority_guard,
     startup_revision_authority_preflight,
 )
-from app.services.revision_backend import canonical_document_revision_backend
+from app.services.revision_backend import (
+    canonical_document_revision_backend,
+    selected_document_revision_backend,
+)
 from app.services.role_sync import RoleSync, get_role_sync, set_role_sync
 from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
 from app.services.vector_store import get_vector_store
@@ -97,7 +100,7 @@ async def init_storage() -> None:
     # Self-heal: clear stale git index.lock files left behind by a
     # crashed prior process. Without this, the affected vault's writes
     # fail silently until an operator removes the lock by hand.
-    if settings.document_revision_backend != "postgres_native":
+    if selected_document_revision_backend() == "bare_git":
         try:
             cleared = GitService().cleanup_stale_locks()
             if cleared:
@@ -148,11 +151,11 @@ def start_workers() -> None:
         logger.debug("app_rollout_worker deferred: no running event loop")
     else:
         app_rollout_worker.start()
-    # external-git kill-switch: the mirror poller must not run when the feature is
-    # off (no claim, no outbound). Gated so a disabled deployment
-    # starts zero mirror I/O; the read paths refuse mirror reads and the marker
-    # backfill (fail-closed safety net) still runs unconditionally at startup.
-    if settings.external_git_enabled:
+    # External-Git mirrors are a Bare-Git subsystem. The feature kill-switch
+    # still gates it within that mode, while PostgreSQL Native composes no
+    # mirror poller because its vault storage has no Git write authority.
+    bare_git_selected = selected_document_revision_backend() == "bare_git"
+    if bare_git_selected and settings.external_git_enabled:
         external_git_poller.start()
     # Auto-backfill vault_id onto pre-upgrade pgvector points (issue #189
     # Phase 2). Non-blocking; search self-activates the vault path once it
@@ -177,7 +180,7 @@ def start_workers() -> None:
     # READS out of asyncio.to_thread's shared default executor.
     write_lane.start_commit_pool()
     started = ["tokenizer_pool", "git_commit_pool", "embed_worker", "delete_worker", "app_rollout_worker", "bm25_stats_refresher", "vault_backfill"]
-    if settings.external_git_enabled:
+    if bare_git_selected and settings.external_git_enabled:
         started.append("external_git_poller")
     if m1_file_transfer_reaper.enabled():
         m1_file_transfer_reaper.start()
@@ -196,7 +199,11 @@ def start_workers() -> None:
     # can produce work and it must issue zero LLM outbound. It is also the only
     # LLM consumer in the request-independent path, so it still stays off when
     # LLM isn't configured (no retry/abandon noise for OSS users without a key).
-    if not settings.external_git_enabled:
+    if not bare_git_selected:
+        logger.info(
+            "metadata_worker disabled (document revision backend is not Bare Git)"
+        )
+    elif not settings.external_git_enabled:
         logger.info(
             "metadata_worker disabled (external_git_enabled=false; it only "
             "fills metadata on external_git mirror imports)"

--- a/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
+++ b/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
@@ -1,0 +1,136 @@
+"""Real lifecycle.init_storage coverage for revision-backend Git composition."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.config import Settings
+
+
+_DATABASE_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
+_IMAGE_DIGEST = "sha256:" + "a" * 64
+
+
+def _settings(tmp_path, backend: str | None = None) -> Settings:
+    values = {"git_storage_path": str(tmp_path / "vaults")}
+    if backend is not None:
+        values["document_revision_backend"] = backend
+    if backend == "postgres_native":
+        values.update(
+            {
+                "document_revision_tenant_id": "tenant-001",
+                "document_revision_namespace": "tenant-001",
+                "document_revision_database_id": _DATABASE_ID,
+                "document_revision_runtime_image_digest": _IMAGE_DIGEST,
+            }
+        )
+    return Settings(**values)
+
+
+def _stub_init_storage_dependencies(monkeypatch, lifecycle, settings, events: list[str]) -> None:
+    monkeypatch.setattr(lifecycle, "settings", settings)
+    monkeypatch.setattr(lifecycle, "_validate_required_settings", lambda: None)
+
+    async def no_op() -> None:
+        pass
+
+    async def authority_preflight() -> str:
+        events.append("authority_preflight")
+        return "ready"
+
+    monkeypatch.setattr(lifecycle, "pre_migration_revision_authority_guard", no_op)
+    monkeypatch.setattr(lifecycle, "init_db", no_op)
+    monkeypatch.setattr(lifecycle, "startup_revision_authority_preflight", authority_preflight)
+
+    class _VectorStore:
+        async def ensure_collection(self) -> None:
+            events.append("vector_store.ensure_collection")
+
+    monkeypatch.setattr(lifecycle, "get_vector_store", lambda: _VectorStore())
+
+    class _Pool:
+        pass
+
+    pool = _Pool()
+
+    async def get_pool():
+        events.append("get_pool")
+        return pool
+
+    monkeypatch.setattr(lifecycle, "get_pool", get_pool)
+
+    class _RoleSync:
+        def __init__(self, received_pool) -> None:
+            assert received_pool is pool
+            events.append("RoleSync")
+
+        async def reconcile_from_catalog(self) -> dict[str, int]:
+            events.append("RoleSync.reconcile_from_catalog")
+            return {"errors": 0}
+
+    monkeypatch.setattr(lifecycle, "RoleSync", _RoleSync)
+    monkeypatch.setattr(lifecycle, "UserSqlExecutor", lambda received_pool: received_pool)
+    monkeypatch.setattr(lifecycle, "set_role_sync", lambda role_sync: None)
+    monkeypatch.setattr(lifecycle, "set_user_sql_executor", lambda executor: None)
+
+
+@pytest.mark.parametrize("configured_backend", [None, "bare_git"])
+async def test_init_storage_default_and_explicit_bare_git_clean_stale_locks(
+    monkeypatch, tmp_path, configured_backend
+):
+    from app.services import lifecycle
+    from app.services.revision_backend import canonical_document_revision_backend
+
+    configured = _settings(tmp_path, configured_backend)
+    selected_backend = canonical_document_revision_backend(configured.document_revision_backend)
+    assert selected_backend == "bare_git"
+    events: list[str] = []
+    _stub_init_storage_dependencies(monkeypatch, lifecycle, configured, events)
+    monkeypatch.setattr(lifecycle, "selected_document_revision_backend", lambda: selected_backend)
+
+    class _TrackingGit:
+        constructed = 0
+        cleanups = 0
+
+        def __init__(self) -> None:
+            type(self).constructed += 1
+
+        def cleanup_stale_locks(self) -> int:
+            type(self).cleanups += 1
+            return 0
+
+    monkeypatch.setattr(lifecycle, "GitService", _TrackingGit)
+
+    await lifecycle.init_storage()
+
+    assert _TrackingGit.constructed == 1
+    assert _TrackingGit.cleanups == 1
+    assert "RoleSync.reconcile_from_catalog" in events
+
+
+async def test_init_storage_postgres_native_never_constructs_git(monkeypatch, tmp_path):
+    from app.services import lifecycle
+    from app.services.revision_backend import canonical_document_revision_backend
+
+    configured = _settings(tmp_path, "postgres_native")
+    selected_backend = canonical_document_revision_backend(configured.document_revision_backend)
+    assert selected_backend == "postgres_native"
+    events: list[str] = []
+    _stub_init_storage_dependencies(monkeypatch, lifecycle, configured, events)
+    monkeypatch.setattr(lifecycle, "selected_document_revision_backend", lambda: selected_backend)
+
+    constructed: list[int] = []
+
+    class _FailingGit:
+        def __init__(self) -> None:
+            constructed.append(1)
+            raise AssertionError("postgres_native init_storage must not construct GitService")
+
+    monkeypatch.setattr(lifecycle, "GitService", _FailingGit)
+
+    await lifecycle.init_storage()
+
+    assert constructed == []
+    assert "RoleSync.reconcile_from_catalog" in events

--- a/backend/tests/test_lifecycle_workers.py
+++ b/backend/tests/test_lifecycle_workers.py
@@ -32,6 +32,16 @@ def _import_lifecycle(monkeypatch, tmp_path):
 def _stub_workers(monkeypatch, lifecycle, started: list[str]) -> None:
     """Replace every worker start hook `start_workers` touches with a recorder."""
 
+    # The production lifecycle receives the process-selected revision backend
+    # from the composition root. Keep these direct lifecycle tests on the
+    # legacy path unless a test explicitly overrides it.
+    monkeypatch.setattr(
+        lifecycle,
+        "selected_document_revision_backend",
+        lambda: "bare_git",
+        raising=False,
+    )
+
     def rec(label: str):
         return lambda *a, **k: started.append(label)
 
@@ -126,6 +136,24 @@ def test_start_workers_skips_metadata_worker_when_external_git_disabled(monkeypa
     assert "metadata_worker" not in started
     # … the poller is off too, while the always-on set still starts.
     assert "external_git_poller" not in started
+    assert "embed_worker" in started
+
+
+def test_start_workers_skips_git_only_workers_for_postgres_native(monkeypatch, tmp_path):
+    lifecycle = _import_lifecycle(monkeypatch, tmp_path)
+    started: list[str] = []
+    _stub_workers(monkeypatch, lifecycle, started)
+    monkeypatch.setattr(lifecycle, "selected_document_revision_backend", lambda: "postgres_native")
+    monkeypatch.setattr(
+        lifecycle,
+        "settings",
+        _settings(external_git_enabled=True, llm_configured=True),
+    )
+
+    lifecycle.start_workers()
+
+    assert "external_git_poller" not in started
+    assert "metadata_worker" not in started
     assert "embed_worker" in started
 
 

--- a/backend/tests/test_native_startup_git_composition_unit.py
+++ b/backend/tests/test_native_startup_git_composition_unit.py
@@ -1,0 +1,78 @@
+"""Native startup must not compose Bare-Git maintenance paths."""
+
+from __future__ import annotations
+
+
+def _patch_lifespan(monkeypatch, main, selected_backend: str, events: list[str]) -> None:
+    monkeypatch.setattr(main, "selected_document_revision_backend", lambda: selected_backend)
+    monkeypatch.setattr(main, "install_secret_redaction", lambda: None)
+
+    async def init_storage() -> None:
+        events.append("init_storage")
+
+    async def backfill_mirror_markers() -> int:
+        events.append("backfill_mirror_markers")
+        return 1
+
+    def check_external_git_capability(_settings) -> None:
+        events.append("check_external_git_capability")
+
+    def start_workers() -> None:
+        events.append("start_workers")
+
+    async def stop_workers() -> None:
+        events.append("stop_workers")
+
+    async def shutdown_storage() -> None:
+        events.append("shutdown_storage")
+
+    def audit_shutdown() -> None:
+        events.append("audit_shutdown")
+
+    monkeypatch.setattr(main, "init_storage", init_storage)
+    monkeypatch.setattr(main.external_git_service, "backfill_mirror_markers", backfill_mirror_markers)
+    monkeypatch.setattr(main, "check_external_git_capability", check_external_git_capability)
+    monkeypatch.setattr(main, "start_workers", start_workers)
+    monkeypatch.setattr(main, "stop_workers", stop_workers)
+    monkeypatch.setattr(main, "shutdown_storage", shutdown_storage)
+    monkeypatch.setattr(main.audit_log, "shutdown", audit_shutdown)
+
+
+async def test_native_lifespan_skips_git_startup_maintenance(monkeypatch, tmp_path):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    from app import main
+
+    events: list[str] = []
+    _patch_lifespan(monkeypatch, main, "postgres_native", events)
+
+    async with main.lifespan(main.app):
+        events.append("serving")
+
+    assert "backfill_mirror_markers" not in events
+    assert "check_external_git_capability" not in events
+    assert events == [
+        "init_storage",
+        "start_workers",
+        "serving",
+        "stop_workers",
+        "shutdown_storage",
+        "audit_shutdown",
+    ]
+
+
+async def test_bare_git_lifespan_keeps_git_startup_maintenance(monkeypatch, tmp_path):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    from app import main
+
+    events: list[str] = []
+    _patch_lifespan(monkeypatch, main, "bare_git", events)
+
+    async with main.lifespan(main.app):
+        events.append("serving")
+
+    assert "backfill_mirror_markers" in events
+    assert "check_external_git_capability" in events


### PR DESCRIPTION
## Summary
- gate Bare-Git startup maintenance by the stable process-selected revision backend
- keep omitted/default and explicit Bare Git startup behavior unchanged
- prevent PostgreSQL Native startup from requiring Git write authority

## Live trigger
A Native standalone backend with `/data/vaults` mounted read-only failed at startup because external-Git mirror marker backfill constructed `GitService` and attempted to create `_worktrees`.

## Validation
- focused startup/lifecycle/backend regressions: 91 passed
- Ruff: passed
- mypy: passed
- Sol High exact-head review: 0 High / 0 Medium

Bare Git remains the omitted/default and selectable backend.