### PR TITLE
chore: refresh detect-secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3464
+        "line_number": 3476
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5372,5 +5372,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T07:27:58Z"
+  "generated_at": "2026-08-12T17:24:09Z"
 }


### PR DESCRIPTION
## Summary

Refresh the tracked detect-secrets baseline metadata after the changelog moved an existing reviewed finding.

## Validation

- The finding count remains unchanged at 661.
- The normalized findings and scanner configuration are unchanged.
- No new secret finding was added.
- A second run of the exact tracked-file hook from `scripts/check.sh` exits successfully without modifying the baseline.
- `git diff --check` passes.

This is intentionally limited to `.secrets.baseline`.
