### PR TITLE
fix(backend): refresh uv lock metadata

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.13.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

Refresh the backend lockfile's editable AKB package metadata from version `0.13.0` to `0.14.1`.

The stale root-package version caused `uv sync --locked --extra dev --project backend` to fail before the repository E2E suite could start.

## Validation

- reproduced the locked-sync failure with CPython 3.14.6 and uv 0.12.3
- regenerated the lockfile with the repository's canonical command
- `uv sync --locked --extra dev --project backend` passed
- the workflow's Python 3.14 assertion passed
- no third-party dependency, marker, source, or hash changed
- `git diff --check` passed
