### PR TITLE
Add isolated product-admin authentication boundary

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -183,6 +183,12 @@ jobs:
         # and triggers hold. It was absent from this list with a
         # since-renumbered migration tuple, so it silently self-skipped in
         # both jobs.
+        #
+        # Recovery-admin provisioning and the dedicated admin browser-session
+        # contract are also database guarantees.  Their ordinary unit-job
+        # collection intentionally skips without Postgres, so keep both files
+        # explicit here: otherwise account uniqueness, exact identity FKs,
+        # session concurrency, and the 072 upgrade path would never gate CI.
         run: >
           pytest
           tests/test_pgvector_ext_bootstrap_e2e.py
@@ -205,6 +211,8 @@ jobs:
           tests/test_app_inventory_postgres.py
           tests/test_app_installation_postgres.py
           tests/test_app_rollout_postgres.py
+          tests/test_recovery_admin_provisioning_postgres.py
+          tests/test_admin_auth_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov/
 /config/*.yaml
 /config/*.bak
 !/config/*.yaml.example
+/config/local-session/
 # Test-bootstrap copy of app.yaml — materialised by backend/tests/conftest.py
 # so `app.config` can import when pytest runs from `backend/` (CWD-relative
 # config search misses the repo-root /config without it).

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,14 +215,14 @@
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "7bd173a7d5330a38f4e220b20348085e38bf232b",
         "is_verified": false,
-        "line_number": 569
+        "line_number": 576
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "ea67b3a75dccf0e8c1d6058e060151a3c5ed90a8",
         "is_verified": false,
-        "line_number": 571
+        "line_number": 578
       }
     ],
     "backend/tests/bench/sparse_shape_bench.py": [
@@ -321,7 +321,7 @@
         "filename": "deploy/k8s/backend.yaml",
         "hashed_secret": "e2c600c1584e7714abc8f7267aaf28fd288c1cc2",
         "is_verified": false,
-        "line_number": 163,
+        "line_number": 169,
         "is_secret": false
       }
     ],
@@ -369,6 +369,14 @@
         "hashed_secret": "68c114871fdf0d526f8500506080843416456625",
         "is_verified": false,
         "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/keycloak-dev/akb-realm.json",
+        "hashed_secret": "83b5bf2767289e194a128e16ac93f5a01503f89b",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
       }
     ],
     "docker-compose.keycloak.yaml": [
@@ -377,7 +385,7 @@
         "filename": "docker-compose.keycloak.yaml",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 75
       }
     ],
     "docker-compose.yaml": [
@@ -5372,5 +5380,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T04:17:04Z"
+  "generated_at": "2026-08-13T05:22:45Z"
 }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,14 @@ store* below.
 # 1. Configure
 cp config/app.yaml.example   config/app.yaml
 cp config/secret.yaml.example config/secret.yaml
-$EDITOR config/secret.yaml   # set embed_api_key (and jwt_secret for any non-local deploy)
+$EDITOR config/secret.yaml   # set embed_api_key and replace system_hmac_secret
+
+# Generate the installation's persistent RSA-3072 local-session keyset.
+# This directory is gitignored; back it up with the other installation secrets.
+cd backend
+uv run python -m app.cli generate-local-session-keyset \
+  --output-dir ../config/local-session
+cd ..
 
 # 2. Run
 docker compose up -d
@@ -320,6 +327,33 @@ username/email, or an already-bound external identity fails closed. The SSO
 command stores no usable local password and does not contact the identity
 provider. Generated output files are create-only and never overwritten; for a
 retry after the file exists, pass that file back with `--password-file`.
+
+Local login issues only the versioned `local-session-rs256-v2` profile:
+RS256 with an installation-owned RSA-3072 key, an RFC 7638 `kid`, exact
+deployment issuer/audience, `jti`, and a public-only JWKS at
+`GET /api/v1/auth/jwks`. AKB never chooses a verifier from an untrusted token
+`alg` header. Upgrading from an HS256 release is an intentional forced-login
+boundary: generate and persist the v2 keyset before rollout, set
+`jwt_algorithm: RS256`, and restart all backends together. Existing HS256 user
+sessions then receive 401 and must sign in again; PATs and service keys are not
+revoked. The old `jwt_secret` may be retained for one release only as migration
+input for short-lived internal HMAC capabilities, or renamed unchanged to
+`system_hmac_secret`; it is never accepted as human-session signing material.
+
+For routine v2 key rotation, generate a new directory while retaining the
+current public JWKS, publish the new immutable Secret/config revision, and
+roll every backend to that exact pair:
+
+```bash
+cd backend
+uv run python -m app.cli generate-local-session-keyset \
+  --output-dir /secure/akb/local-session-next \
+  --retain-jwks /secure/akb/local-session-current/jwks.json
+```
+
+Keep a retained public key for at least `jwt_expire_hours` plus rollout skew,
+then remove it in a later coordinated keyset revision. Restoring the previous
+private/JWKS pair is the rollback; never overwrite key files in place.
 
 ### Vector store (driver-pluggable)
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,27 @@ command stores no usable local password and does not contact the identity
 provider. Generated output files are create-only and never overwritten; for a
 retry after the file exists, pass that file back with `--password-file`.
 
+Open `/admin` for the separate product-administration surface. In `local`
+mode it accepts the provisioned local administrator and returns the same
+`local-session-rs256-v2` profile used by local human authentication, but it
+refuses non-admin accounts. In `sso` mode local credentials are absent:
+`/admin` uses a dedicated confidential `akb-admin` Keycloak client with PKCE
+and nonce, then accepts only the exact pre-bound `(issuer, subject)` whose AKB
+account is still active and `is_admin=true`.
+
+The SSO callback stores no Keycloak access, refresh, or ID token. It creates a
+short-lived opaque HttpOnly admin cookie plus a CSRF token; PostgreSQL stores
+only their hashes plus the exact identity snapshot, and rechecks the account,
+unchanged external binding, and admin flag on every request. The one-time OIDC
+state is also bound to a short-lived
+HttpOnly cookie so a callback copied into another browser fails before token
+exchange. Configure `keycloak_admin_client_secret`, register
+`<public_base_url>/api/v1/admin/auth/keycloak/callback` and
+`<public_base_url>/admin` in the dedicated client, and keep the admin client ID
+out of every API/MCP resource-client path. Browser-facing AKB and Keycloak URLs
+must use HTTPS outside the explicit loopback development exception. Ordinary SSO browser
+login remains staged until its Phase 4 server-side token-custody work lands.
+
 Local login issues only the versioned `local-session-rs256-v2` profile:
 RS256 with an installation-owned RSA-3072 key, an RFC 7638 `kid`, exact
 deployment issuer/audience, `jti`, and a public-only JWKS at

--- a/README.md
+++ b/README.md
@@ -280,13 +280,46 @@ $EDITOR config/secret.yaml   # set embed_api_key (and jwt_secret for any non-loc
 # 2. Run
 docker compose up -d
 
-# 3. Open
+# 3. Provision the designated recovery administrator (local mode)
+#    The password is read from stdin and is never printed by AKB.
+docker compose exec -T backend python -m app.cli provision-recovery-admin local \
+  --username recovery-admin --email recovery-admin@example.com \
+  --password-file - < /secure/operator/recovery-admin.password
+
+# 4. Open
 open http://localhost:3000
 ```
 
 `config/app.yaml` and `config/secret.yaml` are the **single source of runtime
 configuration** — no environment variables are read by the backend. Mount the
 `config/` directory at `/etc/akb/` in any deployment.
+
+Ordinary registration always creates a non-admin account, including on an
+empty database. Administrator bootstrap is available only through the
+operator CLI; there is no unauthenticated HTTP bootstrap endpoint. The CLI
+profile must match `auth_mode`:
+
+```bash
+# Local: have AKB generate the password only when an operator-owned output
+# file is explicitly requested. A new file is created with mode 0600 and the
+# password is not written to stdout, stderr, logs, or application config.
+python -m app.cli provision-recovery-admin local \
+  --username recovery-admin --email recovery-admin@example.com \
+  --generate-password-file /secure/operator/recovery-admin.password
+
+# SSO: pre-bind the product administrator to the exact external identity.
+# Username and email are snapshots; issuer + subject are the identity key.
+python -m app.cli provision-recovery-admin sso \
+  --username recovery-admin --email recovery-admin@example.com \
+  --issuer https://issuer.example.com/realms/akb \
+  --subject exact-provider-subject
+```
+
+The same exact identity is idempotent. A different designation, an existing
+username/email, or an already-bound external identity fails closed. The SSO
+command stores no usable local password and does not contact the identity
+provider. Generated output files are create-only and never overwritten; for a
+retry after the file exists, pass that file back with `--password-file`.
 
 ### Vector store (driver-pluggable)
 

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -570,7 +570,7 @@ async def admin_revoke_user_sessions(
 
     Useful for incident response (account compromise, employee
     offboarding) without needing the user's password and without
-    rotating the global ``jwt_secret`` (which would log out everyone).
+    replacing the local-session verification keyset (which logs out everyone).
     Does not touch PATs — those have their own revoke flow.
     """
     require_local_auth_enabled()

--- a/backend/app/api/routes/admin_auth.py
+++ b/backend/app/api/routes/admin_auth.py
@@ -1,0 +1,284 @@
+"""Mode-separated product-admin browser authentication routes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from urllib.parse import urlsplit
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from app.config import settings
+from app.exceptions import AuthenticationError
+from app.services.admin_auth_service import (
+    ProductAdminIdentity,
+    authenticate_local_product_admin,
+    create_sso_admin_browser_session,
+    resolve_local_product_admin,
+    resolve_prebound_sso_product_admin,
+    resolve_sso_admin_browser_session,
+    revoke_sso_admin_browser_session,
+)
+from app.services.auth_service import AuthenticatedUser
+from app.services.keycloak_oidc import get_keycloak_oidc
+from app.util.text import NFCModel
+
+
+router = APIRouter()
+
+_ADMIN_SESSION_COOKIE = "akb_admin_session"
+_ADMIN_CSRF_COOKIE = "akb_admin_csrf"
+_ADMIN_OIDC_BINDING_COOKIE = "akb_admin_oidc_binding"
+_ADMIN_OIDC_CALLBACK_PATH = "/api/v1/admin/auth/keycloak/callback"
+
+
+class AdminLocalLoginRequest(NFCModel):
+    username: str
+    password: str
+
+
+def _require_mode(expected: str) -> None:
+    if settings.require_auth_mode() != expected:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Admin login route is not enabled")
+
+
+def _admin_sso_ready() -> bool:
+    return bool(
+        settings.keycloak_enabled
+        and settings.keycloak_admin_client_id.strip()
+        and settings.keycloak_admin_client_secret
+    )
+
+
+def _require_admin_sso() -> None:
+    _require_mode("sso")
+    if not _admin_sso_ready():
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Product-admin SSO is not configured",
+        )
+
+
+def _secure_cookie() -> bool:
+    return urlsplit(settings.public_base_url).scheme == "https"
+
+
+def _identity_response(
+    identity: ProductAdminIdentity | AuthenticatedUser,
+) -> dict:
+    return {
+        "id": str(identity.user_id),
+        "username": identity.username,
+        "email": identity.email,
+        "display_name": identity.display_name,
+        "is_admin": True,
+    }
+
+
+def _set_admin_cookies(
+    response: RedirectResponse,
+    *,
+    token: str,
+    csrf_token: str,
+    expires_at: datetime,
+) -> None:
+    max_age = max(
+        1,
+        int((expires_at - datetime.now(timezone.utc)).total_seconds()),
+    )
+    secure = _secure_cookie()
+    response.set_cookie(
+        _ADMIN_SESSION_COOKIE,
+        token,
+        max_age=max_age,
+        secure=secure,
+        httponly=True,
+        samesite="lax",
+        path="/api/v1/admin",
+    )
+    response.set_cookie(
+        _ADMIN_CSRF_COOKIE,
+        csrf_token,
+        max_age=max_age,
+        secure=secure,
+        httponly=False,
+        samesite="lax",
+        path="/",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+def _clear_admin_cookies(response: JSONResponse) -> None:
+    secure = _secure_cookie()
+    response.delete_cookie(
+        _ADMIN_SESSION_COOKIE,
+        secure=secure,
+        httponly=True,
+        samesite="lax",
+        path="/api/v1/admin",
+    )
+    response.delete_cookie(
+        _ADMIN_CSRF_COOKIE,
+        secure=secure,
+        httponly=False,
+        samesite="lax",
+        path="/",
+    )
+
+
+def _set_admin_oidc_binding_cookie(
+    response: RedirectResponse,
+    browser_binding: str,
+) -> None:
+    response.set_cookie(
+        _ADMIN_OIDC_BINDING_COOKIE,
+        browser_binding,
+        max_age=600,
+        secure=_secure_cookie(),
+        httponly=True,
+        samesite="lax",
+        path=_ADMIN_OIDC_CALLBACK_PATH,
+    )
+
+
+def _clear_admin_oidc_binding_cookie(response: RedirectResponse) -> None:
+    response.delete_cookie(
+        _ADMIN_OIDC_BINDING_COOKIE,
+        secure=_secure_cookie(),
+        httponly=True,
+        samesite="lax",
+        path=_ADMIN_OIDC_CALLBACK_PATH,
+    )
+
+
+@router.get("/admin/auth/config", summary="Public product-admin login configuration")
+async def admin_auth_config():
+    mode = settings.require_auth_mode()
+    local_enabled = mode == "local"
+    keycloak_enabled = mode == "sso" and _admin_sso_ready()
+    return {
+        "schema_version": 1,
+        "auth_mode": mode,
+        "local": {
+            "enabled": local_enabled,
+            "login_url": "/api/v1/admin/auth/local/login" if local_enabled else None,
+        },
+        "keycloak": {
+            "enabled": keycloak_enabled,
+            "login_url": ("/api/v1/admin/auth/keycloak/login" if keycloak_enabled else None),
+        },
+    }
+
+
+@router.post("/admin/auth/local/login", summary="Local product-admin login")
+async def admin_local_login(request: AdminLocalLoginRequest):
+    _require_mode("local")
+    return await authenticate_local_product_admin(request.username, request.password)
+
+
+@router.get("/admin/auth/keycloak/login", summary="Keycloak product-admin login")
+async def admin_keycloak_login():
+    _require_admin_sso()
+    issued = await get_keycloak_oidc().begin_admin_login()
+    response = RedirectResponse(
+        issued.location,
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+    _set_admin_oidc_binding_cookie(response, issued.browser_binding)
+    return response
+
+
+@router.get(
+    "/admin/auth/keycloak/callback",
+    summary="Keycloak product-admin callback",
+)
+async def admin_keycloak_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str | None = None,
+):
+    _require_admin_sso()
+    if error is not None or not code or not state:
+        raise AuthenticationError("Product-admin sign-in failed")
+    oidc = get_keycloak_oidc()
+    browser_binding = request.cookies.get(_ADMIN_OIDC_BINDING_COOKIE, "")
+    transient = await oidc.consume_admin_state(state, browser_binding)
+    if not isinstance(transient, dict) or set(transient) != {
+        "code_verifier",
+        "nonce",
+    }:
+        raise AuthenticationError("Product-admin sign-in failed")
+    verifier = transient.get("code_verifier")
+    nonce = transient.get("nonce")
+    if not isinstance(verifier, str) or not isinstance(nonce, str):
+        raise AuthenticationError("Product-admin sign-in failed")
+    tokens = await oidc.exchange_admin_code(code, verifier)
+    id_token = tokens.get("id_token")
+    if tokens.get("token_type") != "Bearer" or not isinstance(id_token, str):
+        raise AuthenticationError("Product-admin sign-in failed")
+    claims = await oidc.verify_admin_id_token(id_token, expected_nonce=nonce)
+    identity = await resolve_prebound_sso_product_admin(claims)
+    issued = await create_sso_admin_browser_session(identity, claims)
+    response = RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
+    _set_admin_cookies(
+        response,
+        token=issued.token,
+        csrf_token=issued.csrf_token,
+        expires_at=issued.expires_at,
+    )
+    _clear_admin_oidc_binding_cookie(response)
+    return response
+
+
+@router.get("/admin/auth/session", summary="Get current product-admin session")
+async def admin_session(
+    request: Request,
+    authorization: str | None = Header(default=None),
+):
+    mode = settings.require_auth_mode()
+    identity: ProductAdminIdentity | AuthenticatedUser
+    if mode == "local":
+        if not authorization:
+            raise AuthenticationError()
+        identity = await resolve_local_product_admin(authorization)
+    else:
+        raw_token = request.cookies.get(_ADMIN_SESSION_COOKIE, "")
+        identity = await resolve_sso_admin_browser_session(raw_token)
+    return {
+        "schema_version": 1,
+        "auth_mode": mode,
+        "user": _identity_response(identity),
+    }
+
+
+@router.post("/admin/auth/logout", summary="End current product-admin session")
+async def admin_logout(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    csrf_header: str | None = Header(default=None, alias="X-AKB-Admin-CSRF"),
+):
+    mode = settings.require_auth_mode()
+    if mode == "local":
+        if not authorization:
+            raise AuthenticationError()
+        await resolve_local_product_admin(authorization)
+        logout_url = "/admin"
+    else:
+        if csrf_header is None:
+            raise AuthenticationError("Invalid admin CSRF token")
+        raw_token = request.cookies.get(_ADMIN_SESSION_COOKIE, "")
+        csrf_cookie = request.cookies.get(_ADMIN_CSRF_COOKIE, "")
+        await revoke_sso_admin_browser_session(
+            raw_token,
+            csrf_cookie,
+            csrf_header,
+        )
+        logout_url = get_keycloak_oidc().admin_logout_url()
+    response = JSONResponse({"logout_url": logout_url})
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    if mode == "sso":
+        _clear_admin_cookies(response)
+    return response

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -165,6 +165,19 @@ async def auth_config():
     }
 
 
+@router.get("/auth/jwks", summary="Local-session public verification keys")
+async def local_session_jwks():
+    """Publish only the bounded public keyset for local-session-rs256-v2."""
+    if settings.require_auth_mode() != "local":
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            "Local human authentication is not enabled",
+        )
+    from app.services.local_session_keys import get_local_session_keyset
+
+    return get_local_session_keyset().public_jwks
+
+
 # ── Staged Keycloak browser surface ───────────────────────────────────
 #
 # Each handler 404s outside SSO mode and returns the stable staging error in

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -89,7 +89,7 @@ def _make_token(slug: str) -> str:
     # _verify_token re-check it) or those tokens won't revoke. (M3.)
     ts = str(int(time.time()))
     msg = f"{slug}:{ts}".encode("utf-8")
-    sig = hmac.new(settings.jwt_secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    sig = hmac.new(settings.system_hmac_secret_effective.encode("utf-8"), msg, hashlib.sha256).hexdigest()
     return f"{ts}.{sig}"
 
 
@@ -104,7 +104,7 @@ def _verify_token(slug: str, token: str) -> bool:
     if abs(time.time() - ts) > _TOKEN_TTL:
         return False
     msg = f"{slug}:{ts_str}".encode("utf-8")
-    expected = hmac.new(settings.jwt_secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    expected = hmac.new(settings.system_hmac_secret_effective.encode("utf-8"), msg, hashlib.sha256).hexdigest()
     return _matches_hmac_hexdigest(expected, sig)
 
 
@@ -124,7 +124,7 @@ def _make_bounded_view_grant(slug: str, *, issued_at: int | None = None) -> str:
         issued + settings.publication_view_grant_session_secs,
     )
     msg = f"grant:{slug}:{issued}:{expires}".encode("utf-8")
-    sig = hmac.new(settings.jwt_secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    sig = hmac.new(settings.system_hmac_secret_effective.encode("utf-8"), msg, hashlib.sha256).hexdigest()
     return f"{issued}.{expires}.{sig}"
 
 
@@ -133,7 +133,7 @@ def _make_view_grant(slug: str, *, issued_at: int | None = None) -> str:
         return _make_bounded_view_grant(slug, issued_at=issued_at)
     issued = int(time.time()) if issued_at is None else issued_at
     msg = f"grant:{slug}:{issued}".encode("utf-8")
-    sig = hmac.new(settings.jwt_secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    sig = hmac.new(settings.system_hmac_secret_effective.encode("utf-8"), msg, hashlib.sha256).hexdigest()
     return f"{issued}.{sig}"
 
 
@@ -170,7 +170,7 @@ def _parse_view_grant(slug: str, grant: str | None) -> tuple[int, int] | None:
         return None
     if expires > issued + settings.publication_view_grant_session_secs:
         return None
-    expected = hmac.new(settings.jwt_secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    expected = hmac.new(settings.system_hmac_secret_effective.encode("utf-8"), msg, hashlib.sha256).hexdigest()
     if not _matches_hmac_hexdigest(expected, sig):
         return None
     return issued, expires

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -9,6 +9,10 @@ The backend container is pip-installed (no uv inside). Use plain `python`
 in all in-container invocations.
 
 Subcommands:
+    provision-recovery-admin   Explicitly provision the designated local or
+                               SSO recovery administrator. Password material
+                               is accepted only by file/stdin and is never
+                               printed.
     reset-password <username>   Generate a temp password for the given user.
                                  Prints the temp password to stdout. Caller
                                  must share it with the user out-of-band.
@@ -18,15 +22,211 @@ Subcommands:
 """
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
+import os
+import secrets
 import sys
+from pathlib import Path
+from typing import NoReturn
 
 
 REPAIR_RESOURCE_HASHES_USAGE = (
     "Usage: python -m app.cli repair-resource-hashes "
     "[--vault NAME] [--documents-only|--files-only] [--limit N]"
 )
+
+PROVISION_RECOVERY_ADMIN_USAGE = (
+    "Usage: python -m app.cli provision-recovery-admin "
+    "{local|sso} --username USER --email EMAIL [profile options]\n"
+    "  local: (--password-file PATH|- | --generate-password-file PATH)\n"
+    "  sso:   --issuer ISSUER --subject SUBJECT"
+)
+
+
+class _CLIUsageError(Exception):
+    pass
+
+
+class _ProvisioningInputError(Exception):
+    pass
+
+
+class _SafeArgumentParser(argparse.ArgumentParser):
+    """Raise a value-free error so an accidental secret argument is not echoed."""
+
+    def error(self, _message: str) -> NoReturn:
+        raise _CLIUsageError()
+
+
+def _recovery_admin_parser() -> argparse.ArgumentParser:
+    parser = _SafeArgumentParser(add_help=False)
+    profiles = parser.add_subparsers(dest="profile", required=True)
+
+    local = profiles.add_parser("local", add_help=False)
+    local.add_argument("--username", required=True)
+    local.add_argument("--email", required=True)
+    password_source = local.add_mutually_exclusive_group(required=True)
+    password_source.add_argument("--password-file")
+    password_source.add_argument("--generate-password-file")
+
+    sso = profiles.add_parser("sso", add_help=False)
+    sso.add_argument("--username", required=True)
+    sso.add_argument("--email", required=True)
+    sso.add_argument("--issuer", required=True)
+    sso.add_argument("--subject", required=True)
+    return parser
+
+
+def _read_password_source(source: str) -> str:
+    try:
+        text = (
+            sys.stdin.read()
+            if source == "-"
+            else Path(source).read_text(encoding="utf-8")
+        )
+    except OSError:
+        raise _ProvisioningInputError("Unable to read the password source") from None
+    password = text.rstrip("\r\n")
+    if not password:
+        raise _ProvisioningInputError("The password source is empty")
+    if "\r" in password or "\n" in password:
+        raise _ProvisioningInputError("The password source must contain one line")
+    return password
+
+
+def _write_generated_password(target: str, password: str) -> Path:
+    if target == "-":
+        raise _ProvisioningInputError("Generated passwords require an explicit file")
+    path = Path(target)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    created = False
+    fd: int | None = None
+    try:
+        fd = os.open(path, flags, 0o600)
+        created = True
+        os.fchmod(fd, 0o600)
+        output = os.fdopen(fd, "w", encoding="utf-8")
+        fd = None  # ownership transferred to the file object
+        with output:
+            output.write(password)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+    except (OSError, ValueError):
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if created:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise _ProvisioningInputError("Unable to create the generated-password file") from None
+    return path
+
+
+def _remove_generated_password(path: Path) -> bool:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        return False
+    return True
+
+
+async def _provision_recovery_admin(args: list[str]) -> int:
+    try:
+        parsed = _recovery_admin_parser().parse_args(args)
+    except _CLIUsageError:
+        print(PROVISION_RECOVERY_ADMIN_USAGE, file=sys.stderr)
+        return 2
+
+    from app.config import AuthModeConfigurationError
+    from app.db.postgres import close_pool, init_db
+    from app.exceptions import AKBError
+    from app.services.recovery_admin_service import (
+        provision_local_recovery_admin,
+        provision_sso_recovery_admin,
+    )
+
+    generated_path: Path | None = None
+    keep_generated = False
+    report: dict | None = None
+    error: tuple[str, str] | None = None
+    try:
+        await init_db()
+        if parsed.profile == "local":
+            if parsed.generate_password_file is not None:
+                password = secrets.token_urlsafe(32)
+                generated_path = _write_generated_password(
+                    parsed.generate_password_file,
+                    password,
+                )
+            else:
+                password = _read_password_source(parsed.password_file)
+            report = await provision_local_recovery_admin(
+                username=parsed.username,
+                email=parsed.email,
+                password=password,
+            )
+        else:
+            report = await provision_sso_recovery_admin(
+                username=parsed.username,
+                email=parsed.email,
+                issuer=parsed.issuer,
+                subject=parsed.subject,
+            )
+        keep_generated = generated_path is not None and bool(report["created"])
+    except AKBError as exc:
+        error = (exc.code or "recovery_admin_provisioning_failed", exc.message)
+    except AuthModeConfigurationError as exc:
+        error = ("recovery_admin_mode_configuration", str(exc))
+    except _ProvisioningInputError as exc:
+        error = ("recovery_admin_secret_source", str(exc))
+    except Exception:
+        # Never render an unexpected exception: driver/library text can include
+        # arguments, and this command handles one-time credential material.
+        error = (
+            "recovery_admin_provisioning_failed",
+            "Recovery administrator provisioning failed",
+        )
+    finally:
+        if generated_path is not None and not keep_generated:
+            if not _remove_generated_password(generated_path):
+                error = (
+                    "recovery_admin_secret_cleanup_failed",
+                    "Generated-password file cleanup failed",
+                )
+        try:
+            await close_pool()
+        except Exception:
+            if error is None:
+                error = (
+                    "recovery_admin_database_cleanup_failed",
+                    "Database connection cleanup failed",
+                )
+
+    if error is not None:
+        print(f"{error[0]}: {error[1]}", file=sys.stderr)
+        return 1
+    assert report is not None
+    public_report = {
+        "user_id": report["user_id"],
+        "username": report["username"],
+        "email": report["email"],
+        "auth_mode": report["auth_mode"],
+        "created": report["created"],
+        "is_admin": report["is_admin"],
+        "is_recovery_admin": report["is_recovery_admin"],
+        "password_file_written": keep_generated,
+    }
+    print(json.dumps(public_report, sort_keys=True))
+    return 0
 
 
 async def _reset_password(username: str) -> int:
@@ -194,13 +394,16 @@ def main(argv: list[str] | None = None) -> int:
     if not argv:
         print("Usage: python -m app.cli <subcommand> [args]", file=sys.stderr)
         print(
-            "Subcommands: reset-password <username>, repair-resource-hashes, "
+            "Subcommands: provision-recovery-admin {local|sso}, "
+            "reset-password <username>, repair-resource-hashes, "
             "initialize-postgres-native, okf-validate <dir>, "
             "okf-export --from-git <worktree> --vault <name> --out <dir>",
             file=sys.stderr,
         )
         return 2
     cmd = argv[0]
+    if cmd == "provision-recovery-admin":
+        return asyncio.run(_provision_recovery_admin(argv[1:]))
     if cmd == "reset-password":
         if len(argv) != 2:
             print("Usage: python -m app.cli reset-password <username>", file=sys.stderr)

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -9,6 +9,9 @@ The backend container is pip-installed (no uv inside). Use plain `python`
 in all in-container invocations.
 
 Subcommands:
+    generate-local-session-keyset
+                               Create a non-overwriting RSA-3072 private key
+                               and public JWKS for local-session-rs256-v2.
     provision-recovery-admin   Explicitly provision the designated local or
                                SSO recovery administrator. Password material
                                is accepted only by file/stdin and is never
@@ -44,6 +47,11 @@ PROVISION_RECOVERY_ADMIN_USAGE = (
     "  sso:   --issuer ISSUER --subject SUBJECT"
 )
 
+GENERATE_LOCAL_SESSION_KEYSET_USAGE = (
+    "Usage: python -m app.cli generate-local-session-keyset "
+    "--output-dir DIR [--retain-jwks PATH ...]"
+)
+
 
 class _CLIUsageError(Exception):
     pass
@@ -51,6 +59,33 @@ class _CLIUsageError(Exception):
 
 class _ProvisioningInputError(Exception):
     pass
+
+
+def _generate_local_session_keyset(args: list[str]) -> int:
+    parser = _SafeArgumentParser(add_help=False)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--retain-jwks", action="append", default=[])
+    try:
+        parsed = parser.parse_args(args)
+    except _CLIUsageError:
+        print(GENERATE_LOCAL_SESSION_KEYSET_USAGE, file=sys.stderr)
+        return 2
+
+    from app.services.local_session_keys import (
+        LocalSessionKeyConfigurationError,
+        generate_local_session_keyset,
+    )
+
+    try:
+        report = generate_local_session_keyset(
+            parsed.output_dir,
+            retain_jwks_paths=parsed.retain_jwks,
+        )
+    except LocalSessionKeyConfigurationError as exc:
+        print(f"local_session_keyset_failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, sort_keys=True))
+    return 0
 
 
 class _SafeArgumentParser(argparse.ArgumentParser):
@@ -394,7 +429,8 @@ def main(argv: list[str] | None = None) -> int:
     if not argv:
         print("Usage: python -m app.cli <subcommand> [args]", file=sys.stderr)
         print(
-            "Subcommands: provision-recovery-admin {local|sso}, "
+            "Subcommands: generate-local-session-keyset, "
+            "provision-recovery-admin {local|sso}, "
             "reset-password <username>, repair-resource-hashes, "
             "initialize-postgres-native, okf-validate <dir>, "
             "okf-export --from-git <worktree> --vault <name> --out <dir>",
@@ -402,6 +438,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
     cmd = argv[0]
+    if cmd == "generate-local-session-keyset":
+        return _generate_local_session_keyset(argv[1:])
     if cmd == "provision-recovery-admin":
         return asyncio.run(_provision_recovery_admin(argv[1:]))
     if cmd == "reset-password":

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -847,6 +847,14 @@ class Settings(BaseModel):
     keycloak_client_id: str = "akb-web"
     keycloak_client_secret: str = ""       # secret.yaml — blank for public (PKCE) clients
     keycloak_public_client: bool = False   # true → PKCE (no client_secret); false → confidential
+    # Dedicated confidential browser client for the product-admin surface.
+    # It is intentionally excluded from keycloak_human_client_ids and cannot
+    # authorize ordinary AKB API bearer traffic. The callback URI is derived
+    # from public_base_url so the deployment and Keycloak registration cannot
+    # silently disagree about path ownership.
+    keycloak_admin_client_id: str = "akb-admin"
+    keycloak_admin_client_secret: str = ""
+    admin_browser_session_ttl_secs: int = Field(default=900, ge=60, le=3600)
     keycloak_verify_ssl: bool = True       # set false only for local self-signed Keycloak
     # Exact identity is issuer/subject and does not require email. Open-mode
     # JIT requires a verified email only when creating a brand-new AKB user;
@@ -1170,6 +1178,18 @@ class Settings(BaseModel):
     def keycloak_end_session_endpoint(self) -> str:
         # Browser-facing → public issuer.
         return f"{self.keycloak_issuer}/protocol/openid-connect/logout"
+
+    @property
+    def keycloak_admin_redirect_uri(self) -> str:
+        """Exact callback owned by the dedicated product-admin client."""
+        return (
+            f"{self.public_base_url.rstrip('/')}"
+            "/api/v1/admin/auth/keycloak/callback"
+        )
+
+    @property
+    def keycloak_admin_post_logout_redirect_uri(self) -> str:
+        return f"{self.public_base_url.rstrip('/')}/admin"
 
     @property
     def api_oauth_audience_effective(self) -> str:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -777,14 +777,26 @@ class Settings(BaseModel):
     document_asset_gc_interval_secs: int = Field(default=300, ge=10, le=86400)
     document_asset_upload_body_timeout_secs: float = Field(default=60.0, ge=1.0, le=900.0)
 
-    # Compatibility HMAC material currently shared by local human sessions,
-    # publication/view grants, and an inventory-cursor fallback. Startup
-    # requires it in every mode so those internal capabilities never use an
-    # empty key. Only local mode selects it as a human credential authority;
-    # Phase 2 will decouple the non-session consumers from future session keys.
+    # Deprecated Phase-1 compatibility input. It is never a human-session
+    # signing authority after the local-session-rs256-v2 cutover. Canonical
+    # runtime config rejects it when supplied; `system_hmac_secret` owns the
+    # remaining publication/cursor HMAC capabilities.
     jwt_secret: str = ""
-    jwt_algorithm: str = "HS256"
+    jwt_algorithm: str = "RS256"
     jwt_expire_hours: int = 24
+
+    # Internal non-session HMAC material. This must be independent of the
+    # local-session private key and of app-token signing material.
+    system_hmac_secret: str = ""
+
+    # Local human-session v2. The keyset is generated explicitly by the
+    # operator, persisted outside the image, and loaded read-only at runtime.
+    # A public JWKS may retain old v2 verification keys for bounded rotation;
+    # the private PEM always identifies the single active signer.
+    local_session_private_key_path: str = ""
+    local_session_jwks_path: str = ""
+    local_session_issuer: str = ""
+    local_session_audience: str = ""
 
     # Canonical install-time discriminator for human authentication. None is
     # allowed only so unrelated tests can construct Settings directly; the real
@@ -1083,6 +1095,28 @@ class Settings(BaseModel):
     def sso_human_auth_enabled(self) -> bool:
         """Derived SSO-human capability for later route/verifier slices."""
         return self.require_auth_mode() == "sso"
+
+    @property
+    def local_session_issuer_effective(self) -> str:
+        """Deployment-bound issuer for local application sessions."""
+        return (self.local_session_issuer or self.public_base_url).rstrip("/")
+
+    @property
+    def local_session_audience_effective(self) -> str:
+        """REST resource audience for local application sessions."""
+        if self.local_session_audience:
+            return self.local_session_audience
+        return f"{self.public_base_url.rstrip('/')}/api"
+
+    @property
+    def system_hmac_secret_effective(self) -> str:
+        """Non-session HMAC authority with one-release legacy input support.
+
+        `jwt_secret` is accepted only as migration input for capabilities that
+        were already HMAC-backed.  It is never consulted by a human-session
+        issuer or verifier after the RS256 v2 cutover.
+        """
+        return self.system_hmac_secret or self.jwt_secret
 
     # ── Keycloak OIDC derived endpoints ───────────────────────────
     # All computed off the realm issuer so only server_url + realm are

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -78,6 +78,41 @@ CREATE TABLE IF NOT EXISTS external_identities (
 
 CREATE INDEX IF NOT EXISTS idx_external_identities_user
     ON external_identities(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
+    ON external_identities(id, user_id);
+
+-- Dedicated product-admin browser sessions. These rows contain only hashes
+-- of opaque AKB session/CSRF values, an exact external-identity FK, and the
+-- issuer/subject snapshot used to invalidate a changed binding. No Keycloak
+-- access, refresh, or ID token is stored here.
+CREATE TABLE IF NOT EXISTS admin_browser_sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    token_hash TEXT NOT NULL UNIQUE
+        CHECK (token_hash ~ '^[0-9a-f]{64}$'),
+    csrf_token_hash TEXT NOT NULL
+        CHECK (csrf_token_hash ~ '^[0-9a-f]{64}$'),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    external_identity_id UUID NOT NULL,
+    identity_issuer TEXT NOT NULL
+        CHECK (char_length(identity_issuer) BETWEEN 1 AND 2048),
+    identity_subject TEXT NOT NULL
+        CHECK (char_length(identity_subject) BETWEEN 1 AND 1024),
+    keycloak_sid TEXT NOT NULL
+        CHECK (char_length(keycloak_sid) BETWEEN 1 AND 255),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT admin_browser_session_external_user_fk
+        FOREIGN KEY (external_identity_id, user_id)
+        REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
+    CONSTRAINT admin_browser_session_positive_lifetime
+        CHECK (expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_expiry
+    ON admin_browser_sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
+    ON admin_browser_sessions(user_id);
 
 -- Durable post-commit cleanup ledger. Token rows are deleted in the same
 -- transaction that suspends an account; PG token roles are DDL and are
@@ -116,9 +151,9 @@ CREATE INDEX IF NOT EXISTS idx_tokens_hash ON tokens(token_hash);
 CREATE INDEX IF NOT EXISTS idx_tokens_user ON tokens(user_id);
 
 -- ============================================================
--- OIDC transients — legacy additive schema retained for compatibility and
--- possible Phase 4 server-side browser-session reuse. Phase 1 browser routes
--- are staged unavailable and leave it empty. See migration 034.
+-- OIDC transients — single-use, TTL-bounded state. The dedicated Phase 2
+-- product-admin client uses kind=admin-state-v1; ordinary SSO browser login
+-- remains staged for Phase 4. See migration 034.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS oidc_transients (
     key         TEXT PRIMARY KEY,

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash TEXT NOT NULL,
     display_name TEXT,
     is_admin BOOLEAN NOT NULL DEFAULT false,
+    is_recovery_admin BOOLEAN NOT NULL DEFAULT false,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     -- JWT revocation cutoff. A JWT is rejected if its `iat` claim is
@@ -52,8 +53,14 @@ CREATE TABLE IF NOT EXISTS users (
         CHECK (account_status IN ('active', 'suspended')),
     account_kind TEXT NOT NULL DEFAULT 'human'
         CONSTRAINT users_account_kind_check
-        CHECK (account_kind IN ('human', 'service'))
+        CHECK (account_kind IN ('human', 'service')),
+    CONSTRAINT users_recovery_admin_requires_admin
+        CHECK (NOT is_recovery_admin OR is_admin)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin
+    ON users ((is_recovery_admin))
+    WHERE is_recovery_admin;
 
 -- Stable external identity binding. Email is a mutable snapshot; verified
 -- OIDC issuer + subject is the permanent key.
@@ -62,6 +69,7 @@ CREATE TABLE IF NOT EXISTS external_identities (
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     issuer TEXT NOT NULL,
     subject TEXT NOT NULL,
+    username_snapshot TEXT,
     email_snapshot TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/backend/app/db/migrations/024_tokens_revoked_before.py
+++ b/backend/app/db/migrations/024_tokens_revoked_before.py
@@ -2,7 +2,7 @@
 
 JWTs are stateless — the server cannot recall an already-issued token
 without keeping per-user state. Before this column, the only way to
-invalidate a leaked/stale JWT was to rotate ``jwt_secret`` (which kills
+invalidate a leaked/stale JWT was to rotate the installation signing key (which kills
 every session in the system).
 
 The column holds the timestamp after which any JWT issued by this user

--- a/backend/app/db/migrations/034_oidc_transients.py
+++ b/backend/app/db/migrations/034_oidc_transients.py
@@ -1,9 +1,9 @@
 """Migration 034: retain the legacy ``oidc_transients`` schema.
 
-The table originally stored authorization-code flow transients. Phase 1
-browser routes are now staged unavailable and issue or redeem no records;
-keeping the additive schema is harmless and avoids a destructive migration.
-Phase 4 may reuse it only as part of the server-side browser-session design.
+The dedicated Phase 2 product-admin client uses a namespaced, single-use
+``admin-state-v1`` record whose payload also binds the initiating browser by
+an opaque-cookie hash. Ordinary SSO browser routes remain staged and may reuse
+a different kind only as part of the Phase 4 browser-session design.
 
 Idempotent: ``CREATE TABLE IF NOT EXISTS``.
 """

--- a/backend/app/db/migrations/071_recovery_admin.py
+++ b/backend/app/db/migrations/071_recovery_admin.py
@@ -1,0 +1,38 @@
+"""Add the explicit singleton recovery-administrator designation."""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE users
+              ADD COLUMN IF NOT EXISTS is_recovery_admin BOOLEAN NOT NULL DEFAULT false;
+            ALTER TABLE external_identities
+              ADD COLUMN IF NOT EXISTS username_snapshot TEXT;
+            """
+        )
+        await conn.execute(
+            """
+            DO $$
+            BEGIN
+              IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                 WHERE conname = 'users_recovery_admin_requires_admin'
+                   AND conrelid = 'users'::regclass
+              ) THEN
+                ALTER TABLE users
+                  ADD CONSTRAINT users_recovery_admin_requires_admin
+                  CHECK (NOT is_recovery_admin OR is_admin);
+              END IF;
+            END $$;
+            """
+        )
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin
+                ON users ((is_recovery_admin))
+                WHERE is_recovery_admin
+            """
+        )

--- a/backend/app/db/migrations/072_admin_browser_sessions.py
+++ b/backend/app/db/migrations/072_admin_browser_sessions.py
@@ -1,0 +1,52 @@
+"""Add exact-bound, short-lived opaque sessions for the SSO admin surface."""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
+                ON external_identities(id, user_id)
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS admin_browser_sessions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                token_hash TEXT NOT NULL UNIQUE
+                    CHECK (token_hash ~ '^[0-9a-f]{64}$'),
+                csrf_token_hash TEXT NOT NULL
+                    CHECK (csrf_token_hash ~ '^[0-9a-f]{64}$'),
+                user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                external_identity_id UUID NOT NULL,
+                identity_issuer TEXT NOT NULL
+                    CHECK (char_length(identity_issuer) BETWEEN 1 AND 2048),
+                identity_subject TEXT NOT NULL
+                    CHECK (char_length(identity_subject) BETWEEN 1 AND 1024),
+                keycloak_sid TEXT NOT NULL
+                    CHECK (char_length(keycloak_sid) BETWEEN 1 AND 255),
+                expires_at TIMESTAMPTZ NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT admin_browser_session_external_user_fk
+                    FOREIGN KEY (external_identity_id, user_id)
+                    REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
+                CONSTRAINT admin_browser_session_positive_lifetime
+                    CHECK (expires_at > created_at)
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_expiry
+                ON admin_browser_sessions(expires_at)
+            """
+        )
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
+                ON admin_browser_sessions(user_id)
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -247,6 +247,7 @@ async def _apply_migrations() -> None:
         "068_vault_file_lifecycle_indexes.py",  # indexed attachment health counts + stale pending File collection
         "069_document_asset_revision_lock_order.py",  # remove redundant vault FK so manifest writes keep vault→asset lock order
         "070_vault_files_s3_key_lookup.py",  # physical-key reachability + pending-delete barrier indexes
+        "071_recovery_admin.py",  # explicit singleton recovery administrator + external username snapshot
     ):
         if filename in applied:
             continue

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -248,6 +248,7 @@ async def _apply_migrations() -> None:
         "069_document_asset_revision_lock_order.py",  # remove redundant vault FK so manifest writes keep vault→asset lock order
         "070_vault_files_s3_key_lookup.py",  # physical-key reachability + pending-delete barrier indexes
         "071_recovery_admin.py",  # explicit singleton recovery administrator + external username snapshot
+        "072_admin_browser_sessions.py",  # short-lived opaque sessions for the dedicated SSO admin client
     ):
         if filename in applied:
             continue

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -123,6 +123,39 @@ class ServiceIdentityAdoptionError(AKBError):
         )
 
 
+class RecoveryAdminConflictError(AKBError):
+    """Provisioning input conflicts with the designated recovery identity."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator conflicts with existing account state",
+            status_code=409,
+            code="recovery_admin_conflict",
+        )
+
+
+class RecoveryAdminModeError(AKBError):
+    """The requested provisioning profile is not the configured auth mode."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator provisioning does not match the configured auth mode",
+            status_code=409,
+            code="recovery_admin_mode_mismatch",
+        )
+
+
+class RecoveryAdminProtectedError(AKBError):
+    """The designated recovery identity must remain an administrator."""
+
+    def __init__(self):
+        super().__init__(
+            "The designated recovery administrator cannot be demoted or deleted",
+            status_code=409,
+            code="recovery_admin_protected",
+        )
+
+
 class ExternalAuthDisabledError(AKBError):
     """External authentication is disabled by deployment policy."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.deps import get_current_user, get_optional_user
 from app.api.routes import (
     access,
+    admin_auth,
     activity,
     assets,
     app_inventory,
@@ -273,7 +274,8 @@ async def _no_store_public_surfaces(request: Request, call_next):
             response.headers["Cache-Control"] = "no-store"
             break
     if (
-        path.startswith("/api/v1/app/installations/")
+        path.startswith("/api/v1/admin/")
+        or path.startswith("/api/v1/app/installations/")
         or path.startswith("/api/v1/app/rollouts")
         or (path.startswith("/api/v1/apps/") and "/rollouts" in path)
         or (
@@ -287,6 +289,7 @@ async def _no_store_public_surfaces(request: Request, call_next):
 
 
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
+app.include_router(admin_auth.router, prefix="/api/v1", tags=["admin-auth"])
 app.include_router(app_identity.router, prefix="/api/v1", tags=["app-identity"])
 app.include_router(app_inventory.router, prefix="/api/v1", tags=["app-inventory"])
 app.include_router(app_installations.router, prefix="/api/v1", tags=["app-installations"])

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -10,7 +10,13 @@ import logging
 import uuid
 
 from app.db.postgres import get_pool
-from app.exceptions import ConflictError, ForbiddenError, NotFoundError, ValidationError
+from app.exceptions import (
+    ConflictError,
+    ForbiddenError,
+    NotFoundError,
+    RecoveryAdminProtectedError,
+    ValidationError,
+)
 from app.models.vault_scope import VaultScope, current_token_uuid, current_vault_scope
 from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
@@ -1677,6 +1683,11 @@ async def delete_user_account(user_id: str) -> dict:
     pool = await get_pool()
 
     async with pool.acquire() as conn:
+        if await conn.fetchval(
+            "SELECT is_recovery_admin FROM users WHERE id = $1",
+            uid,
+        ):
+            raise RecoveryAdminProtectedError()
         owned_vault_names = [
             r["name"] for r in await conn.fetch(
                 "SELECT name FROM vaults WHERE owner_id = $1", uid

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -13,6 +13,7 @@ from app.exceptions import (
     CredentialCleanupIncompleteError,
     ExternalIdentityConflictError,
     NotFoundError,
+    RecoveryAdminProtectedError,
     ServiceIdentityAdoptionError,
     ValidationError,
 )
@@ -672,7 +673,7 @@ async def set_user_admin(user_id: str, *, is_admin: bool, actor_id: str) -> dict
         async with conn.transaction():
             current = await conn.fetchrow(
                 """
-                SELECT account_status, account_kind
+                SELECT account_status, account_kind, is_recovery_admin
                   FROM users WHERE id = $1
                    FOR UPDATE
                 """,
@@ -680,6 +681,8 @@ async def set_user_admin(user_id: str, *, is_admin: bool, actor_id: str) -> dict
             )
             if current is None or current["account_kind"] != "human":
                 raise NotFoundError("Human user", user_id)
+            if not is_admin and current["is_recovery_admin"]:
+                raise RecoveryAdminProtectedError()
             if is_admin and current["account_status"] != "active":
                 raise AccountSuspendedError()
             row = await conn.fetchrow(

--- a/backend/app/services/admin_auth_service.py
+++ b/backend/app/services/admin_auth_service.py
@@ -1,0 +1,338 @@
+"""Product-admin authentication policy kept separate from ordinary login.
+
+The SSO path stores only hashes of short-lived AKB-owned opaque values. It
+never persists or returns Keycloak access, refresh, or ID tokens.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Mapping
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import (
+    AccountSuspendedError,
+    AuthenticationError,
+    ExternalIdentityConflictError,
+    ForbiddenError,
+    MembershipRequiredError,
+)
+from app.repositories.events_repo import emit_event
+from app.services.auth_service import (
+    AuthenticatedUser,
+    login,
+    resolve_delegated_human_authorization,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProductAdminIdentity:
+    user_id: uuid.UUID
+    external_identity_id: uuid.UUID
+    username: str
+    email: str
+    display_name: str | None
+    auth_method: str
+
+
+@dataclass(frozen=True, slots=True)
+class IssuedAdminBrowserSession:
+    token: str
+    csrf_token: str
+    expires_at: datetime
+
+
+def _hash_credential(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _bounded_credential(value: object) -> str | None:
+    if (
+        not isinstance(value, str)
+        or not 20 <= len(value) <= 512
+        or not value.isascii()
+        or not all(character.isalnum() or character in "-_" for character in value)
+    ):
+        return None
+    return value
+
+
+def _required_claim(
+    claims: Mapping[str, object],
+    name: str,
+    *,
+    max_length: int = 1024,
+) -> str:
+    value = claims.get(name)
+    if not isinstance(value, str) or not value.strip() or len(value) > max_length:
+        raise AuthenticationError("Invalid admin identity token")
+    return value
+
+
+def _identity_from_row(row) -> ProductAdminIdentity:
+    return ProductAdminIdentity(
+        user_id=uuid.UUID(str(row["user_id"])),
+        external_identity_id=uuid.UUID(str(row["external_identity_id"])),
+        username=row["username"],
+        email=row["email"] or "",
+        display_name=row["display_name"],
+        auth_method="keycloak",
+    )
+
+
+async def authenticate_local_product_admin(username: str, password: str) -> dict:
+    """Authenticate through local authority and require AKB admin status."""
+    result = await login(username, password)
+    user = result.get("user")
+    if not isinstance(user, dict) or user.get("is_admin") is not True:
+        raise ForbiddenError("Product administrator access is required")
+    return result
+
+
+async def resolve_local_product_admin(authorization: str) -> AuthenticatedUser:
+    user = await resolve_delegated_human_authorization(authorization)
+    if user is None:
+        raise AuthenticationError()
+    if not user.is_admin:
+        raise ForbiddenError("Product administrator access is required")
+    return user
+
+
+async def resolve_prebound_sso_product_admin(
+    claims: Mapping[str, object],
+) -> ProductAdminIdentity:
+    """Resolve an exact binding; never JIT-create or email-adopt an account."""
+    issuer = _required_claim(claims, "iss")
+    subject = _required_claim(claims, "sub")
+    if issuer != settings.keycloak_issuer:
+        raise AuthenticationError("Invalid admin identity token")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                """
+                SELECT e.id AS external_identity_id, e.user_id,
+                       u.username, u.email, u.display_name, u.is_admin,
+                       u.auth_provider, u.account_status, u.account_kind
+                  FROM external_identities e
+                  JOIN users u ON u.id = e.user_id
+                 WHERE e.issuer = $1 AND e.subject = $2
+                 FOR UPDATE OF e
+                """,
+                issuer,
+                subject,
+            )
+            if row is None:
+                raise MembershipRequiredError()
+            if row["account_status"] != "active":
+                raise AccountSuspendedError()
+            if row["account_kind"] != "human" or row["auth_provider"] != "keycloak":
+                raise ExternalIdentityConflictError()
+            if row["is_admin"] is not True:
+                raise ForbiddenError("Product administrator access is required")
+            await conn.execute(
+                "UPDATE external_identities SET last_seen_at = NOW() WHERE id = $1",
+                row["external_identity_id"],
+            )
+    return _identity_from_row(row)
+
+
+async def create_sso_admin_browser_session(
+    identity: ProductAdminIdentity,
+    claims: Mapping[str, object],
+) -> IssuedAdminBrowserSession:
+    issuer = _required_claim(claims, "iss", max_length=2048)
+    subject = _required_claim(claims, "sub")
+    if issuer != settings.keycloak_issuer:
+        raise AuthenticationError("Invalid admin identity token")
+    sid = _required_claim(claims, "sid", max_length=255)
+    raw_expiry = claims.get("exp")
+    if type(raw_expiry) is not int:
+        raise AuthenticationError("Invalid admin identity token")
+
+    now = datetime.now(timezone.utc)
+    try:
+        id_token_expiry = datetime.fromtimestamp(raw_expiry, timezone.utc)
+    except OverflowError, OSError, ValueError:
+        raise AuthenticationError("Invalid admin identity token") from None
+    configured_expiry = now + timedelta(seconds=settings.admin_browser_session_ttl_secs)
+    expires_at = min(id_token_expiry, configured_expiry)
+    if expires_at <= now:
+        raise AuthenticationError("Invalid admin identity token")
+
+    token = secrets.token_urlsafe(32)
+    csrf_token = secrets.token_urlsafe(32)
+    token_hash = _hash_credential(token)
+    csrf_hash = _hash_credential(csrf_token)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"admin-browser-session:{identity.user_id}",
+            )
+            exact_binding_is_live = await conn.fetchval(
+                """
+                SELECT TRUE
+                  FROM external_identities e
+                  JOIN users u ON u.id = e.user_id
+                 WHERE e.id = $1
+                   AND e.user_id = $2
+                   AND e.issuer = $3
+                   AND e.subject = $4
+                   AND u.is_admin
+                   AND u.account_status = 'active'
+                   AND u.account_kind = 'human'
+                   AND u.auth_provider = 'keycloak'
+                 FOR SHARE OF e, u
+                """,
+                identity.external_identity_id,
+                identity.user_id,
+                issuer,
+                subject,
+            )
+            if exact_binding_is_live is not True:
+                raise AuthenticationError("Invalid admin identity token")
+            await conn.execute("DELETE FROM admin_browser_sessions WHERE expires_at <= NOW()")
+            # Retain at most seven existing sessions before adding this one.
+            # This keeps retried IdP flows from growing the table without
+            # bound while allowing a small number of admin devices.
+            await conn.execute(
+                """
+                DELETE FROM admin_browser_sessions
+                 WHERE id IN (
+                    SELECT id
+                      FROM admin_browser_sessions
+                     WHERE user_id = $1
+                     ORDER BY created_at DESC, id DESC
+                    OFFSET 7
+                 )
+                """,
+                identity.user_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO admin_browser_sessions (
+                    token_hash, csrf_token_hash, user_id,
+                    external_identity_id, identity_issuer, identity_subject,
+                    keycloak_sid, expires_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                """,
+                token_hash,
+                csrf_hash,
+                identity.user_id,
+                identity.external_identity_id,
+                issuer,
+                subject,
+                sid,
+                expires_at,
+            )
+            await emit_event(
+                conn,
+                "auth.admin_session_created",
+                actor_id=str(identity.user_id),
+                payload={"auth_method": "keycloak"},
+            )
+    return IssuedAdminBrowserSession(
+        token=token,
+        csrf_token=csrf_token,
+        expires_at=expires_at,
+    )
+
+
+async def resolve_sso_admin_browser_session(
+    raw_token: str,
+) -> ProductAdminIdentity:
+    token = _bounded_credential(raw_token)
+    if token is None:
+        raise AuthenticationError()
+    token_hash = _hash_credential(token)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                """
+                SELECT s.id AS session_id, s.user_id, s.external_identity_id,
+                       u.username, u.email, u.display_name
+                  FROM admin_browser_sessions s
+                  JOIN users u ON u.id = s.user_id
+                  JOIN external_identities e
+                    ON e.id = s.external_identity_id AND e.user_id = s.user_id
+                 WHERE s.token_hash = $1
+                   AND s.expires_at > NOW()
+                   AND s.identity_issuer = $2
+                   AND e.issuer = s.identity_issuer
+                   AND e.subject = s.identity_subject
+                   AND u.is_admin
+                   AND u.account_status = 'active'
+                   AND u.account_kind = 'human'
+                   AND u.auth_provider = 'keycloak'
+                 FOR UPDATE OF s
+                """,
+                token_hash,
+                settings.keycloak_issuer,
+            )
+            if row is None:
+                await conn.execute(
+                    "DELETE FROM admin_browser_sessions WHERE token_hash = $1",
+                    token_hash,
+                )
+            else:
+                await conn.execute(
+                    "UPDATE admin_browser_sessions SET last_seen_at = NOW() WHERE id = $1",
+                    row["session_id"],
+                )
+    if row is None:
+        # Raise only after the cleanup transaction commits. Raising from inside
+        # the transaction would roll back deletion of an expired/demoted row.
+        raise AuthenticationError()
+    return _identity_from_row(row)
+
+
+async def revoke_sso_admin_browser_session(
+    raw_token: str,
+    csrf_cookie: str,
+    csrf_header: str,
+) -> ProductAdminIdentity:
+    token = _bounded_credential(raw_token)
+    cookie = _bounded_credential(csrf_cookie)
+    header = _bounded_credential(csrf_header)
+    if token is None or cookie is None or header is None or not secrets.compare_digest(cookie, header):
+        raise AuthenticationError("Invalid admin CSRF token")
+
+    token_hash = _hash_credential(token)
+    csrf_hash = _hash_credential(cookie)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                """
+                SELECT s.id AS session_id, s.csrf_token_hash,
+                       s.user_id, s.external_identity_id,
+                       u.username, u.email, u.display_name
+                  FROM admin_browser_sessions s
+                  JOIN users u ON u.id = s.user_id
+                 WHERE s.token_hash = $1 AND s.expires_at > NOW()
+                 FOR UPDATE OF s
+                """,
+                token_hash,
+            )
+            if row is None or not secrets.compare_digest(row["csrf_token_hash"], csrf_hash):
+                raise AuthenticationError("Invalid admin CSRF token")
+            await conn.execute(
+                "DELETE FROM admin_browser_sessions WHERE id = $1",
+                row["session_id"],
+            )
+            await emit_event(
+                conn,
+                "auth.admin_session_revoked",
+                actor_id=str(row["user_id"]),
+                payload={"auth_method": "keycloak"},
+            )
+    return _identity_from_row(row)

--- a/backend/app/services/app_identity_service.py
+++ b/backend/app/services/app_identity_service.py
@@ -74,7 +74,7 @@ def _configured_app_secret() -> str:
             status_code=503,
             code="app_identity_unavailable",
         )
-    if secret == settings.jwt_secret:
+    if secret == settings.system_hmac_secret_effective:
         raise AKBError(
             "App token signing is not safely configured",
             status_code=503,

--- a/backend/app/services/app_inventory_service.py
+++ b/backend/app/services/app_inventory_service.py
@@ -45,7 +45,9 @@ _SAFE_ISO = re.compile(
 
 
 def _cursor_secret() -> bytes:
-    configured = (settings.app_token_secret or settings.jwt_secret or "").encode()
+    configured = (
+        settings.app_token_secret or settings.system_hmac_secret_effective or ""
+    ).encode()
     # Unit-only configurations may intentionally leave auth secrets blank.  A
     # deterministic fallback keeps cursors opaque and, more importantly,
     # still binds them to their signed payload rather than exposing JSON.

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -40,11 +40,11 @@ from app.repositories.events_repo import emit_event
 from app.services.auth_policy import require_local_auth_enabled
 from app.services.auth_verifier_profiles import (
     KEYCLOAK_ACCESS_V1,
-    LOCAL_SESSION_LEGACY_V1,
+    LOCAL_SESSION_RS256_V2,
     KeycloakRouteProfile,
     VerifiedPrincipal,
     verify_keycloak_access_v1,
-    verify_local_session_legacy_v1,
+    verify_local_session_rs256_v2,
 )
 from app.services.role_sync import get_role_sync
 
@@ -135,23 +135,35 @@ def create_jwt(
     """
     now = datetime.now(timezone.utc)
     iat = now if not_before is None or not_before <= now else not_before
+    from app.services.local_session_keys import (
+        LOCAL_SESSION_JOSE_TYPE,
+        get_local_session_keyset,
+    )
+
+    keyset = get_local_session_keyset()
     payload = {
+        "iss": settings.local_session_issuer_effective,
+        "aud": settings.local_session_audience_effective,
         "sub": user_id,
         "username": username,
         "exp": iat + timedelta(hours=settings.jwt_expire_hours),
         "iat": iat,
+        "nbf": iat,
+        "jti": str(uuid.uuid4()),
+        "profile": LOCAL_SESSION_RS256_V2,
+        "token_use": "session",
     }
     return jwt.encode(
         payload,
-        settings.jwt_secret,
-        algorithm="HS256",
-        headers={"typ": "JWT"},
+        keyset.private_key,
+        algorithm="RS256",
+        headers={"typ": LOCAL_SESSION_JOSE_TYPE, "kid": keyset.active_kid},
     )
 
 
 def decode_jwt(token: str) -> dict | None:
-    """Compatibility read of the fixed local-session-legacy-v1 profile."""
-    principal = verify_local_session_legacy_v1(token)
+    """Compatibility helper backed only by local-session-rs256-v2."""
+    principal = verify_local_session_rs256_v2(token)
     return dict(principal.claims) if principal is not None else None
 
 
@@ -582,7 +594,7 @@ async def project_verified_principal(
     principal: VerifiedPrincipal,
 ) -> AuthenticatedUser | None:
     """Common verified-human boundary before existing AKB authorization."""
-    if principal.profile_id == LOCAL_SESSION_LEGACY_V1:
+    if principal.profile_id == LOCAL_SESSION_RS256_V2:
         return await _project_local_session_principal(principal)
     if principal.profile_id == KEYCLOAK_ACCESS_V1:
         return await _project_keycloak_principal(principal)
@@ -988,7 +1000,7 @@ async def resolve_rest_user_authorization(
         return await _resolve_pat_or_service(token)
 
     if settings.require_auth_mode() == "local":
-        principal = verify_local_session_legacy_v1(token)
+        principal = verify_local_session_rs256_v2(token)
     else:
         principal = await verify_keycloak_access_v1(token, "api")
     if principal is None:
@@ -1019,7 +1031,7 @@ async def resolve_delegated_human_authorization(
     if token is None or token.startswith("akb_"):
         return None
     if settings.require_auth_mode() == "local":
-        principal = verify_local_session_legacy_v1(token)
+        principal = verify_local_session_rs256_v2(token)
     else:
         principal = await verify_keycloak_access_v1(token, "api")
     if principal is None:
@@ -1065,9 +1077,10 @@ async def _project_local_session_principal(
             # they have by setting tokens_revoked_before = NOW(); any JWT
             # whose iat predates that cutoff fails here even though the
             # signature is valid and exp has not passed. This is the only
-            # mechanism to invalidate a leaked or stale JWT short of
-            # rotating the global jwt_secret (which would log every user
-            # out, not just one).
+            # mechanism to invalidate one leaked or stale session. Replacing
+            # the local-session verification keyset is the installation-wide
+            # forced-reauth mechanism, but is intentionally not a per-user
+            # revocation tool.
             #
             # JWT iat is whole-second (RFC 7519). tokens_revoked_before is
             # sub-second TIMESTAMPTZ. To make same-second writes safe we
@@ -1090,7 +1103,7 @@ async def _project_local_session_principal(
 
 async def _resolve_akb_session_jwt(token: str) -> AuthenticatedUser | None:
     """Compatibility helper for callers that already extracted a local token."""
-    principal = verify_local_session_legacy_v1(token)
+    principal = verify_local_session_rs256_v2(token)
     if principal is None:
         return None
     return await project_verified_principal(principal)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -247,15 +247,10 @@ async def register(username: str, email: str, password: str, display_name: str |
         if existing:
             raise ConflictError("Username or email already exists")
 
-        # Bootstrap: the very first account in a fresh deployment becomes
-        # admin, so a brand-new instance has an operator without a manual
-        # DB edit. `NOT EXISTS (… users)` is evaluated against the table
-        # state before this row, so only a truly empty users table grants
-        # it — existing deployments never retroactively promote anyone.
         is_admin = await conn.fetchval(
             """
             INSERT INTO users (id, username, email, password_hash, display_name, is_admin)
-            VALUES ($1, $2, $3, $4, $5, NOT EXISTS (SELECT 1 FROM users))
+            VALUES ($1, $2, $3, $4, $5, false)
             RETURNING is_admin
             """,
             user_id,
@@ -264,9 +259,6 @@ async def register(username: str, email: str, password: str, display_name: str |
             pw_hash,
             display_name,
         )
-
-    if is_admin:
-        logging.getLogger("akb.auth").info("Bootstrap: first user %r registered — granted admin", username)
 
     # PG-native RBAC: emit the per-user PG role so akb_sql works.
     # Best-effort — reconciler at next startup catches any failure here.

--- a/backend/app/services/auth_verifier_profiles.py
+++ b/backend/app/services/auth_verifier_profiles.py
@@ -12,9 +12,8 @@ import jwt
 
 from app.config import AuthModeConfigurationError, settings
 
-LOCAL_SESSION_LEGACY_V1 = "local-session-legacy-v1"
+LOCAL_SESSION_RS256_V2 = "local-session-rs256-v2"
 KEYCLOAK_ACCESS_V1 = "keycloak-access-v1"
-LOCAL_SESSION_ISSUER = "akb-local"
 
 CredentialType = Literal["session", "access_token"]
 KeycloakRouteProfile = Literal["api", "mcp"]
@@ -41,15 +40,25 @@ class VerifiedPrincipal:
         object.__setattr__(self, "claims", MappingProxyType(dict(self.claims)))
 
 
-def _strict_jose_header(token: str, *, algorithm: str) -> Mapping[str, Any] | None:
+def _strict_jose_header(
+    token: str,
+    *,
+    algorithm: str,
+    jose_type: str = "JWT",
+    require_kid: bool = False,
+) -> Mapping[str, Any] | None:
     try:
         header = jwt.get_unverified_header(token)
     except jwt.PyJWTError:
         return None
-    if header.get("alg") != algorithm or header.get("typ") != "JWT":
+    if header.get("alg") != algorithm or header.get("typ") != jose_type:
         return None
     if _TOKEN_SUPPLIED_KEY_HEADERS.intersection(header):
         return None
+    if require_kid:
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid or len(kid) > 128:
+            return None
     return header
 
 
@@ -67,42 +76,91 @@ def _required_numeric_date(claims: Mapping[str, Any], name: str) -> int | None:
     return value
 
 
-def verify_local_session_legacy_v1(token: str) -> VerifiedPrincipal | None:
-    """Verify the migration-only local human-session profile.
+def verify_local_session_rs256_v2(token: str) -> VerifiedPrincipal | None:
+    """Verify the active local human-session profile with no legacy fallback."""
+    from app.services.local_session_keys import (
+        LOCAL_SESSION_JOSE_TYPE,
+        LocalSessionKeyConfigurationError,
+        get_local_session_keyset,
+    )
 
-    Existing local sessions are fixed to HS256 and the installation secret.
-    The configurable algorithm field is intentionally not consulted.
-    """
-    if _strict_jose_header(token, algorithm="HS256") is None:
+    header = _strict_jose_header(
+        token,
+        algorithm="RS256",
+        jose_type=LOCAL_SESSION_JOSE_TYPE,
+        require_kid=True,
+    )
+    if header is None:
+        return None
+    kid = header["kid"]
+    try:
+        keyset = get_local_session_keyset()
+    except LocalSessionKeyConfigurationError:
+        return None
+    public_key = keyset.public_keys.get(kid)
+    if public_key is None:
+        return None
+    issuer = settings.local_session_issuer_effective
+    audience = settings.local_session_audience_effective
+    if not issuer or not audience:
         return None
     try:
         claims = jwt.decode(
             token,
-            settings.jwt_secret,
-            algorithms=["HS256"],
-            options={"require": ["sub", "username", "iat", "exp"]},
+            public_key,
+            algorithms=["RS256"],
+            issuer=issuer,
+            audience=audience,
+            options={
+                "require": [
+                    "iss",
+                    "aud",
+                    "sub",
+                    "username",
+                    "iat",
+                    "nbf",
+                    "exp",
+                    "jti",
+                    "profile",
+                    "token_use",
+                ]
+            },
         )
     except jwt.PyJWTError:
         return None
 
     subject = _required_nonempty_string(claims, "sub")
     username = _required_nonempty_string(claims, "username")
+    jti = _required_nonempty_string(claims, "jti")
     issued_at = _required_numeric_date(claims, "iat")
+    not_before = _required_numeric_date(claims, "nbf")
     expires_at = _required_numeric_date(claims, "exp")
-    if subject is None or username is None or issued_at is None or expires_at is None or expires_at <= issued_at:
+    if (
+        subject is None
+        or username is None
+        or jti is None
+        or issued_at is None
+        or not_before is None
+        or expires_at is None
+        or expires_at <= issued_at
+        or not_before < issued_at
+        or claims.get("profile") != LOCAL_SESSION_RS256_V2
+        or claims.get("token_use") != "session"
+    ):
         return None
     try:
         uuid.UUID(subject)
+        uuid.UUID(jti)
     except ValueError, AttributeError:
         return None
 
     return VerifiedPrincipal(
-        profile_id=LOCAL_SESSION_LEGACY_V1,
-        issuer=LOCAL_SESSION_ISSUER,
+        profile_id=LOCAL_SESSION_RS256_V2,
+        issuer=issuer,
         subject=subject,
         credential_type="session",
         claims=claims,
-        audience=None,
+        audience=audience,
     )
 
 

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -1,14 +1,15 @@
-"""Pinned Keycloak verification plus dormant browser OIDC primitives.
+"""Pinned Keycloak verification plus separated browser OIDC primitives.
 
 Phase 1 request authorization uses :meth:`verify_access_token` only. The
 route-selected ``keycloak-access-v1`` profile pins RS256, issuer, JWKS, route
 audience, token kind, and required claims before exact ``(issuer, subject)``
 projection. It never treats an ID token as an API access token.
 
-Authorization-code, ID-token, and logout helpers remain internal candidates
-for the Phase 4 server-side browser-session design. No Phase 1 production
-route calls them, and this module has no AKB human-session issuance or account
-adoption entry point. See ``docs/designs/keycloak-oidc/00-overview.md``.
+The dedicated Phase 2 product-admin client uses its own authorization-code,
+PKCE, nonce, ID-token, and logout profile. Ordinary-user browser helpers remain
+dormant candidates for Phase 4. This module has no AKB human-session issuance
+or account-adoption entry point. See
+``docs/designs/keycloak-oidc/00-overview.md``.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import logging
 import secrets
 import time
 import urllib.parse
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
@@ -39,12 +41,18 @@ from app.services.auth_verifier_profiles import (
 
 logger = logging.getLogger("akb.keycloak")
 
-# Reserved Phase 4 authorization-code scopes. The staged Phase 1 browser
-# routes never issue an authorization request.
+# OIDC browser scopes. The admin client uses them now; ordinary-user browser
+# routes remain staged for Phase 4.
 _SCOPE = "openid profile email"
 _TOKEN_SUPPLIED_KEY_HEADERS = frozenset({"jku", "x5u", "jwk", "x5c"})
 _SERVICE_ACCOUNT_CLAIMS = frozenset({"client_id", "clientId", "clientHost", "clientAddress"})
 _JWKS_REFRESH_COOLDOWN_SECONDS = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class AdminAuthorizationRequest:
+    location: str
+    browser_binding: str
 
 
 # ── Transient store (oidc_transients table) ──────────────────────────
@@ -93,8 +101,33 @@ async def _store_consume(key: str, kind: str) -> dict | None:
     return json.loads(payload) if isinstance(payload, str) else payload
 
 
+async def _store_consume_admin_bound(
+    key: str,
+    browser_binding_hash: str,
+) -> dict | None:
+    """Atomically consume admin state only when its browser binding matches."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            DELETE FROM oidc_transients
+             WHERE key = $1
+               AND kind = 'admin-state-v1'
+               AND expires_at > NOW()
+               AND payload->>'browser_binding_hash' = $2
+            RETURNING payload
+            """,
+            key,
+            browser_binding_hash,
+        )
+    if row is None:
+        return None
+    payload = row["payload"]
+    return json.loads(payload) if isinstance(payload, str) else payload
+
+
 class KeycloakOIDC:
-    """Pinned verifier with dormant, PostgreSQL-backed browser helpers."""
+    """Pinned verifier with isolated admin and ordinary browser profiles."""
 
     def __init__(self) -> None:
         # JWKS is cached in-process. Unknown kids may request one bounded,
@@ -176,6 +209,67 @@ class KeycloakOIDC:
         """Verify+consume the CSRF state. Returns {redirect_path, code_verifier?}."""
         return await _store_consume(state, "state")
 
+    async def begin_admin_login(self) -> AdminAuthorizationRequest:
+        """Build the dedicated product-admin authorization request.
+
+        The admin client always uses PKCE in addition to its confidential
+        client authentication. Its state/nonce namespace cannot be consumed by
+        the ordinary browser-flow helpers.
+        """
+        state = secrets.token_urlsafe(32)
+        nonce = secrets.token_urlsafe(32)
+        verifier = self._make_code_verifier()
+        browser_binding = secrets.token_urlsafe(32)
+        await _store_issue(
+            state,
+            "admin-state-v1",
+            {
+                "code_verifier": verifier,
+                "nonce": nonce,
+                "browser_binding_hash": hashlib.sha256(
+                    browser_binding.encode("ascii")
+                ).hexdigest(),
+            },
+            ttl_secs=600,
+        )
+        params = {
+            "client_id": settings.keycloak_admin_client_id,
+            "redirect_uri": settings.keycloak_admin_redirect_uri,
+            "response_type": "code",
+            "scope": _SCOPE,
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": self._make_code_challenge(verifier),
+            "code_challenge_method": "S256",
+        }
+        return AdminAuthorizationRequest(
+            location=(
+                f"{settings.keycloak_authorization_endpoint}?"
+                f"{urllib.parse.urlencode(params)}"
+            ),
+            browser_binding=browser_binding,
+        )
+
+    async def consume_admin_state(
+        self,
+        state: str,
+        browser_binding: str,
+    ) -> dict | None:
+        """Consume state only in the browser that initiated the login."""
+        if not 20 <= len(browser_binding) <= 512:
+            return None
+        actual_hash = hashlib.sha256(browser_binding.encode("utf-8")).hexdigest()
+        payload = await _store_consume_admin_bound(state, actual_hash)
+        if not isinstance(payload, dict):
+            return None
+        expected_hash = payload.pop("browser_binding_hash", None)
+        if not isinstance(expected_hash, str) or not secrets.compare_digest(
+            expected_hash,
+            actual_hash,
+        ):
+            return None
+        return payload
+
     # ── Dormant authorization-code exchange (Phase 4 candidate) ─────
     async def exchange_code_for_tokens(
         self,
@@ -213,7 +307,44 @@ class KeycloakOIDC:
             raise AuthenticationError("Authorization code exchange failed")
         return resp.json()
 
-    # ── Dormant ID-token verification (Phase 4 candidate) ────────────
+    async def exchange_admin_code(self, code: str, code_verifier: str) -> dict[str, Any]:
+        """Exchange one admin-client code without logging token material."""
+        if not code or not code_verifier:
+            raise AuthenticationError("Authorization code exchange failed")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": settings.keycloak_admin_redirect_uri,
+            "client_id": settings.keycloak_admin_client_id,
+            "client_secret": settings.keycloak_admin_client_secret,
+            "code_verifier": code_verifier,
+        }
+        try:
+            response = await self._client().post(
+                settings.keycloak_token_endpoint,
+                data=data,
+            )
+        except httpx.HTTPError as exc:
+            logger.error("Keycloak admin token exchange network error")
+            raise AKBError(
+                "Keycloak unreachable during token exchange",
+                status_code=502,
+            ) from exc
+        if response.status_code != 200:
+            logger.warning(
+                "Keycloak admin token exchange failed with status %s",
+                response.status_code,
+            )
+            raise AuthenticationError("Authorization code exchange failed")
+        try:
+            payload = response.json()
+        except TypeError, ValueError:
+            raise AuthenticationError("Authorization code exchange failed") from None
+        if not isinstance(payload, dict):
+            raise AuthenticationError("Authorization code exchange failed")
+        return payload
+
+    # ── ID-token verification (admin active; ordinary Phase 4 candidate) ──
     async def _fetch_jwks(self, *, force: bool = False) -> dict[str, Any]:
         if self._jwks is not None and not force:
             return self._jwks
@@ -306,10 +437,60 @@ class KeycloakOIDC:
                 issuer=settings.keycloak_issuer,
                 options={"require": ["exp", "iat", "aud", "iss", "sub"]},
             )
-        except jwt.InvalidTokenError as e:
+        except (jwt.PyJWTError, TypeError, ValueError) as e:
             logger.warning("Keycloak ID token verification failed: %s", e)
             raise AuthenticationError(f"Invalid ID token: {e}") from e
 
+        return claims
+
+    async def verify_admin_id_token(
+        self,
+        id_token: str,
+        *,
+        expected_nonce: str,
+    ) -> dict[str, Any]:
+        """Verify the exact Keycloak ID-token profile for `/admin`."""
+        claims = await self.verify_id_token(
+            id_token,
+            client_id=settings.keycloak_admin_client_id,
+        )
+        required_string_limits = {
+            "iss": 2048,
+            "sub": 1024,
+            "azp": 255,
+            "sid": 255,
+            "nonce": 512,
+        }
+        if any(
+            not isinstance(claims.get(name), str)
+            or not claims[name].strip()
+            or len(claims[name]) > limit
+            for name, limit in required_string_limits.items()
+        ):
+            raise AuthenticationError("Invalid admin identity token")
+        if (
+            not isinstance(expected_nonce, str)
+            or not 20 <= len(expected_nonce) <= 512
+            or not expected_nonce.isascii()
+            or not claims["nonce"].isascii()
+            or not secrets.compare_digest(claims["nonce"], expected_nonce)
+        ):
+            raise AuthenticationError("Invalid admin identity token")
+        if claims["azp"] != settings.keycloak_admin_client_id:
+            raise AuthenticationError("Invalid admin identity token")
+        if (
+            type(claims.get("iat")) is not int
+            or type(claims.get("exp")) is not int
+            or claims["exp"] <= claims["iat"]
+        ):
+            raise AuthenticationError("Invalid admin identity token")
+        if _SERVICE_ACCOUNT_CLAIMS.intersection(claims):
+            raise AuthenticationError("Invalid admin identity token")
+        preferred_username = claims.get("preferred_username")
+        if preferred_username is not None and (
+            not isinstance(preferred_username, str) or preferred_username.startswith("service-account-")
+        ):
+            raise AuthenticationError("Invalid admin identity token")
         return claims
 
     # ── Route-selected access-token verification ────────────────────
@@ -379,7 +560,7 @@ class KeycloakOIDC:
                     ]
                 },
             )
-        except (jwt.InvalidTokenError, TypeError, ValueError) as e:
+        except (jwt.PyJWTError, TypeError, ValueError) as e:
             logger.debug("Keycloak access token verification failed: %s", e)
             return None
 
@@ -393,6 +574,11 @@ class KeycloakOIDC:
             if optional_value is not None and not isinstance(optional_value, str):
                 return None
         if "email_verified" in claims and type(claims["email_verified"]) is not bool:
+            return None
+        # The dedicated browser-admin client is an authentication proof only.
+        # Its access token must never become an API or MCP resource credential,
+        # even on the MCP profile where dynamic client IDs are otherwise valid.
+        if claims["azp"] == settings.keycloak_admin_client_id:
             return None
         if route_profile == "api" and claims["azp"] not in settings.keycloak_human_client_ids:
             return None
@@ -427,7 +613,7 @@ class KeycloakOIDC:
             audience=audience,
         )
 
-    # ── Dormant logout URL construction (Phase 4 candidate) ─────────
+    # ── Logout URL construction ──────────────────────────────────────
     def logout_url(self, id_token_hint: str | None, post_logout_redirect: str | None) -> str:
         params: dict[str, str] = {}
         if post_logout_redirect:
@@ -436,6 +622,13 @@ class KeycloakOIDC:
             params["id_token_hint"] = id_token_hint
         else:
             params["client_id"] = settings.keycloak_client_id
+        return f"{settings.keycloak_end_session_endpoint}?{urllib.parse.urlencode(params)}"
+
+    def admin_logout_url(self) -> str:
+        params = {
+            "client_id": settings.keycloak_admin_client_id,
+            "post_logout_redirect_uri": settings.keycloak_admin_post_logout_redirect_uri,
+        }
         return f"{settings.keycloak_end_session_endpoint}?{urllib.parse.urlencode(params)}"
 
 

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -48,13 +48,25 @@ def _validate_required_settings() -> None:
     """Fail fast on missing required config so misconfigured deploys don't
     silently serve unsigned tokens or produce confusing downstream errors."""
     auth_mode = settings.require_auth_mode()
-    if auth_mode == "local" and settings.jwt_algorithm != "HS256":
-        raise RuntimeError("jwt_algorithm must be HS256 while local-session-legacy-v1 is active")
+    if auth_mode == "local" and settings.jwt_algorithm != "RS256":
+        raise RuntimeError(
+            "jwt_algorithm must be RS256 for the local-session-rs256-v2 profile; "
+            "HS256 sessions require forced re-login during upgrade"
+        )
     if settings.mcp_oauth_enabled and settings.api_oauth_audience_effective == settings.mcp_oauth_audience_effective:
         raise RuntimeError("API and MCP OAuth audiences must be distinct resource identifiers")
     missing: list[str] = []
-    if not settings.jwt_secret:
-        missing.append("AKB_JWT_SECRET (compatibility HMAC material — use a strong random string)")
+    if not settings.system_hmac_secret_effective:
+        missing.append("system_hmac_secret (internal non-session HMAC material — use a strong random string)")
+    if auth_mode == "local":
+        if not settings.local_session_private_key_path.strip():
+            missing.append("local_session_private_key_path (auth_mode is local)")
+        if not settings.local_session_jwks_path.strip():
+            missing.append("local_session_jwks_path (auth_mode is local)")
+        if not settings.local_session_issuer_effective:
+            missing.append("local_session_issuer or public_base_url (auth_mode is local)")
+        if not settings.local_session_audience_effective:
+            missing.append("local_session_audience or public_base_url (auth_mode is local)")
     if not settings.db_password:
         missing.append("AKB_DB_PASSWORD")
     if not settings.public_base_url:
@@ -93,6 +105,10 @@ def _validate_required_settings() -> None:
         )
     if missing:
         raise RuntimeError("Required configuration missing:\n  - " + "\n  - ".join(missing))
+    if auth_mode == "local":
+        from app.services.local_session_keys import get_local_session_keyset
+
+        get_local_session_keyset()
 
 
 async def init_storage() -> None:

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from urllib.parse import urlsplit
 
 from app.config import settings
 from app.db.postgres import close_pool, get_pool, init_db
@@ -44,6 +45,29 @@ from app.services.vector_store import get_vector_store
 logger = logging.getLogger("akb.lifecycle")
 
 
+def _is_secure_browser_url(value: str) -> bool:
+    """Require HTTPS for browser authorities, with a narrow loopback exception."""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    if (
+        parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    if parsed.scheme == "https":
+        return True
+    return parsed.scheme == "http" and parsed.hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
+
+
 def _validate_required_settings() -> None:
     """Fail fast on missing required config so misconfigured deploys don't
     silently serve unsigned tokens or produce confusing downstream errors."""
@@ -76,9 +100,9 @@ def _validate_required_settings() -> None:
             "https://akb.example.com)"
         )
     # A configured Keycloak authority always needs its pinned issuer inputs.
-    # Phase 1 SSO serves only as an API resource server, so startup validates
-    # the active human access-token profile but deliberately does not require
-    # dormant browser callback/client-secret inputs owned by Phase 4.
+    # Ordinary SSO browser custody remains staged for Phase 4. The dedicated
+    # Phase 2 product-admin client is active, confidential, and independently
+    # validated here.
     if settings.keycloak_enabled:
         if not settings.keycloak_server_url.strip():
             missing.append("keycloak_server_url (keycloak_enabled is true)")
@@ -91,6 +115,12 @@ def _validate_required_settings() -> None:
                 )
             if not settings.api_oauth_audience_effective.strip():
                 missing.append("api_oauth_audience (auth_mode is sso — human API resource audience is empty)")
+            if not settings.keycloak_admin_client_id.strip():
+                missing.append("keycloak_admin_client_id (auth_mode is sso — product-admin client is empty)")
+            if not settings.keycloak_admin_client_secret:
+                missing.append(
+                    "keycloak_admin_client_secret (auth_mode is sso — confidential product-admin client is required)"
+                )
     # MCP-OAuth (the Resource Server path) reuses the Keycloak JWKS,
     # issuer, and audience-mapped scopes — so it's only meaningful when
     # `keycloak_enabled` is also true. A deployment with mcp_oauth on +
@@ -105,6 +135,17 @@ def _validate_required_settings() -> None:
         )
     if missing:
         raise RuntimeError("Required configuration missing:\n  - " + "\n  - ".join(missing))
+    if auth_mode == "sso":
+        if settings.keycloak_admin_client_id in settings.keycloak_human_client_ids:
+            raise RuntimeError("keycloak_admin_client_id must be dedicated to the product-admin surface")
+        if not _is_secure_browser_url(settings.public_base_url):
+            raise RuntimeError(
+                "auth_mode=sso requires an HTTPS public_base_url; plain HTTP is allowed only on loopback"
+            )
+        if not _is_secure_browser_url(settings.keycloak_server_url):
+            raise RuntimeError(
+                "auth_mode=sso requires an HTTPS public Keycloak URL; plain HTTP is allowed only on loopback"
+            )
     if auth_mode == "local":
         from app.services.local_session_keys import get_local_session_keyset
 

--- a/backend/app/services/local_session_keys.py
+++ b/backend/app/services/local_session_keys.py
@@ -1,0 +1,355 @@
+"""Persistent key material for the ``local-session-rs256-v2`` profile.
+
+The application never invents signing material at startup.  Operators create a
+keyset explicitly, persist it as secret material, and point AKB at the private
+PEM plus its public JWKS.  A new keyset may retain selected old public JWKs so
+ordinary RS256 rotation does not invalidate sessions before their normal TTL.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+LOCAL_SESSION_PROFILE = "local-session-rs256-v2"
+LOCAL_SESSION_ALGORITHM = "RS256"
+LOCAL_SESSION_KEY_SIZE = 3072
+LOCAL_SESSION_PUBLIC_EXPONENT = 65537
+LOCAL_SESSION_JOSE_TYPE = "akb-local-session+jwt"
+
+_MAX_KEY_FILE_BYTES = 64 * 1024
+_MAX_JWKS_FILE_BYTES = 256 * 1024
+_MAX_VERIFICATION_KEYS = 4
+_B64URL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class LocalSessionKeyConfigurationError(RuntimeError):
+    """Safe-to-log local signing-key configuration failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class LocalSessionKeySet:
+    active_kid: str
+    private_key: rsa.RSAPrivateKey
+    public_keys: Mapping[str, rsa.RSAPublicKey]
+    _public_jwks: Mapping[str, object]
+
+    @property
+    def public_jwks(self) -> dict[str, object]:
+        """Return a detached public-only JWKS suitable for an HTTP response."""
+        keys = self._public_jwks["keys"]
+        assert isinstance(keys, tuple)
+        return {"keys": [dict(key) for key in keys]}
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _encode_number(value: int) -> str:
+    length = (value.bit_length() + 7) // 8
+    return _b64url(value.to_bytes(length, "big"))
+
+
+def _decode_number(value: object, *, field: str) -> int:
+    if not isinstance(value, str) or not value or not _B64URL_RE.fullmatch(value):
+        raise LocalSessionKeyConfigurationError(f"local session JWK {field} is invalid")
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except ValueError, UnicodeError:
+        raise LocalSessionKeyConfigurationError(f"local session JWK {field} is invalid") from None
+    if not decoded or _b64url(decoded) != value:
+        raise LocalSessionKeyConfigurationError(f"local session JWK {field} is invalid")
+    return int.from_bytes(decoded, "big")
+
+
+def _thumbprint(*, modulus: str, exponent: str) -> str:
+    canonical = json.dumps(
+        {"e": exponent, "kty": "RSA", "n": modulus},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return _b64url(hashlib.sha256(canonical).digest())
+
+
+def _public_jwk(public_key: rsa.RSAPublicKey) -> dict[str, str]:
+    numbers = public_key.public_numbers()
+    modulus = _encode_number(numbers.n)
+    exponent = _encode_number(numbers.e)
+    return {
+        "kty": "RSA",
+        "kid": _thumbprint(modulus=modulus, exponent=exponent),
+        "use": "sig",
+        "alg": LOCAL_SESSION_ALGORITHM,
+        "n": modulus,
+        "e": exponent,
+    }
+
+
+def _validate_public_jwk(value: object) -> tuple[dict[str, str], rsa.RSAPublicKey]:
+    if not isinstance(value, dict):
+        raise LocalSessionKeyConfigurationError("local session JWKS contains a non-object key")
+    allowed = {"kty", "kid", "use", "alg", "n", "e"}
+    if set(value) != allowed:
+        raise LocalSessionKeyConfigurationError("local session JWK fields do not match the fixed profile")
+    if value.get("kty") != "RSA" or value.get("use") != "sig" or value.get("alg") != LOCAL_SESSION_ALGORITHM:
+        raise LocalSessionKeyConfigurationError("local session JWK does not match the RS256 signing profile")
+    kid = value.get("kid")
+    if not isinstance(kid, str) or not kid or len(kid) > 128:
+        raise LocalSessionKeyConfigurationError("local session JWK kid is invalid")
+    modulus_text = value.get("n")
+    exponent_text = value.get("e")
+    modulus = _decode_number(modulus_text, field="n")
+    exponent = _decode_number(exponent_text, field="e")
+    if exponent != LOCAL_SESSION_PUBLIC_EXPONENT:
+        raise LocalSessionKeyConfigurationError("local session RSA public exponent must be 65537")
+    if modulus.bit_length() != LOCAL_SESSION_KEY_SIZE:
+        raise LocalSessionKeyConfigurationError("local session RSA keys must be exactly 3072 bits")
+    assert isinstance(modulus_text, str)
+    assert isinstance(exponent_text, str)
+    expected_kid = _thumbprint(modulus=modulus_text, exponent=exponent_text)
+    if kid != expected_kid:
+        raise LocalSessionKeyConfigurationError("local session JWK kid must be its RFC 7638 thumbprint")
+    try:
+        public_key = rsa.RSAPublicNumbers(exponent, modulus).public_key()
+    except ValueError:
+        raise LocalSessionKeyConfigurationError("local session RSA public key is invalid") from None
+    canonical = {name: str(value[name]) for name in ("kty", "kid", "use", "alg", "n", "e")}
+    return canonical, public_key
+
+
+def _read_bounded(path: Path, *, maximum: int, private: bool) -> bytes:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        raise LocalSessionKeyConfigurationError("local session key file is unavailable") from None
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise LocalSessionKeyConfigurationError("local session key path must be a regular file")
+        if file_stat.st_size <= 0 or file_stat.st_size > maximum:
+            raise LocalSessionKeyConfigurationError("local session key file size is invalid")
+        if private and stat.S_IMODE(file_stat.st_mode) & 0o077:
+            raise LocalSessionKeyConfigurationError("local session private key must not be group- or world-readable")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            data = handle.read(maximum + 1)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if len(data) > maximum:
+        raise LocalSessionKeyConfigurationError("local session key file size is invalid")
+    return data
+
+
+def _parse_jwks_bytes(data: bytes) -> list[tuple[dict[str, str], rsa.RSAPublicKey]]:
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except UnicodeError, json.JSONDecodeError:
+        raise LocalSessionKeyConfigurationError("local session JWKS is not valid JSON") from None
+    if not isinstance(payload, dict) or set(payload) != {"keys"} or not isinstance(payload["keys"], list):
+        raise LocalSessionKeyConfigurationError("local session JWKS must contain only a keys array")
+    if not 1 <= len(payload["keys"]) <= _MAX_VERIFICATION_KEYS:
+        raise LocalSessionKeyConfigurationError("local session JWKS key count is invalid")
+    parsed = [_validate_public_jwk(item) for item in payload["keys"]]
+    kids = [item[0]["kid"] for item in parsed]
+    if len(set(kids)) != len(kids):
+        raise LocalSessionKeyConfigurationError("local session JWKS contains duplicate kid values")
+    return parsed
+
+
+def load_local_session_keyset(
+    private_key_path: str | Path,
+    jwks_path: str | Path,
+) -> LocalSessionKeySet:
+    """Load and cross-check one active private key and bounded public keyset."""
+    private_bytes = _read_bounded(
+        Path(private_key_path),
+        maximum=_MAX_KEY_FILE_BYTES,
+        private=True,
+    )
+    try:
+        private_key = serialization.load_pem_private_key(private_bytes, password=None)
+    except TypeError, ValueError:
+        raise LocalSessionKeyConfigurationError("local session private key is not a valid unencrypted PEM") from None
+    if not isinstance(private_key, rsa.RSAPrivateKey):
+        raise LocalSessionKeyConfigurationError("local session private key must be RSA")
+    if private_key.key_size != LOCAL_SESSION_KEY_SIZE:
+        raise LocalSessionKeyConfigurationError("local session RSA keys must be exactly 3072 bits")
+    if private_key.private_numbers().public_numbers.e != LOCAL_SESSION_PUBLIC_EXPONENT:
+        raise LocalSessionKeyConfigurationError("local session RSA public exponent must be 65537")
+
+    parsed = _parse_jwks_bytes(_read_bounded(Path(jwks_path), maximum=_MAX_JWKS_FILE_BYTES, private=False))
+    active_jwk = _public_jwk(private_key.public_key())
+    active_kid = active_jwk["kid"]
+    by_kid = {jwk["kid"]: public_key for jwk, public_key in parsed}
+    active_public = by_kid.get(active_kid)
+    if active_public is None or active_public.public_numbers() != private_key.public_key().public_numbers():
+        raise LocalSessionKeyConfigurationError("active local session private key is absent from JWKS")
+
+    canonical_jwks = tuple(MappingProxyType(dict(jwk)) for jwk, _public_key in parsed)
+    return LocalSessionKeySet(
+        active_kid=active_kid,
+        private_key=private_key,
+        public_keys=MappingProxyType(by_kid),
+        _public_jwks=MappingProxyType({"keys": canonical_jwks}),
+    )
+
+
+def _stat_identity(path: str) -> tuple[int, int, int, int]:
+    try:
+        value = Path(path).stat()
+    except OSError:
+        raise LocalSessionKeyConfigurationError("local session key file is unavailable") from None
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+
+@lru_cache(maxsize=8)
+def _cached_keyset(
+    private_path: str,
+    jwks_path: str,
+    _private_identity: tuple[int, int, int, int],
+    _jwks_identity: tuple[int, int, int, int],
+) -> LocalSessionKeySet:
+    return load_local_session_keyset(private_path, jwks_path)
+
+
+def get_local_session_keyset() -> LocalSessionKeySet:
+    from app.config import settings
+
+    private_path = settings.local_session_private_key_path.strip()
+    jwks_path = settings.local_session_jwks_path.strip()
+    if not private_path or not jwks_path:
+        raise LocalSessionKeyConfigurationError("local session key paths are required")
+    return _cached_keyset(
+        private_path,
+        jwks_path,
+        _stat_identity(private_path),
+        _stat_identity(jwks_path),
+    )
+
+
+def clear_local_session_keyset_cache() -> None:
+    _cached_keyset.cache_clear()
+
+
+def _write_exclusive(path: Path, data: bytes, *, mode: int) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, mode)
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _retained_jwks(paths: Sequence[str | Path]) -> list[dict[str, str]]:
+    retained: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_path in paths:
+        parsed = _parse_jwks_bytes(_read_bounded(Path(raw_path), maximum=_MAX_JWKS_FILE_BYTES, private=False))
+        for jwk, _public_key in parsed:
+            if jwk["kid"] in seen:
+                continue
+            seen.add(jwk["kid"])
+            retained.append(jwk)
+    return retained
+
+
+def generate_local_session_keyset(
+    output_dir: str | Path,
+    *,
+    retain_jwks_paths: Sequence[str | Path] = (),
+) -> dict[str, object]:
+    """Create a new, non-overwriting RSA-3072 keyset for operator storage."""
+    target = Path(output_dir)
+    try:
+        target.mkdir(mode=0o700, parents=False, exist_ok=False)
+    except FileExistsError:
+        raise LocalSessionKeyConfigurationError("local session key output already exists") from None
+    except OSError:
+        raise LocalSessionKeyConfigurationError("unable to create local session key output") from None
+
+    private_path = target / "private.pem"
+    jwks_path = target / "jwks.json"
+    created: list[Path] = []
+    try:
+        private_key = rsa.generate_private_key(
+            public_exponent=LOCAL_SESSION_PUBLIC_EXPONENT,
+            key_size=LOCAL_SESSION_KEY_SIZE,
+        )
+        active_jwk = _public_jwk(private_key.public_key())
+        retained = [key for key in _retained_jwks(retain_jwks_paths) if key["kid"] != active_jwk["kid"]]
+        if 1 + len(retained) > _MAX_VERIFICATION_KEYS:
+            raise LocalSessionKeyConfigurationError("too many retained local session verification keys")
+        private_bytes = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        jwks_bytes = (
+            json.dumps(
+                {"keys": [active_jwk, *retained]},
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("ascii")
+            + b"\n"
+        )
+        _write_exclusive(private_path, private_bytes, mode=0o600)
+        created.append(private_path)
+        _write_exclusive(jwks_path, jwks_bytes, mode=0o600)
+        created.append(jwks_path)
+        directory_fd = os.open(target, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception as exc:
+        for path in reversed(created):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        try:
+            target.rmdir()
+        except OSError:
+            pass
+        if isinstance(exc, LocalSessionKeyConfigurationError):
+            raise
+        raise LocalSessionKeyConfigurationError("unable to generate local session keyset") from None
+
+    return {
+        "profile": LOCAL_SESSION_PROFILE,
+        "algorithm": LOCAL_SESSION_ALGORITHM,
+        "key_size": LOCAL_SESSION_KEY_SIZE,
+        "active_kid": active_jwk["kid"],
+        "retained_keys": len(retained),
+        "private_key_path": str(private_path),
+        "jwks_path": str(jwks_path),
+    }

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -1,0 +1,271 @@
+"""Explicit, non-HTTP provisioning for the designated recovery administrator."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import asyncpg
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import (
+    RecoveryAdminConflictError,
+    RecoveryAdminModeError,
+    ValidationError,
+)
+from app.repositories.events_repo import emit_event
+from app.services.auth_service import hash_password_async
+from app.services.role_sync import get_role_sync
+
+
+# Fixed signed-bigint key: stable across processes and PostgreSQL upgrades,
+# unlike a runtime hash whose implementation could change.
+_PROVISIONING_LOCK_ID = 0x414B425245434F56  # "AKBRECOV"
+_SSO_PASSWORD_SENTINEL = "!keycloak-sso:no-local-login!"
+
+
+def _required(value: str, field: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValidationError(f"{field} is required")
+    return normalized
+
+
+def _email(value: str) -> str:
+    return _required(value, "email").lower()
+
+
+def _require_mode(expected: Literal["local", "sso"]) -> None:
+    if settings.require_auth_mode() != expected:
+        raise RecoveryAdminModeError()
+
+
+def _validate_password(password: str) -> None:
+    if len(password) < 12:
+        raise ValidationError("password must be at least 12 characters")
+    if len(password.encode("utf-8")) > 72:
+        raise ValidationError("password must be at most 72 UTF-8 bytes")
+
+
+async def _lock_provisioning(conn) -> None:
+    await conn.execute(
+        "SELECT pg_advisory_xact_lock($1::bigint)",
+        _PROVISIONING_LOCK_ID,
+    )
+
+
+async def _designated_user(conn):
+    return await conn.fetchrow(
+        """
+        SELECT id, username, email, password_hash, is_admin, is_recovery_admin,
+               auth_provider, account_status, account_kind
+          FROM users
+         WHERE is_recovery_admin
+         FOR UPDATE
+        """
+    )
+
+
+def _result(row, *, mode: Literal["local", "sso"], created: bool) -> dict:
+    return {
+        "user_id": str(row["id"]),
+        "username": row["username"],
+        "email": row["email"],
+        "auth_mode": mode,
+        "created": created,
+        "is_admin": bool(row["is_admin"]),
+        "is_recovery_admin": bool(row["is_recovery_admin"]),
+    }
+
+
+async def _emit_provisioned(conn, user_id: uuid.UUID, mode: Literal["local", "sso"]) -> None:
+    await emit_event(
+        conn,
+        "auth.recovery_admin_provisioned",
+        actor_id=None,
+        payload={"user_id": str(user_id), "auth_mode": mode},
+    )
+
+
+async def provision_local_recovery_admin(
+    *,
+    username: str,
+    email: str,
+    password: str,
+) -> dict:
+    """Create the one local recovery admin, or converge on its exact identity."""
+    _require_mode("local")
+    username = _required(username, "username")
+    email = _email(email)
+    _validate_password(password)
+    password_hash = await hash_password_async(password)
+    pool = await get_pool()
+    created = False
+
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await _lock_provisioning(conn)
+                row = await _designated_user(conn)
+                if row is not None:
+                    identity_count = await conn.fetchval(
+                        "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
+                        row["id"],
+                    )
+                    if not (
+                        row["username"] == username
+                        and row["email"].lower() == email
+                        and row["is_admin"]
+                        and row["is_recovery_admin"]
+                        and row["auth_provider"] == "local"
+                        and row["account_status"] == "active"
+                        and row["account_kind"] == "human"
+                        and identity_count == 0
+                    ):
+                        raise RecoveryAdminConflictError()
+                else:
+                    collision = await conn.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM users
+                             WHERE username = $1 OR email = $2
+                        )
+                        """,
+                        username,
+                        email,
+                    )
+                    if collision:
+                        raise RecoveryAdminConflictError()
+                    user_id = uuid.uuid4()
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO users (
+                            id, username, email, password_hash, is_admin,
+                            is_recovery_admin, auth_provider, account_status, account_kind
+                        ) VALUES ($1, $2, $3, $4, true, true, 'local', 'active', 'human')
+                        RETURNING id, username, email, password_hash, is_admin,
+                                  is_recovery_admin, auth_provider, account_status, account_kind
+                        """,
+                        user_id,
+                        username,
+                        email,
+                        password_hash,
+                    )
+                    await _emit_provisioned(conn, user_id, "local")
+                    created = True
+    except (asyncpg.UniqueViolationError, asyncpg.CheckViolationError):
+        raise RecoveryAdminConflictError() from None
+
+    if created:
+        await get_role_sync().on_user_create(row["id"])
+    return _result(row, mode="local", created=created)
+
+
+async def provision_sso_recovery_admin(
+    *,
+    username: str,
+    email: str,
+    issuer: str,
+    subject: str,
+) -> dict:
+    """Pre-bind the one SSO recovery admin to an exact issuer and subject."""
+    _require_mode("sso")
+    username = _required(username, "username")
+    email = _email(email)
+    issuer = _required(issuer, "issuer")
+    subject = _required(subject, "subject")
+    pool = await get_pool()
+    created = False
+
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await _lock_provisioning(conn)
+                row = await _designated_user(conn)
+                if row is not None:
+                    identities = await conn.fetch(
+                        """
+                        SELECT issuer, subject, username_snapshot, email_snapshot
+                          FROM external_identities
+                         WHERE user_id = $1
+                         ORDER BY issuer, subject
+                        """,
+                        row["id"],
+                    )
+                    exact_identity = len(identities) == 1 and (
+                        identities[0]["issuer"] == issuer
+                        and identities[0]["subject"] == subject
+                        and identities[0]["username_snapshot"] == username
+                        and (identities[0]["email_snapshot"] or "").lower() == email
+                    )
+                    if not (
+                        row["username"] == username
+                        and row["email"].lower() == email
+                        and row["password_hash"] == _SSO_PASSWORD_SENTINEL
+                        and row["is_admin"]
+                        and row["is_recovery_admin"]
+                        and row["auth_provider"] == "keycloak"
+                        and row["account_status"] == "active"
+                        and row["account_kind"] == "human"
+                        and exact_identity
+                    ):
+                        raise RecoveryAdminConflictError()
+                else:
+                    user_collision = await conn.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM users
+                             WHERE username = $1 OR email = $2
+                        )
+                        """,
+                        username,
+                        email,
+                    )
+                    identity_collision = await conn.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM external_identities
+                             WHERE issuer = $1 AND subject = $2
+                        )
+                        """,
+                        issuer,
+                        subject,
+                    )
+                    if user_collision or identity_collision:
+                        raise RecoveryAdminConflictError()
+                    user_id = uuid.uuid4()
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO users (
+                            id, username, email, password_hash, is_admin,
+                            is_recovery_admin, auth_provider, account_status, account_kind
+                        ) VALUES ($1, $2, $3, $4, true, true, 'keycloak', 'active', 'human')
+                        RETURNING id, username, email, password_hash, is_admin,
+                                  is_recovery_admin, auth_provider, account_status, account_kind
+                        """,
+                        user_id,
+                        username,
+                        email,
+                        _SSO_PASSWORD_SENTINEL,
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO external_identities (
+                            user_id, issuer, subject, username_snapshot, email_snapshot
+                        ) VALUES ($1, $2, $3, $4, $5)
+                        """,
+                        user_id,
+                        issuer,
+                        subject,
+                        username,
+                        email,
+                    )
+                    await _emit_provisioned(conn, user_id, "sso")
+                    created = True
+    except (asyncpg.UniqueViolationError, asyncpg.CheckViolationError):
+        raise RecoveryAdminConflictError() from None
+
+    if created:
+        await get_role_sync().on_user_create(row["id"])
+    return _result(row, mode="sso", created=created)

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -542,9 +542,16 @@ class E2ERuntime:
 
     def _write_config(self) -> None:
         import yaml
+        from app.services.local_session_keys import generate_local_session_keyset
+
+        local_key_dir = self.config.config_dir / "local-session"
+        generate_local_session_keyset(local_key_dir)
 
         app_config = {
             "auth_mode": "local",
+            "jwt_algorithm": "RS256",
+            "local_session_private_key_path": str(local_key_dir / "private.pem"),
+            "local_session_jwks_path": str(local_key_dir / "jwks.json"),
             "db_host": "127.0.0.1",
             "db_port": 15432,
             "db_name": "akb",
@@ -564,7 +571,7 @@ class E2ERuntime:
         }
         secret_config = {
             "db_password": "akb",
-            "jwt_secret": secrets.token_urlsafe(48),
+            "system_hmac_secret": secrets.token_urlsafe(48),
             "app_token_secret": secrets.token_urlsafe(48),
             "embed_api_key": "ci-stub-no-auth",
             "s3_access_key": "akb-ci",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,18 +19,37 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 _BACKEND_DIR = Path(__file__).resolve().parents[1]
 _REPO_ROOT = _BACKEND_DIR.parent
 
 _BACKEND_CFG_DIR = _BACKEND_DIR / "config"
 _BACKEND_APP_YAML = _BACKEND_CFG_DIR / "app.yaml"
+_BACKEND_LOCAL_KEY_DIR = _BACKEND_CFG_DIR / "local-session"
 
 _EXAMPLE_APP_YAML = _REPO_ROOT / "config" / "app.yaml.example"
 
 if not _BACKEND_APP_YAML.exists() and _EXAMPLE_APP_YAML.exists():
     _BACKEND_CFG_DIR.mkdir(parents=True, exist_ok=True)
-    _BACKEND_APP_YAML.write_text(_EXAMPLE_APP_YAML.read_text())
+    bootstrap_config = yaml.safe_load(_EXAMPLE_APP_YAML.read_text())
+    bootstrap_config["local_session_private_key_path"] = str(
+        _BACKEND_LOCAL_KEY_DIR / "private.pem"
+    )
+    bootstrap_config["local_session_jwks_path"] = str(
+        _BACKEND_LOCAL_KEY_DIR / "jwks.json"
+    )
+    _BACKEND_APP_YAML.write_text(
+        yaml.safe_dump(bootstrap_config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+if not _BACKEND_LOCAL_KEY_DIR.exists():
+    # This module has no app.config import side effect, so the key fixture can
+    # be created before test collection imports the process-global settings.
+    from app.services.local_session_keys import generate_local_session_keyset
+
+    generate_local_session_keyset(_BACKEND_LOCAL_KEY_DIR)
 
 
 @pytest.fixture

--- a/backend/tests/test_admin_auth_boundary_unit.py
+++ b/backend/tests/test_admin_auth_boundary_unit.py
@@ -1,0 +1,540 @@
+"""Mode-separated product-admin browser authentication contracts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from urllib.parse import parse_qs, urlsplit
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.exceptions import AuthenticationError
+
+
+def _jwk(private_key: rsa.RSAPrivateKey) -> dict[str, str]:
+    numbers = private_key.public_key().public_numbers()
+
+    def encode(value: int) -> str:
+        raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return {
+        "kty": "RSA",
+        "kid": "admin-test-key",
+        "use": "sig",
+        "alg": "RS256",
+        "n": encode(numbers.n),
+        "e": encode(numbers.e),
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_authorization_request_uses_dedicated_client_pkce_and_nonce(
+    monkeypatch,
+) -> None:
+    from app.services import keycloak_oidc
+
+    issued: list[tuple[str, str, dict, int]] = []
+
+    async def store(key: str, kind: str, payload: dict, ttl_secs: int) -> None:
+        issued.append((key, kind, payload, ttl_secs))
+
+    monkeypatch.setattr(keycloak_oidc, "_store_issue", store)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "keycloak_client_id", "akb-web", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+
+    request = await keycloak_oidc.KeycloakOIDC().begin_admin_login()
+    query = parse_qs(urlsplit(request.location).query)
+
+    assert query["client_id"] == ["akb-admin"]
+    assert query["redirect_uri"] == ["https://akb.example/api/v1/admin/auth/keycloak/callback"]
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["openid profile email"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert "code_challenge" in query
+    assert "nonce" in query
+    assert "prompt" not in query
+    assert issued == [
+        (
+            query["state"][0],
+            "admin-state-v1",
+            {
+                "code_verifier": issued[0][2]["code_verifier"],
+                "nonce": query["nonce"][0],
+                "browser_binding_hash": hashlib.sha256(request.browser_binding.encode("ascii")).hexdigest(),
+            },
+            600,
+        )
+    ]
+    assert 43 <= len(issued[0][2]["code_verifier"]) <= 128
+    assert request.browser_binding not in issued[0][2].values()
+
+
+def test_admin_login_sets_browser_binding_cookie(monkeypatch) -> None:
+    from app.api.routes import admin_auth
+    from app.services.keycloak_oidc import AdminAuthorizationRequest
+
+    class OIDC:
+        async def begin_admin_login(self):
+            return AdminAuthorizationRequest(
+                location="https://id.example/authorize?state=one-time-state",
+                browser_binding="browser-binding-value-that-is-long-enough",
+            )
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_secret", "secret", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+    monkeypatch.setattr(admin_auth, "get_keycloak_oidc", lambda: OIDC())
+
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+    response = TestClient(app).get(
+        "/api/v1/admin/auth/keycloak/login",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("https://id.example/authorize")
+    binding_cookie = next(
+        value for value in response.headers.get_list("set-cookie") if value.startswith("akb_admin_oidc_binding=")
+    )
+    assert "browser-binding-value-that-is-long-enough" in binding_cookie
+    assert "HttpOnly" in binding_cookie
+    assert "Path=/api/v1/admin/auth/keycloak/callback" in binding_cookie
+    assert "SameSite=lax" in binding_cookie
+    assert "Secure" in binding_cookie
+
+
+@pytest.mark.asyncio
+async def test_admin_code_exchange_uses_confidential_client_and_never_logs_tokens(
+    monkeypatch,
+    caplog,
+) -> None:
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    requests: list[dict[str, str]] = []
+
+    class Response:
+        status_code = 200
+        text = "must-not-be-logged-access-or-refresh-token"
+
+        @staticmethod
+        def json():
+            return {"token_type": "Bearer", "id_token": "id-token"}
+
+    class Client:
+        async def post(self, _url: str, *, data: dict[str, str]):
+            requests.append(data)
+            return Response()
+
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example", raising=False)
+    monkeypatch.setattr(settings, "keycloak_internal_url", "", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(
+        settings,
+        "keycloak_admin_client_secret",
+        "admin-client-secret",  # pragma: allowlist secret
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+    service = KeycloakOIDC()
+    monkeypatch.setattr(service, "_client", lambda: Client())
+
+    result = await service.exchange_admin_code("one-time-code", "pkce-verifier")
+
+    assert result == {"token_type": "Bearer", "id_token": "id-token"}
+    assert requests == [
+        {
+            "grant_type": "authorization_code",
+            "code": "one-time-code",
+            "redirect_uri": "https://akb.example/api/v1/admin/auth/keycloak/callback",
+            "client_id": "akb-admin",
+            "client_secret": "admin-client-secret",  # pragma: allowlist secret
+            "code_verifier": "pkce-verifier",
+        }
+    ]
+    assert "must-not-be-logged" not in caplog.text
+    assert "admin-client-secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_admin_id_token_requires_exact_client_nonce_and_human_session(
+    monkeypatch,
+) -> None:
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    service = KeycloakOIDC()
+    service._jwks = {"keys": [_jwk(private_key)]}
+    now = int(datetime.now(timezone.utc).timestamp())
+    expected_nonce = "expected-nonce-value-that-is-long-enough"
+
+    def mint(**overrides: object) -> str:
+        claims: dict[str, object] = {
+            "iss": "https://id.example/realms/akb",
+            "aud": "akb-admin",
+            "azp": "akb-admin",
+            "sub": str(uuid.uuid4()),
+            "sid": str(uuid.uuid4()),
+            "nonce": expected_nonce,
+            "iat": now,
+            "exp": now + 300,
+        }
+        claims.update(overrides)
+        return jwt.encode(
+            claims,
+            private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            ),
+            algorithm="RS256",
+            headers={"kid": "admin-test-key", "typ": "JWT"},
+        )
+
+    claims = await service.verify_admin_id_token(
+        mint(),
+        expected_nonce=expected_nonce,
+    )
+    assert claims["aud"] == "akb-admin"
+
+    for rejected in (
+        mint(nonce="attacker-nonce"),
+        mint(nonce="관리자-nonce"),
+        mint(aud="akb-web"),
+        mint(azp="akb-web"),
+        mint(sid=""),
+        mint(iat=str(now)),
+        mint(exp=str(now + 300)),
+    ):
+        with pytest.raises(AuthenticationError):
+            await service.verify_admin_id_token(
+                rejected,
+                expected_nonce=expected_nonce,
+            )
+
+    for malformed_key in (
+        {
+            "kty": "RSA",
+            "kid": "admin-test-key",
+            "use": "sig",
+            "alg": "RS256",
+            "n": "!!!",
+            "e": "AQAB",
+        },
+        {
+            "kty": "RSA",
+            "kid": "admin-test-key",
+            "use": "sig",
+            "alg": "RS256",
+            "e": "AQAB",
+        },
+    ):
+        service._jwks = {"keys": [malformed_key]}
+        with pytest.raises(AuthenticationError):
+            await service.verify_admin_id_token(
+                mint(),
+                expected_nonce=expected_nonce,
+            )
+
+
+def test_admin_public_config_exposes_only_the_selected_login_surface(monkeypatch) -> None:
+    from app.api.routes import admin_auth
+
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+
+    @app.exception_handler(AuthenticationError)
+    async def authentication_error(_request, exc: AuthenticationError):
+        return JSONResponse({"error": exc.message}, status_code=exc.status_code)
+
+    client = TestClient(app)
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    local = client.get("/api/v1/admin/auth/config")
+    assert local.status_code == 200
+    assert local.json() == {
+        "schema_version": 1,
+        "auth_mode": "local",
+        "local": {"enabled": True, "login_url": "/api/v1/admin/auth/local/login"},
+        "keycloak": {"enabled": False, "login_url": None},
+    }
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_secret", "secret", raising=False)
+    sso = client.get("/api/v1/admin/auth/config")
+    assert sso.status_code == 200
+    assert sso.json() == {
+        "schema_version": 1,
+        "auth_mode": "sso",
+        "local": {"enabled": False, "login_url": None},
+        "keycloak": {
+            "enabled": True,
+            "login_url": "/api/v1/admin/auth/keycloak/login",
+        },
+    }
+
+
+def test_wrong_mode_admin_login_routes_are_hidden(monkeypatch) -> None:
+    from app.api.routes import admin_auth
+
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+    client = TestClient(app)
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    assert (
+        client.post(
+            "/api/v1/admin/auth/local/login",
+            json={"username": "admin", "password": "password"},  # pragma: allowlist secret
+        ).status_code
+        == 404
+    )
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    assert client.get("/api/v1/admin/auth/keycloak/login").status_code == 404
+
+
+def test_sso_admin_callback_issues_only_short_opaque_cookies(monkeypatch) -> None:
+    from app.api.routes import admin_auth
+    from app.services.admin_auth_service import (
+        IssuedAdminBrowserSession,
+        ProductAdminIdentity,
+    )
+
+    admin = ProductAdminIdentity(
+        user_id=uuid.uuid4(),
+        external_identity_id=uuid.uuid4(),
+        username="admin",
+        email="admin@example.com",
+        display_name="Admin",
+        auth_method="keycloak",
+    )
+    issued = IssuedAdminBrowserSession(
+        token="opaque-session-value",
+        csrf_token="opaque-csrf-value",
+        expires_at=datetime.fromtimestamp(2_000_000_000, timezone.utc),
+    )
+
+    class OIDC:
+        async def consume_admin_state(self, state: str, browser_binding: str):
+            assert (state, browser_binding) == (
+                "one-time-state",
+                "browser-binding-value-that-is-long-enough",
+            )
+            return {"code_verifier": "verifier", "nonce": "nonce"}
+
+        async def exchange_admin_code(self, code: str, verifier: str):
+            assert (code, verifier) == ("one-time-code", "verifier")
+            return {
+                "token_type": "Bearer",
+                "access_token": "keycloak-access-secret",
+                "refresh_token": "keycloak-refresh-secret",
+                "id_token": "keycloak-id-secret",
+            }
+
+        async def verify_admin_id_token(self, token: str, *, expected_nonce: str):
+            assert (token, expected_nonce) == ("keycloak-id-secret", "nonce")
+            return {
+                "iss": "https://id.example/realms/akb",
+                "sub": "admin-subject",
+                "sid": "admin-sid",
+                "exp": 2_000_000_000,
+            }
+
+    async def project(claims):
+        assert claims["sub"] == "admin-subject"
+        return admin
+
+    async def create_session(identity, claims):
+        assert identity == admin
+        assert claims["sid"] == "admin-sid"
+        return issued
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_secret", "secret", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+    monkeypatch.setattr(admin_auth, "get_keycloak_oidc", lambda: OIDC())
+    monkeypatch.setattr(admin_auth, "resolve_prebound_sso_product_admin", project)
+    monkeypatch.setattr(admin_auth, "create_sso_admin_browser_session", create_session)
+
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+    client = TestClient(app)
+    client.cookies.set(
+        "akb_admin_oidc_binding",
+        "browser-binding-value-that-is-long-enough",
+        path="/api/v1/admin/auth/keycloak/callback",
+    )
+    response = client.get(
+        "/api/v1/admin/auth/keycloak/callback",
+        params={"code": "one-time-code", "state": "one-time-state"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin"
+    cookies = response.headers.get_list("set-cookie")
+    assert any(
+        value.startswith("akb_admin_session=opaque-session-value;")
+        and "HttpOnly" in value
+        and "Path=/api/v1/admin" in value
+        and "SameSite=lax" in value
+        and "Secure" in value
+        for value in cookies
+    )
+    assert any(
+        value.startswith("akb_admin_oidc_binding=")
+        and "Max-Age=0" in value
+        and "Path=/api/v1/admin/auth/keycloak/callback" in value
+        for value in cookies
+    )
+    assert any(
+        value.startswith("akb_admin_csrf=opaque-csrf-value;")
+        and "HttpOnly" not in value
+        and "Path=/" in value
+        and "SameSite=lax" in value
+        and "Secure" in value
+        for value in cookies
+    )
+    rendered = "\n".join(f"{name}: {value}" for name, value in response.headers.items())
+    assert "keycloak-access-secret" not in rendered
+    assert "keycloak-refresh-secret" not in rendered
+    assert "keycloak-id-secret" not in rendered
+
+
+def test_admin_session_is_mode_selected_and_sso_logout_requires_csrf(monkeypatch) -> None:
+    from app.api.routes import admin_auth
+    from app.services.admin_auth_service import ProductAdminIdentity
+
+    identity = ProductAdminIdentity(
+        user_id=uuid.uuid4(),
+        external_identity_id=uuid.uuid4(),
+        username="admin",
+        email="admin@example.com",
+        display_name=None,
+        auth_method="keycloak",
+    )
+    calls: list[tuple[str, str, str]] = []
+
+    async def resolve_sso(token: str):
+        assert token == "opaque-session"
+        return identity
+
+    async def revoke(token: str, csrf_cookie: str, csrf_header: str):
+        calls.append((token, csrf_cookie, csrf_header))
+        return identity
+
+    class OIDC:
+        def admin_logout_url(self):
+            return "https://id.example/logout?client_id=akb-admin"
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_secret", "secret", raising=False)
+    monkeypatch.setattr(admin_auth, "resolve_sso_admin_browser_session", resolve_sso)
+    monkeypatch.setattr(admin_auth, "revoke_sso_admin_browser_session", revoke)
+    monkeypatch.setattr(admin_auth, "get_keycloak_oidc", lambda: OIDC())
+
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+
+    @app.exception_handler(AuthenticationError)
+    async def authentication_error(_request, exc: AuthenticationError):
+        return JSONResponse({"error": exc.message}, status_code=exc.status_code)
+
+    client = TestClient(app)
+    client.cookies.set("akb_admin_session", "opaque-session")
+    client.cookies.set("akb_admin_csrf", "csrf-value")
+
+    session = client.get("/api/v1/admin/auth/session")
+    assert session.status_code == 200
+    assert session.json()["user"] == {
+        "id": str(identity.user_id),
+        "username": "admin",
+        "email": "admin@example.com",
+        "display_name": None,
+        "is_admin": True,
+    }
+
+    assert client.post("/api/v1/admin/auth/logout").status_code == 401
+    logout = client.post(
+        "/api/v1/admin/auth/logout",
+        headers={"X-AKB-Admin-CSRF": "csrf-value"},
+    )
+    assert logout.status_code == 200
+    assert logout.json()["logout_url"].startswith("https://id.example/logout")
+    assert calls == [("opaque-session", "csrf-value", "csrf-value")]
+
+
+@pytest.mark.asyncio
+async def test_admin_session_rejects_unbounded_keycloak_claims_before_database(
+    monkeypatch,
+) -> None:
+    from app.services import admin_auth_service
+    from app.services.admin_auth_service import ProductAdminIdentity
+
+    identity = ProductAdminIdentity(
+        user_id=uuid.uuid4(),
+        external_identity_id=uuid.uuid4(),
+        username="admin",
+        email="admin@example.com",
+        display_name=None,
+        auth_method="keycloak",
+    )
+
+    async def no_database():
+        raise AssertionError("invalid claims must fail before database access")
+
+    monkeypatch.setattr(admin_auth_service, "get_pool", no_database)
+    now = int(datetime.now(timezone.utc).timestamp())
+    for claims in (
+        {"sid": "s" * 256, "exp": now + 300},
+        {"sid": "valid-sid", "exp": 10**100},
+    ):
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.create_sso_admin_browser_session(
+                identity,
+                claims,
+            )
+
+
+@pytest.mark.asyncio
+async def test_admin_session_rejects_non_urlsafe_csrf_before_database(
+    monkeypatch,
+) -> None:
+    from app.services import admin_auth_service
+
+    async def no_database():
+        raise AssertionError("invalid credentials must fail before database access")
+
+    monkeypatch.setattr(admin_auth_service, "get_pool", no_database)
+    with pytest.raises(AuthenticationError):
+        await admin_auth_service.revoke_sso_admin_browser_session(
+            "s" * 32,
+            "관리자-csrf-token-value-that-is-long-enough",
+            "관리자-csrf-token-value-that-is-long-enough",
+        )

--- a/backend/tests/test_admin_auth_postgres.py
+++ b/backend/tests/test_admin_auth_postgres.py
@@ -1,0 +1,379 @@
+"""PostgreSQL proof for exact admin binding and opaque session custody.
+
+This file is pinned in the live-PostgreSQL CI job.  The ordinary unit job has
+no database and would otherwise skip every assertion here, including the 072
+fresh-schema/upgrade-schema catalog-equivalence check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit, urlunsplit
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+def _dsn_for_database(dsn: str, database: str) -> str:
+    parsed = urlsplit(dsn)
+    return urlunsplit(parsed._replace(path=f"/{database}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+async def _admin_schema_shape(conn) -> dict[str, tuple[tuple[object, ...], ...]]:
+    """Return the database-owned shape introduced by migration 072."""
+    columns = await conn.fetch(
+        """
+        SELECT column_name, data_type, is_nullable, column_default
+          FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'admin_browser_sessions'
+         ORDER BY ordinal_position
+        """
+    )
+    constraints = await conn.fetch(
+        """
+        SELECT conname, contype, pg_get_constraintdef(oid), convalidated
+          FROM pg_constraint
+         WHERE conrelid = 'admin_browser_sessions'::regclass
+         ORDER BY conname
+        """
+    )
+    indexes = await conn.fetch(
+        """
+        SELECT indexrelid::regclass::text, pg_get_indexdef(indexrelid), indisvalid
+          FROM pg_index
+         WHERE indrelid = 'admin_browser_sessions'::regclass
+            OR indexrelid = 'external_identities_id_user_key'::regclass
+         ORDER BY indexrelid::regclass::text
+        """
+    )
+    return {
+        "columns": tuple(tuple(row) for row in columns),
+        "constraints": tuple(tuple(row) for row in constraints),
+        "indexes": tuple(tuple(row) for row in indexes),
+    }
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_admin_auth_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        conn = await asyncpg.connect(target_dsn)
+        try:
+            await conn.execute(_INIT_SQL)
+            from app.db.postgres import _load_migration
+
+            fresh_admin_shape = await _admin_schema_shape(conn)
+            await conn.execute("DROP TABLE admin_browser_sessions")
+            await conn.execute("DROP INDEX external_identities_id_user_key")
+            admin_session_migration = _load_migration("072_admin_browser_sessions.py")
+            assert admin_session_migration is not None
+            await admin_session_migration.migrate(conn=conn)
+            await admin_session_migration.migrate(conn=conn)
+            assert await _admin_schema_shape(conn) == fresh_admin_shape
+
+            events_migration = _load_migration("015_events_outbox.py")
+            assert events_migration is not None
+            await events_migration.migrate(conn=conn)
+        finally:
+            await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+async def test_sso_admin_is_exact_prebound_opaque_and_live_rechecked(
+    monkeypatch,
+) -> None:
+    from app.config import settings
+    from app.exceptions import AuthenticationError, ForbiddenError, MembershipRequiredError
+    from app.services import admin_auth_service, keycloak_oidc
+
+    async with _fresh_database() as pool:
+
+        async def get_test_pool():
+            return pool
+
+        monkeypatch.setattr(admin_auth_service, "get_pool", get_test_pool)
+        monkeypatch.setattr(keycloak_oidc, "get_pool", get_test_pool)
+        monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+        monkeypatch.setattr(
+            settings,
+            "keycloak_server_url",
+            "https://id.example",
+            raising=False,
+        )
+        monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+        monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+        monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+        monkeypatch.setattr(settings, "admin_browser_session_ttl_secs", 300, raising=False)
+
+        oidc = keycloak_oidc.KeycloakOIDC()
+        rejected_request = await oidc.begin_admin_login()
+        rejected_state = parse_qs(urlsplit(rejected_request.location).query)["state"][0]
+        assert await keycloak_oidc._store_consume(rejected_state, "ordinary-state") is None
+        assert (
+            await oidc.consume_admin_state(
+                rejected_state,
+                "wrong-browser-binding-value-that-is-long-enough",
+            )
+            is None
+        )
+        rejected_transient = await oidc.consume_admin_state(
+            rejected_state,
+            rejected_request.browser_binding,
+        )
+        assert rejected_transient is not None
+        assert set(rejected_transient) == {"nonce", "code_verifier"}
+        assert await oidc.consume_admin_state(rejected_state, rejected_request.browser_binding) is None
+
+        accepted_request = await oidc.begin_admin_login()
+        accepted_state = parse_qs(urlsplit(accepted_request.location).query)["state"][0]
+        accepted_transient = await oidc.consume_admin_state(
+            accepted_state,
+            accepted_request.browser_binding,
+        )
+        assert accepted_transient is not None
+        assert set(accepted_transient) == {"nonce", "code_verifier"}
+        assert await oidc.consume_admin_state(accepted_state, accepted_request.browser_binding) is None
+
+        admin_user_id = uuid.uuid4()
+        member_user_id = uuid.uuid4()
+        admin_identity_id = uuid.uuid4()
+        member_identity_id = uuid.uuid4()
+        async with pool.acquire() as conn:
+            await conn.executemany(
+                """
+                INSERT INTO users (
+                    id, username, email, password_hash, is_admin,
+                    auth_provider, account_status, account_kind
+                ) VALUES ($1, $2, $3, '!sso!', $4, 'keycloak', 'active', 'human')
+                """,
+                [
+                    (admin_user_id, "admin", "admin@example.com", True),
+                    (member_user_id, "member", "member@example.com", False),
+                ],
+            )
+            await conn.executemany(
+                """
+                INSERT INTO external_identities (id, user_id, issuer, subject)
+                VALUES ($1, $2, $3, $4)
+                """,
+                [
+                    (
+                        admin_identity_id,
+                        admin_user_id,
+                        settings.keycloak_issuer,
+                        "admin-subject",
+                    ),
+                    (
+                        member_identity_id,
+                        member_user_id,
+                        settings.keycloak_issuer,
+                        "member-subject",
+                    ),
+                ],
+            )
+
+        claims = {
+            "iss": settings.keycloak_issuer,
+            "sub": "admin-subject",
+            "sid": "keycloak-session-id",
+            "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
+        }
+        identity = await admin_auth_service.resolve_prebound_sso_product_admin(claims)
+        assert identity.user_id == admin_user_id
+        assert identity.external_identity_id == admin_identity_id
+
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.create_sso_admin_browser_session(
+                identity,
+                {**claims, "sub": "member-subject"},
+            )
+
+        with pytest.raises(MembershipRequiredError):
+            await admin_auth_service.resolve_prebound_sso_product_admin({**claims, "sub": "unknown-subject"})
+        with pytest.raises(ForbiddenError):
+            await admin_auth_service.resolve_prebound_sso_product_admin({**claims, "sub": "member-subject"})
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT COUNT(*) FROM users") == 2
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO admin_browser_sessions (
+                        token_hash, csrf_token_hash, user_id,
+                        external_identity_id, identity_issuer, identity_subject,
+                        keycloak_sid, expires_at
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6,
+                        'sid', NOW() + INTERVAL '5 minutes'
+                    )
+                    """,
+                    "a" * 64,
+                    "b" * 64,
+                    admin_user_id,
+                    member_identity_id,
+                    settings.keycloak_issuer,
+                    "member-subject",
+                )
+
+        issued = await admin_auth_service.create_sso_admin_browser_session(
+            identity,
+            claims,
+        )
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM admin_browser_sessions WHERE user_id = $1",
+                admin_user_id,
+            )
+            assert row is not None
+            assert issued.token not in tuple(str(value) for value in row.values())
+            assert issued.csrf_token not in tuple(str(value) for value in row.values())
+            assert len(row["token_hash"]) == len(row["csrf_token_hash"]) == 64
+
+        resolved = await admin_auth_service.resolve_sso_admin_browser_session(issued.token)
+        assert resolved.user_id == admin_user_id
+
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.revoke_sso_admin_browser_session(
+                issued.token,
+                issued.csrf_token,
+                "wrong-csrf-token-that-is-long-enough",
+            )
+        await admin_auth_service.revoke_sso_admin_browser_session(
+            issued.token,
+            issued.csrf_token,
+            issued.csrf_token,
+        )
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(issued.token)
+
+        concurrent_sessions = await asyncio.gather(
+            *(admin_auth_service.create_sso_admin_browser_session(identity, claims) for _ in range(12))
+        )
+        assert len(concurrent_sessions) == 12
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM admin_browser_sessions WHERE user_id = $1",
+                    admin_user_id,
+                )
+                == 8
+            )
+            await conn.execute(
+                "DELETE FROM admin_browser_sessions WHERE user_id = $1",
+                admin_user_id,
+            )
+
+        replacement = await admin_auth_service.create_sso_admin_browser_session(
+            identity,
+            claims,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE external_identities SET issuer = $2 WHERE id = $1",
+                admin_identity_id,
+                "https://replacement.example/realms/akb",
+            )
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(replacement.token)
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM admin_browser_sessions WHERE user_id = $1",
+                    admin_user_id,
+                )
+                == 0
+            )
+            await conn.execute(
+                "UPDATE external_identities SET issuer = $2 WHERE id = $1",
+                admin_identity_id,
+                settings.keycloak_issuer,
+            )
+
+        replacement = await admin_auth_service.create_sso_admin_browser_session(
+            identity,
+            claims,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE external_identities SET subject = $2 WHERE id = $1",
+                admin_identity_id,
+                "replacement-admin-subject",
+            )
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(replacement.token)
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM admin_browser_sessions WHERE user_id = $1",
+                    admin_user_id,
+                )
+                == 0
+            )
+            await conn.execute(
+                "UPDATE external_identities SET subject = $2 WHERE id = $1",
+                admin_identity_id,
+                "admin-subject",
+            )
+
+        replacement = await admin_auth_service.create_sso_admin_browser_session(
+            identity,
+            claims,
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE users SET is_admin = false WHERE id = $1",
+                admin_user_id,
+            )
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(replacement.token)
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT COUNT(*) FROM admin_browser_sessions WHERE user_id = $1",
+                    admin_user_id,
+                )
+                == 0
+            )

--- a/backend/tests/test_app_identity_unit.py
+++ b/backend/tests/test_app_identity_unit.py
@@ -16,8 +16,8 @@ from app.services import app_identity_service, auth_service
 def _configure_secrets(monkeypatch) -> None:
     monkeypatch.setattr(
         settings,
-        "jwt_secret",
-        "user-session-signing-material-long-enough",
+        "system_hmac_secret",
+        "system-capability-hmac-material-long-enough",
         raising=False,
     )
     monkeypatch.setattr(
@@ -68,8 +68,9 @@ def test_app_token_contains_identity_not_registry_authority(monkeypatch):
     }.isdisjoint(claims)
 
 
-def test_matching_user_and_app_signing_secrets_fail_closed(monkeypatch):
-    monkeypatch.setattr(settings, "jwt_secret", "same-signing-material", raising=False)
+def test_matching_system_hmac_and_app_signing_secrets_fail_closed(monkeypatch):
+    monkeypatch.setattr(settings, "system_hmac_secret", "same-signing-material", raising=False)
+    monkeypatch.setattr(settings, "jwt_secret", "irrelevant-migration-input", raising=False)
     monkeypatch.setattr(settings, "app_token_secret", "same-signing-material", raising=False)
 
     with pytest.raises(AKBError) as exc:
@@ -91,7 +92,7 @@ async def test_explicit_app_token_type_never_reaches_user_lookup(monkeypatch):
             "iat": now,
             "exp": now + timedelta(minutes=5),
         },
-        settings.jwt_secret,
+        settings.system_hmac_secret_effective,
         algorithm="HS256",
         headers={"typ": app_identity_service.APP_TOKEN_TYPE},
     )
@@ -102,9 +103,7 @@ async def test_explicit_app_token_type_never_reaches_user_lookup(monkeypatch):
     monkeypatch.setattr(auth_service, "get_pool", forbidden_pool)
 
     assert await auth_service.resolve_token(f"Bearer {app_shaped}") is None
-    assert await auth_service.resolve_akb_session_authorization(
-        f"Bearer {app_shaped}"
-    ) is None
+    assert await auth_service.resolve_akb_session_authorization(f"Bearer {app_shaped}") is None
 
 
 def test_supported_capabilities_are_control_plane_only():

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -20,6 +20,17 @@ def _load(
     return app_config._load_settings()
 
 
+def _local_key_values(tmp_path: Path) -> dict[str, str]:
+    from app.services.local_session_keys import generate_local_session_keyset
+
+    key_dir = tmp_path / "local-session"
+    generate_local_session_keyset(key_dir)
+    return {
+        "local_session_private_key_path": str(key_dir / "private.pem"),
+        "local_session_jwks_path": str(key_dir / "jwks.json"),
+    }
+
+
 def test_runtime_load_accepts_explicit_local_auth_mode(
     monkeypatch,
     tmp_path: Path,
@@ -204,6 +215,7 @@ def test_local_mode_keeps_keycloak_separate_for_mcp_oauth(
         monkeypatch,
         tmp_path,
         {
+            **_local_key_values(tmp_path),
             "auth_mode": "local",
             "keycloak_enabled": True,
             "mcp_oauth_enabled": True,
@@ -246,11 +258,12 @@ def test_local_mcp_oauth_startup_does_not_require_human_oidc_client_config(
         monkeypatch,
         tmp_path,
         {
+            **_local_key_values(tmp_path),
             "auth_mode": "local",
             "keycloak_enabled": True,
             "mcp_oauth_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
-            "jwt_secret": "test-jwt-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
         },
@@ -274,7 +287,7 @@ def test_sso_startup_requires_active_human_api_verifier_config_only(
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "",
-            "jwt_secret": "test-jwt-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
         },
@@ -306,7 +319,7 @@ def test_sso_startup_defers_browser_callback_inputs_until_browser_sessions_exist
             "keycloak_client_id": "akb-web",
             "keycloak_redirect_uri": "",
             "keycloak_client_secret": "",
-            "jwt_secret": "test-jwt-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
         },
@@ -316,7 +329,7 @@ def test_sso_startup_defers_browser_callback_inputs_until_browser_sessions_exist
     lifecycle._validate_required_settings()
 
 
-def test_sso_startup_rejects_missing_compatibility_hmac_secret(
+def test_sso_startup_rejects_missing_system_hmac_secret(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -337,13 +350,13 @@ def test_sso_startup_rejects_missing_compatibility_hmac_secret(
     )
     monkeypatch.setattr(lifecycle, "settings", loaded)
 
-    assert loaded.jwt_secret == ""
+    assert loaded.system_hmac_secret == ""
     assert loaded.app_token_secret == ""
-    with pytest.raises(RuntimeError, match="AKB_JWT_SECRET"):
+    with pytest.raises(RuntimeError, match="system_hmac_secret"):
         lifecycle._validate_required_settings()
 
 
-def test_sso_startup_does_not_select_legacy_hs256_human_profile(
+def test_sso_startup_accepts_legacy_jwt_secret_only_as_system_hmac_migration_input(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -369,7 +382,7 @@ def test_sso_startup_does_not_select_legacy_hs256_human_profile(
     lifecycle._validate_required_settings()
 
 
-def test_local_startup_requires_legacy_session_secret_independently_of_app_secret(
+def test_local_startup_requires_system_hmac_and_persistent_signing_keys(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -387,8 +400,12 @@ def test_local_startup_requires_legacy_session_secret_independently_of_app_secre
     )
     monkeypatch.setattr(lifecycle, "settings", loaded)
 
-    with pytest.raises(RuntimeError, match="AKB_JWT_SECRET"):
+    with pytest.raises(RuntimeError) as exc_info:
         lifecycle._validate_required_settings()
+    message = str(exc_info.value)
+    assert "system_hmac_secret" in message
+    assert "local_session_private_key_path" in message
+    assert "local_session_jwks_path" in message
 
 
 def test_api_audience_has_distinct_public_resource_default() -> None:
@@ -431,7 +448,7 @@ def test_startup_rejects_equal_api_and_mcp_audiences(
         lifecycle._validate_required_settings()
 
 
-def test_startup_rejects_configurable_algorithm_for_fixed_legacy_profile(
+def test_startup_rejects_hs256_after_local_v2_cutover(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -442,13 +459,13 @@ def test_startup_rejects_configurable_algorithm_for_fixed_legacy_profile(
         tmp_path,
         {
             "auth_mode": "local",
-            "jwt_algorithm": "RS256",
-            "jwt_secret": "test-jwt-secret",  # pragma: allowlist secret
+            "jwt_algorithm": "HS256",
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
         },
     )
     monkeypatch.setattr(lifecycle, "settings", loaded)
 
-    with pytest.raises(RuntimeError, match="local-session-legacy-v1"):
+    with pytest.raises(RuntimeError, match="local-session-rs256-v2"):
         lifecycle._validate_required_settings()

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -303,7 +303,7 @@ def test_sso_startup_requires_active_human_api_verifier_config_only(
     assert "keycloak_client_secret" not in message
 
 
-def test_sso_startup_defers_browser_callback_inputs_until_browser_sessions_exist(
+def test_sso_startup_defers_ordinary_browser_inputs_but_requires_admin_client(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -326,7 +326,105 @@ def test_sso_startup_defers_browser_callback_inputs_until_browser_sessions_exist
     )
     monkeypatch.setattr(lifecycle, "settings", loaded)
 
+    with pytest.raises(RuntimeError, match="keycloak_admin_client_secret"):
+        lifecycle._validate_required_settings()
+
+
+def test_sso_admin_client_is_dedicated_and_callback_is_deployment_bound(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.services import lifecycle
+
+    loaded = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            "auth_mode": "sso",
+            "keycloak_enabled": True,
+            "keycloak_server_url": "https://auth.example.com",
+            "keycloak_client_id": "akb-web",
+            "keycloak_admin_client_id": "akb-admin",
+            "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
+            "db_password": "test-db-password",  # pragma: allowlist secret
+            "public_base_url": "https://akb.example.com",
+        },
+    )
+    monkeypatch.setattr(lifecycle, "settings", loaded)
+
     lifecycle._validate_required_settings()
+    assert loaded.keycloak_admin_redirect_uri == (
+        "https://akb.example.com/api/v1/admin/auth/keycloak/callback"
+    )
+    assert loaded.keycloak_admin_post_logout_redirect_uri == (
+        "https://akb.example.com/admin"
+    )
+    assert "akb-admin" not in loaded.keycloak_human_client_ids
+
+
+def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.services import lifecycle
+
+    reused = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            "auth_mode": "sso",
+            "keycloak_enabled": True,
+            "keycloak_server_url": "https://auth.example.com",
+            "keycloak_client_id": "akb-web",
+            "keycloak_admin_client_id": "akb-web",
+            "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
+            "db_password": "test-db-password",  # pragma: allowlist secret
+            "public_base_url": "https://akb.example.com",
+        },
+    )
+    monkeypatch.setattr(lifecycle, "settings", reused)
+    with pytest.raises(RuntimeError, match="dedicated"):
+        lifecycle._validate_required_settings()
+
+    insecure = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            "auth_mode": "sso",
+            "keycloak_enabled": True,
+            "keycloak_server_url": "https://auth.example.com",
+            "keycloak_client_id": "akb-web",
+            "keycloak_admin_client_id": "akb-admin",
+            "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
+            "db_password": "test-db-password",  # pragma: allowlist secret
+            "public_base_url": "http://akb.example.com",
+        },
+    )
+    monkeypatch.setattr(lifecycle, "settings", insecure)
+    with pytest.raises(RuntimeError, match="HTTPS"):
+        lifecycle._validate_required_settings()
+
+    insecure_issuer = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            "auth_mode": "sso",
+            "keycloak_enabled": True,
+            "keycloak_server_url": "http://auth.example.com",
+            "keycloak_client_id": "akb-web",
+            "keycloak_admin_client_id": "akb-admin",
+            "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+            "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
+            "db_password": "test-db-password",  # pragma: allowlist secret
+            "public_base_url": "https://akb.example.com",
+        },
+    )
+    monkeypatch.setattr(lifecycle, "settings", insecure_issuer)
+    with pytest.raises(RuntimeError, match="HTTPS public Keycloak"):
+        lifecycle._validate_required_settings()
 
 
 def test_sso_startup_rejects_missing_system_hmac_secret(
@@ -344,6 +442,7 @@ def test_sso_startup_rejects_missing_system_hmac_secret(
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_redirect_uri": "https://akb.example.com/auth/keycloak/callback",
             "keycloak_client_secret": "test-keycloak-client-secret",  # pragma: allowlist secret
+            "keycloak_admin_client_secret": "test-admin-client-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
         },
@@ -371,6 +470,7 @@ def test_sso_startup_accepts_legacy_jwt_secret_only_as_system_hmac_migration_inp
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_redirect_uri": "https://akb.example.com/auth/keycloak/callback",
             "keycloak_client_secret": "test-keycloak-client-secret",  # pragma: allowlist secret
+            "keycloak_admin_client_secret": "test-admin-client-secret",  # pragma: allowlist secret
             "jwt_algorithm": "RS256",
             "jwt_secret": "compatibility-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret

--- a/backend/tests/test_auth_verifier_profiles_unit.py
+++ b/backend/tests/test_auth_verifier_profiles_unit.py
@@ -486,6 +486,49 @@ async def test_keycloak_mcp_profile_does_not_apply_static_human_azp_allowlist(
         is not None
     )
 
+    admin_client_token = _mint_keycloak_token(
+        rsa_keypair,
+        issuer=issuer,
+        audience=mcp_audience,
+        claim_overrides={"azp": settings.keycloak_admin_client_id},
+    )
+    assert (
+        await service.verify_access_token(
+            admin_client_token,
+            mcp_audience,
+            route_profile="mcp",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_keycloak_access_v1_rejects_malformed_trusted_rsa_jwk(
+    monkeypatch,
+    rsa_keypair,
+):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    issuer, api_audience, _ = _configure_keycloak(monkeypatch)
+    malformed = {**rsa_keypair["jwk"]}
+    malformed.pop("n")
+    service = KeycloakOIDC()
+    service._jwks = {"keys": [malformed]}
+    token = _mint_keycloak_token(
+        rsa_keypair,
+        issuer=issuer,
+        audience=api_audience,
+    )
+
+    assert (
+        await service.verify_access_token(
+            token,
+            api_audience,
+            route_profile="api",
+        )
+        is None
+    )
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/backend/tests/test_auth_verifier_profiles_unit.py
+++ b/backend/tests/test_auth_verifier_profiles_unit.py
@@ -172,7 +172,7 @@ async def test_rest_local_mode_selects_only_local_profile_without_fallback(monke
     from app.services import auth_service
 
     monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
-    principal = _principal("local-session-legacy-v1")
+    principal = _principal("local-session-rs256-v2")
     actor = _actor()
     calls: list[str] = []
 
@@ -187,7 +187,7 @@ async def test_rest_local_mode_selects_only_local_profile_without_fallback(monke
         assert value is principal
         return actor
 
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", verify_local)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", verify_local)
     monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", forbidden_keycloak)
     monkeypatch.setattr(auth_service, "project_verified_principal", project)
 
@@ -196,7 +196,7 @@ async def test_rest_local_mode_selects_only_local_profile_without_fallback(monke
     assert resolved is actor
     assert calls == ["local:opaque.jwt"]
 
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", lambda _token: None)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", lambda _token: None)
     assert await auth_service.resolve_rest_user_authorization("Bearer rejected.jwt") is None
 
 
@@ -220,7 +220,7 @@ async def test_rest_sso_mode_selects_only_api_access_profile_without_fallback(mo
         assert value is principal
         return actor
 
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", forbidden_local)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", forbidden_local)
     monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", verify_keycloak)
     monkeypatch.setattr(auth_service, "project_verified_principal", project)
 
@@ -239,30 +239,20 @@ async def test_rest_sso_mode_selects_only_api_access_profile_without_fallback(mo
 @pytest.mark.asyncio
 async def test_rest_sso_mode_rejects_a_valid_local_session_jwt(monkeypatch):
     from app.services import auth_service
-    from app.services.auth_verifier_profiles import verify_local_session_legacy_v1
+    from app.services.auth_service import create_jwt
+    from app.services.auth_verifier_profiles import verify_local_session_rs256_v2
     from app.services.keycloak_oidc import KeycloakOIDC
 
-    secret = "required-compatibility-hmac-secret"  # pragma: allowlist secret
-    now = int(datetime.now(timezone.utc).timestamp())
-    local_token = jwt.encode(
-        {
-            "sub": str(uuid.uuid4()),
-            "username": "local-alice",
-            "iat": now,
-            "exp": now + 300,
-        },
-        secret,
-        algorithm="HS256",
-        headers={"typ": "JWT"},
-    )
-    monkeypatch.setattr(settings, "jwt_secret", secret, raising=False)
-    assert verify_local_session_legacy_v1(local_token) is not None
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example.com", raising=False)
+    local_token = create_jwt(str(uuid.uuid4()), "local-alice")
+    assert verify_local_session_rs256_v2(local_token) is not None
 
     _, api_audience, _ = _configure_keycloak(monkeypatch)
     service = KeycloakOIDC()
 
     async def forbidden_fetch(*, force: bool = False):
-        raise AssertionError(f"HS256 local token must fail before JWKS fetch: {force}")
+        raise AssertionError(f"local-session token must fail before JWKS fetch: {force}")
 
     async def verify_keycloak(token: str, route_profile: str):
         assert route_profile == "api"
@@ -279,7 +269,7 @@ async def test_rest_sso_mode_rejects_a_valid_local_session_jwt(monkeypatch):
         raise AssertionError("a local session must be rejected before projection")
 
     service._fetch_jwks = forbidden_fetch  # type: ignore[method-assign]
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", forbidden_local)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", forbidden_local)
     monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", verify_keycloak)
     monkeypatch.setattr(auth_service, "project_verified_principal", forbidden_projection)
 
@@ -294,9 +284,9 @@ async def test_delegated_human_resolver_is_mode_selected_and_preserves_primary_c
     from app.services import auth_service
 
     monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
-    principal = _principal("local-session-legacy-v1")
+    principal = _principal("local-session-rs256-v2")
     actor = _actor()
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", lambda _token: principal)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", lambda _token: principal)
 
     async def project(_principal):
         return actor
@@ -368,46 +358,8 @@ async def test_mcp_never_accepts_local_session_jwt(monkeypatch):
     def forbidden_local(_token: str):
         raise AssertionError("MCP must not invoke the local-session verifier")
 
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", forbidden_local)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", forbidden_local)
     assert await auth_service.resolve_mcp_authorization("Bearer local.session.jwt") is None
-
-
-def test_local_session_legacy_v1_is_fixed_hs256_with_strict_current_claims(monkeypatch):
-    from app.services.auth_verifier_profiles import verify_local_session_legacy_v1
-
-    secret = "local-session-test-secret-at-least-32-bytes"  # pragma: allowlist secret
-    monkeypatch.setattr(settings, "jwt_secret", secret, raising=False)
-    now = int(datetime.now(timezone.utc).timestamp())
-    claims = {
-        "sub": str(uuid.uuid4()),
-        "username": "alice",
-        "iat": now,
-        "exp": now + 300,
-    }
-    token = jwt.encode(claims, secret, algorithm="HS256", headers={"typ": "JWT"})
-
-    principal = verify_local_session_legacy_v1(token)
-
-    assert principal is not None
-    assert principal.profile_id == "local-session-legacy-v1"
-    assert principal.subject == claims["sub"]
-    assert principal.claims["username"] == "alice"
-
-    unsigned = jwt.encode(claims, key="", algorithm="none", headers={"typ": "JWT"})
-    assert verify_local_session_legacy_v1(unsigned) is None
-    assert verify_local_session_legacy_v1(_replace_header(token, alg="RS256")) is None
-    assert verify_local_session_legacy_v1(_replace_header(token, typ="AKB-APP")) is None
-
-    for required in ("sub", "username", "iat", "exp"):
-        incomplete = dict(claims)
-        incomplete.pop(required)
-        encoded = jwt.encode(
-            incomplete,
-            secret,
-            algorithm="HS256",
-            headers={"typ": "JWT"},
-        )
-        assert verify_local_session_legacy_v1(encoded) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_delegated_file_upload_unit.py
+++ b/backend/tests/test_delegated_file_upload_unit.py
@@ -70,12 +70,12 @@ async def test_secondary_resolver_accepts_only_mode_selected_human_without_mutat
     observed: list[str] = []
     monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
     principal = VerifiedPrincipal(
-        profile_id="local-session-legacy-v1",
-        issuer="akb-local",
+        profile_id="local-session-rs256-v2",
+        issuer=settings.local_session_issuer_effective,
         subject=delegated.user_id,
         credential_type="session",
         claims={"iat": 1},
-        audience=None,
+        audience=settings.local_session_audience_effective,
     )
 
     def _verify_session(raw: str):
@@ -86,7 +86,7 @@ async def test_secondary_resolver_accepts_only_mode_selected_human_without_mutat
         assert value is principal
         return delegated
 
-    monkeypatch.setattr(auth_service, "verify_local_session_legacy_v1", _verify_session)
+    monkeypatch.setattr(auth_service, "verify_local_session_rs256_v2", _verify_session)
     monkeypatch.setattr(auth_service, "project_verified_principal", _project)
     raw = "delegated-human.jwt"
     token_marker = current_token_id.set("primary-service-token-id")

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -198,7 +198,7 @@ def test_runtime_root_is_private_and_separate(tmp_path):
         assert stat.S_IMODE(directory.stat().st_mode) == 0o700
 
 
-def test_runtime_configures_local_auth_mode_and_distinct_app_token_secret(tmp_path):
+def test_runtime_configures_local_auth_mode_keys_and_distinct_app_token_secret(tmp_path):
     runtime = E2ERuntime(make_config(tmp_path))
     prepare_private_runtime_root(runtime.config.runtime_root)
 
@@ -211,8 +211,11 @@ def test_runtime_configures_local_auth_mode_and_distinct_app_token_secret(tmp_pa
         (runtime.config.config_dir / "secret.yaml").read_text(encoding="utf-8")
     )
     assert app_config["auth_mode"] == "local"
+    assert app_config["jwt_algorithm"] == "RS256"
+    assert Path(app_config["local_session_private_key_path"]).is_file()
+    assert Path(app_config["local_session_jwks_path"]).is_file()
     assert secret_config["app_token_secret"]
-    assert secret_config["app_token_secret"] != secret_config["jwt_secret"]
+    assert secret_config["app_token_secret"] != secret_config["system_hmac_secret"]
 
 
 def test_suite_summary_uses_last_complete_line_and_fails_closed():

--- a/backend/tests/test_local_session_rs256_v2_unit.py
+++ b/backend/tests/test_local_session_rs256_v2_unit.py
@@ -1,0 +1,370 @@
+"""Local-session RS256 v2 key lifecycle and verifier contracts."""
+
+from __future__ import annotations
+
+import json
+import stat
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.config import settings
+
+
+@pytest.fixture
+def configured_keyset(tmp_path: Path, monkeypatch) -> dict[str, object]:
+    from app.services.local_session_keys import (
+        clear_local_session_keyset_cache,
+        generate_local_session_keyset,
+    )
+
+    output_dir = tmp_path / "local-session-v2"
+    report = generate_local_session_keyset(output_dir)
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    monkeypatch.setattr(
+        settings,
+        "public_base_url",
+        "https://akb.example.test",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "local_session_private_key_path",
+        str(output_dir / "private.pem"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "local_session_jwks_path",
+        str(output_dir / "jwks.json"),
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "local_session_issuer", "", raising=False)
+    monkeypatch.setattr(settings, "local_session_audience", "", raising=False)
+    clear_local_session_keyset_cache()
+    return {"directory": output_dir, "report": report}
+
+
+def _mint(
+    private_key,
+    *,
+    kid: str,
+    issuer: str = "https://akb.example.test",
+    audience: str = "https://akb.example.test/api",
+    header_typ: str = "akb-local-session+jwt",
+    header_extra: dict[str, object] | None = None,
+    claim_overrides: dict[str, object] | None = None,
+) -> str:
+    now = int(datetime.now(timezone.utc).timestamp())
+    claims: dict[str, object] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": str(uuid.uuid4()),
+        "username": "alice",
+        "iat": now,
+        "nbf": now,
+        "exp": now + 300,
+        "jti": str(uuid.uuid4()),
+        "profile": "local-session-rs256-v2",
+        "token_use": "session",
+    }
+    if claim_overrides:
+        claims.update(claim_overrides)
+    headers: dict[str, object] = {"typ": header_typ, "kid": kid}
+    if header_extra:
+        headers.update(header_extra)
+    return jwt.encode(claims, private_key, algorithm="RS256", headers=headers)
+
+
+def test_generator_creates_rsa3072_keyset_without_overwriting(tmp_path: Path) -> None:
+    from app.services.local_session_keys import (
+        LocalSessionKeyConfigurationError,
+        generate_local_session_keyset,
+        load_local_session_keyset,
+    )
+
+    output_dir = tmp_path / "keys"
+    report = generate_local_session_keyset(output_dir)
+    private_path = output_dir / "private.pem"
+    jwks_path = output_dir / "jwks.json"
+
+    assert report == {
+        "profile": "local-session-rs256-v2",
+        "algorithm": "RS256",
+        "key_size": 3072,
+        "active_kid": report["active_kid"],
+        "retained_keys": 0,
+        "private_key_path": str(private_path),
+        "jwks_path": str(jwks_path),
+    }
+    assert stat.S_IMODE(private_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(jwks_path.stat().st_mode) == 0o600
+    assert "private" not in jwks_path.read_text(encoding="utf-8").lower()
+
+    loaded = load_local_session_keyset(private_path, jwks_path)
+    assert loaded.private_key.key_size == 3072
+    assert loaded.active_kid == report["active_kid"]
+    assert loaded.public_jwks == json.loads(jwks_path.read_text(encoding="utf-8"))
+
+    with pytest.raises(LocalSessionKeyConfigurationError, match="already exists"):
+        generate_local_session_keyset(output_dir)
+
+
+def test_loader_rejects_mismatched_or_weak_private_material(tmp_path: Path) -> None:
+    from app.services.local_session_keys import (
+        LocalSessionKeyConfigurationError,
+        generate_local_session_keyset,
+        load_local_session_keyset,
+    )
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    generate_local_session_keyset(first)
+    generate_local_session_keyset(second)
+
+    with pytest.raises(LocalSessionKeyConfigurationError, match="absent from JWKS"):
+        load_local_session_keyset(first / "private.pem", second / "jwks.json")
+
+    weak_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    weak_path = tmp_path / "weak-private.pem"
+    weak_path.write_bytes(
+        weak_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    weak_path.chmod(0o600)
+    with pytest.raises(LocalSessionKeyConfigurationError, match="exactly 3072 bits"):
+        load_local_session_keyset(weak_path, first / "jwks.json")
+
+
+def test_loader_enforces_private_mode_and_supports_kubernetes_secret_symlinks(
+    tmp_path: Path,
+) -> None:
+    from app.services.local_session_keys import (
+        LocalSessionKeyConfigurationError,
+        generate_local_session_keyset,
+        load_local_session_keyset,
+    )
+
+    generated = tmp_path / "generated"
+    generate_local_session_keyset(generated)
+    private_path = generated / "private.pem"
+    private_path.chmod(0o640)
+    with pytest.raises(LocalSessionKeyConfigurationError, match="group- or world-readable"):
+        load_local_session_keyset(private_path, generated / "jwks.json")
+
+    private_path.chmod(0o400)
+    mount = tmp_path / "mounted-secret"
+    revision = mount / "..2026_08_13"
+    revision.mkdir(parents=True)
+    mounted_private = revision / "private.pem"
+    mounted_jwks = revision / "jwks.json"
+    mounted_private.write_bytes(private_path.read_bytes())
+    mounted_jwks.write_bytes((generated / "jwks.json").read_bytes())
+    mounted_private.chmod(0o400)
+    mounted_jwks.chmod(0o400)
+    (mount / "..data").symlink_to(revision.name)
+    (mount / "private.pem").symlink_to("..data/private.pem")
+    (mount / "jwks.json").symlink_to("..data/jwks.json")
+
+    assert (
+        load_local_session_keyset(
+            mount / "private.pem",
+            mount / "jwks.json",
+        ).private_key.key_size
+        == 3072
+    )
+
+
+def test_create_and_verify_v2_survives_process_cache_reset(configured_keyset) -> None:
+    from app.services.auth_service import create_jwt
+    from app.services.auth_verifier_profiles import (
+        LOCAL_SESSION_RS256_V2,
+        verify_local_session_rs256_v2,
+    )
+    from app.services.local_session_keys import clear_local_session_keyset_cache
+
+    subject = str(uuid.uuid4())
+    token = create_jwt(subject, "alice")
+    header = jwt.get_unverified_header(token)
+    unverified = jwt.decode(token, options={"verify_signature": False})
+
+    assert header == {
+        "alg": "RS256",
+        "kid": configured_keyset["report"]["active_kid"],
+        "typ": "akb-local-session+jwt",
+    }
+    assert unverified["iss"] == "https://akb.example.test"
+    assert unverified["aud"] == "https://akb.example.test/api"
+    assert unverified["profile"] == LOCAL_SESSION_RS256_V2
+    assert unverified["token_use"] == "session"
+    assert uuid.UUID(unverified["jti"])
+
+    clear_local_session_keyset_cache()
+    principal = verify_local_session_rs256_v2(token)
+    assert principal is not None
+    assert principal.profile_id == LOCAL_SESSION_RS256_V2
+    assert principal.subject == subject
+    assert principal.audience == "https://akb.example.test/api"
+
+
+def test_cutover_rejects_legacy_hs256_and_strictly_checks_v2_profile(
+    configured_keyset,
+) -> None:
+    from app.services.auth_verifier_profiles import verify_local_session_rs256_v2
+    from app.services.local_session_keys import get_local_session_keyset
+
+    keyset = get_local_session_keyset()
+    valid = _mint(keyset.private_key, kid=keyset.active_kid)
+    assert verify_local_session_rs256_v2(valid) is not None
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    legacy = jwt.encode(
+        {
+            "sub": str(uuid.uuid4()),
+            "username": "alice",
+            "iat": now,
+            "exp": now + 300,
+        },
+        "legacy-hs256-secret-must-not-be-used",  # pragma: allowlist secret
+        algorithm="HS256",
+        headers={"typ": "JWT"},
+    )
+    assert verify_local_session_rs256_v2(legacy) is None
+
+    rejected = [
+        _mint(keyset.private_key, kid="unknown-kid"),
+        _mint(keyset.private_key, kid=keyset.active_kid, header_typ="JWT"),
+        _mint(
+            keyset.private_key,
+            kid=keyset.active_kid,
+            header_extra={"jku": "https://attacker.example/jwks.json"},
+        ),
+        _mint(keyset.private_key, kid=keyset.active_kid, issuer="https://other.example"),
+        _mint(keyset.private_key, kid=keyset.active_kid, audience="https://other.example/api"),
+        _mint(
+            keyset.private_key,
+            kid=keyset.active_kid,
+            claim_overrides={"profile": "local-session-rs256-v3"},
+        ),
+        _mint(
+            keyset.private_key,
+            kid=keyset.active_kid,
+            claim_overrides={"token_use": "access_token"},
+        ),
+    ]
+    assert all(verify_local_session_rs256_v2(token) is None for token in rejected)
+
+
+def test_rotation_retains_only_explicit_v2_public_keys(
+    configured_keyset,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from app.services.auth_service import create_jwt
+    from app.services.auth_verifier_profiles import verify_local_session_rs256_v2
+    from app.services.local_session_keys import (
+        clear_local_session_keyset_cache,
+        generate_local_session_keyset,
+    )
+
+    old_token = create_jwt(str(uuid.uuid4()), "alice")
+    old_kid = jwt.get_unverified_header(old_token)["kid"]
+    old_dir = configured_keyset["directory"]
+
+    rotated_dir = tmp_path / "rotated"
+    report = generate_local_session_keyset(
+        rotated_dir,
+        retain_jwks_paths=[old_dir / "jwks.json"],
+    )
+    monkeypatch.setattr(
+        settings,
+        "local_session_private_key_path",
+        str(rotated_dir / "private.pem"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "local_session_jwks_path",
+        str(rotated_dir / "jwks.json"),
+        raising=False,
+    )
+    clear_local_session_keyset_cache()
+
+    new_token = create_jwt(str(uuid.uuid4()), "alice")
+    new_kid = jwt.get_unverified_header(new_token)["kid"]
+
+    assert old_kid != new_kid == report["active_kid"]
+    assert report["retained_keys"] == 1
+    assert verify_local_session_rs256_v2(old_token) is not None
+    assert verify_local_session_rs256_v2(new_token) is not None
+
+
+def test_expired_or_non_numeric_v2_dates_are_rejected(configured_keyset) -> None:
+    from app.services.auth_verifier_profiles import verify_local_session_rs256_v2
+    from app.services.local_session_keys import get_local_session_keyset
+
+    keyset = get_local_session_keyset()
+    now = datetime.now(timezone.utc)
+    expired = _mint(
+        keyset.private_key,
+        kid=keyset.active_kid,
+        claim_overrides={
+            "iat": int((now - timedelta(minutes=10)).timestamp()),
+            "nbf": int((now - timedelta(minutes=10)).timestamp()),
+            "exp": int((now - timedelta(minutes=5)).timestamp()),
+        },
+    )
+    bad_iat = _mint(
+        keyset.private_key,
+        kid=keyset.active_kid,
+        claim_overrides={"iat": "not-a-number"},
+    )
+    assert verify_local_session_rs256_v2(expired) is None
+    assert verify_local_session_rs256_v2(bad_iat) is None
+
+
+@pytest.mark.asyncio
+async def test_public_jwks_is_local_only_and_contains_no_private_material(
+    configured_keyset,
+    monkeypatch,
+) -> None:
+    from fastapi import HTTPException
+
+    from app.api.routes.auth import local_session_jwks
+
+    published = await local_session_jwks()
+    assert published == json.loads((configured_keyset["directory"] / "jwks.json").read_text(encoding="utf-8"))
+    assert all(set(key) == {"kty", "kid", "use", "alg", "n", "e"} for key in published["keys"])
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        await local_session_jwks()
+    assert exc_info.value.status_code == 404
+
+
+def test_cli_generates_keyset_without_rendering_private_material(tmp_path, capsys) -> None:
+    from app import cli
+
+    output_dir = tmp_path / "cli-keyset"
+    assert cli._generate_local_session_keyset(["--output-dir", str(output_dir)]) == 0
+
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    private_text = (output_dir / "private.pem").read_text(encoding="ascii")
+    assert report["key_size"] == 3072
+    assert "PRIVATE KEY" not in captured.out
+    assert private_text not in captured.out
+    assert captured.err == ""
+
+    assert cli._generate_local_session_keyset(["--output-dir", str(output_dir)]) == 1
+    captured = capsys.readouterr()
+    assert "already exists" in captured.err
+    assert private_text not in captured.err

--- a/backend/tests/test_recovery_admin_cli_unit.py
+++ b/backend/tests/test_recovery_admin_cli_unit.py
@@ -1,0 +1,257 @@
+"""Secret-handling contracts for the recovery-admin operator CLI."""
+
+from __future__ import annotations
+
+import json
+import stat
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_SECRET = "generated-secret-must-never-be-printed"  # pragma: allowlist secret
+
+
+def _result(*, mode: str, created: bool = True) -> dict:
+    return {
+        "user_id": "11111111-1111-4111-8111-111111111111",
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "auth_mode": mode,
+        "created": created,
+        "is_admin": True,
+        "is_recovery_admin": True,
+    }
+
+
+def _patch_database(monkeypatch):
+    from app.db import postgres
+
+    async def _init_db():
+        return None
+
+    async def _close_pool():
+        return None
+
+    monkeypatch.setattr(postgres, "init_db", _init_db)
+    monkeypatch.setattr(postgres, "close_pool", _close_pool)
+
+
+async def test_generated_password_is_only_written_to_requested_0600_file(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    caplog,
+):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    monkeypatch.setattr(cli.secrets, "token_urlsafe", lambda _size: _SECRET)
+    observed = {}
+
+    async def _provision(**kwargs):
+        observed.update(kwargs)
+        return _result(mode="local")
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_local_recovery_admin",
+        _provision,
+    )
+    password_path = tmp_path / "recovery-password"
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--generate-password-file",
+            str(password_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert observed["password"] == _SECRET
+    assert password_path.read_text() == f"{_SECRET}\n"
+    assert stat.S_IMODE(password_path.stat().st_mode) == 0o600
+    assert _SECRET not in captured.out
+    assert _SECRET not in captured.err
+    assert _SECRET not in caplog.text
+    report = json.loads(captured.out)
+    assert report["password_file_written"] is True
+    assert "password" not in report
+
+
+async def test_supplied_password_file_is_not_echoed(monkeypatch, tmp_path, capsys):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    source = tmp_path / "mounted-secret"
+    source.write_text(f"{_SECRET}\n")
+    observed = {}
+
+    async def _provision(**kwargs):
+        observed.update(kwargs)
+        return _result(mode="local")
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_local_recovery_admin",
+        _provision,
+    )
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--password-file",
+            str(source),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert observed["password"] == _SECRET
+    assert _SECRET not in captured.out
+    assert _SECRET not in captured.err
+    assert json.loads(captured.out)["password_file_written"] is False
+
+
+async def test_generated_file_is_removed_on_conflict_without_secret_disclosure(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.exceptions import RecoveryAdminConflictError
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    monkeypatch.setattr(cli.secrets, "token_urlsafe", lambda _size: _SECRET)
+
+    async def _conflict(**_kwargs):
+        raise RecoveryAdminConflictError()
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_local_recovery_admin",
+        _conflict,
+    )
+    password_path = tmp_path / "recovery-password"
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--generate-password-file",
+            str(password_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert not password_path.exists()
+    assert "recovery_admin_conflict" in captured.err
+    assert _SECRET not in captured.out
+    assert _SECRET not in captured.err
+
+
+async def test_generated_file_is_removed_when_exact_identity_already_exists(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    monkeypatch.setattr(cli.secrets, "token_urlsafe", lambda _size: _SECRET)
+
+    async def _already_provisioned(**_kwargs):
+        return _result(mode="local", created=False)
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_local_recovery_admin",
+        _already_provisioned,
+    )
+    password_path = tmp_path / "unused-recovery-password"
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--generate-password-file",
+            str(password_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert not password_path.exists()
+    assert json.loads(captured.out)["password_file_written"] is False
+    assert _SECRET not in captured.out
+    assert _SECRET not in captured.err
+
+
+async def test_sso_profile_accepts_only_external_identity_and_usage_errors_hide_values(
+    monkeypatch,
+    capsys,
+):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    observed = {}
+
+    async def _provision(**kwargs):
+        observed.update(kwargs)
+        return _result(mode="sso")
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_sso_recovery_admin",
+        _provision,
+    )
+    valid_args = [
+        "sso",
+        "--username",
+        "recovery-admin",
+        "--email",
+        "recovery-admin@example.com",
+        "--issuer",
+        "https://issuer.example.com/realms/akb",
+        "--subject",
+        "stable-admin-subject",
+    ]
+
+    assert await cli._provision_recovery_admin(valid_args) == 0
+    assert observed == {
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "issuer": "https://issuer.example.com/realms/akb",
+        "subject": "stable-admin-subject",
+    }
+    capsys.readouterr()
+
+    assert await cli._provision_recovery_admin(
+        [*valid_args, "--password", _SECRET]
+    ) == 2
+    captured = capsys.readouterr()
+    assert _SECRET not in captured.out
+    assert _SECRET not in captured.err

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -1,0 +1,525 @@
+"""PostgreSQL contracts for explicit recovery-admin provisioning."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_LOCAL_PASSWORD = "local-recovery-password"  # pragma: allowlist secret
+_CONCURRENT_PASSWORD = "concurrent-recovery-password"  # pragma: allowlist secret
+
+
+def _dsn_for_database(dsn: str, database: str) -> str:
+    parsed = urlsplit(dsn)
+    return urlunsplit(parsed._replace(path=f"/{database}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_recovery_admin_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        conn = await asyncpg.connect(target_dsn)
+        try:
+            await conn.execute(_INIT_SQL)
+            from app.db.postgres import _load_migration
+
+            events_migration = _load_migration("015_events_outbox.py")
+            assert events_migration is not None
+            await events_migration.migrate(conn=conn)
+        finally:
+            await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=8)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+class _RoleSync:
+    def __init__(self):
+        self.created: list[uuid.UUID] = []
+        self.deleted: list[uuid.UUID] = []
+
+    async def on_user_create(self, user_id):
+        self.created.append(uuid.UUID(str(user_id)))
+
+    async def on_user_delete(self, user_id):
+        self.deleted.append(uuid.UUID(str(user_id)))
+
+
+@pytest.fixture
+async def services(monkeypatch):
+    async with _fresh_database() as pool:
+        from app.services import (
+            access_service,
+            account_service,
+            auth_service,
+            recovery_admin_service,
+        )
+
+        role_sync = _RoleSync()
+
+        async def _get_pool():
+            return pool
+
+        for module in (
+            access_service,
+            account_service,
+            auth_service,
+            recovery_admin_service,
+        ):
+            monkeypatch.setattr(module, "get_pool", _get_pool)
+        for module in (access_service, account_service, auth_service, recovery_admin_service):
+            monkeypatch.setattr(module, "get_role_sync", lambda: role_sync)
+
+        yield pool, role_sync, recovery_admin_service, account_service, access_service, auth_service
+
+
+async def test_fresh_and_populated_local_registration_are_non_admin(services, monkeypatch):
+    pool, _, _, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    first = await auth_service.register(
+        f"ordinary-{uuid.uuid4().hex[:8]}",
+        f"ordinary-{uuid.uuid4().hex[:8]}@example.com",
+        "ordinary-password-one",
+    )
+    second = await auth_service.register(
+        f"ordinary-{uuid.uuid4().hex[:8]}",
+        f"ordinary-{uuid.uuid4().hex[:8]}@example.com",
+        "ordinary-password-two",
+    )
+
+    assert first["is_admin"] is False
+    assert second["is_admin"] is False
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE is_admin") == 0
+
+
+async def test_local_provisioning_empty_database_and_exact_repeat_converge(services, monkeypatch):
+    pool, role_sync, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    kwargs = {
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "password": _LOCAL_PASSWORD,
+    }
+
+    first = await service.provision_local_recovery_admin(**kwargs)
+    repeated = await service.provision_local_recovery_admin(**kwargs)
+
+    assert first["created"] is True
+    assert repeated["created"] is False
+    assert repeated["user_id"] == first["user_id"]
+    assert first["is_admin"] is True
+    assert first["is_recovery_admin"] is True
+    assert role_sync.created == [uuid.UUID(first["user_id"])]
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT username, email, password_hash, is_admin, is_recovery_admin,
+                   auth_provider, account_kind
+              FROM users WHERE id = $1
+            """,
+            uuid.UUID(first["user_id"]),
+        )
+        identity_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
+            uuid.UUID(first["user_id"]),
+        )
+    assert row["username"] == kwargs["username"]
+    assert row["email"] == kwargs["email"]
+    assert row["is_admin"] is True
+    assert row["is_recovery_admin"] is True
+    assert row["auth_provider"] == "local"
+    assert row["account_kind"] == "human"
+    assert auth_service.verify_password(kwargs["password"], row["password_hash"])
+    assert identity_count == 0
+
+
+async def test_local_provisioning_never_adopts_an_existing_email(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    async with pool.acquire() as conn:
+        ordinary_id = await conn.fetchval(
+            """
+            INSERT INTO users (username, email, password_hash, is_admin)
+            VALUES ('ordinary', 'claimed@example.com', '!existing!', false)
+            RETURNING id
+            """
+        )
+
+    with pytest.raises(RecoveryAdminConflictError):
+        await service.provision_local_recovery_admin(
+            username="recovery-admin",
+            email="claimed@example.com",
+            password=_LOCAL_PASSWORD,
+        )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT is_admin, is_recovery_admin FROM users WHERE id = $1",
+            ordinary_id,
+        )
+    assert dict(row) == {"is_admin": False, "is_recovery_admin": False}
+
+
+async def test_concurrent_exact_local_provisioning_creates_one_identity(services, monkeypatch):
+    pool, role_sync, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    password = _CONCURRENT_PASSWORD
+    password_hash = auth_service.hash_password(password)
+
+    async def _hash_once(_password):
+        return password_hash
+
+    monkeypatch.setattr(service, "hash_password_async", _hash_once)
+    results = await asyncio.gather(
+        *[
+            service.provision_local_recovery_admin(
+                username="recovery-admin",
+                email="recovery-admin@example.com",
+                password=password,
+            )
+            for _ in range(4)
+        ]
+    )
+
+    assert sum(result["created"] for result in results) == 1
+    assert len({result["user_id"] for result in results}) == 1
+    assert len(role_sync.created) == 1
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 1
+
+
+async def test_concurrent_conflicting_designations_fail_closed(services, monkeypatch):
+    pool, _, service, _, _, auth_service = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    password_hash = auth_service.hash_password(_CONCURRENT_PASSWORD)
+
+    async def _hash_once(_password):
+        return password_hash
+
+    monkeypatch.setattr(service, "hash_password_async", _hash_once)
+    results = await asyncio.gather(
+        service.provision_local_recovery_admin(
+            username="recovery-one",
+            email="recovery-one@example.com",
+            password=_CONCURRENT_PASSWORD,
+        ),
+        service.provision_local_recovery_admin(
+            username="recovery-two",
+            email="recovery-two@example.com",
+            password=_CONCURRENT_PASSWORD,
+        ),
+        return_exceptions=True,
+    )
+
+    assert sum(isinstance(result, RecoveryAdminConflictError) for result in results) == 1
+    assert sum(isinstance(result, dict) and result["created"] for result in results) == 1
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE is_recovery_admin") == 1
+
+
+async def test_sso_prebinding_is_exact_idempotent_and_has_no_local_password(services, monkeypatch):
+    pool, role_sync, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    kwargs = {
+        "username": "sso-recovery-admin",
+        "email": "sso-recovery-admin@example.com",
+        "issuer": "https://issuer.example.com/realms/akb",
+        "subject": "stable-admin-subject",
+    }
+
+    first = await service.provision_sso_recovery_admin(**kwargs)
+    repeated = await service.provision_sso_recovery_admin(**kwargs)
+
+    assert first["created"] is True
+    assert repeated["created"] is False
+    assert repeated["user_id"] == first["user_id"]
+    assert role_sync.created == [uuid.UUID(first["user_id"])]
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT u.password_hash, u.auth_provider, u.is_admin,
+                   u.is_recovery_admin, e.issuer, e.subject,
+                   e.username_snapshot, e.email_snapshot
+              FROM users u
+              JOIN external_identities e ON e.user_id = u.id
+             WHERE u.id = $1
+            """,
+            uuid.UUID(first["user_id"]),
+        )
+    assert row["auth_provider"] == "keycloak"
+    assert row["is_admin"] is True
+    assert row["is_recovery_admin"] is True
+    assert row["issuer"] == kwargs["issuer"]
+    assert row["subject"] == kwargs["subject"]
+    assert row["username_snapshot"] == kwargs["username"]
+    assert row["email_snapshot"] == kwargs["email"]
+    assert auth_service.verify_password("any-local-password", row["password_hash"]) is False
+
+
+async def test_sso_prebinding_never_links_an_email_or_existing_binding(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    existing_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, is_admin)
+            VALUES ($1, 'ordinary', 'claimed@example.com', '!existing!', false)
+            """,
+            existing_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO external_identities (user_id, issuer, subject, email_snapshot)
+            VALUES ($1, 'https://issuer.example.com/realms/akb', 'claimed-subject',
+                    'claimed@example.com')
+            """,
+            existing_id,
+        )
+
+    attempts = (
+        {
+            "username": "new-recovery",
+            "email": "claimed@example.com",
+            "issuer": "https://other-issuer.example.com/realms/akb",
+            "subject": "new-subject",
+        },
+        {
+            "username": "another-recovery",
+            "email": "another@example.com",
+            "issuer": "https://issuer.example.com/realms/akb",
+            "subject": "claimed-subject",
+        },
+    )
+    for kwargs in attempts:
+        with pytest.raises(RecoveryAdminConflictError):
+            await service.provision_sso_recovery_admin(**kwargs)
+
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 1
+        assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE is_admin") == 0
+
+
+async def test_wrong_mode_rejects_before_password_or_database(services, monkeypatch):
+    _, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminModeError
+
+    async def _must_not_hash(_password):
+        raise AssertionError("wrong-mode provisioning must reject before password work")
+
+    async def _must_not_get_pool():
+        raise AssertionError("wrong-mode provisioning must reject before database access")
+
+    monkeypatch.setattr(service, "hash_password_async", _must_not_hash)
+    monkeypatch.setattr(service, "get_pool", _must_not_get_pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    with pytest.raises(RecoveryAdminModeError):
+        await service.provision_local_recovery_admin(
+            username="recovery-admin",
+            email="recovery-admin@example.com",
+            password=_LOCAL_PASSWORD,
+        )
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    with pytest.raises(RecoveryAdminModeError):
+        await service.provision_sso_recovery_admin(
+            username="recovery-admin",
+            email="recovery-admin@example.com",
+            issuer="https://issuer.example.com/realms/akb",
+            subject="stable-admin-subject",
+        )
+
+
+async def test_recovery_admin_cannot_be_demoted_or_deleted(services, monkeypatch):
+    pool, _, service, account_service, access_service, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminProtectedError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+
+    with pytest.raises(RecoveryAdminProtectedError):
+        await account_service.set_user_admin(
+            provisioned["user_id"],
+            is_admin=False,
+            actor_id="operator",
+        )
+    with pytest.raises(RecoveryAdminProtectedError):
+        await access_service.delete_user_account(provisioned["user_id"])
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT is_admin, is_recovery_admin FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert dict(row) == {"is_admin": True, "is_recovery_admin": True}
+
+
+async def test_normal_admin_can_still_be_demoted_and_deleted(services):
+    pool, role_sync, _, account_service, access_service, _ = services
+    user_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, is_admin)
+            VALUES ($1, 'ordinary-admin', 'ordinary-admin@example.com', '!hash!', true)
+            """,
+            user_id,
+        )
+
+    demoted = await account_service.set_user_admin(
+        str(user_id),
+        is_admin=False,
+        actor_id="operator",
+    )
+    deleted = await access_service.delete_user_account(str(user_id))
+
+    assert demoted["is_admin"] is False
+    assert deleted["deleted"] is True
+    assert role_sync.deleted == [user_id]
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE id = $1", user_id) == 0
+
+
+async def test_migration_upgrades_old_schema_and_is_idempotent(services):
+    pool, _, _, _, _, _ = services
+    from app.db.postgres import _load_migration
+
+    async with pool.acquire() as conn:
+        await conn.execute("DROP INDEX users_one_recovery_admin")
+        await conn.execute(
+            "ALTER TABLE users DROP CONSTRAINT users_recovery_admin_requires_admin"
+        )
+        await conn.execute("ALTER TABLE users DROP COLUMN is_recovery_admin")
+        await conn.execute("ALTER TABLE external_identities DROP COLUMN username_snapshot")
+
+        migration = _load_migration("071_recovery_admin.py")
+        assert migration is not None
+        await migration.migrate(conn)
+        await migration.migrate(conn)
+
+        user_column = await conn.fetchval(
+            """
+            SELECT is_nullable = 'NO'
+              FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = 'users'
+               AND column_name = 'is_recovery_admin'
+            """
+        )
+        snapshot_column = await conn.fetchval(
+            """
+            SELECT is_nullable = 'YES'
+              FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = 'external_identities'
+               AND column_name = 'username_snapshot'
+            """
+        )
+        constraint = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM pg_constraint
+             WHERE conrelid = 'users'::regclass
+               AND conname = 'users_recovery_admin_requires_admin'
+            """
+        )
+        unique_index = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM pg_indexes
+             WHERE schemaname = 'public' AND tablename = 'users'
+               AND indexname = 'users_one_recovery_admin'
+            """
+        )
+        recovery_id = uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, is_admin, is_recovery_admin
+            ) VALUES ($1, 'migration-recovery', 'migration-recovery@example.com',
+                      '!hash!', true, true)
+            """,
+            recovery_id,
+        )
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                "UPDATE users SET is_admin = false WHERE id = $1",
+                recovery_id,
+            )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO users (
+                    username, email, password_hash, is_admin, is_recovery_admin
+                ) VALUES ('migration-recovery-two',
+                          'migration-recovery-two@example.com', '!hash!', true, true)
+                """
+            )
+
+    assert user_column is True
+    assert snapshot_column is True
+    assert constraint == 1
+    assert unique_index == 1

--- a/backend/tests/test_recovery_admin_provisioning_unit.py
+++ b/backend/tests/test_recovery_admin_provisioning_unit.py
@@ -1,0 +1,68 @@
+"""Focused unit contracts for explicit recovery-admin provisioning."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import settings
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Acquire:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _Pool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _Acquire(self._conn)
+
+
+class _RegistrationConnection:
+    async def fetchrow(self, query, *_args):
+        assert "SELECT id FROM users" in query
+        return None
+
+    async def fetchval(self, query, *_args):
+        # Model PostgreSQL's result for the legacy first-user-wins INSERT.
+        return "NOT EXISTS (SELECT 1 FROM users)" in query
+
+
+class _RoleSync:
+    async def on_user_create(self, _user_id):
+        return None
+
+
+async def test_first_local_registration_is_never_implicitly_admin(monkeypatch):
+    from app.services import auth_service
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+
+    async def _get_pool():
+        return _Pool(_RegistrationConnection())
+
+    async def _hash_password(_password):
+        return "bcrypt-hash"
+
+    monkeypatch.setattr(auth_service, "get_pool", _get_pool)
+    monkeypatch.setattr(auth_service, "hash_password_async", _hash_password)
+    monkeypatch.setattr(auth_service, "get_role_sync", lambda: _RoleSync())
+
+    result = await auth_service.register(
+        "ordinary-member",
+        "ordinary-member@example.com",
+        "operator-supplied-password",
+    )
+
+    assert result["is_admin"] is False

--- a/backend/tests/test_vault_scope_e2e.sh
+++ b/backend/tests/test_vault_scope_e2e.sh
@@ -5,9 +5,8 @@
 # Proves the token-scoping backstop end-to-end against a live backend:
 # a PAT minted with a vault_scope can only MUTATE vaults inside that
 # scope, even when its user OWNS the target vault. Reads are unaffected.
-# The user is the first-registered account (admin on a fresh DB), so the
-# out-of-scope-write denial ALSO demonstrates that a scoped admin token
-# does not bypass the scope.
+# The user owns both test vaults, so the out-of-scope-write denial also
+# demonstrates that ownership does not bypass the token scope.
 #
 set -uo pipefail
 

--- a/backend/tests/test_vault_scope_sql_e2e.sh
+++ b/backend/tests/test_vault_scope_sql_e2e.sh
@@ -14,12 +14,10 @@
 # request reaches PG. The denial is therefore PG refusing the `akb_token_<tid>`
 # role, whose membership = owner-ACL ∩ scope.
 #
-# The user is the first-registered account (admin on a fresh DB), so the
-# out-of-scope denial ALSO demonstrates that a scoped ADMIN token does not
-# bypass (the executor switches to akb_token_<tid> with precedence over the
-# is_admin bypass). And reads are confined on THIS surface too (stricter than
-# surface 1's read-broad doc tools — defense-in-depth on the raw-SQL power
-# tool), which test 4 asserts.
+# The user owns both test vaults, so the out-of-scope denial demonstrates that
+# ownership does not bypass the scoped PostgreSQL role. Reads are confined on
+# THIS surface too (stricter than surface 1's read-broad doc tools —
+# defense-in-depth on the raw-SQL power tool), which test 4 asserts.
 #
 set -uo pipefail
 

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -42,10 +42,14 @@ async def services(monkeypatch):
     from app.db.postgres import _load_migration
     from app.services import account_service, auth_service, password_service
 
-    migration = _load_migration("043_workspace_account_governance.py")
-    assert migration is not None
     async with pool.acquire() as conn:
-        await migration.migrate(conn=conn)
+        for filename in (
+            "043_workspace_account_governance.py",
+            "071_recovery_admin.py",
+        ):
+            migration = _load_migration(filename)
+            assert migration is not None
+            await migration.migrate(conn=conn)
 
     role_sync = RecordingRoleSync()
 

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -149,6 +149,8 @@ document_asset_upload_body_timeout_secs: 60
 # === Auth (jwt_secret is in secret.yaml) ===
 # REQUIRED canonical human-login mode. Fresh runtime config never infers this
 # from legacy booleans. Choose exactly one: local | sso.
+# Provision the designated administrator explicitly with
+# `python -m app.cli provision-recovery-admin`; ordinary registration is never admin.
 auth_mode: local
 jwt_algorithm: HS256
 jwt_expire_hours: 24

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -146,14 +146,27 @@ file_pending_upload_ttl_hours: 24
 document_asset_gc_interval_secs: 300
 document_asset_upload_body_timeout_secs: 60
 
-# === Auth (jwt_secret is in secret.yaml) ===
+# === Auth (system_hmac_secret is in secret.yaml) ===
 # REQUIRED canonical human-login mode. Fresh runtime config never infers this
 # from legacy booleans. Choose exactly one: local | sso.
 # Provision the designated administrator explicitly with
 # `python -m app.cli provision-recovery-admin`; ordinary registration is never admin.
 auth_mode: local
-jwt_algorithm: HS256
+jwt_algorithm: RS256
 jwt_expire_hours: 24
+# Generate once before the first local-mode start:
+#   cd backend
+#   uv run python -m app.cli generate-local-session-keyset \
+#     --output-dir ../config/local-session
+# The private PEM and public JWKS must survive restarts and stay outside the
+# image. Replacing them without retaining the prior public JWK forces every
+# local user to sign in again.
+local_session_private_key_path: /etc/akb/local-session/private.pem
+local_session_jwks_path: /etc/akb/local-session/jwks.json
+# Blank binds both claims to public_base_url. Override only when a deployment
+# needs a stable issuer/audience across an intentional public URL migration.
+local_session_issuer: ""
+local_session_audience: ""
 publication_view_grant_ttl_secs: 600
 # Rolling upgrades must keep this true until every backend instance can read
 # both the two-field and bounded three-field grant formats.
@@ -163,7 +176,7 @@ publication_view_grant_session_secs: 3600
 # === App identity exchange ===
 # Short-lived app tokens never carry Vaults, installations, or capabilities;
 # every app request rechecks the live registry. The signing secret lives in
-# secret.yaml and must differ from jwt_secret.
+# secret.yaml and must differ from system_hmac_secret.
 app_token_ttl_seconds: 300
 app_credential_overlap_seconds: 300
 

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -198,11 +198,14 @@ app_credential_overlap_seconds: 300
 #
 # keycloak_enabled: false
 # keycloak_enrollment_mode: open           # open | invite_only | disabled
-# keycloak_server_url: "https://auth.example.com"   # no /realms suffix (browser-facing; sets the issuer)
+# keycloak_server_url: "https://auth.example.com"   # no /realms suffix; HTTPS outside loopback
 # keycloak_internal_url: ""          # optional backchannel URL (server→Keycloak); blank → use server_url
 # keycloak_realm: "akb"
 # keycloak_client_id: "akb-web"
 # keycloak_public_client: false      # true → PKCE (no client_secret needed)
+# keycloak_admin_client_id: "akb-admin"  # dedicated confidential /admin client;
+#                                         # must differ from every ordinary human client
+# admin_browser_session_ttl_secs: 900     # also capped by the verified ID-token expiry
 # keycloak_verify_ssl: true          # false only for local self-signed Keycloak
 # keycloak_require_verified_email: true   # refuse unverified email for open-mode JIT.
 #                                         # Exact subject bindings need no email claim.
@@ -210,9 +213,12 @@ app_credential_overlap_seconds: 300
 #                                         # controlled emails.
 # keycloak_link_by_email is a deprecated migration marker; omit it. Setting it
 # to true fails canonical startup. Exact pre-binding is the only account-link path.
-# The callback settings below are reserved for the future server-custodied
-# browser session release. Phase 1 validates access tokens only and returns a
-# staged-unavailable response from browser login/callback/logout/exchange routes.
+# The ordinary-user callback settings below are reserved for the future
+# server-custodied browser session release. Ordinary browser
+# login/callback/logout/exchange routes remain staged unavailable. `/admin`
+# is active in SSO mode through the separate akb-admin client; register its
+# exact callback as `<public_base_url>/api/v1/admin/auth/keycloak/callback`
+# and its post-logout redirect as `<public_base_url>/admin`.
 # keycloak_redirect_uri: "https://akb.example.com/api/v1/auth/keycloak/callback"
 # keycloak_post_login_path: "/auth/callback"
 # keycloak_post_login_allowed_origins: []   # companion-app origins allowed to receive the SSO
@@ -230,7 +236,8 @@ app_credential_overlap_seconds: 300
 # mcp_oauth_enabled: false
 # mcp_oauth_audience: ""               # default: <public_base_url>/mcp
 # API and MCP audiences must remain distinct.
-# keycloak_client_secret lives in secret.yaml (never commit it)
+# keycloak_client_secret and keycloak_admin_client_secret live in secret.yaml
+# (never commit either value)
 
 # === Server ===
 host: 0.0.0.0

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -23,6 +23,11 @@ app_token_secret: dev-only-app-token-change-me-before-deploying
 # (PKCE) clients. NEVER commit a real value.
 keycloak_client_secret: ""
 
+# Required in SSO mode. Secret for the dedicated confidential `akb-admin`
+# client used only by `/admin`; generate independently from akb-web. AKB stores
+# no Keycloak access, refresh, or ID token after the callback.
+keycloak_admin_client_secret: ""
+
 # === Embedding API key (required) ===
 # Provider key for `embed_base_url` in app.yaml. In platform_hard mode this is
 # the workload's platform gateway credential, not the upstream provider key.

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -6,13 +6,13 @@
 # in docker-compose.yaml. Change both for any non-local deploy.
 db_password: akb
 
-# === JWT — signs auth tokens. ===
-# REPLACE before any non-local deploy. Generate one:  openssl rand -hex 32
-jwt_secret: dev-only-change-me-before-deploying-anywhere-real
+# === Internal HMAC capabilities (never signs human sessions) ===
+# REPLACE before any non-local deploy. Generate one: openssl rand -hex 32
+system_hmac_secret: dev-only-change-me-before-deploying-anywhere-real
 
 # === App token exchange signing secret ===
 # Required only when app credential exchange is used. Must differ from
-# jwt_secret. Generate independently: openssl rand -hex 32
+# system_hmac_secret. Generate independently: openssl rand -hex 32
 app_token_secret: dev-only-app-token-change-me-before-deploying
 
 # === Keycloak client secret (optional) ===

--- a/deploy/all-in-one/README.md
+++ b/deploy/all-in-one/README.md
@@ -70,15 +70,17 @@ boot and persisted in `/var/lib/akb/state.env`.
 | postgres   | 5432      | supervisord |
 | redis      | 6379      | supervisord |
 | minio      | 9000/9001 | supervisord |
-| seed (one-shot — demo user + vault + PAT) | – | supervisord |
+| seed (one-shot — admin-owned demo vault + PAT) | – | supervisord |
 
 `entrypoint.sh` runs idempotent bootstrap on every boot:
 
-1. Generates and persists random `DB_PASSWORD`, `JWT_SECRET`,
+1. Generates and persists random `DB_PASSWORD`, `SYSTEM_HMAC_SECRET`,
    `S3_SECRET_KEY`, `DEMO_PASSWORD`, `DEMO_PAT` under
    `/var/lib/akb/state.env` on first run.
-2. Renders `/etc/akb/secret.yaml` from `secret.yaml.template`.
-3. `initdb`s the PG cluster, creates the `akb` role + database, and
+2. Generates and persists the RSA-3072 `local-session-rs256-v2` keyset under
+   `/var/lib/akb/local-session` and renders `/etc/akb/secret.yaml`.
+3. `initdb`s the PG cluster, creates the `akb` role + database, explicitly
+   provisions the demo identity as the designated product/recovery admin, and
    installs the `vector` extension.
 4. Creates the MinIO `akb-files` bucket once MinIO is up (background).
 5. Hands off to supervisord — which starts everything and runs `seed.py`

--- a/deploy/all-in-one/app.yaml
+++ b/deploy/all-in-one/app.yaml
@@ -36,8 +36,12 @@ s3_region: us-east-1
 
 # === Auth ===
 auth_mode: local
-jwt_algorithm: HS256
+jwt_algorithm: RS256
 jwt_expire_hours: 24
+local_session_private_key_path: /var/lib/akb/local-session/private.pem
+local_session_jwks_path: /var/lib/akb/local-session/jwks.json
+local_session_issuer: ""
+local_session_audience: ""
 
 # === Server ===
 host: 0.0.0.0

--- a/deploy/all-in-one/entrypoint.sh
+++ b/deploy/all-in-one/entrypoint.sh
@@ -17,7 +17,7 @@ mkdir -p /var/lib/akb
 if [ ! -f "${SECRET_STATE}" ]; then
   cat > "${SECRET_STATE}" <<EOF
 DB_PASSWORD=$(python3 -c 'import secrets;print(secrets.token_urlsafe(24))')
-JWT_SECRET=$(python3 -c 'import secrets;print(secrets.token_hex(32))')
+SYSTEM_HMAC_SECRET=$(python3 -c 'import secrets;print(secrets.token_hex(32))')
 S3_ACCESS_KEY=akb-allinone
 S3_SECRET_KEY=$(python3 -c 'import secrets;print(secrets.token_urlsafe(24))')
 DEMO_USERNAME=demo
@@ -31,6 +31,18 @@ fi
 # shellcheck disable=SC1090
 . "${SECRET_STATE}"
 
+# One-release compatibility for an existing all-in-one data volume.  The old
+# JWT secret becomes internal HMAC material only; it is never used to accept or
+# issue a human session after this image starts.
+if [ -z "${SYSTEM_HMAC_SECRET:-}" ]; then
+  if [ -n "${JWT_SECRET:-}" ]; then
+    SYSTEM_HMAC_SECRET="${JWT_SECRET}"
+  else
+    SYSTEM_HMAC_SECRET="$(python3 -c 'import secrets;print(secrets.token_hex(32))')"
+    printf '\nSYSTEM_HMAC_SECRET=%s\n' "${SYSTEM_HMAC_SECRET}" >> "${SECRET_STATE}"
+  fi
+fi
+
 # Caller-supplied API keys override (still optional — Glama introspection
 # works without them).
 EMBED_API_KEY="${EMBED_API_KEY:-}"
@@ -43,7 +55,7 @@ LLM_MODEL="${LLM_MODEL:-}"
 RERANK_API_KEY="${RERANK_API_KEY:-}"
 
 export POSTGRES_DB=akb POSTGRES_USER=akb POSTGRES_PASSWORD="${DB_PASSWORD}"
-export DB_PASSWORD JWT_SECRET S3_ACCESS_KEY S3_SECRET_KEY \
+export DB_PASSWORD SYSTEM_HMAC_SECRET S3_ACCESS_KEY S3_SECRET_KEY \
        EMBED_API_KEY LLM_API_KEY RERANK_API_KEY \
        DEMO_USERNAME DEMO_EMAIL DEMO_PASSWORD DEMO_VAULT DEMO_PAT
 
@@ -68,12 +80,21 @@ python3 - <<'PY'
 import os, pathlib
 tpl = pathlib.Path("/etc/akb/secret.yaml.template").read_text()
 out = tpl
-for key in ("DB_PASSWORD", "JWT_SECRET", "EMBED_API_KEY", "LLM_API_KEY",
+for key in ("DB_PASSWORD", "SYSTEM_HMAC_SECRET", "EMBED_API_KEY", "LLM_API_KEY",
             "RERANK_API_KEY", "S3_ACCESS_KEY", "S3_SECRET_KEY"):
     out = out.replace("${" + key + "}", os.environ.get(key, ""))
 pathlib.Path("/etc/akb/secret.yaml").write_text(out)
 os.chmod("/etc/akb/secret.yaml", 0o600)
 PY
+
+# Generate the local-session signer exactly once on persistent storage.  The
+# CLI is non-overwriting, so a partial or conflicting keyset fails the boot
+# instead of silently replacing the installation identity.
+LOCAL_SESSION_KEY_DIR=/var/lib/akb/local-session
+if [ ! -d "${LOCAL_SESSION_KEY_DIR}" ]; then
+  python3 -m app.cli generate-local-session-keyset \
+    --output-dir "${LOCAL_SESSION_KEY_DIR}"
+fi
 
 # Override app.yaml fields the user supplied via ENV.
 python3 - <<'PY'
@@ -132,6 +153,21 @@ if [ "$(bootstrap_sql "SELECT 1 FROM pg_roles WHERE rolname='akb'")" != "1" ]; t
 fi
 gosu postgres "${PG_BIN}/psql" -h /tmp -U postgres -d akb \
     -c "CREATE EXTENSION IF NOT EXISTS vector;" >/dev/null
+
+# The installer, not ordinary registration, owns the first administrator.
+# Re-running converges on the exact designated identity and never prints the
+# password material.
+ADMIN_PASSWORD_FILE="$(mktemp)"
+printf '%s\n' "${DEMO_PASSWORD}" > "${ADMIN_PASSWORD_FILE}"
+chmod 600 "${ADMIN_PASSWORD_FILE}"
+if ! python3 -m app.cli provision-recovery-admin local \
+  --username "${DEMO_USERNAME}" \
+  --email "${DEMO_EMAIL}" \
+  --password-file "${ADMIN_PASSWORD_FILE}"; then
+  rm -f "${ADMIN_PASSWORD_FILE}"
+  exit 1
+fi
+rm -f "${ADMIN_PASSWORD_FILE}"
 
 gosu postgres "${PG_BIN}/pg_ctl" -D "${PGDATA}" -w stop
 

--- a/deploy/all-in-one/secret.yaml.template
+++ b/deploy/all-in-one/secret.yaml.template
@@ -1,7 +1,7 @@
 # Templated by entrypoint.sh on container start. ${VAR} placeholders are
 # filled from environment variables; missing/empty stays empty.
 db_password: "${DB_PASSWORD}"
-jwt_secret: "${JWT_SECRET}"
+system_hmac_secret: "${SYSTEM_HMAC_SECRET}"
 
 embed_api_key: "${EMBED_API_KEY}"
 llm_api_key: "${LLM_API_KEY}"

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -64,7 +64,7 @@ After the script finishes:
 
 ```bash
 kubectl edit configmap akb-app-config -n akb   # set embed_*, llm_*, s3_*, public_base_url
-kubectl edit secret    akb-secret-config -n akb # set jwt_secret, embed_api_key, …
+kubectl edit secret    akb-secret-config -n akb # set system_hmac_secret, embed_api_key, …
 ```
 
 The placeholder ConfigMap in `backend.yaml` matches `config/app.yaml.example`
@@ -96,19 +96,31 @@ Secrets) goes here too.
 
 ## Secrets
 
-Two Secrets are NOT created by `deploy.sh` — manage them out-of-band so
+Three Secrets are NOT created by `deploy.sh` — manage them out-of-band so
 re-runs don't clobber real credentials with placeholders:
 
 - `akb-secret-config` — `secret.yaml` mounted at `/etc/akb/secret.yaml`
-  in the backend pod. Required keys: `db_password`, `jwt_secret`,
+  in the backend pod. Required keys: `db_password`, `system_hmac_secret`,
   `embed_api_key` (and optionally `llm_api_key`, `rerank_api_key`,
   `s3_*_key`, `vector_api_key`, `redis_password`).
+- `akb-local-session-keys` — the persistent RSA-3072 private key and public
+  JWKS for `local-session-rs256-v2`. Generate them explicitly once and back
+  them up with the installation. Replacing both files without retaining the
+  old public JWK intentionally forces every local user to sign in again.
 - `redis-credentials` — single key `password`, referenced by the Redis
   CR. Skip if you disable the event stream (`redis_url: ""`).
 
 ```bash
 kubectl create secret generic akb-secret-config -n akb \
   --from-file=secret.yaml=./secret.yaml
+
+cd backend
+uv run python -m app.cli generate-local-session-keyset \
+  --output-dir ../local-session-keys
+cd ..
+kubectl create secret generic akb-local-session-keys -n akb \
+  --from-file=private.pem=./local-session-keys/private.pem \
+  --from-file=jwks.json=./local-session-keys/jwks.json
 
 PW=$(openssl rand -base64 32)
 kubectl create secret generic redis-credentials -n akb \

--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -38,6 +38,9 @@ data:
 
     # Required canonical human-login mode. This base deployment is local.
     auth_mode: local
+    jwt_algorithm: RS256
+    local_session_private_key_path: /etc/akb/local-session/private.pem
+    local_session_jwks_path: /etc/akb/local-session/jwks.json
 
     # Vector store — default driver is pgvector inside the main PG pod
     # (`pgvector/pgvector:pg16` ships with the extension). Override
@@ -65,7 +68,7 @@ data:
 #   stringData:
 #     secret.yaml: |
 #       db_password: <postgres password>
-#       jwt_secret:  <openssl rand -hex 32>
+#       system_hmac_secret: <openssl rand -hex 32>
 #       embed_api_key: <provider key>
 #       llm_api_key: <provider key>
 #       rerank_api_key: <cohere key>
@@ -109,6 +112,9 @@ spec:
             - name: secret-config
               mountPath: /etc/akb/secret.yaml
               subPath: secret.yaml
+              readOnly: true
+            - name: local-session-keys
+              mountPath: /etc/akb/local-session
               readOnly: true
             - name: vaultdata
               mountPath: /data/vaults
@@ -161,6 +167,10 @@ spec:
         - name: secret-config
           secret:
             secretName: akb-secret-config
+        - name: local-session-keys
+          secret:
+            secretName: akb-local-session-keys
+            defaultMode: 0400
         - name: vaultdata
           persistentVolumeClaim:
             claimName: akb-vaultdata

--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -169,7 +169,7 @@ spec:
             secretName: akb-secret-config
         - name: local-session-keys
           secret:
-            secretName: akb-local-session-keys
+            secretName: akb-local-session-keys # pragma: allowlist secret
             defaultMode: 0400
         - name: vaultdata
           persistentVolumeClaim:

--- a/deploy/keycloak-dev/akb-realm.json
+++ b/deploy/keycloak-dev/akb-realm.json
@@ -48,6 +48,27 @@
       "attributes": {
         "use.refresh.tokens": "true"
       }
+    },
+    {
+      "clientId": "akb-admin",
+      "name": "AKB product administration",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-akb-admin-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:3000/api/v1/admin/auth/keycloak/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:3000"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:3000/admin"
+      }
     }
   ],
   "clientScopes": [
@@ -149,6 +170,19 @@
     ]
   },
   "users": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "username": "product-admin",
+      "email": "product-admin@example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Product",
+      "lastName": "Admin",
+      "credentials": [
+        { "type": "password", "value": "product-admin-password", "temporary": false }
+      ],
+      "realmRoles": ["default-roles-akb"]
+    },
     {
       "username": "alice",
       "email": "alice@example.com",

--- a/docker-compose.keycloak.yaml
+++ b/docker-compose.keycloak.yaml
@@ -1,7 +1,7 @@
 # OPTIONAL local Keycloak overlay — for developing/testing the route-selected
-# Keycloak access-token verifier and the MCP OAuth Resource Server path.
-# Browser login/callback/logout/exchange routes are intentionally unavailable
-# in the current phase. This overlay is NOT part of the default stack.
+# Keycloak verifier, the dedicated product-admin browser login, and the MCP
+# OAuth Resource Server path. Ordinary-user browser login remains staged.
+# This overlay is NOT part of the default stack.
 #
 # Usage:
 #   docker compose -f docker-compose.yaml -f docker-compose.keycloak.yaml up
@@ -15,13 +15,26 @@
 #   keycloak_internal_url: "http://keycloak:8080"     # backend → keycloak container
 #   keycloak_realm: "akb"
 #   keycloak_client_id: "akb-web"
+#   keycloak_admin_client_id: "akb-admin"
 #   keycloak_verify_ssl: false
 #   api_oauth_audience: "http://localhost:8000/api"
+#   public_base_url: "http://localhost:3000"          # same-origin SPA + /api proxy
 #
-# Test user (in the imported realm): alice / alice-password (alice@example.com).
-# The imported confidential client's fixed dev secret may be used by a test
-# client to obtain a token; AKB itself does not consume a browser callback
-# secret in this phase.
+# In config/secret.yaml:
+#   keycloak_admin_client_secret: "local-akb-admin-dev-secret"
+#
+# Pre-bind the imported product-admin fixture before opening
+# http://localhost:3000/admin (password: product-admin-password):
+#
+#   docker compose exec backend python -m app.cli provision-recovery-admin sso \
+#     --username product-admin --email product-admin@example.com \
+#     --issuer http://localhost:8080/realms/akb \
+#     --subject 00000000-0000-4000-8000-000000000001
+#
+# Ordinary test user: alice / alice-password (alice@example.com).
+# The `akb-web` fixed dev secret may be used by a headless test client to
+# obtain an ordinary API token. AKB consumes only the separate `akb-admin`
+# secret for its active product-admin callback in this phase.
 #
 # === MCP OAuth path === additionally:
 #
@@ -49,7 +62,7 @@
 # walkthrough.
 #
 # The realm import ships FIXED dev client secrets ("local-akb-dev-secret",
-# "local-akb-mcp-test-secret"). Throwaway local values (same spirit as
+# "local-akb-mcp-test-secret", "local-akb-admin-dev-secret"). Throwaway local values (same spirit as
 # the hard-coded `akb` Postgres password in docker-compose.yaml) — never
 # reuse them anywhere real.
 

--- a/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
+++ b/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-stage: design
+stage: implementation
 created: 2026-08-13
 updated: 2026-08-13
 ---
@@ -8,7 +8,9 @@ updated: 2026-08-13
 # Authentication Mode Boundary
 
 This is the Phase 0 architecture decision for
-[#357](https://github.com/dnotitia/akb/issues/357). Implementation is pending.
+[#357](https://github.com/dnotitia/akb/issues/357). The Phase 1 mode and
+verifier boundary and the Phase 2 local-session/admin-provisioning subset are
+implemented; browser SSO and provider control remain staged.
 The record fixes the authority and security boundaries that later phases must
 preserve without fixing their route layout, claim schema, or code structure.
 Public revision and review summaries are recorded in
@@ -233,15 +235,31 @@ claim field names.
 
 ## Open Decisions
 
+The Phase 2 implementation fixed these previously open choices:
+
+- `local-session-rs256-v2` uses RS256 with an installation-owned RSA-3072
+  private key, an RFC 7638-thumbprinted `kid`, exact issuer and API audience,
+  a dedicated JOSE type, `jti`, profile, token-use, and numeric lifetime
+  claims;
+- key generation is an explicit, non-overwriting operator action; the private
+  PEM and bounded public JWKS are persistent deployment secrets, while only
+  the public JWKS is exposed by the local-mode API;
+- rotation activates a new private key and may retain up to three explicitly
+  supplied prior public keys for verification; rollback restores the prior
+  immutable private/JWKS pair;
+- the HS256 cutover uses immediate reauthentication. No legacy human-session
+  verifier remains and the old `jwt_secret` is accepted for one release only
+  as migration input for non-session HMAC capabilities; and
+- the recovery administrator is provisioned explicitly through a non-HTTP,
+  single-designation command. Local provisioning creates a password-backed
+  admin; SSO provisioning pre-binds an exact issuer and subject with no usable
+  local password. Ordinary registration never creates an administrator.
+
 The following remain open until their owning implementation phase:
 
-- the first asymmetric local profile's algorithm, key parameters, claims,
-  storage, publication, and rotation details;
 - the concrete OIDC issuer and AKB audience/resource identifiers, accepted
   credential type, and provider-specific representation selected by the first
   versioned OIDC profile;
-- immediate reauthentication versus a bounded legacy symmetric-session window,
-  including the window's exact duration;
 - whether legacy hybrid installations require a bounded compatibility release
   or must select a canonical mode before upgrade;
 - the exact configuration migration and invalid-combination diagnostics;
@@ -250,8 +268,7 @@ The following remain open until their owning implementation phase:
   Workspace Account Governance remains authoritative;
 - browser-side session transport and server-side token custody, refresh,
   logout, and revocation mechanics;
-- product-admin bootstrap credentials, recovery ceremony, and exact control
-  endpoints; and
+- product-admin browser-session transport and exact control endpoints; and
 - versioned public login-options and admin-control API shapes.
 
 No implementation should infer one of these choices from this ADR. The owning

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -1,7 +1,7 @@
 # Keycloak OIDC boundary
 
-**Status:** Phase 1 verifier and projection boundary active; browser session
-cutover staged unavailable
+**Status:** Phase 2 local verifier/admin provisioning active; ordinary SSO
+browser session cutover staged unavailable
 
 The accepted
 [Authentication Mode Boundary](../../design/accepted/2026-08-13-authentication-mode-boundary/README.md)
@@ -14,7 +14,7 @@ are authoritative. This document records the current implementation shape.
 Human REST and delegated-human routes select exactly one verifier from the
 canonical `auth_mode`:
 
-- `local` selects `local-session-legacy-v1` only;
+- `local` selects `local-session-rs256-v2` only;
 - `sso` selects `keycloak-access-v1` only.
 
 `keycloak-access-v1` is a Keycloak 26-compatible RS256 access-token profile.
@@ -35,6 +35,15 @@ session JWTs are never MCP credentials.
 No token header selects an algorithm, issuer, key source, or fallback
 verifier. Token-supplied key URLs/material are rejected. An unknown `kid` may
 cause one refresh from the same pinned JWKS endpoint and then fails.
+
+`local-session-rs256-v2` is RS256 over an installation-owned RSA-3072 key.
+The active private key and bounded public JWKS are explicit persistent
+operator inputs; startup never creates ephemeral signing material. Tokens bind
+an RFC 7638 `kid`, exact deployment issuer and API audience, JOSE type,
+profile/token-use claims, `jti`, and numeric lifetime claims. The public-only
+keyset is available from `/api/v1/auth/jwks` in local mode. The Phase 2 cutover
+uses immediate reauthentication: the legacy HS256 verifier and issuance path
+are absent, so an old session fails rather than trying another profile.
 
 ## Exact AKB account projection
 

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -1,7 +1,7 @@
 # Keycloak OIDC boundary
 
-**Status:** Phase 2 local verifier/admin provisioning active; ordinary SSO
-browser session cutover staged unavailable
+**Status:** Phase 2 local verifier, admin provisioning, and dedicated admin
+browser session active; ordinary SSO browser session cutover staged unavailable
 
 The accepted
 [Authentication Mode Boundary](../../design/accepted/2026-08-13-authentication-mode-boundary/README.md)
@@ -64,7 +64,37 @@ grants. Phase 2 owns explicit product-admin seeding for an exact identity.
 `keycloak_link_by_email` remains readable only as a deprecated Phase 3
 migration/readiness input; canonical runtime rejects `true`.
 
-## Browser routes are staged unavailable
+## Dedicated product-admin browser boundary
+
+`/admin` is a separate route and policy surface in both modes:
+
+| Mode | Product-admin authentication |
+| --- | --- |
+| `local` | Dedicated admin login endpoint authenticates local credentials, requires the live AKB `is_admin` decision, and returns `local-session-rs256-v2`. |
+| `sso` | Dedicated confidential `akb-admin` client uses authorization code + PKCE + nonce. Only an exact, pre-bound `(issuer, subject)` active human with live AKB admin status is admitted. |
+
+The admin client is excluded from `keycloak_human_client_ids`, and its `azp`
+is explicitly refused by both API and MCP access-token profiles, so its token
+cannot become a resource credential. The callback verifies the
+fixed RS256 issuer/client/nonce/session profile and does not JIT-provision or
+email-adopt an account. Its single-use state is bound to the initiating browser
+through the hash of a short-lived HttpOnly cookie, preventing a callback copied
+into another browser from creating an admin session. It discards all Keycloak
+token material after proof,
+then creates a short-lived AKB-owned opaque HttpOnly session and separate CSRF
+cookie. PostgreSQL stores only SHA-256 hashes, the exact external-identity FK,
+the bound issuer/subject snapshot, the Keycloak session ID, and expiry. Every
+admin request rechecks the account, unchanged exact binding, status, kind,
+provider, and `is_admin`; demotion or binding mutation/removal invalidates the
+next request. The session lifetime is capped by both
+`admin_browser_session_ttl_secs` and the verified ID-token expiry.
+
+This intentionally does not implement refresh-token custody, ordinary-user
+BFF sessions, back-channel logout, or long-lived provider sessions. Those
+remain Phase 4 work; the short admin session bounds IdP-side revocation lag in
+this MVP.
+
+## Ordinary browser routes are staged unavailable
 
 Phase 1 does not expose a browser token transport:
 

--- a/frontend/src/__tests__/app-route-contract.test.ts
+++ b/frontend/src/__tests__/app-route-contract.test.ts
@@ -4,6 +4,7 @@ import { appRouteBoundaryForPath, appRouteContract } from "@/app-route-contract"
 describe("application route contract", () => {
   it("keeps route, component, and shell ownership explicit", () => {
     expect(appRouteContract).toEqual([
+      { path: "/admin", component: "AdminPage", boundary: "admin" },
       { path: "/auth", component: "AuthPage", boundary: "auth" },
       { path: "/auth/forgot", component: "AuthForgotPage", boundary: "auth" },
       { path: "/auth/callback", component: "AuthCallbackPage", boundary: "auth" },
@@ -44,6 +45,7 @@ describe("application route contract", () => {
   });
 
   it.each([
+    ["/admin", "admin"],
     ["/auth", "auth"],
     ["/auth/forgot", "auth"],
     ["/p/storybook-guide", "public"],

--- a/frontend/src/app-route-contract.ts
+++ b/frontend/src/app-route-contract.ts
@@ -1,6 +1,6 @@
 import { matchRoutes, type RouteObject } from "react-router-dom";
 
-export type AppRouteBoundary = "auth" | "public" | "app-layout" | "vault-shell";
+export type AppRouteBoundary = "admin" | "auth" | "public" | "app-layout" | "vault-shell";
 
 export interface AppRouteDefinition {
   path: string;
@@ -16,6 +16,7 @@ export interface AppRouteDefinition {
  * intentionally a review gate for route, page, and shell-owner changes.
  */
 export const appRouteContract = [
+  { path: "/admin", component: "AdminPage", boundary: "admin" },
   { path: "/auth", component: "AuthPage", boundary: "auth" },
   { path: "/auth/forgot", component: "AuthForgotPage", boundary: "auth" },
   { path: "/auth/callback", component: "AuthCallbackPage", boundary: "auth" },

--- a/frontend/src/app-routes.tsx
+++ b/frontend/src/app-routes.tsx
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import { Navigate, Route, Routes, useParams } from "react-router-dom";
 import { Layout } from "@/components/layout";
 import { VaultShell } from "@/components/vault-shell";
+import AdminPage from "@/pages/admin";
 import AuthPage from "@/pages/auth";
 import AuthForgotPage from "@/pages/auth-forgot";
 import AuthCallbackPage from "@/pages/auth-callback";
@@ -41,6 +42,7 @@ function SkillRedirect() {
 }
 
 const routeComponents = {
+  AdminPage,
   AuthPage,
   AuthForgotPage,
   AuthCallbackPage,
@@ -77,7 +79,7 @@ function renderRoutes(boundaries: readonly AppRouteBoundary[]) {
 export function AppRoutes() {
   return (
     <Routes>
-      {renderRoutes(["auth", "public"])}
+      {renderRoutes(["admin", "auth", "public"])}
       <Route element={<Layout />}>
         {renderRoutes(["app-layout"])}
         <Route element={<VaultShell />}>

--- a/frontend/src/lib/__tests__/admin-auth-config.test.ts
+++ b/frontend/src/lib/__tests__/admin-auth-config.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ADMIN_AUTH_CONFIG_UNAVAILABLE,
+  getAdminAuthConfig,
+} from "../api";
+
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+
+describe("getAdminAuthConfig v1", () => {
+  it("accepts exactly one local admin login surface", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response({
+      schema_version: 1,
+      auth_mode: "local",
+      local: {
+        enabled: true,
+        login_url: "/api/v1/admin/auth/local/login",
+      },
+      keycloak: { enabled: false, login_url: null },
+    })));
+
+    expect(await getAdminAuthConfig()).toEqual({
+      available: true,
+      schema_version: 1,
+      auth_mode: "local",
+      local: {
+        enabled: true,
+        login_url: "/api/v1/admin/auth/local/login",
+      },
+      keycloak: { enabled: false, login_url: null },
+    });
+  });
+
+  it.each([
+    ["both enabled", {
+      schema_version: 1,
+      auth_mode: "sso",
+      local: { enabled: true, login_url: "/local" },
+      keycloak: { enabled: true, login_url: "/sso" },
+    }],
+    ["wrong-mode URL", {
+      schema_version: 1,
+      auth_mode: "local",
+      local: { enabled: true, login_url: "/api/v1/admin/auth/local/login" },
+      keycloak: { enabled: false, login_url: "/hidden-sso" },
+    }],
+    ["unknown property", {
+      schema_version: 1,
+      auth_mode: "sso",
+      local: { enabled: false, login_url: null },
+      keycloak: { enabled: true, login_url: "/api/v1/admin/auth/keycloak/login" },
+      local_fallback: true,
+    }],
+  ])("fails closed for %s", async (_name, body) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(body)));
+    expect(await getAdminAuthConfig()).toEqual(ADMIN_AUTH_CONFIG_UNAVAILABLE);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -312,6 +312,160 @@ export async function getAuthConfig(): Promise<AuthConfig> {
   }
 }
 
+export interface AdminAuthConfig {
+  available: boolean;
+  schema_version: 1 | null;
+  auth_mode: AuthMode | null;
+  local: { enabled: boolean; login_url: string | null };
+  keycloak: { enabled: boolean; login_url: string | null };
+}
+
+export const ADMIN_AUTH_CONFIG_UNAVAILABLE: AdminAuthConfig = {
+  available: false,
+  schema_version: null,
+  auth_mode: null,
+  local: { enabled: false, login_url: null },
+  keycloak: { enabled: false, login_url: null },
+};
+
+export function parseAdminAuthConfig(value: unknown): AdminAuthConfig {
+  const root = record(value);
+  const local = record(root?.local);
+  const keycloak = record(root?.keycloak);
+  const mode = root?.auth_mode;
+  const localUrl = local?.login_url;
+  const keycloakUrl = keycloak?.login_url;
+  if (
+    !hasExactKeys(root, ["schema_version", "auth_mode", "local", "keycloak"]) ||
+    !hasExactKeys(local, ["enabled", "login_url"]) ||
+    !hasExactKeys(keycloak, ["enabled", "login_url"]) ||
+    root?.schema_version !== 1 ||
+    (mode !== "local" && mode !== "sso") ||
+    typeof local?.enabled !== "boolean" ||
+    typeof keycloak?.enabled !== "boolean" ||
+    (localUrl !== null && typeof localUrl !== "string") ||
+    (keycloakUrl !== null && typeof keycloakUrl !== "string") ||
+    local.enabled !== (mode === "local") ||
+    keycloak.enabled !== (mode === "sso") ||
+    localUrl !== (mode === "local" ? "/api/v1/admin/auth/local/login" : null) ||
+    keycloakUrl !== (mode === "sso" ? "/api/v1/admin/auth/keycloak/login" : null)
+  ) {
+    return ADMIN_AUTH_CONFIG_UNAVAILABLE;
+  }
+  return {
+    available: true,
+    schema_version: 1,
+    auth_mode: mode,
+    local: { enabled: local.enabled, login_url: localUrl },
+    keycloak: { enabled: keycloak.enabled, login_url: keycloakUrl },
+  };
+}
+
+export async function getAdminAuthConfig(): Promise<AdminAuthConfig> {
+  try {
+    const response = await fetch(`${API_BASE}/admin/auth/config`);
+    if (!response.ok) return ADMIN_AUTH_CONFIG_UNAVAILABLE;
+    return parseAdminAuthConfig(await response.json());
+  } catch {
+    return ADMIN_AUTH_CONFIG_UNAVAILABLE;
+  }
+}
+
+export interface AdminSession {
+  schema_version: 1;
+  auth_mode: AuthMode;
+  user: {
+    id: string;
+    username: string;
+    email: string;
+    display_name: string | null;
+    is_admin: true;
+  };
+}
+
+function parseAdminSession(value: unknown): AdminSession {
+  const root = record(value);
+  const user = record(root?.user);
+  const mode = root?.auth_mode;
+  if (
+    !hasExactKeys(root, ["schema_version", "auth_mode", "user"]) ||
+    !hasExactKeys(user, ["id", "username", "email", "display_name", "is_admin"]) ||
+    root?.schema_version !== 1 ||
+    (mode !== "local" && mode !== "sso") ||
+    typeof user?.id !== "string" ||
+    typeof user?.username !== "string" ||
+    typeof user?.email !== "string" ||
+    (user?.display_name !== null && typeof user?.display_name !== "string") ||
+    user?.is_admin !== true
+  ) {
+    throw new Error("Invalid product-admin session response");
+  }
+  return {
+    schema_version: 1,
+    auth_mode: mode,
+    user: {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      display_name: user.display_name as string | null,
+      is_admin: true,
+    },
+  };
+}
+
+function adminHeaders(headers?: HeadersInit): Headers {
+  const result = new Headers(headers);
+  const token = getToken();
+  if (token) result.set("Authorization", `Bearer ${token}`);
+  return result;
+}
+
+function cookieValue(name: string): string | null {
+  const prefix = `${encodeURIComponent(name)}=`;
+  for (const entry of document.cookie.split(";")) {
+    const candidate = entry.trim();
+    if (candidate.startsWith(prefix)) {
+      return decodeURIComponent(candidate.slice(prefix.length));
+    }
+  }
+  return null;
+}
+
+export async function getAdminSession(): Promise<AdminSession | null> {
+  const response = await fetch(`${API_BASE}/admin/auth/session`, {
+    credentials: "same-origin",
+    headers: adminHeaders(),
+  });
+  if (response.status === 401 || response.status === 403) return null;
+  if (!response.ok) await throwJsonApiError(response);
+  return parseAdminSession(await response.json());
+}
+
+export const adminLocalLogin = (username: string, password: string) =>
+  fetch(`${API_BASE}/admin/auth/local/login`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  }).then(parseAuthResponse);
+
+export async function adminLogout(): Promise<{ logout_url: string }> {
+  const headers = adminHeaders();
+  const csrf = cookieValue("akb_admin_csrf");
+  if (csrf) headers.set("X-AKB-Admin-CSRF", csrf);
+  const response = await fetch(`${API_BASE}/admin/auth/logout`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers,
+  });
+  if (!response.ok) await throwJsonApiError(response);
+  const payload = record(await response.json());
+  if (!hasExactKeys(payload, ["logout_url"]) || typeof payload.logout_url !== "string") {
+    throw new Error("Invalid product-admin logout response");
+  }
+  return { logout_url: payload.logout_url };
+}
+
 // ── Auth (token) ──
 export const getMe = () => api<any>("/auth/me");
 export const createPAT = (name: string, scopes?: string[], expires_days?: number) =>

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -1,0 +1,130 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import {
+  adminLocalLogin,
+  getAdminAuthConfig,
+  getAdminSession,
+  setToken,
+} from "@/lib/api";
+import AdminPage from "../admin";
+
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getAdminAuthConfig: vi.fn(),
+    getAdminSession: vi.fn(),
+    adminLocalLogin: vi.fn(),
+    adminLogout: vi.fn(),
+    setToken: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/use-theme", () => ({
+  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+}));
+
+const localConfig = {
+  available: true,
+  schema_version: 1 as const,
+  auth_mode: "local" as const,
+  local: {
+    enabled: true,
+    login_url: "/api/v1/admin/auth/local/login",
+  },
+  keycloak: { enabled: false, login_url: null },
+};
+
+const ssoConfig = {
+  available: true,
+  schema_version: 1 as const,
+  auth_mode: "sso" as const,
+  local: { enabled: false, login_url: null },
+  keycloak: {
+    enabled: true,
+    login_url: "/api/v1/admin/auth/keycloak/login",
+  },
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/admin"]}>
+        <AdminPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getAdminSession).mockResolvedValue(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminPage mode boundary", () => {
+  it("shows only local admin credentials in local mode", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(localConfig);
+    renderPage();
+
+    expect(await screen.findByLabelText("Username")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /keycloak/i })).toBeNull();
+  });
+
+  it("shows only the dedicated Keycloak entry in SSO mode", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /keycloak/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Username")).toBeNull();
+    expect(screen.queryByRole("button", { name: /local/i })).toBeNull();
+  });
+
+  it("submits local credentials from the user action and stores the RS256 session", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(localConfig);
+    vi.mocked(adminLocalLogin).mockResolvedValue({ token: "local-admin-session" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText("Username"), "admin");
+    await user.type(screen.getByLabelText("Password"), "password");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(adminLocalLogin).toHaveBeenCalledWith("admin", "password");
+    });
+    expect(setToken).toHaveBeenCalledWith("local-admin-session");
+  });
+
+  it("renders an authenticated AKB product admin without ordinary app layout", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    renderPage();
+
+    expect(await screen.findByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Logo } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme-toggle";
+import {
+  adminLocalLogin,
+  adminLogout,
+  getAdminAuthConfig,
+  getAdminSession,
+  setToken,
+} from "@/lib/api";
+
+
+export default function AdminPage() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const configQuery = useQuery({
+    queryKey: ["admin-auth-config", 1],
+    queryFn: getAdminAuthConfig,
+    staleTime: 30_000,
+  });
+  const config = configQuery.data;
+  const sessionQuery = useQuery({
+    queryKey: ["admin-session", 1],
+    queryFn: getAdminSession,
+    enabled: config?.available === true,
+    staleTime: 10_000,
+  });
+  const session =
+    sessionQuery.data?.auth_mode === config?.auth_mode
+      ? sessionQuery.data
+      : undefined;
+
+  async function submitLocal(event: React.FormEvent) {
+    event.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      const result = await adminLocalLogin(username, password);
+      if (!result.token || typeof result.token !== "string") {
+        throw new Error(result.error || "The server returned no admin session");
+      }
+      setToken(result.token);
+      setPassword("");
+      await sessionQuery.refetch();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Product-admin sign-in failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function startKeycloak() {
+    if (config?.keycloak.login_url) {
+      window.location.assign(config.keycloak.login_url);
+    }
+  }
+
+  async function signOut() {
+    setError("");
+    setSubmitting(true);
+    try {
+      const result = await adminLogout();
+      if (session?.auth_mode === "local") setToken(null);
+      if (session?.auth_mode === "sso") {
+        window.location.assign(result.logout_url);
+        return;
+      }
+      await sessionQuery.refetch();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Sign-out failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const unavailable =
+    configQuery.isError ||
+    (configQuery.isSuccess && config?.available !== true);
+
+  return (
+    <div className="relative min-h-dvh overflow-hidden bg-background text-foreground">
+      <div className="aurora-bg" aria-hidden />
+      <header className="relative z-10 flex h-16 items-center justify-between border-b border-border bg-surface/80 px-5 backdrop-blur-md sm:px-8">
+        <Logo size={30} subtitle />
+        <ThemeToggle />
+      </header>
+
+      <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-lg items-center px-5 py-12 sm:px-8">
+        <section className="w-full rounded-[var(--radius-xl)] border border-border bg-surface p-6 shadow-lg sm:p-8" aria-labelledby="admin-heading">
+          <div className="mb-7">
+            <p className="coord mb-2 text-primary">CONTROL PLANE</p>
+            <h1 id="admin-heading" className="font-display text-2xl font-semibold tracking-tight">
+              Product administration
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-foreground-muted">
+              This sign-in is separate from the ordinary AKB user surface.
+            </p>
+          </div>
+
+          {(configQuery.isPending || (config?.available && sessionQuery.isPending)) && (
+            <p className="text-sm text-foreground-muted" role="status">Verifying admin policy…</p>
+          )}
+
+          {unavailable && (
+            <Alert variant="destructive">
+              Product-admin authentication configuration could not be verified.
+            </Alert>
+          )}
+
+          {sessionQuery.isError && (
+            <Alert variant="destructive">
+              The current product-admin session could not be verified.
+            </Alert>
+          )}
+
+          {session && (
+            <div className="space-y-5">
+              <div className="rounded-[var(--radius-lg)] border border-border bg-surface-2 p-4">
+                <p className="font-medium">{session.user.display_name || session.user.username}</p>
+                <p className="mt-1 text-sm text-foreground-muted">{session.user.email}</p>
+                <p className="coord mt-3">{session.auth_mode.toUpperCase()} ADMIN SESSION</p>
+              </div>
+              {error && <Alert variant="destructive">{error}</Alert>}
+              <Button type="button" variant="outline" className="w-full" loading={submitting} onClick={signOut}>
+                Sign out
+              </Button>
+            </div>
+          )}
+
+          {!session && sessionQuery.isSuccess && config?.available && config.auth_mode === "local" && config.local.enabled && (
+            <form className="space-y-4" onSubmit={submitLocal}>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium" htmlFor="admin-username">Username</label>
+                <Input id="admin-username" name="username" autoComplete="username" value={username} onChange={(event) => setUsername(event.target.value)} required autoFocus />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium" htmlFor="admin-password">Password</label>
+                <Input id="admin-password" name="password" type="password" autoComplete="current-password" value={password} onChange={(event) => setPassword(event.target.value)} required />
+              </div>
+              {error && <Alert variant="destructive">{error}</Alert>}
+              <Button type="submit" size="lg" className="w-full" loading={submitting}>
+                Sign in
+              </Button>
+            </form>
+          )}
+
+          {!session && sessionQuery.isSuccess && config?.available && config.auth_mode === "sso" && config.keycloak.enabled && (
+            <div className="space-y-4">
+              {error && <Alert variant="destructive">{error}</Alert>}
+              <Button type="button" size="lg" className="w-full" onClick={startKeycloak}>
+                Sign in with Keycloak
+              </Button>
+              <p className="text-xs leading-5 text-foreground-muted">
+                Only an identity pre-bound to an active AKB product administrator is accepted.
+              </p>
+            </div>
+          )}
+
+          <div className="mt-7 border-t border-border pt-5 text-center">
+            <Link className="text-sm text-link hover:text-link-hover hover:underline" to="/auth">
+              Go to ordinary user sign-in
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

- add explicit recovery-admin provisioning for both local and SSO installations
- replace local browser sessions with a persistent, versioned RS256 token profile
- add a separate `/admin` browser surface that is isolated from ordinary AKB user authentication
- use a dedicated confidential Keycloak admin client in SSO mode with authorization code, PKCE, and nonce validation
- project only exact pre-bound `(issuer, subject)` identities and issue short-lived opaque AKB admin sessions
- reject the admin client from API and MCP access-token profiles
- add PostgreSQL-backed migration, locking, invalidation, and CI coverage

## Why

AKB needs an explicit authentication-mode boundary before adding configurable upstream IdPs. Product administration must not accidentally share ordinary-user login, JIT projection, or bearer-token behavior. This change establishes that boundary while preserving local-mode operation and keeping ordinary-user SSO work staged.

## Security properties

- no Keycloak access, refresh, or ID token is stored in the admin session
- every admin request rechecks the current exact external identity and live AKB administrator status
- identity re-binding, account deactivation, provider change, or admin demotion invalidates the session
- OIDC state is bound to the initiating browser and is consumed atomically
- public AKB and Keycloak URLs require HTTPS except exact loopback development URLs
- malformed JWT/JWK, temporal claims, nonce, and CSRF inputs fail closed
- concurrent session issuance is bounded with PostgreSQL locking

## Deferred follow-up

- ordinary-user browser SSO and runtime IdP enable/disable controls remain in later slices
- the production standalone SSO bundle will prove Keycloak realm-native administrator policy and bootstrap-account retirement in an isolated deployment fixture

## Validation

- backend: 2,090 passed, 236 skipped, 47 deselected
- frontend: 436 tests passed across 63 files
- frontend TypeScript and production build passed
- repository `scripts/check.sh` passed, including Ruff, mypy, Bandit, ESLint, SDK packaging/consumer proof, generated-type drift, and secret scanning
- PostgreSQL fresh-init/upgrade schema equivalence and migration idempotence passed

Part of #357
