### PR TITLE
Add standalone Keycloak SSO bootstrap

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -16,6 +16,10 @@ Subcommands:
                                SSO recovery administrator. Password material
                                is accepted only by file/stdin and is never
                                printed.
+    bootstrap-standalone-sso   Converge the bundled Keycloak realm, clients,
+                               signing profile, and exact AKB recovery-admin
+                               projection; then retire the temporary bootstrap
+                               service account.
     reset-password <username>   Generate a temp password for the given user.
                                  Prints the temp password to stdout. Caller
                                  must share it with the user out-of-band.
@@ -52,6 +56,13 @@ GENERATE_LOCAL_SESSION_KEYSET_USAGE = (
     "--output-dir DIR [--retain-jwks PATH ...]"
 )
 
+STANDALONE_SSO_BOOTSTRAP_USAGE = (
+    "Usage: python -m app.cli bootstrap-standalone-sso "
+    "--bootstrap-client-id ID --bootstrap-client-secret-file PATH "
+    "--product-admin-username USER --product-admin-email EMAIL "
+    "--product-admin-password-file PATH"
+)
+
 
 class _CLIUsageError(Exception):
     pass
@@ -59,6 +70,15 @@ class _CLIUsageError(Exception):
 
 class _ProvisioningInputError(Exception):
     pass
+
+
+async def _initialize_operator_database() -> None:
+    """Initialize schema and the user-role projection needed by admin CLIs."""
+    from app.db.postgres import get_pool, init_db
+    from app.services.role_sync import RoleSync, set_role_sync
+
+    await init_db()
+    set_role_sync(RoleSync(await get_pool()))
 
 
 def _generate_local_session_keyset(args: list[str]) -> int:
@@ -131,6 +151,24 @@ def _read_password_source(source: str) -> str:
     return password
 
 
+def _read_optional_bootstrap_secret_file(source: str) -> str:
+    if source == "-":
+        raise _ProvisioningInputError("Standalone SSO secrets require explicit files")
+    try:
+        text = Path(source).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        # The default overlay keeps required Secret objects with retired
+        # sentinel values.  A custom steady-state overlay may unmount them;
+        # receipt-backed readback then proves the permanent management path.
+        return ""
+    except OSError:
+        raise _ProvisioningInputError("Unable to read the bootstrap secret source") from None
+    secret = text.rstrip("\r\n")
+    if "\r" in secret or "\n" in secret:
+        raise _ProvisioningInputError("A bootstrap secret source must contain one line")
+    return secret
+
+
 def _write_generated_password(target: str, password: str) -> Path:
     if target == "-":
         raise _ProvisioningInputError("Generated passwords require an explicit file")
@@ -182,7 +220,7 @@ async def _provision_recovery_admin(args: list[str]) -> int:
         return 2
 
     from app.config import AuthModeConfigurationError
-    from app.db.postgres import close_pool, init_db
+    from app.db.postgres import close_pool
     from app.exceptions import AKBError
     from app.services.recovery_admin_service import (
         provision_local_recovery_admin,
@@ -194,7 +232,7 @@ async def _provision_recovery_admin(args: list[str]) -> int:
     report: dict | None = None
     error: tuple[str, str] | None = None
     try:
-        await init_db()
+        await _initialize_operator_database()
         if parsed.profile == "local":
             if parsed.generate_password_file is not None:
                 password = secrets.token_urlsafe(32)
@@ -261,6 +299,169 @@ async def _provision_recovery_admin(args: list[str]) -> int:
         "password_file_written": keep_generated,
     }
     print(json.dumps(public_report, sort_keys=True))
+    return 0
+
+
+def _standalone_sso_parser() -> argparse.ArgumentParser:
+    parser = _SafeArgumentParser(add_help=False)
+    parser.add_argument("--bootstrap-client-id", required=True)
+    parser.add_argument("--bootstrap-client-secret-file", required=True)
+    parser.add_argument("--product-admin-username", required=True)
+    parser.add_argument("--product-admin-email", required=True)
+    parser.add_argument("--product-admin-password-file", required=True)
+    return parser
+
+
+async def _bootstrap_standalone_sso(args: list[str]) -> int:
+    try:
+        parsed = _standalone_sso_parser().parse_args(args)
+    except _CLIUsageError:
+        print(STANDALONE_SSO_BOOTSTRAP_USAGE, file=sys.stderr)
+        return 2
+
+    from app.config import AuthModeConfigurationError, settings
+    from app.db.postgres import close_pool
+    from app.services.recovery_admin_service import provision_sso_recovery_admin
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        StandaloneSSOBootstrapSpec,
+        bootstrap_standalone_sso,
+    )
+    from app.services.standalone_sso_keycloak import KeycloakStandaloneSSOControl
+    from app.services.standalone_sso_receipt import (
+        load_standalone_sso_retirement_receipt,
+        record_standalone_sso_retirement_receipt,
+    )
+
+    control: KeycloakStandaloneSSOControl | None = None
+    report: dict[str, object] | None = None
+    error: tuple[str, str] | None = None
+    try:
+        bootstrap_secret = _read_optional_bootstrap_secret_file(
+            parsed.bootstrap_client_secret_file
+        )
+        product_admin_password = _read_optional_bootstrap_secret_file(
+            parsed.product_admin_password_file
+        )
+        if settings.require_auth_mode() != "sso" or not settings.keycloak_enabled:
+            raise _ProvisioningInputError(
+                "Standalone SSO bootstrap requires auth_mode=sso and Keycloak enabled"
+            )
+        required = {
+            "keycloak_server_url": settings.keycloak_server_url,
+            "keycloak_internal_url or keycloak_server_url": (
+                settings.keycloak_internal_url or settings.keycloak_server_url
+            ),
+            "keycloak_realm": settings.keycloak_realm,
+            "public_base_url": settings.public_base_url,
+            "keycloak_client_id": settings.keycloak_client_id,
+            "keycloak_client_secret": settings.keycloak_client_secret,
+            "keycloak_admin_client_id": settings.keycloak_admin_client_id,
+            "keycloak_admin_client_secret": settings.keycloak_admin_client_secret,
+            "keycloak_management_client_id": settings.keycloak_management_client_id,
+            "keycloak_management_client_secret": (
+                settings.keycloak_management_client_secret
+            ),
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise _ProvisioningInputError(
+                "Standalone SSO configuration is incomplete: " + ", ".join(missing)
+            )
+        if settings.keycloak_public_client:
+            raise _ProvisioningInputError(
+                "Bundled standalone SSO requires a confidential API client"
+            )
+        credentials = [
+            settings.keycloak_client_secret,
+            settings.keycloak_admin_client_secret,
+            settings.keycloak_management_client_secret,
+            bootstrap_secret,
+            product_admin_password,
+        ]
+        configured_credentials = [value for value in credentials if value]
+        if len(set(configured_credentials)) != len(configured_credentials):
+            raise _ProvisioningInputError(
+                "Standalone SSO credentials must be independently generated"
+            )
+        client_ids = {
+            settings.keycloak_client_id,
+            settings.keycloak_admin_client_id,
+            settings.keycloak_management_client_id,
+        }
+        if len(client_ids) != 3:
+            raise _ProvisioningInputError(
+                "Standalone SSO API, admin, and management clients must be distinct"
+            )
+
+        spec = StandaloneSSOBootstrapSpec(
+            keycloak_internal_url=(
+                settings.keycloak_internal_url or settings.keycloak_server_url
+            ),
+            keycloak_public_url=settings.keycloak_server_url,
+            realm=settings.keycloak_realm,
+            akb_public_url=settings.public_base_url,
+            bootstrap_client_id=parsed.bootstrap_client_id,
+            bootstrap_client_secret=bootstrap_secret,
+            management_client_id=settings.keycloak_management_client_id,
+            management_client_secret=settings.keycloak_management_client_secret,
+            api_client_id=settings.keycloak_client_id,
+            api_client_secret=settings.keycloak_client_secret,
+            admin_client_id=settings.keycloak_admin_client_id,
+            admin_client_secret=settings.keycloak_admin_client_secret,
+            product_admin_username=parsed.product_admin_username,
+            product_admin_email=parsed.product_admin_email,
+            product_admin_password=product_admin_password,
+        )
+        await _initialize_operator_database()
+        control = KeycloakStandaloneSSOControl(
+            verify_ssl=settings.keycloak_verify_ssl
+        )
+        report = await bootstrap_standalone_sso(
+            spec,
+            control=control,
+            provision_admin=provision_sso_recovery_admin,
+            load_retirement_receipt=load_standalone_sso_retirement_receipt,
+            record_retirement_receipt=record_standalone_sso_retirement_receipt,
+        )
+    except StandaloneSSOBootstrapError as exc:
+        error = (exc.code, "Standalone SSO bootstrap failed")
+    except AuthModeConfigurationError as exc:
+        error = ("standalone_sso_mode_configuration", str(exc))
+    except _ProvisioningInputError as exc:
+        error = ("standalone_sso_input_invalid", str(exc))
+    except Exception:
+        # Keycloak, HTTP, database, and driver exceptions may retain request
+        # bodies or DSNs. Never render an unexpected exception from this
+        # credential-bearing command.
+        error = (
+            "standalone_sso_bootstrap_failed",
+            "Standalone SSO bootstrap failed",
+        )
+    finally:
+        if control is not None:
+            try:
+                await control.aclose()
+            except Exception:
+                if error is None:
+                    error = (
+                        "standalone_sso_keycloak_cleanup_failed",
+                        "Keycloak connection cleanup failed",
+                    )
+        try:
+            await close_pool()
+        except Exception:
+            if error is None:
+                error = (
+                    "standalone_sso_database_cleanup_failed",
+                    "Database connection cleanup failed",
+                )
+
+    if error is not None:
+        print(f"{error[0]}: {error[1]}", file=sys.stderr)
+        return 1
+    assert report is not None
+    print(json.dumps(report, sort_keys=True))
     return 0
 
 
@@ -431,6 +632,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Subcommands: generate-local-session-keyset, "
             "provision-recovery-admin {local|sso}, "
+            "bootstrap-standalone-sso, "
             "reset-password <username>, repair-resource-hashes, "
             "initialize-postgres-native, okf-validate <dir>, "
             "okf-export --from-git <worktree> --vault <name> --out <dir>",
@@ -442,6 +644,8 @@ def main(argv: list[str] | None = None) -> int:
         return _generate_local_session_keyset(argv[1:])
     if cmd == "provision-recovery-admin":
         return asyncio.run(_provision_recovery_admin(argv[1:]))
+    if cmd == "bootstrap-standalone-sso":
+        return asyncio.run(_bootstrap_standalone_sso(argv[1:]))
     if cmd == "reset-password":
         if len(argv) != 2:
             print("Usage: python -m app.cli reset-password <username>", file=sys.stderr)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -854,6 +854,12 @@ class Settings(BaseModel):
     # silently disagree about path ownership.
     keycloak_admin_client_id: str = "akb-admin"
     keycloak_admin_client_secret: str = ""
+    # Permanent least-privilege service account used by the standalone
+    # product-admin control plane after Keycloak's one-time bootstrap service
+    # account has been removed. Managed deployments may leave this blank when
+    # the platform owns IdP changes out of band.
+    keycloak_management_client_id: str = "akb-sso-manager"
+    keycloak_management_client_secret: str = ""
     admin_browser_session_ttl_secs: int = Field(default=900, ge=60, le=3600)
     keycloak_verify_ssl: bool = True       # set false only for local self-signed Keycloak
     # Exact identity is issuer/subject and does not require email. Open-mode

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -114,6 +114,31 @@ CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_expiry
 CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
     ON admin_browser_sessions(user_id);
 
+-- A monotonic, non-secret receipt written only after the temporary bundled
+-- Keycloak bootstrap client has been deleted and its credential rejected.
+-- It lets later init-container runs prove that an absent one-time Secret is
+-- expected, while a prematurely removed Secret fails closed.
+CREATE TABLE IF NOT EXISTS standalone_sso_bootstrap_retirements (
+    profile TEXT PRIMARY KEY
+        CHECK (char_length(profile) BETWEEN 1 AND 128),
+    issuer TEXT NOT NULL
+        CHECK (char_length(issuer) BETWEEN 1 AND 2048),
+    realm_id TEXT NOT NULL
+        CHECK (char_length(realm_id) BETWEEN 1 AND 255),
+    bootstrap_client_id TEXT NOT NULL
+        CHECK (char_length(bootstrap_client_id) BETWEEN 1 AND 255),
+    management_client_uuid TEXT NOT NULL
+        CHECK (char_length(management_client_uuid) BETWEEN 1 AND 255),
+    admin_client_uuid TEXT NOT NULL
+        CHECK (char_length(admin_client_uuid) BETWEEN 1 AND 255),
+    api_client_uuid TEXT NOT NULL
+        CHECK (char_length(api_client_uuid) BETWEEN 1 AND 255),
+    product_admin_subject TEXT NOT NULL
+        CHECK (char_length(product_admin_subject) BETWEEN 1 AND 1024),
+    akb_user_id UUID NOT NULL,
+    retired_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 -- Durable post-commit cleanup ledger. Token rows are deleted in the same
 -- transaction that suspends an account; PG token roles are DDL and are
 -- cleaned afterward. Failed DDL remains retryable without restoring a token.

--- a/backend/app/db/migrations/073_sso_bootstrap_receipt.py
+++ b/backend/app/db/migrations/073_sso_bootstrap_receipt.py
@@ -1,0 +1,31 @@
+"""Add durable evidence for verified standalone SSO bootstrap retirement."""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS standalone_sso_bootstrap_retirements (
+                profile TEXT PRIMARY KEY
+                    CHECK (char_length(profile) BETWEEN 1 AND 128),
+                issuer TEXT NOT NULL
+                    CHECK (char_length(issuer) BETWEEN 1 AND 2048),
+                realm_id TEXT NOT NULL
+                    CHECK (char_length(realm_id) BETWEEN 1 AND 255),
+                bootstrap_client_id TEXT NOT NULL
+                    CHECK (char_length(bootstrap_client_id) BETWEEN 1 AND 255),
+                management_client_uuid TEXT NOT NULL
+                    CHECK (char_length(management_client_uuid) BETWEEN 1 AND 255),
+                admin_client_uuid TEXT NOT NULL
+                    CHECK (char_length(admin_client_uuid) BETWEEN 1 AND 255),
+                api_client_uuid TEXT NOT NULL
+                    CHECK (char_length(api_client_uuid) BETWEEN 1 AND 255),
+                product_admin_subject TEXT NOT NULL
+                    CHECK (char_length(product_admin_subject) BETWEEN 1 AND 1024),
+                akb_user_id UUID NOT NULL,
+                retired_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -249,6 +249,7 @@ async def _apply_migrations() -> None:
         "070_vault_files_s3_key_lookup.py",  # physical-key reachability + pending-delete barrier indexes
         "071_recovery_admin.py",  # explicit singleton recovery administrator + external username snapshot
         "072_admin_browser_sessions.py",  # short-lived opaque sessions for the dedicated SSO admin client
+        "073_sso_bootstrap_receipt.py",  # durable proof that the temporary bundled-Keycloak client was retired
     ):
         if filename in applied:
             continue

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -241,6 +241,11 @@ class KeycloakOIDC:
             "nonce": nonce,
             "code_challenge": self._make_code_challenge(verifier),
             "code_challenge_method": "S256",
+            # Product administration is a recovery surface.  Never satisfy it
+            # from a pre-existing realm/broker SSO cookie; force a fresh native
+            # credential ceremony whose exact AMR is verified below.
+            "prompt": "login",
+            "max_age": "0",
         }
         return AdminAuthorizationRequest(
             location=(
@@ -485,6 +490,8 @@ class KeycloakOIDC:
         ):
             raise AuthenticationError("Invalid admin identity token")
         if _SERVICE_ACCOUNT_CLAIMS.intersection(claims):
+            raise AuthenticationError("Invalid admin identity token")
+        if claims.get("amr") != ["pwd"]:
             raise AuthenticationError("Invalid admin identity token")
         preferred_username = claims.get("preferred_username")
         if preferred_username is not None and (

--- a/backend/app/services/standalone_sso_bootstrap.py
+++ b/backend/app/services/standalone_sso_bootstrap.py
@@ -1,0 +1,354 @@
+"""Fail-closed lifecycle for a bundled standalone SSO installation.
+
+This module owns ordering, not transport.  A deployment-specific Keycloak
+control adapter performs the Admin REST calls while this state machine ensures
+that the temporary bootstrap credential survives until all durable recovery
+paths and the exact AKB product-admin projection have been read back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+import re
+from typing import Protocol
+
+
+MANAGEMENT_REALM_ROLES = (
+    "manage-identity-providers",
+    "query-clients",
+    "query-users",
+    "view-clients",
+    "view-realm",
+    "view-users",
+)
+STANDALONE_SSO_RECEIPT_PROFILE = "bundled-keycloak-v1"
+_BOOTSTRAP_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+
+
+class StandaloneSSOBootstrapError(RuntimeError):
+    """A value-free installation refusal suitable for operator output."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class StandaloneSSOBootstrapSpec:
+    keycloak_internal_url: str
+    keycloak_public_url: str
+    realm: str
+    akb_public_url: str
+    bootstrap_client_id: str
+    bootstrap_client_secret: str = field(repr=False)
+    management_client_id: str
+    management_client_secret: str = field(repr=False)
+    api_client_id: str
+    api_client_secret: str = field(repr=False)
+    admin_client_id: str
+    admin_client_secret: str = field(repr=False)
+    product_admin_username: str
+    product_admin_email: str
+    product_admin_password: str = field(repr=False)
+
+    @property
+    def issuer(self) -> str:
+        return f"{self.keycloak_public_url.rstrip('/')}/realms/{self.realm}"
+
+    @property
+    def admin_redirect_uri(self) -> str:
+        return (
+            f"{self.akb_public_url.rstrip('/')}"
+            "/api/v1/admin/auth/keycloak/callback"
+        )
+
+    @property
+    def admin_post_logout_redirect_uri(self) -> str:
+        return f"{self.akb_public_url.rstrip('/')}/admin"
+
+
+@dataclass(frozen=True, slots=True)
+class StandaloneSSOReadback:
+    realm_id: str
+    product_admin_subject: str
+    admin_client_uuid: str
+    management_client_uuid: str
+    api_client_uuid: str
+    active_signing_kid: str
+    active_signing_bits: int
+    passive_rs256_keys: int
+    management_roles: tuple[str, ...]
+    management_scope_roles: tuple[str, ...]
+    admin_native_amr: str
+    product_admin_federated_identities: int
+
+
+@dataclass(frozen=True, slots=True)
+class StandaloneSSORetirementReceipt:
+    """Non-secret, durable proof binding bootstrap retirement to one install."""
+
+    profile: str
+    issuer: str
+    realm_id: str
+    bootstrap_client_id: str
+    management_client_uuid: str
+    admin_client_uuid: str
+    api_client_uuid: str
+    product_admin_subject: str
+    akb_user_id: str
+
+
+class StandaloneSSOControl(Protocol):
+    async def acquire_management(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+    ) -> str | None: ...
+
+    async def acquire_bootstrap(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+    ) -> str | None: ...
+
+    async def reconcile(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> StandaloneSSOReadback: ...
+
+    async def readback(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        management_token: str,
+    ) -> StandaloneSSOReadback: ...
+
+    async def retire_bootstrap(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> None: ...
+
+    async def assert_bootstrap_retired(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> None: ...
+
+
+ProvisionAdmin = Callable[..., Awaitable[Mapping[str, object]]]
+LoadRetirementReceipt = Callable[
+    [], Awaitable[StandaloneSSORetirementReceipt | None]
+]
+RecordRetirementReceipt = Callable[
+    [StandaloneSSORetirementReceipt], Awaitable[None]
+]
+
+
+def _validate_readback(readback: StandaloneSSOReadback) -> None:
+    required = (
+        readback.realm_id,
+        readback.product_admin_subject,
+        readback.admin_client_uuid,
+        readback.management_client_uuid,
+        readback.api_client_uuid,
+        readback.active_signing_kid,
+    )
+    if any(not value.strip() for value in required):
+        raise StandaloneSSOBootstrapError("keycloak_readback_incomplete")
+    if readback.active_signing_bits != 3072:
+        raise StandaloneSSOBootstrapError("keycloak_signing_profile_mismatch")
+    if readback.passive_rs256_keys < 1:
+        raise StandaloneSSOBootstrapError("keycloak_rotation_window_missing")
+    if tuple(sorted(readback.management_roles)) != MANAGEMENT_REALM_ROLES:
+        raise StandaloneSSOBootstrapError("keycloak_management_roles_mismatch")
+    if tuple(sorted(readback.management_scope_roles)) != MANAGEMENT_REALM_ROLES:
+        raise StandaloneSSOBootstrapError("keycloak_management_scope_mismatch")
+    if readback.admin_native_amr != "pwd":
+        raise StandaloneSSOBootstrapError("keycloak_admin_native_amr_missing")
+    if readback.product_admin_federated_identities != 0:
+        raise StandaloneSSOBootstrapError("keycloak_admin_identity_is_federated")
+
+
+def _validate_projection(result: Mapping[str, object]) -> str:
+    user_id = result.get("user_id")
+    if (
+        not isinstance(user_id, str)
+        or not user_id
+        or result.get("is_admin") is not True
+        or result.get("is_recovery_admin") is not True
+    ):
+        raise StandaloneSSOBootstrapError("akb_product_admin_readback_failed")
+    return user_id
+
+
+def _expected_retirement_receipt(
+    spec: StandaloneSSOBootstrapSpec,
+    readback: StandaloneSSOReadback,
+    *,
+    akb_user_id: str,
+) -> StandaloneSSORetirementReceipt:
+    return StandaloneSSORetirementReceipt(
+        profile=STANDALONE_SSO_RECEIPT_PROFILE,
+        issuer=spec.issuer,
+        realm_id=readback.realm_id,
+        bootstrap_client_id=spec.bootstrap_client_id,
+        management_client_uuid=readback.management_client_uuid,
+        admin_client_uuid=readback.admin_client_uuid,
+        api_client_uuid=readback.api_client_uuid,
+        product_admin_subject=readback.product_admin_subject,
+        akb_user_id=akb_user_id,
+    )
+
+
+def _validate_receipt_static_binding(
+    receipt: StandaloneSSORetirementReceipt,
+    spec: StandaloneSSOBootstrapSpec,
+) -> None:
+    if (
+        receipt.profile != STANDALONE_SSO_RECEIPT_PROFILE
+        or receipt.issuer != spec.issuer
+        or receipt.bootstrap_client_id != spec.bootstrap_client_id
+    ):
+        raise StandaloneSSOBootstrapError(
+            "keycloak_bootstrap_retirement_receipt_mismatch"
+        )
+
+
+async def bootstrap_standalone_sso(
+    spec: StandaloneSSOBootstrapSpec,
+    *,
+    control: StandaloneSSOControl,
+    provision_admin: ProvisionAdmin,
+    load_retirement_receipt: LoadRetirementReceipt,
+    record_retirement_receipt: RecordRetirementReceipt,
+) -> dict[str, object]:
+    """Converge one standalone SSO install without a recovery-credential gap."""
+
+    if (
+        not spec.realm
+        or spec.realm != spec.realm.strip()
+        or spec.realm.casefold() == "master"
+    ):
+        # The master realm owns emergency bootstrap authority. Treating it as
+        # AKB's product realm would mutate Keycloak's control plane and could
+        # make the subsequent exact-client retirement destructive.
+        raise StandaloneSSOBootstrapError("keycloak_product_realm_invalid")
+    if _BOOTSTRAP_CLIENT_ID_RE.fullmatch(spec.bootstrap_client_id) is None:
+        raise StandaloneSSOBootstrapError("keycloak_bootstrap_client_id_invalid")
+
+    retirement_receipt = await load_retirement_receipt()
+    if retirement_receipt is not None:
+        _validate_receipt_static_binding(retirement_receipt, spec)
+
+    management_token = await control.acquire_management(spec)
+    bootstrap_token = await control.acquire_bootstrap(spec)
+    if management_token is None and bootstrap_token is None:
+        raise StandaloneSSOBootstrapError(
+            "keycloak_install_credential_unavailable"
+        )
+    if retirement_receipt is None and bootstrap_token is None:
+        raise StandaloneSSOBootstrapError(
+            "keycloak_bootstrap_retirement_receipt_missing"
+        )
+    if retirement_receipt is not None and bootstrap_token is not None:
+        raise StandaloneSSOBootstrapError(
+            "keycloak_bootstrap_client_reactivated"
+        )
+    if bootstrap_token is not None and not spec.product_admin_password:
+        # Validate the one-time recovery input before reconcile creates or
+        # changes any realm resource.  Readback-only reruns intentionally do
+        # not need the original password.
+        raise StandaloneSSOBootstrapError(
+            "keycloak_product_admin_password_unavailable"
+        )
+    if bootstrap_token is not None and (
+        len(spec.product_admin_password) < 12
+        or spec.product_admin_password == spec.product_admin_username
+        or spec.product_admin_password == spec.product_admin_email
+    ):
+        raise StandaloneSSOBootstrapError(
+            "keycloak_product_admin_password_policy"
+        )
+
+    keycloak_mutated = bootstrap_token is not None
+    if bootstrap_token is not None:
+        mode = "fresh" if management_token is None else "recovery"
+        readback = await control.reconcile(
+            spec,
+            bootstrap_token=bootstrap_token,
+        )
+    else:
+        mode = "readback"
+        assert management_token is not None
+        readback = await control.readback(
+            spec,
+            management_token=management_token,
+        )
+    _validate_readback(readback)
+
+    projection = await provision_admin(
+        username=spec.product_admin_username,
+        email=spec.product_admin_email,
+        issuer=spec.issuer,
+        subject=readback.product_admin_subject,
+    )
+    user_id = _validate_projection(projection)
+
+    # Re-authenticate through the permanent path after projection.  A client
+    # merely present in a prior read-back is not yet a proven recovery path.
+    permanent_token = await control.acquire_management(spec)
+    if permanent_token is None:
+        raise StandaloneSSOBootstrapError(
+            "keycloak_management_credential_unavailable"
+        )
+    final_readback = await control.readback(
+        spec,
+        management_token=permanent_token,
+    )
+    _validate_readback(final_readback)
+    if final_readback != readback:
+        raise StandaloneSSOBootstrapError("keycloak_readback_changed")
+
+    expected_receipt = _expected_retirement_receipt(
+        spec,
+        final_readback,
+        akb_user_id=user_id,
+    )
+
+    if bootstrap_token is not None:
+        await control.retire_bootstrap(
+            spec,
+            bootstrap_token=bootstrap_token,
+        )
+        await control.assert_bootstrap_retired(
+            spec,
+            bootstrap_token=bootstrap_token,
+        )
+        await record_retirement_receipt(expected_receipt)
+        if await load_retirement_receipt() != expected_receipt:
+            raise StandaloneSSOBootstrapError(
+                "keycloak_bootstrap_retirement_receipt_write_failed"
+            )
+    elif retirement_receipt != expected_receipt:
+        raise StandaloneSSOBootstrapError(
+            "keycloak_bootstrap_retirement_receipt_mismatch"
+        )
+
+    created = projection.get("created")
+    return {
+        "mode": mode,
+        "keycloak_mutated": keycloak_mutated,
+        "bootstrap_admin_retired": True,
+        "realm_id": final_readback.realm_id,
+        "product_admin_subject": final_readback.product_admin_subject,
+        "akb_user_id": user_id,
+        "akb_admin_created": created is True,
+        "active_signing_kid": final_readback.active_signing_kid,
+        "active_signing_bits": final_readback.active_signing_bits,
+        "passive_rs256_keys": final_readback.passive_rs256_keys,
+        "management_roles": list(final_readback.management_roles),
+    }

--- a/backend/app/services/standalone_sso_keycloak.py
+++ b/backend/app/services/standalone_sso_keycloak.py
@@ -1,0 +1,1444 @@
+"""Keycloak Admin REST adapter for the standalone SSO bootstrap lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+from collections.abc import Mapping
+import re
+from typing import Any
+from urllib.parse import quote
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    load_der_public_key,
+    load_pem_public_key,
+)
+import httpx
+
+from app.services.standalone_sso_bootstrap import (
+    MANAGEMENT_REALM_ROLES,
+    StandaloneSSOBootstrapError,
+    StandaloneSSOBootstrapSpec,
+    StandaloneSSOReadback,
+)
+
+
+_KEY_PROVIDER_TYPE = "org.keycloak.keys.KeyProvider"
+_ACTIVE_KEY_PROVIDER_NAME = "akb-rs256-3072-active"
+_NATIVE_AMR_CONFIG_ALIAS = "akb-native-password-amr"
+_API_AUDIENCE_MAPPER_NAME = "akb-api-audience"
+_ADMIN_AMR_MAPPER_NAME = "akb-admin-native-amr"
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+
+
+def _fail(code: str) -> StandaloneSSOBootstrapError:
+    return StandaloneSSOBootstrapError(code)
+
+
+def _object(value: object, code: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _fail(code)
+    return value
+
+
+def _objects(value: object, code: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise _fail(code)
+    return value
+
+
+def _required_string(value: Mapping[str, object], key: str, code: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result:
+        raise _fail(code)
+    return result
+
+
+def _exact(items: list[dict[str, Any]], key: str, value: str, code: str) -> dict[str, Any] | None:
+    matches = [item for item in items if item.get(key) == value]
+    if len(matches) > 1:
+        raise _fail(code)
+    return matches[0] if matches else None
+
+
+def _path(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _rsa_public_key_size(public_key: str) -> int:
+    """Measure Keycloak's bounded PEM or unpadded-base64 DER public key."""
+    if not public_key or len(public_key) > 16_384:
+        raise _fail("keycloak_active_rs256_key_invalid")
+    try:
+        if public_key.startswith("-----BEGIN PUBLIC KEY-----"):
+            parsed = load_pem_public_key(public_key.encode("ascii"))
+        else:
+            padding = "=" * (-len(public_key) % 4)
+            der = base64.b64decode(public_key + padding, validate=True)
+            parsed = load_der_public_key(der)
+    except (UnicodeEncodeError, ValueError, TypeError, binascii.Error) as exc:
+        raise _fail("keycloak_active_rs256_key_invalid") from exc
+    if not isinstance(parsed, rsa.RSAPublicKey):
+        raise _fail("keycloak_active_rs256_key_invalid")
+    return parsed.key_size
+
+
+class KeycloakStandaloneSSOControl:
+    """Narrow, secret-redacting Admin REST implementation."""
+
+    def __init__(self, *, verify_ssl: bool = True) -> None:
+        self._verify_ssl = verify_ssl
+        self._clients: dict[str, httpx.AsyncClient] = {}
+
+    def _client(self, spec: StandaloneSSOBootstrapSpec) -> httpx.AsyncClient:
+        base_url = spec.keycloak_internal_url.rstrip("/")
+        client = self._clients.get(base_url)
+        if client is None:
+            client = httpx.AsyncClient(
+                base_url=base_url,
+                verify=self._verify_ssl,
+                timeout=httpx.Timeout(20.0, connect=10.0),
+            )
+            self._clients[base_url] = client
+        return client
+
+    async def aclose(self) -> None:
+        clients, self._clients = list(self._clients.values()), {}
+        for client in clients:
+            await client.aclose()
+
+    async def _token(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        realm: str,
+        client_id: str,
+        client_secret: str,
+    ) -> str | None:
+        if not client_id or not client_secret:
+            return None
+        try:
+            response = await self._client(spec).post(
+                f"/realms/{_path(realm)}/protocol/openid-connect/token",
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                },
+            )
+        except httpx.HTTPError as exc:
+            raise _fail("keycloak_unreachable") from exc
+        if response.status_code in {400, 401, 403, 404}:
+            return None
+        if response.status_code != 200:
+            raise _fail("keycloak_token_request_failed")
+        try:
+            body = _object(response.json(), "keycloak_token_response_invalid")
+        except (TypeError, ValueError) as exc:
+            raise _fail("keycloak_token_response_invalid") from exc
+        token = body.get("access_token")
+        if not isinstance(token, str) or not token:
+            raise _fail("keycloak_token_response_invalid")
+        return token
+
+    async def acquire_management(self, spec: StandaloneSSOBootstrapSpec) -> str | None:
+        return await self._token(
+            spec,
+            realm=spec.realm,
+            client_id=spec.management_client_id,
+            client_secret=spec.management_client_secret,
+        )
+
+    async def acquire_bootstrap(self, spec: StandaloneSSOBootstrapSpec) -> str | None:
+        return await self._token(
+            spec,
+            realm="master",
+            client_id=spec.bootstrap_client_id,
+            client_secret=spec.bootstrap_client_secret,
+        )
+
+    async def _request(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        method: str,
+        path: str,
+        *,
+        token: str,
+        json_body: object | None = None,
+        params: Mapping[str, str | int | float | bool | None] | None = None,
+        expected: frozenset[int] = frozenset({200}),
+        code: str = "keycloak_admin_request_failed",
+    ) -> httpx.Response:
+        try:
+            response = await self._client(spec).request(
+                method,
+                path,
+                headers={"Authorization": f"Bearer {token}"},
+                json=json_body,
+                params=params,
+            )
+        except httpx.HTTPError as exc:
+            raise _fail("keycloak_unreachable") from exc
+        if response.status_code not in expected:
+            raise _fail(code)
+        return response
+
+    async def _json(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        path: str,
+        *,
+        token: str,
+        params: Mapping[str, str | int | float | bool | None] | None = None,
+        code: str,
+    ) -> object:
+        response = await self._request(
+            spec,
+            "GET",
+            path,
+            token=token,
+            params=params,
+            code=code,
+        )
+        try:
+            return response.json()
+        except (TypeError, ValueError) as exc:
+            raise _fail(code) from exc
+
+    async def _realm(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> dict[str, Any] | None:
+        response = await self._request(
+            spec,
+            "GET",
+            f"/admin/realms/{_path(spec.realm)}",
+            token=token,
+            expected=frozenset({200, 404}),
+            code="keycloak_realm_read_failed",
+        )
+        if response.status_code == 404:
+            return None
+        try:
+            return _object(response.json(), "keycloak_realm_read_failed")
+        except (TypeError, ValueError) as exc:
+            raise _fail("keycloak_realm_read_failed") from exc
+
+    async def _reconcile_realm(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> dict[str, Any]:
+        existing = await self._realm(spec, token=token)
+        desired = self._realm_profile(spec)
+        if existing is None:
+            await self._request(
+                spec,
+                "POST",
+                "/admin/realms",
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_realm_create_failed",
+            )
+        else:
+            updated = dict(existing)
+            updated.update(desired)
+            await self._request(
+                spec,
+                "PUT",
+                f"/admin/realms/{_path(spec.realm)}",
+                token=token,
+                json_body=updated,
+                expected=frozenset({204}),
+                code="keycloak_realm_update_failed",
+            )
+        realm = await self._realm(spec, token=token)
+        if realm is None or not self._realm_matches(spec, realm):
+            raise _fail("keycloak_realm_readback_failed")
+        _required_string(realm, "id", "keycloak_realm_readback_failed")
+        return realm
+
+    @staticmethod
+    def _realm_profile(spec: StandaloneSSOBootstrapSpec) -> dict[str, Any]:
+        return {
+            "realm": spec.realm,
+            "enabled": True,
+            "displayName": "AKB",
+            "registrationAllowed": False,
+            "registrationEmailAsUsername": False,
+            "editUsernameAllowed": False,
+            "resetPasswordAllowed": False,
+            "loginWithEmailAllowed": False,
+            "duplicateEmailsAllowed": False,
+            "verifyEmail": False,
+            "bruteForceProtected": True,
+            "passwordPolicy": (  # pragma: allowlist secret
+                "length(12) and notUsername and notEmail"
+            ),
+            "defaultSignatureAlgorithm": "RS256",
+            "adminEventsEnabled": True,
+            # Keycloak's detailed admin events persist the JSON representation
+            # sent to Admin REST. Bootstrap requests contain client secrets and
+            # the one-time product-admin password, so retain operation audit
+            # events but never store their request representations.
+            "adminEventsDetailsEnabled": False,
+        }
+
+    @classmethod
+    def _realm_matches(
+        cls,
+        spec: StandaloneSSOBootstrapSpec,
+        realm: Mapping[str, object],
+    ) -> bool:
+        return all(
+            realm.get(key) == value
+            for key, value in cls._realm_profile(spec).items()
+        )
+
+    async def _list_clients(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        realm: str,
+        client_id: str,
+        *,
+        token: str,
+    ) -> list[dict[str, Any]]:
+        value = await self._json(
+            spec,
+            f"/admin/realms/{_path(realm)}/clients",
+            token=token,
+            params={"clientId": client_id},
+            code="keycloak_client_read_failed",
+        )
+        return _objects(value, "keycloak_client_read_failed")
+
+    async def _exact_client(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        realm: str,
+        client_id: str,
+        *,
+        token: str,
+    ) -> dict[str, Any] | None:
+        clients = await self._list_clients(spec, realm, client_id, token=token)
+        return _exact(
+            clients,
+            "clientId",
+            client_id,
+            "keycloak_client_duplicate",
+        )
+
+    async def _reconcile_client(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        desired: dict[str, Any],
+        *,
+        token: str,
+    ) -> dict[str, Any]:
+        client_id = _required_string(desired, "clientId", "keycloak_client_invalid")
+        existing = await self._exact_client(
+            spec,
+            spec.realm,
+            client_id,
+            token=token,
+        )
+        if existing is None:
+            await self._request(
+                spec,
+                "POST",
+                f"/admin/realms/{_path(spec.realm)}/clients",
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_client_create_failed",
+            )
+        else:
+            client_uuid = _required_string(
+                existing,
+                "id",
+                "keycloak_client_read_failed",
+            )
+            updated = dict(existing)
+            updated.update(desired)
+            await self._request(
+                spec,
+                "PUT",
+                f"/admin/realms/{_path(spec.realm)}/clients/{_path(client_uuid)}",
+                token=token,
+                json_body=updated,
+                expected=frozenset({204}),
+                code="keycloak_client_update_failed",
+            )
+        readback = await self._exact_client(
+            spec,
+            spec.realm,
+            client_id,
+            token=token,
+        )
+        if readback is None:
+            raise _fail("keycloak_client_readback_failed")
+        return readback
+
+    @staticmethod
+    def _api_client(spec: StandaloneSSOBootstrapSpec) -> dict[str, Any]:
+        return {
+            "clientId": spec.api_client_id,
+            "name": "AKB browser and API",
+            "enabled": True,
+            "protocol": "openid-connect",
+            "publicClient": False,
+            "secret": spec.api_client_secret,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": False,
+            "serviceAccountsEnabled": False,
+            "implicitFlowEnabled": False,
+            "fullScopeAllowed": False,
+            "redirectUris": [
+                f"{spec.akb_public_url.rstrip('/')}/api/v1/auth/keycloak/callback"
+            ],
+            "webOrigins": [spec.akb_public_url.rstrip("/")],
+            "defaultClientScopes": ["profile", "email"],
+            "optionalClientScopes": [],
+            "attributes": {
+                "pkce.code.challenge.method": "S256",
+                "post.logout.redirect.uris": f"{spec.akb_public_url.rstrip('/')}/*",
+            },
+        }
+
+    @staticmethod
+    def _admin_client(spec: StandaloneSSOBootstrapSpec) -> dict[str, Any]:
+        return {
+            "clientId": spec.admin_client_id,
+            "name": "AKB product administration",
+            "enabled": True,
+            "protocol": "openid-connect",
+            "publicClient": False,
+            "secret": spec.admin_client_secret,
+            "standardFlowEnabled": True,
+            "directAccessGrantsEnabled": False,
+            "serviceAccountsEnabled": False,
+            "implicitFlowEnabled": False,
+            "fullScopeAllowed": False,
+            "redirectUris": [spec.admin_redirect_uri],
+            "webOrigins": [spec.akb_public_url.rstrip("/")],
+            "defaultClientScopes": ["profile", "email"],
+            "optionalClientScopes": [],
+            "attributes": {
+                "pkce.code.challenge.method": "S256",
+                "post.logout.redirect.uris": spec.admin_post_logout_redirect_uri,
+            },
+        }
+
+    @staticmethod
+    def _management_client(spec: StandaloneSSOBootstrapSpec) -> dict[str, Any]:
+        return {
+            "clientId": spec.management_client_id,
+            "name": "AKB SSO provider management",
+            "enabled": True,
+            "protocol": "openid-connect",
+            "publicClient": False,
+            "secret": spec.management_client_secret,
+            "standardFlowEnabled": False,
+            "directAccessGrantsEnabled": False,
+            "serviceAccountsEnabled": True,
+            "implicitFlowEnabled": False,
+            "fullScopeAllowed": False,
+            "redirectUris": [],
+            "webOrigins": [],
+            # Keycloak attaches this built-in scope to every service-account
+            # client; declaring it makes read-back exact without broadening
+            # realm-management role scope.
+            "defaultClientScopes": ["service_account"],
+            "optionalClientScopes": [],
+        }
+
+    async def _protocol_mappers(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        client_uuid: str,
+        *,
+        token: str,
+    ) -> list[dict[str, Any]]:
+        value = await self._json(
+            spec,
+            (
+                f"/admin/realms/{_path(spec.realm)}/clients/{_path(client_uuid)}"
+                "/protocol-mappers/models"
+            ),
+            token=token,
+            code="keycloak_mapper_read_failed",
+        )
+        return _objects(value, "keycloak_mapper_read_failed")
+
+    async def _reconcile_mapper(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        client_uuid: str,
+        desired: dict[str, Any],
+        *,
+        token: str,
+    ) -> dict[str, Any]:
+        name = _required_string(desired, "name", "keycloak_mapper_invalid")
+        existing = _exact(
+            await self._protocol_mappers(spec, client_uuid, token=token),
+            "name",
+            name,
+            "keycloak_mapper_duplicate",
+        )
+        base = (
+            f"/admin/realms/{_path(spec.realm)}/clients/{_path(client_uuid)}"
+            "/protocol-mappers/models"
+        )
+        if existing is None:
+            await self._request(
+                spec,
+                "POST",
+                base,
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_mapper_create_failed",
+            )
+        else:
+            mapper_id = _required_string(existing, "id", "keycloak_mapper_read_failed")
+            updated = dict(desired)
+            updated["id"] = mapper_id
+            await self._request(
+                spec,
+                "PUT",
+                f"{base}/{_path(mapper_id)}",
+                token=token,
+                json_body=updated,
+                expected=frozenset({204}),
+                code="keycloak_mapper_update_failed",
+            )
+        readback = _exact(
+            await self._protocol_mappers(spec, client_uuid, token=token),
+            "name",
+            name,
+            "keycloak_mapper_duplicate",
+        )
+        if readback is None:
+            raise _fail("keycloak_mapper_readback_failed")
+        return readback
+
+    async def _reconcile_native_amr(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> None:
+        value = await self._json(
+            spec,
+            f"/admin/realms/{_path(spec.realm)}/authentication/flows/browser/executions",
+            token=token,
+            code="keycloak_auth_flow_read_failed",
+        )
+        executions = _objects(value, "keycloak_auth_flow_read_failed")
+        matches = [
+            item
+            for item in executions
+            if item.get("providerId") == "auth-username-password-form"
+        ]
+        if len(matches) != 1:
+            raise _fail("keycloak_native_password_execution_ambiguous")
+        execution = matches[0]
+        execution_id = _required_string(
+            execution,
+            "id",
+            "keycloak_auth_flow_read_failed",
+        )
+        config_id = execution.get("authenticationConfig")
+        desired = {
+            "alias": _NATIVE_AMR_CONFIG_ALIAS,
+            "config": {
+                "default.reference.value": "pwd",
+                "default.reference.maxAge": "300",
+            },
+        }
+        if config_id is None:
+            await self._request(
+                spec,
+                "POST",
+                (
+                    f"/admin/realms/{_path(spec.realm)}/authentication/executions/"
+                    f"{_path(execution_id)}/config"
+                ),
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_native_amr_create_failed",
+            )
+        elif isinstance(config_id, str) and config_id:
+            updated = dict(desired)
+            updated["id"] = config_id
+            await self._request(
+                spec,
+                "PUT",
+                (
+                    f"/admin/realms/{_path(spec.realm)}/authentication/config/"
+                    f"{_path(config_id)}"
+                ),
+                token=token,
+                json_body=updated,
+                expected=frozenset({204}),
+                code="keycloak_native_amr_update_failed",
+            )
+        else:
+            raise _fail("keycloak_auth_flow_read_failed")
+
+    async def _native_amr_readback(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> str:
+        value = await self._json(
+            spec,
+            f"/admin/realms/{_path(spec.realm)}/authentication/flows/browser/executions",
+            token=token,
+            code="keycloak_auth_flow_read_failed",
+        )
+        matches = [
+            item
+            for item in _objects(value, "keycloak_auth_flow_read_failed")
+            if item.get("providerId") == "auth-username-password-form"
+        ]
+        if len(matches) != 1:
+            raise _fail("keycloak_native_password_execution_ambiguous")
+        config_id = matches[0].get("authenticationConfig")
+        if not isinstance(config_id, str) or not config_id:
+            raise _fail("keycloak_native_amr_readback_failed")
+        config = _object(
+            await self._json(
+                spec,
+                (
+                    f"/admin/realms/{_path(spec.realm)}/authentication/config/"
+                    f"{_path(config_id)}"
+                ),
+                token=token,
+                code="keycloak_native_amr_readback_failed",
+            ),
+            "keycloak_native_amr_readback_failed",
+        )
+        if config.get("alias") != _NATIVE_AMR_CONFIG_ALIAS:
+            raise _fail("keycloak_native_amr_readback_failed")
+        values = config.get("config")
+        if (
+            not isinstance(values, dict)
+            or values.get("default.reference.value") != "pwd"
+            or values.get("default.reference.maxAge") != "300"
+        ):
+            raise _fail("keycloak_native_amr_readback_failed")
+        return "pwd"
+
+    async def _reconcile_signing_key(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        realm_id: str,
+        *,
+        token: str,
+    ) -> None:
+        path = f"/admin/realms/{_path(spec.realm)}/components"
+        value = await self._json(
+            spec,
+            path,
+            token=token,
+            params={"parent": realm_id, "type": _KEY_PROVIDER_TYPE},
+            code="keycloak_key_provider_read_failed",
+        )
+        components = _objects(value, "keycloak_key_provider_read_failed")
+        existing = _exact(
+            components,
+            "name",
+            _ACTIVE_KEY_PROVIDER_NAME,
+            "keycloak_key_provider_duplicate",
+        )
+        desired = {
+            "name": _ACTIVE_KEY_PROVIDER_NAME,
+            "providerId": "rsa-generated",
+            "providerType": _KEY_PROVIDER_TYPE,
+            "parentId": realm_id,
+            "config": {
+                "priority": ["200"],
+                "enabled": ["true"],
+                "active": ["true"],
+                "algorithm": ["RS256"],
+                "keySize": ["3072"],
+            },
+        }
+        if existing is None:
+            await self._request(
+                spec,
+                "POST",
+                path,
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_key_provider_create_failed",
+            )
+        else:
+            component_id = _required_string(
+                existing,
+                "id",
+                "keycloak_key_provider_read_failed",
+            )
+            updated = dict(desired)
+            updated["id"] = component_id
+            await self._request(
+                spec,
+                "PUT",
+                f"{path}/{_path(component_id)}",
+                token=token,
+                json_body=updated,
+                expected=frozenset({204}),
+                code="keycloak_key_provider_update_failed",
+            )
+
+    async def _reconcile_management_roles(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        management_uuid: str,
+        *,
+        token: str,
+    ) -> None:
+        realm_path = f"/admin/realms/{_path(spec.realm)}"
+        service_user = _object(
+            await self._json(
+                spec,
+                f"{realm_path}/clients/{_path(management_uuid)}/service-account-user",
+                token=token,
+                code="keycloak_management_service_account_read_failed",
+            ),
+            "keycloak_management_service_account_read_failed",
+        )
+        service_user_id = _required_string(
+            service_user,
+            "id",
+            "keycloak_management_service_account_read_failed",
+        )
+        realm_management = await self._exact_client(
+            spec,
+            spec.realm,
+            "realm-management",
+            token=token,
+        )
+        if realm_management is None:
+            raise _fail("keycloak_realm_management_client_missing")
+        realm_management_uuid = _required_string(
+            realm_management,
+            "id",
+            "keycloak_realm_management_client_missing",
+        )
+        role_base = f"{realm_path}/clients/{_path(realm_management_uuid)}/roles"
+        desired_roles: list[dict[str, Any]] = []
+        for role_name in MANAGEMENT_REALM_ROLES:
+            desired_roles.append(
+                _object(
+                    await self._json(
+                        spec,
+                        f"{role_base}/{_path(role_name)}",
+                        token=token,
+                        code="keycloak_management_role_missing",
+                    ),
+                    "keycloak_management_role_missing",
+                )
+            )
+        mapping_path = (
+            f"{realm_path}/users/{_path(service_user_id)}/role-mappings/clients/"
+            f"{_path(realm_management_uuid)}"
+        )
+        current = _objects(
+            await self._json(
+                spec,
+                mapping_path,
+                token=token,
+                code="keycloak_management_role_read_failed",
+            ),
+            "keycloak_management_role_read_failed",
+        )
+        current_by_name = {
+            _required_string(item, "name", "keycloak_management_role_read_failed"): item
+            for item in current
+        }
+        desired_names = set(MANAGEMENT_REALM_ROLES)
+        extras = [item for name, item in current_by_name.items() if name not in desired_names]
+        missing = [item for item in desired_roles if item.get("name") not in current_by_name]
+        if extras:
+            await self._request(
+                spec,
+                "DELETE",
+                mapping_path,
+                token=token,
+                json_body=extras,
+                expected=frozenset({204}),
+                code="keycloak_management_role_remove_failed",
+            )
+        if missing:
+            await self._request(
+                spec,
+                "POST",
+                mapping_path,
+                token=token,
+                json_body=missing,
+                expected=frozenset({204}),
+                code="keycloak_management_role_assign_failed",
+            )
+
+        # With fullScopeAllowed=false, user role mappings alone are not put in
+        # this client's access token. Scope exactly the same six
+        # realm-management roles so the permanent token is usable without
+        # exposing every role the service account might acquire later.
+        scope_path = (
+            f"{realm_path}/clients/{_path(management_uuid)}/scope-mappings/clients/"
+            f"{_path(realm_management_uuid)}"
+        )
+        current_scope = _objects(
+            await self._json(
+                spec,
+                scope_path,
+                token=token,
+                code="keycloak_management_scope_read_failed",
+            ),
+            "keycloak_management_scope_read_failed",
+        )
+        current_scope_by_name = {
+            _required_string(item, "name", "keycloak_management_scope_read_failed"): item
+            for item in current_scope
+        }
+        scope_extras = [
+            item
+            for name, item in current_scope_by_name.items()
+            if name not in desired_names
+        ]
+        scope_missing = [
+            item for item in desired_roles if item.get("name") not in current_scope_by_name
+        ]
+        if scope_extras:
+            await self._request(
+                spec,
+                "DELETE",
+                scope_path,
+                token=token,
+                json_body=scope_extras,
+                expected=frozenset({204}),
+                code="keycloak_management_scope_remove_failed",
+            )
+        if scope_missing:
+            await self._request(
+                spec,
+                "POST",
+                scope_path,
+                token=token,
+                json_body=scope_missing,
+                expected=frozenset({204}),
+                code="keycloak_management_scope_assign_failed",
+            )
+
+    async def _management_roles(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        management_uuid: str,
+        *,
+        token: str,
+    ) -> tuple[str, ...]:
+        realm_path = f"/admin/realms/{_path(spec.realm)}"
+        service_user = _object(
+            await self._json(
+                spec,
+                f"{realm_path}/clients/{_path(management_uuid)}/service-account-user",
+                token=token,
+                code="keycloak_management_service_account_read_failed",
+            ),
+            "keycloak_management_service_account_read_failed",
+        )
+        service_user_id = _required_string(
+            service_user,
+            "id",
+            "keycloak_management_service_account_read_failed",
+        )
+        realm_management = await self._exact_client(
+            spec,
+            spec.realm,
+            "realm-management",
+            token=token,
+        )
+        if realm_management is None:
+            raise _fail("keycloak_realm_management_client_missing")
+        realm_management_uuid = _required_string(
+            realm_management,
+            "id",
+            "keycloak_realm_management_client_missing",
+        )
+        roles = _objects(
+            await self._json(
+                spec,
+                (
+                    f"{realm_path}/users/{_path(service_user_id)}/role-mappings/clients/"
+                    f"{_path(realm_management_uuid)}"
+                ),
+                token=token,
+                code="keycloak_management_role_read_failed",
+            ),
+            "keycloak_management_role_read_failed",
+        )
+        return tuple(
+            sorted(
+                _required_string(item, "name", "keycloak_management_role_read_failed")
+                for item in roles
+            )
+        )
+
+    async def _management_scope_roles(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        management_uuid: str,
+        *,
+        token: str,
+    ) -> tuple[str, ...]:
+        realm_management = await self._exact_client(
+            spec,
+            spec.realm,
+            "realm-management",
+            token=token,
+        )
+        if realm_management is None:
+            raise _fail("keycloak_realm_management_client_missing")
+        realm_management_uuid = _required_string(
+            realm_management,
+            "id",
+            "keycloak_realm_management_client_missing",
+        )
+        roles = _objects(
+            await self._json(
+                spec,
+                (
+                    f"/admin/realms/{_path(spec.realm)}/clients/"
+                    f"{_path(management_uuid)}/scope-mappings/clients/"
+                    f"{_path(realm_management_uuid)}"
+                ),
+                token=token,
+                code="keycloak_management_scope_read_failed",
+            ),
+            "keycloak_management_scope_read_failed",
+        )
+        return tuple(
+            sorted(
+                _required_string(item, "name", "keycloak_management_scope_read_failed")
+                for item in roles
+            )
+        )
+
+    async def _exact_user(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> dict[str, Any] | None:
+        value = await self._json(
+            spec,
+            f"/admin/realms/{_path(spec.realm)}/users",
+            token=token,
+            params={"username": spec.product_admin_username, "exact": "true"},
+            code="keycloak_product_admin_read_failed",
+        )
+        return _exact(
+            _objects(value, "keycloak_product_admin_read_failed"),
+            "username",
+            spec.product_admin_username,
+            "keycloak_product_admin_duplicate",
+        )
+
+    async def _reconcile_product_admin(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> dict[str, Any]:
+        existing = await self._exact_user(spec, token=token)
+        if not spec.product_admin_password:
+            raise _fail("keycloak_product_admin_password_unavailable")
+        if existing is None:
+            desired = {
+                "username": spec.product_admin_username,
+                "email": spec.product_admin_email,
+                "enabled": True,
+                "emailVerified": True,
+                "firstName": "AKB",
+                "lastName": "Product Administrator",
+                "requiredActions": ["UPDATE_PASSWORD"],
+                "credentials": [
+                    {
+                        "type": "password",
+                        "value": spec.product_admin_password,
+                        "temporary": True,
+                    }
+                ],
+            }
+            await self._request(
+                spec,
+                "POST",
+                f"/admin/realms/{_path(spec.realm)}/users",
+                token=token,
+                json_body=desired,
+                expected=frozenset({201}),
+                code="keycloak_product_admin_create_failed",
+            )
+            user = await self._exact_user(spec, token=token)
+        else:
+            user = existing
+        if user is None:
+            raise _fail("keycloak_product_admin_readback_failed")
+        if not self._product_admin_is_native(user):
+            raise _fail("keycloak_admin_identity_is_federated")
+        if not self._product_admin_matches(spec, user):
+            raise _fail("keycloak_product_admin_readback_failed")
+        if existing is not None:
+            user_id = _required_string(
+                user,
+                "id",
+                "keycloak_product_admin_readback_failed",
+            )
+            if await self._federated_identity_count(
+                spec,
+                user_id,
+                token=token,
+            ):
+                # Never add a local recovery credential to a brokered user.
+                # The dedicated product admin must remain realm-native.
+                raise _fail("keycloak_admin_identity_is_federated")
+            await self._request(
+                spec,
+                "PUT",
+                (
+                    f"/admin/realms/{_path(spec.realm)}/users/{_path(user_id)}"
+                    "/reset-password"
+                ),
+                token=token,
+                json_body={
+                    "type": "password",
+                    "value": spec.product_admin_password,
+                    "temporary": True,
+                },
+                expected=frozenset({204}),
+                code="keycloak_product_admin_password_reset_failed",
+            )
+            user = await self._exact_user(spec, token=token)
+            if user is None:
+                raise _fail("keycloak_product_admin_readback_failed")
+            if not self._product_admin_is_native(user):
+                raise _fail("keycloak_admin_identity_is_federated")
+            if not self._product_admin_matches(spec, user):
+                raise _fail("keycloak_product_admin_readback_failed")
+        if user.get("requiredActions") != ["UPDATE_PASSWORD"]:
+            raise _fail("keycloak_product_admin_update_password_missing")
+        await self._require_product_admin_password(spec, user, token=token)
+        return user
+
+    @staticmethod
+    def _product_admin_is_native(user: Mapping[str, object]) -> bool:
+        return user.get("federationLink") in {None, ""}
+
+    @staticmethod
+    def _product_admin_matches(
+        spec: StandaloneSSOBootstrapSpec,
+        user: Mapping[str, object],
+    ) -> bool:
+        return (
+            user.get("email") == spec.product_admin_email
+            and user.get("enabled") is True
+            and user.get("emailVerified") is True
+        )
+
+    async def _require_product_admin_password(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        user: Mapping[str, object],
+        *,
+        token: str,
+    ) -> None:
+        user_id = _required_string(user, "id", "keycloak_product_admin_readback_failed")
+        credentials = _objects(
+            await self._json(
+                spec,
+                f"/admin/realms/{_path(spec.realm)}/users/{_path(user_id)}/credentials",
+                token=token,
+                code="keycloak_product_admin_credential_read_failed",
+            ),
+            "keycloak_product_admin_credential_read_failed",
+        )
+        if not any(item.get("type") == "password" for item in credentials):
+            raise _fail("keycloak_product_admin_password_missing")
+
+    async def _federated_identity_count(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        user_id: str,
+        *,
+        token: str,
+    ) -> int:
+        value = await self._json(
+            spec,
+            (
+                f"/admin/realms/{_path(spec.realm)}/users/{_path(user_id)}"
+                "/federated-identity"
+            ),
+            token=token,
+            code="keycloak_product_admin_federation_read_failed",
+        )
+        return len(_objects(value, "keycloak_product_admin_federation_read_failed"))
+
+    async def _key_readback(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        token: str,
+    ) -> tuple[str, int, int]:
+        body = _object(
+            await self._json(
+                spec,
+                f"/admin/realms/{_path(spec.realm)}/keys",
+                token=token,
+                code="keycloak_keys_read_failed",
+            ),
+            "keycloak_keys_read_failed",
+        )
+        active = body.get("active")
+        if not isinstance(active, dict):
+            raise _fail("keycloak_keys_read_failed")
+        active_kid = active.get("RS256")
+        if not isinstance(active_kid, str) or not active_kid:
+            raise _fail("keycloak_active_rs256_key_missing")
+        keys = _objects(body.get("keys"), "keycloak_keys_read_failed")
+        matching = [
+            item
+            for item in keys
+            if item.get("kid") == active_kid
+            and item.get("algorithm") == "RS256"
+            and str(item.get("use", "")).upper() == "SIG"
+        ]
+        if len(matching) != 1:
+            raise _fail("keycloak_active_rs256_key_ambiguous")
+        public_key = matching[0].get("publicKey")
+        if not isinstance(public_key, str) or not public_key:
+            raise _fail("keycloak_active_rs256_key_invalid")
+        active_bits = _rsa_public_key_size(public_key)
+        passive = sum(
+            1
+            for item in keys
+            if item.get("algorithm") == "RS256"
+            and str(item.get("use", "")).upper() == "SIG"
+            and item.get("kid") != active_kid
+            and str(item.get("status", "")).upper() != "DISABLED"
+        )
+        return active_kid, active_bits, passive
+
+    @staticmethod
+    def _selected_client_matches(
+        actual: Mapping[str, object],
+        expected: Mapping[str, object],
+    ) -> bool:
+        fields = (
+            "clientId",
+            "enabled",
+            "protocol",
+            "publicClient",
+            "standardFlowEnabled",
+            "directAccessGrantsEnabled",
+            "serviceAccountsEnabled",
+            "implicitFlowEnabled",
+            "fullScopeAllowed",
+            "redirectUris",
+            "webOrigins",
+        )
+        if not all(actual.get(field) == expected.get(field) for field in fields):
+            return False
+        for field in ("defaultClientScopes", "optionalClientScopes"):
+            actual_values = actual.get(field)
+            expected_values = expected.get(field)
+            if not isinstance(actual_values, list) or not isinstance(
+                expected_values,
+                list,
+            ):
+                return False
+            if set(actual_values) != set(expected_values):
+                return False
+        actual_attributes = actual.get("attributes")
+        expected_attributes = expected.get("attributes", {})
+        if not isinstance(actual_attributes, dict) or not isinstance(
+            expected_attributes,
+            dict,
+        ):
+            return False
+        return all(
+            actual_attributes.get(key) == value
+            for key, value in expected_attributes.items()
+        )
+
+    async def reconcile(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> StandaloneSSOReadback:
+        realm = await self._reconcile_realm(spec, token=bootstrap_token)
+        realm_id = _required_string(realm, "id", "keycloak_realm_readback_failed")
+        await self._reconcile_signing_key(
+            spec,
+            realm_id,
+            token=bootstrap_token,
+        )
+        await self._reconcile_native_amr(spec, token=bootstrap_token)
+
+        api = await self._reconcile_client(
+            spec,
+            self._api_client(spec),
+            token=bootstrap_token,
+        )
+        admin = await self._reconcile_client(
+            spec,
+            self._admin_client(spec),
+            token=bootstrap_token,
+        )
+        management = await self._reconcile_client(
+            spec,
+            self._management_client(spec),
+            token=bootstrap_token,
+        )
+        api_uuid = _required_string(api, "id", "keycloak_client_readback_failed")
+        admin_uuid = _required_string(admin, "id", "keycloak_client_readback_failed")
+        management_uuid = _required_string(
+            management,
+            "id",
+            "keycloak_client_readback_failed",
+        )
+        await self._reconcile_mapper(
+            spec,
+            api_uuid,
+            {
+                "name": _API_AUDIENCE_MAPPER_NAME,
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": False,
+                "config": {
+                    "included.custom.audience": (
+                        f"{spec.akb_public_url.rstrip('/')}/api"
+                    ),
+                    "id.token.claim": "false",
+                    "access.token.claim": "true",
+                    "lightweight.claim": "false",
+                },
+            },
+            token=bootstrap_token,
+        )
+        await self._reconcile_mapper(
+            spec,
+            admin_uuid,
+            {
+                "name": _ADMIN_AMR_MAPPER_NAME,
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-amr-mapper",
+                "consentRequired": False,
+                "config": {
+                    "id.token.claim": "true",
+                    "access.token.claim": "false",
+                    "lightweight.claim": "false",
+                },
+            },
+            token=bootstrap_token,
+        )
+        await self._reconcile_management_roles(
+            spec,
+            management_uuid,
+            token=bootstrap_token,
+        )
+        await self._reconcile_product_admin(spec, token=bootstrap_token)
+        return await self.readback(spec, management_token=bootstrap_token)
+
+    async def readback(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        management_token: str,
+    ) -> StandaloneSSOReadback:
+        realm = await self._realm(spec, token=management_token)
+        if realm is None or not self._realm_matches(spec, realm):
+            raise _fail("keycloak_realm_readback_failed")
+        realm_id = _required_string(realm, "id", "keycloak_realm_readback_failed")
+
+        expected_clients = (
+            (self._api_client(spec), "api"),
+            (self._admin_client(spec), "admin"),
+            (self._management_client(spec), "management"),
+        )
+        clients: dict[str, dict[str, Any]] = {}
+        for expected, role in expected_clients:
+            client_id = _required_string(expected, "clientId", "keycloak_client_invalid")
+            actual = await self._exact_client(
+                spec,
+                spec.realm,
+                client_id,
+                token=management_token,
+            )
+            if actual is None or not self._selected_client_matches(actual, expected):
+                raise _fail("keycloak_client_readback_failed")
+            clients[role] = actual
+        api_uuid = _required_string(clients["api"], "id", "keycloak_client_readback_failed")
+        admin_uuid = _required_string(
+            clients["admin"],
+            "id",
+            "keycloak_client_readback_failed",
+        )
+        management_uuid = _required_string(
+            clients["management"],
+            "id",
+            "keycloak_client_readback_failed",
+        )
+
+        api_mapper = _exact(
+            await self._protocol_mappers(spec, api_uuid, token=management_token),
+            "name",
+            _API_AUDIENCE_MAPPER_NAME,
+            "keycloak_mapper_duplicate",
+        )
+        if (
+            api_mapper is None
+            or api_mapper.get("protocolMapper") != "oidc-audience-mapper"
+            or not isinstance(api_mapper.get("config"), dict)
+            or api_mapper["config"].get("included.custom.audience")
+            != f"{spec.akb_public_url.rstrip('/')}/api"
+            or api_mapper["config"].get("id.token.claim") != "false"
+            or api_mapper["config"].get("access.token.claim") != "true"
+        ):
+            raise _fail("keycloak_api_audience_readback_failed")
+        admin_mapper = _exact(
+            await self._protocol_mappers(spec, admin_uuid, token=management_token),
+            "name",
+            _ADMIN_AMR_MAPPER_NAME,
+            "keycloak_mapper_duplicate",
+        )
+        if (
+            admin_mapper is None
+            or admin_mapper.get("protocolMapper") != "oidc-amr-mapper"
+            or not isinstance(admin_mapper.get("config"), dict)
+            or admin_mapper["config"].get("id.token.claim") != "true"
+            or admin_mapper["config"].get("access.token.claim") != "false"
+        ):
+            raise _fail("keycloak_admin_amr_mapper_readback_failed")
+
+        product_admin = await self._exact_user(spec, token=management_token)
+        if product_admin is None:
+            raise _fail("keycloak_product_admin_readback_failed")
+        if not self._product_admin_is_native(product_admin):
+            raise _fail("keycloak_admin_identity_is_federated")
+        if not self._product_admin_matches(
+            spec,
+            product_admin,
+        ):
+            raise _fail("keycloak_product_admin_readback_failed")
+        await self._require_product_admin_password(
+            spec,
+            product_admin,
+            token=management_token,
+        )
+        product_admin_id = _required_string(
+            product_admin,
+            "id",
+            "keycloak_product_admin_readback_failed",
+        )
+        federation_count = await self._federated_identity_count(
+            spec,
+            product_admin_id,
+            token=management_token,
+        )
+        active_kid, active_bits, passive = await self._key_readback(
+            spec,
+            token=management_token,
+        )
+        native_amr = await self._native_amr_readback(
+            spec,
+            token=management_token,
+        )
+        roles = await self._management_roles(
+            spec,
+            management_uuid,
+            token=management_token,
+        )
+        scope_roles = await self._management_scope_roles(
+            spec,
+            management_uuid,
+            token=management_token,
+        )
+        return StandaloneSSOReadback(
+            realm_id=realm_id,
+            product_admin_subject=product_admin_id,
+            admin_client_uuid=admin_uuid,
+            management_client_uuid=management_uuid,
+            api_client_uuid=api_uuid,
+            active_signing_kid=active_kid,
+            active_signing_bits=active_bits,
+            passive_rs256_keys=passive,
+            management_roles=roles,
+            management_scope_roles=scope_roles,
+            admin_native_amr=native_amr,
+            product_admin_federated_identities=federation_count,
+        )
+
+    async def retire_bootstrap(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> None:
+        if _CLIENT_ID_RE.fullmatch(spec.bootstrap_client_id) is None:
+            raise _fail("keycloak_bootstrap_client_id_invalid")
+        client = await self._exact_client(
+            spec,
+            "master",
+            spec.bootstrap_client_id,
+            token=bootstrap_token,
+        )
+        if client is None:
+            raise _fail("keycloak_bootstrap_client_missing")
+        client_uuid = _required_string(
+            client,
+            "id",
+            "keycloak_bootstrap_client_invalid",
+        )
+        await self._request(
+            spec,
+            "DELETE",
+            f"/admin/realms/master/clients/{_path(client_uuid)}",
+            token=bootstrap_token,
+            expected=frozenset({204}),
+            code="keycloak_bootstrap_client_retire_failed",
+        )
+
+    async def assert_bootstrap_retired(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        bootstrap_token: str,
+    ) -> None:
+        for attempt in range(5):
+            prior = await self._request(
+                spec,
+                "GET",
+                "/admin/realms/master",
+                token=bootstrap_token,
+                expected=frozenset({200, 401, 403}),
+                code="keycloak_bootstrap_retirement_check_failed",
+            )
+            prior_token_denied = prior.status_code in {401, 403}
+            new_token_denied = await self.acquire_bootstrap(spec) is None
+            if prior_token_denied and new_token_denied:
+                return
+            if attempt < 4:
+                await asyncio.sleep(0.5)
+        raise _fail("keycloak_bootstrap_client_still_active")

--- a/backend/app/services/standalone_sso_receipt.py
+++ b/backend/app/services/standalone_sso_receipt.py
@@ -1,0 +1,117 @@
+"""Durable, non-secret evidence for standalone SSO bootstrap retirement."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.db.postgres import get_pool
+from app.services.standalone_sso_bootstrap import (
+    STANDALONE_SSO_RECEIPT_PROFILE,
+    StandaloneSSOBootstrapError,
+    StandaloneSSORetirementReceipt,
+)
+
+
+# Stable signed-bigint key ("AKBSSORP") serializes the singleton receipt write.
+_RECEIPT_LOCK_ID = 0x414B4253534F5250
+
+_SELECT_RECEIPT = """
+    SELECT profile, issuer, realm_id, bootstrap_client_id,
+           management_client_uuid, admin_client_uuid, api_client_uuid,
+           product_admin_subject, akb_user_id
+      FROM standalone_sso_bootstrap_retirements
+     WHERE profile = $1
+"""
+
+
+def _error() -> StandaloneSSOBootstrapError:
+    return StandaloneSSOBootstrapError(
+        "keycloak_bootstrap_retirement_receipt_mismatch"
+    )
+
+
+def _validated_user_id(receipt: StandaloneSSORetirementReceipt) -> uuid.UUID:
+    fields = (
+        receipt.issuer,
+        receipt.realm_id,
+        receipt.bootstrap_client_id,
+        receipt.management_client_uuid,
+        receipt.admin_client_uuid,
+        receipt.api_client_uuid,
+        receipt.product_admin_subject,
+        receipt.akb_user_id,
+    )
+    if receipt.profile != STANDALONE_SSO_RECEIPT_PROFILE or any(
+        not value.strip() for value in fields
+    ):
+        raise _error()
+    try:
+        return uuid.UUID(receipt.akb_user_id)
+    except (ValueError, AttributeError):
+        raise _error() from None
+
+
+def _from_row(row) -> StandaloneSSORetirementReceipt:
+    return StandaloneSSORetirementReceipt(
+        profile=row["profile"],
+        issuer=row["issuer"],
+        realm_id=row["realm_id"],
+        bootstrap_client_id=row["bootstrap_client_id"],
+        management_client_uuid=row["management_client_uuid"],
+        admin_client_uuid=row["admin_client_uuid"],
+        api_client_uuid=row["api_client_uuid"],
+        product_admin_subject=row["product_admin_subject"],
+        akb_user_id=str(row["akb_user_id"]),
+    )
+
+
+async def load_standalone_sso_retirement_receipt(
+) -> StandaloneSSORetirementReceipt | None:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            _SELECT_RECEIPT,
+            STANDALONE_SSO_RECEIPT_PROFILE,
+        )
+    return None if row is None else _from_row(row)
+
+
+async def record_standalone_sso_retirement_receipt(
+    receipt: StandaloneSSORetirementReceipt,
+) -> None:
+    """Insert once after verified deletion; never replace conflicting proof."""
+
+    akb_user_id = _validated_user_id(receipt)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock($1::bigint)",
+                _RECEIPT_LOCK_ID,
+            )
+            existing = await conn.fetchrow(
+                _SELECT_RECEIPT,
+                STANDALONE_SSO_RECEIPT_PROFILE,
+            )
+            if existing is not None:
+                if _from_row(existing) != receipt:
+                    raise _error()
+                return
+            await conn.execute(
+                """
+                INSERT INTO standalone_sso_bootstrap_retirements (
+                    profile, issuer, realm_id, bootstrap_client_id,
+                    management_client_uuid, admin_client_uuid, api_client_uuid,
+                    product_admin_subject, akb_user_id
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                """,
+                receipt.profile,
+                receipt.issuer,
+                receipt.realm_id,
+                receipt.bootstrap_client_id,
+                receipt.management_client_uuid,
+                receipt.admin_client_uuid,
+                receipt.api_client_uuid,
+                receipt.product_admin_subject,
+                akb_user_id,
+            )

--- a/backend/tests/test_admin_auth_boundary_unit.py
+++ b/backend/tests/test_admin_auth_boundary_unit.py
@@ -63,9 +63,10 @@ async def test_admin_authorization_request_uses_dedicated_client_pkce_and_nonce(
     assert query["response_type"] == ["code"]
     assert query["scope"] == ["openid profile email"]
     assert query["code_challenge_method"] == ["S256"]
+    assert query["prompt"] == ["login"]
+    assert query["max_age"] == ["0"]
     assert "code_challenge" in query
     assert "nonce" in query
-    assert "prompt" not in query
     assert issued == [
         (
             query["state"][0],
@@ -195,6 +196,7 @@ async def test_admin_id_token_requires_exact_client_nonce_and_human_session(
             "sub": str(uuid.uuid4()),
             "sid": str(uuid.uuid4()),
             "nonce": expected_nonce,
+            "amr": ["pwd"],
             "iat": now,
             "exp": now + 300,
         }
@@ -221,6 +223,10 @@ async def test_admin_id_token_requires_exact_client_nonce_and_human_session(
         mint(nonce="관리자-nonce"),
         mint(aud="akb-web"),
         mint(azp="akb-web"),
+        mint(amr=[]),
+        mint(amr=["pwd", "otp"]),
+        mint(amr=["broker"]),
+        mint(amr="pwd"),
         mint(sid=""),
         mint(iat=str(now)),
         mint(exp=str(now + 300)),

--- a/backend/tests/test_recovery_admin_cli_unit.py
+++ b/backend/tests/test_recovery_admin_cli_unit.py
@@ -26,16 +26,60 @@ def _result(*, mode: str, created: bool = True) -> dict:
 
 
 def _patch_database(monkeypatch):
+    from app import cli
     from app.db import postgres
 
-    async def _init_db():
+    async def _initialize_operator_database():
         return None
 
     async def _close_pool():
         return None
 
-    monkeypatch.setattr(postgres, "init_db", _init_db)
+    monkeypatch.setattr(
+        cli,
+        "_initialize_operator_database",
+        _initialize_operator_database,
+    )
     monkeypatch.setattr(postgres, "close_pool", _close_pool)
+
+
+async def test_operator_database_initialization_installs_role_sync(monkeypatch):
+    from app import cli
+    from app.db import postgres
+    from app.services import role_sync
+
+    events: list[object] = []
+    pool = object()
+
+    async def _init_db():
+        events.append("init-db")
+
+    async def _get_pool():
+        events.append("get-pool")
+        return pool
+
+    class _RoleSync:
+        def __init__(self, actual_pool):
+            assert actual_pool is pool
+            events.append("construct-role-sync")
+
+    def _set_role_sync(instance):
+        assert isinstance(instance, _RoleSync)
+        events.append("set-role-sync")
+
+    monkeypatch.setattr(postgres, "init_db", _init_db)
+    monkeypatch.setattr(postgres, "get_pool", _get_pool)
+    monkeypatch.setattr(role_sync, "RoleSync", _RoleSync)
+    monkeypatch.setattr(role_sync, "set_role_sync", _set_role_sync)
+
+    await cli._initialize_operator_database()
+
+    assert events == [
+        "init-db",
+        "get-pool",
+        "construct-role-sync",
+        "set-role-sync",
+    ]
 
 
 async def test_generated_password_is_only_written_to_requested_0600_file(

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import uuid
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
@@ -523,3 +524,55 @@ async def test_migration_upgrades_old_schema_and_is_idempotent(services):
     assert snapshot_column is True
     assert constraint == 1
     assert unique_index == 1
+
+
+async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(
+    services,
+    monkeypatch,
+):
+    pool, _, _, _, _, _ = services
+    from app.db.postgres import _load_migration
+    from app.services import standalone_sso_receipt as receipt_service
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE,
+        StandaloneSSOBootstrapError,
+        StandaloneSSORetirementReceipt,
+    )
+
+    async with pool.acquire() as conn:
+        await conn.execute("DROP TABLE standalone_sso_bootstrap_retirements")
+        migration = _load_migration("073_sso_bootstrap_receipt.py")
+        assert migration is not None
+        await migration.migrate(conn)
+        await migration.migrate(conn)
+
+    async def _get_pool():
+        return pool
+
+    monkeypatch.setattr(receipt_service, "get_pool", _get_pool)
+    expected = StandaloneSSORetirementReceipt(
+        profile=STANDALONE_SSO_RECEIPT_PROFILE,
+        issuer="https://auth.akb.example.com/realms/akb",
+        realm_id="akb-realm-id",
+        bootstrap_client_id="akb-bootstrap-temporary",
+        management_client_uuid="management-client-uuid",
+        admin_client_uuid="admin-client-uuid",
+        api_client_uuid="api-client-uuid",
+        product_admin_subject="00000000-0000-4000-8000-000000000001",
+        akb_user_id="11111111-1111-4111-8111-111111111111",
+    )
+
+    assert await receipt_service.load_standalone_sso_retirement_receipt() is None
+    await receipt_service.record_standalone_sso_retirement_receipt(expected)
+    await receipt_service.record_standalone_sso_retirement_receipt(expected)
+    assert await receipt_service.load_standalone_sso_retirement_receipt() == expected
+
+    with pytest.raises(StandaloneSSOBootstrapError):
+        await receipt_service.record_standalone_sso_retirement_receipt(
+            replace(expected, issuer="https://other.example.com/realms/akb")
+        )
+
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM standalone_sso_bootstrap_retirements"
+        ) == 1

--- a/backend/tests/test_standalone_sso_bootstrap_unit.py
+++ b/backend/tests/test_standalone_sso_bootstrap_unit.py
@@ -1,0 +1,542 @@
+"""Lifecycle contracts for the standalone SSO installation bootstrap."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, replace
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BOOTSTRAP_SECRET = "temporary-bootstrap-secret-must-not-leak"  # pragma: allowlist secret
+_MANAGEMENT_SECRET = "permanent-management-secret-must-not-leak"  # pragma: allowlist secret
+_ADMIN_CLIENT_SECRET = "admin-browser-secret-must-not-leak"  # pragma: allowlist secret
+_PRODUCT_ADMIN_PASSWORD = "one-time-product-admin-password"  # pragma: allowlist secret
+
+
+def _spec():
+    from app.services.standalone_sso_bootstrap import StandaloneSSOBootstrapSpec
+
+    return StandaloneSSOBootstrapSpec(
+        keycloak_internal_url="http://keycloak:8080",
+        keycloak_public_url="https://auth.akb.example.com",
+        realm="akb",
+        akb_public_url="https://akb.example.com",
+        bootstrap_client_id="akb-bootstrap-temporary",
+        bootstrap_client_secret=_BOOTSTRAP_SECRET,
+        management_client_id="akb-sso-manager",
+        management_client_secret=_MANAGEMENT_SECRET,
+        api_client_id="akb-web",
+        api_client_secret="api-browser-secret-must-not-leak",  # pragma: allowlist secret
+        admin_client_id="akb-admin",
+        admin_client_secret=_ADMIN_CLIENT_SECRET,
+        product_admin_username="product-admin",
+        product_admin_email="product-admin@example.com",
+        product_admin_password=_PRODUCT_ADMIN_PASSWORD,
+    )
+
+
+def _readback():
+    from app.services.standalone_sso_bootstrap import StandaloneSSOReadback
+
+    return StandaloneSSOReadback(
+        realm_id="akb-realm-id",
+        product_admin_subject="00000000-0000-4000-8000-000000000001",
+        admin_client_uuid="admin-client-uuid",
+        management_client_uuid="management-client-uuid",
+        api_client_uuid="api-client-uuid",
+        active_signing_kid="rsa-3072-active-kid",
+        active_signing_bits=3072,
+        passive_rs256_keys=1,
+        management_roles=(
+            "manage-identity-providers",
+            "query-clients",
+            "query-users",
+            "view-clients",
+            "view-realm",
+            "view-users",
+        ),
+        management_scope_roles=(
+            "manage-identity-providers",
+            "query-clients",
+            "query-users",
+            "view-clients",
+            "view-realm",
+            "view-users",
+        ),
+        admin_native_amr="pwd",
+        product_admin_federated_identities=0,
+    )
+
+
+def _receipt(*, user_id: str = "11111111-1111-4111-8111-111111111111"):
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE,
+        StandaloneSSORetirementReceipt,
+    )
+
+    readback = _readback()
+    return StandaloneSSORetirementReceipt(
+        profile=STANDALONE_SSO_RECEIPT_PROFILE,
+        issuer=_spec().issuer,
+        realm_id=readback.realm_id,
+        bootstrap_client_id=_spec().bootstrap_client_id,
+        management_client_uuid=readback.management_client_uuid,
+        admin_client_uuid=readback.admin_client_uuid,
+        api_client_uuid=readback.api_client_uuid,
+        product_admin_subject=readback.product_admin_subject,
+        akb_user_id=user_id,
+    )
+
+
+class _Control:
+    def __init__(self, *, manager_available: bool, bootstrap_available: bool):
+        self.manager_available = manager_available
+        self.bootstrap_available = bootstrap_available
+        self.events: list[str] = []
+        self._readback = _readback()
+
+    async def acquire_management(self, _spec):
+        self.events.append("acquire-management")
+        return "manager-token" if self.manager_available else None
+
+    async def acquire_bootstrap(self, _spec):
+        self.events.append("acquire-bootstrap")
+        return "bootstrap-token" if self.bootstrap_available else None
+
+    async def reconcile(self, _spec, *, bootstrap_token: str):
+        assert bootstrap_token == "bootstrap-token"
+        self.events.append("reconcile-keycloak")
+        self.manager_available = True
+        return self._readback
+
+    async def readback(self, _spec, *, management_token: str):
+        assert management_token == "manager-token"
+        self.events.append("readback-keycloak")
+        return self._readback
+
+    async def retire_bootstrap(self, _spec, *, bootstrap_token: str):
+        assert bootstrap_token == "bootstrap-token"
+        self.events.append("retire-bootstrap")
+        self.bootstrap_available = False
+
+    async def assert_bootstrap_retired(self, _spec, *, bootstrap_token: str):
+        assert bootstrap_token == "bootstrap-token"
+        self.events.append("assert-bootstrap-retired")
+        assert self.bootstrap_available is False
+
+
+class _ReceiptStore:
+    def __init__(self, events: list[str], receipt=None):
+        self.events = events
+        self.receipt = receipt
+
+    async def load(self):
+        self.events.append("load-retirement-receipt")
+        return self.receipt
+
+    async def record(self, receipt):
+        self.events.append("record-retirement-receipt")
+        self.receipt = receipt
+
+
+async def test_fresh_bootstrap_retires_temporary_admin_only_after_akb_projection():
+    from app.services.standalone_sso_bootstrap import bootstrap_standalone_sso
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _provision(**kwargs):
+        control.events.append("provision-akb-admin")
+        assert kwargs == {
+            "username": "product-admin",
+            "email": "product-admin@example.com",
+            "issuer": "https://auth.akb.example.com/realms/akb",
+            "subject": "00000000-0000-4000-8000-000000000001",
+        }
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": True,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    report = await bootstrap_standalone_sso(
+        _spec(),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert control.events == [
+        "load-retirement-receipt",
+        "acquire-management",
+        "acquire-bootstrap",
+        "reconcile-keycloak",
+        "provision-akb-admin",
+        "acquire-management",
+        "readback-keycloak",
+        "retire-bootstrap",
+        "assert-bootstrap-retired",
+        "record-retirement-receipt",
+        "load-retirement-receipt",
+    ]
+    assert receipts.receipt == _receipt()
+    assert report["mode"] == "fresh"
+    assert report["bootstrap_admin_retired"] is True
+    assert report["product_admin_subject"] == _readback().product_admin_subject
+    assert report["akb_user_id"] == "11111111-1111-4111-8111-111111111111"
+    assert report["active_signing_bits"] == 3072
+    serialized = str(report)
+    for secret in (
+        _BOOTSTRAP_SECRET,
+        _MANAGEMENT_SECRET,
+        _ADMIN_CLIENT_SECRET,
+        _PRODUCT_ADMIN_PASSWORD,
+        "api-browser-secret-must-not-leak",
+    ):
+        assert secret not in serialized
+
+
+async def test_completed_bootstrap_rerun_is_read_only_and_does_not_need_temp_admin():
+    from app.services.standalone_sso_bootstrap import bootstrap_standalone_sso
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(control.events, _receipt())
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    report = await bootstrap_standalone_sso(
+        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert control.events == [
+        "load-retirement-receipt",
+        "acquire-management",
+        "acquire-bootstrap",
+        "readback-keycloak",
+        "provision-akb-admin",
+        "acquire-management",
+        "readback-keycloak",
+    ]
+    assert report["mode"] == "readback"
+    assert report["keycloak_mutated"] is False
+    assert report["akb_admin_created"] is False
+
+
+async def test_partial_bootstrap_uses_remaining_temp_admin_then_retires_it():
+    from app.services.standalone_sso_bootstrap import bootstrap_standalone_sso
+
+    control = _Control(manager_available=True, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    report = await bootstrap_standalone_sso(
+        _spec(),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert "reconcile-keycloak" in control.events
+    assert control.events.index("retire-bootstrap") > control.events.index(
+        "provision-akb-admin"
+    )
+    assert report["mode"] == "recovery"
+
+
+async def test_akb_projection_failure_preserves_temporary_recovery_credential():
+    from app.services.standalone_sso_bootstrap import bootstrap_standalone_sso
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _fail(**_kwargs):
+        control.events.append("provision-akb-admin")
+        raise RuntimeError("database unavailable")
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await bootstrap_standalone_sso(
+            _spec(),
+            control=control,
+            provision_admin=_fail,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert "retire-bootstrap" not in control.events
+    assert control.bootstrap_available is True
+
+
+async def test_no_authorized_install_credential_fails_closed():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=False)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("AKB projection must not run")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            _spec(),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_install_credential_unavailable"
+
+
+async def test_master_realm_can_never_be_selected_as_the_akb_product_realm():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("master-realm refusal must precede projection")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), realm="master"),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_product_realm_invalid"
+    assert control.events == []
+
+
+async def test_invalid_bootstrap_client_id_stops_before_external_calls():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("invalid destructive target must fail during preflight")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), bootstrap_client_id="../other-client"),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_client_id_invalid"
+    assert control.events == []
+
+
+async def test_removed_bootstrap_secret_without_retirement_receipt_fails_closed():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(control.events)
+    spec = replace(_spec(), bootstrap_client_secret="", product_admin_password="")
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("AKB projection must not run without retirement evidence")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            spec,
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_retirement_receipt_missing"
+    assert control.events == [
+        "load-retirement-receipt",
+        "acquire-management",
+        "acquire-bootstrap",
+    ]
+
+
+async def test_missing_product_admin_password_stops_before_keycloak_mutation():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("projection must not run without the one-time password")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), product_admin_password=""),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_product_admin_password_unavailable"
+    assert control.events == [
+        "load-retirement-receipt",
+        "acquire-management",
+        "acquire-bootstrap",
+    ]
+
+
+@pytest.mark.parametrize(
+    "password",
+    ["short", "product-admin", "product-admin@example.com"],
+)
+async def test_invalid_product_admin_password_stops_before_keycloak_mutation(password):
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("invalid password must fail before reconciliation")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), product_admin_password=password),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_product_admin_password_policy"
+    assert "reconcile-keycloak" not in control.events
+
+
+async def test_readback_rejects_receipt_bound_to_another_installation():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(
+        control.events,
+        replace(_receipt(), realm_id="different-realm-id"),
+    )
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+            control=control,
+            provision_admin=_provision,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_retirement_receipt_mismatch"
+
+
+async def test_recorded_retirement_rejects_a_reactivated_bootstrap_client():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events, _receipt())
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("a reactivated bootstrap client must stop convergence")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            _spec(),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_client_reactivated"
+    assert "reconcile-keycloak" not in control.events
+
+
+async def test_spec_repr_and_mapping_never_expose_secret_values():
+    spec = _spec()
+    rendered = repr(spec)
+    # asdict is intentionally not used by production reporting; this assertion
+    # documents why the state machine emits an explicit allowlisted report.
+    assert asdict(spec)["bootstrap_client_secret"] == _BOOTSTRAP_SECRET
+    for secret in (
+        _BOOTSTRAP_SECRET,
+        _MANAGEMENT_SECRET,
+        _ADMIN_CLIENT_SECRET,
+        _PRODUCT_ADMIN_PASSWORD,
+        "api-browser-secret-must-not-leak",
+    ):
+        assert secret not in rendered
+
+
+async def test_management_role_profile_is_least_privilege_and_exact():
+    from app.services.standalone_sso_bootstrap import MANAGEMENT_REALM_ROLES
+
+    assert MANAGEMENT_REALM_ROLES == (
+        "manage-identity-providers",
+        "query-clients",
+        "query-users",
+        "view-clients",
+        "view-realm",
+        "view-users",
+    )
+    assert "realm-admin" not in MANAGEMENT_REALM_ROLES
+    assert "manage-clients" not in MANAGEMENT_REALM_ROLES
+    assert "manage-users" not in MANAGEMENT_REALM_ROLES

--- a/backend/tests/test_standalone_sso_cli_unit.py
+++ b/backend/tests/test_standalone_sso_cli_unit.py
@@ -1,0 +1,301 @@
+"""Secret-safe operator CLI contracts for bundled standalone SSO."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BOOTSTRAP_SECRET = "bootstrap-secret-never-print"  # pragma: allowlist secret
+_PRODUCT_PASSWORD = "product-password-never-print"  # pragma: allowlist secret
+_MANAGEMENT_SECRET = "management-secret-never-print"  # pragma: allowlist secret
+_API_SECRET = "api-secret-never-print"  # pragma: allowlist secret
+_ADMIN_SECRET = "admin-secret-never-print"  # pragma: allowlist secret
+
+
+def _patch_database(monkeypatch) -> None:
+    from app import cli
+    from app.db import postgres
+
+    async def _initialize_operator_database() -> None:
+        return None
+
+    async def _close_pool() -> None:
+        return None
+
+    monkeypatch.setattr(
+        cli,
+        "_initialize_operator_database",
+        _initialize_operator_database,
+    )
+    monkeypatch.setattr(postgres, "close_pool", _close_pool)
+
+
+def _patch_sso_settings(monkeypatch) -> None:
+    from app.config import settings
+
+    values = {
+        "auth_mode": "sso",
+        "keycloak_enabled": True,
+        "keycloak_server_url": "https://auth.akb.example.com",
+        "keycloak_internal_url": "http://keycloak:8080",
+        "keycloak_realm": "akb",
+        "keycloak_client_id": "akb-web",
+        "keycloak_client_secret": _API_SECRET,
+        "keycloak_public_client": False,
+        "keycloak_admin_client_id": "akb-admin",
+        "keycloak_admin_client_secret": _ADMIN_SECRET,
+        "keycloak_management_client_id": "akb-sso-manager",
+        "keycloak_management_client_secret": _MANAGEMENT_SECRET,
+        "keycloak_verify_ssl": True,
+        "public_base_url": "https://akb.example.com",
+    }
+    for name, value in values.items():
+        monkeypatch.setattr(settings, name, value, raising=False)
+
+
+def _arguments(bootstrap_file: str, product_password_file: str) -> list[str]:
+    return [
+        "--bootstrap-client-id",
+        "akb-bootstrap-temporary",
+        "--bootstrap-client-secret-file",
+        bootstrap_file,
+        "--product-admin-username",
+        "product-admin",
+        "--product-admin-email",
+        "product-admin@example.com",
+        "--product-admin-password-file",
+        product_password_file,
+    ]
+
+
+async def test_bootstrap_cli_reads_only_secret_files_and_emits_allowlisted_report(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    caplog,
+):
+    from app import cli
+    from app.services import standalone_sso_bootstrap, standalone_sso_keycloak
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    bootstrap_file = tmp_path / "bootstrap-client-secret"
+    product_password_file = tmp_path / "product-admin-password"
+    bootstrap_file.write_text(f"{_BOOTSTRAP_SECRET}\n")
+    product_password_file.write_text(f"{_PRODUCT_PASSWORD}\n")
+    observed: dict[str, object] = {}
+
+    class _Control:
+        def __init__(self, *, verify_ssl: bool) -> None:
+            observed["verify_ssl"] = verify_ssl
+
+        async def aclose(self) -> None:
+            observed["closed"] = True
+
+    async def _bootstrap(
+        spec,
+        *,
+        control,
+        provision_admin,
+        load_retirement_receipt,
+        record_retirement_receipt,
+    ):
+        observed["spec"] = spec
+        observed["control"] = control
+        observed["provision_admin"] = provision_admin
+        observed["load_retirement_receipt"] = load_retirement_receipt
+        observed["record_retirement_receipt"] = record_retirement_receipt
+        return {
+            "mode": "fresh",
+            "keycloak_mutated": True,
+            "bootstrap_admin_retired": True,
+            "realm_id": "akb-realm-id",
+            "product_admin_subject": "product-admin-subject",
+            "akb_user_id": "akb-user-id",
+            "akb_admin_created": True,
+            "active_signing_kid": "active-kid",
+            "active_signing_bits": 3072,
+            "passive_rs256_keys": 1,
+            "management_roles": ["view-realm"],
+        }
+
+    monkeypatch.setattr(
+        standalone_sso_keycloak,
+        "KeycloakStandaloneSSOControl",
+        _Control,
+    )
+    monkeypatch.setattr(
+        standalone_sso_bootstrap,
+        "bootstrap_standalone_sso",
+        _bootstrap,
+    )
+
+    exit_code = await cli._bootstrap_standalone_sso(
+        _arguments(str(bootstrap_file), str(product_password_file))
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    spec = observed["spec"]
+    assert spec.bootstrap_client_secret == _BOOTSTRAP_SECRET
+    assert spec.product_admin_password == _PRODUCT_PASSWORD
+    assert spec.management_client_secret == _MANAGEMENT_SECRET
+    assert spec.api_client_secret == _API_SECRET
+    assert spec.admin_client_secret == _ADMIN_SECRET
+    assert observed["verify_ssl"] is True
+    assert observed["closed"] is True
+    assert callable(observed["load_retirement_receipt"])
+    assert callable(observed["record_retirement_receipt"])
+    report = json.loads(captured.out)
+    assert report["bootstrap_admin_retired"] is True
+    assert report["active_signing_bits"] == 3072
+    assert "product_admin_password" not in report
+    rendered = captured.out + captured.err + caplog.text
+    assert all(secret not in rendered for secret in _all_secrets())
+
+
+async def test_bootstrap_cli_redacts_unexpected_exception_and_rejects_secret_args(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.services import standalone_sso_bootstrap, standalone_sso_keycloak
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    bootstrap_file = tmp_path / "bootstrap-client-secret"
+    product_password_file = tmp_path / "product-admin-password"
+    bootstrap_file.write_text(f"{_BOOTSTRAP_SECRET}\n")
+    product_password_file.write_text(f"{_PRODUCT_PASSWORD}\n")
+
+    class _Control:
+        def __init__(self, *, verify_ssl: bool) -> None:
+            assert verify_ssl is True
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _fail(*_args, **_kwargs):
+        raise RuntimeError(" ".join(_all_secrets()))
+
+    monkeypatch.setattr(
+        standalone_sso_keycloak,
+        "KeycloakStandaloneSSOControl",
+        _Control,
+    )
+    monkeypatch.setattr(
+        standalone_sso_bootstrap,
+        "bootstrap_standalone_sso",
+        _fail,
+    )
+
+    assert await cli._bootstrap_standalone_sso(
+        _arguments(str(bootstrap_file), str(product_password_file))
+    ) == 1
+    captured = capsys.readouterr()
+    assert "standalone_sso_bootstrap_failed" in captured.err
+    assert all(secret not in captured.out + captured.err for secret in _all_secrets())
+
+    assert await cli._bootstrap_standalone_sso(
+        [
+            *_arguments(str(bootstrap_file), str(product_password_file)),
+            "--secret",
+            _BOOTSTRAP_SECRET,
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert all(secret not in captured.out + captured.err for secret in _all_secrets())
+
+
+async def test_bootstrap_cli_rerun_allows_removed_one_time_secret_files(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.services import standalone_sso_bootstrap, standalone_sso_keycloak
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    observed: dict[str, object] = {}
+
+    class _Control:
+        def __init__(self, *, verify_ssl: bool) -> None:
+            assert verify_ssl is True
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _readback(spec, **_kwargs):
+        observed["bootstrap_secret"] = spec.bootstrap_client_secret
+        observed["product_password"] = spec.product_admin_password
+        return {
+            "mode": "readback",
+            "keycloak_mutated": False,
+            "bootstrap_admin_retired": True,
+        }
+
+    monkeypatch.setattr(
+        standalone_sso_keycloak,
+        "KeycloakStandaloneSSOControl",
+        _Control,
+    )
+    monkeypatch.setattr(
+        standalone_sso_bootstrap,
+        "bootstrap_standalone_sso",
+        _readback,
+    )
+    missing_bootstrap = tmp_path / "removed-bootstrap-secret"
+    missing_password = tmp_path / "removed-product-password"
+
+    assert await cli._bootstrap_standalone_sso(
+        _arguments(str(missing_bootstrap), str(missing_password))
+    ) == 0
+    assert observed == {"bootstrap_secret": "", "product_password": ""}
+    assert json.loads(capsys.readouterr().out)["mode"] == "readback"
+
+
+async def test_bootstrap_cli_rejects_reused_credentials_before_mutation(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.config import settings
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    monkeypatch.setattr(
+        settings,
+        "keycloak_admin_client_secret",
+        _API_SECRET,
+        raising=False,
+    )
+    bootstrap_file = tmp_path / "bootstrap-client-secret"
+    product_password_file = tmp_path / "product-admin-password"
+    bootstrap_file.write_text(f"{_BOOTSTRAP_SECRET}\n")
+    product_password_file.write_text(f"{_PRODUCT_PASSWORD}\n")
+
+    assert await cli._bootstrap_standalone_sso(
+        _arguments(str(bootstrap_file), str(product_password_file))
+    ) == 1
+
+    captured = capsys.readouterr()
+    assert "standalone_sso_input_invalid" in captured.err
+    assert "independently generated" in captured.err
+    assert all(secret not in captured.out + captured.err for secret in _all_secrets())
+
+
+def _all_secrets() -> tuple[str, ...]:
+    return (
+        _BOOTSTRAP_SECRET,
+        _PRODUCT_PASSWORD,
+        _MANAGEMENT_SECRET,
+        _API_SECRET,
+        _ADMIN_SECRET,
+    )

--- a/backend/tests/test_standalone_sso_deployment_unit.py
+++ b/backend/tests/test_standalone_sso_deployment_unit.py
@@ -1,0 +1,151 @@
+"""Static safety contracts for the generic standalone SSO Kustomize overlay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+_OVERLAY = _ROOT / "deploy" / "k8s" / "standalone-sso"
+
+
+def _documents(name: str) -> list[dict]:
+    with (_OVERLAY / name).open(encoding="utf-8") as source:
+        return [item for item in yaml.safe_load_all(source) if isinstance(item, dict)]
+
+
+def _one(name: str, *, kind: str, resource_name: str | None) -> dict:
+    matches = [
+        item
+        for item in _documents(name)
+        if item.get("kind") == kind
+        and item.get("metadata", {}).get("name") == resource_name
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_overlay_owns_dedicated_keycloak_and_database_without_committed_secrets():
+    kustomization = _one(
+        "kustomization.yaml",
+        kind="Kustomization",
+        resource_name=None,
+    )
+    assert {
+        "akb-postgres.yaml",
+        "keycloak-postgres.yaml",
+        "keycloak.yaml",
+        "keycloak-ingress.yaml",
+    }.issubset(set(kustomization["resources"]))
+
+    for path in _OVERLAY.glob("*.yaml"):
+        for document in _documents(path.name):
+            assert document.get("kind") != "Secret"
+            assert "stringData" not in document
+
+    keycloak = _one("keycloak.yaml", kind="StatefulSet", resource_name="keycloak")
+    keycloak_postgres = _one(
+        "keycloak-postgres.yaml",
+        kind="StatefulSet",
+        resource_name="keycloak-postgres",
+    )
+    assert keycloak["spec"]["template"]["spec"]["containers"][0]["image"].count(
+        "@sha256:"
+    ) == 1
+    assert keycloak_postgres["spec"]["template"]["spec"]["containers"][0][
+        "image"
+    ].count("@sha256:") == 1
+
+
+def test_keycloak_bootstrap_secret_is_required_for_first_boot_and_not_a_human_admin():
+    keycloak = _one("keycloak.yaml", kind="StatefulSet", resource_name="keycloak")
+    env = {
+        item["name"]: item
+        for item in keycloak["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    assert env["KC_BOOTSTRAP_ADMIN_CLIENT_ID"]["value"] == (
+        "akb-bootstrap-temporary"
+    )
+    reference = env["KC_BOOTSTRAP_ADMIN_CLIENT_SECRET"]["valueFrom"][
+        "secretKeyRef"
+    ]
+    assert reference == {
+        "name": "akb-keycloak-bootstrap",
+        "key": "client-secret",
+    }
+    assert "KC_BOOTSTRAP_ADMIN_USERNAME" not in env
+    assert "KC_BOOTSTRAP_ADMIN_PASSWORD" not in env
+
+
+def test_backend_patch_removes_local_key_authority_and_mounts_one_time_inputs_only_in_init():
+    deployment = _one(
+        "backend-deployment-patch.yaml",
+        kind="Deployment",
+        resource_name="backend",
+    )
+    pod = deployment["spec"]["template"]["spec"]
+    init = pod["initContainers"][0]
+    assert init["command"] == [
+        "python",
+        "-m",
+        "app.cli",
+        "bootstrap-standalone-sso",
+    ]
+    init_mounts = {item["name"] for item in init["volumeMounts"]}
+    assert {"keycloak-bootstrap", "product-admin-bootstrap"}.issubset(init_mounts)
+    main_mounts = {item["name"] for item in pod["containers"][0]["volumeMounts"]}
+    assert "keycloak-bootstrap" not in main_mounts
+    assert "product-admin-bootstrap" not in main_mounts
+    assert pod["containers"][0]["volumeMounts"][0]["$patch"] == "delete"
+    volumes = {item["name"]: item for item in pod["volumes"]}
+    assert volumes["local-session-keys"]["$patch"] == "delete"
+    assert "optional" not in volumes["keycloak-bootstrap"]["secret"]
+    assert "optional" not in volumes["product-admin-bootstrap"]["secret"]
+
+
+def test_sso_runtime_config_has_one_mode_and_three_distinct_confidential_clients():
+    patch = _one(
+        "backend-config-patch.yaml",
+        kind="ConfigMap",
+        resource_name="akb-app-config",
+    )
+    config = yaml.safe_load(patch["data"]["app.yaml"])
+    assert config["auth_mode"] == "sso"
+    assert config["keycloak_enabled"] is True
+    assert config["keycloak_public_client"] is False
+    assert "local_session_private_key_path" not in config
+    assert "local_session_jwks_path" not in config
+    clients = {
+        config["keycloak_client_id"],
+        config["keycloak_admin_client_id"],
+        config["keycloak_management_client_id"],
+    }
+    assert clients == {"akb-web", "akb-admin", "akb-sso-manager"}
+    assert config["keycloak_internal_url"] == "http://keycloak:8080"
+    assert config["keycloak_server_url"].startswith("https://")
+
+
+def test_kustomize_render_has_no_local_session_mount_when_kubectl_is_available():
+    kubectl = shutil.which("kubectl")
+    if kubectl is None:
+        pytest.skip("kubectl is not installed on this test host")
+    result = subprocess.run(
+        [
+            kubectl,
+            "kustomize",
+            "--load-restrictor=LoadRestrictionsNone",
+            str(_OVERLAY),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert "local-session-keys" not in result.stdout
+    assert "auth_mode: sso" in result.stdout
+    assert "kind: Secret" not in result.stdout

--- a/backend/tests/test_standalone_sso_keycloak_unit.py
+++ b/backend/tests/test_standalone_sso_keycloak_unit.py
@@ -1,0 +1,545 @@
+"""Focused transport and read-back contracts for the Keycloak adapter."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import replace
+import json
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+import httpx
+import pytest
+
+from app.services.standalone_sso_bootstrap import (
+    StandaloneSSOBootstrapError,
+    StandaloneSSOBootstrapSpec,
+)
+from app.services.standalone_sso_keycloak import KeycloakStandaloneSSOControl
+
+
+pytestmark = pytest.mark.asyncio
+
+_SECRETS = (
+    "temporary-bootstrap-secret-must-not-leak",  # pragma: allowlist secret
+    "permanent-management-secret-must-not-leak",  # pragma: allowlist secret
+    "api-browser-secret-must-not-leak",  # pragma: allowlist secret
+    "admin-browser-secret-must-not-leak",  # pragma: allowlist secret
+    "one-time-product-admin-password",  # pragma: allowlist secret
+)
+
+
+def _spec() -> StandaloneSSOBootstrapSpec:
+    return StandaloneSSOBootstrapSpec(
+        keycloak_internal_url="http://keycloak:8080",
+        keycloak_public_url="https://auth.akb.example.com",
+        realm="akb",
+        akb_public_url="https://akb.example.com",
+        bootstrap_client_id="akb-bootstrap-temporary",
+        bootstrap_client_secret=_SECRETS[0],
+        management_client_id="akb-sso-manager",
+        management_client_secret=_SECRETS[1],
+        api_client_id="akb-web",
+        api_client_secret=_SECRETS[2],
+        admin_client_id="akb-admin",
+        admin_client_secret=_SECRETS[3],
+        product_admin_username="product-admin",
+        product_admin_email="product-admin@example.com",
+        product_admin_password=_SECRETS[4],
+    )
+
+
+def _control(
+    handler: httpx.MockTransport,
+) -> tuple[KeycloakStandaloneSSOControl, StandaloneSSOBootstrapSpec]:
+    spec = _spec()
+    control = KeycloakStandaloneSSOControl()
+    control._clients[spec.keycloak_internal_url] = httpx.AsyncClient(  # noqa: SLF001
+        base_url=spec.keycloak_internal_url,
+        transport=handler,
+    )
+    return control, spec
+
+
+async def test_admin_rest_failure_never_includes_response_or_request_secrets():
+    response_body = " ".join(_SECRETS)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text=response_body)
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control.acquire_bootstrap(spec)
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_token_request_failed"
+    rendered = f"{captured.value!s} {captured.value!r}"
+    assert all(secret not in rendered for secret in _SECRETS)
+
+
+async def test_removed_bootstrap_secret_skips_token_request():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("an absent retired credential must not be transmitted")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    spec = replace(spec, bootstrap_client_secret="")
+    try:
+        assert await control.acquire_bootstrap(spec) is None
+    finally:
+        await control.aclose()
+
+
+async def test_keycloak_internal_base_path_is_preserved():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/auth/realms/master/protocol/openid-connect/token"
+        return httpx.Response(200, json={"access_token": "opaque-token"})
+
+    spec = replace(_spec(), keycloak_internal_url="http://keycloak:8080/auth")
+    control = KeycloakStandaloneSSOControl()
+    control._clients[spec.keycloak_internal_url] = httpx.AsyncClient(  # noqa: SLF001
+        base_url=f"{spec.keycloak_internal_url}/",
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        assert await control.acquire_bootstrap(spec) == "opaque-token"
+    finally:
+        await control.aclose()
+
+
+async def test_duplicate_exact_client_fails_closed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/admin/realms/akb/clients"
+        assert request.url.params["clientId"] == "akb-web"
+        return httpx.Response(
+            200,
+            json=[
+                {"id": "first", "clientId": "akb-web"},
+                {"id": "second", "clientId": "akb-web"},
+            ],
+        )
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._exact_client(  # noqa: SLF001
+                spec,
+                spec.realm,
+                spec.api_client_id,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_client_duplicate"
+
+
+async def test_signing_key_readback_measures_active_key_and_rotation_window():
+    active_public = base64.b64encode(
+        rsa.generate_private_key(public_exponent=65537, key_size=3072)
+        .public_key()
+        .public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+    ).decode("ascii").rstrip("=")
+    passive_public = (
+        rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        .public_key()
+        .public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+        .decode("ascii")
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/admin/realms/akb/keys"
+        return httpx.Response(
+            200,
+            json={
+                "active": {"RS256": "active-kid"},
+                "keys": [
+                    {
+                        "kid": "active-kid",
+                        "algorithm": "RS256",
+                        "use": "SIG",
+                        "status": "ACTIVE",
+                        "publicKey": active_public,
+                    },
+                    {
+                        "kid": "passive-kid",
+                        "algorithm": "RS256",
+                        "use": "SIG",
+                        "status": "PASSIVE",
+                        "publicKey": passive_public,
+                    },
+                    {
+                        "kid": "disabled-kid",
+                        "algorithm": "RS256",
+                        "use": "SIG",
+                        "status": "DISABLED",
+                        "publicKey": passive_public,
+                    },
+                ],
+            },
+        )
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        measured = await control._key_readback(  # noqa: SLF001
+            spec,
+            token="opaque-token",  # pragma: allowlist secret
+        )
+    finally:
+        await control.aclose()
+
+    assert measured == ("active-kid", 3072, 1)
+
+
+async def test_bootstrap_retirement_deletes_only_exact_master_client_and_reauth_denies():
+    deleted_paths: list[str] = []
+    retired = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal retired
+        if request.url.path == "/admin/realms/master/clients":
+            assert request.url.params["clientId"] == "akb-bootstrap-temporary"
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "bootstrap-client-uuid",
+                        "clientId": "akb-bootstrap-temporary",
+                    }
+                ],
+            )
+        if request.url.path == "/admin/realms/master/clients/bootstrap-client-uuid":
+            assert request.method == "DELETE"
+            retired = True
+            deleted_paths.append(request.url.path)
+            return httpx.Response(204)
+        if request.url.path == "/admin/realms/master":
+            assert retired is True
+            return httpx.Response(401)
+        if request.url.path == "/realms/master/protocol/openid-connect/token":
+            assert retired is True
+            return httpx.Response(401)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        await control.retire_bootstrap(
+            spec,
+            bootstrap_token="opaque-bootstrap-token",  # pragma: allowlist secret
+        )
+        await control.assert_bootstrap_retired(
+            spec,
+            bootstrap_token="opaque-bootstrap-token",  # pragma: allowlist secret
+        )
+    finally:
+        await control.aclose()
+
+    assert deleted_paths == [
+        "/admin/realms/master/clients/bootstrap-client-uuid"
+    ]
+
+
+async def test_missing_one_time_password_cannot_create_product_admin():
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(f"{request.method} {request.url.path}")
+        assert request.method == "GET"
+        assert request.url.path == "/admin/realms/akb/users"
+        return httpx.Response(200, json=[])
+
+    control, spec = _control(httpx.MockTransport(handler))
+    spec = replace(spec, product_admin_password="")
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_product_admin_password_unavailable"
+    assert requests == ["GET /admin/realms/akb/users"]
+
+
+async def test_existing_product_admin_password_is_reset_to_the_operator_input():
+    requests: list[str] = []
+    user_reads = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal user_reads
+        requests.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/admin/realms/akb/users":
+            user_reads += 1
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                        "requiredActions": (
+                            ["UPDATE_PASSWORD"] if user_reads > 1 else []
+                        ),
+                    }
+                ],
+            )
+        if request.url.path.endswith("/reset-password"):
+            assert request.method == "PUT"
+            assert json.loads(request.content) == {
+                "type": "password",
+                "value": _SECRETS[4],
+                "temporary": True,
+            }
+            return httpx.Response(204)
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(200, json=[])
+        if request.url.path.endswith("/credentials"):
+            return httpx.Response(200, json=[{"type": "password"}])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        user = await control._reconcile_product_admin(  # noqa: SLF001
+            spec,
+            token="opaque-token",  # pragma: allowlist secret
+        )
+    finally:
+        await control.aclose()
+
+    assert user["id"] == "product-admin-uuid"
+    assert requests == [
+        "GET /admin/realms/akb/users",
+        "GET /admin/realms/akb/users/product-admin-uuid/federated-identity",
+        "PUT /admin/realms/akb/users/product-admin-uuid/reset-password",
+        "GET /admin/realms/akb/users",
+        "GET /admin/realms/akb/users/product-admin-uuid/credentials",
+    ]
+
+
+async def test_product_admin_password_change_requirement_must_read_back():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/admin/realms/akb/users":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                        "requiredActions": [],
+                    }
+                ],
+            )
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(200, json=[])
+        if request.url.path.endswith("/reset-password"):
+            return httpx.Response(204)
+        if request.url.path.endswith("/credentials"):
+            return httpx.Response(200, json=[{"type": "password"}])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_product_admin_update_password_missing"
+
+
+async def test_product_admin_federation_race_after_password_reset_is_rejected():
+    user_reads = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal user_reads
+        if request.url.path == "/admin/realms/akb/users":
+            user_reads += 1
+            user = {
+                "id": "product-admin-uuid",
+                "username": "product-admin",
+                "email": "product-admin@example.com",
+                "enabled": True,
+                "emailVerified": True,
+                "requiredActions": ["UPDATE_PASSWORD"],
+            }
+            if user_reads > 1:
+                user["federationLink"] = "racing-storage-provider"
+            return httpx.Response(200, json=[user])
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(200, json=[])
+        if request.url.path.endswith("/reset-password"):
+            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_admin_identity_is_federated"
+
+
+async def test_existing_product_admin_cannot_be_adopted_without_one_time_password():
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(f"{request.method} {request.url.path}")
+        assert request.url.path == "/admin/realms/akb/users"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "product-admin-uuid",
+                    "username": "product-admin",
+                    "email": "product-admin@example.com",
+                    "enabled": True,
+                    "emailVerified": True,
+                }
+            ],
+        )
+
+    control, spec = _control(httpx.MockTransport(handler))
+    spec = replace(spec, product_admin_password="")
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_product_admin_password_unavailable"
+    assert requests == ["GET /admin/realms/akb/users"]
+
+
+async def test_existing_federated_identity_is_rejected_before_password_mutation():
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/admin/realms/akb/users":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                    }
+                ],
+            )
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(
+                200,
+                json=[{"identityProvider": "upstream", "userId": "external"}],
+            )
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_admin_identity_is_federated"
+    assert requests == [
+        "GET /admin/realms/akb/users",
+        "GET /admin/realms/akb/users/product-admin-uuid/federated-identity",
+    ]
+
+
+async def test_existing_user_storage_federation_is_rejected_before_password_mutation():
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(f"{request.method} {request.url.path}")
+        assert request.url.path == "/admin/realms/akb/users"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "product-admin-uuid",
+                    "username": "product-admin",
+                    "email": "product-admin@example.com",
+                    "enabled": True,
+                    "emailVerified": True,
+                    "federationLink": "ldap-storage-provider",
+                }
+            ],
+        )
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(StandaloneSSOBootstrapError) as captured:
+            await control._reconcile_product_admin(  # noqa: SLF001
+                spec,
+                token="opaque-token",  # pragma: allowlist secret
+            )
+    finally:
+        await control.aclose()
+
+    assert captured.value.code == "keycloak_admin_identity_is_federated"
+    assert requests == ["GET /admin/realms/akb/users"]
+
+
+async def test_realm_audits_operations_without_secret_bearing_representations():
+    profile = KeycloakStandaloneSSOControl._realm_profile(_spec())  # noqa: SLF001
+
+    assert profile["adminEventsEnabled"] is True
+    assert profile["adminEventsDetailsEnabled"] is False
+
+
+async def test_realm_sets_a_lean_product_admin_password_policy_from_creation():
+    profile = KeycloakStandaloneSSOControl._realm_profile(_spec())  # noqa: SLF001
+
+    assert profile["passwordPolicy"] == (  # pragma: allowlist secret
+        "length(12) and notUsername and notEmail"
+    )
+
+
+async def test_client_profiles_separate_user_admin_and_management_authorities():
+    spec = _spec()
+    api = KeycloakStandaloneSSOControl._api_client(spec)  # noqa: SLF001
+    admin = KeycloakStandaloneSSOControl._admin_client(spec)  # noqa: SLF001
+    management = KeycloakStandaloneSSOControl._management_client(spec)  # noqa: SLF001
+
+    assert {api["clientId"], admin["clientId"], management["clientId"]} == {
+        "akb-web",
+        "akb-admin",
+        "akb-sso-manager",
+    }
+    assert api["redirectUris"] == [
+        "https://akb.example.com/api/v1/auth/keycloak/callback"
+    ]
+    assert admin["redirectUris"] == [
+        "https://akb.example.com/api/v1/admin/auth/keycloak/callback"
+    ]
+    assert api["attributes"]["pkce.code.challenge.method"] == "S256"
+    assert admin["attributes"]["pkce.code.challenge.method"] == "S256"
+    assert management["standardFlowEnabled"] is False
+    assert management["serviceAccountsEnabled"] is True
+    assert management["defaultClientScopes"] == ["service_account"]
+    assert management["redirectUris"] == []

--- a/backend/tests/test_standalone_sso_receipt_unit.py
+++ b/backend/tests/test_standalone_sso_receipt_unit.py
@@ -1,0 +1,129 @@
+"""Durable retirement-receipt contracts for bundled standalone SSO."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _receipt():
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE,
+        StandaloneSSORetirementReceipt,
+    )
+
+    return StandaloneSSORetirementReceipt(
+        profile=STANDALONE_SSO_RECEIPT_PROFILE,
+        issuer="https://auth.akb.example.com/realms/akb",
+        realm_id="akb-realm-id",
+        bootstrap_client_id="akb-bootstrap-temporary",
+        management_client_uuid="management-client-uuid",
+        admin_client_uuid="admin-client-uuid",
+        api_client_uuid="api-client-uuid",
+        product_admin_subject="00000000-0000-4000-8000-000000000001",
+        akb_user_id="11111111-1111-4111-8111-111111111111",
+    )
+
+
+class _Transaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Connection:
+    def __init__(self):
+        self.row: dict | None = None
+        self.writes = 0
+
+    def transaction(self):
+        return _Transaction()
+
+    async def execute(self, sql: str, *args):
+        if "pg_advisory_xact_lock" in sql:
+            return "SELECT 1"
+        assert "INSERT INTO standalone_sso_bootstrap_retirements" in sql
+        self.writes += 1
+        if self.row is None:
+            fields = (
+                "profile",
+                "issuer",
+                "realm_id",
+                "bootstrap_client_id",
+                "management_client_uuid",
+                "admin_client_uuid",
+                "api_client_uuid",
+                "product_admin_subject",
+                "akb_user_id",
+            )
+            self.row = dict(zip(fields, args, strict=True))
+        return "INSERT 0 1"
+
+    async def fetchrow(self, sql: str, *_args):
+        assert "FROM standalone_sso_bootstrap_retirements" in sql
+        return self.row
+
+
+class _Acquire:
+    def __init__(self, conn: _Connection):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Pool:
+    def __init__(self, conn: _Connection):
+        self.conn = conn
+
+    def acquire(self):
+        return _Acquire(self.conn)
+
+
+async def test_receipt_round_trip_is_exact_idempotent_and_conflict_safe(monkeypatch):
+    from app.services import standalone_sso_receipt as service
+    from app.services.standalone_sso_bootstrap import StandaloneSSOBootstrapError
+
+    conn = _Connection()
+
+    async def _get_pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(service, "get_pool", _get_pool)
+    expected = _receipt()
+
+    assert await service.load_standalone_sso_retirement_receipt() is None
+    await service.record_standalone_sso_retirement_receipt(expected)
+    assert await service.load_standalone_sso_retirement_receipt() == expected
+    await service.record_standalone_sso_retirement_receipt(expected)
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await service.record_standalone_sso_retirement_receipt(
+            replace(expected, realm_id="other-realm-id")
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_retirement_receipt_mismatch"
+    assert await service.load_standalone_sso_retirement_receipt() == expected
+    assert conn.writes == 1
+
+
+async def test_receipt_schema_is_present_for_fresh_and_upgraded_databases():
+    from pathlib import Path
+
+    backend = Path(__file__).resolve().parents[1]
+    init_sql = (backend / "app" / "db" / "init.sql").read_text()
+    migration = backend / "app" / "db" / "migrations" / "073_sso_bootstrap_receipt.py"
+    registry = (backend / "app" / "db" / "postgres.py").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS standalone_sso_bootstrap_retirements" in init_sql
+    assert migration.is_file()
+    assert '"073_sso_bootstrap_receipt.py"' in registry

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -205,6 +205,8 @@ app_credential_overlap_seconds: 300
 # keycloak_public_client: false      # true → PKCE (no client_secret needed)
 # keycloak_admin_client_id: "akb-admin"  # dedicated confidential /admin client;
 #                                         # must differ from every ordinary human client
+# keycloak_management_client_id: "akb-sso-manager" # standalone bundle only:
+#                                         # permanent least-privilege IdP control client
 # admin_browser_session_ttl_secs: 900     # also capped by the verified ID-token expiry
 # keycloak_verify_ssl: true          # false only for local self-signed Keycloak
 # keycloak_require_verified_email: true   # refuse unverified email for open-mode JIT.
@@ -236,8 +238,9 @@ app_credential_overlap_seconds: 300
 # mcp_oauth_enabled: false
 # mcp_oauth_audience: ""               # default: <public_base_url>/mcp
 # API and MCP audiences must remain distinct.
-# keycloak_client_secret and keycloak_admin_client_secret live in secret.yaml
-# (never commit either value)
+# keycloak_client_secret, keycloak_admin_client_secret, and the optional
+# standalone keycloak_management_client_secret live in secret.yaml (never
+# commit any value)
 
 # === Server ===
 host: 0.0.0.0

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -28,6 +28,12 @@ keycloak_client_secret: ""
 # no Keycloak access, refresh, or ID token after the callback.
 keycloak_admin_client_secret: ""
 
+# Standalone bundled SSO only. Permanent service-account credential for the
+# exact least-privilege IdP management/read-back role set. Managed/shared
+# Keycloak deployments leave this blank because their owner control plane
+# performs mutations.
+keycloak_management_client_secret: ""
+
 # === Embedding API key (required) ===
 # Provider key for `embed_base_url` in app.yaml. In platform_hard mode this is
 # the workload's platform gateway credential, not the upstream provider key.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -20,6 +20,8 @@ deploy/k8s/
 ├── backend.yaml           # Deployment + ConfigMap (vector_store_driver: pgvector)
 ├── frontend.yaml          # Deployment + Service
 ├── ingress.yaml           # placeholder host (akb.example.com)
+├── standalone-sso/        # AKB + owned Keycloak 26.7 + dedicated Keycloak DB;
+│                          # temporary bootstrap service-account retirement
 └── internal/              # gitignored — operator-private overlays
     ├── deploy-internal.sh
     ├── cluster-issuer.yaml
@@ -42,6 +44,11 @@ inside the Postgres pod. Other options:
 
 The `internal/` overlay shows the Qdrant pattern for the production
 cluster.
+
+For a standalone installation whose canonical human-auth mode is `sso`, use
+[`standalone-sso/README.md`](standalone-sso/README.md). That overlay owns its
+Keycloak lifecycle and dedicated database. Do not apply it to a managed tenant
+that reuses a platform-owned/shared Keycloak realm.
 
 ## Quickstart (generic)
 

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -1,0 +1,138 @@
+# Standalone SSO Kubernetes bundle
+
+This overlay adds a Keycloak 26.7 broker and a dedicated Keycloak PostgreSQL
+database to the standalone AKB stack. It owns exactly one AKB realm and is not
+the deployment shape for a managed tenant that reuses a platform-owned
+Keycloak.
+
+The bundle implements the product-administrator bootstrap and recovery slice:
+
+1. Keycloak creates one temporary master-realm service account on its first
+   start.
+2. The AKB bootstrap init container creates and reads back the `akb` realm,
+   separate `akb-web`, `akb-admin`, and `akb-sso-manager` clients, the
+   RSA-3072 active signing key, the native product administrator, and the exact
+   AKB administrator projection.
+3. It proves the permanent management credential, deletes the temporary
+   bootstrap client, verifies that credential is rejected, and records a
+   non-secret retirement receipt in the AKB database.
+4. A subsequent init-container run is read-only and succeeds without either
+   original one-time value only when its current Keycloak and AKB identities
+   exactly match that durable receipt.
+
+Ordinary-user browser SSO remains staged until the server-side token-custody
+slice is released. `/admin` uses the dedicated confidential client and requires
+a fresh native Keycloak password ceremony; a brokered upstream identity is not
+accepted as the recovery administrator.
+
+## Required operator inputs
+
+Patch these public values in an operator overlay before applying:
+
+- `akb.example.com` in the AKB Ingress and `akb-app-config`
+- `auth.akb.example.com` in the Keycloak Ingress, `KC_HOSTNAME`, and
+  `akb-app-config`
+- `product-admin-username` and `product-admin-email` in
+  `akb-sso-bootstrap-config`
+- the immutable `akb-backend` and `akb-frontend` image references
+- TLS issuer/secret names and storage classes as needed
+
+The following Secrets are deliberately absent from Kustomize output. Create
+them with a secret manager, Sealed Secrets, or `kubectl create secret`; never
+commit their values.
+
+| Secret | Required keys | Lifecycle |
+|---|---|---|
+| `akb-postgres-credentials` | `POSTGRES_DB=akb`, `POSTGRES_USER=akbuser`, `POSTGRES_PASSWORD` | durable |
+| `akb-keycloak-db-credentials` | `POSTGRES_DB=keycloak`, `POSTGRES_USER=keycloak`, `POSTGRES_PASSWORD` | durable |
+| `akb-secret-config` | `secret.yaml` | durable |
+| `akb-keycloak-bootstrap` | `client-secret` | one-time |
+| `akb-product-admin-bootstrap` | `password` | one-time |
+
+The mounted `secret.yaml` must include the AKB database password plus three
+independently generated confidential-client secrets:
+
+```yaml
+db_password: <same value as akb-postgres-credentials>
+system_hmac_secret: <independent random value>
+keycloak_client_secret: <akb-web secret>
+keycloak_admin_client_secret: <akb-admin secret>
+keycloak_management_client_secret: <akb-sso-manager secret>
+embed_api_key: <provider key, if required>
+```
+
+Generate each credential independently. The product-admin password is
+temporary, must be at least 12 characters, must differ from its username and
+email, and Keycloak forces `UPDATE_PASSWORD` on first login. The realm enforces
+the same lean policy for the replacement password. The bootstrap client secret
+is not the product-admin password.
+
+Render and validate the public overlay before applying:
+
+```bash
+kubectl kustomize --load-restrictor=LoadRestrictionsNone \
+  deploy/k8s/standalone-sso > rendered-standalone-sso.yaml
+kubectl apply --dry-run=client --validate=false \
+  -f rendered-standalone-sso.yaml
+```
+
+Apply only after all durable and one-time Secrets exist. Wait for the backend
+pod's `bootstrap-standalone-sso` init container and main container to complete,
+then inspect the init log. Its JSON report contains only IDs, key metadata, and
+the exact role names; it never contains credential values.
+
+## Retire one-time material
+
+The init container deletes the temporary Keycloak client only after all
+durable recovery paths and the AKB administrator projection have been read
+back. Its successful report also means the exact retirement receipt was
+written and read back from AKB PostgreSQL. After that report succeeds:
+
+1. Preserve the product-admin password through an approved installer handoff;
+   the administrator needs it for the forced first-login password change.
+2. Replace both Secret values with fresh, unrelated retirement sentinels. Keep
+   the Secret objects because the default first-boot manifest deliberately
+   requires them; this prevents an empty Keycloak database from initializing
+   without any recovery credential.
+3. Restart the Keycloak StatefulSet so the original bootstrap value is no
+   longer in its process environment.
+4. Restart the backend Deployment. Its init container must complete in
+   `readback` mode using only `akb-sso-manager`.
+5. Confirm `/admin` can complete native login and that the ordinary local
+   login/register endpoints remain unavailable.
+
+Do not remove or replace either one-time value before the first successful
+report. The Secret references are required on first boot because Keycloak's
+startup bootstrap settings are ignored after the master realm exists. An
+absent value without a matching retirement receipt fails closed; it is never
+treated as proof that the client was deleted. A custom steady-state overlay may
+remove the two mounts and the Keycloak bootstrap environment entries, and then
+delete the Secret objects, but only after the receipt-backed report succeeds.
+A partial run before deletion deliberately leaves the temporary service account
+available so the same inputs can repair the installation. A crash after
+Keycloak accepted the delete but before PostgreSQL committed the receipt also
+fails closed. For that rare recovery case, or if both temporary and permanent
+credentials are lost, stop every Keycloak node and follow Keycloak's official
+`bootstrap-admin service` recovery procedure before rerunning convergence; do
+not add a permanent master administrator to this bundle.
+
+## Signing-key rotation and rollback
+
+The bootstrap makes an RSA-3072/RS256 provider active and requires at least one
+other enabled RS256 signing key to remain published. Inspect the realm's
+`/admin/realms/akb/keys` read-back before and after every rotation; the active
+`kid` must resolve to a 3072-bit signing key and the previous `kid` must remain
+in JWKS for at least the maximum issued-token lifetime plus verifier cache
+overlap.
+
+For a planned rotation, add a newly generated RSA-3072/RS256 provider at a
+higher priority, verify token issuance and AKB validation against its new
+`kid`, and only then demote the prior provider to passive. Roll back by making
+the still-retained prior RSA-3072 provider active again. Do not use the bundled
+Keycloak default RSA-2048 key as the active rollback target, delete a passive
+private key while its tokens may still exist, or rotate Keycloak and AKB
+verifier configuration in one unverified step.
+
+Keycloak and both database images are digest-pinned. Candidate validation must
+also replace both AKB application tags with immutable digests; `:latest` is
+only the generic base's operator placeholder.

--- a/deploy/k8s/standalone-sso/akb-postgres.yaml
+++ b/deploy/k8s/standalone-sso/akb-postgres.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: akb
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: akb-postgres
+  template:
+    metadata:
+      labels:
+        app: akb-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg16@sha256:a36250871de0833b8757561c72f2477ef1ddd1101afa4e617fb552e0de514c6b
+          imagePullPolicy: IfNotPresent
+          args:
+            - -c
+            - shared_buffers=512MB
+            - -c
+            - effective_cache_size=1536MB
+            - -c
+            - max_connections=100
+          ports:
+            - name: postgres
+              containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: akb-postgres-credentials
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+            - name: dshm
+              mountPath: /dev/shm
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 3Gi
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - akbuser
+                - -d
+                - akb
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: akb
+spec:
+  clusterIP: None
+  selector:
+    app: akb-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres

--- a/deploy/k8s/standalone-sso/backend-config-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-config-patch.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: akb-app-config
+  namespace: akb
+data:
+  app.yaml: |
+    db_host: postgres
+    db_port: 5432
+    db_name: akb
+    db_user: akbuser
+    git_storage_path: /data/vaults
+
+    embed_base_url: https://api.openai.com/v1
+    embed_model: text-embedding-3-small
+    embed_dimensions: 1536
+    llm_base_url: ""
+    llm_model: ""
+    rerank_enabled: false
+    s3_endpoint_url: ""
+    s3_bucket: akb-files
+
+    auth_mode: sso
+    jwt_algorithm: RS256
+    keycloak_enabled: true
+    keycloak_server_url: https://auth.akb.example.com
+    keycloak_internal_url: http://keycloak:8080
+    keycloak_realm: akb
+    keycloak_client_id: akb-web
+    keycloak_public_client: false
+    keycloak_admin_client_id: akb-admin
+    keycloak_management_client_id: akb-sso-manager
+    keycloak_enrollment_mode: open
+    keycloak_require_verified_email: true
+    keycloak_redirect_uri: https://akb.example.com/api/v1/auth/keycloak/callback
+    api_oauth_audience: https://akb.example.com/api
+    keycloak_verify_ssl: true
+
+    vector_store_driver: pgvector
+    vector_store_dsn: ""
+    vector_store_schema: vector_index
+    vector_store_sparse_shape: posting
+    vector_url: ""
+    vector_collection: chunks
+
+    public_base_url: https://akb.example.com
+    redis_url: ""

--- a/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: akb
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: bootstrap-standalone-sso
+          image: akb-backend:latest
+          imagePullPolicy: Always
+          command:
+            - python
+            - -m
+            - app.cli
+            - bootstrap-standalone-sso
+          args:
+            - --bootstrap-client-id
+            - $(AKB_BOOTSTRAP_CLIENT_ID)
+            - --bootstrap-client-secret-file
+            - /var/run/akb-bootstrap/keycloak/client-secret
+            - --product-admin-username
+            - $(AKB_PRODUCT_ADMIN_USERNAME)
+            - --product-admin-email
+            - $(AKB_PRODUCT_ADMIN_EMAIL)
+            - --product-admin-password-file
+            - /var/run/akb-bootstrap/product-admin/password
+          env:
+            - name: AKB_BOOTSTRAP_CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: akb-sso-bootstrap-config
+                  key: bootstrap-client-id
+            - name: AKB_PRODUCT_ADMIN_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: akb-sso-bootstrap-config
+                  key: product-admin-username
+            - name: AKB_PRODUCT_ADMIN_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: akb-sso-bootstrap-config
+                  key: product-admin-email
+          volumeMounts:
+            - name: app-config
+              mountPath: /etc/akb/app.yaml
+              subPath: app.yaml
+              readOnly: true
+            - name: secret-config
+              mountPath: /etc/akb/secret.yaml
+              subPath: secret.yaml
+              readOnly: true
+            - name: keycloak-bootstrap
+              mountPath: /var/run/akb-bootstrap/keycloak
+              readOnly: true
+            - name: product-admin-bootstrap
+              mountPath: /var/run/akb-bootstrap/product-admin
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      containers:
+        - name: backend
+          volumeMounts:
+            - name: local-session-keys
+              $patch: delete
+      volumes:
+        - name: local-session-keys
+          $patch: delete
+        - name: keycloak-bootstrap
+          secret:
+            secretName: akb-keycloak-bootstrap # pragma: allowlist secret
+            defaultMode: 0400
+        - name: product-admin-bootstrap
+          secret:
+            secretName: akb-product-admin-bootstrap # pragma: allowlist secret
+            defaultMode: 0400

--- a/deploy/k8s/standalone-sso/bootstrap-config.yaml
+++ b/deploy/k8s/standalone-sso/bootstrap-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: akb-sso-bootstrap-config
+  namespace: akb
+data:
+  bootstrap-client-id: akb-bootstrap-temporary
+  product-admin-username: admin
+  product-admin-email: admin@example.com

--- a/deploy/k8s/standalone-sso/keycloak-ingress.yaml
+++ b/deploy/k8s/standalone-sso/keycloak-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak-ingress
+  namespace: akb
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - auth.akb.example.com
+      secretName: akb-keycloak-tls # pragma: allowlist secret
+  rules:
+    - host: auth.akb.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: keycloak
+                port:
+                  number: 8080

--- a/deploy/k8s/standalone-sso/keycloak-postgres.yaml
+++ b/deploy/k8s/standalone-sso/keycloak-postgres.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgres
+  namespace: akb
+spec:
+  serviceName: keycloak-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: akb-keycloak-postgres
+  template:
+    metadata:
+      labels:
+        app: akb-keycloak-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: akb-keycloak-db-credentials
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - keycloak
+                - -d
+                - keycloak
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgres
+  namespace: akb
+spec:
+  clusterIP: None
+  selector:
+    app: akb-keycloak-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres

--- a/deploy/k8s/standalone-sso/keycloak.yaml
+++ b/deploy/k8s/standalone-sso/keycloak.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: akb
+spec:
+  serviceName: keycloak-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: akb-keycloak
+  template:
+    metadata:
+      labels:
+        app: akb-keycloak
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.7.0@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
+          imagePullPolicy: IfNotPresent
+          args:
+            - start
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: management
+              containerPort: 9000
+          env:
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL_HOST
+              value: keycloak-postgres
+            - name: KC_DB_URL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: akb-keycloak-db-credentials
+                  key: POSTGRES_DB
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: akb-keycloak-db-credentials
+                  key: POSTGRES_USER
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: akb-keycloak-db-credentials
+                  key: POSTGRES_PASSWORD
+            - name: KC_HOSTNAME
+              value: https://auth.akb.example.com
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_PROXY_HEADERS
+              value: xforwarded
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_METRICS_ENABLED
+              value: "true"
+            - name: KC_BOOTSTRAP_ADMIN_CLIENT_ID
+              value: akb-bootstrap-temporary
+            - name: KC_BOOTSTRAP_ADMIN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: akb-keycloak-bootstrap
+                  key: client-secret
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /health/started
+              port: management
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: management
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: management
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 6
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: akb
+spec:
+  clusterIP: None
+  selector:
+    app: akb-keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: akb
+spec:
+  selector:
+    app: akb-keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/k8s/standalone-sso/kustomization.yaml
+++ b/deploy/k8s/standalone-sso/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: akb
+
+resources:
+  - ../namespace.yaml
+  - akb-postgres.yaml
+  - ../backend.yaml
+  - ../frontend.yaml
+  - ../ingress.yaml
+  - bootstrap-config.yaml
+  - keycloak-postgres.yaml
+  - keycloak.yaml
+  - keycloak-ingress.yaml
+
+patches:
+  - path: backend-config-patch.yaml
+  - path: backend-deployment-patch.yaml


### PR DESCRIPTION
## Summary

- add a fail-closed standalone SSO bootstrap that converges a dedicated Keycloak realm, separate API/admin/management clients, RSA-3072 signing keys, and a native product administrator
- retire the temporary bootstrap client only after permanent-management reauthentication and denial read-back, then persist a monotonic bootstrap receipt
- harden `/admin` browser authentication to require a fresh native-password Keycloak session
- add a secret-free Kubernetes overlay for an AKB, Keycloak, Keycloak PostgreSQL, and AKB PostgreSQL bundle
- repair recovery-admin role synchronization uncovered by the new bootstrap path

## Why

AKB's SSO mode needs an installation-owned identity broker and administrator boundary without retaining a permanent realm-wide bootstrap credential. The deployed state must be reproducible, independently verifiable, and safe to restart after initial convergence.

This is the standalone SSO bootstrap phase of #357. Provider configuration and login-page provider controls remain follow-up work.

## Security properties

- rejects the Keycloak master realm as the target realm
- accepts secrets only through files and redacts reports and errors
- requires independently generated credentials
- configures a password policy and Keycloak admin-event auditing without storing request representations
- rejects federated or brokered product-admin identities
- pins the exact management service-account roles and scope mappings
- verifies both an already-issued bootstrap token and new token issuance are denied after retirement
- rejects missing, mismatched, or reactivated retirement state

## Validation

- backend: 2,171 passed, 247 skipped
- focused standalone SSO/auth suites: 55 passed
- frontend: design check, typecheck, lint, 436 tests, production build
- SDK: build, typecheck, code generation, package proof, 48 tests
- Ruff, MyPy, Bandit, tracked-file secret scan
- Kustomize render and Kubernetes client dry-run
- disposable Keycloak 26.7 + PostgreSQL convergence, receipt/read-back, sentinel restart, RSA-3072 verification, bootstrap-token denial, and complete teardown