### PR TITLE
feat: add runtime SSO provider control

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -379,6 +379,26 @@
         "is_secret": false
       }
     ],
+    "deploy/keycloak-dev/broker-chain/broker-realm.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/keycloak-dev/broker-chain/broker-realm.json",
+        "hashed_secret": "11c0e40e2d3611401a4acf3a4e0c41ddfecce0ab",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      }
+    ],
+    "deploy/keycloak-dev/broker-chain/upstream-realm.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/keycloak-dev/broker-chain/upstream-realm.json",
+        "hashed_secret": "3e0768d4636492ba86dc6766e1849cd9d699178c",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      }
+    ],
     "docker-compose.keycloak.yaml": [
       {
         "type": "Secret Keyword",

--- a/README.md
+++ b/README.md
@@ -336,6 +336,15 @@ refuses non-admin accounts. In `sso` mode local credentials are absent:
 and nonce, then accepts only the exact pre-bound `(issuer, subject)` whose AKB
 account is still active and `is_admin=true`.
 
+In SSO mode the same `/admin` surface can configure a built-in upstream IdP,
+save it disabled, inspect its exact broker redirect URI, and enable or disable
+its ordinary-login option without redeploying AKB. The option becomes a usable
+button only when the server-side browser-session capability is ready. Client
+secrets are write-only, and an enabled provider must be disabled before
+reconfiguration.
+See the [SSO provider guide](./docs/sso/README.md) and the first reference
+integration, [Keycloak OIDC behind Keycloak](./docs/sso/providers/keycloak-oidc.md).
+
 The SSO callback stores no Keycloak access, refresh, or ID token. It creates a
 short-lived opaque HttpOnly admin cookie plus a CSRF token; PostgreSQL stores
 only their hashes plus the exact identity snapshot, and rechecks the account,

--- a/backend/app/api/routes/admin_auth.py
+++ b/backend/app/api/routes/admin_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
-from fastapi import APIRouter, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.config import settings
@@ -18,6 +18,7 @@ from app.services.admin_auth_service import (
     resolve_prebound_sso_product_admin,
     resolve_sso_admin_browser_session,
     revoke_sso_admin_browser_session,
+    validate_sso_admin_browser_session_csrf,
 )
 from app.services.auth_service import AuthenticatedUser
 from app.services.keycloak_oidc import get_keycloak_oidc
@@ -35,6 +36,42 @@ _ADMIN_OIDC_CALLBACK_PATH = "/api/v1/admin/auth/keycloak/callback"
 class AdminLocalLoginRequest(NFCModel):
     username: str
     password: str
+
+
+ProductAdminActor = ProductAdminIdentity | AuthenticatedUser
+
+
+async def get_current_product_admin(
+    request: Request,
+    authorization: str | None = Header(default=None),
+) -> ProductAdminActor:
+    """Resolve the mode-selected product-admin credential."""
+    if settings.require_auth_mode() == "local":
+        if not authorization:
+            raise AuthenticationError()
+        return await resolve_local_product_admin(authorization)
+    return await resolve_sso_admin_browser_session(
+        request.cookies.get(_ADMIN_SESSION_COOKIE, "")
+    )
+
+
+async def get_product_admin_mutation(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    csrf_header: str | None = Header(default=None, alias="X-AKB-Admin-CSRF"),
+) -> ProductAdminActor:
+    """Resolve admin authority and require CSRF for cookie-backed SSO."""
+    if settings.require_auth_mode() == "local":
+        if not authorization:
+            raise AuthenticationError()
+        return await resolve_local_product_admin(authorization)
+    if csrf_header is None:
+        raise AuthenticationError("Invalid admin CSRF token")
+    return await validate_sso_admin_browser_session_csrf(
+        request.cookies.get(_ADMIN_SESSION_COOKIE, ""),
+        request.cookies.get(_ADMIN_CSRF_COOKIE, ""),
+        csrf_header,
+    )
 
 
 def _require_mode(expected: str) -> None:
@@ -234,18 +271,9 @@ async def admin_keycloak_callback(
 
 @router.get("/admin/auth/session", summary="Get current product-admin session")
 async def admin_session(
-    request: Request,
-    authorization: str | None = Header(default=None),
+    identity: ProductAdminActor = Depends(get_current_product_admin),
 ):
     mode = settings.require_auth_mode()
-    identity: ProductAdminIdentity | AuthenticatedUser
-    if mode == "local":
-        if not authorization:
-            raise AuthenticationError()
-        identity = await resolve_local_product_admin(authorization)
-    else:
-        raw_token = request.cookies.get(_ADMIN_SESSION_COOKIE, "")
-        identity = await resolve_sso_admin_browser_session(raw_token)
     return {
         "schema_version": 1,
         "auth_mode": mode,

--- a/backend/app/api/routes/admin_sso.py
+++ b/backend/app/api/routes/admin_sso.py
@@ -1,0 +1,266 @@
+"""Product-admin API for runtime SSO provider configuration."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation
+
+from app.api.routes.admin_auth import (
+    ProductAdminActor,
+    get_current_product_admin,
+    get_product_admin_mutation,
+)
+from app.config import settings
+from app.services import audit_log
+from app.sso.keycloak_admin import (
+    ProviderControlError,
+    get_keycloak_provider_control,
+)
+from app.sso.models import (
+    ProviderConfigureSpec,
+    ProviderMutationReadback,
+    ProviderReadback,
+)
+from app.sso.registry import provider_types
+
+
+class ConfigureProviderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider_type: str = Field(min_length=1, max_length=80)
+    display_name: str = Field(min_length=1, max_length=80)
+    issuer: str = Field(min_length=1, max_length=2048)
+    discovery_url: str = Field(min_length=1, max_length=2048)
+    client_id: str = Field(min_length=1, max_length=255)
+    # Skip Pydantic's value-echoing type error for this write-only field. The
+    # authenticated route validates the raw value and returns a value-less
+    # provider error, while OpenAPI still describes a nullable string.
+    client_secret: SkipValidation[str] | None = Field(default=None, repr=False)
+
+
+_CONFLICT_CODES = frozenset(
+    {
+        "keycloak_provider_control_delegated",
+        "provider_alias_conflict",
+        "provider_disable_before_reconfigure",
+        "provider_configuration_invalid",
+        "keycloak_provider_readback_failed",
+    }
+)
+_NOT_FOUND_CODES = frozenset({"provider_not_found"})
+_SAFE_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
+_INVALID_CODES = frozenset(
+    {
+        "unsupported_sso_provider_type",
+        "provider_type_mismatch",
+        "provider_alias_invalid",
+        "provider_display_name_invalid",
+        "provider_issuer_invalid",
+        "provider_issuer_is_broker",
+        "provider_discovery_url_invalid",
+        "provider_discovery_url_mismatch",
+        "provider_discovery_issuer_mismatch",
+        "provider_discovery_authorization_url_invalid",
+        "provider_discovery_token_url_invalid",
+        "provider_discovery_jwks_url_invalid",
+        "provider_discovery_optional_url_invalid",
+        "provider_client_id_invalid",
+        "provider_client_secret_invalid",
+        "provider_client_secret_required",
+    }
+)
+
+
+def _require_sso_mode() -> None:
+    if settings.require_auth_mode() != "sso":
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            "SSO provider control is not enabled",
+        )
+
+
+router = APIRouter(dependencies=[Depends(_require_sso_mode)])
+
+
+def _raise_control_error(error: ProviderControlError) -> None:
+    if error.code in _INVALID_CODES:
+        status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+        message = "SSO provider configuration is invalid"
+    elif error.code in _NOT_FOUND_CODES:
+        status_code = status.HTTP_404_NOT_FOUND
+        message = "SSO provider was not found"
+    elif error.code in _CONFLICT_CODES:
+        status_code = status.HTTP_409_CONFLICT
+        message = "SSO provider state conflicts with this operation"
+    else:
+        status_code = status.HTTP_502_BAD_GATEWAY
+        message = "SSO provider authority is unavailable"
+    raise HTTPException(
+        status_code,
+        detail={"message": message, "code": error.code},
+    ) from error
+
+
+def _audit(
+    action: str,
+    actor: ProductAdminActor,
+    alias: str,
+    *,
+    outcome: str = "ok",
+    code: str | None = None,
+    provider: ProviderReadback | None = None,
+    mutation: ProviderMutationReadback | None = None,
+    provider_type: str | None = None,
+) -> None:
+    meta = mutation.audit_view() if mutation is not None else None
+    if meta is None and provider is not None:
+        meta = provider.audit_view()
+    if meta is None and provider_type is not None:
+        meta = {"provider_type": provider_type}
+    if _SAFE_ALIAS_RE.fullmatch(alias):
+        target = f"provider={alias}"
+    else:
+        digest = hashlib.sha256(alias.encode("utf-8")).hexdigest()[:16]
+        target = f"provider=<invalid:sha256:{digest}>"
+    audit_log.record(
+        action=action,
+        actor=actor.username,
+        actor_id=str(actor.user_id),
+        target=target,
+        outcome=outcome,
+        code=code,
+        meta=meta,
+    )
+
+
+@router.get("/admin/sso/providers", summary="List managed SSO providers")
+async def list_sso_providers(
+    _actor: ProductAdminActor = Depends(get_current_product_admin),
+):
+    control = get_keycloak_provider_control()
+    providers: tuple[ProviderReadback, ...] = ()
+    if control.control_mode == "direct":
+        try:
+            providers = await control.list_providers(force_refresh=True)
+        except ProviderControlError as error:
+            _raise_control_error(error)
+    return {
+        "schema_version": 1,
+        "auth_mode": "sso",
+        "control_mode": control.control_mode,
+        "supported_provider_types": list(provider_types()),
+        "providers": [provider.admin_view() for provider in providers],
+    }
+
+
+@router.put(
+    "/admin/sso/providers/{alias}",
+    summary="Configure a disabled SSO provider",
+)
+async def configure_sso_provider(
+    alias: str,
+    request: ConfigureProviderRequest,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    _audit(
+        "admin.sso.provider.configure.requested",
+        actor,
+        alias,
+        provider_type=request.provider_type,
+    )
+    try:
+        raw_secret: object = request.client_secret
+        if raw_secret is not None and not isinstance(raw_secret, str):
+            raise ProviderControlError("provider_client_secret_invalid")
+        spec = ProviderConfigureSpec(
+            provider_type=request.provider_type,
+            alias=alias,
+            display_name=request.display_name,
+            issuer=request.issuer,
+            discovery_url=request.discovery_url,
+            client_id=request.client_id,
+            client_secret=raw_secret,
+        )
+        mutation = await get_keycloak_provider_control().configure(spec)
+    except ProviderControlError as error:
+        _audit(
+            "admin.sso.provider.configure",
+            actor,
+            alias,
+            outcome="error",
+            code=error.code,
+            provider_type=request.provider_type,
+        )
+        _raise_control_error(error)
+    except Exception:
+        _audit(
+            "admin.sso.provider.configure",
+            actor,
+            alias,
+            outcome="error",
+            code="internal_error",
+            provider_type=request.provider_type,
+        )
+        raise
+    _audit("admin.sso.provider.configure", actor, alias, mutation=mutation)
+    return {"provider": mutation.after.admin_view()}
+
+
+async def _toggle_sso_provider(
+    alias: str,
+    *,
+    enabled: bool,
+    actor: ProductAdminActor,
+) -> dict[str, object]:
+    verb = "enable" if enabled else "disable"
+    _audit(f"admin.sso.provider.{verb}.requested", actor, alias)
+    try:
+        mutation = await get_keycloak_provider_control().set_enabled(
+            alias,
+            enabled=enabled,
+        )
+    except ProviderControlError as error:
+        _audit(
+            f"admin.sso.provider.{verb}",
+            actor,
+            alias,
+            outcome="error",
+            code=error.code,
+        )
+        _raise_control_error(error)
+    except Exception:
+        _audit(
+            f"admin.sso.provider.{verb}",
+            actor,
+            alias,
+            outcome="error",
+            code="internal_error",
+        )
+        raise
+    _audit(f"admin.sso.provider.{verb}", actor, alias, mutation=mutation)
+    return {"provider": mutation.after.admin_view()}
+
+
+@router.post(
+    "/admin/sso/providers/{alias}/enable",
+    summary="Enable a configured SSO provider",
+)
+async def enable_sso_provider(
+    alias: str,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    return await _toggle_sso_provider(alias, enabled=True, actor=actor)
+
+
+@router.post(
+    "/admin/sso/providers/{alias}/disable",
+    summary="Disable an SSO provider",
+)
+async def disable_sso_provider(
+    alias: str,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    return await _toggle_sso_provider(alias, enabled=False, actor=actor)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -2,8 +2,9 @@
 
 import uuid
 from typing import NoReturn
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import ConfigDict, Field, field_validator
 
 from app.api.deps import get_current_user
@@ -29,6 +30,10 @@ from app.services.auth_service import (
 from app.services.auth_policy import (
     SSO_BROWSER_SESSION_READY,
     require_local_auth_enabled,
+)
+from app.sso.keycloak_admin import (
+    ProviderControlError,
+    get_keycloak_provider_control,
 )
 from app.util.text import NFCModel
 
@@ -139,13 +144,41 @@ async def login_user(req: LoginRequest):
 
 
 @router.get("/auth/config", summary="Public auth configuration")
-async def auth_config():
-    """Unauthenticated versioned capabilities; reveals no secrets."""
+async def auth_config(response: Response):
+    """Return unauthenticated versioned capabilities without secrets."""
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
     mode = settings.require_auth_mode()
     human_sso_enabled = mode == "sso" and settings.keycloak_enabled
     browser_session_ready = human_sso_enabled and SSO_BROWSER_SESSION_READY
+    providers: list[dict[str, object]] = []
+    if human_sso_enabled:
+        control = get_keycloak_provider_control()
+        if control.control_mode != "direct":
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "SSO provider catalog is unavailable",
+            )
+        try:
+            catalog = await control.list_providers(allow_stale=True)
+        except ProviderControlError as exc:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "SSO provider catalog is unavailable",
+            ) from exc
+        providers = [
+            provider.public_view(
+                login_url=(
+                    f"/api/v1/auth/sso/{quote(provider.alias, safe='')}/login"
+                    if browser_session_ready
+                    else None
+                )
+            )
+            for provider in catalog
+            if provider.state == "enabled"
+        ]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "auth_mode": mode,
         "local_auth": {
             "enabled": mode == "local",
@@ -153,12 +186,8 @@ async def auth_config():
         "keycloak": {
             "enabled": human_sso_enabled,
             "browser_session_ready": browser_session_ready,
-            "login_url": (
-                "/api/v1/auth/keycloak/login"
-                if browser_session_ready
-                else None
-            ),
         },
+        "providers": providers,
         "mcp_oauth": {
             "enabled": settings.mcp_oauth_enabled,
         },

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.api.deps import get_current_user, get_optional_user
 from app.api.routes import (
     access,
     admin_auth,
+    admin_sso,
     activity,
     assets,
     app_inventory,
@@ -274,7 +275,8 @@ async def _no_store_public_surfaces(request: Request, call_next):
             response.headers["Cache-Control"] = "no-store"
             break
     if (
-        path.startswith("/api/v1/admin/")
+        path == "/api/v1/auth/config"
+        or path.startswith("/api/v1/admin/")
         or path.startswith("/api/v1/app/installations/")
         or path.startswith("/api/v1/app/rollouts")
         or (path.startswith("/api/v1/apps/") and "/rollouts" in path)
@@ -290,6 +292,7 @@ async def _no_store_public_surfaces(request: Request, call_next):
 
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(admin_auth.router, prefix="/api/v1", tags=["admin-auth"])
+app.include_router(admin_sso.router, prefix="/api/v1", tags=["admin-sso"])
 app.include_router(app_identity.router, prefix="/api/v1", tags=["app-identity"])
 app.include_router(app_inventory.router, prefix="/api/v1", tags=["app-inventory"])
 app.include_router(app_installations.router, prefix="/api/v1", tags=["app-installations"])

--- a/backend/app/services/admin_auth_service.py
+++ b/backend/app/services/admin_auth_service.py
@@ -295,6 +295,69 @@ async def resolve_sso_admin_browser_session(
     return _identity_from_row(row)
 
 
+async def validate_sso_admin_browser_session_csrf(
+    raw_token: str,
+    csrf_cookie: str,
+    csrf_header: str,
+) -> ProductAdminIdentity:
+    """Resolve one live SSO admin session and its double-submit CSRF proof.
+
+    The token, CSRF hash, exact external binding, and current AKB admin status
+    are checked in one database lookup so a demotion or identity rebind takes
+    effect before the control-plane mutation can start.
+    """
+    token = _bounded_credential(raw_token)
+    cookie = _bounded_credential(csrf_cookie)
+    header = _bounded_credential(csrf_header)
+    if (
+        token is None
+        or cookie is None
+        or header is None
+        or not secrets.compare_digest(cookie, header)
+    ):
+        raise AuthenticationError("Invalid admin CSRF token")
+
+    token_hash = _hash_credential(token)
+    csrf_hash = _hash_credential(cookie)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                """
+                SELECT s.id AS session_id, s.csrf_token_hash,
+                       s.user_id, s.external_identity_id,
+                       u.username, u.email, u.display_name
+                  FROM admin_browser_sessions s
+                  JOIN users u ON u.id = s.user_id
+                  JOIN external_identities e
+                    ON e.id = s.external_identity_id AND e.user_id = s.user_id
+                 WHERE s.token_hash = $1
+                   AND s.expires_at > NOW()
+                   AND s.identity_issuer = $2
+                   AND e.issuer = s.identity_issuer
+                   AND e.subject = s.identity_subject
+                   AND u.is_admin
+                   AND u.account_status = 'active'
+                   AND u.account_kind = 'human'
+                   AND u.auth_provider = 'keycloak'
+                 FOR UPDATE OF s
+                """,
+                token_hash,
+                settings.keycloak_issuer,
+            )
+            if (
+                row is None
+                or not isinstance(row["csrf_token_hash"], str)
+                or not secrets.compare_digest(row["csrf_token_hash"], csrf_hash)
+            ):
+                raise AuthenticationError("Invalid admin CSRF token")
+            await conn.execute(
+                "UPDATE admin_browser_sessions SET last_seen_at = NOW() WHERE id = $1",
+                row["session_id"],
+            )
+    return _identity_from_row(row)
+
+
 async def revoke_sso_admin_browser_session(
     raw_token: str,
     csrf_cookie: str,

--- a/backend/app/sso/__init__.py
+++ b/backend/app/sso/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in SSO provider contribution surface.
+
+The package deliberately exposes a small, code-reviewed registry. It is not a
+dynamic plugin loader and never accepts arbitrary Keycloak representations.
+"""

--- a/backend/app/sso/keycloak_admin.py
+++ b/backend/app/sso/keycloak_admin.py
@@ -1,0 +1,625 @@
+"""Narrow Keycloak Admin REST control for built-in upstream SSO providers.
+
+The adapter accepts provider-neutral specifications and renders only the
+code-reviewed representation from the explicit registry. It never accepts an
+arbitrary Keycloak JSON document, returns a secret, or includes upstream
+response bodies in an error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+import time
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from app.sso.models import (
+    ProviderConfigureSpec,
+    ProviderMutationReadback,
+    ProviderReadback,
+)
+from app.sso.providers import keycloak_oidc
+from app.sso.providers.keycloak_oidc import ProviderDefinitionError
+from app.sso.registry import ProviderDefinition, provider_definition
+
+
+_CATALOG_LIMIT = 100
+_CACHE_FRESH_SECONDS = 15.0
+_CACHE_STALE_SECONDS = 60.0
+_FAILURE_BACKOFF_SECONDS = 5.0
+_MAX_RESPONSE_BYTES = 1_048_576
+
+
+class ProviderControlError(RuntimeError):
+    """Value-less control-plane failure safe for logs and API responses."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _fail(code: str) -> ProviderControlError:
+    return ProviderControlError(code)
+
+
+def _path(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _object(value: object, *, code: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _fail(code)
+    return value
+
+
+def _objects(value: object, *, code: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise _fail(code)
+    return value
+
+
+def _same_provider_configuration(
+    before: ProviderReadback,
+    after: ProviderReadback,
+) -> bool:
+    """Compare identity-affecting fields while ignoring the enabled state."""
+    return (
+        before.provider_type,
+        before.alias,
+        before.display_name,
+        before.issuer,
+        before.discovery_url,
+        before.client_id,
+        before.client_secret_configured,
+        before.redirect_uri,
+        before.supports_logout,
+        before.supports_identity_migration,
+    ) == (
+        after.provider_type,
+        after.alias,
+        after.display_name,
+        after.issuer,
+        after.discovery_url,
+        after.client_id,
+        after.client_secret_configured,
+        after.redirect_uri,
+        after.supports_logout,
+        after.supports_identity_migration,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class KeycloakAdminConfig:
+    internal_base_url: str
+    public_base_url: str
+    realm: str
+    management_client_id: str
+    management_client_secret: str = field(repr=False)
+    verify_ssl: bool
+
+    @property
+    def broker_issuer(self) -> str:
+        return f"{self.public_base_url.rstrip('/')}/realms/{self.realm}"
+
+
+class KeycloakProviderControl:
+    """Read, configure, and toggle only AKB-marked provider instances."""
+
+    def __init__(
+        self,
+        config: KeycloakAdminConfig,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.config = config
+        self._transport = transport
+        self._monotonic = monotonic
+        self._catalog: tuple[ProviderReadback, ...] | None = None
+        self._catalog_at = 0.0
+        self._catalog_error_code: str | None = None
+        self._catalog_error_at = 0.0
+        self._catalog_lock = asyncio.Lock()
+
+    @property
+    def control_mode(self) -> str:
+        if (
+            self.config.management_client_id.strip()
+            and self.config.management_client_secret
+        ):
+            return "direct"
+        return "delegated"
+
+    def _require_direct(self) -> None:
+        if self.control_mode != "direct":
+            raise _fail("keycloak_provider_control_delegated")
+        if (
+            not self.config.internal_base_url.strip()
+            or not self.config.public_base_url.strip()
+            or not self.config.realm.strip()
+        ):
+            raise _fail("keycloak_provider_control_invalid")
+
+    @asynccontextmanager
+    async def _client(self):
+        base_url = f"{self.config.internal_base_url.rstrip('/')}/"
+        async with httpx.AsyncClient(
+            base_url=base_url,
+            verify=self.config.verify_ssl,
+            timeout=httpx.Timeout(20.0, connect=10.0),
+            transport=self._transport,
+        ) as client:
+            yield client
+
+    @staticmethod
+    def _json(response: httpx.Response, *, code: str) -> object:
+        try:
+            return response.json()
+        except (TypeError, ValueError) as exc:
+            raise _fail(code) from exc
+
+    async def _bounded_request(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        *,
+        code: str,
+        headers: Mapping[str, str] | None = None,
+        json_body: object | None = None,
+        form_body: Mapping[str, str] | None = None,
+        params: Mapping[str, str | int | bool] | None = None,
+    ) -> httpx.Response:
+        request = client.build_request(
+            method,
+            path,
+            headers=headers,
+            json=json_body,
+            data=form_body,
+            params=params,
+        )
+        response: httpx.Response | None = None
+        try:
+            response = await client.send(request, stream=True)
+            content = bytearray()
+            async for chunk in response.aiter_bytes():
+                if len(content) + len(chunk) > _MAX_RESPONSE_BYTES:
+                    raise _fail(code)
+                content.extend(chunk)
+            return httpx.Response(
+                response.status_code,
+                headers=response.headers,
+                content=bytes(content),
+                request=request,
+            )
+        except ProviderControlError:
+            raise
+        except httpx.HTTPError as exc:
+            raise _fail("keycloak_provider_control_unreachable") from exc
+        finally:
+            if response is not None:
+                await response.aclose()
+
+    async def _token(self, client: httpx.AsyncClient) -> str:
+        response = await self._bounded_request(
+            client,
+            "POST",
+            (
+                f"/realms/{_path(self.config.realm)}"
+                "/protocol/openid-connect/token"
+            ),
+            code="keycloak_provider_token_invalid",
+            form_body={
+                "grant_type": "client_credentials",
+                "client_id": self.config.management_client_id,
+                "client_secret": self.config.management_client_secret,
+            },
+        )
+        if response.status_code != 200:
+            raise _fail("keycloak_provider_control_unauthorized")
+        body = _object(
+            self._json(response, code="keycloak_provider_token_invalid"),
+            code="keycloak_provider_token_invalid",
+        )
+        token = body.get("access_token")
+        if not isinstance(token, str) or not token or len(token) > 16_384:
+            raise _fail("keycloak_provider_token_invalid")
+        return token
+
+    async def _request(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        *,
+        token: str,
+        expected: frozenset[int],
+        code: str,
+        json_body: object | None = None,
+        params: Mapping[str, str | int | bool] | None = None,
+    ) -> httpx.Response:
+        response = await self._bounded_request(
+            client,
+            method,
+            path,
+            code=code,
+            headers={"Authorization": f"Bearer {token}"},
+            json_body=json_body,
+            params=params,
+        )
+        if response.status_code not in expected:
+            raise _fail(code)
+        return response
+
+    def _instances_path(self) -> str:
+        return (
+            f"/admin/realms/{_path(self.config.realm)}"
+            "/identity-provider/instances"
+        )
+
+    async def _get_exact(
+        self,
+        client: httpx.AsyncClient,
+        token: str,
+        alias: str,
+    ) -> dict[str, Any] | None:
+        response = await self._request(
+            client,
+            "GET",
+            f"{self._instances_path()}/{_path(alias)}",
+            token=token,
+            expected=frozenset({200, 404}),
+            code="keycloak_provider_read_failed",
+        )
+        if response.status_code == 404:
+            return None
+        return _object(
+            self._json(response, code="keycloak_provider_read_failed"),
+            code="keycloak_provider_read_failed",
+        )
+
+    @staticmethod
+    def _definition_for_representation(
+        representation: Mapping[str, object],
+    ) -> ProviderDefinition | None:
+        config = representation.get("config")
+        if not isinstance(config, dict):
+            return None
+        provider_type = config.get(keycloak_oidc.MARKER_TYPE_KEY)
+        if not isinstance(provider_type, str):
+            return None
+        try:
+            definition = provider_definition(provider_type)
+        except ValueError:
+            return None
+        if not definition.module.is_managed_representation(representation):
+            return None
+        return definition
+
+    def _readback(
+        self,
+        definition: ProviderDefinition,
+        representation: Mapping[str, object],
+    ) -> ProviderReadback:
+        return definition.module.readback(
+            representation,
+            broker_base_url=self.config.public_base_url,
+            broker_issuer=self.config.broker_issuer,
+            realm=self.config.realm,
+        )
+
+    async def _fetch_catalog(self) -> tuple[ProviderReadback, ...]:
+        self._require_direct()
+        async with self._client() as client:
+            token = await self._token(client)
+            response = await self._request(
+                client,
+                "GET",
+                self._instances_path(),
+                token=token,
+                params={"first": 0, "max": _CATALOG_LIMIT + 1, "realmOnly": True},
+                expected=frozenset({200}),
+                code="keycloak_provider_list_failed",
+            )
+            values = _objects(
+                self._json(response, code="keycloak_provider_list_failed"),
+                code="keycloak_provider_list_failed",
+            )
+        if len(values) > _CATALOG_LIMIT:
+            raise _fail("keycloak_provider_catalog_truncated")
+        providers: list[ProviderReadback] = []
+        aliases: set[str] = set()
+        for value in values:
+            definition = self._definition_for_representation(value)
+            if definition is None:
+                continue
+            provider = self._readback(definition, value)
+            if not provider.alias or provider.alias in aliases:
+                raise _fail("keycloak_provider_catalog_invalid")
+            aliases.add(provider.alias)
+            providers.append(provider)
+        return tuple(sorted(providers, key=lambda item: item.alias))
+
+    async def list_providers(
+        self,
+        *,
+        force_refresh: bool = False,
+        allow_stale: bool = False,
+    ) -> tuple[ProviderReadback, ...]:
+        self._require_direct()
+        now = self._monotonic()
+        if (
+            not force_refresh
+            and self._catalog is not None
+            and now - self._catalog_at <= _CACHE_FRESH_SECONDS
+        ):
+            return self._catalog
+        if (
+            not force_refresh
+            and self._catalog_error_code is not None
+            and now - self._catalog_error_at <= _FAILURE_BACKOFF_SECONDS
+        ):
+            stale_limit = _CACHE_FRESH_SECONDS + _CACHE_STALE_SECONDS
+            if (
+                allow_stale
+                and self._catalog is not None
+                and now - self._catalog_at <= stale_limit
+            ):
+                return self._catalog
+            raise _fail(self._catalog_error_code)
+        async with self._catalog_lock:
+            now = self._monotonic()
+            if (
+                not force_refresh
+                and self._catalog is not None
+                and now - self._catalog_at <= _CACHE_FRESH_SECONDS
+            ):
+                return self._catalog
+            if (
+                not force_refresh
+                and self._catalog_error_code is not None
+                and now - self._catalog_error_at <= _FAILURE_BACKOFF_SECONDS
+            ):
+                stale_limit = _CACHE_FRESH_SECONDS + _CACHE_STALE_SECONDS
+                if (
+                    allow_stale
+                    and self._catalog is not None
+                    and now - self._catalog_at <= stale_limit
+                ):
+                    return self._catalog
+                raise _fail(self._catalog_error_code)
+            try:
+                catalog = await self._fetch_catalog()
+            except ProviderControlError as error:
+                now = self._monotonic()
+                self._catalog_error_code = error.code
+                self._catalog_error_at = now
+                stale_limit = _CACHE_FRESH_SECONDS + _CACHE_STALE_SECONDS
+                if (
+                    allow_stale
+                    and not force_refresh
+                    and self._catalog is not None
+                    and now - self._catalog_at <= stale_limit
+                ):
+                    return self._catalog
+                raise
+            self._catalog = catalog
+            self._catalog_at = self._monotonic()
+            self._catalog_error_code = None
+            self._catalog_error_at = 0.0
+            return catalog
+
+    async def _import_discovery(
+        self,
+        client: httpx.AsyncClient,
+        token: str,
+        definition: ProviderDefinition,
+        spec: ProviderConfigureSpec,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            client,
+            "POST",
+            (
+                f"/admin/realms/{_path(self.config.realm)}"
+                "/identity-provider/import-config"
+            ),
+            token=token,
+            json_body={
+                "providerId": definition.module.KEYCLOAK_PROVIDER_ID,
+                "fromUrl": spec.discovery_url,
+            },
+            expected=frozenset({200}),
+            code="keycloak_provider_discovery_import_failed",
+        )
+        return _object(
+            self._json(response, code="keycloak_provider_discovery_import_failed"),
+            code="keycloak_provider_discovery_import_failed",
+        )
+
+    async def configure(
+        self,
+        spec: ProviderConfigureSpec,
+    ) -> ProviderMutationReadback:
+        self._require_direct()
+        try:
+            definition = provider_definition(spec.provider_type)
+            validated = definition.module.validate_spec(
+                spec,
+                broker_issuer=self.config.broker_issuer,
+            )
+        except (ValueError, ProviderDefinitionError) as exc:
+            code = getattr(exc, "code", "unsupported_sso_provider_type")
+            raise _fail(code) from exc
+
+        async with self._client() as client:
+            token = await self._token(client)
+            existing = await self._get_exact(client, token, validated.alias)
+            preserve_secret = False
+            existing_readback: ProviderReadback | None = None
+            if existing is None:
+                if validated.client_secret is None:
+                    raise _fail("provider_client_secret_required")
+            else:
+                existing_definition = self._definition_for_representation(existing)
+                if (
+                    existing_definition is None
+                    or existing_definition.provider_type != definition.provider_type
+                ):
+                    raise _fail("provider_alias_conflict")
+                existing_readback = self._readback(existing_definition, existing)
+                if existing.get("enabled") is True:
+                    raise _fail("provider_disable_before_reconfigure")
+                if validated.client_secret is None:
+                    if not existing_readback.client_secret_configured:
+                        raise _fail("provider_client_secret_required")
+                    preserve_secret = True
+
+            imported = await self._import_discovery(
+                client,
+                token,
+                definition,
+                validated,
+            )
+            try:
+                desired = definition.module.render_representation(
+                    validated,
+                    imported,
+                    preserve_secret=preserve_secret,
+                )
+            except ProviderDefinitionError as exc:
+                raise _fail(exc.code) from exc
+            if existing is None:
+                await self._request(
+                    client,
+                    "POST",
+                    self._instances_path(),
+                    token=token,
+                    json_body=desired,
+                    expected=frozenset({201}),
+                    code="keycloak_provider_create_failed",
+                )
+            else:
+                await self._request(
+                    client,
+                    "PUT",
+                    f"{self._instances_path()}/{_path(validated.alias)}",
+                    token=token,
+                    json_body=desired,
+                    expected=frozenset({204}),
+                    code="keycloak_provider_update_failed",
+                )
+            representation = await self._get_exact(client, token, validated.alias)
+        if representation is None:
+            raise _fail("keycloak_provider_readback_failed")
+        readback = self._readback(definition, representation)
+        if (
+            readback.alias != validated.alias
+            or readback.display_name != validated.display_name
+            or readback.issuer != validated.issuer
+            or readback.discovery_url != validated.discovery_url
+            or readback.client_id != validated.client_id
+            or not readback.client_secret_configured
+            or readback.state != "configured_disabled"
+        ):
+            raise _fail("keycloak_provider_readback_failed")
+        self._catalog = None
+        self._catalog_at = 0.0
+        self._catalog_error_code = None
+        self._catalog_error_at = 0.0
+        return ProviderMutationReadback(before=existing_readback, after=readback)
+
+    async def set_enabled(
+        self,
+        alias: str,
+        *,
+        enabled: bool,
+    ) -> ProviderMutationReadback:
+        self._require_direct()
+        try:
+            validated_alias = keycloak_oidc.validate_alias(alias)
+        except ProviderDefinitionError as exc:
+            raise _fail(exc.code) from exc
+        async with self._client() as client:
+            token = await self._token(client)
+            representation = await self._get_exact(client, token, validated_alias)
+            if representation is None:
+                raise _fail("provider_not_found")
+            definition = self._definition_for_representation(representation)
+            if definition is None:
+                raise _fail("provider_alias_conflict")
+            current = self._readback(definition, representation)
+            if enabled and current.state == "configuration_error":
+                raise _fail("provider_configuration_invalid")
+
+            already_desired = (
+                representation.get("enabled") is enabled
+                and representation.get("hideOnLogin") is (not enabled)
+            )
+            if not already_desired:
+                desired = definition.module.with_enabled(
+                    representation,
+                    enabled=enabled,
+                )
+                await self._request(
+                    client,
+                    "PUT",
+                    f"{self._instances_path()}/{_path(validated_alias)}",
+                    token=token,
+                    json_body=desired,
+                    expected=frozenset({204}),
+                    code="keycloak_provider_toggle_failed",
+                )
+                representation = await self._get_exact(client, token, validated_alias)
+                if representation is None:
+                    raise _fail("keycloak_provider_readback_failed")
+            readback = self._readback(definition, representation)
+        if readback.alias != validated_alias:
+            raise _fail("keycloak_provider_readback_failed")
+        if not _same_provider_configuration(current, readback):
+            raise _fail("keycloak_provider_readback_failed")
+        if enabled and readback.state != "enabled":
+            raise _fail("keycloak_provider_readback_failed")
+        if not enabled and not (
+            representation.get("enabled") is False
+            and representation.get("hideOnLogin") is True
+        ):
+            raise _fail("keycloak_provider_readback_failed")
+        self._catalog = None
+        self._catalog_at = 0.0
+        self._catalog_error_code = None
+        self._catalog_error_at = 0.0
+        return ProviderMutationReadback(before=current, after=readback)
+
+
+def _runtime_config() -> KeycloakAdminConfig:
+    from app.config import settings
+
+    return KeycloakAdminConfig(
+        internal_base_url=(
+            settings.keycloak_internal_url or settings.keycloak_server_url
+        ),
+        public_base_url=settings.keycloak_server_url,
+        realm=settings.keycloak_realm,
+        management_client_id=settings.keycloak_management_client_id,
+        management_client_secret=settings.keycloak_management_client_secret,
+        verify_ssl=settings.keycloak_verify_ssl,
+    )
+
+
+_runtime_control: KeycloakProviderControl | None = None
+_runtime_control_config: KeycloakAdminConfig | None = None
+
+
+def get_keycloak_provider_control() -> KeycloakProviderControl:
+    """Return the process control, rebuilding if runtime settings changed."""
+    global _runtime_control, _runtime_control_config
+    config = _runtime_config()
+    if _runtime_control is None or _runtime_control_config != config:
+        _runtime_control = KeycloakProviderControl(config)
+        _runtime_control_config = config
+    return _runtime_control

--- a/backend/app/sso/models.py
+++ b/backend/app/sso/models.py
@@ -1,0 +1,93 @@
+"""Provider-neutral models for the AKB SSO control plane."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+ProviderState = Literal[
+    "configured_disabled",
+    "enabled",
+    "configuration_error",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderConfigureSpec:
+    provider_type: str
+    alias: str
+    display_name: str
+    issuer: str
+    discovery_url: str
+    client_id: str
+    client_secret: str | None = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderReadback:
+    provider_type: str
+    alias: str
+    display_name: str
+    state: ProviderState
+    enabled: bool
+    issuer: str | None
+    discovery_url: str | None
+    client_id: str | None
+    client_secret_configured: bool
+    redirect_uri: str
+    supports_logout: bool
+    supports_identity_migration: bool
+
+    def admin_view(self) -> dict[str, object]:
+        return {
+            "provider_type": self.provider_type,
+            "alias": self.alias,
+            "display_name": self.display_name,
+            "state": self.state,
+            "enabled": self.enabled,
+            "issuer": self.issuer,
+            "discovery_url": self.discovery_url,
+            "client_id": self.client_id,
+            "client_secret_configured": self.client_secret_configured,
+            "redirect_uri": self.redirect_uri,
+            "capabilities": {
+                "supports_logout": self.supports_logout,
+                "supports_identity_migration": self.supports_identity_migration,
+            },
+        }
+
+    def public_view(self, *, login_url: str | None) -> dict[str, object]:
+        return {
+            "provider_type": self.provider_type,
+            "alias": self.alias,
+            "display_name": self.display_name,
+            "login_url": login_url,
+        }
+
+    def audit_view(self) -> dict[str, object]:
+        """Return bounded, secret-free mutation evidence."""
+        return {
+            "provider_type": self.provider_type,
+            "alias": self.alias,
+            "display_name": self.display_name,
+            "state": self.state,
+            "enabled": self.enabled,
+            "issuer": self.issuer,
+            "client_id": self.client_id,
+            "client_secret_configured": self.client_secret_configured,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderMutationReadback:
+    """Secret-free before/after evidence from one successful mutation."""
+
+    before: ProviderReadback | None
+    after: ProviderReadback
+
+    def audit_view(self) -> dict[str, object]:
+        return {
+            "before": self.before.audit_view() if self.before is not None else None,
+            "after": self.after.audit_view(),
+        }

--- a/backend/app/sso/providers/__init__.py
+++ b/backend/app/sso/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in SSO provider definitions."""

--- a/backend/app/sso/providers/keycloak_oidc.py
+++ b/backend/app/sso/providers/keycloak_oidc.py
@@ -1,0 +1,405 @@
+"""Reference upstream provider: a Keycloak realm brokered through Keycloak."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+from urllib.parse import quote, urlsplit
+
+from app.sso.models import ProviderConfigureSpec, ProviderReadback, ProviderState
+from app.util.text import to_nfc
+
+
+PROVIDER_TYPE = "keycloak-oidc"
+KEYCLOAK_PROVIDER_ID = "oidc"
+MARKER_TYPE_KEY = "akbProviderType"
+MARKER_SCHEMA_KEY = "akbProviderSchema"
+MARKER_SCHEMA_VALUE = "1"
+MASKED_SECRET = "**********"  # pragma: allowlist secret
+_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:@/-]{1,255}$")
+
+
+class ProviderDefinitionError(ValueError):
+    """Value-less provider contract rejection safe for public diagnostics."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def validate_alias(value: str) -> str:
+    alias = _clean_text(value, maximum=63, code="provider_alias_invalid")
+    if not _ALIAS_RE.fullmatch(alias):
+        raise ProviderDefinitionError("provider_alias_invalid")
+    return alias
+
+
+def _clean_text(value: str, *, maximum: int, code: str) -> str:
+    cleaned = to_nfc(value).strip()
+    if (
+        not cleaned
+        or len(cleaned) > maximum
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in cleaned)
+    ):
+        raise ProviderDefinitionError(code)
+    return cleaned
+
+
+def _opaque_secret(value: str, *, code: str) -> str:
+    if (
+        not value
+        or len(value) > 4096
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise ProviderDefinitionError(code)
+    return value
+
+
+def _https_url(value: str, *, code: str) -> str:
+    cleaned = _clean_text(value, maximum=2048, code=code)
+    try:
+        parsed = urlsplit(cleaned)
+        port = parsed.port
+    except ValueError as exc:
+        raise ProviderDefinitionError(code) from exc
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or (port is not None and not 1 <= port <= 65535)
+    ):
+        raise ProviderDefinitionError(code)
+    return cleaned
+
+
+def _issuer_identity(value: str) -> tuple[str, int | None, str]:
+    parsed = urlsplit(value)
+    port = parsed.port
+    if port == 443:
+        port = None
+    return (
+        (parsed.hostname or "").lower(),
+        port,
+        parsed.path.rstrip("/"),
+    )
+
+
+def validate_spec(spec: ProviderConfigureSpec, *, broker_issuer: str) -> ProviderConfigureSpec:
+    if spec.provider_type != PROVIDER_TYPE:
+        raise ProviderDefinitionError("provider_type_mismatch")
+    alias = validate_alias(spec.alias)
+    display_name = _clean_text(
+        spec.display_name,
+        maximum=80,
+        code="provider_display_name_invalid",
+    )
+    issuer = _https_url(spec.issuer, code="provider_issuer_invalid").rstrip("/")
+    if _issuer_identity(issuer) == _issuer_identity(broker_issuer):
+        raise ProviderDefinitionError("provider_issuer_is_broker")
+    discovery_url = _https_url(
+        spec.discovery_url,
+        code="provider_discovery_url_invalid",
+    )
+    expected_discovery = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    if discovery_url != expected_discovery:
+        raise ProviderDefinitionError("provider_discovery_url_mismatch")
+    client_id = _clean_text(spec.client_id, maximum=255, code="provider_client_id_invalid")
+    if not _CLIENT_ID_RE.fullmatch(client_id):
+        raise ProviderDefinitionError("provider_client_id_invalid")
+    secret = spec.client_secret
+    if secret is not None:
+        secret = _opaque_secret(secret, code="provider_client_secret_invalid")
+    return ProviderConfigureSpec(
+        provider_type=PROVIDER_TYPE,
+        alias=alias,
+        display_name=display_name,
+        issuer=issuer,
+        discovery_url=discovery_url,
+        client_id=client_id,
+        client_secret=secret,
+    )
+
+
+def is_managed_representation(value: Mapping[str, object]) -> bool:
+    config = value.get("config")
+    return bool(
+        isinstance(config, dict)
+        and config.get(MARKER_TYPE_KEY) == PROVIDER_TYPE
+        and config.get(MARKER_SCHEMA_KEY) == MARKER_SCHEMA_VALUE
+    )
+
+
+def _required_imported_url(
+    imported: Mapping[str, object],
+    key: str,
+    *,
+    code: str,
+) -> str:
+    value = imported.get(key)
+    if not isinstance(value, str):
+        raise ProviderDefinitionError(code)
+    return _https_url(value, code=code)
+
+
+def _required_keycloak_endpoint(
+    imported: Mapping[str, object],
+    key: str,
+    *,
+    issuer: str,
+    suffix: str,
+    code: str,
+) -> str:
+    value = _required_imported_url(imported, key, code=code)
+    if value != f"{issuer}{suffix}":
+        raise ProviderDefinitionError(code)
+    return value
+
+
+def render_representation(
+    spec: ProviderConfigureSpec,
+    imported: Mapping[str, object],
+    *,
+    preserve_secret: bool,
+) -> dict[str, object]:
+    imported_issuer = imported.get("issuer")
+    if imported_issuer != spec.issuer:
+        raise ProviderDefinitionError("provider_discovery_issuer_mismatch")
+    authorization_url = _required_keycloak_endpoint(
+        imported,
+        "authorizationUrl",
+        issuer=spec.issuer,
+        suffix="/protocol/openid-connect/auth",
+        code="provider_discovery_authorization_url_invalid",
+    )
+    token_url = _required_keycloak_endpoint(
+        imported,
+        "tokenUrl",
+        issuer=spec.issuer,
+        suffix="/protocol/openid-connect/token",
+        code="provider_discovery_token_url_invalid",
+    )
+    jwks_url = _required_keycloak_endpoint(
+        imported,
+        "jwksUrl",
+        issuer=spec.issuer,
+        suffix="/protocol/openid-connect/certs",
+        code="provider_discovery_jwks_url_invalid",
+    )
+    config: dict[str, str] = {
+        "issuer": spec.issuer,
+        "authorizationUrl": authorization_url,
+        "tokenUrl": token_url,
+        "jwksUrl": jwks_url,
+        "useJwksUrl": "true",
+        "validateSignature": "true",
+        "clientId": spec.client_id,
+        "clientSecret": MASKED_SECRET if preserve_secret else spec.client_secret or "",
+        "clientAuthMethod": "client_secret_basic",
+        "defaultScope": "openid profile email",
+        "syncMode": "IMPORT",
+        "pkceEnabled": "true",
+        "pkceMethod": "S256",
+        "metadataDescriptorUrl": spec.discovery_url,
+        MARKER_TYPE_KEY: PROVIDER_TYPE,
+        MARKER_SCHEMA_KEY: MARKER_SCHEMA_VALUE,
+    }
+    optional_endpoints = {
+        "userInfoUrl": "/protocol/openid-connect/userinfo",
+        "logoutUrl": "/protocol/openid-connect/logout",
+        "tokenIntrospectionUrl": "/protocol/openid-connect/token/introspect",
+    }
+    for key, suffix in optional_endpoints.items():
+        value = imported.get(key)
+        if value is not None:
+            if not isinstance(value, str):
+                raise ProviderDefinitionError("provider_discovery_optional_url_invalid")
+            endpoint = _https_url(
+                value,
+                code="provider_discovery_optional_url_invalid",
+            )
+            if endpoint != f"{spec.issuer}{suffix}":
+                raise ProviderDefinitionError("provider_discovery_optional_url_invalid")
+            config[key] = endpoint
+    return {
+        "alias": spec.alias,
+        "displayName": spec.display_name,
+        "providerId": KEYCLOAK_PROVIDER_ID,
+        "enabled": False,
+        "trustEmail": False,
+        "storeToken": False,
+        "addReadTokenRoleOnCreate": False,
+        "authenticateByDefault": False,
+        "linkOnly": False,
+        "hideOnLogin": True,
+        "firstBrokerLoginFlowAlias": "first broker login",
+        "config": config,
+    }
+
+
+def with_enabled(
+    representation: Mapping[str, object],
+    *,
+    enabled: bool,
+) -> dict[str, object]:
+    updated = dict(representation)
+    updated["enabled"] = enabled
+    updated["hideOnLogin"] = not enabled
+    return updated
+
+
+def _config_string(config: Mapping[str, object], key: str) -> str | None:
+    value = config.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _secret_configured(config: Mapping[str, object]) -> bool:
+    value = _config_string(config, "clientSecret")
+    return bool(
+        value
+        and (
+            value == MASKED_SECRET
+            or (
+                value.startswith("${vault.")
+                and value.endswith("}")
+                and len(value) <= 512
+                and "{" not in value[2:]
+                and "}" not in value[:-1]
+            )
+        )
+    )
+
+
+def readback(
+    representation: Mapping[str, object],
+    *,
+    broker_base_url: str,
+    broker_issuer: str,
+    realm: str,
+) -> ProviderReadback:
+    config_value = representation.get("config")
+    config: Mapping[str, object] = config_value if isinstance(config_value, dict) else {}
+    alias_value = representation.get("alias")
+    raw_alias = alias_value if isinstance(alias_value, str) else ""
+    alias_is_valid = True
+    try:
+        alias = validate_alias(raw_alias)
+    except ProviderDefinitionError:
+        alias = ""
+        alias_is_valid = False
+    display_value = representation.get("displayName")
+    display_is_valid = True
+    try:
+        display_name = _clean_text(
+            display_value if isinstance(display_value, str) else "",
+            maximum=80,
+            code="provider_display_name_invalid",
+        )
+    except ProviderDefinitionError:
+        display_name = alias
+        display_is_valid = False
+    secret_configured = _secret_configured(config)
+    raw_issuer = _config_string(config, "issuer")
+    raw_discovery_url = _config_string(config, "metadataDescriptorUrl")
+    raw_client_id = _config_string(config, "clientId")
+    issuer: str | None = None
+    discovery_url: str | None = None
+    client_id: str | None = None
+    values_are_valid = False
+    if (
+        alias_is_valid
+        and display_is_valid
+        and raw_issuer is not None
+        and raw_discovery_url is not None
+        and raw_client_id is not None
+    ):
+        try:
+            validated = validate_spec(
+                ProviderConfigureSpec(
+                    provider_type=PROVIDER_TYPE,
+                    alias=alias,
+                    display_name=display_name,
+                    issuer=raw_issuer,
+                    discovery_url=raw_discovery_url,
+                    client_id=raw_client_id,
+                    client_secret=MASKED_SECRET,
+                ),
+                broker_issuer=broker_issuer,
+            )
+            expected_endpoints = {
+                "authorizationUrl": "/protocol/openid-connect/auth",
+                "tokenUrl": "/protocol/openid-connect/token",
+                "jwksUrl": "/protocol/openid-connect/certs",
+            }
+            for key, suffix in expected_endpoints.items():
+                value = _config_string(config, key)
+                if value != f"{validated.issuer}{suffix}":
+                    raise ProviderDefinitionError("provider_readback_url_invalid")
+            optional_endpoints = {
+                "userInfoUrl": "/protocol/openid-connect/userinfo",
+                "logoutUrl": "/protocol/openid-connect/logout",
+                "tokenIntrospectionUrl": "/protocol/openid-connect/token/introspect",
+            }
+            for key, suffix in optional_endpoints.items():
+                value = _config_string(config, key)
+                if value is not None and value != f"{validated.issuer}{suffix}":
+                    raise ProviderDefinitionError("provider_readback_url_invalid")
+            issuer = validated.issuer
+            discovery_url = validated.discovery_url
+            client_id = validated.client_id
+            values_are_valid = True
+        except ProviderDefinitionError:
+            values_are_valid = False
+    common_matches = all(
+        (
+            values_are_valid,
+            representation.get("providerId") == KEYCLOAK_PROVIDER_ID,
+            representation.get("trustEmail") is False,
+            representation.get("storeToken") is False,
+            representation.get("addReadTokenRoleOnCreate") is False,
+            representation.get("authenticateByDefault") is False,
+            representation.get("linkOnly") is False,
+            representation.get("firstBrokerLoginFlowAlias") == "first broker login",
+            config.get(MARKER_TYPE_KEY) == PROVIDER_TYPE,
+            config.get(MARKER_SCHEMA_KEY) == MARKER_SCHEMA_VALUE,
+            config.get("useJwksUrl") == "true",
+            config.get("validateSignature") == "true",
+            config.get("clientAuthMethod") == "client_secret_basic",
+            config.get("defaultScope") == "openid profile email",
+            config.get("syncMode") == "IMPORT",
+            config.get("pkceEnabled") == "true",
+            config.get("pkceMethod") == "S256",
+            secret_configured,
+        )
+    )
+    enabled = representation.get("enabled") is True
+    hidden = representation.get("hideOnLogin") is True
+    if common_matches and enabled and not hidden:
+        state: ProviderState = "enabled"
+    elif common_matches and not enabled and hidden:
+        state = "configured_disabled"
+    else:
+        state = "configuration_error"
+    redirect_uri = (
+        f"{broker_base_url.rstrip('/')}/realms/{quote(realm, safe='')}/broker/"
+        f"{quote(alias, safe='')}/endpoint"
+    )
+    return ProviderReadback(
+        provider_type=PROVIDER_TYPE,
+        alias=alias,
+        display_name=display_name,
+        state=state,
+        enabled=enabled,
+        issuer=issuer,
+        discovery_url=discovery_url,
+        client_id=client_id,
+        client_secret_configured=secret_configured,
+        redirect_uri=redirect_uri,
+        supports_logout=True,
+        # Exact old/new binding prelink and readiness are delivered by the
+        # migration slice, not inferred merely because Keycloak can federate.
+        supports_identity_migration=False,
+    )

--- a/backend/app/sso/registry.py
+++ b/backend/app/sso/registry.py
@@ -1,0 +1,33 @@
+"""Explicit built-in SSO provider registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import ModuleType
+
+from app.sso.providers import keycloak_oidc
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDefinition:
+    provider_type: str
+    module: ModuleType
+
+
+_DEFINITIONS = {
+    keycloak_oidc.PROVIDER_TYPE: ProviderDefinition(
+        provider_type=keycloak_oidc.PROVIDER_TYPE,
+        module=keycloak_oidc,
+    ),
+}
+
+
+def provider_definition(provider_type: str) -> ProviderDefinition:
+    try:
+        return _DEFINITIONS[provider_type]
+    except KeyError as exc:
+        raise ValueError("unsupported_sso_provider_type") from exc
+
+
+def provider_types() -> tuple[str, ...]:
+    return tuple(sorted(_DEFINITIONS))

--- a/backend/tests/test_admin_auth_postgres.py
+++ b/backend/tests/test_admin_auth_postgres.py
@@ -276,6 +276,21 @@ async def test_sso_admin_is_exact_prebound_opaque_and_live_rechecked(
         assert resolved.user_id == admin_user_id
 
         with pytest.raises(AuthenticationError):
+            await admin_auth_service.validate_sso_admin_browser_session_csrf(
+                issued.token,
+                issued.csrf_token,
+                "wrong-csrf-token-that-is-long-enough",
+            )
+        mutation_identity = (
+            await admin_auth_service.validate_sso_admin_browser_session_csrf(
+                issued.token,
+                issued.csrf_token,
+                issued.csrf_token,
+            )
+        )
+        assert mutation_identity.user_id == admin_user_id
+
+        with pytest.raises(AuthenticationError):
             await admin_auth_service.revoke_sso_admin_browser_session(
                 issued.token,
                 issued.csrf_token,

--- a/backend/tests/test_admin_sso_routes_unit.py
+++ b/backend/tests/test_admin_sso_routes_unit.py
@@ -1,0 +1,317 @@
+"""HTTP contracts for product-admin SSO provider control."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.api.routes import admin_auth, admin_sso
+from app.config import settings
+from app.exceptions import AuthenticationError
+from app.services.admin_auth_service import ProductAdminIdentity
+from app.sso.keycloak_admin import ProviderControlError
+from app.sso.models import ProviderMutationReadback, ProviderReadback
+
+
+_SECRET = "write-only-provider-secret-must-not-leak"  # pragma: allowlist secret
+
+
+def _admin() -> ProductAdminIdentity:
+    return ProductAdminIdentity(
+        user_id=uuid.uuid4(),
+        external_identity_id=uuid.uuid4(),
+        username="product-admin",
+        email="admin@example.com",
+        display_name="Product Admin",
+        auth_method="keycloak",
+    )
+
+
+def _provider(
+    *,
+    state: str = "configured_disabled",
+    enabled: bool | None = None,
+) -> ProviderReadback:
+    is_enabled = state == "enabled" if enabled is None else enabled
+    return ProviderReadback(
+        provider_type="keycloak-oidc",
+        alias="workforce",
+        display_name="Company SSO",
+        state=state,  # type: ignore[arg-type]
+        enabled=is_enabled,
+        issuer="https://accounts.example.com/realms/workforce",
+        discovery_url=(
+            "https://accounts.example.com/realms/workforce/"
+            ".well-known/openid-configuration"
+        ),
+        client_id="akb-broker",
+        client_secret_configured=True,
+        redirect_uri=(
+            "https://auth.akb.example.com/realms/akb/"
+            "broker/workforce/endpoint"
+        ),
+        supports_logout=True,
+        supports_identity_migration=False,
+    )
+
+
+class Control:
+    control_mode = "direct"
+
+    def __init__(self) -> None:
+        self.providers = [_provider()]
+        self.configured_secret: str | None = None
+        self.toggles: list[tuple[str, bool]] = []
+
+    async def list_providers(self, **_kwargs):
+        return tuple(self.providers)
+
+    async def configure(self, spec):
+        self.configured_secret = spec.client_secret
+        return ProviderMutationReadback(before=None, after=_provider())
+
+    async def set_enabled(self, alias: str, *, enabled: bool):
+        self.toggles.append((alias, enabled))
+        return ProviderMutationReadback(
+            before=_provider(),
+            after=_provider(
+                state="enabled" if enabled else "configured_disabled",
+                enabled=enabled,
+            ),
+        )
+
+
+def _client(monkeypatch, control: Control, *, admin=None) -> TestClient:
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(
+        admin_sso,
+        "get_keycloak_provider_control",
+        lambda: control,
+    )
+    app = FastAPI()
+    app.include_router(admin_sso.router, prefix="/api/v1")
+    actor = admin or _admin()
+    app.dependency_overrides[admin_auth.get_current_product_admin] = lambda: actor
+    app.dependency_overrides[admin_auth.get_product_admin_mutation] = lambda: actor
+    return TestClient(app)
+
+
+def test_admin_catalog_is_versioned_bounded_and_secret_free(monkeypatch):
+    response = _client(monkeypatch, Control()).get("/api/v1/admin/sso/providers")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": 1,
+        "auth_mode": "sso",
+        "control_mode": "direct",
+        "supported_provider_types": ["keycloak-oidc"],
+        "providers": [_provider().admin_view()],
+    }
+    assert _SECRET not in response.text
+
+
+def test_delegated_catalog_is_explicit_without_attempting_a_read(monkeypatch):
+    class Delegated(Control):
+        control_mode = "delegated"
+
+        async def list_providers(self, **_kwargs):
+            raise AssertionError("delegated control must not call Admin REST")
+
+    response = _client(monkeypatch, Delegated()).get(
+        "/api/v1/admin/sso/providers"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["control_mode"] == "delegated"
+    assert response.json()["providers"] == []
+
+
+def test_local_mode_hides_the_control_surface_before_admin_resolution(monkeypatch):
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    app = FastAPI()
+    app.include_router(admin_sso.router, prefix="/api/v1")
+
+    response = TestClient(app).get("/api/v1/admin/sso/providers")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "SSO provider control is not enabled"
+
+
+def test_configure_accepts_secret_once_and_audits_only_redacted_metadata(monkeypatch):
+    control = Control()
+    records: list[dict[str, object]] = []
+    monkeypatch.setattr(admin_sso.audit_log, "record", lambda **value: records.append(value))
+    response = _client(monkeypatch, control).put(
+        "/api/v1/admin/sso/providers/workforce",
+        json={
+            "provider_type": "keycloak-oidc",
+            "display_name": "Company SSO",
+            "issuer": "https://accounts.example.com/realms/workforce",
+            "discovery_url": (
+                "https://accounts.example.com/realms/workforce/"
+                ".well-known/openid-configuration"
+            ),
+            "client_id": "akb-broker",
+            "client_secret": _SECRET,
+        },
+    )
+
+    assert response.status_code == 200
+    assert control.configured_secret == _SECRET
+    assert _SECRET not in response.text
+    assert _SECRET not in repr(records)
+    assert [record["action"] for record in records] == [
+        "admin.sso.provider.configure.requested",
+        "admin.sso.provider.configure",
+    ]
+    assert records[-1]["meta"] == {
+        "before": None,
+        "after": _provider().audit_view(),
+    }
+
+
+@pytest.mark.parametrize(
+    ("suffix", "enabled"),
+    [("enable", True), ("disable", False)],
+)
+def test_enable_disable_are_explicit_mutations(monkeypatch, suffix, enabled):
+    control = Control()
+    response = _client(monkeypatch, control).post(
+        f"/api/v1/admin/sso/providers/workforce/{suffix}"
+    )
+
+    assert response.status_code == 200
+    assert control.toggles == [("workforce", enabled)]
+    assert response.json()["provider"]["state"] == (
+        "enabled" if enabled else "configured_disabled"
+    )
+
+
+def test_provider_errors_are_status_mapped_without_leaking_values(monkeypatch):
+    class Broken(Control):
+        async def configure(self, spec):
+            assert spec.client_secret == _SECRET
+            raise ProviderControlError("provider_disable_before_reconfigure")
+
+    response = _client(monkeypatch, Broken()).put(
+        "/api/v1/admin/sso/providers/workforce",
+        json={
+            "provider_type": "keycloak-oidc",
+            "display_name": "Company SSO",
+            "issuer": "https://accounts.example.com/realms/workforce",
+            "discovery_url": (
+                "https://accounts.example.com/realms/workforce/"
+                ".well-known/openid-configuration"
+            ),
+            "client_id": "akb-broker",
+            "client_secret": _SECRET,
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == (
+        "provider_disable_before_reconfigure"
+    )
+    assert _SECRET not in response.text
+
+
+def test_invalid_secret_json_type_is_rejected_without_echoing_its_value(monkeypatch):
+    leaked_value = "nested-secret-must-not-be-returned"  # pragma: allowlist secret
+
+    response = _client(monkeypatch, Control()).put(
+        "/api/v1/admin/sso/providers/workforce",
+        json={
+            "provider_type": "keycloak-oidc",
+            "display_name": "Company SSO",
+            "issuer": "https://accounts.example.com/realms/workforce",
+            "discovery_url": (
+                "https://accounts.example.com/realms/workforce/"
+                ".well-known/openid-configuration"
+            ),
+            "client_id": "akb-broker",
+            "client_secret": {"value": leaked_value},
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "provider_client_secret_invalid"
+    assert leaked_value not in response.text
+
+
+def test_invalid_alias_is_hashed_in_audit_instead_of_reflected(monkeypatch):
+    class InvalidAlias(Control):
+        async def configure(self, _spec):
+            raise ProviderControlError("provider_alias_invalid")
+
+    records: list[dict[str, object]] = []
+    monkeypatch.setattr(admin_sso.audit_log, "record", lambda **value: records.append(value))
+
+    response = _client(monkeypatch, InvalidAlias()).put(
+        "/api/v1/admin/sso/providers/unsafe%0Aalias",
+        json={
+            "provider_type": "keycloak-oidc",
+            "display_name": "Company SSO",
+            "issuer": "https://accounts.example.com/realms/workforce",
+            "discovery_url": (
+                "https://accounts.example.com/realms/workforce/"
+                ".well-known/openid-configuration"
+            ),
+            "client_id": "akb-broker",
+            "client_secret": _SECRET,
+        },
+    )
+
+    assert response.status_code == 422
+    assert all(record["target"].startswith("provider=<invalid:sha256:") for record in records)
+    assert "unsafe" not in repr(records)
+
+
+def test_unexpected_mutation_failures_still_emit_a_result_audit(monkeypatch):
+    class Broken(Control):
+        async def configure(self, _spec):
+            raise RuntimeError("unexpected control failure")
+
+    records: list[dict[str, object]] = []
+    monkeypatch.setattr(admin_sso.audit_log, "record", lambda **value: records.append(value))
+
+    with pytest.raises(RuntimeError, match="unexpected control failure"):
+        _client(monkeypatch, Broken(), admin=_admin()).put(
+            "/api/v1/admin/sso/providers/workforce",
+            json={
+                "provider_type": "keycloak-oidc",
+                "display_name": "Company SSO",
+                "issuer": "https://accounts.example.com/realms/workforce",
+                "discovery_url": (
+                    "https://accounts.example.com/realms/workforce/"
+                    ".well-known/openid-configuration"
+                ),
+                "client_id": "akb-broker",
+                "client_secret": _SECRET,
+            },
+        )
+
+    assert records[-1]["outcome"] == "error"
+    assert records[-1]["code"] == "internal_error"
+    assert _SECRET not in repr(records)
+
+
+async def test_sso_mutation_dependency_rejects_missing_csrf_before_resolution(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+
+    class Request:
+        cookies = {
+            "akb_admin_session": "opaque-session-value-that-is-long-enough",
+            "akb_admin_csrf": "opaque-csrf-value-that-is-long-enough",
+        }
+
+    with pytest.raises(AuthenticationError, match="Invalid admin CSRF token"):
+        await admin_auth.get_product_admin_mutation(  # type: ignore[arg-type]
+            Request(),
+            authorization=None,
+            csrf_header=None,
+        )

--- a/backend/tests/test_auth_config_shape_unit.py
+++ b/backend/tests/test_auth_config_shape_unit.py
@@ -4,57 +4,121 @@ from __future__ import annotations
 
 import asyncio
 
+from fastapi import HTTPException, Response
+import pytest
+
+from app.api.routes import auth
 from app.config import settings
+from app.sso.keycloak_admin import ProviderControlError
+from app.sso.models import ProviderReadback
+
+
+def _provider(alias: str, state: str) -> ProviderReadback:
+    return ProviderReadback(
+        provider_type="keycloak-oidc",
+        alias=alias,
+        display_name=alias.title(),
+        state=state,  # type: ignore[arg-type]
+        enabled=state == "enabled",
+        issuer=f"https://{alias}.example.com/realms/workforce",
+        discovery_url=(
+            f"https://{alias}.example.com/realms/workforce/"
+            ".well-known/openid-configuration"
+        ),
+        client_id="akb-broker",
+        client_secret_configured=True,
+        redirect_uri=(
+            f"https://auth.akb.example.com/realms/akb/broker/{alias}/endpoint"
+        ),
+        supports_logout=True,
+        supports_identity_migration=False,
+    )
+
+
+class Control:
+    control_mode = "direct"
+
+    async def list_providers(self, **_kwargs):
+        return (
+            _provider("workforce", "enabled"),
+            _provider("disabled", "configured_disabled"),
+            _provider("broken", "configuration_error"),
+        )
 
 
 def _call() -> dict:
-    from app.api.routes.auth import auth_config
-
-    return asyncio.run(auth_config())
+    return asyncio.run(auth.auth_config(Response()))
 
 
-def test_v1_local_config_derives_human_capabilities_from_mode(monkeypatch):
+def test_v2_auth_config_is_never_http_cached(monkeypatch):
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    response = Response()
+
+    asyncio.run(auth.auth_config(response))
+
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_v2_local_config_derives_human_capabilities_without_control_read(
+    monkeypatch,
+):
+    class MustNotRead:
+        @property
+        def control_mode(self):
+            raise AssertionError("local mode must not inspect Keycloak providers")
+
     monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
     monkeypatch.setattr(settings, "local_auth_enabled", False, raising=False)
     monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
     monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(auth, "get_keycloak_provider_control", lambda: MustNotRead())
 
     assert _call() == {
-        "schema_version": 1,
+        "schema_version": 2,
         "auth_mode": "local",
         "local_auth": {"enabled": True},
         "keycloak": {
             "enabled": False,
             "browser_session_ready": False,
-            "login_url": None,
         },
+        "providers": [],
         "mcp_oauth": {"enabled": True},
     }
 
 
-def test_v1_sso_config_is_explicitly_staged_without_login_url(monkeypatch):
+def test_v2_sso_config_lists_only_enabled_provider_buttons(monkeypatch):
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
     monkeypatch.setattr(settings, "local_auth_enabled", True, raising=False)
     monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
     monkeypatch.setattr(settings, "mcp_oauth_enabled", False, raising=False)
+    monkeypatch.setattr(auth, "get_keycloak_provider_control", lambda: Control())
 
     assert _call() == {
-        "schema_version": 1,
+        "schema_version": 2,
         "auth_mode": "sso",
         "local_auth": {"enabled": False},
         "keycloak": {
             "enabled": True,
             "browser_session_ready": False,
-            "login_url": None,
         },
+        "providers": [
+            {
+                "provider_type": "keycloak-oidc",
+                "alias": "workforce",
+                "display_name": "Workforce",
+                "login_url": None,
+            }
+        ],
         "mcp_oauth": {"enabled": False},
     }
 
 
-def test_v1_public_config_has_only_non_secret_capability_fields(monkeypatch):
+def test_v2_public_config_has_only_non_secret_capability_fields(monkeypatch):
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
     monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
     monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(auth, "get_keycloak_provider_control", lambda: Control())
 
     cfg = _call()
 
@@ -63,12 +127,32 @@ def test_v1_public_config_has_only_non_secret_capability_fields(monkeypatch):
         "auth_mode",
         "local_auth",
         "keycloak",
+        "providers",
         "mcp_oauth",
     }
     assert set(cfg["local_auth"]) == {"enabled"}
-    assert set(cfg["keycloak"]) == {
-        "enabled",
-        "browser_session_ready",
-        "login_url",
-    }
+    assert set(cfg["keycloak"]) == {"enabled", "browser_session_ready"}
     assert set(cfg["mcp_oauth"]) == {"enabled"}
+    assert "secret" not in repr(cfg).lower()
+
+
+@pytest.mark.parametrize("delegated", [True, False])
+def test_v2_sso_config_fails_closed_without_a_verified_catalog(
+    monkeypatch,
+    delegated,
+):
+    class Unavailable:
+        control_mode = "delegated" if delegated else "direct"
+
+        async def list_providers(self, **_kwargs):
+            raise ProviderControlError("keycloak_provider_list_failed")
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(auth, "get_keycloak_provider_control", lambda: Unavailable())
+
+    with pytest.raises(HTTPException) as captured:
+        _call()
+
+    assert captured.value.status_code == 503
+    assert captured.value.detail == "SSO provider catalog is unavailable"

--- a/backend/tests/test_sso_broker_chain_fixture_unit.py
+++ b/backend/tests/test_sso_broker_chain_fixture_unit.py
@@ -1,0 +1,72 @@
+"""Static safety contract for the disposable two-Keycloak fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from app.services.standalone_sso_bootstrap import MANAGEMENT_REALM_ROLES
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURE = _ROOT / "deploy" / "keycloak-dev" / "broker-chain"
+
+
+def test_broker_chain_uses_two_pinned_keycloaks_and_no_persistent_volume():
+    compose = yaml.safe_load((_FIXTURE / "compose.yaml").read_text())
+    assert set(compose["services"]) == {"broker", "upstream"}
+    images = {service["image"] for service in compose["services"].values()}
+    assert len(images) == 1
+    assert next(iter(images)).startswith("quay.io/keycloak/keycloak@sha256:")
+    assert "volumes" not in compose
+
+
+def test_realms_are_distinct_and_upstream_client_is_code_pkce_only():
+    broker = json.loads((_FIXTURE / "broker-realm.json").read_text())
+    upstream = json.loads((_FIXTURE / "upstream-realm.json").read_text())
+    assert (broker["realm"], upstream["realm"]) == ("akb", "workforce")
+    client = next(
+        value for value in upstream["clients"] if value["clientId"] == "akb-broker"
+    )
+    assert client["standardFlowEnabled"] is True
+    assert client["implicitFlowEnabled"] is False
+    assert client["directAccessGrantsEnabled"] is False
+    assert client["serviceAccountsEnabled"] is False
+    assert client["attributes"]["pkce.code.challenge.method"] == "S256"
+
+
+def test_fixture_management_authority_matches_the_product_bootstrap_profile():
+    broker = json.loads((_FIXTURE / "broker-realm.json").read_text())
+    client = next(
+        value
+        for value in broker["clients"]
+        if value["clientId"] == "akb-sso-manager"
+    )
+    service_account = next(
+        value
+        for value in broker["users"]
+        if value["serviceAccountClientId"] == "akb-sso-manager"
+    )
+    scoped = broker["clientScopeMappings"]["realm-management"]
+
+    assert client["fullScopeAllowed"] is False
+    assert client["defaultClientScopes"] == ["service_account"]
+    assert set(service_account["clientRoles"]["realm-management"]) == set(
+        MANAGEMENT_REALM_ROLES
+    )
+    assert scoped == [{
+        "client": "akb-sso-manager",
+        "roles": list(MANAGEMENT_REALM_ROLES),
+    }]
+
+
+def test_runner_has_unique_scope_guarded_teardown_and_secret_free_receipt():
+    runner = (_FIXTURE / "run.sh").read_text()
+    exercise = (_FIXTURE / "exercise.py").read_text()
+    assert 'project_name="akb-sso-broker-chain-$$"' in runner
+    assert "down --volumes --remove-orphans" in runner
+    assert 'cert_dir="$(mktemp -d ' in runner
+    assert 'if [[ "$cert_dir" ==' in runner
+    assert '"client_secret_exposed": False' in exercise

--- a/backend/tests/test_sso_keycloak_admin_unit.py
+++ b/backend/tests/test_sso_keycloak_admin_unit.py
@@ -1,0 +1,399 @@
+"""State-transition and transport contracts for runtime IdP control."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import httpx
+import pytest
+
+from app.sso.keycloak_admin import (
+    KeycloakAdminConfig,
+    KeycloakProviderControl,
+    ProviderControlError,
+)
+from app.sso.models import ProviderConfigureSpec
+from app.sso.providers.keycloak_oidc import MASKED_SECRET
+
+
+pytestmark = pytest.mark.asyncio
+
+_SECRET = "upstream-client-secret-must-not-leak"  # pragma: allowlist secret
+_NEW_SECRET = "rotated-client-secret-must-not-leak"  # pragma: allowlist secret
+_MANAGEMENT_SECRET = "management-secret-must-not-leak"  # pragma: allowlist secret
+_ISSUER = "https://accounts.example.com/realms/workforce"
+
+
+def _config(*, management_secret: str = _MANAGEMENT_SECRET) -> KeycloakAdminConfig:
+    return KeycloakAdminConfig(
+        internal_base_url="https://keycloak.internal.example.com/auth",
+        public_base_url="https://auth.akb.example.com",
+        realm="akb",
+        management_client_id="akb-sso-manager",
+        management_client_secret=management_secret,
+        verify_ssl=True,
+    )
+
+
+def _spec(**changes: object) -> ProviderConfigureSpec:
+    values: dict[str, object] = {
+        "provider_type": "keycloak-oidc",
+        "alias": "workforce",
+        "display_name": "Company SSO",
+        "issuer": _ISSUER,
+        "discovery_url": f"{_ISSUER}/.well-known/openid-configuration",
+        "client_id": "akb-broker",
+        "client_secret": _SECRET,
+    }
+    values.update(changes)
+    return ProviderConfigureSpec(**values)  # type: ignore[arg-type]
+
+
+class KeycloakFixture:
+    def __init__(self) -> None:
+        self.providers: dict[str, dict[str, object]] = {}
+        self.requests: list[tuple[str, str]] = []
+        self.fail_admin = False
+        self.drift_readback_after_write = False
+        self._drift_readback = False
+
+    def _readback(self, provider: dict[str, object]) -> dict[str, object]:
+        result = deepcopy(provider)
+        config = result.get("config")
+        assert isinstance(config, dict)
+        if config.get("clientSecret"):
+            config["clientSecret"] = MASKED_SECRET
+        if self._drift_readback:
+            result["displayName"] = "Unexpected SSO"
+        return result
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        self.requests.append((request.method, path))
+        if path == "/auth/realms/akb/protocol/openid-connect/token":
+            form = dict(item.split("=", 1) for item in request.content.decode().split("&"))
+            assert form["grant_type"] == "client_credentials"
+            return httpx.Response(200, json={"access_token": "opaque-management-token"})
+        if self.fail_admin:
+            return httpx.Response(500, text=f"never expose {_SECRET} {_MANAGEMENT_SECRET}")
+        if path == "/auth/admin/realms/akb/identity-provider/import-config":
+            body = json.loads(request.content)
+            assert body == {
+                "providerId": "oidc",
+                "fromUrl": f"{_ISSUER}/.well-known/openid-configuration",
+            }
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": _ISSUER,
+                    "authorizationUrl": f"{_ISSUER}/protocol/openid-connect/auth",
+                    "tokenUrl": f"{_ISSUER}/protocol/openid-connect/token",
+                    "jwksUrl": f"{_ISSUER}/protocol/openid-connect/certs",
+                    "userInfoUrl": f"{_ISSUER}/protocol/openid-connect/userinfo",
+                    "logoutUrl": f"{_ISSUER}/protocol/openid-connect/logout",
+                    "untrustedImportedField": "must-not-pass-through",
+                },
+            )
+        collection = "/auth/admin/realms/akb/identity-provider/instances"
+        if path == collection and request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[self._readback(provider) for provider in self.providers.values()],
+            )
+        if path == collection and request.method == "POST":
+            provider = json.loads(request.content)
+            alias = provider["alias"]
+            if alias in self.providers:
+                return httpx.Response(409)
+            self.providers[alias] = provider
+            if self.drift_readback_after_write:
+                self._drift_readback = True
+            return httpx.Response(201)
+        prefix = f"{collection}/"
+        if path.startswith(prefix):
+            alias = path.removeprefix(prefix)
+            provider = self.providers.get(alias)
+            if request.method == "GET":
+                return (
+                    httpx.Response(404)
+                    if provider is None
+                    else httpx.Response(200, json=self._readback(provider))
+                )
+            if request.method == "PUT":
+                if provider is None:
+                    return httpx.Response(404)
+                updated = json.loads(request.content)
+                updated_config = updated.get("config")
+                old_config = provider.get("config")
+                assert isinstance(updated_config, dict)
+                assert isinstance(old_config, dict)
+                if updated_config.get("clientSecret") == MASKED_SECRET:
+                    updated_config["clientSecret"] = old_config["clientSecret"]
+                self.providers[alias] = updated
+                if self.drift_readback_after_write:
+                    self._drift_readback = True
+                return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {request.method} {path}")
+
+
+def _control(fixture: KeycloakFixture, **kwargs) -> KeycloakProviderControl:
+    return KeycloakProviderControl(
+        _config(),
+        transport=httpx.MockTransport(fixture.handler),
+        **kwargs,
+    )
+
+
+async def test_management_secret_is_excluded_from_config_repr():
+    assert _MANAGEMENT_SECRET not in repr(_config())
+
+
+async def test_configure_creates_disabled_then_exactly_reads_back():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+
+    mutation = await control.configure(_spec())
+    provider = mutation.after
+
+    assert mutation.before is None
+    assert provider.state == "configured_disabled"
+    assert provider.client_secret_configured is True
+    stored = fixture.providers["workforce"]
+    assert stored["enabled"] is False
+    assert stored["hideOnLogin"] is True
+    config = stored["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == _SECRET
+    assert "untrustedImportedField" not in config
+
+
+async def test_configure_rejects_a_valid_but_non_exact_readback():
+    fixture = KeycloakFixture()
+    fixture.drift_readback_after_write = True
+    control = _control(fixture)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.configure(_spec())
+
+    assert captured.value.code == "keycloak_provider_readback_failed"
+
+
+async def test_new_provider_requires_a_write_only_secret_before_any_import():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.configure(_spec(client_secret=None))
+
+    assert captured.value.code == "provider_client_secret_required"
+    assert all("import-config" not in path for _, path in fixture.requests)
+
+
+async def test_existing_unmanaged_alias_is_never_adopted_or_overwritten():
+    fixture = KeycloakFixture()
+    fixture.providers["workforce"] = {
+        "alias": "workforce",
+        "providerId": "oidc",
+        "enabled": True,
+        "config": {"clientSecret": "pre-existing"},  # pragma: allowlist secret
+    }
+    control = _control(fixture)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.configure(_spec())
+
+    assert captured.value.code == "provider_alias_conflict"
+    assert fixture.providers["workforce"]["enabled"] is True
+
+
+async def test_enabled_provider_must_be_disabled_before_reconfiguration():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    await control.set_enabled("workforce", enabled=True)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.configure(_spec(display_name="Renamed SSO", client_secret=None))
+
+    assert captured.value.code == "provider_disable_before_reconfigure"
+
+
+async def test_reconfigure_preserves_secret_or_rotates_it_explicitly():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+
+    preserved = (await control.configure(
+        _spec(display_name="Renamed SSO", client_secret=None)
+    )).after
+    config = fixture.providers["workforce"]["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == _SECRET
+    assert preserved.display_name == "Renamed SSO"
+
+    rotated = (await control.configure(_spec(client_secret=_NEW_SECRET))).after
+    config = fixture.providers["workforce"]["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == _NEW_SECRET
+    assert rotated.state == "configured_disabled"
+
+
+async def test_enable_disable_are_read_back_and_idempotent():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+
+    enabled_mutation = await control.set_enabled("workforce", enabled=True)
+    enabled = enabled_mutation.after
+    enabled_again = (await control.set_enabled("workforce", enabled=True)).after
+    disabled = (await control.set_enabled("workforce", enabled=False)).after
+
+    assert enabled_mutation.before is not None
+    assert enabled_mutation.before.state == "configured_disabled"
+    assert enabled.state == enabled_again.state == "enabled"
+    assert disabled.state == "configured_disabled"
+    assert fixture.providers["workforce"]["enabled"] is False
+    assert fixture.providers["workforce"]["hideOnLogin"] is True
+
+
+async def test_toggle_rejects_identity_configuration_drift_during_write():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    fixture.drift_readback_after_write = True
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.set_enabled("workforce", enabled=True)
+
+    assert captured.value.code == "keycloak_provider_readback_failed"
+
+
+async def test_configuration_error_cannot_be_enabled_but_can_be_forced_hidden():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    config = fixture.providers["workforce"]["config"]
+    assert isinstance(config, dict)
+    config["validateSignature"] = "false"
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.set_enabled("workforce", enabled=True)
+    assert captured.value.code == "provider_configuration_invalid"
+
+    disabled = (await control.set_enabled("workforce", enabled=False)).after
+    assert disabled.state == "configuration_error"
+    assert fixture.providers["workforce"]["enabled"] is False
+    assert fixture.providers["workforce"]["hideOnLogin"] is True
+
+
+async def test_catalog_uses_bounded_stale_cache_but_admin_refresh_fails_closed():
+    fixture = KeycloakFixture()
+    now = [100.0]
+    control = _control(fixture, monotonic=lambda: now[0])
+    await control.configure(_spec())
+    await control.set_enabled("workforce", enabled=True)
+    assert [item.alias for item in await control.list_providers()] == ["workforce"]
+
+    fixture.fail_admin = True
+    now[0] += 16
+    stale = await control.list_providers(allow_stale=True)
+    assert [item.alias for item in stale] == ["workforce"]
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.list_providers(force_refresh=True)
+    assert captured.value.code == "keycloak_provider_list_failed"
+
+    now[0] += 61
+    with pytest.raises(ProviderControlError):
+        await control.list_providers(allow_stale=True)
+
+
+async def test_catalog_accepts_exact_limit_and_rejects_truncation():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    template = fixture.providers.pop("workforce")
+    for index in range(100):
+        alias = f"workforce-{index:03d}"
+        provider = deepcopy(template)
+        provider["alias"] = alias
+        provider["displayName"] = alias
+        fixture.providers[alias] = provider
+
+    assert len(await control.list_providers(force_refresh=True)) == 100
+
+    overflow = deepcopy(template)
+    overflow["alias"] = "workforce-overflow"
+    overflow["displayName"] = "workforce-overflow"
+    fixture.providers["workforce-overflow"] = overflow
+    with pytest.raises(ProviderControlError) as captured:
+        await control.list_providers(force_refresh=True)
+    assert captured.value.code == "keycloak_provider_catalog_truncated"
+
+
+async def test_catalog_failure_backoff_prevents_public_retry_stampede():
+    fixture = KeycloakFixture()
+    now = [100.0]
+    control = _control(fixture, monotonic=lambda: now[0])
+    fixture.fail_admin = True
+
+    with pytest.raises(ProviderControlError):
+        await control.list_providers()
+    requests_after_first_failure = list(fixture.requests)
+
+    with pytest.raises(ProviderControlError):
+        await control.list_providers()
+    assert fixture.requests == requests_after_first_failure
+
+    now[0] += 6
+    with pytest.raises(ProviderControlError):
+        await control.list_providers()
+    assert len(fixture.requests) > len(requests_after_first_failure)
+
+
+async def test_keycloak_responses_are_bounded_while_streaming():
+    def oversized_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/protocol/openid-connect/token"):
+            return httpx.Response(200, json={"access_token": "management-token"})
+        return httpx.Response(200, content=b"x" * 1_048_577)
+
+    control = KeycloakProviderControl(
+        _config(),
+        transport=httpx.MockTransport(oversized_handler),
+    )
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.list_providers(force_refresh=True)
+
+    assert captured.value.code == "keycloak_provider_list_failed"
+
+
+async def test_transport_errors_never_include_secrets_or_response_bodies():
+    fixture = KeycloakFixture()
+    fixture.fail_admin = True
+    control = _control(fixture)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.list_providers(force_refresh=True)
+
+    rendered = f"{captured.value!s} {captured.value!r}"
+    assert captured.value.code == "keycloak_provider_list_failed"
+    assert all(
+        value not in rendered
+        for value in (_SECRET, _NEW_SECRET, _MANAGEMENT_SECRET)
+    )
+
+
+async def test_delegated_control_mode_never_attempts_keycloak_management():
+    fixture = KeycloakFixture()
+    control = KeycloakProviderControl(
+        _config(management_secret=""),
+        transport=httpx.MockTransport(fixture.handler),
+    )
+
+    assert control.control_mode == "delegated"
+    with pytest.raises(ProviderControlError) as captured:
+        await control.list_providers(force_refresh=True)
+    assert captured.value.code == "keycloak_provider_control_delegated"
+    assert fixture.requests == []

--- a/backend/tests/test_sso_provider_contract_unit.py
+++ b/backend/tests/test_sso_provider_contract_unit.py
@@ -1,0 +1,321 @@
+"""Pure contracts for the built-in SSO provider contribution boundary."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from app.sso.models import ProviderConfigureSpec
+from app.sso.providers import keycloak_oidc
+from app.sso.providers.keycloak_oidc import ProviderDefinitionError
+from app.sso.registry import provider_definition, provider_types
+
+
+_BROKER_BASE_URL = "https://auth.akb.example.com"
+_BROKER_ISSUER = f"{_BROKER_BASE_URL}/realms/akb"
+_UPSTREAM_ISSUER = "https://accounts.example.com/realms/workforce"
+_SECRET = "upstream-client-secret-must-not-leak"  # pragma: allowlist secret
+
+
+def _spec(**changes: object) -> ProviderConfigureSpec:
+    values: dict[str, object] = {
+        "provider_type": "keycloak-oidc",
+        "alias": "workforce",
+        "display_name": "Company SSO",
+        "issuer": _UPSTREAM_ISSUER,
+        "discovery_url": f"{_UPSTREAM_ISSUER}/.well-known/openid-configuration",
+        "client_id": "akb-broker",
+        "client_secret": _SECRET,
+    }
+    values.update(changes)
+    return ProviderConfigureSpec(**values)  # type: ignore[arg-type]
+
+
+def _imported(**changes: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "issuer": _UPSTREAM_ISSUER,
+        "authorizationUrl": f"{_UPSTREAM_ISSUER}/protocol/openid-connect/auth",
+        "tokenUrl": f"{_UPSTREAM_ISSUER}/protocol/openid-connect/token",
+        "jwksUrl": f"{_UPSTREAM_ISSUER}/protocol/openid-connect/certs",
+        "userInfoUrl": f"{_UPSTREAM_ISSUER}/protocol/openid-connect/userinfo",
+        "logoutUrl": f"{_UPSTREAM_ISSUER}/protocol/openid-connect/logout",
+    }
+    values.update(changes)
+    return values
+
+
+def _keycloak_readback(*, enabled: bool = False) -> dict[str, object]:
+    rendered = keycloak_oidc.render_representation(
+        _spec(),
+        _imported(untrustedImportedField="must-not-pass-through"),
+        preserve_secret=False,
+    )
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    config["clientSecret"] = keycloak_oidc.MASKED_SECRET
+    return keycloak_oidc.with_enabled(rendered, enabled=enabled)
+
+
+def _readback(representation: dict[str, object]):
+    return keycloak_oidc.readback(
+        representation,
+        broker_base_url=_BROKER_BASE_URL,
+        broker_issuer=_BROKER_ISSUER,
+        realm="akb",
+    )
+
+
+def test_registry_is_explicit_and_contains_only_the_reference_provider():
+    assert provider_types() == ("keycloak-oidc",)
+    definition = provider_definition("keycloak-oidc")
+    assert definition.provider_type == "keycloak-oidc"
+    assert definition.module is keycloak_oidc
+
+    with pytest.raises(ValueError, match="unsupported_sso_provider_type"):
+        provider_definition("arbitrary-keycloak-json")
+
+
+def test_valid_spec_renders_a_disabled_allowlisted_representation():
+    spec = keycloak_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+    rendered = keycloak_oidc.render_representation(
+        spec,
+        _imported(untrustedImportedField="must-not-pass-through"),
+        preserve_secret=False,
+    )
+
+    assert rendered["providerId"] == "oidc"
+    assert rendered["enabled"] is False
+    assert rendered["hideOnLogin"] is True
+    assert rendered["trustEmail"] is False
+    assert rendered["storeToken"] is False
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == _SECRET
+    assert config["clientAuthMethod"] == "client_secret_basic"
+    assert config["validateSignature"] == "true"
+    assert config["useJwksUrl"] == "true"
+    assert config["pkceEnabled"] == "true"
+    assert config["pkceMethod"] == "S256"
+    assert config["akbProviderType"] == "keycloak-oidc"
+    assert "untrustedImportedField" not in config
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        ({"provider_type": "oidc"}, "provider_type_mismatch"),
+        ({"alias": "../workforce"}, "provider_alias_invalid"),
+        ({"issuer": "http://accounts.example.com"}, "provider_issuer_invalid"),
+        (
+            {"issuer": f"{_UPSTREAM_ISSUER}?tenant=one"},
+            "provider_issuer_invalid",
+        ),
+        (
+            {
+                "issuer": f"{_BROKER_ISSUER}/",
+                "discovery_url": f"{_BROKER_ISSUER}/.well-known/openid-configuration",
+            },
+            "provider_issuer_is_broker",
+        ),
+        (
+            {
+                "issuer": "https://AUTH.AKB.EXAMPLE.COM:443/realms/akb",
+                "discovery_url": (
+                    "https://AUTH.AKB.EXAMPLE.COM:443/realms/akb/"
+                    ".well-known/openid-configuration"
+                ),
+            },
+            "provider_issuer_is_broker",
+        ),
+        (
+            {"discovery_url": "https://accounts.example.com/custom-discovery"},
+            "provider_discovery_url_mismatch",
+        ),
+        ({"client_id": "client id with spaces"}, "provider_client_id_invalid"),
+    ],
+)
+def test_invalid_specs_are_rejected_with_value_less_codes(changes, code):
+    with pytest.raises(ProviderDefinitionError) as captured:
+        keycloak_oidc.validate_spec(_spec(**changes), broker_issuer=_BROKER_ISSUER)
+
+    assert captured.value.code == code
+    assert _SECRET not in f"{captured.value!s} {captured.value!r}"
+
+
+def test_discovery_issuer_must_exactly_match_configured_issuer():
+    spec = keycloak_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+
+    with pytest.raises(ProviderDefinitionError) as captured:
+        keycloak_oidc.render_representation(
+            spec,
+            _imported(issuer="https://different.example.com/realms/workforce"),
+            preserve_secret=False,
+        )
+
+    assert captured.value.code == "provider_discovery_issuer_mismatch"
+
+
+def test_keycloak_discovery_endpoints_must_match_the_exact_issuer():
+    spec = keycloak_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+
+    with pytest.raises(ProviderDefinitionError) as captured:
+        keycloak_oidc.render_representation(
+            spec,
+            _imported(tokenUrl="https://tokens.example.net/oauth/token"),
+            preserve_secret=False,
+        )
+
+    assert captured.value.code == "provider_discovery_token_url_invalid"
+
+
+def test_trailing_slash_issuer_is_canonicalized_before_discovery_readback():
+    spec = keycloak_oidc.validate_spec(
+        _spec(
+            issuer=f"{_UPSTREAM_ISSUER}/",
+            discovery_url=f"{_UPSTREAM_ISSUER}/.well-known/openid-configuration",
+        ),
+        broker_issuer=_BROKER_ISSUER,
+    )
+
+    assert spec.issuer == _UPSTREAM_ISSUER
+    assert keycloak_oidc.render_representation(
+        spec,
+        _imported(),
+        preserve_secret=False,
+    )["enabled"] is False
+
+
+def test_reconfigure_uses_only_keycloaks_masked_secret_sentinel():
+    spec_without_secret = replace(_spec(), client_secret=None)
+    rendered = keycloak_oidc.render_representation(
+        spec_without_secret,
+        _imported(),
+        preserve_secret=True,
+    )
+
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == keycloak_oidc.MASKED_SECRET
+
+
+def test_client_secret_is_validated_but_never_trimmed_or_unicode_normalized():
+    opaque = " leading-e\u0301-trailing "
+
+    validated = keycloak_oidc.validate_spec(
+        _spec(client_secret=opaque),
+        broker_issuer=_BROKER_ISSUER,
+    )
+
+    assert validated.client_secret == opaque
+
+
+def test_client_secret_rejects_control_characters():
+    with pytest.raises(ProviderDefinitionError) as captured:
+        keycloak_oidc.validate_spec(
+            _spec(client_secret="line-one\nline-two"),  # pragma: allowlist secret
+            broker_issuer=_BROKER_ISSUER,
+        )
+
+    assert captured.value.code == "provider_client_secret_invalid"
+
+
+def test_readback_recognizes_only_exact_disabled_and_enabled_profiles():
+    disabled = _readback(_keycloak_readback())
+    enabled = _readback(_keycloak_readback(enabled=True))
+
+    assert disabled.state == "configured_disabled"
+    assert enabled.state == "enabled"
+    assert enabled.client_secret_configured is True
+    assert enabled.redirect_uri == (
+        "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint"
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("providerId",), "saml"),
+        (("trustEmail",), True),
+        (("hideOnLogin",), True),
+        (("config", "validateSignature"), "false"),
+        (("config", "authorizationUrl"), "http://accounts.example.com/auth"),
+        (("config", "metadataDescriptorUrl"), "https://accounts.example.com/custom"),
+        (("config", "clientSecret"), ""),
+    ],
+)
+def test_readback_fails_closed_on_profile_drift(path, value):
+    representation = _keycloak_readback(enabled=True)
+    target = representation
+    for key in path[:-1]:
+        nested = target[key]
+        assert isinstance(nested, dict)
+        target = nested
+    target[path[-1]] = value
+
+    assert _readback(representation).state == "configuration_error"
+
+
+def test_views_are_bounded_and_never_expose_the_client_secret():
+    representation = _keycloak_readback(enabled=True)
+    provider = _readback(representation)
+    views = (
+        provider.admin_view(),
+        provider.public_view(login_url="/api/v1/auth/sso/workforce/login"),
+        provider.audit_view(),
+    )
+
+    rendered = repr(views)
+    assert _SECRET not in rendered
+    assert keycloak_oidc.MASKED_SECRET not in rendered
+    assert set(views[1]) == {
+        "provider_type",
+        "alias",
+        "display_name",
+        "login_url",
+    }
+
+
+def test_secret_bearing_specs_do_not_render_secrets_in_repr():
+    assert _SECRET not in repr(_spec())
+
+
+def test_readback_does_not_mutate_the_keycloak_representation():
+    representation = _keycloak_readback(enabled=True)
+    before = deepcopy(representation)
+
+    _readback(representation)
+
+    assert representation == before
+
+
+def test_drifted_unvalidated_values_are_not_reflected_to_admin_or_audit_views():
+    representation = _keycloak_readback(enabled=True)
+    representation["displayName"] = "unsafe\nlabel"
+    config = representation["config"]
+    assert isinstance(config, dict)
+    config["issuer"] = (
+        "https://user:drift-secret@example.com/realms/workforce"  # pragma: allowlist secret
+    )
+
+    provider = _readback(representation)
+    rendered = repr((provider.admin_view(), provider.audit_view()))
+
+    assert provider.state == "configuration_error"
+    assert provider.display_name == "workforce"
+    assert provider.issuer is None
+    assert "drift-secret" not in rendered
+    assert "unsafe" not in rendered
+
+
+def test_only_complete_bounded_keycloak_vault_references_count_as_secrets():
+    representation = _keycloak_readback(enabled=True)
+    config = representation["config"]
+    assert isinstance(config, dict)
+    config["clientSecret"] = "${vault.upstream-client}"
+    assert _readback(representation).client_secret_configured is True
+
+    config["clientSecret"] = "${vault.unclosed"
+    assert _readback(representation).state == "configuration_error"
+    assert _readback(representation).client_secret_configured is False

--- a/deploy/keycloak-dev/broker-chain/README.md
+++ b/deploy/keycloak-dev/broker-chain/README.md
@@ -1,0 +1,23 @@
+# Two-Keycloak broker-chain fixture
+
+This disposable fixture proves the `keycloak-oidc` contribution against two
+real Keycloak 26.7 processes. It configures the upstream provider disabled,
+reads it back, proves masked-secret preservation on a disabled reconfigure,
+enables it, verifies `kc_idp_hint` redirects to the upstream realm, disables
+it, and prints a secret-free JSON receipt.
+
+Requirements: Docker Compose, OpenSSL, curl, and `uv`.
+
+```bash
+deploy/keycloak-dev/broker-chain/run.sh
+```
+
+The runner generates a one-day self-signed certificate in a private temporary
+directory, uses a unique Compose project, and always tears down containers,
+networks, volumes, and certificates. All committed credentials are explicitly
+fixture-only. The runner uses `--insecure`/`verify_ssl=False` only for its
+ephemeral certificate; production SSO must verify TLS.
+
+The fixed host ports are `19443` for the broker and `19444` for the upstream
+realm. Do not run this fixture against a shared Keycloak or reuse its realm
+files as production credentials.

--- a/deploy/keycloak-dev/broker-chain/broker-realm.json
+++ b/deploy/keycloak-dev/broker-chain/broker-realm.json
@@ -1,0 +1,70 @@
+{
+  "realm": "akb",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "clients": [
+    {
+      "clientId": "akb-sso-manager",
+      "name": "AKB SSO fixture management",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "fixture-only-management-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
+      "defaultClientScopes": ["service_account"],
+      "optionalClientScopes": []
+    },
+    {
+      "clientId": "fixture-browser",
+      "name": "Broker chain browser probe",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "implicitFlowEnabled": false,
+      "redirectUris": ["https://client.localhost/callback"],
+      "webOrigins": []
+    }
+  ],
+  "users": [
+    {
+      "username": "service-account-akb-sso-manager",
+      "enabled": true,
+      "serviceAccountClientId": "akb-sso-manager",
+      "clientRoles": {
+        "realm-management": [
+          "manage-identity-providers",
+          "query-clients",
+          "query-users",
+          "view-clients",
+          "view-realm",
+          "view-users"
+        ]
+      }
+    }
+  ],
+  "clientScopeMappings": {
+    "realm-management": [
+      {
+        "client": "akb-sso-manager",
+        "roles": [
+          "manage-identity-providers",
+          "query-clients",
+          "query-users",
+          "view-clients",
+          "view-realm",
+          "view-users"
+        ]
+      }
+    ]
+  }
+}

--- a/deploy/keycloak-dev/broker-chain/compose.yaml
+++ b/deploy/keycloak-dev/broker-chain/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  broker:
+    image: quay.io/keycloak/keycloak@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: fixture-admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: fixture-only-admin-password # pragma: allowlist secret
+      KC_HOSTNAME: https://broker.localhost:19443
+      KC_HTTPS_CERTIFICATE_FILE: /certs/tls.crt
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /certs/tls.key
+      KC_TRUSTSTORE_PATHS: /certs/tls.crt
+      KC_HEALTH_ENABLED: "true"
+    extra_hosts:
+      - upstream.localhost:host-gateway
+    ports:
+      - "19443:8443"
+    volumes:
+      - ${AKB_SSO_FIXTURE_CERT_DIR:?run through run.sh}:/certs:ro
+      - ./broker-realm.json:/opt/keycloak/data/import/akb-realm.json:ro
+
+  upstream:
+    image: quay.io/keycloak/keycloak@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: fixture-admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: fixture-only-admin-password # pragma: allowlist secret
+      KC_HOSTNAME: https://upstream.localhost:19444
+      KC_HTTPS_CERTIFICATE_FILE: /certs/tls.crt
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /certs/tls.key
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "19444:8443"
+    volumes:
+      - ${AKB_SSO_FIXTURE_CERT_DIR:?run through run.sh}:/certs:ro
+      - ./upstream-realm.json:/opt/keycloak/data/import/workforce-realm.json:ro

--- a/deploy/keycloak-dev/broker-chain/exercise.py
+++ b/deploy/keycloak-dev/broker-chain/exercise.py
@@ -1,0 +1,114 @@
+"""Exercise the real two-Keycloak provider lifecycle without printing secrets."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+
+from app.sso.keycloak_admin import KeycloakAdminConfig, KeycloakProviderControl
+from app.sso.models import ProviderConfigureSpec
+
+
+BROKER = "https://broker.localhost:19443"
+UPSTREAM_ISSUER = "https://upstream.localhost:19444/realms/workforce"
+
+
+async def main() -> None:
+    control = KeycloakProviderControl(
+        KeycloakAdminConfig(
+            internal_base_url=BROKER,
+            public_base_url=BROKER,
+            realm="akb",
+            management_client_id="akb-sso-manager",
+            management_client_secret="fixture-only-management-secret",  # pragma: allowlist secret
+            verify_ssl=False,
+        )
+    )
+    configured_mutation = await control.configure(
+        ProviderConfigureSpec(
+            provider_type="keycloak-oidc",
+            alias="workforce",
+            display_name="Company SSO",
+            issuer=UPSTREAM_ISSUER,
+            discovery_url=f"{UPSTREAM_ISSUER}/.well-known/openid-configuration",
+            client_id="akb-broker",
+            client_secret="fixture-only-upstream-client-secret",  # pragma: allowlist secret
+        )
+    )
+    configured = configured_mutation.after
+    if configured_mutation.before is not None or configured.state != "configured_disabled":
+        raise RuntimeError("fixture_configure_readback_failed")
+    preserved_mutation = await control.configure(
+        ProviderConfigureSpec(
+            provider_type="keycloak-oidc",
+            alias="workforce",
+            display_name="Company SSO",
+            issuer=UPSTREAM_ISSUER,
+            discovery_url=f"{UPSTREAM_ISSUER}/.well-known/openid-configuration",
+            client_id="akb-broker",
+            client_secret=None,
+        )
+    )
+    if (
+        preserved_mutation.before is None
+        or not preserved_mutation.before.client_secret_configured
+        or not preserved_mutation.after.client_secret_configured
+    ):
+        raise RuntimeError("fixture_secret_preservation_failed")
+    enabled_mutation = await control.set_enabled("workforce", enabled=True)
+    enabled = enabled_mutation.after
+    catalog = await control.list_providers(force_refresh=True)
+    if enabled.state != "enabled" or [item.alias for item in catalog] != ["workforce"]:
+        raise RuntimeError("fixture_enable_readback_failed")
+
+    async with httpx.AsyncClient(verify=False, follow_redirects=True) as client:
+        response = await client.get(
+            f"{BROKER}/realms/akb/protocol/openid-connect/auth",
+            params={
+                "client_id": "fixture-browser",
+                "redirect_uri": "https://client.localhost/callback",
+                "response_type": "code",
+                "scope": "openid",
+                "kc_idp_hint": "workforce",
+            },
+        )
+    if response.status_code != 200:
+        raise RuntimeError("fixture_broker_redirect_failed")
+    upstream_request = next(
+        (
+            item.request.url
+            for item in (*response.history, response)
+            if item.request.url.host == "upstream.localhost"
+            and item.request.url.path
+            == "/realms/workforce/protocol/openid-connect/auth"
+        ),
+        None,
+    )
+    if upstream_request is None or upstream_request.params.get("client_id") != "akb-broker":
+        raise RuntimeError("fixture_upstream_redirect_invalid")
+
+    disabled = (await control.set_enabled("workforce", enabled=False)).after
+    if disabled.state != "configured_disabled":
+        raise RuntimeError("fixture_disable_readback_failed")
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "provider_type": enabled.provider_type,
+                "alias": enabled.alias,
+                "configure_state": configured.state,
+                "enabled_state": enabled.state,
+                "disabled_state": disabled.state,
+                "broker_redirect": "verified",
+                "secret_preservation": "verified",  # pragma: allowlist secret
+                "client_secret_exposed": False,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/deploy/keycloak-dev/broker-chain/run.sh
+++ b/deploy/keycloak-dev/broker-chain/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$fixture_root/../../.." && pwd)"
+cert_dir="$(mktemp -d "${TMPDIR:-/tmp}/akb-sso-broker-chain.XXXXXX")"
+project_name="akb-sso-broker-chain-$$"
+compose_file="$fixture_root/compose.yaml"
+
+cleanup() {
+  AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
+    --project-name "$project_name" --file "$compose_file" \
+    down --volumes --remove-orphans >/dev/null 2>&1 || true
+  if [[ "$cert_dir" == "${TMPDIR:-/tmp}/akb-sso-broker-chain."* ]]; then
+    rm -rf -- "$cert_dir"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
+  -subj "/CN=AKB SSO broker-chain fixture" \
+  -addext "subjectAltName=DNS:broker.localhost,DNS:upstream.localhost" \
+  -keyout "$cert_dir/tls.key" -out "$cert_dir/tls.crt" >/dev/null 2>&1
+chmod 600 "$cert_dir/tls.key"
+
+AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
+  --project-name "$project_name" --file "$compose_file" up --detach
+
+for endpoint in \
+  "https://broker.localhost:19443/realms/master/.well-known/openid-configuration" \
+  "https://upstream.localhost:19444/realms/workforce/.well-known/openid-configuration"
+do
+  ready=false
+  for _attempt in $(seq 1 90); do
+    if curl --fail --silent --insecure "$endpoint" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [[ "$ready" != true ]]; then
+    echo "Keycloak fixture did not become ready" >&2
+    exit 1
+  fi
+done
+
+cd "$repo_root/backend"
+uv run --locked python "$fixture_root/exercise.py"

--- a/deploy/keycloak-dev/broker-chain/upstream-realm.json
+++ b/deploy/keycloak-dev/broker-chain/upstream-realm.json
@@ -1,0 +1,49 @@
+{
+  "realm": "workforce",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "clients": [
+    {
+      "clientId": "akb-broker",
+      "name": "AKB broker fixture",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "fixture-only-upstream-client-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
+      "redirectUris": [
+        "https://broker.localhost:19443/realms/akb/broker/workforce/endpoint"
+      ],
+      "webOrigins": [],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["profile", "email"],
+      "optionalClientScopes": []
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "email": "alice@example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Alice",
+      "lastName": "Fixture",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "fixture-only-alice-password",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -1,7 +1,7 @@
 # Keycloak OIDC boundary
 
-**Status:** Phase 2 local verifier, admin provisioning, and dedicated admin
-browser session active; ordinary SSO browser session cutover staged unavailable
+**Status:** Phase 3A provider control and dedicated admin browser session active;
+exact identity migration and ordinary SSO browser-session cutover staged unavailable
 
 The accepted
 [Authentication Mode Boundary](../../design/accepted/2026-08-13-authentication-mode-boundary/README.md)
@@ -94,6 +94,22 @@ BFF sessions, back-channel logout, or long-lived provider sessions. Those
 remain Phase 4 work; the short admin session bounds IdP-side revocation lag in
 this MVP.
 
+## Runtime provider control
+
+In SSO mode, `/admin` manages an explicit registry of built-in upstream
+providers. The first provider is `keycloak-oidc`, which brokers a distinct
+Keycloak issuer behind the installation's Keycloak realm. Configuration always
+lands disabled; enable and disable are separate mutations and each result is
+read back from Keycloak. An enabled provider must be disabled before it can be
+reconfigured.
+
+The permanent realm-scoped management client is separate from the one-time
+standalone bootstrap client. A missing management credential produces explicit
+`delegated` control ownership and never falls back to a broader credential.
+Provider client secrets are write-only and excluded from admin, public, event,
+and audit views. The contribution contract and operator guide live under
+[`docs/sso/`](../../sso/README.md).
+
 ## Ordinary browser routes are staged unavailable
 
 Phase 1 does not expose a browser token transport:
@@ -109,30 +125,38 @@ exchange, token write, or SSO identity marker write. Phase 4 owns server-side
 access/refresh token custody, browser session transport, refresh, logout, and
 revocation before these routes can become available.
 
-## Public capability schema v1
+## Public capability schema v2
 
 `GET /api/v1/auth/config` publishes only non-secret capabilities:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "auth_mode": "sso",
   "local_auth": { "enabled": false },
   "keycloak": {
     "enabled": true,
-    "browser_session_ready": false,
-    "login_url": null
+    "browser_session_ready": false
   },
+  "providers": [
+    {
+      "provider_type": "keycloak-oidc",
+      "alias": "workforce",
+      "display_name": "Company SSO",
+      "login_url": null
+    }
+  ],
   "mcp_oauth": { "enabled": false }
 }
 ```
 
 `local_auth.enabled` derives from `auth_mode`. `keycloak.enabled` means the
 ordinary human SSO authority, so local mode with Keycloak enabled solely for
-MCP still publishes it as `false`. Until Phase 4, browser readiness is false
-and `login_url` is null. MCP OAuth remains orthogonal.
+MCP still publishes it as `false`. `providers` contains only exact enabled,
+non-drifted provider read-backs. Until Phase 4, browser readiness is false and
+each provider `login_url` is null. MCP OAuth remains orthogonal.
 
-Clients accept only schema v1 with a known mode and internally consistent
+Clients accept only schema v2 with a known mode and internally consistent
 capabilities. Fetch failure, non-success status, malformed JSON, old/missing
 shape, unknown version/mode, or mode contradiction yields a deny-all
 unavailable state; clients never infer local mode.

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -1,0 +1,66 @@
+# SSO provider control
+
+AKB uses Keycloak as its SSO broker in `auth_mode: sso`. The broker is an
+identity boundary, not an AKB authorization database: AKB continues to own
+accounts, administrator status, Vault roles, PATs, and service credentials.
+
+The ordinary login page is mode-exclusive. Once the browser-session boundary
+is enabled:
+
+- `local` shows AKB login, registration, and local password recovery only;
+- `sso` shows only enabled upstream providers returned by the versioned public
+  provider catalog. It never offers a local-password fallback.
+
+Product administration remains separate at `/admin`. A product administrator
+can configure an upstream provider while it is disabled, inspect the exact
+redirect URI, and then enable or disable it without redeploying AKB.
+
+## Provider lifecycle
+
+```text
+not configured → configured_disabled → enabled
+                         ↑                │
+                         └──── disable ───┘
+```
+
+Configuration and activation are deliberately separate. Updating an enabled
+provider is refused until it is disabled. Every mutation is read back from
+Keycloak before AKB reports success, and a drifted representation enters
+`configuration_error` rather than being advertised for login.
+
+Client secrets are write-only. They may be supplied when a provider is created
+or rotated, but are never returned by an AKB API, included in the public login
+catalog, or written to audit metadata. Leaving the secret blank while editing
+an existing disabled provider preserves Keycloak's stored value.
+
+## Control ownership
+
+The admin API reports one of two control modes:
+
+- `direct`: this AKB installation has its realm-scoped management credential,
+  so `/admin` can manage its own provider instances;
+- `delegated`: a platform or deployment operator owns provider changes out of
+  band. AKB does not attempt a management call or silently broaden its access.
+
+The standalone SSO bundle provisions a dedicated `akb-sso-manager` service
+account with only the Keycloak realm-management roles needed for provider
+control. It does not retain the one-time bootstrap credential.
+
+## Built-in providers
+
+- [Keycloak OIDC behind Keycloak](providers/keycloak-oidc.md) is the first
+  reference contribution.
+
+Additional OSS providers should follow [Adding a provider](adding-a-provider.md).
+The registry is explicit and code-reviewed; AKB does not load arbitrary
+Keycloak JSON or runtime Python plugins.
+
+Ordinary browser-session custody, refresh, logout, and revocation are a
+separate boundary. An enabled provider is listed by name before that boundary
+is active, but its login URL remains unavailable until the server-side browser
+session capability is ready.
+
+## Primary references
+
+- [Keycloak Server Administration Guide: identity brokering](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker)
+- [Keycloak Admin REST API: identity-provider instances](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_identity_providers)

--- a/docs/sso/adding-a-provider.md
+++ b/docs/sso/adding-a-provider.md
@@ -1,0 +1,73 @@
+# Adding a built-in SSO provider
+
+This is the contribution contract for provider integrations shipped by AKB.
+It keeps provider setup consistent without turning the admin page into an
+arbitrary Keycloak representation editor.
+
+## Source layout
+
+```text
+backend/app/sso/
+├── models.py
+├── registry.py
+└── providers/
+    └── <provider_type>.py
+
+docs/sso/providers/
+└── <provider_type>.md
+```
+
+Add the provider module to the explicit map in `backend/app/sso/registry.py`.
+Do not use import scanning, entry points, uploaded code, or configuration that
+selects a Python module at runtime.
+
+## Provider module contract
+
+A provider definition must expose a stable lowercase `PROVIDER_TYPE`, the
+Keycloak provider ID it renders, and these bounded operations:
+
+1. Validate a provider-neutral configuration. Reject unknown provider types,
+   unsafe aliases, invalid URLs, and the broker's own issuer.
+2. Render a complete disabled Keycloak representation from an allowlist.
+   Never pass through an imported discovery response wholesale.
+3. Mark the representation with AKB's provider type and schema version.
+4. Toggle only `enabled` and `hideOnLogin` for activation changes.
+5. Read the representation back into `configured_disabled`, `enabled`, or
+   `configuration_error` using an exact security profile.
+6. Produce separate admin, public, and audit views. None may contain a client
+   secret or Keycloak's masked-secret sentinel.
+
+Provider errors must use stable value-less codes. Do not include request
+values, upstream bodies, tokens, or secrets in exception messages.
+
+## Security defaults
+
+The rendered profile must be secure by construction. For OIDC providers this
+normally includes authorization code flow, signature validation, JWKS, an
+exact issuer, PKCE S256 where supported, and a bounded scope set. Trusting
+email, storing upstream tokens, broad token roles, implicit flow, password
+grant, or account linking by email require an explicit design review and must
+not be enabled as convenience defaults.
+
+Configuration always lands disabled. Creation requires a client secret;
+reconfiguration may use Keycloak's masked-secret preservation sentinel only
+after exact read-back proved that the existing managed provider has a secret.
+
+## Required tests
+
+Contributions must cover:
+
+- accepted and rejected configuration boundaries;
+- exact rendered representation and ignored discovery fields;
+- secret creation, preservation, rotation, and redaction;
+- unmanaged alias collision;
+- disabled-before-reconfigure enforcement;
+- enable, disable, idempotency, and read-back drift;
+- public catalog inclusion only for an exact enabled profile;
+- strict frontend parsing and a named provider button;
+- a live two-authority fixture when the provider depends on another identity
+  server.
+
+The live fixture must use disposable credentials and namespaces. It must not
+modify a shared Keycloak realm or depend on an internal-only host in public
+repository content.

--- a/docs/sso/providers/keycloak-oidc.md
+++ b/docs/sso/providers/keycloak-oidc.md
@@ -1,0 +1,69 @@
+# Keycloak OIDC behind Keycloak
+
+Provider type: `keycloak-oidc`
+
+This integration brokers an upstream Keycloak realm through the Keycloak realm
+owned by an AKB SSO installation. The two issuers must be distinct. They may be
+on separate servers or separate realms, but the upstream issuer cannot be the
+AKB broker realm itself.
+
+## Upstream client
+
+Create a confidential OpenID Connect client in the upstream realm with:
+
+- standard authorization code flow enabled;
+- implicit flow, direct access grants, and service accounts disabled;
+- PKCE method `S256`;
+- scopes `openid profile email`;
+- the exact redirect URI shown by AKB after the provider is saved.
+
+The redirect URI has this Keycloak broker shape:
+
+```text
+https://<broker-host>/realms/<akb-realm>/broker/<alias>/endpoint
+```
+
+Both the browser and AKB's broker must be able to reach the configured issuer.
+Use the issuer published by the upstream realm, not an admin-console URL or a
+server-internal hostname that produces a different `iss` claim.
+
+## Configure in AKB
+
+1. Sign in at `/admin` with the product-administrator identity.
+2. Under **SSO providers**, enter a stable alias, the user-facing button label,
+   upstream issuer, client ID, and client secret.
+3. Save the disabled configuration.
+4. Copy the read-back redirect URI into the upstream client's exact redirect
+   URI allowlist if it was not registered already.
+5. Enable the provider.
+
+AKB derives the discovery URL as
+`<issuer>/.well-known/openid-configuration`. The imported document supplies
+only allowlisted OIDC endpoints. Because this provider type is specifically
+Keycloak, its authorization, token, JWKS, user-info, logout, and introspection
+endpoints must be the standard paths beneath that exact issuer; metadata that
+redirects broker back-channel traffic to another origin is rejected. The
+resulting broker profile validates
+signatures through JWKS, requires the exact issuer, uses
+`client_secret_basic`, requests `openid profile email`, enables PKCE S256, and
+starts disabled and hidden.
+
+Saving a provider asks the broker Keycloak to fetch that HTTPS discovery URL.
+Treat product-admin access as authority to configure identity-network egress,
+and enforce the installation's approved IdP destinations with DNS, firewall,
+service-mesh, or Kubernetes NetworkPolicy controls. Do not grant `/admin` to a
+tenant that must not choose those destinations; use delegated platform control
+for that topology.
+
+AKB deliberately leaves `trustEmail`, upstream-token storage, and read-token
+role creation disabled. Keycloak's first-broker-login flow may create its
+internal broker user, but that does not grant an AKB role or administrator
+status. AKB account projection and authorization remain separate and exact.
+
+To rotate the upstream client secret, disable the provider, edit it with the
+new secret, save, and enable it again. Leaving the secret field blank preserves
+the existing value; no UI or API can read it back.
+
+The provider catalog does not advertise identity-migration support yet. Exact
+old/new subject prelink and readiness are a separate migration slice; an IdP
+being configurable is not evidence that existing AKB accounts were preserved.

--- a/frontend/src/lib/__tests__/admin-sso-config.test.ts
+++ b/frontend/src/lib/__tests__/admin-sso-config.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  configureAdminSsoProvider,
+  getAdminSsoCatalog,
+  parseAdminSsoCatalog,
+  setAdminSsoProviderEnabled,
+} from "../api";
+
+
+const provider = {
+  provider_type: "keycloak-oidc",
+  alias: "workforce",
+  display_name: "Company SSO",
+  state: "configured_disabled",
+  enabled: false,
+  issuer: "https://accounts.example.com/realms/workforce",
+  discovery_url: "https://accounts.example.com/realms/workforce/.well-known/openid-configuration",
+  client_id: "akb-broker",
+  client_secret_configured: true,
+  redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
+  capabilities: {
+    supports_logout: true,
+    supports_identity_migration: false,
+  },
+};
+
+const catalog = {
+  schema_version: 1,
+  auth_mode: "sso",
+  control_mode: "direct",
+  supported_provider_types: ["keycloak-oidc"],
+  providers: [provider],
+};
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.cookie = "akb_admin_csrf=; Max-Age=0; Path=/";
+});
+
+describe("admin SSO provider API", () => {
+  it("strictly parses the versioned secret-free catalog", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => Promise.resolve(response(catalog))));
+
+    expect(await getAdminSsoCatalog()).toEqual(catalog);
+    expect(JSON.stringify(await getAdminSsoCatalog())).not.toContain("client_secret\"");
+  });
+
+  it.each([
+    ["extra root field", { ...catalog, arbitrary: true }],
+    ["delegated catalog with provider data", { ...catalog, control_mode: "delegated" }],
+    ["duplicate alias", { ...catalog, providers: [provider, provider] }],
+    ["provider type outside registry", {
+      ...catalog,
+      providers: [{ ...provider, provider_type: "google" }],
+    }],
+    ["contradictory enabled state", {
+      ...catalog,
+      providers: [{ ...provider, state: "enabled", enabled: false }],
+    }],
+    ["exact state without a configured secret", {
+      ...catalog,
+      providers: [{ ...provider, client_secret_configured: false }], // pragma: allowlist secret
+    }],
+    ["unsafe display label", {
+      ...catalog,
+      providers: [{ ...provider, display_name: "unsafe\nlabel" }],
+    }],
+    ["provider secret field", {
+      ...catalog,
+      providers: [{ ...provider, client_secret: "leaked" }], // pragma: allowlist secret
+    }],
+  ])("rejects %s", (_name, value) => {
+    expect(() => parseAdminSsoCatalog(value)).toThrow(/Invalid SSO provider/);
+  });
+
+  it("sends a write-only secret with same-origin CSRF and never expects it back", async () => {
+    document.cookie = "akb_admin_csrf=csrf-proof-value; Path=/";
+    const fetchMock = vi.fn().mockResolvedValue(response({ provider }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await configureAdminSsoProvider("workforce", {
+      provider_type: "keycloak-oidc",
+      display_name: "Company SSO",
+      issuer: provider.issuer,
+      discovery_url: provider.discovery_url,
+      client_id: "akb-broker",
+      client_secret: "write-only-secret", // pragma: allowlist secret
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("PUT");
+    expect(init.credentials).toBe("same-origin");
+    expect((init.headers as Headers).get("X-AKB-Admin-CSRF")).toBe("csrf-proof-value");
+    expect(JSON.parse(init.body)).toMatchObject({ client_secret: "write-only-secret" }); // pragma: allowlist secret
+    expect(JSON.stringify(result)).not.toContain("write-only-secret");
+  });
+
+  it("uses an explicit enable endpoint with no body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response({
+      provider: { ...provider, state: "enabled", enabled: true },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await setAdminSsoProviderEnabled("workforce", true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/admin/sso/providers/workforce/enable",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty("body");
+  });
+});

--- a/frontend/src/lib/__tests__/auth-config.test.ts
+++ b/frontend/src/lib/__tests__/auth-config.test.ts
@@ -10,145 +10,117 @@ function response(body: unknown, status = 200): Response {
   });
 }
 
+const local = {
+  schema_version: 2,
+  auth_mode: "local",
+  local_auth: { enabled: true },
+  keycloak: { enabled: false, browser_session_ready: false },
+  providers: [],
+  mcp_oauth: { enabled: true },
+};
+
+const stagedSso = {
+  schema_version: 2,
+  auth_mode: "sso",
+  local_auth: { enabled: false },
+  keycloak: { enabled: true, browser_session_ready: false },
+  providers: [{
+    provider_type: "keycloak-oidc",
+    alias: "workforce",
+    display_name: "Company SSO",
+    login_url: null,
+  }],
+  mcp_oauth: { enabled: false },
+};
+
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 
-describe("getAuthConfig v1", () => {
-  it("accepts an exact local-mode v1 payload", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response({
-      schema_version: 1,
-      auth_mode: "local",
-      local_auth: { enabled: true },
-      keycloak: {
-        enabled: false,
-        browser_session_ready: false,
-        login_url: null,
-      },
-      mcp_oauth: { enabled: true },
-    })));
+describe("getAuthConfig v2", () => {
+  it("accepts an exact local-mode v2 payload", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(local)));
 
     expect(await getAuthConfig()).toEqual({
       available: true,
-      schema_version: 1,
-      auth_mode: "local",
-      local_auth: { enabled: true },
-      keycloak: {
-        enabled: false,
-        browser_session_ready: false,
-        login_url: null,
-      },
-      mcp_oauth: { enabled: true },
+      ...local,
     });
   });
 
+  it("accepts named providers only when every login URL is server-owned", async () => {
+    const ready = {
+      ...stagedSso,
+      keycloak: { enabled: true, browser_session_ready: true },
+      providers: [{
+        ...stagedSso.providers[0],
+        login_url: "/api/v1/auth/sso/workforce/login",
+      }],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(ready)));
+
+    expect(await getAuthConfig()).toEqual({ available: true, ...ready });
+  });
+
   it.each([
-    ["old shape", { local_auth: { enabled: true }, keycloak: { enabled: false } }],
-    ["unknown schema", { schema_version: 2, auth_mode: "local" }],
-    ["missing mode", { schema_version: 1 }],
-    ["unknown mode", { schema_version: 1, auth_mode: "hybrid" }],
-    [
-      "additional root property",
-      {
-        schema_version: 1,
-        auth_mode: "local",
-        local_auth: { enabled: true },
-        keycloak: {
-          enabled: false,
-          browser_session_ready: false,
-          login_url: null,
-        },
-        mcp_oauth: { enabled: false },
-        local_auth_override: true,
-      },
-    ],
-    [
-      "additional nested property",
-      {
-        schema_version: 1,
-        auth_mode: "sso",
-        local_auth: { enabled: false },
-        keycloak: {
-          enabled: true,
-          browser_session_ready: false,
-          login_url: null,
-          fallback_to_local: true,
-        },
-        mcp_oauth: { enabled: false },
-      },
-    ],
-    [
-      "mode contradiction",
-      {
-        schema_version: 1,
-        auth_mode: "sso",
-        local_auth: { enabled: true },
-        keycloak: {
-          enabled: true,
-          browser_session_ready: false,
-          login_url: null,
-        },
-        mcp_oauth: { enabled: false },
-      },
-    ],
-    [
-      "local mode advertising human SSO",
-      {
-        schema_version: 1,
-        auth_mode: "local",
-        local_auth: { enabled: true },
-        keycloak: {
-          enabled: true,
-          browser_session_ready: false,
-          login_url: null,
-        },
-        mcp_oauth: { enabled: true },
-      },
-    ],
-    [
-      "SSO mode without its human authority",
-      {
-        schema_version: 1,
-        auth_mode: "sso",
-        local_auth: { enabled: false },
-        keycloak: {
-          enabled: false,
-          browser_session_ready: false,
-          login_url: null,
-        },
-        mcp_oauth: { enabled: false },
-      },
-    ],
-    [
-      "staged SSO advertising a login URL",
-      {
-        schema_version: 1,
-        auth_mode: "sso",
-        local_auth: { enabled: false },
-        keycloak: {
-          enabled: true,
-          browser_session_ready: false,
-          login_url: "/api/v1/auth/keycloak/login",
-        },
-        mcp_oauth: { enabled: false },
-      },
-    ],
-    [
-      "ready SSO without a login URL",
-      {
-        schema_version: 1,
-        auth_mode: "sso",
-        local_auth: { enabled: false },
-        keycloak: {
-          enabled: true,
-          browser_session_ready: true,
-          login_url: null,
-        },
-        mcp_oauth: { enabled: false },
-      },
-    ],
+    ["old v1 shape", {
+      schema_version: 1,
+      auth_mode: "local",
+      local_auth: { enabled: true },
+      keycloak: { enabled: false, browser_session_ready: false, login_url: null },
+      mcp_oauth: { enabled: false },
+    }],
+    ["missing mode", { ...local, auth_mode: undefined }],
+    ["unknown mode", { ...local, auth_mode: "hybrid" }],
+    ["additional root property", { ...local, local_auth_override: true }],
+    ["additional nested property", {
+      ...stagedSso,
+      keycloak: { ...stagedSso.keycloak, fallback_to_local: true },
+    }],
+    ["mode contradiction", {
+      ...stagedSso,
+      local_auth: { enabled: true },
+    }],
+    ["local mode advertising human SSO", {
+      ...local,
+      keycloak: { enabled: true, browser_session_ready: false },
+    }],
+    ["local mode advertising providers", {
+      ...local,
+      providers: stagedSso.providers,
+    }],
+    ["SSO mode without its broker authority", {
+      ...stagedSso,
+      keycloak: { enabled: false, browser_session_ready: false },
+    }],
+    ["staged provider advertising a login URL", {
+      ...stagedSso,
+      providers: [{
+        ...stagedSso.providers[0],
+        login_url: "/api/v1/auth/sso/workforce/login",
+      }],
+    }],
+    ["ready provider with an external URL", {
+      ...stagedSso,
+      keycloak: { enabled: true, browser_session_ready: true },
+      providers: [{
+        ...stagedSso.providers[0],
+        login_url: "https://attacker.example/login",
+      }],
+    }],
+    ["ready provider without a login URL", {
+      ...stagedSso,
+      keycloak: { enabled: true, browser_session_ready: true },
+    }],
+    ["duplicate provider alias", {
+      ...stagedSso,
+      providers: [stagedSso.providers[0], stagedSso.providers[0]],
+    }],
+    ["provider with an extra property", {
+      ...stagedSso,
+      providers: [{ ...stagedSso.providers[0], client_id: "must-not-be-public" }],
+    }],
   ])("fails closed for %s", async (_name, body) => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(body)));
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -219,16 +219,23 @@ export const authLogin = (username: string, password: string) =>
 
 export type AuthMode = "local" | "sso";
 
+export interface AuthProviderOption {
+  provider_type: string;
+  alias: string;
+  display_name: string;
+  login_url: string | null;
+}
+
 export interface AuthConfig {
   available: boolean;
-  schema_version: 1 | null;
+  schema_version: 2 | null;
   auth_mode: AuthMode | null;
   local_auth: { enabled: boolean };
   keycloak: {
     enabled: boolean;
     browser_session_ready: boolean;
-    login_url: string | null;
   };
+  providers: AuthProviderOption[];
   mcp_oauth: { enabled: boolean };
 }
 
@@ -240,8 +247,8 @@ export const AUTH_CONFIG_UNAVAILABLE: AuthConfig = {
   keycloak: {
     enabled: false,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [],
   mcp_oauth: { enabled: false },
 };
 
@@ -261,42 +268,85 @@ function hasExactKeys(
   return actual.length === exact.length && actual.every((key, index) => key === exact[index]);
 }
 
+function hasControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
 export function parseAuthConfig(value: unknown): AuthConfig {
   const root = record(value);
   const localAuth = record(root?.local_auth);
   const keycloak = record(root?.keycloak);
   const mcpOauth = record(root?.mcp_oauth);
   const mode = root?.auth_mode;
-  const loginUrl = keycloak?.login_url;
+  const providerValues = root?.providers;
   if (
-    !hasExactKeys(root, ["schema_version", "auth_mode", "local_auth", "keycloak", "mcp_oauth"]) ||
+    !hasExactKeys(root, ["schema_version", "auth_mode", "local_auth", "keycloak", "providers", "mcp_oauth"]) ||
     !hasExactKeys(localAuth, ["enabled"]) ||
-    !hasExactKeys(keycloak, ["enabled", "browser_session_ready", "login_url"]) ||
+    !hasExactKeys(keycloak, ["enabled", "browser_session_ready"]) ||
     !hasExactKeys(mcpOauth, ["enabled"]) ||
-    root?.schema_version !== 1 ||
+    root?.schema_version !== 2 ||
     (mode !== "local" && mode !== "sso") ||
     typeof localAuth?.enabled !== "boolean" ||
     typeof keycloak?.enabled !== "boolean" ||
     typeof keycloak?.browser_session_ready !== "boolean" ||
-    (loginUrl !== null && typeof loginUrl !== "string") ||
+    !Array.isArray(providerValues) ||
+    providerValues.length > 100 ||
     typeof mcpOauth?.enabled !== "boolean" ||
     localAuth.enabled !== (mode === "local") ||
     keycloak.enabled !== (mode === "sso") ||
-    (keycloak.browser_session_ready && (!keycloak.enabled || !loginUrl)) ||
-    (!keycloak.browser_session_ready && loginUrl !== null)
+    (keycloak.browser_session_ready && !keycloak.enabled) ||
+    (mode === "local" && providerValues.length !== 0)
   ) {
     return AUTH_CONFIG_UNAVAILABLE;
   }
+  const aliases = new Set<string>();
+  const providers: AuthProviderOption[] = [];
+  for (const value of providerValues) {
+    const provider = record(value);
+    if (!hasExactKeys(provider, ["provider_type", "alias", "display_name", "login_url"])) {
+      return AUTH_CONFIG_UNAVAILABLE;
+    }
+    const providerType = provider.provider_type;
+    const alias = provider.alias;
+    const displayName = provider.display_name;
+    const loginUrl = provider.login_url;
+    if (
+      typeof providerType !== "string" ||
+      !/^[a-z0-9][a-z0-9-]{0,79}$/.test(providerType) ||
+      typeof alias !== "string" ||
+      !/^[a-z0-9][a-z0-9._-]{0,62}$/.test(alias) ||
+      aliases.has(alias) ||
+      typeof displayName !== "string" ||
+      !displayName.trim() ||
+      displayName.length > 80 ||
+      hasControlCharacters(displayName) ||
+      (loginUrl !== null && typeof loginUrl !== "string") ||
+      (!keycloak.browser_session_ready && loginUrl !== null) ||
+      (keycloak.browser_session_ready && loginUrl !== `/api/v1/auth/sso/${alias}/login`)
+    ) {
+      return AUTH_CONFIG_UNAVAILABLE;
+    }
+    aliases.add(alias);
+    providers.push({
+      provider_type: providerType,
+      alias,
+      display_name: displayName,
+      login_url: loginUrl,
+    });
+  }
   return {
     available: true,
-    schema_version: 1,
+    schema_version: 2,
     auth_mode: mode,
     local_auth: { enabled: localAuth.enabled },
     keycloak: {
       enabled: keycloak.enabled,
       browser_session_ready: keycloak.browser_session_ready,
-      login_url: loginUrl,
     },
+    providers,
     mcp_oauth: { enabled: mcpOauth.enabled },
   };
 }
@@ -464,6 +514,210 @@ export async function adminLogout(): Promise<{ logout_url: string }> {
     throw new Error("Invalid product-admin logout response");
   }
   return { logout_url: payload.logout_url };
+}
+
+export type AdminSsoProviderState =
+  | "configured_disabled"
+  | "enabled"
+  | "configuration_error";
+
+export interface AdminSsoProvider {
+  provider_type: string;
+  alias: string;
+  display_name: string;
+  state: AdminSsoProviderState;
+  enabled: boolean;
+  issuer: string | null;
+  discovery_url: string | null;
+  client_id: string | null;
+  client_secret_configured: boolean;
+  redirect_uri: string;
+  capabilities: {
+    supports_logout: boolean;
+    supports_identity_migration: boolean;
+  };
+}
+
+export interface AdminSsoCatalog {
+  schema_version: 1;
+  auth_mode: "sso";
+  control_mode: "direct" | "delegated";
+  supported_provider_types: string[];
+  providers: AdminSsoProvider[];
+}
+
+function parseAdminSsoProvider(value: unknown): AdminSsoProvider {
+  const provider = record(value);
+  const capabilities = record(provider?.capabilities);
+  const state = provider?.state;
+  if (
+    !hasExactKeys(provider, [
+      "provider_type", "alias", "display_name", "state", "enabled", "issuer",
+      "discovery_url", "client_id", "client_secret_configured",
+      "redirect_uri", "capabilities",
+    ]) ||
+    !hasExactKeys(capabilities, ["supports_logout", "supports_identity_migration"]) ||
+    typeof provider.provider_type !== "string" ||
+    !/^[a-z0-9][a-z0-9-]{0,79}$/.test(provider.provider_type) ||
+    typeof provider.alias !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{0,62}$/.test(provider.alias) ||
+    typeof provider.display_name !== "string" ||
+    !provider.display_name.trim() ||
+    provider.display_name.length > 80 ||
+    hasControlCharacters(provider.display_name) ||
+    (state !== "configured_disabled" && state !== "enabled" && state !== "configuration_error") ||
+    typeof provider.enabled !== "boolean" ||
+    (state === "enabled" && provider.enabled !== true) ||
+    (state === "configured_disabled" && provider.enabled !== false) ||
+    (provider.issuer !== null && (
+      typeof provider.issuer !== "string" ||
+      provider.issuer.length > 2048 ||
+      hasControlCharacters(provider.issuer)
+    )) ||
+    (provider.discovery_url !== null && (
+      typeof provider.discovery_url !== "string" ||
+      provider.discovery_url.length > 2048 ||
+      hasControlCharacters(provider.discovery_url)
+    )) ||
+    (provider.client_id !== null && (
+      typeof provider.client_id !== "string" ||
+      provider.client_id.length > 255 ||
+      hasControlCharacters(provider.client_id)
+    )) ||
+    typeof provider.client_secret_configured !== "boolean" || // pragma: allowlist secret
+    typeof provider.redirect_uri !== "string" ||
+    !provider.redirect_uri ||
+    provider.redirect_uri.length > 2048 ||
+    hasControlCharacters(provider.redirect_uri) ||
+    ((state === "enabled" || state === "configured_disabled") && (
+      provider.issuer === null ||
+      provider.discovery_url === null ||
+      provider.client_id === null ||
+      provider.client_secret_configured !== true // pragma: allowlist secret
+    )) ||
+    typeof capabilities.supports_logout !== "boolean" ||
+    typeof capabilities.supports_identity_migration !== "boolean"
+  ) {
+    throw new Error("Invalid SSO provider response");
+  }
+  return {
+    provider_type: provider.provider_type,
+    alias: provider.alias,
+    display_name: provider.display_name,
+    state,
+    enabled: provider.enabled,
+    issuer: provider.issuer as string | null,
+    discovery_url: provider.discovery_url as string | null,
+    client_id: provider.client_id as string | null,
+    client_secret_configured: provider.client_secret_configured,
+    redirect_uri: provider.redirect_uri,
+    capabilities: {
+      supports_logout: capabilities.supports_logout,
+      supports_identity_migration: capabilities.supports_identity_migration,
+    },
+  };
+}
+
+export function parseAdminSsoCatalog(value: unknown): AdminSsoCatalog {
+  const root = record(value);
+  const types = root?.supported_provider_types;
+  const values = root?.providers;
+  if (
+    !hasExactKeys(root, [
+      "schema_version", "auth_mode", "control_mode",
+      "supported_provider_types", "providers",
+    ]) ||
+    root.schema_version !== 1 ||
+    root.auth_mode !== "sso" ||
+    (root.control_mode !== "direct" && root.control_mode !== "delegated") ||
+    !Array.isArray(types) ||
+    types.length > 32 ||
+    types.some((type) => typeof type !== "string" || !/^[a-z0-9][a-z0-9-]{0,79}$/.test(type)) ||
+    new Set(types).size !== types.length ||
+    !Array.isArray(values) ||
+    values.length > 100 ||
+    (root.control_mode === "delegated" && values.length !== 0)
+  ) {
+    throw new Error("Invalid SSO provider catalog response");
+  }
+  const providers = values.map(parseAdminSsoProvider);
+  if (
+    new Set(providers.map((provider) => provider.alias)).size !== providers.length ||
+    providers.some((provider) => !types.includes(provider.provider_type))
+  ) {
+    throw new Error("Invalid SSO provider catalog response");
+  }
+  return {
+    schema_version: 1,
+    auth_mode: "sso",
+    control_mode: root.control_mode,
+    supported_provider_types: types,
+    providers,
+  };
+}
+
+function adminSsoHeaders({ mutation = false }: { mutation?: boolean } = {}): Headers {
+  const headers = adminHeaders();
+  if (mutation) {
+    headers.set("Content-Type", "application/json");
+    const csrf = cookieValue("akb_admin_csrf");
+    if (csrf) headers.set("X-AKB-Admin-CSRF", csrf);
+  }
+  return headers;
+}
+
+export async function getAdminSsoCatalog(): Promise<AdminSsoCatalog> {
+  const response = await fetch(`${API_BASE}/admin/sso/providers`, {
+    credentials: "same-origin",
+    headers: adminSsoHeaders(),
+  });
+  if (!response.ok) await throwJsonApiError(response);
+  return parseAdminSsoCatalog(await response.json());
+}
+
+export interface ConfigureAdminSsoProvider {
+  provider_type: string;
+  display_name: string;
+  issuer: string;
+  discovery_url: string;
+  client_id: string;
+  client_secret?: string;
+}
+
+async function parseAdminSsoMutation(response: Response): Promise<AdminSsoProvider> {
+  if (!response.ok) await throwJsonApiError(response);
+  const payload = record(await response.json());
+  if (!hasExactKeys(payload, ["provider"])) {
+    throw new Error("Invalid SSO provider mutation response");
+  }
+  return parseAdminSsoProvider(payload.provider);
+}
+
+export function configureAdminSsoProvider(
+  alias: string,
+  input: ConfigureAdminSsoProvider,
+): Promise<AdminSsoProvider> {
+  return fetch(`${API_BASE}/admin/sso/providers/${encodeURIComponent(alias)}`, {
+    method: "PUT",
+    credentials: "same-origin",
+    headers: adminSsoHeaders({ mutation: true }),
+    body: JSON.stringify(input),
+  }).then(parseAdminSsoMutation);
+}
+
+export function setAdminSsoProviderEnabled(
+  alias: string,
+  enabled: boolean,
+): Promise<AdminSsoProvider> {
+  const verb = enabled ? "enable" : "disable";
+  return fetch(
+    `${API_BASE}/admin/sso/providers/${encodeURIComponent(alias)}/${verb}`,
+    {
+      method: "POST",
+      credentials: "same-origin",
+      headers: adminSsoHeaders({ mutation: true }),
+    },
+  ).then(parseAdminSsoMutation);
 }
 
 // ── Auth (token) ──

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -6,8 +6,11 @@ import { MemoryRouter } from "react-router-dom";
 
 import {
   adminLocalLogin,
+  configureAdminSsoProvider,
   getAdminAuthConfig,
   getAdminSession,
+  getAdminSsoCatalog,
+  setAdminSsoProviderEnabled,
   setToken,
 } from "@/lib/api";
 import AdminPage from "../admin";
@@ -21,6 +24,9 @@ vi.mock("@/lib/api", async () => {
     getAdminSession: vi.fn(),
     adminLocalLogin: vi.fn(),
     adminLogout: vi.fn(),
+    getAdminSsoCatalog: vi.fn(),
+    configureAdminSsoProvider: vi.fn(),
+    setAdminSsoProviderEnabled: vi.fn(),
     setToken: vi.fn(),
   };
 });
@@ -51,6 +57,31 @@ const ssoConfig = {
   },
 };
 
+const provider = {
+  provider_type: "keycloak-oidc",
+  alias: "workforce",
+  display_name: "Company SSO",
+  state: "enabled" as const,
+  enabled: true,
+  issuer: "https://accounts.example.com/realms/workforce",
+  discovery_url: "https://accounts.example.com/realms/workforce/.well-known/openid-configuration",
+  client_id: "akb-broker",
+  client_secret_configured: true,
+  redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
+  capabilities: {
+    supports_logout: true,
+    supports_identity_migration: false,
+  },
+};
+
+const directCatalog = {
+  schema_version: 1 as const,
+  auth_mode: "sso" as const,
+  control_mode: "direct" as const,
+  supported_provider_types: ["keycloak-oidc"],
+  providers: [provider],
+};
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -66,6 +97,13 @@ function renderPage() {
 
 beforeEach(() => {
   vi.mocked(getAdminSession).mockResolvedValue(null);
+  vi.mocked(getAdminSsoCatalog).mockResolvedValue(directCatalog);
+  vi.mocked(configureAdminSsoProvider).mockResolvedValue({
+    ...provider,
+    state: "configured_disabled",
+    enabled: false,
+  });
+  vi.mocked(setAdminSsoProviderEnabled).mockResolvedValue(provider);
 });
 
 afterEach(() => {
@@ -126,5 +164,119 @@ describe("AdminPage mode boundary", () => {
     expect(await screen.findByText("Admin")).toBeInTheDocument();
     expect(screen.getByText("admin@example.com")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /SSO providers/i })).toBeInTheDocument();
+    expect(screen.getByText("Company SSO")).toBeInTheDocument();
+  });
+
+  it("toggles a configured provider without redeploying", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(setAdminSsoProviderEnabled).toHaveBeenCalledWith("workforce", false);
+    });
+  });
+
+  it("keeps emergency disable available for an enabled drifted provider", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    vi.mocked(getAdminSsoCatalog).mockResolvedValue({
+      ...directCatalog,
+      providers: [{ ...provider, state: "configuration_error", enabled: true }],
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    const disable = await screen.findByRole("button", { name: "Disable" });
+    expect(disable).toBeEnabled();
+    await user.click(disable);
+
+    await waitFor(() => {
+      expect(setAdminSsoProviderEnabled).toHaveBeenCalledWith("workforce", false);
+    });
+  });
+
+  it("derives discovery from issuer and sends the client secret only on save", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.clear(await screen.findByLabelText("Alias"));
+    await user.type(screen.getByLabelText("Alias"), "partners");
+    await user.type(screen.getByLabelText("Button label"), "Partner SSO");
+    await user.type(screen.getByLabelText("Upstream issuer"), "https://id.example.com/realms/partners/");
+    await user.type(screen.getByLabelText("Client ID"), "akb-partners");
+    await user.type(screen.getByLabelText("Client secret"), "one-time-input");
+    await user.click(screen.getByRole("button", { name: /Save disabled configuration/i }));
+
+    await waitFor(() => {
+      expect(configureAdminSsoProvider).toHaveBeenCalledWith("partners", {
+        provider_type: "keycloak-oidc",
+        display_name: "Partner SSO",
+        issuer: "https://id.example.com/realms/partners",
+        discovery_url: "https://id.example.com/realms/partners/.well-known/openid-configuration",
+        client_id: "akb-partners",
+        client_secret: "one-time-input", // pragma: allowlist secret
+      });
+    });
+  });
+
+  it("shows delegated ownership without rendering direct controls", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    vi.mocked(getAdminSsoCatalog).mockResolvedValue({
+      ...directCatalog,
+      control_mode: "delegated",
+      providers: [],
+    });
+    renderPage();
+
+    expect(await screen.findByText(/managed by the deployment operator/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Client secret")).toBeNull();
   });
 });

--- a/frontend/src/pages/__tests__/auth-forgot.test.tsx
+++ b/frontend/src/pages/__tests__/auth-forgot.test.tsx
@@ -24,14 +24,14 @@ describe("AuthForgotPage", () => {
   it("renders password guidance only for validated local mode", async () => {
     vi.mocked(getAuthConfig).mockResolvedValue({
       available: true,
-      schema_version: 1,
+      schema_version: 2,
       auth_mode: "local",
       local_auth: { enabled: true },
       keycloak: {
         enabled: false,
         browser_session_ready: false,
-        login_url: null,
       },
+      providers: [],
       mcp_oauth: { enabled: false },
     });
 
@@ -44,14 +44,19 @@ describe("AuthForgotPage", () => {
   it.each([
     ["sso", {
       available: true,
-      schema_version: 1 as const,
+      schema_version: 2 as const,
       auth_mode: "sso" as const,
       local_auth: { enabled: false },
       keycloak: {
         enabled: true,
         browser_session_ready: false,
-        login_url: null,
       },
+      providers: [{
+        provider_type: "keycloak-oidc",
+        alias: "workforce",
+        display_name: "Company SSO",
+        login_url: null,
+      }],
       mcp_oauth: { enabled: false },
     }],
     ["unavailable", AUTH_CONFIG_UNAVAILABLE],

--- a/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
+++ b/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
@@ -30,14 +30,14 @@ vi.mock("@/lib/api", () => ({
   // hidden and AuthPage's mount effect resolves cleanly.
   getAuthConfig: vi.fn().mockResolvedValue({
     available: true,
-    schema_version: 1,
+    schema_version: 2,
     auth_mode: "local",
     local_auth: { enabled: true },
     keycloak: {
       enabled: false,
       browser_session_ready: false,
-      login_url: null,
     },
+    providers: [],
     mcp_oauth: { enabled: false },
   }),
 }));

--- a/frontend/src/pages/__tests__/auth-sso-only.test.tsx
+++ b/frontend/src/pages/__tests__/auth-sso-only.test.tsx
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
-import { AUTH_CONFIG_UNAVAILABLE, getAuthConfig } from "@/lib/api";
+import {
+  AUTH_CONFIG_UNAVAILABLE,
+  getAuthConfig,
+  getToken,
+  setToken,
+} from "@/lib/api";
 import AuthPage from "../auth";
 
 
@@ -28,27 +33,32 @@ vi.mock("react-router-dom", async () => {
 
 const localConfig = {
   available: true,
-  schema_version: 1 as const,
+  schema_version: 2 as const,
   auth_mode: "local" as const,
   local_auth: { enabled: true },
   keycloak: {
     enabled: false,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [],
   mcp_oauth: { enabled: false },
 };
 
 const stagedSsoConfig = {
   available: true,
-  schema_version: 1 as const,
+  schema_version: 2 as const,
   auth_mode: "sso" as const,
   local_auth: { enabled: false },
   keycloak: {
     enabled: true,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [{
+    provider_type: "keycloak-oidc",
+    alias: "workforce",
+    display_name: "Company SSO",
+    login_url: null,
+  }],
   mcp_oauth: { enabled: false },
 };
 
@@ -62,6 +72,7 @@ function renderAuth() {
 
 beforeEach(() => {
   window.history.replaceState({}, "", "/auth");
+  vi.mocked(getToken).mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -91,7 +102,7 @@ describe("AuthPage mode gate", () => {
     expect(screen.queryByLabelText(/Username/i)).toBeNull();
     expect(screen.queryByRole("tab", { name: /Register/i })).toBeNull();
     expect(screen.queryByRole("link", { name: /Forgot password/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Sign in with SSO/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Company SSO/i })).toBeNull();
   });
 
   it("does not treat ?local=1 as an SSO-mode escape", async () => {
@@ -102,6 +113,17 @@ describe("AuthPage mode gate", () => {
 
     expect(await screen.findByText(/SSO browser sign-in is not available yet/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/Username/i)).toBeNull();
+  });
+
+  it("clears a stale local JWT instead of redirecting it through SSO mode", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(stagedSsoConfig);
+    vi.mocked(getToken).mockReturnValue("legacy-local-session");
+
+    renderAuth();
+
+    expect(await screen.findByText(/SSO browser sign-in is not available yet/i)).toBeInTheDocument();
+    expect(setToken).toHaveBeenCalledWith(null);
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   it("fails closed when public auth configuration is unavailable", async () => {
@@ -119,14 +141,30 @@ describe("AuthPage mode gate", () => {
       keycloak: {
         enabled: true,
         browser_session_ready: true,
-        login_url: "/api/v1/auth/keycloak/login",
       },
+      providers: [{
+        ...stagedSsoConfig.providers[0],
+        login_url: "/api/v1/auth/sso/workforce/login",
+      }],
     });
 
     renderAuth();
 
-    expect(await screen.findByRole("button", { name: /Sign in with SSO/i })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Sign in with Company SSO/i })).toBeInTheDocument();
     expect(screen.queryByLabelText(/Username/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Sign in with SSO$/i })).toBeNull();
     expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("shows setup pending rather than a local fallback when no IdP is enabled", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue({
+      ...stagedSsoConfig,
+      providers: [],
+    });
+
+    renderAuth();
+
+    expect(await screen.findByText(/No SSO providers are enabled/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Username/i)).toBeNull();
   });
 });

--- a/frontend/src/pages/__tests__/settings-admin-search.test.tsx
+++ b/frontend/src/pages/__tests__/settings-admin-search.test.tsx
@@ -45,14 +45,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(api.getAuthConfig).mockResolvedValue({
     available: true,
-    schema_version: 1,
+    schema_version: 2,
     auth_mode: "local",
     local_auth: { enabled: true },
     keycloak: {
       enabled: false,
       browser_session_ready: false,
-      login_url: null,
     },
+    providers: [],
     mcp_oauth: { enabled: false },
   });
 });
@@ -85,14 +85,19 @@ describe("Admin tab search + sort", () => {
   it("hides admin password reset controls in SSO mode", async () => {
     vi.mocked(api.getAuthConfig).mockResolvedValue({
       available: true,
-      schema_version: 1,
+      schema_version: 2,
       auth_mode: "sso",
       local_auth: { enabled: false },
       keycloak: {
         enabled: true,
         browser_session_ready: false,
-        login_url: null,
       },
+      providers: [{
+        provider_type: "keycloak-oidc",
+        alias: "workforce",
+        display_name: "Company SSO",
+        login_url: null,
+      }],
       mcp_oauth: { enabled: true },
     });
 

--- a/frontend/src/pages/__tests__/settings-profile-edit.test.tsx
+++ b/frontend/src/pages/__tests__/settings-profile-edit.test.tsx
@@ -44,27 +44,32 @@ const USER = {
 
 const LOCAL_AUTH_CONFIG = {
   available: true,
-  schema_version: 1,
+  schema_version: 2,
   auth_mode: "local",
   local_auth: { enabled: true },
   keycloak: {
     enabled: false,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [],
   mcp_oauth: { enabled: false },
 };
 
 const SSO_AUTH_CONFIG = {
   available: true,
-  schema_version: 1,
+  schema_version: 2,
   auth_mode: "sso",
   local_auth: { enabled: false },
   keycloak: {
     enabled: true,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [{
+    provider_type: "keycloak-oidc",
+    alias: "workforce",
+    display_name: "Company SSO",
+    login_url: null,
+  }],
   mcp_oauth: { enabled: true },
 };
 

--- a/frontend/src/pages/__tests__/settings-tokens-setup.test.tsx
+++ b/frontend/src/pages/__tests__/settings-tokens-setup.test.tsx
@@ -21,14 +21,14 @@ vi.mock("@/lib/api", () => ({
   // these tests stay focused on the PAT-mint UX they were written for.
   getAuthConfig: vi.fn().mockResolvedValue({
     available: true,
-    schema_version: 1,
+    schema_version: 2,
     auth_mode: "local",
     local_auth: { enabled: true },
     keycloak: {
       enabled: false,
       browser_session_ready: false,
-      login_url: null,
     },
+    providers: [],
     mcp_oauth: { enabled: false },
   }),
 }));
@@ -89,14 +89,19 @@ describe("Tokens setup guide smart default", () => {
     const { getAuthConfig, getMe, listPATs } = await import("@/lib/api");
     (getAuthConfig as any).mockResolvedValue({
       available: true,
-      schema_version: 1,
+      schema_version: 2,
       auth_mode: "sso",
       local_auth: { enabled: false },
       keycloak: {
         enabled: true,
         browser_session_ready: false,
-        login_url: null,
       },
+      providers: [{
+        provider_type: "keycloak-oidc",
+        alias: "workforce",
+        display_name: "Company SSO",
+        login_url: null,
+      }],
       mcp_oauth: { enabled: true },
     });
     (getMe as any).mockResolvedValue({ user_id: "u1", username: "u", email: "u@x", is_admin: false });

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -3,16 +3,22 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 
 import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Panel, PanelHeader } from "@/components/ui/panel";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
   adminLocalLogin,
   adminLogout,
+  configureAdminSsoProvider,
   getAdminAuthConfig,
   getAdminSession,
+  getAdminSsoCatalog,
+  setAdminSsoProviderEnabled,
   setToken,
+  type AdminSsoProvider,
 } from "@/lib/api";
 
 
@@ -93,7 +99,7 @@ export default function AdminPage() {
         <ThemeToggle />
       </header>
 
-      <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-lg items-center px-5 py-12 sm:px-8">
+      <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-3xl items-center px-5 py-12 sm:px-8">
         <section className="w-full rounded-[var(--radius-xl)] border border-border bg-surface p-6 shadow-lg sm:p-8" aria-labelledby="admin-heading">
           <div className="mb-7">
             <p className="coord mb-2 text-primary">CONTROL PLANE</p>
@@ -128,6 +134,7 @@ export default function AdminPage() {
                 <p className="mt-1 text-sm text-foreground-muted">{session.user.email}</p>
                 <p className="coord mt-3">{session.auth_mode.toUpperCase()} ADMIN SESSION</p>
               </div>
+              {session.auth_mode === "sso" && <SsoProviderControl />}
               {error && <Alert variant="destructive">{error}</Alert>}
               <Button type="button" variant="outline" className="w-full" loading={submitting} onClick={signOut}>
                 Sign out
@@ -171,6 +178,203 @@ export default function AdminPage() {
           </div>
         </section>
       </main>
+    </div>
+  );
+}
+
+const EMPTY_PROVIDER_FORM = {
+  alias: "",
+  displayName: "",
+  issuer: "",
+  clientId: "",
+  clientSecret: "",
+};
+
+function providerBadge(state: AdminSsoProvider["state"]) {
+  if (state === "enabled") return <Badge variant="success">Enabled</Badge>;
+  if (state === "configuration_error") return <Badge variant="error">Configuration error</Badge>;
+  return <Badge variant="pending">Disabled</Badge>;
+}
+
+function SsoProviderControl() {
+  const [form, setForm] = useState(EMPTY_PROVIDER_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [togglingAlias, setTogglingAlias] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const catalogQuery = useQuery({
+    queryKey: ["admin-sso-catalog", 1],
+    queryFn: getAdminSsoCatalog,
+    staleTime: 10_000,
+  });
+  const catalog = catalogQuery.data;
+
+  function setField(field: keyof typeof form, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+    setError("");
+    setNotice("");
+  }
+
+  function editProvider(provider: AdminSsoProvider) {
+    setForm({
+      alias: provider.alias,
+      displayName: provider.display_name,
+      issuer: provider.issuer || "",
+      clientId: provider.client_id || "",
+      clientSecret: "",
+    });
+    setError("");
+    setNotice("Leave the client secret blank to preserve the configured value.");
+  }
+
+  async function saveProvider(event: React.FormEvent) {
+    event.preventDefault();
+    setError("");
+    setNotice("");
+    setSubmitting(true);
+    const issuer = form.issuer.trim().replace(/\/+$/, "");
+    try {
+      await configureAdminSsoProvider(form.alias.trim(), {
+        provider_type: "keycloak-oidc",
+        display_name: form.displayName.trim(),
+        issuer,
+        discovery_url: `${issuer}/.well-known/openid-configuration`,
+        client_id: form.clientId.trim(),
+        ...(form.clientSecret ? { client_secret: form.clientSecret } : {}),
+      });
+      setForm((current) => ({ ...current, clientSecret: "" }));
+      setNotice("Provider configuration was saved disabled. Enable it after checking the redirect URI.");
+      await catalogQuery.refetch();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Provider configuration failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function toggleProvider(provider: AdminSsoProvider) {
+    const enabled = !provider.enabled;
+    setError("");
+    setNotice("");
+    setTogglingAlias(provider.alias);
+    try {
+      await setAdminSsoProviderEnabled(provider.alias, enabled);
+      setNotice(`${provider.display_name} was ${enabled ? "enabled" : "disabled"}.`);
+      await catalogQuery.refetch();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Provider state change failed");
+    } finally {
+      setTogglingAlias(null);
+    }
+  }
+
+  if (catalogQuery.isPending) {
+    return <p className="text-sm text-foreground-muted" role="status">Loading SSO providers…</p>;
+  }
+  if (catalogQuery.isError || !catalog) {
+    return <Alert variant="destructive">SSO provider configuration could not be loaded.</Alert>;
+  }
+  if (catalog.control_mode === "delegated") {
+    return (
+      <Alert variant="info" title="SSO providers are managed by the deployment operator">
+        This installation does not expose direct Keycloak provider control.
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-4" aria-labelledby="sso-providers-heading">
+      <div>
+        <h2 id="sso-providers-heading" className="font-display text-xl font-semibold tracking-tight">
+          SSO providers
+        </h2>
+        <p className="mt-1 text-sm leading-6 text-foreground-muted">
+          Enabled providers become the only ordinary-user sign-in options. Changes do not require a redeploy.
+        </p>
+      </div>
+
+      {error && <Alert variant="destructive">{error}</Alert>}
+      {notice && <Alert variant="success">{notice}</Alert>}
+
+      {catalog.providers.length === 0 ? (
+        <Alert variant="info">No upstream SSO provider is configured yet.</Alert>
+      ) : (
+        <Panel flush>
+          <PanelHeader label="Configured providers" count={catalog.providers.length} />
+          <div className="divide-y divide-border">
+            {catalog.providers.map((provider) => (
+              <div key={provider.alias} className="p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">{provider.display_name}</p>
+                      {providerBadge(provider.state)}
+                    </div>
+                    <p className="coord mt-1">{provider.alias} · {provider.provider_type}</p>
+                    <p className="mt-2 break-all text-xs leading-5 text-foreground-muted">
+                      Redirect URI: {provider.redirect_uri}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <Button type="button" size="sm" variant="outline" onClick={() => editProvider(provider)}>
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={provider.enabled ? "outline" : "default"}
+                      disabled={provider.state === "configuration_error" && !provider.enabled}
+                      loading={togglingAlias === provider.alias}
+                      onClick={() => toggleProvider(provider)}
+                    >
+                      {provider.enabled ? "Disable" : "Enable"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Panel>
+      )}
+
+      <Panel inset={false} flush>
+        <PanelHeader label="Keycloak OIDC provider" />
+        <form className="grid gap-4 p-4 sm:grid-cols-2" onSubmit={saveProvider}>
+          <AdminField label="Alias" id="sso-alias" value={form.alias} onChange={(value) => setField("alias", value)} pattern="[a-z0-9][a-z0-9._-]{0,62}" autoComplete="off" required />
+          <AdminField label="Button label" id="sso-display-name" value={form.displayName} onChange={(value) => setField("displayName", value)} maxLength={80} autoComplete="organization" required />
+          <div className="sm:col-span-2">
+            <AdminField label="Upstream issuer" id="sso-issuer" type="url" value={form.issuer} onChange={(value) => setField("issuer", value)} placeholder="https://id.example.com/realms/workforce" autoComplete="url" required />
+          </div>
+          <AdminField label="Client ID" id="sso-client-id" value={form.clientId} onChange={(value) => setField("clientId", value)} autoComplete="off" required />
+          <AdminField label="Client secret" id="sso-client-secret" type="password" value={form.clientSecret} onChange={(value) => setField("clientSecret", value)} placeholder="Required for a new provider" autoComplete="new-password" />
+          <div className="sm:col-span-2">
+            <Button type="submit" loading={submitting}>Save disabled configuration</Button>
+            <p className="mt-2 text-xs leading-5 text-foreground-muted">
+              Discovery uses the issuer&apos;s standard .well-known endpoint. Secrets are write-only.
+            </p>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}
+
+function AdminField({
+  label,
+  id,
+  value,
+  onChange,
+  ...props
+}: {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "id" | "value" | "onChange">) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium" htmlFor={id}>{label}</label>
+      <Input id={id} value={value} onChange={(event) => onChange(event.target.value)} {...props} />
     </div>
   );
 }

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -48,32 +48,39 @@ export default function AuthPage() {
     authConfig?.available === true &&
     authConfig.auth_mode === "local" &&
     authConfig.local_auth.enabled;
-  const ssoLoginUrl =
+  const ssoConfigEnabled =
     authConfig?.available === true &&
     authConfig.auth_mode === "sso" &&
-    authConfig.keycloak.enabled &&
-    authConfig.keycloak.browser_session_ready
-      ? authConfig.keycloak.login_url
-      : null;
+    authConfig.keycloak.enabled;
+  const ssoProviders = ssoConfigEnabled ? authConfig.providers : [];
+  const usableSsoProviders =
+    ssoConfigEnabled && authConfig.keycloak.browser_session_ready
+      ? ssoProviders.filter((provider) => provider.login_url !== null)
+      : [];
 
   useEffect(() => {
-    // Already signed in (back button / bookmark)? Don't re-show the form.
-    if (getToken()) {
-      navigate(next, { replace: true });
-      return;
-    }
     let cancelled = false;
     void getAuthConfig().then((config) => {
-      if (!cancelled) setAuthConfig(config);
+      if (cancelled) return;
+      setAuthConfig(config);
+      if (config.available !== true) return;
+      if (config.auth_mode === "sso") {
+        // A pre-cutover local JWT must never drive the SSO browser path or
+        // bounce the auth guard in a redirect loop.
+        if (getToken()) setToken(null);
+        return;
+      }
+      // Already signed in (back button / bookmark)? Don't re-show the local form.
+      if (getToken()) navigate(next, { replace: true });
     });
     return () => {
       cancelled = true;
     };
   }, [navigate, next]);
 
-  function startSso() {
-    if (!ssoLoginUrl) return;
-    window.location.href = `${ssoLoginUrl}?redirect=${encodeURIComponent(next)}`;
+  function startSso(loginUrl: string | null) {
+    if (!loginUrl) return;
+    window.location.href = `${loginUrl}?redirect=${encodeURIComponent(next)}`;
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -209,19 +216,38 @@ export default function AuthPage() {
               </Tabs>
             )}
 
-            {authConfig !== null && !localAuthEnabled && !ssoLoginUrl && (
+            {authConfig !== null && !localAuthEnabled && authConfig.available !== true && (
               <Alert variant="destructive">
-                {authConfig.available && authConfig.auth_mode === "sso"
-                  ? "SSO browser sign-in is not available yet. Contact your administrator."
-                  : "Sign-in is unavailable because authentication configuration could not be verified."}
+                Sign-in is unavailable because authentication configuration could not be verified.
               </Alert>
             )}
 
-            {ssoLoginUrl && (
-              <div>
-                <Button type="button" variant="outline" size="lg" className="w-full" onClick={startSso}>
-                  Sign in with SSO
-                </Button>
+            {ssoConfigEnabled && ssoProviders.length === 0 && (
+              <Alert variant="destructive">
+                No SSO providers are enabled. Contact your administrator.
+              </Alert>
+            )}
+
+            {ssoConfigEnabled && ssoProviders.length > 0 && usableSsoProviders.length === 0 && (
+              <Alert variant="destructive">
+                SSO browser sign-in is not available yet. Contact your administrator.
+              </Alert>
+            )}
+
+            {usableSsoProviders.length > 0 && (
+              <div className="space-y-3">
+                {usableSsoProviders.map((provider) => (
+                  <Button
+                    key={provider.alias}
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    className="w-full"
+                    onClick={() => startSso(provider.login_url)}
+                  >
+                    Sign in with {provider.display_name}
+                  </Button>
+                ))}
               </div>
             )}
           </div>

--- a/frontend/src/stories/page-story-fixtures.ts
+++ b/frontend/src/stories/page-story-fixtures.ts
@@ -4,26 +4,31 @@ import type { PublicationResponse } from "@/lib/api";
 export const API = "/api/v1";
 
 export const localAuthConfig = {
-  schema_version: 1,
+  schema_version: 2,
   auth_mode: "local",
   local_auth: { enabled: true },
   keycloak: {
     enabled: false,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [],
   mcp_oauth: { enabled: false },
 };
 
 export const stagedSsoAuthConfig = {
-  schema_version: 1,
+  schema_version: 2,
   auth_mode: "sso",
   local_auth: { enabled: false },
   keycloak: {
     enabled: true,
     browser_session_ready: false,
-    login_url: null,
   },
+  providers: [{
+    provider_type: "keycloak-oidc",
+    alias: "workforce",
+    display_name: "Company SSO",
+    login_url: null,
+  }],
   mcp_oauth: { enabled: true },
 };
 


### PR DESCRIPTION
Part of #357.

## Summary
- add a versioned built-in SSO provider registry and strict Keycloak OIDC reference adapter
- add product-admin configure, enable, disable, exact read-back, CSRF, audit, and write-only secret boundaries
- publish a fail-closed auth-config v2 provider catalog and mode-exclusive login UI
- add an OSS contribution guide and a disposable two-Keycloak 26.7 broker-chain fixture

This is Phase 3A. Exact old/new identity prelink and ordinary browser-session custody remain explicitly unavailable until their follow-up gates pass.

## Verification
- backend unit suite: 2198 passed, 236 skipped, 47 deselected
- focused SSO contracts: 66 passed
- frontend unit suite: 457 passed; focused auth/admin suite: 45 passed
- ruff, mypy, bandit, eslint, TypeScript, SDK build/typecheck/48 tests/codegen/packed proof passed
- tracked-file secret scan and diff check passed
- real two-Keycloak fixture passed configure, masked-secret preservation, enable, broker redirect, disable, and guarded teardown