### PR TITLE
feat(sso): preserve AKB identities across Keycloak broker migration

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -213,6 +213,7 @@ jobs:
           tests/test_app_rollout_postgres.py
           tests/test_recovery_admin_provisioning_postgres.py
           tests/test_admin_auth_postgres.py
+          tests/test_sso_identity_migration_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/backend/app/api/routes/admin_sso.py
+++ b/backend/app/api/routes/admin_sso.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
@@ -19,7 +20,15 @@ from app.sso.keycloak_admin import (
     ProviderControlError,
     get_keycloak_provider_control,
 )
+from app.sso.identity_migration import (
+    IdentityMigrationError,
+    IdentityMigrationReadback,
+    apply_identity_migration,
+    inspect_identity_migration,
+    rollback_identity_migration,
+)
 from app.sso.models import (
+    IdentityPrelinkReadback,
     ProviderConfigureSpec,
     ProviderMutationReadback,
     ProviderReadback,
@@ -41,6 +50,46 @@ class ConfigureProviderRequest(BaseModel):
     client_secret: SkipValidation[str] | None = Field(default=None, repr=False)
 
 
+class IdentityMigrationRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        # Runtime defaults prevent Pydantic's missing-field error from echoing
+        # sibling subjects.  Keep the public contract truthful: all three
+        # strings are still semantically required and null is never accepted.
+        json_schema_extra={
+            "required": [
+                "existing_user_id",
+                "upstream_subject",
+                "broker_subject",
+            ],
+            "properties": {
+                "existing_user_id": {
+                    "title": "Existing User Id",
+                    "type": "string",
+                },
+                "upstream_subject": {
+                    "title": "Upstream Subject",
+                    "type": "string",
+                },
+                "broker_subject": {
+                    "title": "Broker Subject",
+                    "type": "string",
+                },
+            },
+        },
+    )
+
+    # These identifiers are intentionally validated in the value-less domain
+    # boundary.  Pydantic's ordinary type error includes rejected input, which
+    # would reflect an opaque IdP subject into the HTTP response.
+    # Defaults route missing fields through the same value-less domain errors;
+    # a Pydantic `missing` error would otherwise echo the full input object and
+    # therefore the other opaque subject.
+    existing_user_id: SkipValidation[str] | None = Field(default=None, repr=False)
+    upstream_subject: SkipValidation[str] | None = Field(default=None, repr=False)
+    broker_subject: SkipValidation[str] | None = Field(default=None, repr=False)
+
+
 _CONFLICT_CODES = frozenset(
     {
         "keycloak_provider_control_delegated",
@@ -48,9 +97,18 @@ _CONFLICT_CODES = frozenset(
         "provider_disable_before_reconfigure",
         "provider_configuration_invalid",
         "keycloak_provider_readback_failed",
+        "identity_prelink_user_mismatch",
+        "identity_prelink_user_inactive",
+        "identity_prelink_user_not_native",
+        "identity_prelink_local_credential_present",
+        "identity_prelink_missing",
+        "identity_prelink_subject_mismatch",
+        "identity_prelink_ambiguous",
+        "identity_migration_provider_must_be_disabled",
+        "identity_migration_prelink_changed",
     }
 )
-_NOT_FOUND_CODES = frozenset({"provider_not_found"})
+_NOT_FOUND_CODES = frozenset({"provider_not_found", "identity_prelink_user_not_found"})
 _SAFE_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
 _INVALID_CODES = frozenset(
     {
@@ -70,6 +128,7 @@ _INVALID_CODES = frozenset(
         "provider_client_id_invalid",
         "provider_client_secret_invalid",
         "provider_client_secret_required",
+        "identity_prelink_subject_invalid",
     }
 )
 
@@ -114,12 +173,15 @@ def _audit(
     provider: ProviderReadback | None = None,
     mutation: ProviderMutationReadback | None = None,
     provider_type: str | None = None,
+    meta: dict[str, object] | None = None,
 ) -> None:
-    meta = mutation.audit_view() if mutation is not None else None
-    if meta is None and provider is not None:
-        meta = provider.audit_view()
-    if meta is None and provider_type is not None:
-        meta = {"provider_type": provider_type}
+    audit_meta = meta
+    if audit_meta is None and mutation is not None:
+        audit_meta = mutation.audit_view()
+    if audit_meta is None and provider is not None:
+        audit_meta = provider.audit_view()
+    if audit_meta is None and provider_type is not None:
+        audit_meta = {"provider_type": provider_type}
     if _SAFE_ALIAS_RE.fullmatch(alias):
         target = f"provider={alias}"
     else:
@@ -132,8 +194,71 @@ def _audit(
         target=target,
         outcome=outcome,
         code=code,
-        meta=meta,
+        meta=audit_meta,
     )
+
+
+def _subject_digest(value: object) -> str:
+    if not isinstance(value, str):
+        return "<invalid>"
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        return "<invalid>"
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical_user_id(value: object) -> str:
+    try:
+        return str(uuid.UUID(value))  # type: ignore[arg-type]
+    except (AttributeError, TypeError, ValueError):
+        return "<invalid>"
+
+
+def _identity_audit_meta(
+    request: IdentityMigrationRequest,
+    *,
+    prelink: IdentityPrelinkReadback | None = None,
+    migration: IdentityMigrationReadback | None = None,
+) -> dict[str, object]:
+    meta: dict[str, object] = {
+        "existing_user_id": _canonical_user_id(request.existing_user_id),
+        "old_subject_sha256": _subject_digest(request.upstream_subject),
+        "new_subject_sha256": _subject_digest(request.broker_subject),
+    }
+    if prelink is not None:
+        meta.update(
+            {
+                "provider_state": prelink.provider_state,
+                "old_issuer": prelink.upstream_issuer,
+                "new_issuer": prelink.broker_issuer,
+            }
+        )
+    if migration is not None:
+        meta["migration_state"] = migration.state
+    return meta
+
+
+def _raise_identity_migration_error(error: IdentityMigrationError) -> None:
+    if error.code in {
+        "identity_migration_user_id_invalid",
+        "identity_migration_issuer_invalid",
+        "identity_migration_subject_invalid",
+        "identity_migration_actor_invalid",
+        "identity_migration_binding_unchanged",
+    }:
+        status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+        message = "Identity migration request is invalid"
+    elif error.code == "identity_migration_target_not_found":
+        status_code = status.HTTP_404_NOT_FOUND
+        message = "Identity migration target was not found"
+    else:
+        status_code = status.HTTP_409_CONFLICT
+        message = "Identity migration state conflicts with this operation"
+    raise HTTPException(
+        status_code,
+        detail={"message": message, "code": error.code},
+    ) from error
 
 
 @router.get("/admin/sso/providers", summary="List managed SSO providers")
@@ -264,3 +389,218 @@ async def disable_sso_provider(
     actor: ProductAdminActor = Depends(get_product_admin_mutation),
 ):
     return await _toggle_sso_provider(alias, enabled=False, actor=actor)
+
+
+def _prelink_response(
+    prelink: IdentityPrelinkReadback,
+    migration: IdentityMigrationReadback,
+) -> dict[str, object]:
+    # Do not reflect opaque subjects; the state proves the exact values in the
+    # authenticated request were read back from both authorities.
+    return {
+        "schema_version": 1,
+        "prelink": {
+            "provider_alias": prelink.provider_alias,
+            "provider_state": prelink.provider_state,
+            "upstream_issuer": prelink.upstream_issuer,
+            "broker_issuer": prelink.broker_issuer,
+            "broker_username": prelink.broker_username,
+        },
+        "migration": migration.admin_view(),
+    }
+
+
+def _same_identity_prelink(
+    before: IdentityPrelinkReadback,
+    after: IdentityPrelinkReadback,
+) -> bool:
+    return (
+        before.provider_alias,
+        before.upstream_issuer,
+        before.broker_issuer,
+        before.upstream_subject,
+        before.broker_subject,
+    ) == (
+        after.provider_alias,
+        after.upstream_issuer,
+        after.broker_issuer,
+        after.upstream_subject,
+        after.broker_subject,
+    ) and after.provider_state == "configured_disabled"
+
+
+async def _verify_and_inspect_identity_migration(
+    alias: str,
+    request: IdentityMigrationRequest,
+) -> tuple[IdentityPrelinkReadback, IdentityMigrationReadback]:
+    prelink = await get_keycloak_provider_control().verify_identity_prelink(
+        alias,
+        broker_subject=request.broker_subject,  # type: ignore[arg-type]
+        upstream_subject=request.upstream_subject,  # type: ignore[arg-type]
+    )
+    migration = await inspect_identity_migration(
+        existing_user_id=request.existing_user_id,  # type: ignore[arg-type]
+        old_issuer=prelink.upstream_issuer,
+        old_subject=request.upstream_subject,  # type: ignore[arg-type]
+        new_issuer=prelink.broker_issuer,
+        new_subject=request.broker_subject,  # type: ignore[arg-type]
+    )
+    return prelink, migration
+
+
+@router.post(
+    "/admin/sso/providers/{alias}/identity-migrations/preflight",
+    summary="Verify an exact broker identity migration without writing",
+)
+async def preflight_sso_identity_migration(
+    alias: str,
+    request: IdentityMigrationRequest,
+    _actor: ProductAdminActor = Depends(get_current_product_admin),
+):
+    try:
+        prelink, migration = await _verify_and_inspect_identity_migration(
+            alias,
+            request,
+        )
+    except ProviderControlError as error:
+        _raise_control_error(error)
+    except IdentityMigrationError as error:
+        _raise_identity_migration_error(error)
+    return _prelink_response(prelink, migration)
+
+
+async def _mutate_sso_identity_migration(
+    alias: str,
+    request: IdentityMigrationRequest,
+    actor: ProductAdminActor,
+    *,
+    operation: str,
+) -> dict[str, object]:
+    if operation not in {"apply", "rollback"}:
+        raise RuntimeError("unsupported identity migration operation")
+    action = f"admin.sso.identity_migration.{operation}"
+    _audit(
+        f"{action}.requested",
+        actor,
+        alias,
+        meta=_identity_audit_meta(request),
+    )
+    prelink: IdentityPrelinkReadback | None = None
+    try:
+        control = get_keycloak_provider_control()
+        prelink = await control.verify_identity_prelink(
+            alias,
+            broker_subject=request.broker_subject,  # type: ignore[arg-type]
+            upstream_subject=request.upstream_subject,  # type: ignore[arg-type]
+        )
+        if prelink.provider_state != "configured_disabled":
+            raise ProviderControlError(
+                "identity_migration_provider_must_be_disabled"
+            )
+        arguments = {
+            "existing_user_id": request.existing_user_id,
+            "old_issuer": prelink.upstream_issuer,
+            "old_subject": request.upstream_subject,
+            "new_issuer": prelink.broker_issuer,
+            "new_subject": request.broker_subject,
+            "actor_id": actor.username,
+        }
+        if operation == "apply":
+            migration = await apply_identity_migration(**arguments)  # type: ignore[arg-type]
+            try:
+                confirmed = await control.verify_identity_prelink(
+                    alias,
+                    broker_subject=request.broker_subject,  # type: ignore[arg-type]
+                    upstream_subject=request.upstream_subject,  # type: ignore[arg-type]
+                )
+                if not _same_identity_prelink(prelink, confirmed):
+                    raise ProviderControlError("identity_migration_prelink_changed")
+            except ProviderControlError as original_error:
+                if migration.binding_changed:
+                    try:
+                        await rollback_identity_migration(**arguments)  # type: ignore[arg-type]
+                    except Exception as compensation_error:
+                        raise ProviderControlError(
+                            "identity_migration_compensation_failed"
+                        ) from compensation_error
+                raise original_error
+            prelink = confirmed
+        else:
+            migration = await rollback_identity_migration(**arguments)  # type: ignore[arg-type]
+    except ProviderControlError as error:
+        _audit(
+            action,
+            actor,
+            alias,
+            outcome="error",
+            code=error.code,
+            meta=_identity_audit_meta(request, prelink=prelink),
+        )
+        _raise_control_error(error)
+    except IdentityMigrationError as error:
+        _audit(
+            action,
+            actor,
+            alias,
+            outcome="error",
+            code=error.code,
+            meta=_identity_audit_meta(request, prelink=prelink),
+        )
+        _raise_identity_migration_error(error)
+    except Exception:
+        _audit(
+            action,
+            actor,
+            alias,
+            outcome="error",
+            code="internal_error",
+            meta=_identity_audit_meta(request, prelink=prelink),
+        )
+        raise
+    _audit(
+        action,
+        actor,
+        alias,
+        meta=_identity_audit_meta(
+            request,
+            prelink=prelink,
+            migration=migration,
+        ),
+    )
+    if prelink is None:  # pragma: no cover - assigned before every success path
+        raise RuntimeError("identity migration prelink read-back missing")
+    return _prelink_response(prelink, migration)
+
+
+@router.post(
+    "/admin/sso/providers/{alias}/identity-migrations/apply",
+    summary="Bind an operator-prelinked broker identity to an AKB user",
+)
+async def apply_sso_identity_migration(
+    alias: str,
+    request: IdentityMigrationRequest,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    return await _mutate_sso_identity_migration(
+        alias,
+        request,
+        actor,
+        operation="apply",
+    )
+
+
+@router.post(
+    "/admin/sso/providers/{alias}/identity-migrations/rollback",
+    summary="Remove an AKB broker identity binding before operator cleanup",
+)
+async def rollback_sso_identity_migration(
+    alias: str,
+    request: IdentityMigrationRequest,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    return await _mutate_sso_identity_migration(
+        alias,
+        request,
+        actor,
+        operation="rollback",
+    )

--- a/backend/app/services/standalone_sso_keycloak.py
+++ b/backend/app/services/standalone_sso_keycloak.py
@@ -403,7 +403,11 @@ class KeycloakStandaloneSSOControl:
                 f"{spec.akb_public_url.rstrip('/')}/api/v1/auth/keycloak/callback"
             ],
             "webOrigins": [spec.akb_public_url.rstrip("/")],
-            "defaultClientScopes": ["profile", "email"],
+            # Keycloak 26.x puts the access-token subject mapper in its
+            # built-in `basic` client scope.  Omitting it yields a validly
+            # signed browser access token with no `sub`, which AKB must and
+            # does reject at the exact-identity boundary.
+            "defaultClientScopes": ["basic", "profile", "email"],
             "optionalClientScopes": [],
             "attributes": {
                 "pkce.code.challenge.method": "S256",
@@ -427,7 +431,7 @@ class KeycloakStandaloneSSOControl:
             "fullScopeAllowed": False,
             "redirectUris": [spec.admin_redirect_uri],
             "webOrigins": [spec.akb_public_url.rstrip("/")],
-            "defaultClientScopes": ["profile", "email"],
+            "defaultClientScopes": ["basic", "profile", "email"],
             "optionalClientScopes": [],
             "attributes": {
                 "pkce.code.challenge.method": "S256",

--- a/backend/app/sso/identity_migration.py
+++ b/backend/app/sso/identity_migration.py
@@ -1,0 +1,428 @@
+"""Exact external-identity continuity for an existing AKB account.
+
+This module deliberately does less than ordinary account projection.  It does
+not discover or adopt an account by email, mutate the user profile, revoke a
+credential, or move a grant.  A caller must name both an existing AKB user and
+that user's exact old ``(issuer, subject)`` binding.  The only successful
+first-time mutation is insertion of one additional exact binding for the same
+user.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+import uuid
+
+from app.db.postgres import get_pool
+from app.repositories.events_repo import emit_event
+
+
+IdentityMigrationState = Literal["ready_to_link", "linked"]
+_MAX_ISSUER_LENGTH = 2048
+_MAX_SUBJECT_LENGTH = 1024
+
+
+class IdentityMigrationError(RuntimeError):
+    """Value-less migration rejection safe for API and audit diagnostics."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityMigrationReadback:
+    """Secret-free evidence for one exact identity-continuity decision."""
+
+    user_id: uuid.UUID
+    state: IdentityMigrationState
+    old_issuer: str
+    new_issuer: str
+    # Internal mutation ownership.  This is deliberately omitted from the
+    # admin response: callers need it only to decide whether this exact call
+    # owns a compensating write after a cross-authority post-check fails.
+    binding_changed: bool = False
+
+    def admin_view(self) -> dict[str, str]:
+        return {
+            "user_id": str(self.user_id),
+            "state": self.state,
+            "old_issuer": self.old_issuer,
+            "new_issuer": self.new_issuer,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _IdentitySnapshot:
+    username: str | None
+    email: str | None
+
+
+def _user_uuid(value: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(value)
+    except (AttributeError, TypeError, ValueError):
+        raise IdentityMigrationError("identity_migration_user_id_invalid") from None
+
+
+def _identity_part(value: str, *, kind: Literal["issuer", "subject"]) -> str:
+    maximum = _MAX_ISSUER_LENGTH if kind == "issuer" else _MAX_SUBJECT_LENGTH
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > maximum
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise IdentityMigrationError(f"identity_migration_{kind}_invalid")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise IdentityMigrationError(
+            f"identity_migration_{kind}_invalid"
+        ) from None
+    # ``subject`` is an opaque, case-sensitive identifier.  Do not strip or
+    # Unicode-normalize it; changing even one code point changes the identity.
+    return value
+
+
+def _actor(value: str) -> str:
+    if not isinstance(value, str):
+        raise IdentityMigrationError("identity_migration_actor_invalid")
+    cleaned = value.strip()
+    if (
+        not cleaned
+        or len(cleaned) > 255
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in cleaned)
+    ):
+        raise IdentityMigrationError("identity_migration_actor_invalid")
+    try:
+        cleaned.encode("utf-8")
+    except UnicodeEncodeError:
+        raise IdentityMigrationError("identity_migration_actor_invalid") from None
+    return cleaned
+
+
+def _lock_key(issuer: str, subject: str) -> str:
+    # Keep this byte-for-byte compatible with account_service's external
+    # identity creation lock so migration and ordinary projection serialize.
+    return f"external-identity:{len(issuer)}:{issuer}{subject}"
+
+
+def _validated_request(
+    *,
+    existing_user_id: str,
+    old_issuer: str,
+    old_subject: str,
+    new_issuer: str,
+    new_subject: str,
+) -> tuple[uuid.UUID, str, str, str, str]:
+    user_id = _user_uuid(existing_user_id)
+    old_issuer = _identity_part(old_issuer, kind="issuer")
+    old_subject = _identity_part(old_subject, kind="subject")
+    new_issuer = _identity_part(new_issuer, kind="issuer")
+    new_subject = _identity_part(new_subject, kind="subject")
+    if (old_issuer, old_subject) == (new_issuer, new_subject):
+        raise IdentityMigrationError("identity_migration_binding_unchanged")
+    return user_id, old_issuer, old_subject, new_issuer, new_subject
+
+
+async def _inspect_in_conn(
+    conn,
+    *,
+    user_id: uuid.UUID,
+    old_issuer: str,
+    old_subject: str,
+    new_issuer: str,
+    new_subject: str,
+    lock_user: bool,
+) -> tuple[IdentityMigrationReadback, _IdentitySnapshot]:
+    lock_clause = " FOR UPDATE" if lock_user else ""
+    user = await conn.fetchrow(
+        """
+        SELECT id, username, email, auth_provider, account_status, account_kind
+          FROM users
+         WHERE id = $1
+        """
+        + lock_clause,
+        user_id,
+    )
+    if user is None:
+        raise IdentityMigrationError("identity_migration_target_not_found")
+    if user["account_status"] != "active":
+        raise IdentityMigrationError("identity_migration_target_inactive")
+    if user["account_kind"] != "human":
+        raise IdentityMigrationError("identity_migration_target_not_human")
+    if user["auth_provider"] != "keycloak":
+        raise IdentityMigrationError("identity_migration_target_not_external")
+
+    old_binding = await conn.fetchrow(
+        """
+        SELECT user_id, username_snapshot, email_snapshot
+          FROM external_identities
+         WHERE issuer = $1 AND subject = $2
+        """
+        + lock_clause,
+        old_issuer,
+        old_subject,
+    )
+    if old_binding is None or old_binding["user_id"] != user_id:
+        raise IdentityMigrationError("identity_migration_old_binding_missing")
+
+    new_owner = await conn.fetchval(
+        """
+        SELECT user_id
+          FROM external_identities
+         WHERE issuer = $1 AND subject = $2
+        """
+        + lock_clause,
+        new_issuer,
+        new_subject,
+    )
+    if new_owner is not None and new_owner != user_id:
+        raise IdentityMigrationError("identity_migration_new_binding_conflict")
+
+    state: IdentityMigrationState = (
+        "linked" if new_owner == user_id else "ready_to_link"
+    )
+    return (
+        IdentityMigrationReadback(
+            user_id=user_id,
+            state=state,
+            old_issuer=old_issuer,
+            new_issuer=new_issuer,
+        ),
+        _IdentitySnapshot(
+            username=(
+                old_binding["username_snapshot"]
+                if isinstance(old_binding["username_snapshot"], str)
+                else None
+            ),
+            email=(
+                old_binding["email_snapshot"]
+                if isinstance(old_binding["email_snapshot"], str)
+                else None
+            ),
+        ),
+    )
+
+
+async def inspect_identity_migration(
+    *,
+    existing_user_id: str,
+    old_issuer: str,
+    old_subject: str,
+    new_issuer: str,
+    new_subject: str,
+) -> IdentityMigrationReadback:
+    """Dry-run an exact identity addition without acquiring mutation locks."""
+
+    user_id, old_issuer, old_subject, new_issuer, new_subject = _validated_request(
+        existing_user_id=existing_user_id,
+        old_issuer=old_issuer,
+        old_subject=old_subject,
+        new_issuer=new_issuer,
+        new_subject=new_subject,
+    )
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        readback, _ = await _inspect_in_conn(
+            conn,
+            user_id=user_id,
+            old_issuer=old_issuer,
+            old_subject=old_subject,
+            new_issuer=new_issuer,
+            new_subject=new_subject,
+            lock_user=False,
+        )
+    return readback
+
+
+async def apply_identity_migration(
+    *,
+    existing_user_id: str,
+    old_issuer: str,
+    old_subject: str,
+    new_issuer: str,
+    new_subject: str,
+    actor_id: str,
+) -> IdentityMigrationReadback:
+    """Idempotently add a verified broker identity to one exact AKB user."""
+
+    user_id, old_issuer, old_subject, new_issuer, new_subject = _validated_request(
+        existing_user_id=existing_user_id,
+        old_issuer=old_issuer,
+        old_subject=old_subject,
+        new_issuer=new_issuer,
+        new_subject=new_subject,
+    )
+    actor_id = _actor(actor_id)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # Globally deterministic order prevents old/new inversions from
+            # deadlocking and serializes with ordinary account projection.
+            for key in sorted(
+                {
+                    _lock_key(old_issuer, old_subject),
+                    _lock_key(new_issuer, new_subject),
+                }
+            ):
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    key,
+                )
+
+            before, old_binding = await _inspect_in_conn(
+                conn,
+                user_id=user_id,
+                old_issuer=old_issuer,
+                old_subject=old_subject,
+                new_issuer=new_issuer,
+                new_subject=new_subject,
+                lock_user=True,
+            )
+            if before.state == "linked":
+                return before
+
+            identity_id = await conn.fetchval(
+                """
+                INSERT INTO external_identities (
+                    user_id, issuer, subject, username_snapshot, email_snapshot
+                )
+                SELECT $1, $2, $3,
+                       COALESCE($4, u.username),
+                       COALESCE($5, u.email)
+                  FROM users u
+                 WHERE u.id = $1
+                ON CONFLICT (issuer, subject) DO NOTHING
+                RETURNING id
+                """,
+                user_id,
+                new_issuer,
+                new_subject,
+                old_binding.username,
+                old_binding.email,
+            )
+            if identity_id is None:
+                # Defensive read-back for a writer that did not use the shared
+                # advisory lock.  Never turn its binding into ours.
+                owner = await conn.fetchval(
+                    """
+                    SELECT user_id FROM external_identities
+                     WHERE issuer = $1 AND subject = $2
+                    """,
+                    new_issuer,
+                    new_subject,
+                )
+                if owner != user_id:
+                    raise IdentityMigrationError(
+                        "identity_migration_new_binding_conflict"
+                    )
+            else:
+                await emit_event(
+                    conn,
+                    "auth.external_identity_migrated",
+                    actor_id=actor_id,
+                    payload={
+                        "user_id": str(user_id),
+                        "old_issuer": old_issuer,
+                        "old_subject": old_subject,
+                        "new_issuer": new_issuer,
+                        "new_subject": new_subject,
+                    },
+                )
+
+    return IdentityMigrationReadback(
+        user_id=user_id,
+        state="linked",
+        old_issuer=old_issuer,
+        new_issuer=new_issuer,
+        binding_changed=identity_id is not None,
+    )
+
+
+async def rollback_identity_migration(
+    *,
+    existing_user_id: str,
+    old_issuer: str,
+    old_subject: str,
+    new_issuer: str,
+    new_subject: str,
+    actor_id: str,
+) -> IdentityMigrationReadback:
+    """Idempotently remove only the added broker binding.
+
+    The old exact binding is revalidated under the same locks before deletion.
+    Keycloak prelink cleanup is intentionally outside this database boundary
+    and remains a one-time operator action after this read-back succeeds.
+    """
+
+    user_id, old_issuer, old_subject, new_issuer, new_subject = _validated_request(
+        existing_user_id=existing_user_id,
+        old_issuer=old_issuer,
+        old_subject=old_subject,
+        new_issuer=new_issuer,
+        new_subject=new_subject,
+    )
+    actor_id = _actor(actor_id)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            for key in sorted(
+                {
+                    _lock_key(old_issuer, old_subject),
+                    _lock_key(new_issuer, new_subject),
+                }
+            ):
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    key,
+                )
+
+            before, _ = await _inspect_in_conn(
+                conn,
+                user_id=user_id,
+                old_issuer=old_issuer,
+                old_subject=old_subject,
+                new_issuer=new_issuer,
+                new_subject=new_subject,
+                lock_user=True,
+            )
+            if before.state == "ready_to_link":
+                return before
+
+            deleted_id = await conn.fetchval(
+                """
+                DELETE FROM external_identities
+                 WHERE user_id = $1 AND issuer = $2 AND subject = $3
+             RETURNING id
+                """,
+                user_id,
+                new_issuer,
+                new_subject,
+            )
+            if deleted_id is None:
+                raise IdentityMigrationError(
+                    "identity_migration_new_binding_conflict"
+                )
+            await emit_event(
+                conn,
+                "auth.external_identity_migration_rolled_back",
+                actor_id=actor_id,
+                payload={
+                    "user_id": str(user_id),
+                    "old_issuer": old_issuer,
+                    "old_subject": old_subject,
+                    "new_issuer": new_issuer,
+                    "new_subject": new_subject,
+                },
+            )
+
+    return IdentityMigrationReadback(
+        user_id=user_id,
+        state="ready_to_link",
+        old_issuer=old_issuer,
+        new_issuer=new_issuer,
+        binding_changed=True,
+    )

--- a/backend/app/sso/keycloak_admin.py
+++ b/backend/app/sso/keycloak_admin.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 import httpx
 
 from app.sso.models import (
+    IdentityPrelinkReadback,
     ProviderConfigureSpec,
     ProviderMutationReadback,
     ProviderReadback,
@@ -33,6 +34,7 @@ _CACHE_FRESH_SECONDS = 15.0
 _CACHE_STALE_SECONDS = 60.0
 _FAILURE_BACKOFF_SECONDS = 5.0
 _MAX_RESPONSE_BYTES = 1_048_576
+_MAX_SUBJECT_LENGTH = 1024
 
 
 class ProviderControlError(RuntimeError):
@@ -49,6 +51,23 @@ def _fail(code: str) -> ProviderControlError:
 
 def _path(value: str) -> str:
     return quote(value, safe="")
+
+
+def _opaque_subject(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_SUBJECT_LENGTH
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise _fail("identity_prelink_subject_invalid")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise _fail("identity_prelink_subject_invalid") from None
+    # OIDC subjects are opaque and case-sensitive.  Whitespace is not
+    # normalized: it either identifies the exact Keycloak user/link or fails.
+    return value
 
 
 def _object(value: object, *, code: str) -> dict[str, Any]:
@@ -594,6 +613,145 @@ class KeycloakProviderControl:
         self._catalog_error_code = None
         self._catalog_error_at = 0.0
         return ProviderMutationReadback(before=current, after=readback)
+
+    async def verify_identity_prelink(
+        self,
+        alias: str,
+        *,
+        broker_subject: str,
+        upstream_subject: str,
+    ) -> IdentityPrelinkReadback:
+        """Verify a one-time operator-created broker link without mutating it.
+
+        The permanent AKB management client needs only read access to users and
+        federated identities.  Creating the native broker user and attaching
+        the federated identity remain explicit Keycloak-operator actions.
+        """
+
+        self._require_direct()
+        try:
+            validated_alias = keycloak_oidc.validate_alias(alias)
+        except ProviderDefinitionError as exc:
+            raise _fail(exc.code) from exc
+        broker_subject = _opaque_subject(broker_subject)
+        upstream_subject = _opaque_subject(upstream_subject)
+
+        async with self._client() as client:
+            token = await self._token(client)
+            representation = await self._get_exact(client, token, validated_alias)
+            if representation is None:
+                raise _fail("provider_not_found")
+            definition = self._definition_for_representation(representation)
+            if definition is None:
+                raise _fail("provider_alias_conflict")
+            provider = self._readback(definition, representation)
+            if provider.state == "configuration_error" or provider.issuer is None:
+                raise _fail("provider_configuration_invalid")
+
+            user_base = (
+                f"/admin/realms/{_path(self.config.realm)}/users/"
+                f"{_path(broker_subject)}"
+            )
+            user_response = await self._request(
+                client,
+                "GET",
+                user_base,
+                token=token,
+                expected=frozenset({200, 404}),
+                code="identity_prelink_read_failed",
+            )
+            if user_response.status_code == 404:
+                raise _fail("identity_prelink_user_not_found")
+            user = _object(
+                self._json(user_response, code="identity_prelink_read_failed"),
+                code="identity_prelink_read_failed",
+            )
+            if user.get("id") != broker_subject:
+                raise _fail("identity_prelink_user_mismatch")
+            if user.get("enabled") is not True:
+                raise _fail("identity_prelink_user_inactive")
+            federation_link = user.get("federationLink")
+            if federation_link not in (None, ""):
+                raise _fail("identity_prelink_user_not_native")
+            username = user.get("username")
+            if (
+                not isinstance(username, str)
+                or not username
+                or len(username) > 255
+                or any(
+                    ord(character) < 0x20 or ord(character) == 0x7F
+                    for character in username
+                )
+            ):
+                raise _fail("identity_prelink_read_failed")
+            required_actions = user.get("requiredActions", [])
+            if required_actions is None:
+                required_actions = []
+            if not isinstance(required_actions, list) or any(
+                not isinstance(action, str) or not action
+                for action in required_actions
+            ):
+                raise _fail("identity_prelink_read_failed")
+            if required_actions:
+                # UPDATE_PASSWORD, CONFIGURE_TOTP, and WebAuthn registration
+                # can mint a local login authority after this check.
+                raise _fail("identity_prelink_local_credential_present")
+
+            credential_response = await self._request(
+                client,
+                "GET",
+                f"{user_base}/credentials",
+                token=token,
+                expected=frozenset({200}),
+                code="identity_prelink_read_failed",
+            )
+            credentials = _objects(
+                self._json(
+                    credential_response,
+                    code="identity_prelink_read_failed",
+                ),
+                code="identity_prelink_read_failed",
+            )
+            if credentials:
+                # Passwordless WebAuthn, OTP, and recovery credentials are
+                # local login authorities too.  A migration broker user must
+                # be reachable only through its exact upstream federation.
+                raise _fail("identity_prelink_local_credential_present")
+
+            link_response = await self._request(
+                client,
+                "GET",
+                f"{user_base}/federated-identity",
+                token=token,
+                expected=frozenset({200}),
+                code="identity_prelink_read_failed",
+            )
+            links = _objects(
+                self._json(link_response, code="identity_prelink_read_failed"),
+                code="identity_prelink_read_failed",
+            )
+            if not links:
+                raise _fail("identity_prelink_missing")
+            if len(links) != 1:
+                raise _fail("identity_prelink_ambiguous")
+            link = links[0]
+            if link.get("identityProvider") != validated_alias:
+                raise _fail("identity_prelink_missing")
+            if link.get("userId") != upstream_subject:
+                raise _fail("identity_prelink_subject_mismatch")
+            linked_username = link.get("userName")
+            if not isinstance(linked_username, str) or not linked_username:
+                raise _fail("identity_prelink_read_failed")
+
+        return IdentityPrelinkReadback(
+            provider_alias=validated_alias,
+            provider_state=provider.state,
+            upstream_issuer=provider.issuer,
+            broker_issuer=self.config.broker_issuer,
+            broker_subject=broker_subject,
+            upstream_subject=upstream_subject,
+            broker_username=username,
+        )
 
 
 def _runtime_config() -> KeycloakAdminConfig:

--- a/backend/app/sso/models.py
+++ b/backend/app/sso/models.py
@@ -91,3 +91,16 @@ class ProviderMutationReadback:
             "before": self.before.audit_view() if self.before is not None else None,
             "after": self.after.audit_view(),
         }
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityPrelinkReadback:
+    """Exact, read-only evidence for a brokered Keycloak user link."""
+
+    provider_alias: str
+    provider_state: ProviderState
+    upstream_issuer: str
+    broker_issuer: str
+    broker_subject: str = field(repr=False)
+    upstream_subject: str = field(repr=False)
+    broker_username: str

--- a/backend/app/sso/providers/keycloak_oidc.py
+++ b/backend/app/sso/providers/keycloak_oidc.py
@@ -399,7 +399,8 @@ def readback(
         client_secret_configured=secret_configured,
         redirect_uri=redirect_uri,
         supports_logout=True,
-        # Exact old/new binding prelink and readiness are delivered by the
-        # migration slice, not inferred merely because Keycloak can federate.
-        supports_identity_migration=False,
+        # This capability means AKB can verify an operator-created exact
+        # Keycloak prelink and atomically add the broker identity to one
+        # existing AKB user.  It does not imply automatic/email-based linking.
+        supports_identity_migration=True,
     )

--- a/backend/tests/test_admin_sso_routes_unit.py
+++ b/backend/tests/test_admin_sso_routes_unit.py
@@ -13,7 +13,15 @@ from app.config import settings
 from app.exceptions import AuthenticationError
 from app.services.admin_auth_service import ProductAdminIdentity
 from app.sso.keycloak_admin import ProviderControlError
-from app.sso.models import ProviderMutationReadback, ProviderReadback
+from app.sso.identity_migration import (
+    IdentityMigrationError,
+    IdentityMigrationReadback,
+)
+from app.sso.models import (
+    IdentityPrelinkReadback,
+    ProviderMutationReadback,
+    ProviderReadback,
+)
 
 
 _SECRET = "write-only-provider-secret-must-not-leak"  # pragma: allowlist secret
@@ -54,7 +62,7 @@ def _provider(
             "broker/workforce/endpoint"
         ),
         supports_logout=True,
-        supports_identity_migration=False,
+        supports_identity_migration=True,
     )
 
 
@@ -81,6 +89,23 @@ class Control:
                 state="enabled" if enabled else "configured_disabled",
                 enabled=enabled,
             ),
+        )
+
+    async def verify_identity_prelink(
+        self,
+        alias: str,
+        *,
+        broker_subject: str,
+        upstream_subject: str,
+    ) -> IdentityPrelinkReadback:
+        return IdentityPrelinkReadback(
+            provider_alias=alias,
+            provider_state=self.providers[0].state,
+            upstream_issuer="https://accounts.example.com/realms/workforce",
+            broker_issuer="https://auth.akb.example.com/realms/akb",
+            broker_subject=broker_subject,
+            upstream_subject=upstream_subject,
+            broker_username="alice",
         )
 
 
@@ -315,3 +340,370 @@ async def test_sso_mutation_dependency_rejects_missing_csrf_before_resolution(
             authorization=None,
             csrf_header=None,
         )
+
+
+def test_identity_migration_preflight_derives_both_issuers_server_side(monkeypatch):
+    user_id = uuid.uuid4()
+    captured: dict[str, object] = {}
+
+    async def _inspect(**values):
+        captured.update(values)
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="ready_to_link",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    monkeypatch.setattr(admin_sso, "inspect_identity_migration", _inspect)
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/preflight",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["schema_version"] == 1
+    assert captured == {
+        "existing_user_id": str(user_id),
+        "old_issuer": "https://accounts.example.com/realms/workforce",
+        "old_subject": "upstream-subject",
+        "new_issuer": "https://auth.akb.example.com/realms/akb",
+        "new_subject": "broker-subject",
+    }
+    assert response.json()["migration"]["state"] == "ready_to_link"
+
+
+def test_identity_migration_apply_requires_provider_disabled_before_db_write(
+    monkeypatch,
+):
+    control = Control()
+    control.providers = [_provider(state="enabled")]
+
+    async def _must_not_apply(**_values):
+        raise AssertionError("enabled provider must not mutate AKB identity state")
+
+    monkeypatch.setattr(admin_sso, "apply_identity_migration", _must_not_apply)
+    response = _client(monkeypatch, control).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/apply",
+        json={
+            "existing_user_id": str(uuid.uuid4()),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == (
+        "identity_migration_provider_must_be_disabled"
+    )
+
+
+def test_identity_migration_apply_is_audited_without_raw_subjects(monkeypatch):
+    user_id = uuid.uuid4()
+    records: list[dict[str, object]] = []
+    applied: list[dict[str, object]] = []
+
+    async def _apply(**values):
+        applied.append(values)
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="linked",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    monkeypatch.setattr(admin_sso, "apply_identity_migration", _apply)
+    monkeypatch.setattr(admin_sso.audit_log, "record", lambda **value: records.append(value))
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/apply",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["migration"] == {
+        "user_id": str(user_id),
+        "state": "linked",
+        "old_issuer": "https://accounts.example.com/realms/workforce",
+        "new_issuer": "https://auth.akb.example.com/realms/akb",
+    }
+    assert applied[0]["actor_id"] == "product-admin"
+    assert [record["action"] for record in records] == [
+        "admin.sso.identity_migration.apply.requested",
+        "admin.sso.identity_migration.apply",
+    ]
+    assert "upstream-subject" not in repr(records)
+    assert "broker-subject" not in repr(records)
+    assert records[-1]["meta"]["old_subject_sha256"]
+    assert records[-1]["meta"]["new_subject_sha256"]
+
+
+def test_identity_migration_apply_compensates_fresh_binding_on_postcheck_drift(
+    monkeypatch,
+):
+    user_id = uuid.uuid4()
+    rollbacks: list[dict[str, object]] = []
+
+    class DriftAfterApply(Control):
+        def __init__(self) -> None:
+            super().__init__()
+            self.prelink_reads = 0
+
+        async def verify_identity_prelink(self, *args, **kwargs):
+            self.prelink_reads += 1
+            if self.prelink_reads == 2:
+                raise ProviderControlError("identity_prelink_missing")
+            return await super().verify_identity_prelink(*args, **kwargs)
+
+    async def _readback(**values):
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="ready_to_link",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    async def _apply(**values):
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="linked",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+            binding_changed=True,
+        )
+
+    async def _rollback(**values):
+        rollbacks.append(values)
+        return await _readback(**values)
+
+    monkeypatch.setattr(admin_sso, "apply_identity_migration", _apply)
+    monkeypatch.setattr(admin_sso, "rollback_identity_migration", _rollback)
+    response = _client(monkeypatch, DriftAfterApply()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/apply",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "identity_prelink_missing"
+    assert len(rollbacks) == 1
+
+
+def test_identity_migration_postcheck_never_removes_a_preexisting_binding(
+    monkeypatch,
+):
+    user_id = uuid.uuid4()
+
+    class DriftAfterIdempotentApply(Control):
+        def __init__(self) -> None:
+            super().__init__()
+            self.prelink_reads = 0
+
+        async def verify_identity_prelink(self, *args, **kwargs):
+            self.prelink_reads += 1
+            if self.prelink_reads == 2:
+                raise ProviderControlError("identity_prelink_missing")
+            return await super().verify_identity_prelink(*args, **kwargs)
+
+    async def _linked(**values):
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="linked",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    async def _must_not_rollback(**_values):
+        raise AssertionError("a binding owned by an earlier call must remain")
+
+    monkeypatch.setattr(admin_sso, "apply_identity_migration", _linked)
+    monkeypatch.setattr(
+        admin_sso,
+        "rollback_identity_migration",
+        _must_not_rollback,
+    )
+    response = _client(monkeypatch, DriftAfterIdempotentApply()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/apply",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "identity_prelink_missing"
+
+
+def test_identity_migration_postcheck_never_removes_a_concurrent_binding(
+    monkeypatch,
+):
+    user_id = uuid.uuid4()
+    rollbacks: list[dict[str, object]] = []
+
+    class DriftAfterConcurrentApply(Control):
+        def __init__(self) -> None:
+            super().__init__()
+            self.prelink_reads = 0
+
+        async def verify_identity_prelink(self, *args, **kwargs):
+            self.prelink_reads += 1
+            if self.prelink_reads == 2:
+                raise ProviderControlError("identity_prelink_missing")
+            return await super().verify_identity_prelink(*args, **kwargs)
+
+    async def _ready(**values):
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="ready_to_link",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    async def _concurrently_linked(**values):
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="linked",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    async def _rollback(**values):
+        rollbacks.append(values)
+        return await _ready(**values)
+
+    monkeypatch.setattr(admin_sso, "apply_identity_migration", _concurrently_linked)
+    monkeypatch.setattr(admin_sso, "rollback_identity_migration", _rollback)
+    response = _client(monkeypatch, DriftAfterConcurrentApply()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/apply",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "identity_prelink_missing"
+    assert rollbacks == []
+
+
+def test_identity_migration_rollback_is_exact_audited_and_idempotent(monkeypatch):
+    user_id = uuid.uuid4()
+    records: list[dict[str, object]] = []
+    rolled_back: list[dict[str, object]] = []
+
+    async def _rollback(**values):
+        rolled_back.append(values)
+        return IdentityMigrationReadback(
+            user_id=user_id,
+            state="ready_to_link",
+            old_issuer=values["old_issuer"],
+            new_issuer=values["new_issuer"],
+        )
+
+    monkeypatch.setattr(admin_sso, "rollback_identity_migration", _rollback)
+    monkeypatch.setattr(admin_sso.audit_log, "record", lambda **value: records.append(value))
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/rollback",
+        json={
+            "existing_user_id": str(user_id),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["migration"]["state"] == "ready_to_link"
+    assert rolled_back[0]["actor_id"] == "product-admin"
+    assert [record["action"] for record in records] == [
+        "admin.sso.identity_migration.rollback.requested",
+        "admin.sso.identity_migration.rollback",
+    ]
+    assert "upstream-subject" not in repr(records)
+    assert "broker-subject" not in repr(records)
+
+
+def test_identity_migration_conflicts_are_value_less(monkeypatch):
+    async def _inspect(**_values):
+        raise IdentityMigrationError("identity_migration_old_binding_missing")
+
+    monkeypatch.setattr(admin_sso, "inspect_identity_migration", _inspect)
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/preflight",
+        json={
+            "existing_user_id": str(uuid.uuid4()),
+            "upstream_subject": "upstream-subject",
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == (
+        "identity_migration_old_binding_missing"
+    )
+
+
+def test_identity_migration_malformed_subject_type_is_not_echoed(monkeypatch):
+    leaked = "subject-value-must-not-be-reflected"
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/preflight",
+        json={
+            "existing_user_id": str(uuid.uuid4()),
+            "upstream_subject": {"value": leaked},
+            "broker_subject": "broker-subject",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "identity_migration_subject_invalid"
+    assert leaked not in response.text
+
+
+def test_identity_migration_missing_subject_does_not_echo_the_other_subject(
+    monkeypatch,
+):
+    leaked = "present-subject-must-not-be-reflected"
+    response = _client(monkeypatch, Control()).post(
+        "/api/v1/admin/sso/providers/workforce/identity-migrations/preflight",
+        json={
+            "existing_user_id": str(uuid.uuid4()),
+            "upstream_subject": leaked,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "identity_migration_subject_invalid"
+    assert leaked not in response.text
+
+
+def test_identity_migration_audit_digest_handles_non_utf8_subject():
+    assert admin_sso._subject_digest("\ud800") == "<invalid>"
+
+
+def test_identity_migration_openapi_keeps_all_identifiers_required_strings():
+    schema = admin_sso.IdentityMigrationRequest.model_json_schema()
+
+    assert schema["required"] == [
+        "existing_user_id",
+        "upstream_subject",
+        "broker_subject",
+    ]
+    assert {
+        name: value["type"]
+        for name, value in schema["properties"].items()
+    } == {
+        "existing_user_id": "string",
+        "upstream_subject": "string",
+        "broker_subject": "string",
+    }

--- a/backend/tests/test_auth_config_shape_unit.py
+++ b/backend/tests/test_auth_config_shape_unit.py
@@ -31,7 +31,7 @@ def _provider(alias: str, state: str) -> ProviderReadback:
             f"https://auth.akb.example.com/realms/akb/broker/{alias}/endpoint"
         ),
         supports_logout=True,
-        supports_identity_migration=False,
+        supports_identity_migration=True,
     )
 
 

--- a/backend/tests/test_sso_broker_chain_fixture_unit.py
+++ b/backend/tests/test_sso_broker_chain_fixture_unit.py
@@ -1,4 +1,4 @@
-"""Static safety contract for the disposable two-Keycloak fixture."""
+"""Static safety contract for the disposable broker-chain fixture."""
 
 from __future__ import annotations
 
@@ -14,12 +14,23 @@ _ROOT = Path(__file__).resolve().parents[2]
 _FIXTURE = _ROOT / "deploy" / "keycloak-dev" / "broker-chain"
 
 
-def test_broker_chain_uses_two_pinned_keycloaks_and_no_persistent_volume():
+def test_broker_chain_uses_pinned_images_and_no_persistent_volume():
     compose = yaml.safe_load((_FIXTURE / "compose.yaml").read_text())
-    assert set(compose["services"]) == {"broker", "upstream"}
-    images = {service["image"] for service in compose["services"].values()}
-    assert len(images) == 1
-    assert next(iter(images)).startswith("quay.io/keycloak/keycloak@sha256:")
+    services = compose["services"]
+    assert set(services) == {"broker", "upstream", "postgres"}
+    assert services["broker"]["image"] == services["upstream"]["image"]
+    assert services["broker"]["image"].startswith(
+        "quay.io/keycloak/keycloak@sha256:"
+    )
+    assert services["postgres"]["image"].startswith("postgres:16-alpine@sha256:")
+    assert services["postgres"]["tmpfs"] == ["/var/lib/postgresql/data"]
+    assert services["broker"]["ports"] == ["127.0.0.1:19443:8443"]
+    assert services["upstream"]["ports"] == ["127.0.0.1:19444:19444"]
+    assert services["postgres"]["ports"] == ["127.0.0.1:19445:5432"]
+    assert "extra_hosts" not in services["broker"]
+    assert services["upstream"]["networks"]["default"]["aliases"] == [
+        "upstream.localhost"
+    ]
     assert "volumes" not in compose
 
 
@@ -34,7 +45,18 @@ def test_realms_are_distinct_and_upstream_client_is_code_pkce_only():
     assert client["implicitFlowEnabled"] is False
     assert client["directAccessGrantsEnabled"] is False
     assert client["serviceAccountsEnabled"] is False
+    assert client["fullScopeAllowed"] is False
     assert client["attributes"]["pkce.code.challenge.method"] == "S256"
+    browser = next(
+        value for value in broker["clients"] if value["clientId"] == "fixture-browser"
+    )
+    probe = next(
+        value for value in upstream["clients"] if value["clientId"] == "upstream-probe"
+    )
+    for public_client in (browser, probe):
+        assert public_client["publicClient"] is True
+        assert public_client["fullScopeAllowed"] is False
+        assert public_client["defaultClientScopes"] == ["basic", "profile", "email"]
 
 
 def test_fixture_management_authority_matches_the_product_bootstrap_profile():

--- a/backend/tests/test_sso_identity_migration_postgres.py
+++ b/backend/tests/test_sso_identity_migration_postgres.py
@@ -1,0 +1,378 @@
+"""PostgreSQL contract for exact old/new external-identity continuity."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_OLD_ISSUER = "https://upstream.example.com/realms/workforce"
+_NEW_ISSUER = "https://broker.example.com/realms/akb"
+
+
+async def test_migration_rejects_non_utf8_subject_before_database(monkeypatch):
+    from app.sso import identity_migration
+
+    async def _must_not_get_pool():
+        raise AssertionError("invalid identity must fail before database access")
+
+    monkeypatch.setattr(identity_migration, "get_pool", _must_not_get_pool)
+    with pytest.raises(identity_migration.IdentityMigrationError) as captured:
+        await identity_migration.inspect_identity_migration(
+            existing_user_id=str(uuid.uuid4()),
+            old_issuer=_OLD_ISSUER,
+            old_subject="\ud800",
+            new_issuer=_NEW_ISSUER,
+            new_subject="new-subject",
+        )
+
+    assert captured.value.code == "identity_migration_subject_invalid"
+
+
+@pytest.fixture
+async def migration_store(monkeypatch):
+    try:
+        admin = await asyncpg.connect(_DSN, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(
+                "REQUIRE_REAL_PG=1 but Postgres is not reachable at AKB_TEST_DSN"
+            )
+        pytest.skip("Postgres unreachable at AKB_TEST_DSN")
+
+    schema = "sso_identity_migration_" + uuid.uuid4().hex
+    await admin.execute(f'CREATE SCHEMA "{schema}"')
+    pool = await asyncpg.create_pool(
+        _DSN,
+        min_size=1,
+        max_size=4,
+        server_settings={"search_path": schema},
+    )
+    events: list[tuple[str, str, dict[str, object]]] = []
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE users (
+                    id UUID PRIMARY KEY,
+                    username TEXT NOT NULL UNIQUE,
+                    email TEXT NOT NULL UNIQUE,
+                    display_name TEXT,
+                    is_admin BOOLEAN NOT NULL DEFAULT false,
+                    auth_provider TEXT NOT NULL,
+                    account_status TEXT NOT NULL,
+                    account_kind TEXT NOT NULL
+                );
+                CREATE TABLE external_identities (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    issuer TEXT NOT NULL,
+                    subject TEXT NOT NULL,
+                    username_snapshot TEXT,
+                    email_snapshot TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE (issuer, subject)
+                );
+                CREATE TABLE tokens (
+                    id UUID PRIMARY KEY,
+                    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    name TEXT NOT NULL,
+                    token_hash TEXT NOT NULL UNIQUE,
+                    token_prefix TEXT NOT NULL
+                );
+                CREATE TABLE vaults (
+                    id UUID PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    owner_id UUID REFERENCES users(id)
+                );
+                CREATE TABLE vault_access (
+                    vault_id UUID NOT NULL REFERENCES vaults(id),
+                    user_id UUID NOT NULL REFERENCES users(id),
+                    role TEXT NOT NULL,
+                    UNIQUE (vault_id, user_id)
+                );
+                """
+            )
+
+        from app.sso import identity_migration
+
+        async def _get_pool():
+            return pool
+
+        async def _emit_event(conn, event_type, *, actor_id, payload):
+            events.append((event_type, actor_id, payload))
+
+        monkeypatch.setattr(identity_migration, "get_pool", _get_pool)
+        monkeypatch.setattr(identity_migration, "emit_event", _emit_event)
+        yield pool, events, identity_migration
+    finally:
+        await pool.close()
+        await admin.execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await admin.close()
+
+
+async def _seed_continuity_state(pool):
+    user_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    vault_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, display_name, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, 'alice', 'alice@example.com', 'Alice', false,
+                      'keycloak', 'active', 'human')
+            """,
+            user_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO external_identities (
+                user_id, issuer, subject, username_snapshot, email_snapshot
+            ) VALUES ($1, $2, 'old-subject', 'alice', 'alice@example.com')
+            """,
+            user_id,
+            _OLD_ISSUER,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix)
+            VALUES ($1, $2, 'continuity-pat', $3, 'akb_test')
+            """,
+            token_id,
+            user_id,
+            uuid.uuid4().hex,
+        )
+        await conn.execute(
+            "INSERT INTO vaults (id, name, owner_id) VALUES ($1, 'owned', $2)",
+            vault_id,
+            user_id,
+        )
+        await conn.execute(
+            "INSERT INTO vault_access VALUES ($1, $2, 'writer')",
+            vault_id,
+            user_id,
+        )
+    return user_id, token_id, vault_id
+
+
+async def test_exact_migration_is_dry_run_first_idempotent_and_preserves_account_state(
+    migration_store,
+):
+    pool, events, service = migration_store
+    user_id, token_id, vault_id = await _seed_continuity_state(pool)
+
+    before = await service.inspect_identity_migration(
+        existing_user_id=str(user_id),
+        old_issuer=_OLD_ISSUER,
+        old_subject="old-subject",
+        new_issuer=_NEW_ISSUER,
+        new_subject="new-subject",
+    )
+    assert before.state == "ready_to_link"
+    assert events == []
+
+    first, second = await asyncio.gather(
+        *[
+            service.apply_identity_migration(
+                existing_user_id=str(user_id),
+                old_issuer=_OLD_ISSUER,
+                old_subject="old-subject",
+                new_issuer=_NEW_ISSUER,
+                new_subject="new-subject",
+                actor_id="product-admin",
+            )
+            for _ in range(2)
+        ]
+    )
+    assert first.state == second.state == "linked"
+    assert sorted([first.binding_changed, second.binding_changed]) == [False, True]
+
+    async with pool.acquire() as conn:
+        bindings = await conn.fetch(
+            """
+            SELECT user_id, issuer, subject, username_snapshot, email_snapshot
+              FROM external_identities
+             WHERE user_id = $1
+             ORDER BY issuer
+            """,
+            user_id,
+        )
+        user = await conn.fetchrow("SELECT * FROM users WHERE id = $1", user_id)
+        token_owner = await conn.fetchval("SELECT user_id FROM tokens WHERE id = $1", token_id)
+        vault_owner = await conn.fetchval("SELECT owner_id FROM vaults WHERE id = $1", vault_id)
+        vault_role = await conn.fetchval(
+            "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            vault_id,
+            user_id,
+        )
+
+    assert [(row["issuer"], row["subject"]) for row in bindings] == [
+        (_NEW_ISSUER, "new-subject"),
+        (_OLD_ISSUER, "old-subject"),
+    ]
+    assert all(row["user_id"] == user_id for row in bindings)
+    assert bindings[0]["username_snapshot"] == "alice"
+    assert bindings[0]["email_snapshot"] == "alice@example.com"
+    assert (user["username"], user["email"], user["display_name"]) == (
+        "alice",
+        "alice@example.com",
+        "Alice",
+    )
+    assert token_owner == vault_owner == user_id
+    assert vault_role == "writer"
+    assert events == [
+        (
+            "auth.external_identity_migrated",
+            "product-admin",
+            {
+                "user_id": str(user_id),
+                "old_issuer": _OLD_ISSUER,
+                "old_subject": "old-subject",
+                "new_issuer": _NEW_ISSUER,
+                "new_subject": "new-subject",
+            },
+        )
+    ]
+
+    rolled_back = await asyncio.gather(
+        *[
+            service.rollback_identity_migration(
+                existing_user_id=str(user_id),
+                old_issuer=_OLD_ISSUER,
+                old_subject="old-subject",
+                new_issuer=_NEW_ISSUER,
+                new_subject="new-subject",
+                actor_id="product-admin",
+            )
+            for _ in range(2)
+        ]
+    )
+    assert [item.state for item in rolled_back] == [
+        "ready_to_link",
+        "ready_to_link",
+    ]
+    assert sorted(item.binding_changed for item in rolled_back) == [False, True]
+    async with pool.acquire() as conn:
+        remaining = await conn.fetch(
+            "SELECT issuer, subject FROM external_identities WHERE user_id = $1",
+            user_id,
+        )
+        assert await conn.fetchval(
+            "SELECT user_id FROM tokens WHERE id = $1",
+            token_id,
+        ) == user_id
+        assert await conn.fetchval(
+            "SELECT owner_id FROM vaults WHERE id = $1",
+            vault_id,
+        ) == user_id
+        assert await conn.fetchval(
+            "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            vault_id,
+            user_id,
+        ) == "writer"
+    assert [(row["issuer"], row["subject"]) for row in remaining] == [
+        (_OLD_ISSUER, "old-subject")
+    ]
+    assert events[-1] == (
+        "auth.external_identity_migration_rolled_back",
+        "product-admin",
+        {
+            "user_id": str(user_id),
+            "old_issuer": _OLD_ISSUER,
+            "old_subject": "old-subject",
+            "new_issuer": _NEW_ISSUER,
+            "new_subject": "new-subject",
+        },
+    )
+    assert [event[0] for event in events] == [
+        "auth.external_identity_migrated",
+        "auth.external_identity_migration_rolled_back",
+    ]
+
+
+async def test_migration_never_adopts_by_email_or_crosses_an_existing_binding(
+    migration_store,
+):
+    pool, events, service = migration_store
+    user_id, _, _ = await _seed_continuity_state(pool)
+    other_user_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, display_name, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, 'other', 'other@example.com', 'Other', false,
+                      'keycloak', 'active', 'human')
+            """,
+            other_user_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO external_identities (user_id, issuer, subject)
+            VALUES ($1, $2, 'claimed-new-subject')
+            """,
+            other_user_id,
+            _NEW_ISSUER,
+        )
+
+    with pytest.raises(service.IdentityMigrationError) as captured:
+        await service.apply_identity_migration(
+            existing_user_id=str(user_id),
+            old_issuer=_OLD_ISSUER,
+            old_subject="old-subject",
+            new_issuer=_NEW_ISSUER,
+            new_subject="claimed-new-subject",
+            actor_id="product-admin",
+        )
+
+    assert captured.value.code == "identity_migration_new_binding_conflict"
+    assert events == []
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
+            user_id,
+        ) == 1
+
+
+@pytest.mark.parametrize(
+    ("column", "value", "code"),
+    [
+        ("account_status", "suspended", "identity_migration_target_inactive"),
+        ("account_kind", "service", "identity_migration_target_not_human"),
+        ("auth_provider", "local", "identity_migration_target_not_external"),
+    ],
+)
+async def test_migration_requires_the_exact_active_external_human(
+    migration_store,
+    column,
+    value,
+    code,
+):
+    pool, _, service = migration_store
+    user_id, _, _ = await _seed_continuity_state(pool)
+    async with pool.acquire() as conn:
+        await conn.execute(f'UPDATE users SET "{column}" = $2 WHERE id = $1', user_id, value)
+
+    with pytest.raises(service.IdentityMigrationError) as captured:
+        await service.inspect_identity_migration(
+            existing_user_id=str(user_id),
+            old_issuer=_OLD_ISSUER,
+            old_subject="old-subject",
+            new_issuer=_NEW_ISSUER,
+            new_subject="new-subject",
+        )
+
+    assert captured.value.code == code

--- a/backend/tests/test_sso_keycloak_admin_unit.py
+++ b/backend/tests/test_sso_keycloak_admin_unit.py
@@ -53,6 +53,9 @@ def _spec(**changes: object) -> ProviderConfigureSpec:
 class KeycloakFixture:
     def __init__(self) -> None:
         self.providers: dict[str, dict[str, object]] = {}
+        self.users: dict[str, dict[str, object]] = {}
+        self.credentials: dict[str, list[dict[str, object]]] = {}
+        self.federated_identities: dict[str, list[dict[str, object]]] = {}
         self.requests: list[tuple[str, str]] = []
         self.fail_admin = False
         self.drift_readback_after_write = False
@@ -134,6 +137,28 @@ class KeycloakFixture:
                 if self.drift_readback_after_write:
                     self._drift_readback = True
                 return httpx.Response(204)
+        users = "/auth/admin/realms/akb/users/"
+        if path.startswith(users) and request.method == "GET":
+            suffix = path.removeprefix(users)
+            if suffix.endswith("/credentials"):
+                user_id = suffix.removesuffix("/credentials")
+                if user_id not in self.users:
+                    return httpx.Response(404)
+                return httpx.Response(200, json=self.credentials.get(user_id, []))
+            if suffix.endswith("/federated-identity"):
+                user_id = suffix.removesuffix("/federated-identity")
+                if user_id not in self.users:
+                    return httpx.Response(404)
+                return httpx.Response(
+                    200,
+                    json=self.federated_identities.get(user_id, []),
+                )
+            user = self.users.get(suffix)
+            return (
+                httpx.Response(404)
+                if user is None
+                else httpx.Response(200, json=user)
+            )
         raise AssertionError(f"unexpected request: {request.method} {path}")
 
 
@@ -396,4 +421,171 @@ async def test_delegated_control_mode_never_attempts_keycloak_management():
     with pytest.raises(ProviderControlError) as captured:
         await control.list_providers(force_refresh=True)
     assert captured.value.code == "keycloak_provider_control_delegated"
+    assert fixture.requests == []
+
+
+async def test_identity_prelink_verifies_exact_native_passwordless_broker_user():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    fixture.users["broker-subject"] = {
+        "id": "broker-subject",
+        "username": "alice",
+        "enabled": True,
+    }
+    fixture.federated_identities["broker-subject"] = [
+        {
+            "identityProvider": "workforce",
+            "userId": "upstream-subject",
+            "userName": "alice",
+        }
+    ]
+
+    prelink = await control.verify_identity_prelink(
+        "workforce",
+        broker_subject="broker-subject",
+        upstream_subject="upstream-subject",
+    )
+
+    assert prelink.provider_alias == "workforce"
+    assert prelink.provider_state == "configured_disabled"
+    assert prelink.upstream_issuer == _ISSUER
+    assert prelink.broker_issuer == "https://auth.akb.example.com/realms/akb"
+    assert prelink.broker_subject == "broker-subject"
+    assert prelink.upstream_subject == "upstream-subject"
+    assert "broker-subject" not in repr(prelink)
+    assert "upstream-subject" not in repr(prelink)
+    assert all(
+        method == "GET" or "/protocol/openid-connect/token" in path
+        for method, path in fixture.requests
+        if "/users/" in path
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "code"),
+    [
+        ("missing_user", "identity_prelink_user_not_found"),
+        ("disabled_user", "identity_prelink_user_inactive"),
+        ("federated_storage_user", "identity_prelink_user_not_native"),
+        ("local_password", "identity_prelink_local_credential_present"),
+        ("local_passkey", "identity_prelink_local_credential_present"),
+        ("required_action", "identity_prelink_local_credential_present"),
+        ("missing_link", "identity_prelink_missing"),
+        ("wrong_subject", "identity_prelink_subject_mismatch"),
+        ("duplicate_link", "identity_prelink_ambiguous"),
+        ("other_provider_link", "identity_prelink_ambiguous"),
+    ],
+)
+async def test_identity_prelink_fails_closed_on_non_exact_keycloak_state(
+    mutation,
+    code,
+):
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    if mutation != "missing_user":
+        fixture.users["broker-subject"] = {
+            "id": "broker-subject",
+            "username": "alice",
+            "enabled": mutation != "disabled_user",
+        }
+        if mutation == "federated_storage_user":
+            fixture.users["broker-subject"]["federationLink"] = "ldap-provider"
+        if mutation == "local_password":
+            fixture.credentials["broker-subject"] = [{"type": "password"}]
+        if mutation == "local_passkey":
+            fixture.credentials["broker-subject"] = [{"type": "webauthn-passwordless"}]
+        if mutation == "required_action":
+            fixture.users["broker-subject"]["requiredActions"] = ["UPDATE_PASSWORD"]
+        if mutation == "wrong_subject":
+            fixture.federated_identities["broker-subject"] = [
+                {
+                    "identityProvider": "workforce",
+                    "userId": "someone-else",
+                    "userName": "alice",
+                }
+            ]
+        elif mutation == "duplicate_link":
+            fixture.federated_identities["broker-subject"] = [
+                {
+                    "identityProvider": "workforce",
+                    "userId": "upstream-subject",
+                    "userName": "alice",
+                },
+                {
+                    "identityProvider": "workforce",
+                    "userId": "upstream-subject",
+                    "userName": "alice-duplicate",
+                },
+            ]
+        elif mutation == "other_provider_link":
+            fixture.federated_identities["broker-subject"] = [
+                {
+                    "identityProvider": "workforce",
+                    "userId": "upstream-subject",
+                    "userName": "alice",
+                },
+                {
+                    "identityProvider": "unexpected-provider",
+                    "userId": "another-subject",
+                    "userName": "alice",
+                },
+            ]
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.verify_identity_prelink(
+            "workforce",
+            broker_subject="broker-subject",
+            upstream_subject="upstream-subject",
+        )
+
+    assert captured.value.code == code
+
+
+async def test_identity_prelink_rejects_unmanaged_or_drifted_provider():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+    config = fixture.providers["workforce"]["config"]
+    assert isinstance(config, dict)
+    config["validateSignature"] = "false"
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.verify_identity_prelink(
+            "workforce",
+            broker_subject="broker-subject",
+            upstream_subject="upstream-subject",
+        )
+
+    assert captured.value.code == "provider_configuration_invalid"
+
+
+async def test_identity_prelink_subjects_are_opaque_and_excluded_from_repr():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_spec())
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.verify_identity_prelink(
+            "workforce",
+            broker_subject=" broker-subject ",
+            upstream_subject="upstream-subject",
+        )
+
+    assert captured.value.code == "identity_prelink_user_not_found"
+
+
+async def test_identity_prelink_rejects_non_utf8_subject_before_network():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.verify_identity_prelink(
+            "workforce",
+            broker_subject="\ud800",
+            upstream_subject="upstream-subject",
+        )
+
+    assert captured.value.code == "identity_prelink_subject_invalid"
     assert fixture.requests == []

--- a/backend/tests/test_standalone_sso_keycloak_unit.py
+++ b/backend/tests/test_standalone_sso_keycloak_unit.py
@@ -539,6 +539,8 @@ async def test_client_profiles_separate_user_admin_and_management_authorities():
     ]
     assert api["attributes"]["pkce.code.challenge.method"] == "S256"
     assert admin["attributes"]["pkce.code.challenge.method"] == "S256"
+    assert api["defaultClientScopes"] == ["basic", "profile", "email"]
+    assert admin["defaultClientScopes"] == ["basic", "profile", "email"]
     assert management["standardFlowEnabled"] is False
     assert management["serviceAccountsEnabled"] is True
     assert management["defaultClientScopes"] == ["service_account"]

--- a/deploy/keycloak-dev/broker-chain/README.md
+++ b/deploy/keycloak-dev/broker-chain/README.md
@@ -1,10 +1,19 @@
 # Two-Keycloak broker-chain fixture
 
 This disposable fixture proves the `keycloak-oidc` contribution against two
-real Keycloak 26.7 processes. It configures the upstream provider disabled,
-reads it back, proves masked-secret preservation on a disabled reconfigure,
-enables it, verifies `kc_idp_hint` redirects to the upstream realm, disables
-it, and prints a secret-free JSON receipt.
+real Keycloak 26.7 processes and a temporary PostgreSQL 16 database. It
+configures the upstream provider disabled, proves masked-secret preservation,
+and uses a one-time fixture operator to create one native broker user and exact
+federated link. The permanent management account then reads that link back
+with its exact six-role set and without `manage-users`.
+
+The fixture completes Authorization Code + PKCE login through both realms,
+verifies the broker access token against AKB's production verifier, and proves
+that it resolves to the existing AKB user while the user's PAT, owned Vault,
+and writer grant remain valid. A separate upstream token is deliberately given
+the AKB API audience and still must be rejected. Finally, the provider is
+disabled, the AKB identity binding is rolled back, the operator removes the
+Keycloak prelink/user, and a secret-free JSON receipt is printed.
 
 Requirements: Docker Compose, OpenSSL, curl, and `uv`.
 
@@ -12,12 +21,14 @@ Requirements: Docker Compose, OpenSSL, curl, and `uv`.
 deploy/keycloak-dev/broker-chain/run.sh
 ```
 
-The runner generates a one-day self-signed certificate in a private temporary
-directory, uses a unique Compose project, and always tears down containers,
-networks, volumes, and certificates. All committed credentials are explicitly
-fixture-only. The runner uses `--insecure`/`verify_ssl=False` only for its
-ephemeral certificate; production SSO must verify TLS.
+The runner generates a one-day self-signed certificate and minimal AKB config
+in private temporary directories, uses a unique Compose project, and verifies
+that teardown leaves no labeled container, network, or volume. All committed
+credentials are explicitly fixture-only. The runner uses
+`--insecure`/`verify_ssl=False` only for its ephemeral certificate; production
+SSO must verify TLS.
 
-The fixed host ports are `19443` for the broker and `19444` for the upstream
-realm. Do not run this fixture against a shared Keycloak or reuse its realm
-files as production credentials.
+The fixed host ports are `19443` for the broker, `19444` for the upstream realm,
+and `19445` for PostgreSQL. All three bind to `127.0.0.1` only. Do not run this
+fixture against a shared Keycloak or reuse its realm files as production
+credentials.

--- a/deploy/keycloak-dev/broker-chain/broker-realm.json
+++ b/deploy/keycloak-dev/broker-chain/broker-realm.json
@@ -31,8 +31,28 @@
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
       "redirectUris": ["https://client.localhost/callback"],
-      "webOrigins": []
+      "webOrigins": [],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["basic", "profile", "email"],
+      "optionalClientScopes": [],
+      "protocolMappers": [
+        {
+          "name": "akb-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "https://broker.localhost:19443/api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": [

--- a/deploy/keycloak-dev/broker-chain/compose.yaml
+++ b/deploy/keycloak-dev/broker-chain/compose.yaml
@@ -10,10 +10,8 @@ services:
       KC_HTTPS_CERTIFICATE_KEY_FILE: /certs/tls.key
       KC_TRUSTSTORE_PATHS: /certs/tls.crt
       KC_HEALTH_ENABLED: "true"
-    extra_hosts:
-      - upstream.localhost:host-gateway
     ports:
-      - "19443:8443"
+      - "127.0.0.1:19443:8443"
     volumes:
       - ${AKB_SSO_FIXTURE_CERT_DIR:?run through run.sh}:/certs:ro
       - ./broker-realm.json:/opt/keycloak/data/import/akb-realm.json:ro
@@ -25,11 +23,27 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: fixture-admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: fixture-only-admin-password # pragma: allowlist secret
       KC_HOSTNAME: https://upstream.localhost:19444
+      KC_HTTPS_PORT: "19444"
       KC_HTTPS_CERTIFICATE_FILE: /certs/tls.crt
       KC_HTTPS_CERTIFICATE_KEY_FILE: /certs/tls.key
       KC_HEALTH_ENABLED: "true"
     ports:
-      - "19444:8443"
+      - "127.0.0.1:19444:19444"
+    networks:
+      default:
+        aliases:
+          - upstream.localhost
     volumes:
       - ${AKB_SSO_FIXTURE_CERT_DIR:?run through run.sh}:/certs:ro
       - ./upstream-realm.json:/opt/keycloak/data/import/workforce-realm.json:ro
+
+  postgres:
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+    environment:
+      POSTGRES_USER: akb
+      POSTGRES_PASSWORD: akb # pragma: allowlist secret
+      POSTGRES_DB: akb
+    ports:
+      - "127.0.0.1:19445:5432"
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/deploy/keycloak-dev/broker-chain/exercise.py
+++ b/deploy/keycloak-dev/broker-chain/exercise.py
@@ -1,18 +1,547 @@
-"""Exercise the real two-Keycloak provider lifecycle without printing secrets."""
+"""Prove exact identity continuity through a real two-Keycloak broker chain."""
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+from html import unescape
+from html.parser import HTMLParser
 import json
+import secrets
+from typing import Any
+from urllib.parse import parse_qs, urljoin, urlsplit
+import uuid
 
 import httpx
+import jwt
 
-from app.sso.keycloak_admin import KeycloakAdminConfig, KeycloakProviderControl
+from app.db import postgres
+from app.services import auth_service, keycloak_oidc
+from app.services.access_service import check_vault_access
+from app.services.auth_verifier_profiles import verify_keycloak_access_v1
+from app.sso.identity_migration import (
+    apply_identity_migration,
+    inspect_identity_migration,
+    rollback_identity_migration,
+)
+from app.sso.keycloak_admin import (
+    KeycloakAdminConfig,
+    KeycloakProviderControl,
+    ProviderControlError,
+)
 from app.sso.models import ProviderConfigureSpec
 
 
 BROKER = "https://broker.localhost:19443"
-UPSTREAM_ISSUER = "https://upstream.localhost:19444/realms/workforce"
+BROKER_ISSUER = f"{BROKER}/realms/akb"
+UPSTREAM = "https://upstream.localhost:19444"
+UPSTREAM_ISSUER = f"{UPSTREAM}/realms/workforce"
+API_AUDIENCE = f"{BROKER}/api"
+_MANAGEMENT_ROLES = {
+    "manage-identity-providers",
+    "query-clients",
+    "query-users",
+    "view-clients",
+    "view-realm",
+    "view-users",
+}
+
+
+def _fail(code: str) -> RuntimeError:
+    return RuntimeError(code)
+
+
+def _require_object(value: object, code: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _fail(code)
+    return value
+
+
+def _require_objects(value: object, code: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise _fail(code)
+    return value
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+class _FormParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.forms: list[dict[str, object]] = []
+        self._form: dict[str, object] | None = None
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        values = dict(attrs)
+        if tag == "form":
+            self._form = {
+                "action": values.get("action", ""),
+                "method": (values.get("method") or "get").lower(),
+                "inputs": {},
+            }
+        elif tag == "input" and self._form is not None:
+            name = values.get("name")
+            if name:
+                inputs = self._form["inputs"]
+                assert isinstance(inputs, dict)
+                inputs[name] = values.get("value") or ""
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form" and self._form is not None:
+            self.forms.append(self._form)
+            self._form = None
+
+
+def _login_form(response: httpx.Response) -> tuple[str, dict[str, str]]:
+    parser = _FormParser()
+    parser.feed(response.text)
+    for form in parser.forms:
+        inputs = form.get("inputs")
+        if not isinstance(inputs, dict) or not {"username", "password"}.issubset(inputs):
+            continue
+        action = form.get("action")
+        method = form.get("method")
+        if not isinstance(action, str) or not action or method != "post":
+            break
+        return (
+            urljoin(str(response.url), unescape(action)),
+            {
+                key: value
+                for key, value in inputs.items()
+                if isinstance(key, str) and isinstance(value, str)
+            },
+        )
+    raise _fail("fixture_login_form_missing")
+
+
+async def _authorization_code_tokens(
+    *,
+    issuer: str,
+    client_id: str,
+    redirect_uri: str,
+    username: str,
+    password: str,
+    extra_authorize: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    verifier, challenge = _pkce()
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "openid profile email",
+        "state": secrets.token_urlsafe(24),
+        "nonce": secrets.token_urlsafe(24),
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    params.update(extra_authorize or {})
+    callback_code: str | None = None
+    submitted = False
+    async with httpx.AsyncClient(
+        verify=False,
+        follow_redirects=False,
+        timeout=httpx.Timeout(20.0, connect=10.0),
+    ) as client:
+        response = await client.get(
+            f"{issuer}/protocol/openid-connect/auth",
+            params=params,
+        )
+        for _ in range(30):
+            if response.status_code in {301, 302, 303, 307, 308}:
+                location = response.headers.get("location")
+                if not location:
+                    raise _fail("fixture_authorization_redirect_invalid")
+                target = urljoin(str(response.url), location)
+                if target.startswith(redirect_uri):
+                    query = parse_qs(urlsplit(target).query)
+                    if "error" in query:
+                        raise _fail("fixture_authorization_rejected")
+                    values = query.get("code", [])
+                    if len(values) != 1 or not values[0]:
+                        raise _fail("fixture_authorization_code_missing")
+                    callback_code = values[0]
+                    break
+                response = await client.get(target)
+                continue
+            if response.status_code == 200 and not submitted:
+                action, data = _login_form(response)
+                data.update(
+                    {
+                        "username": username,
+                        "password": password,
+                        "login": data.get("login") or "Sign In",
+                    }
+                )
+                response = await client.post(action, data=data)
+                submitted = True
+                continue
+            raise _fail("fixture_authorization_flow_failed")
+        if callback_code is None:
+            raise _fail("fixture_authorization_flow_exhausted")
+        token_response = await client.post(
+            f"{issuer}/protocol/openid-connect/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "code": callback_code,
+                "code_verifier": verifier,
+            },
+        )
+    if token_response.status_code != 200:
+        raise _fail("fixture_authorization_code_exchange_failed")
+    tokens = _require_object(token_response.json(), "fixture_token_response_invalid")
+    if not isinstance(tokens.get("access_token"), str):
+        raise _fail("fixture_access_token_missing")
+    return tokens
+
+
+async def _admin_token(client: httpx.AsyncClient, base_url: str) -> str:
+    response = await client.post(
+        f"{base_url}/realms/master/protocol/openid-connect/token",
+        data={
+            "grant_type": "password",
+            "client_id": "admin-cli",
+            "username": "fixture-admin",
+            "password": "fixture-only-admin-password",  # pragma: allowlist secret
+        },
+    )
+    if response.status_code != 200:
+        raise _fail("fixture_admin_token_failed")
+    value = _require_object(response.json(), "fixture_admin_token_invalid").get(
+        "access_token"
+    )
+    if not isinstance(value, str) or not value:
+        raise _fail("fixture_admin_token_invalid")
+    return value
+
+
+async def _exact_client(
+    client: httpx.AsyncClient,
+    *,
+    admin_token: str,
+    client_id: str,
+) -> dict[str, Any]:
+    response = await client.get(
+        f"{BROKER}/admin/realms/akb/clients",
+        params={"clientId": client_id},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    if response.status_code != 200:
+        raise _fail("fixture_client_read_failed")
+    matches = [
+        item
+        for item in _require_objects(response.json(), "fixture_client_read_failed")
+        if item.get("clientId") == client_id
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("id"), str):
+        raise _fail("fixture_client_not_exact")
+    return matches[0]
+
+
+async def _assert_management_roles(
+    client: httpx.AsyncClient,
+    *,
+    admin_token: str,
+) -> None:
+    management = await _exact_client(
+        client,
+        admin_token=admin_token,
+        client_id="akb-sso-manager",
+    )
+    realm_management = await _exact_client(
+        client,
+        admin_token=admin_token,
+        client_id="realm-management",
+    )
+    management_uuid = management["id"]
+    realm_management_uuid = realm_management["id"]
+    service_response = await client.get(
+        (
+            f"{BROKER}/admin/realms/akb/clients/{management_uuid}"
+            "/service-account-user"
+        ),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    if service_response.status_code != 200:
+        raise _fail("fixture_management_service_account_read_failed")
+    service_user = _require_object(
+        service_response.json(),
+        "fixture_management_service_account_read_failed",
+    )
+    service_user_id = service_user.get("id")
+    if not isinstance(service_user_id, str):
+        raise _fail("fixture_management_service_account_read_failed")
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    role_response = await client.get(
+        (
+            f"{BROKER}/admin/realms/akb/users/{service_user_id}"
+            f"/role-mappings/clients/{realm_management_uuid}"
+        ),
+        headers=headers,
+    )
+    scope_response = await client.get(
+        (
+            f"{BROKER}/admin/realms/akb/clients/{management_uuid}"
+            f"/scope-mappings/clients/{realm_management_uuid}"
+        ),
+        headers=headers,
+    )
+    if role_response.status_code != 200 or scope_response.status_code != 200:
+        raise _fail("fixture_management_role_read_failed")
+    role_names = {
+        item.get("name")
+        for item in _require_objects(
+            role_response.json(),
+            "fixture_management_role_read_failed",
+        )
+    }
+    scope_names = {
+        item.get("name")
+        for item in _require_objects(
+            scope_response.json(),
+            "fixture_management_role_read_failed",
+        )
+    }
+    if role_names != _MANAGEMENT_ROLES or scope_names != _MANAGEMENT_ROLES:
+        raise _fail("fixture_management_roles_not_least_privilege")
+    if "manage-users" in role_names or "manage-users" in scope_names:
+        raise _fail("fixture_management_manage_users_present")
+
+
+async def _operator_prelink() -> tuple[str, str]:
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        upstream_admin = await _admin_token(client, UPSTREAM)
+        upstream_response = await client.get(
+            f"{UPSTREAM}/admin/realms/workforce/users",
+            params={"username": "alice", "exact": "true"},
+            headers={"Authorization": f"Bearer {upstream_admin}"},
+        )
+        if upstream_response.status_code != 200:
+            raise _fail("fixture_upstream_user_read_failed")
+        upstream_users = _require_objects(
+            upstream_response.json(),
+            "fixture_upstream_user_read_failed",
+        )
+        if len(upstream_users) != 1 or not isinstance(upstream_users[0].get("id"), str):
+            raise _fail("fixture_upstream_user_not_exact")
+        upstream_subject = upstream_users[0]["id"]
+
+        broker_admin = await _admin_token(client, BROKER)
+        create_response = await client.post(
+            f"{BROKER}/admin/realms/akb/users",
+            headers={"Authorization": f"Bearer {broker_admin}"},
+            json={
+                "username": "alice",
+                "email": "alice@example.com",
+                "emailVerified": True,
+                "enabled": True,
+                "firstName": "Alice",
+                "lastName": "Fixture",
+            },
+        )
+        if create_response.status_code != 201:
+            raise _fail("fixture_broker_user_create_failed")
+        location = create_response.headers.get("location")
+        broker_subject = urlsplit(location or "").path.rsplit("/", 1)[-1]
+        if not broker_subject:
+            raise _fail("fixture_broker_user_location_invalid")
+        link_response = await client.post(
+            (
+                f"{BROKER}/admin/realms/akb/users/{broker_subject}"
+                "/federated-identity/workforce"
+            ),
+            headers={"Authorization": f"Bearer {broker_admin}"},
+            json={
+                "identityProvider": "workforce",
+                "userId": upstream_subject,
+                "userName": "alice",
+            },
+        )
+        if link_response.status_code != 204:
+            raise _fail("fixture_prelink_create_failed")
+
+        await _assert_management_roles(client, admin_token=broker_admin)
+    return upstream_subject, broker_subject
+
+
+async def _operator_remove_prelink(broker_subject: str) -> None:
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        broker_admin = await _admin_token(client, BROKER)
+        headers = {"Authorization": f"Bearer {broker_admin}"}
+        unlink = await client.delete(
+            (
+                f"{BROKER}/admin/realms/akb/users/{broker_subject}"
+                "/federated-identity/workforce"
+            ),
+            headers=headers,
+        )
+        if unlink.status_code != 204:
+            raise _fail("fixture_prelink_remove_failed")
+        delete_user = await client.delete(
+            f"{BROKER}/admin/realms/akb/users/{broker_subject}",
+            headers=headers,
+        )
+        if delete_user.status_code != 204:
+            raise _fail("fixture_broker_user_remove_failed")
+
+
+async def _seed_akb(upstream_subject: str) -> dict[str, object]:
+    await postgres.init_db()
+    pool = await postgres.get_pool()
+    user_id = uuid.uuid4()
+    other_user_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    owned_vault_id = uuid.uuid4()
+    shared_vault_id = uuid.uuid4()
+    raw_pat, token_hash, token_prefix = auth_service.generate_pat()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                INSERT INTO users (
+                    id, username, email, password_hash, display_name, is_admin,
+                    auth_provider, account_status, account_kind
+                ) VALUES
+                    ($1, 'alice', 'alice@example.com', $2, 'Alice', false,
+                     'keycloak', 'active', 'human'),
+                    ($3, 'owner', 'owner@example.com', $4, 'Fixture Owner', false,
+                     'keycloak', 'active', 'human')
+                """,
+                user_id,
+                "!keycloak-sso:no-local-login!",  # pragma: allowlist secret
+                other_user_id,
+                "!keycloak-sso:no-local-login!",  # pragma: allowlist secret
+            )
+            await conn.execute(
+                """
+                INSERT INTO external_identities (
+                    user_id, issuer, subject, username_snapshot, email_snapshot
+                ) VALUES ($1, $2, $3, 'alice', 'alice@example.com')
+                """,
+                user_id,
+                UPSTREAM_ISSUER,
+                upstream_subject,
+            )
+            await conn.execute(
+                """
+                INSERT INTO tokens (
+                    id, user_id, name, token_hash, token_prefix, scopes, key_class
+                ) VALUES ($1, $2, 'continuity-pat', $3, $4,
+                          ARRAY['read', 'write'], 'pat')
+                """,
+                token_id,
+                user_id,
+                token_hash,
+                token_prefix,
+            )
+            await conn.execute(
+                """
+                INSERT INTO vaults (id, name, git_path, owner_id)
+                VALUES
+                    ($1, 'continuity-owned', '/tmp/continuity-owned.git', $2),
+                    ($3, 'continuity-shared', '/tmp/continuity-shared.git', $4)
+                """,
+                owned_vault_id,
+                user_id,
+                shared_vault_id,
+                other_user_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO vault_access (vault_id, user_id, role, granted_by)
+                VALUES ($1, $2, 'writer', $3)
+                """,
+                shared_vault_id,
+                user_id,
+                other_user_id,
+            )
+    return {
+        "pool": pool,
+        "user_id": user_id,
+        "token_id": token_id,
+        "raw_pat": raw_pat,
+        "owned_vault_id": owned_vault_id,
+        "shared_vault_id": shared_vault_id,
+    }
+
+
+async def _assert_continuity(
+    state: dict[str, object],
+    *,
+    upstream_subject: str,
+    broker_subject: str,
+    expect_broker_binding: bool,
+) -> None:
+    pool = state["pool"]
+    user_id = state["user_id"]
+    token_id = state["token_id"]
+    assert hasattr(pool, "acquire")
+    async with pool.acquire() as conn:  # type: ignore[union-attr]
+        user = await conn.fetchrow(
+            "SELECT id, username, account_status, account_kind FROM users WHERE id = $1",
+            user_id,
+        )
+        bindings = await conn.fetch(
+            """
+            SELECT issuer, subject, user_id FROM external_identities
+             WHERE user_id = $1 ORDER BY issuer
+            """,
+            user_id,
+        )
+        token_owner = await conn.fetchval(
+            "SELECT user_id FROM tokens WHERE id = $1",
+            token_id,
+        )
+        owned = await conn.fetchval(
+            "SELECT owner_id FROM vaults WHERE id = $1",
+            state["owned_vault_id"],
+        )
+        role = await conn.fetchval(
+            "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            state["shared_vault_id"],
+            user_id,
+        )
+    if user is None or user["id"] != user_id:
+        raise _fail("fixture_user_continuity_failed")
+    if user["account_status"] != "active" or user["account_kind"] != "human":
+        raise _fail("fixture_user_governance_changed")
+    expected = [(UPSTREAM_ISSUER, upstream_subject)]
+    if expect_broker_binding:
+        expected.insert(0, (BROKER_ISSUER, broker_subject))
+    actual = [(row["issuer"], row["subject"]) for row in bindings]
+    if actual != expected or any(row["user_id"] != user_id for row in bindings):
+        raise _fail("fixture_external_identity_continuity_failed")
+    if token_owner != user_id or owned != user_id or role != "writer":
+        raise _fail("fixture_authorization_continuity_failed")
+
+    pat_user = await auth_service.resolve_rest_user_authorization(
+        f"Bearer {state['raw_pat']}"
+    )
+    if pat_user is None or pat_user.user_id != str(user_id):
+        raise _fail("fixture_pat_continuity_failed")
+    owned_access = await check_vault_access(
+        str(user_id),
+        "continuity-owned",
+        "owner",
+    )
+    shared_access = await check_vault_access(
+        str(user_id),
+        "continuity-shared",
+        "writer",
+    )
+    if owned_access["role"] != "owner" or shared_access["role"] != "writer":
+        raise _fail("fixture_vault_access_continuity_failed")
 
 
 async def main() -> None:
@@ -38,8 +567,12 @@ async def main() -> None:
         )
     )
     configured = configured_mutation.after
-    if configured_mutation.before is not None or configured.state != "configured_disabled":
-        raise RuntimeError("fixture_configure_readback_failed")
+    if (
+        configured_mutation.before is not None
+        or configured.state != "configured_disabled"
+        or not configured.supports_identity_migration
+    ):
+        raise _fail("fixture_configure_readback_failed")
     preserved_mutation = await control.configure(
         ProviderConfigureSpec(
             provider_type="keycloak-oidc",
@@ -56,53 +589,157 @@ async def main() -> None:
         or not preserved_mutation.before.client_secret_configured
         or not preserved_mutation.after.client_secret_configured
     ):
-        raise RuntimeError("fixture_secret_preservation_failed")
-    enabled_mutation = await control.set_enabled("workforce", enabled=True)
-    enabled = enabled_mutation.after
+        raise _fail("fixture_secret_preservation_failed")
+
+    upstream_subject, broker_subject = await _operator_prelink()
+    prelink = await control.verify_identity_prelink(
+        "workforce",
+        broker_subject=broker_subject,
+        upstream_subject=upstream_subject,
+    )
+    if (
+        prelink.provider_state != "configured_disabled"
+        or prelink.upstream_issuer != UPSTREAM_ISSUER
+        or prelink.broker_issuer != BROKER_ISSUER
+    ):
+        raise _fail("fixture_prelink_readback_failed")
+
+    state = await _seed_akb(upstream_subject)
+    migration = await inspect_identity_migration(
+        existing_user_id=str(state["user_id"]),
+        old_issuer=UPSTREAM_ISSUER,
+        old_subject=upstream_subject,
+        new_issuer=BROKER_ISSUER,
+        new_subject=broker_subject,
+    )
+    if migration.state != "ready_to_link":
+        raise _fail("fixture_migration_preflight_failed")
+    linked = await apply_identity_migration(
+        existing_user_id=str(state["user_id"]),
+        old_issuer=UPSTREAM_ISSUER,
+        old_subject=upstream_subject,
+        new_issuer=BROKER_ISSUER,
+        new_subject=broker_subject,
+        actor_id="fixture-product-admin",
+    )
+    if linked.state != "linked":
+        raise _fail("fixture_migration_apply_failed")
+    await _assert_continuity(
+        state,
+        upstream_subject=upstream_subject,
+        broker_subject=broker_subject,
+        expect_broker_binding=True,
+    )
+
+    enabled = (await control.set_enabled("workforce", enabled=True)).after
     catalog = await control.list_providers(force_refresh=True)
     if enabled.state != "enabled" or [item.alias for item in catalog] != ["workforce"]:
-        raise RuntimeError("fixture_enable_readback_failed")
+        raise _fail("fixture_enable_readback_failed")
 
-    async with httpx.AsyncClient(verify=False, follow_redirects=True) as client:
-        response = await client.get(
-            f"{BROKER}/realms/akb/protocol/openid-connect/auth",
-            params={
-                "client_id": "fixture-browser",
-                "redirect_uri": "https://client.localhost/callback",
-                "response_type": "code",
-                "scope": "openid",
-                "kc_idp_hint": "workforce",
-            },
-        )
-    if response.status_code != 200:
-        raise RuntimeError("fixture_broker_redirect_failed")
-    upstream_request = next(
-        (
-            item.request.url
-            for item in (*response.history, response)
-            if item.request.url.host == "upstream.localhost"
-            and item.request.url.path
-            == "/realms/workforce/protocol/openid-connect/auth"
-        ),
-        None,
+    broker_tokens = await _authorization_code_tokens(
+        issuer=BROKER_ISSUER,
+        client_id="fixture-browser",
+        redirect_uri="https://client.localhost/callback",
+        username="alice",
+        password="fixture-only-alice-password",  # pragma: allowlist secret
+        extra_authorize={"kc_idp_hint": "workforce"},
     )
-    if upstream_request is None or upstream_request.params.get("client_id") != "akb-broker":
-        raise RuntimeError("fixture_upstream_redirect_invalid")
+    broker_access_token = broker_tokens["access_token"]
+    keycloak_oidc._service = None  # noqa: SLF001 - disposable process fixture
+    principal = await verify_keycloak_access_v1(broker_access_token, "api")
+    if principal is None:
+        raise _fail("fixture_broker_token_profile_verification_failed")
+    if principal.subject != broker_subject:
+        raise _fail("fixture_broker_token_subject_not_prelinked_user")
+    broker_user = await auth_service.project_verified_principal(principal)
+    if broker_user is None or broker_user.user_id != str(state["user_id"]):
+        raise _fail("fixture_broker_token_projection_failed")
+    await _assert_continuity(
+        state,
+        upstream_subject=upstream_subject,
+        broker_subject=broker_subject,
+        expect_broker_binding=True,
+    )
+
+    upstream_tokens = await _authorization_code_tokens(
+        issuer=UPSTREAM_ISSUER,
+        client_id="upstream-probe",
+        redirect_uri="https://upstream-client.localhost/callback",
+        username="alice",
+        password="fixture-only-alice-password",  # pragma: allowlist secret
+    )
+    upstream_access_token = upstream_tokens["access_token"]
+    upstream_claims = jwt.decode(
+        upstream_access_token,
+        options={"verify_signature": False},
+    )
+    raw_audience = upstream_claims.get("aud")
+    audiences = {raw_audience} if isinstance(raw_audience, str) else set(raw_audience or [])
+    if upstream_claims.get("iss") != UPSTREAM_ISSUER or API_AUDIENCE not in audiences:
+        raise _fail("fixture_upstream_collision_probe_invalid")
+    if (
+        await auth_service.resolve_keycloak_access_token(
+            upstream_access_token,
+            route_profile="api",
+        )
+        is not None
+    ):
+        raise _fail("fixture_upstream_token_accepted")
 
     disabled = (await control.set_enabled("workforce", enabled=False)).after
     if disabled.state != "configured_disabled":
-        raise RuntimeError("fixture_disable_readback_failed")
+        raise _fail("fixture_disable_readback_failed")
+    rolled_back = await rollback_identity_migration(
+        existing_user_id=str(state["user_id"]),
+        old_issuer=UPSTREAM_ISSUER,
+        old_subject=upstream_subject,
+        new_issuer=BROKER_ISSUER,
+        new_subject=broker_subject,
+        actor_id="fixture-product-admin",
+    )
+    if rolled_back.state != "ready_to_link":
+        raise _fail("fixture_migration_rollback_failed")
+    await _assert_continuity(
+        state,
+        upstream_subject=upstream_subject,
+        broker_subject=broker_subject,
+        expect_broker_binding=False,
+    )
+    await _operator_remove_prelink(broker_subject)
+    try:
+        await control.verify_identity_prelink(
+            "workforce",
+            broker_subject=broker_subject,
+            upstream_subject=upstream_subject,
+        )
+    except ProviderControlError as error:
+        if error.code != "identity_prelink_user_not_found":
+            raise
+    else:
+        raise _fail("fixture_operator_cleanup_not_observed")
+
+    service = keycloak_oidc._service  # noqa: SLF001 - disposable process fixture
+    if service is not None:
+        await service.aclose()
+        keycloak_oidc._service = None  # noqa: SLF001
+    await postgres.close_pool()
     print(
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "provider_type": enabled.provider_type,
                 "alias": enabled.alias,
                 "configure_state": configured.state,
                 "enabled_state": enabled.state,
                 "disabled_state": disabled.state,
-                "broker_redirect": "verified",
-                "secret_preservation": "verified",  # pragma: allowlist secret
+                "management_roles": "least-privilege-readback-verified",
+                "prelink": "exact-readback-verified",
+                "broker_login": "authorization-code-pkce-verified",
+                "akb_user_continuity": "verified",
+                "pat_continuity": "verified",
+                "vault_continuity": "owner-and-writer-verified",
+                "upstream_token_rejected": True,
+                "rollback": "binding-and-operator-cleanup-verified",
                 "client_secret_exposed": False,
             },
             sort_keys=True,

--- a/deploy/keycloak-dev/broker-chain/run.sh
+++ b/deploy/keycloak-dev/broker-chain/run.sh
@@ -4,24 +4,84 @@ set -euo pipefail
 fixture_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$fixture_root/../../.." && pwd)"
 cert_dir="$(mktemp -d "${TMPDIR:-/tmp}/akb-sso-broker-chain.XXXXXX")"
+fixture_run_dir="$(mktemp -d "${TMPDIR:-/tmp}/akb-sso-broker-run.XXXXXX")"
 project_name="akb-sso-broker-chain-$$"
 compose_file="$fixture_root/compose.yaml"
 
 cleanup() {
+  result=$?
+  trap - EXIT INT TERM
+  set +e
   AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
     --project-name "$project_name" --file "$compose_file" \
-    down --volumes --remove-orphans >/dev/null 2>&1 || true
+    down --volumes --remove-orphans >/dev/null 2>&1
+  down_status=$?
+  container_leftovers="$(
+    docker ps --all --quiet \
+      --filter "label=com.docker.compose.project=$project_name"
+  )"
+  container_status=$?
+  network_leftovers="$(
+    docker network ls --quiet \
+      --filter "label=com.docker.compose.project=$project_name"
+  )"
+  network_status=$?
+  volume_leftovers="$(
+    docker volume ls --quiet \
+      --filter "label=com.docker.compose.project=$project_name"
+  )"
+  volume_status=$?
+  if [[ "$down_status" -ne 0 || "$container_status" -ne 0 || \
+        "$network_status" -ne 0 || "$volume_status" -ne 0 ]]; then
+    echo "Broker-chain fixture teardown could not be verified" >&2
+    result=1
+  fi
+  if [[ -n "$container_leftovers$network_leftovers$volume_leftovers" ]]; then
+    echo "Broker-chain fixture teardown left Compose resources" >&2
+    result=1
+  fi
   if [[ "$cert_dir" == "${TMPDIR:-/tmp}/akb-sso-broker-chain."* ]]; then
     rm -rf -- "$cert_dir"
+  else
+    echo "Refusing to remove unexpected certificate directory" >&2
+    result=1
   fi
+  if [[ "$fixture_run_dir" == "${TMPDIR:-/tmp}/akb-sso-broker-run."* ]]; then
+    rm -rf -- "$fixture_run_dir"
+  else
+    echo "Refusing to remove unexpected fixture directory" >&2
+    result=1
+  fi
+  exit "$result"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
   -subj "/CN=AKB SSO broker-chain fixture" \
   -addext "subjectAltName=DNS:broker.localhost,DNS:upstream.localhost" \
   -keyout "$cert_dir/tls.key" -out "$cert_dir/tls.crt" >/dev/null 2>&1
 chmod 600 "$cert_dir/tls.key"
+
+mkdir -p "$fixture_run_dir/config"
+cat >"$fixture_run_dir/config/app.yaml" <<'YAML'
+auth_mode: sso
+keycloak_enabled: true
+keycloak_server_url: https://broker.localhost:19443
+keycloak_realm: akb
+keycloak_client_id: fixture-browser
+keycloak_public_client: true
+keycloak_enrollment_mode: invite_only
+keycloak_verify_ssl: false
+public_base_url: https://broker.localhost:19443
+api_oauth_audience: https://broker.localhost:19443/api
+db_host: localhost
+db_port: 19445
+db_name: akb
+db_user: akb
+db_password: akb # pragma: allowlist secret
+YAML
 
 AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
   --project-name "$project_name" --file "$compose_file" up --detach
@@ -44,5 +104,21 @@ do
   fi
 done
 
-cd "$repo_root/backend"
-uv run --locked python "$fixture_root/exercise.py"
+postgres_ready=false
+for _attempt in $(seq 1 60); do
+  if AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
+    --project-name "$project_name" --file "$compose_file" \
+    exec -T postgres pg_isready --username akb --dbname akb >/dev/null 2>&1; then
+    postgres_ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$postgres_ready" != true ]]; then
+  echo "Postgres fixture did not become ready" >&2
+  exit 1
+fi
+
+cd "$fixture_run_dir"
+PYTHONPATH="$repo_root/backend" uv run --project "$repo_root/backend" \
+  --locked python "$fixture_root/exercise.py"

--- a/deploy/keycloak-dev/broker-chain/upstream-realm.json
+++ b/deploy/keycloak-dev/broker-chain/upstream-realm.json
@@ -25,8 +25,41 @@
       "attributes": {
         "pkce.code.challenge.method": "S256"
       },
-      "defaultClientScopes": ["profile", "email"],
+      "defaultClientScopes": ["basic", "profile", "email"],
       "optionalClientScopes": []
+    },
+    {
+      "clientId": "upstream-probe",
+      "name": "Upstream token rejection probe",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
+      "redirectUris": ["https://upstream-client.localhost/callback"],
+      "webOrigins": [],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["basic", "profile", "email"],
+      "optionalClientScopes": [],
+      "protocolMappers": [
+        {
+          "name": "akb-api-audience-collision-probe",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "https://broker.localhost:19443/api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": [

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -44,7 +44,9 @@ The admin API reports one of two control modes:
 
 The standalone SSO bundle provisions a dedicated `akb-sso-manager` service
 account with only the Keycloak realm-management roles needed for provider
-control. It does not retain the one-time bootstrap credential.
+control and read-only user/prelink verification. It has no `manage-users`;
+broker-user and federated-link mutations require a separate one-time Keycloak
+operator. It does not retain the bootstrap credential.
 
 ## Built-in providers
 
@@ -59,6 +61,13 @@ Ordinary browser-session custody, refresh, logout, and revocation are a
 separate boundary. An enabled provider is listed by name before that boundary
 is active, but its login URL remains unavailable until the server-side browser
 session capability is ready.
+
+Existing-account migration is an exact identity operation, not a normal
+first-login convenience. See the reference provider's
+[continuity runbook](providers/keycloak-oidc.md#existing-account-continuity).
+AKB verifies an operator-created Keycloak prelink and adds the broker
+`(issuer, sub)` to the same AKB user without changing PAT or Vault ownership.
+Email and username never select the target account.
 
 ## Primary references
 

--- a/docs/sso/adding-a-provider.md
+++ b/docs/sso/adding-a-provider.md
@@ -53,6 +53,12 @@ Configuration always lands disabled. Creation requires a client secret;
 reconfiguration may use Keycloak's masked-secret preservation sentinel only
 after exact read-back proved that the existing managed provider has a secret.
 
+Leave `supports_identity_migration` false unless the contribution can prove an
+operator-created broker user and its sole federated link by exact provider
+alias and upstream subject. Email or username similarity is never sufficient.
+The migration must preserve the existing AKB user ID, PATs, and Vault grants,
+remain disabled through apply/read-back, and provide an exact rollback path.
+
 ## Required tests
 
 Contributions must cover:
@@ -64,6 +70,8 @@ Contributions must cover:
 - disabled-before-reconfigure enforcement;
 - enable, disable, idempotency, and read-back drift;
 - public catalog inclusion only for an exact enabled profile;
+- identity-migration capability false by default, or exact prelink,
+  conflict, continuity, and rollback proofs when enabled;
 - strict frontend parsing and a named provider button;
 - a live two-authority fixture when the provider depends on another identity
   server.

--- a/docs/sso/providers/keycloak-oidc.md
+++ b/docs/sso/providers/keycloak-oidc.md
@@ -14,7 +14,8 @@ Create a confidential OpenID Connect client in the upstream realm with:
 - standard authorization code flow enabled;
 - implicit flow, direct access grants, and service accounts disabled;
 - PKCE method `S256`;
-- scopes `openid profile email`;
+- scopes `openid profile email` and the Keycloak built-in `basic` default
+  client scope so access tokens contain the canonical `sub` claim;
 - the exact redirect URI shown by AKB after the provider is saved.
 
 The redirect URI has this Keycloak broker shape:
@@ -64,6 +65,79 @@ To rotate the upstream client secret, disable the provider, edit it with the
 new secret, save, and enable it again. Leaving the secret field blank preserves
 the existing value; no UI or API can read it back.
 
-The provider catalog does not advertise identity-migration support yet. Exact
-old/new subject prelink and readiness are a separate migration slice; an IdP
-being configurable is not evidence that existing AKB accounts were preserved.
+## Existing-account continuity
+
+Changing from an upstream realm to an AKB broker changes the trusted identity
+from `(upstream issuer, upstream sub)` to `(broker issuer, broker sub)`. Do not
+join those identities by email or username. For each existing account:
+
+1. Disable the provider and keep it hidden from ordinary login.
+2. Resolve the existing AKB `users.id` from its exact upstream issuer and
+   subject. Local-only, missing, inactive, service, or conflicting accounts
+   require manual resolution.
+3. Using a one-time Keycloak operator credential, create a native,
+   passwordless broker user and attach the exact federated identity with
+   `identityProvider=<alias>` and `userId=<upstream sub>`.
+4. Call the authenticated preflight endpoint with the provider alias, existing
+   AKB user ID, upstream subject, and broker subject. AKB derives both issuers
+   server-side, verifies the disabled managed provider, native enabled broker
+   user, absence of every local credential or credential-registration required
+   action, and exactly one federated link to the selected provider, then
+   verifies the old AKB binding without writing.
+5. Call `identity-migrations/apply` with the same body and product-admin CSRF
+   header. AKB adds only the broker identity row to the same user. It does not
+   update the user profile, adopt by email, revoke a PAT, or move a Vault role.
+6. Read back `state=linked`, then enable the provider. Keep the old binding for
+   the rollback window.
+
+The relevant paths are:
+
+```text
+POST /api/v1/admin/sso/providers/<alias>/identity-migrations/preflight
+POST /api/v1/admin/sso/providers/<alias>/identity-migrations/apply
+POST /api/v1/admin/sso/providers/<alias>/identity-migrations/rollback
+```
+
+All three accept this shape; callers do not supply either issuer:
+
+```json
+{
+  "existing_user_id": "<canonical AKB user UUID>",
+  "upstream_subject": "<opaque upstream sub>",
+  "broker_subject": "<opaque broker user UUID/sub>"
+}
+```
+
+Apply and rollback require the provider to remain disabled and use the SSO
+product-admin double-submit CSRF boundary. Operations are idempotent and audit
+only subject digests at the admin API boundary. The domain event records the
+exact old/new identity so an operator can reconcile the transaction.
+
+For rollback, disable the provider first, call the AKB rollback endpoint and
+read back `state=ready_to_link`, then use the one-time Keycloak operator to
+remove the federated link and broker user. The permanent `akb-sso-manager`
+credential intentionally cannot perform these user mutations.
+
+## Least-privilege split
+
+The permanent management service account has only these realm-management role
+and client-scope mappings:
+
+```text
+manage-identity-providers
+query-clients
+query-users
+view-clients
+view-realm
+view-users
+```
+
+It has no `manage-users`. Provider lifecycle and exact prelink read-back are
+available at runtime; broker user creation, federated-link mutation, and final
+cleanup stay explicit one-time Keycloak operator actions.
+
+Run `deploy/keycloak-dev/broker-chain/run.sh` before enabling a release. The
+disposable two-Keycloak fixture completes Authorization Code + PKCE login,
+projects the broker access token to the same AKB user, proves PAT and Vault
+continuity, rejects an upstream token even when it carries the AKB API
+audience, then exercises rollback and operator cleanup.

--- a/frontend/src/lib/__tests__/admin-sso-config.test.ts
+++ b/frontend/src/lib/__tests__/admin-sso-config.test.ts
@@ -21,7 +21,7 @@ const provider = {
   redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
   capabilities: {
     supports_logout: true,
-    supports_identity_migration: false,
+    supports_identity_migration: true,
   },
 };
 

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -70,7 +70,7 @@ const provider = {
   redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
   capabilities: {
     supports_logout: true,
-    supports_identity_migration: false,
+    supports_identity_migration: true,
   },
 };
 


### PR DESCRIPTION
## Summary

- add an exact existing-account migration from an upstream `(issuer, sub)` to the bundled Keycloak broker identity without changing the AKB user, PATs, or Vault grants
- verify a disabled managed provider, native enabled broker user, no local credential path, and exactly one federated identity before applying or rolling back
- make apply/rollback idempotent and concurrency-safe, with post-write Keycloak read-back and compensation owned only by the call that inserted the binding
- add the Keycloak `basic` client scope required for canonical access-token `sub` claims
- expand the disposable broker-chain fixture to two digest-pinned Keycloak 26.7 instances plus temporary PostgreSQL, with loopback-only host ports and teardown verification
- document the least-privilege operator split, contribution contract, continuity runbook, and rollback order

Part of #357.

## Security and compatibility

- issuers are derived server-side; email and username never select the AKB account
- raw subjects are excluded from API responses and admin audit metadata
- the permanent management client has no `manage-users`; one-time Keycloak operator actions remain separate
- upstream tokens are rejected even when they carry the AKB API audience
- public provider capability changes from `supports_identity_migration=false` to `true` only for the exact Keycloak reference flow

## Validation

- `pytest -q tests`: 2266 passed, 247 skipped
- SSO-focused backend suite: 141 passed
- `scripts/check.sh`: Ruff, mypy, Bandit, ESLint, TypeScript, SDK build/typecheck/tests/drift/packed proof, frontend 457 tests, and secret scan passed
- frontend production build passed
- disposable two-Keycloak broker-chain E2E passed Authorization Code + PKCE, exact prelink, AKB user/PAT/Vault continuity, upstream-token rejection, rollback, operator cleanup, and zero labeled resource leftovers
