### PR TITLE
fix(sso): separate internal backchannel callback

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -425,6 +425,9 @@ async def _bootstrap_standalone_sso(args: list[str]) -> int:
             product_admin_username=parsed.product_admin_username,
             product_admin_email=parsed.product_admin_email,
             product_admin_password=product_admin_password,
+            backchannel_logout_uri=(
+                settings.keycloak_backchannel_logout_uri_effective
+            ),
             upgrade_client_id=parsed.upgrade_client_id,
             upgrade_client_secret=upgrade_secret,
         )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -775,6 +775,11 @@ class Settings(BaseModel):
     # browser-facing authorization/logout endpoints always use
     # keycloak_server_url, so the `iss` claim stays the public URL.
     keycloak_internal_url: str = ""
+    # Exact AKB endpoint Keycloak calls for OIDC back-channel logout. This is
+    # an AKB callback, not a Keycloak endpoint: split-horizon deployments may
+    # need an in-cluster Service URL even though browser redirects use
+    # public_base_url. Blank preserves the public-origin default.
+    keycloak_backchannel_logout_uri: str = ""
     keycloak_realm: str = "akb"
     keycloak_client_id: str = "akb-web"
     keycloak_client_secret: str = ""  # secret.yaml — blank for public (PKCE) clients
@@ -1138,6 +1143,13 @@ class Settings(BaseModel):
     def keycloak_backchannel_logout_endpoint(self) -> str:
         """Server-to-Keycloak refresh-token revocation endpoint."""
         return f"{self._keycloak_backchannel_issuer}/protocol/openid-connect/logout"
+
+    @property
+    def keycloak_backchannel_logout_uri_effective(self) -> str:
+        """Exact AKB callback registered on the Keycloak browser client."""
+        if self.keycloak_backchannel_logout_uri:
+            return self.keycloak_backchannel_logout_uri
+        return f"{self.public_base_url.rstrip('/')}/api/v1/auth/keycloak/backchannel-logout"
 
     @property
     def keycloak_browser_redirect_uri(self) -> str:

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -211,6 +211,11 @@ CREATE TABLE IF NOT EXISTS standalone_sso_bootstrap_retirements (
     product_admin_subject TEXT NOT NULL
         CHECK (char_length(product_admin_subject) BETWEEN 1 AND 1024),
     akb_user_id UUID NOT NULL,
+    backchannel_logout_uri TEXT
+        CHECK (
+            backchannel_logout_uri IS NULL OR
+            char_length(backchannel_logout_uri) BETWEEN 1 AND 2048
+        ),
     retired_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/backend/app/db/migrations/075_sso_callback_receipt.py
+++ b/backend/app/db/migrations/075_sso_callback_receipt.py
@@ -1,0 +1,17 @@
+"""Bind current standalone SSO receipts to the effective callback URI."""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE standalone_sso_bootstrap_retirements
+                ADD COLUMN IF NOT EXISTS backchannel_logout_uri TEXT
+                    CHECK (
+                        backchannel_logout_uri IS NULL OR
+                        char_length(backchannel_logout_uri) BETWEEN 1 AND 2048
+                    )
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -257,6 +257,7 @@ async def _apply_migrations() -> None:
         "072_admin_browser_sessions.py",  # short-lived opaque sessions for the dedicated SSO admin client
         "073_sso_bootstrap_receipt.py",  # durable proof that the temporary bundled-Keycloak client was retired
         "074_sso_browser_sessions.py",  # encrypted ordinary-user SSO browser-session custody
+        "075_sso_callback_receipt.py",  # bind current SSO receipts to the effective back-channel callback
     ):
         if filename in applied:
             continue

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -38,6 +38,7 @@ from app.services.revision_backend import (
     canonical_document_revision_backend,
     selected_document_revision_backend,
 )
+from app.services.sso_callback_urls import is_backchannel_logout_uri
 from app.services.role_sync import RoleSync, get_role_sync, set_role_sync
 from app.services.user_sql_executor import UserSqlExecutor, set_user_sql_executor
 from app.services.vector_store import get_vector_store
@@ -157,6 +158,12 @@ def _validate_required_settings() -> None:
         if not _is_secure_browser_url(settings.keycloak_server_url):
             raise RuntimeError(
                 "auth_mode=sso requires an HTTPS public Keycloak URL; plain HTTP is allowed only on loopback"
+            )
+        if not is_backchannel_logout_uri(
+            settings.keycloak_backchannel_logout_uri_effective
+        ):
+            raise RuntimeError(
+                "auth_mode=sso requires an exact HTTP(S) AKB back-channel logout URI"
             )
     if auth_mode == "local":
         from app.services.local_session_keys import get_local_session_keyset

--- a/backend/app/services/sso_callback_urls.py
+++ b/backend/app/services/sso_callback_urls.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit
 
 BACKCHANNEL_LOGOUT_PATH = "/api/v1/auth/keycloak/backchannel-logout"
 _DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+_LEGACY_IPV4_COMPONENT_RE = re.compile(r"^(?:0x[0-9a-f]+|[0-9]+)$")
 
 
 def _is_callback_host(value: str) -> bool:
@@ -19,9 +20,12 @@ def _is_callback_host(value: str) -> bool:
         return False
     # Refuse IPv4-looking alternatives that different URL consumers may
     # normalize differently (for example, dotted octal or a short address).
-    if value.replace(".", "").isdigit():
+    labels = value.split(".")
+    if value.replace(".", "").isdigit() or (
+        1 <= len(labels) <= 4 and all(_LEGACY_IPV4_COMPONENT_RE.fullmatch(label) for label in labels)
+    ):
         return False
-    return all(_DNS_LABEL_RE.fullmatch(label) for label in value.split("."))
+    return all(_DNS_LABEL_RE.fullmatch(label) for label in labels)
 
 
 def _has_canonical_authority(value: str, hostname: str) -> bool:

--- a/backend/app/services/sso_callback_urls.py
+++ b/backend/app/services/sso_callback_urls.py
@@ -1,0 +1,75 @@
+"""Shared validation for server-facing SSO callback targets."""
+
+import ipaddress
+import re
+from urllib.parse import urlsplit
+
+
+BACKCHANNEL_LOGOUT_PATH = "/api/v1/auth/keycloak/backchannel-logout"
+_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+
+
+def _is_callback_host(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        pass
+    if ":" in value or value.endswith(".") or len(value) > 253:
+        return False
+    # Refuse IPv4-looking alternatives that different URL consumers may
+    # normalize differently (for example, dotted octal or a short address).
+    if value.replace(".", "").isdigit():
+        return False
+    return all(_DNS_LABEL_RE.fullmatch(label) for label in value.split("."))
+
+
+def _has_canonical_authority(value: str, hostname: str) -> bool:
+    authority = urlsplit(value).netloc
+    if authority.startswith("["):
+        closing = authority.find("]")
+        if closing < 0 or authority[1:closing] != hostname:
+            return False
+        suffix = authority[closing + 1 :]
+        return not suffix or (suffix.startswith(":") and len(suffix) > 1 and suffix[1:].isdigit())
+    if authority.count(":") > 1:
+        return False
+    authority_host, separator, port_text = authority.rpartition(":")
+    if not separator:
+        return authority == hostname
+    return authority_host == hostname and bool(port_text) and port_text.isdigit()
+
+
+def is_backchannel_logout_uri(value: str) -> bool:
+    """Accept only the exact HTTP(S) endpoint owned by AKB."""
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 2048
+        or not value.isascii()
+        or any(ord(character) <= 0x20 or ord(character) == 0x7F for character in value)
+        or "?" in value
+        or "#" in value
+        or "\\" in value
+    ):
+        return False
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except TypeError, ValueError:
+        return False
+    hostname = parsed.hostname
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.scheme == parsed.scheme.lower()
+        and hostname
+        and hostname == hostname.lower()
+        and _is_callback_host(hostname)
+        and _has_canonical_authority(value, hostname)
+        and parsed.username is None
+        and parsed.password is None
+        and (port is None or 1 <= port <= 65535)
+        and parsed.path == BACKCHANNEL_LOGOUT_PATH
+        and not parsed.query
+        and not parsed.fragment
+        and parsed.geturl() == value
+    )

--- a/backend/app/services/standalone_sso_bootstrap.py
+++ b/backend/app/services/standalone_sso_bootstrap.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass, field
 import re
 from typing import Protocol
 
+from app.services.sso_callback_urls import (
+    BACKCHANNEL_LOGOUT_PATH,
+    is_backchannel_logout_uri,
+)
+
 
 MANAGEMENT_REALM_ROLES = (
     "manage-identity-providers",
@@ -23,9 +28,11 @@ MANAGEMENT_REALM_ROLES = (
     "view-users",
 )
 STANDALONE_SSO_RECEIPT_PROFILE_V1 = "bundled-keycloak-v1"
-STANDALONE_SSO_RECEIPT_PROFILE = "bundled-keycloak-v2"
+STANDALONE_SSO_RECEIPT_PROFILE_V2 = "bundled-keycloak-v2"
+STANDALONE_SSO_RECEIPT_PROFILE = "bundled-keycloak-v3"
 STANDALONE_SSO_RECEIPT_PROFILES = (
     STANDALONE_SSO_RECEIPT_PROFILE,
+    STANDALONE_SSO_RECEIPT_PROFILE_V2,
     STANDALONE_SSO_RECEIPT_PROFILE_V1,
 )
 _BOOTSTRAP_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
@@ -56,6 +63,7 @@ class StandaloneSSOBootstrapSpec:
     product_admin_username: str
     product_admin_email: str
     product_admin_password: str = field(repr=False)
+    backchannel_logout_uri: str = ""
     upgrade_client_id: str = "akb-bootstrap-upgrade-v2"
     upgrade_client_secret: str = field(default="", repr=False)
 
@@ -65,14 +73,22 @@ class StandaloneSSOBootstrapSpec:
 
     @property
     def admin_redirect_uri(self) -> str:
-        return (
-            f"{self.akb_public_url.rstrip('/')}"
-            "/api/v1/admin/auth/keycloak/callback"
-        )
+        return f"{self.akb_public_url.rstrip('/')}/api/v1/admin/auth/keycloak/callback"
 
     @property
     def admin_post_logout_redirect_uri(self) -> str:
         return f"{self.akb_public_url.rstrip('/')}/admin"
+
+    @property
+    def backchannel_logout_uri_effective(self) -> str:
+        if self.backchannel_logout_uri:
+            return self.backchannel_logout_uri
+        return f"{self.akb_public_url.rstrip('/')}{BACKCHANNEL_LOGOUT_PATH}"
+
+    @property
+    def legacy_backchannel_logout_uri(self) -> str:
+        """Public callback encoded by the retired v1/v2 profiles."""
+        return f"{self.akb_public_url.rstrip('/')}{BACKCHANNEL_LOGOUT_PATH}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,7 +159,14 @@ class StandaloneSSOControl(Protocol):
         management_token: str,
     ) -> StandaloneSSOReadback: ...
 
-    async def upgrade_v1_to_v2(
+    async def readback_legacy_v2(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        management_token: str,
+    ) -> StandaloneSSOReadback: ...
+
+    async def upgrade_legacy_to_current(
         self,
         spec: StandaloneSSOBootstrapSpec,
         *,
@@ -180,12 +203,8 @@ class StandaloneSSOControl(Protocol):
 
 
 ProvisionAdmin = Callable[..., Awaitable[Mapping[str, object]]]
-LoadRetirementReceipt = Callable[
-    [], Awaitable[StandaloneSSORetirementReceipt | None]
-]
-RecordRetirementReceipt = Callable[
-    [StandaloneSSORetirementReceipt], Awaitable[None]
-]
+LoadRetirementReceipt = Callable[[], Awaitable[StandaloneSSORetirementReceipt | None]]
+RecordRetirementReceipt = Callable[[StandaloneSSORetirementReceipt], Awaitable[None]]
 
 
 def _validate_readback(readback: StandaloneSSOReadback) -> None:
@@ -252,20 +271,18 @@ def _validate_receipt_static_binding(
 ) -> None:
     if receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE_V1:
         expected_client_ids = {spec.bootstrap_client_id}
-    elif receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE:
+    elif receipt.profile in {
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
+        STANDALONE_SSO_RECEIPT_PROFILE,
+    }:
         expected_client_ids = {
             spec.bootstrap_client_id,
             spec.upgrade_client_id,
         }
     else:
         expected_client_ids = set()
-    if (
-        receipt.issuer != spec.issuer
-        or receipt.bootstrap_client_id not in expected_client_ids
-    ):
-        raise StandaloneSSOBootstrapError(
-            "keycloak_bootstrap_retirement_receipt_mismatch"
-        )
+    if receipt.issuer != spec.issuer or receipt.bootstrap_client_id not in expected_client_ids:
+        raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
 
 
 async def bootstrap_standalone_sso(
@@ -278,11 +295,7 @@ async def bootstrap_standalone_sso(
 ) -> dict[str, object]:
     """Converge one standalone SSO install without a recovery-credential gap."""
 
-    if (
-        not spec.realm
-        or spec.realm != spec.realm.strip()
-        or spec.realm.casefold() == "master"
-    ):
+    if not spec.realm or spec.realm != spec.realm.strip() or spec.realm.casefold() == "master":
         # The master realm owns emergency bootstrap authority. Treating it as
         # AKB's product realm would mutate Keycloak's control plane and could
         # make the subsequent exact-client retirement destructive.
@@ -293,94 +306,84 @@ async def bootstrap_standalone_sso(
         raise StandaloneSSOBootstrapError("keycloak_upgrade_client_id_invalid")
     if spec.bootstrap_client_id == spec.upgrade_client_id:
         raise StandaloneSSOBootstrapError("keycloak_one_time_client_ids_reused")
+    if not is_backchannel_logout_uri(spec.backchannel_logout_uri_effective):
+        raise StandaloneSSOBootstrapError("keycloak_backchannel_logout_uri_invalid")
 
     retirement_receipt = await load_retirement_receipt()
     if retirement_receipt is not None:
         _validate_receipt_static_binding(retirement_receipt, spec)
-    legacy_upgrade = (
-        retirement_receipt is not None
-        and retirement_receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE_V1
+    source_profile = retirement_receipt.profile if retirement_receipt else None
+    legacy_v1 = source_profile == STANDALONE_SSO_RECEIPT_PROFILE_V1
+    legacy_v2 = source_profile == STANDALONE_SSO_RECEIPT_PROFILE_V2
+    legacy_profile = legacy_v1 or legacy_v2
+    metadata_upgrade_required = legacy_v1 or (
+        legacy_v2 and spec.backchannel_logout_uri_effective != spec.legacy_backchannel_logout_uri
     )
 
     management_token = await control.acquire_management(spec)
     bootstrap_token = await control.acquire_bootstrap(spec)
     upgrade_token = (
-        await control.acquire_upgrade(spec)
-        if legacy_upgrade or spec.upgrade_client_secret
-        else None
+        await control.acquire_upgrade(spec) if metadata_upgrade_required or spec.upgrade_client_secret else None
     )
-    if (
-        management_token is None
-        and bootstrap_token is None
-        and upgrade_token is None
-    ):
-        raise StandaloneSSOBootstrapError(
-            "keycloak_install_credential_unavailable"
-        )
+    if management_token is None and bootstrap_token is None and upgrade_token is None:
+        raise StandaloneSSOBootstrapError("keycloak_install_credential_unavailable")
 
     if retirement_receipt is None:
         if bootstrap_token is None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_bootstrap_retirement_receipt_missing"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_missing")
         if upgrade_token is not None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_upgrade_client_unexpected"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_client_unexpected")
         if not spec.product_admin_password:
             # Validate the one-time recovery input before reconcile creates or
             # changes any realm resource. Readback and profile-upgrade runs do
             # not need the original product-admin password.
-            raise StandaloneSSOBootstrapError(
-                "keycloak_product_admin_password_unavailable"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_product_admin_password_unavailable")
         if (
             len(spec.product_admin_password) < 12
             or spec.product_admin_password == spec.product_admin_username
             or spec.product_admin_password == spec.product_admin_email
         ):
-            raise StandaloneSSOBootstrapError(
-                "keycloak_product_admin_password_policy"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_product_admin_password_policy")
         mode = "fresh" if management_token is None else "recovery"
         keycloak_mutated = True
         readback = await control.reconcile(
             spec,
             bootstrap_token=bootstrap_token,
         )
-    elif legacy_upgrade:
+    elif legacy_profile:
         if bootstrap_token is not None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_bootstrap_client_reactivated"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_client_reactivated")
         if management_token is None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_management_credential_unavailable"
-            )
-        if upgrade_token is None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_upgrade_credential_required"
-            )
-        mode = "upgrade-v1-to-v2"
+            raise StandaloneSSOBootstrapError("keycloak_management_credential_unavailable")
+        if metadata_upgrade_required and upgrade_token is None:
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_credential_required")
+        if not metadata_upgrade_required and upgrade_token is not None:
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_client_unexpected")
+        mode = (
+            "upgrade-v1-to-v3"
+            if legacy_v1
+            else ("upgrade-v2-to-v3" if metadata_upgrade_required else "upgrade-v2-to-v3-readback")
+        )
         keycloak_mutated = False
-        readback = await control.readback_legacy_v1(
-            spec,
-            management_token=management_token,
+        readback = await (
+            control.readback_legacy_v1(
+                spec,
+                management_token=management_token,
+            )
+            if legacy_v1
+            else control.readback_legacy_v2(
+                spec,
+                management_token=management_token,
+            )
         )
     else:
         if bootstrap_token is not None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_bootstrap_client_reactivated"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_client_reactivated")
         if upgrade_token is not None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_upgrade_client_reactivated"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_client_reactivated")
         mode = "readback"
         if management_token is None:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_management_credential_unavailable"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_management_credential_unavailable")
         keycloak_mutated = False
         readback = await control.readback(
             spec,
@@ -396,37 +399,34 @@ async def bootstrap_standalone_sso(
     )
     user_id = _validate_projection(projection)
 
-    if legacy_upgrade:
+    if legacy_profile:
         assert retirement_receipt is not None
         expected_legacy_receipt = _expected_retirement_receipt(
             spec,
             readback,
             akb_user_id=user_id,
-            profile=STANDALONE_SSO_RECEIPT_PROFILE_V1,
-            retired_client_id=spec.bootstrap_client_id,
+            profile=retirement_receipt.profile,
+            retired_client_id=retirement_receipt.bootstrap_client_id,
         )
         if retirement_receipt != expected_legacy_receipt:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_bootstrap_retirement_receipt_mismatch"
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
+        if metadata_upgrade_required:
+            assert upgrade_token is not None
+            upgraded_readback = await control.upgrade_legacy_to_current(
+                spec,
+                upgrade_token=upgrade_token,
             )
-        assert upgrade_token is not None
-        upgraded_readback = await control.upgrade_v1_to_v2(
-            spec,
-            upgrade_token=upgrade_token,
-        )
-        _validate_readback(upgraded_readback)
-        if upgraded_readback != readback:
-            raise StandaloneSSOBootstrapError("keycloak_upgrade_readback_changed")
-        readback = upgraded_readback
-        keycloak_mutated = True
+            _validate_readback(upgraded_readback)
+            if upgraded_readback != readback:
+                raise StandaloneSSOBootstrapError("keycloak_upgrade_readback_changed")
+            readback = upgraded_readback
+            keycloak_mutated = True
 
     # Re-authenticate through the permanent path after projection.  A client
     # merely present in a prior read-back is not yet a proven recovery path.
     permanent_token = await control.acquire_management(spec)
     if permanent_token is None:
-        raise StandaloneSSOBootstrapError(
-            "keycloak_management_credential_unavailable"
-        )
+        raise StandaloneSSOBootstrapError("keycloak_management_credential_unavailable")
     final_readback = await control.readback(
         spec,
         management_token=permanent_token,
@@ -441,11 +441,9 @@ async def bootstrap_standalone_sso(
         akb_user_id=user_id,
         retired_client_id=(
             spec.upgrade_client_id
-            if legacy_upgrade
+            if metadata_upgrade_required
             else (
-                retirement_receipt.bootstrap_client_id
-                if retirement_receipt is not None
-                else spec.bootstrap_client_id
+                retirement_receipt.bootstrap_client_id if retirement_receipt is not None else spec.bootstrap_client_id
             )
         ),
     )
@@ -462,10 +460,8 @@ async def bootstrap_standalone_sso(
         )
         await record_retirement_receipt(expected_receipt)
         if await load_retirement_receipt() != expected_receipt:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_bootstrap_retirement_receipt_write_failed"
-            )
-    elif legacy_upgrade:
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_write_failed")
+    elif legacy_profile and metadata_upgrade_required:
         assert upgrade_token is not None
         await control.retire_upgrade(
             spec,
@@ -477,13 +473,13 @@ async def bootstrap_standalone_sso(
         )
         await record_retirement_receipt(expected_receipt)
         if await load_retirement_receipt() != expected_receipt:
-            raise StandaloneSSOBootstrapError(
-                "keycloak_upgrade_retirement_receipt_write_failed"
-            )
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_retirement_receipt_write_failed")
+    elif legacy_profile:
+        await record_retirement_receipt(expected_receipt)
+        if await load_retirement_receipt() != expected_receipt:
+            raise StandaloneSSOBootstrapError("keycloak_profile_retirement_receipt_write_failed")
     elif retirement_receipt != expected_receipt:
-        raise StandaloneSSOBootstrapError(
-            "keycloak_bootstrap_retirement_receipt_mismatch"
-        )
+        raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
 
     created = projection.get("created")
     return {

--- a/backend/app/services/standalone_sso_bootstrap.py
+++ b/backend/app/services/standalone_sso_bootstrap.py
@@ -120,6 +120,7 @@ class StandaloneSSORetirementReceipt:
     api_client_uuid: str
     product_admin_subject: str
     akb_user_id: str
+    backchannel_logout_uri: str | None = None
 
 
 class StandaloneSSOControl(Protocol):
@@ -166,10 +167,26 @@ class StandaloneSSOControl(Protocol):
         management_token: str,
     ) -> StandaloneSSOReadback: ...
 
+    async def readback_callback_migration(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        source_backchannel_logout_uri: str,
+        management_token: str,
+    ) -> StandaloneSSOReadback: ...
+
     async def upgrade_legacy_to_current(
         self,
         spec: StandaloneSSOBootstrapSpec,
         *,
+        upgrade_token: str,
+    ) -> StandaloneSSOReadback: ...
+
+    async def upgrade_callback_to_current(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        source_backchannel_logout_uri: str,
         upgrade_token: str,
     ) -> StandaloneSSOReadback: ...
 
@@ -204,7 +221,15 @@ class StandaloneSSOControl(Protocol):
 
 ProvisionAdmin = Callable[..., Awaitable[Mapping[str, object]]]
 LoadRetirementReceipt = Callable[[], Awaitable[StandaloneSSORetirementReceipt | None]]
-RecordRetirementReceipt = Callable[[StandaloneSSORetirementReceipt], Awaitable[None]]
+
+
+class RecordRetirementReceipt(Protocol):
+    def __call__(
+        self,
+        receipt: StandaloneSSORetirementReceipt,
+        *,
+        previous_receipt: StandaloneSSORetirementReceipt | None = None,
+    ) -> Awaitable[None]: ...
 
 
 def _validate_readback(readback: StandaloneSSOReadback) -> None:
@@ -251,6 +276,7 @@ def _expected_retirement_receipt(
     akb_user_id: str,
     profile: str = STANDALONE_SSO_RECEIPT_PROFILE,
     retired_client_id: str | None = None,
+    backchannel_logout_uri: str | None = None,
 ) -> StandaloneSSORetirementReceipt:
     return StandaloneSSORetirementReceipt(
         profile=profile,
@@ -262,6 +288,11 @@ def _expected_retirement_receipt(
         api_client_uuid=readback.api_client_uuid,
         product_admin_subject=readback.product_admin_subject,
         akb_user_id=akb_user_id,
+        backchannel_logout_uri=(
+            backchannel_logout_uri
+            if backchannel_logout_uri is not None
+            else (spec.backchannel_logout_uri_effective if profile == STANDALONE_SSO_RECEIPT_PROFILE else None)
+        ),
     )
 
 
@@ -271,17 +302,32 @@ def _validate_receipt_static_binding(
 ) -> None:
     if receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE_V1:
         expected_client_ids = {spec.bootstrap_client_id}
-    elif receipt.profile in {
-        STANDALONE_SSO_RECEIPT_PROFILE_V2,
-        STANDALONE_SSO_RECEIPT_PROFILE,
-    }:
+    elif receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE_V2:
         expected_client_ids = {
             spec.bootstrap_client_id,
             spec.upgrade_client_id,
         }
+    elif receipt.profile == STANDALONE_SSO_RECEIPT_PROFILE:
+        expected_client_ids = {
+            spec.bootstrap_client_id,
+            spec.upgrade_client_id,
+        }
+        if receipt.backchannel_logout_uri is None or not is_backchannel_logout_uri(receipt.backchannel_logout_uri):
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
     else:
         expected_client_ids = set()
-    if receipt.issuer != spec.issuer or receipt.bootstrap_client_id not in expected_client_ids:
+    if (
+        receipt.issuer != spec.issuer
+        or receipt.bootstrap_client_id not in expected_client_ids
+        or (
+            receipt.profile
+            in {
+                STANDALONE_SSO_RECEIPT_PROFILE_V1,
+                STANDALONE_SSO_RECEIPT_PROFILE_V2,
+            }
+            and receipt.backchannel_logout_uri is not None
+        )
+    ):
         raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
 
 
@@ -316,14 +362,23 @@ async def bootstrap_standalone_sso(
     legacy_v1 = source_profile == STANDALONE_SSO_RECEIPT_PROFILE_V1
     legacy_v2 = source_profile == STANDALONE_SSO_RECEIPT_PROFILE_V2
     legacy_profile = legacy_v1 or legacy_v2
-    metadata_upgrade_required = legacy_v1 or (
+    legacy_mutation_required = legacy_v1 or (
         legacy_v2 and spec.backchannel_logout_uri_effective != spec.legacy_backchannel_logout_uri
     )
+    source_callback_uri: str | None = None
+    if source_profile == STANDALONE_SSO_RECEIPT_PROFILE:
+        assert retirement_receipt is not None
+        assert retirement_receipt.backchannel_logout_uri is not None
+        source_callback_uri = retirement_receipt.backchannel_logout_uri
+    callback_migration_required = (
+        source_callback_uri is not None and source_callback_uri != spec.backchannel_logout_uri_effective
+    )
+    mutation_upgrade_required = legacy_mutation_required or callback_migration_required
 
     management_token = await control.acquire_management(spec)
     bootstrap_token = await control.acquire_bootstrap(spec)
     upgrade_token = (
-        await control.acquire_upgrade(spec) if metadata_upgrade_required or spec.upgrade_client_secret else None
+        await control.acquire_upgrade(spec) if mutation_upgrade_required or spec.upgrade_client_secret else None
     )
     if management_token is None and bootstrap_token is None and upgrade_token is None:
         raise StandaloneSSOBootstrapError("keycloak_install_credential_unavailable")
@@ -355,14 +410,14 @@ async def bootstrap_standalone_sso(
             raise StandaloneSSOBootstrapError("keycloak_bootstrap_client_reactivated")
         if management_token is None:
             raise StandaloneSSOBootstrapError("keycloak_management_credential_unavailable")
-        if metadata_upgrade_required and upgrade_token is None:
+        if legacy_mutation_required and upgrade_token is None:
             raise StandaloneSSOBootstrapError("keycloak_upgrade_credential_required")
-        if not metadata_upgrade_required and upgrade_token is not None:
+        if not legacy_mutation_required and upgrade_token is not None:
             raise StandaloneSSOBootstrapError("keycloak_upgrade_client_unexpected")
         mode = (
             "upgrade-v1-to-v3"
             if legacy_v1
-            else ("upgrade-v2-to-v3" if metadata_upgrade_required else "upgrade-v2-to-v3-readback")
+            else ("upgrade-v2-to-v3" if legacy_mutation_required else "upgrade-v2-to-v3-readback")
         )
         keycloak_mutated = False
         readback = await (
@@ -375,6 +430,21 @@ async def bootstrap_standalone_sso(
                 spec,
                 management_token=management_token,
             )
+        )
+    elif callback_migration_required:
+        if bootstrap_token is not None:
+            raise StandaloneSSOBootstrapError("keycloak_bootstrap_client_reactivated")
+        if management_token is None:
+            raise StandaloneSSOBootstrapError("keycloak_management_credential_unavailable")
+        if upgrade_token is None:
+            raise StandaloneSSOBootstrapError("keycloak_upgrade_credential_required")
+        assert source_callback_uri is not None
+        mode = "upgrade-v3-callback"
+        keycloak_mutated = False
+        readback = await control.readback_callback_migration(
+            spec,
+            source_backchannel_logout_uri=source_callback_uri,
+            management_token=management_token,
         )
     else:
         if bootstrap_token is not None:
@@ -399,21 +469,35 @@ async def bootstrap_standalone_sso(
     )
     user_id = _validate_projection(projection)
 
-    if legacy_profile:
+    if legacy_profile or callback_migration_required:
         assert retirement_receipt is not None
-        expected_legacy_receipt = _expected_retirement_receipt(
+        expected_source_receipt = _expected_retirement_receipt(
             spec,
             readback,
             akb_user_id=user_id,
             profile=retirement_receipt.profile,
             retired_client_id=retirement_receipt.bootstrap_client_id,
+            backchannel_logout_uri=retirement_receipt.backchannel_logout_uri,
         )
-        if retirement_receipt != expected_legacy_receipt:
+        if retirement_receipt != expected_source_receipt:
             raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
-        if metadata_upgrade_required:
+        if legacy_mutation_required:
             assert upgrade_token is not None
             upgraded_readback = await control.upgrade_legacy_to_current(
                 spec,
+                upgrade_token=upgrade_token,
+            )
+            _validate_readback(upgraded_readback)
+            if upgraded_readback != readback:
+                raise StandaloneSSOBootstrapError("keycloak_upgrade_readback_changed")
+            readback = upgraded_readback
+            keycloak_mutated = True
+        elif callback_migration_required:
+            assert upgrade_token is not None
+            assert source_callback_uri is not None
+            upgraded_readback = await control.upgrade_callback_to_current(
+                spec,
+                source_backchannel_logout_uri=source_callback_uri,
                 upgrade_token=upgrade_token,
             )
             _validate_readback(upgraded_readback)
@@ -441,7 +525,7 @@ async def bootstrap_standalone_sso(
         akb_user_id=user_id,
         retired_client_id=(
             spec.upgrade_client_id
-            if metadata_upgrade_required
+            if mutation_upgrade_required
             else (
                 retirement_receipt.bootstrap_client_id if retirement_receipt is not None else spec.bootstrap_client_id
             )
@@ -461,7 +545,7 @@ async def bootstrap_standalone_sso(
         await record_retirement_receipt(expected_receipt)
         if await load_retirement_receipt() != expected_receipt:
             raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_write_failed")
-    elif legacy_profile and metadata_upgrade_required:
+    elif mutation_upgrade_required:
         assert upgrade_token is not None
         await control.retire_upgrade(
             spec,
@@ -471,7 +555,10 @@ async def bootstrap_standalone_sso(
             spec,
             upgrade_token=upgrade_token,
         )
-        await record_retirement_receipt(expected_receipt)
+        await record_retirement_receipt(
+            expected_receipt,
+            previous_receipt=(retirement_receipt if callback_migration_required else None),
+        )
         if await load_retirement_receipt() != expected_receipt:
             raise StandaloneSSOBootstrapError("keycloak_upgrade_retirement_receipt_write_failed")
     elif legacy_profile:

--- a/backend/app/services/standalone_sso_keycloak.py
+++ b/backend/app/services/standalone_sso_keycloak.py
@@ -1279,7 +1279,8 @@ class KeycloakStandaloneSSOControl:
         *,
         management_token: str,
         require_identity_provider_mapper: bool,
-        legacy_backchannel_logout: bool,
+        source_backchannel_logout_uri: str | None,
+        allow_current_backchannel_logout: bool,
     ) -> StandaloneSSOReadback:
         realm = await self._realm(spec, token=management_token)
         if realm is None or not self._realm_matches(spec, realm):
@@ -1290,7 +1291,7 @@ class KeycloakStandaloneSSOControl:
             (
                 self._api_client(
                     spec,
-                    backchannel_logout_uri=(spec.legacy_backchannel_logout_uri if legacy_backchannel_logout else None),
+                    backchannel_logout_uri=source_backchannel_logout_uri,
                 ),
                 "api",
             ),
@@ -1310,7 +1311,7 @@ class KeycloakStandaloneSSOControl:
                 actual,
                 expected,
             )
-            if not matches and actual is not None and role == "api" and legacy_backchannel_logout:
+            if not matches and actual is not None and role == "api" and allow_current_backchannel_logout:
                 # A crash after the one-time authority updated the client but
                 # before receipt persistence must converge on retry. Accept
                 # only the exact source or exact target representation.
@@ -1451,7 +1452,8 @@ class KeycloakStandaloneSSOControl:
             spec,
             management_token=management_token,
             require_identity_provider_mapper=True,
-            legacy_backchannel_logout=False,
+            source_backchannel_logout_uri=None,
+            allow_current_backchannel_logout=False,
         )
 
     async def readback_legacy_v1(
@@ -1464,7 +1466,8 @@ class KeycloakStandaloneSSOControl:
             spec,
             management_token=management_token,
             require_identity_provider_mapper=False,
-            legacy_backchannel_logout=True,
+            source_backchannel_logout_uri=spec.legacy_backchannel_logout_uri,
+            allow_current_backchannel_logout=True,
         )
 
     async def readback_legacy_v2(
@@ -1477,7 +1480,23 @@ class KeycloakStandaloneSSOControl:
             spec,
             management_token=management_token,
             require_identity_provider_mapper=True,
-            legacy_backchannel_logout=True,
+            source_backchannel_logout_uri=spec.legacy_backchannel_logout_uri,
+            allow_current_backchannel_logout=True,
+        )
+
+    async def readback_callback_migration(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        source_backchannel_logout_uri: str,
+        management_token: str,
+    ) -> StandaloneSSOReadback:
+        return await self._readback(
+            spec,
+            management_token=management_token,
+            require_identity_provider_mapper=True,
+            source_backchannel_logout_uri=source_backchannel_logout_uri,
+            allow_current_backchannel_logout=True,
         )
 
     async def upgrade_legacy_to_current(
@@ -1515,6 +1534,38 @@ class KeycloakStandaloneSSOControl:
             spec,
             api_uuid,
             self._api_identity_provider_mapper(),
+            token=upgrade_token,
+        )
+        return await self.readback(
+            spec,
+            management_token=upgrade_token,
+        )
+
+    async def upgrade_callback_to_current(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        source_backchannel_logout_uri: str,
+        upgrade_token: str,
+    ) -> StandaloneSSOReadback:
+        expected_source = self._api_client(
+            spec,
+            backchannel_logout_uri=source_backchannel_logout_uri,
+        )
+        api = await self._exact_client(
+            spec,
+            spec.realm,
+            spec.api_client_id,
+            token=upgrade_token,
+        )
+        if api is None or not (
+            self._selected_client_matches(api, expected_source)
+            or self._selected_client_matches(api, self._api_client(spec))
+        ):
+            raise _fail("keycloak_client_readback_failed")
+        await self._reconcile_client(
+            spec,
+            self._api_client(spec),
             token=upgrade_token,
         )
         return await self.readback(

--- a/backend/app/services/standalone_sso_keycloak.py
+++ b/backend/app/services/standalone_sso_keycloak.py
@@ -392,7 +392,11 @@ class KeycloakStandaloneSSOControl:
         return readback
 
     @staticmethod
-    def _api_client(spec: StandaloneSSOBootstrapSpec) -> dict[str, Any]:
+    def _api_client(
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        backchannel_logout_uri: str | None = None,
+    ) -> dict[str, Any]:
         return {
             "clientId": spec.api_client_id,
             "name": "AKB browser and API",
@@ -418,7 +422,9 @@ class KeycloakStandaloneSSOControl:
                 "pkce.code.challenge.method": "S256",
                 "post.logout.redirect.uris": f"{spec.akb_public_url.rstrip('/')}/*",
                 "backchannel.logout.url": (
-                    f"{spec.akb_public_url.rstrip('/')}/api/v1/auth/keycloak/backchannel-logout"
+                    backchannel_logout_uri
+                    if backchannel_logout_uri is not None
+                    else spec.backchannel_logout_uri_effective
                 ),
                 "backchannel.logout.session.required": "true",
             },
@@ -1273,6 +1279,7 @@ class KeycloakStandaloneSSOControl:
         *,
         management_token: str,
         require_identity_provider_mapper: bool,
+        legacy_backchannel_logout: bool,
     ) -> StandaloneSSOReadback:
         realm = await self._realm(spec, token=management_token)
         if realm is None or not self._realm_matches(spec, realm):
@@ -1280,7 +1287,13 @@ class KeycloakStandaloneSSOControl:
         realm_id = _required_string(realm, "id", "keycloak_realm_readback_failed")
 
         expected_clients = (
-            (self._api_client(spec), "api"),
+            (
+                self._api_client(
+                    spec,
+                    backchannel_logout_uri=(spec.legacy_backchannel_logout_uri if legacy_backchannel_logout else None),
+                ),
+                "api",
+            ),
             (self._admin_client(spec), "admin"),
             (self._management_client(spec), "management"),
         )
@@ -1293,8 +1306,21 @@ class KeycloakStandaloneSSOControl:
                 client_id,
                 token=management_token,
             )
-            if actual is None or not self._selected_client_matches(actual, expected):
+            matches = actual is not None and self._selected_client_matches(
+                actual,
+                expected,
+            )
+            if not matches and actual is not None and role == "api" and legacy_backchannel_logout:
+                # A crash after the one-time authority updated the client but
+                # before receipt persistence must converge on retry. Accept
+                # only the exact source or exact target representation.
+                matches = self._selected_client_matches(
+                    actual,
+                    self._api_client(spec),
+                )
+            if not matches:
                 raise _fail("keycloak_client_readback_failed")
+            assert actual is not None
             clients[role] = actual
         api_uuid = _required_string(clients["api"], "id", "keycloak_client_readback_failed")
         admin_uuid = _required_string(
@@ -1425,6 +1451,7 @@ class KeycloakStandaloneSSOControl:
             spec,
             management_token=management_token,
             require_identity_provider_mapper=True,
+            legacy_backchannel_logout=False,
         )
 
     async def readback_legacy_v1(
@@ -1437,24 +1464,53 @@ class KeycloakStandaloneSSOControl:
             spec,
             management_token=management_token,
             require_identity_provider_mapper=False,
+            legacy_backchannel_logout=True,
         )
 
-    async def upgrade_v1_to_v2(
+    async def readback_legacy_v2(
+        self,
+        spec: StandaloneSSOBootstrapSpec,
+        *,
+        management_token: str,
+    ) -> StandaloneSSOReadback:
+        return await self._readback(
+            spec,
+            management_token=management_token,
+            require_identity_provider_mapper=True,
+            legacy_backchannel_logout=True,
+        )
+
+    async def upgrade_legacy_to_current(
         self,
         spec: StandaloneSSOBootstrapSpec,
         *,
         upgrade_token: str,
     ) -> StandaloneSSOReadback:
-        expected_api = self._api_client(spec)
+        expected_api = self._api_client(
+            spec,
+            backchannel_logout_uri=spec.legacy_backchannel_logout_uri,
+        )
         api = await self._exact_client(
             spec,
             spec.realm,
             spec.api_client_id,
             token=upgrade_token,
         )
-        if api is None or not self._selected_client_matches(api, expected_api):
+        if api is None or not (
+            self._selected_client_matches(api, expected_api)
+            or self._selected_client_matches(api, self._api_client(spec))
+        ):
             raise _fail("keycloak_client_readback_failed")
-        api_uuid = _required_string(api, "id", "keycloak_client_readback_failed")
+        reconciled = await self._reconcile_client(
+            spec,
+            self._api_client(spec),
+            token=upgrade_token,
+        )
+        api_uuid = _required_string(
+            reconciled,
+            "id",
+            "keycloak_client_readback_failed",
+        )
         await self._reconcile_mapper(
             spec,
             api_uuid,

--- a/backend/app/services/standalone_sso_receipt.py
+++ b/backend/app/services/standalone_sso_receipt.py
@@ -11,6 +11,7 @@ from app.services.standalone_sso_bootstrap import (
     StandaloneSSOBootstrapError,
     StandaloneSSORetirementReceipt,
 )
+from app.services.sso_callback_urls import is_backchannel_logout_uri
 
 
 # Stable signed-bigint key ("AKBSSORP") serializes the singleton receipt write.
@@ -19,16 +20,14 @@ _RECEIPT_LOCK_ID = 0x414B4253534F5250
 _SELECT_RECEIPT = """
     SELECT profile, issuer, realm_id, bootstrap_client_id,
            management_client_uuid, admin_client_uuid, api_client_uuid,
-           product_admin_subject, akb_user_id
+           product_admin_subject, akb_user_id, backchannel_logout_uri
       FROM standalone_sso_bootstrap_retirements
      WHERE profile = $1
 """
 
 
 def _error() -> StandaloneSSOBootstrapError:
-    return StandaloneSSOBootstrapError(
-        "keycloak_bootstrap_retirement_receipt_mismatch"
-    )
+    return StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_mismatch")
 
 
 def _validated_user_id(receipt: StandaloneSSORetirementReceipt) -> uuid.UUID:
@@ -42,13 +41,16 @@ def _validated_user_id(receipt: StandaloneSSORetirementReceipt) -> uuid.UUID:
         receipt.product_admin_subject,
         receipt.akb_user_id,
     )
-    if receipt.profile != STANDALONE_SSO_RECEIPT_PROFILE or any(
-        not value.strip() for value in fields
+    if (
+        receipt.profile != STANDALONE_SSO_RECEIPT_PROFILE
+        or any(not value.strip() for value in fields)
+        or receipt.backchannel_logout_uri is None
+        or not is_backchannel_logout_uri(receipt.backchannel_logout_uri)
     ):
         raise _error()
     try:
         return uuid.UUID(receipt.akb_user_id)
-    except (ValueError, AttributeError):
+    except ValueError, AttributeError:
         raise _error() from None
 
 
@@ -63,11 +65,28 @@ def _from_row(row) -> StandaloneSSORetirementReceipt:
         api_client_uuid=row["api_client_uuid"],
         product_admin_subject=row["product_admin_subject"],
         akb_user_id=str(row["akb_user_id"]),
+        backchannel_logout_uri=row["backchannel_logout_uri"],
     )
 
 
-async def load_standalone_sso_retirement_receipt(
-) -> StandaloneSSORetirementReceipt | None:
+def _same_installation(
+    source: StandaloneSSORetirementReceipt,
+    target: StandaloneSSORetirementReceipt,
+) -> bool:
+    return (
+        source.profile == target.profile == STANDALONE_SSO_RECEIPT_PROFILE
+        and source.issuer == target.issuer
+        and source.realm_id == target.realm_id
+        and source.management_client_uuid == target.management_client_uuid
+        and source.admin_client_uuid == target.admin_client_uuid
+        and source.api_client_uuid == target.api_client_uuid
+        and source.product_admin_subject == target.product_admin_subject
+        and source.akb_user_id == target.akb_user_id
+        and source.backchannel_logout_uri != target.backchannel_logout_uri
+    )
+
+
+async def load_standalone_sso_retirement_receipt() -> StandaloneSSORetirementReceipt | None:
     pool = await get_pool()
     async with pool.acquire() as conn:
         for profile in STANDALONE_SSO_RECEIPT_PROFILES:
@@ -82,10 +101,14 @@ async def load_standalone_sso_retirement_receipt(
 
 async def record_standalone_sso_retirement_receipt(
     receipt: StandaloneSSORetirementReceipt,
+    *,
+    previous_receipt: StandaloneSSORetirementReceipt | None = None,
 ) -> None:
-    """Insert once after verified deletion; never replace conflicting proof."""
+    """Insert once, or replace one exact current callback receipt by CAS."""
 
     akb_user_id = _validated_user_id(receipt)
+    if previous_receipt is not None:
+        _validated_user_id(previous_receipt)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
@@ -98,16 +121,61 @@ async def record_standalone_sso_retirement_receipt(
                 STANDALONE_SSO_RECEIPT_PROFILE,
             )
             if existing is not None:
-                if _from_row(existing) != receipt:
+                current = _from_row(existing)
+                if current == receipt:
+                    return
+                if (
+                    previous_receipt is None
+                    or current != previous_receipt
+                    or not _same_installation(previous_receipt, receipt)
+                ):
+                    raise _error()
+                update_result = await conn.execute(
+                    """
+                    UPDATE standalone_sso_bootstrap_retirements
+                       SET issuer = $2,
+                           realm_id = $3,
+                           bootstrap_client_id = $4,
+                           management_client_uuid = $5,
+                           admin_client_uuid = $6,
+                           api_client_uuid = $7,
+                           product_admin_subject = $8,
+                           akb_user_id = $9,
+                           backchannel_logout_uri = $10,
+                           retired_at = NOW()
+                     WHERE profile = $1
+                       AND backchannel_logout_uri = $11
+                    """,
+                    receipt.profile,
+                    receipt.issuer,
+                    receipt.realm_id,
+                    receipt.bootstrap_client_id,
+                    receipt.management_client_uuid,
+                    receipt.admin_client_uuid,
+                    receipt.api_client_uuid,
+                    receipt.product_admin_subject,
+                    akb_user_id,
+                    receipt.backchannel_logout_uri,
+                    previous_receipt.backchannel_logout_uri,
+                )
+                if update_result != "UPDATE 1":
+                    raise _error()
+                updated = await conn.fetchrow(
+                    _SELECT_RECEIPT,
+                    STANDALONE_SSO_RECEIPT_PROFILE,
+                )
+                if updated is None or _from_row(updated) != receipt:
                     raise _error()
                 return
+            if previous_receipt is not None:
+                raise _error()
             await conn.execute(
                 """
                 INSERT INTO standalone_sso_bootstrap_retirements (
                     profile, issuer, realm_id, bootstrap_client_id,
                     management_client_uuid, admin_client_uuid, api_client_uuid,
-                    product_admin_subject, akb_user_id
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                    product_admin_subject, akb_user_id, backchannel_logout_uri
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 """,
                 receipt.profile,
                 receipt.issuer,
@@ -118,4 +186,5 @@ async def record_standalone_sso_retirement_receipt(
                 receipt.api_client_uuid,
                 receipt.product_admin_subject,
                 akb_user_id,
+                receipt.backchannel_logout_uri,
             )

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -397,6 +397,9 @@ def test_sso_backchannel_logout_uri_defaults_public_and_rejects_non_callback_tar
         "http://backend:8000/api/v1/auth/keycloak/backchannel-logout?redirect=unsafe",
         "file:///api/v1/auth/keycloak/backchannel-logout",
         "http://user@backend:8000/api/v1/auth/keycloak/backchannel-logout",
+        "http://0x7f000001/api/v1/auth/keycloak/backchannel-logout",
+        "http://0x7f.0x0.0x0.0x1/api/v1/auth/keycloak/backchannel-logout",
+        "http://0x7f.0.0.1/api/v1/auth/keycloak/backchannel-logout",
     ):
         configured = _load(
             monkeypatch,
@@ -406,6 +409,17 @@ def test_sso_backchannel_logout_uri_defaults_public_and_rejects_non_callback_tar
         monkeypatch.setattr(lifecycle, "settings", configured)
         with pytest.raises(RuntimeError, match="back-channel logout URI"):
             lifecycle._validate_required_settings()
+
+    dns_host = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            **common,
+            "keycloak_backchannel_logout_uri": ("http://0x7f.example.com:8000/api/v1/auth/keycloak/backchannel-logout"),
+        },
+    )
+    monkeypatch.setattr(lifecycle, "settings", dns_host)
+    lifecycle._validate_required_settings()
 
 
 def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -349,18 +349,63 @@ def test_sso_admin_client_is_dedicated_and_callback_is_deployment_bound(
             "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
             "db_password": "test-db-password",  # pragma: allowlist secret
             "public_base_url": "https://akb.example.com",
+            "keycloak_backchannel_logout_uri": ("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
         },
     )
     monkeypatch.setattr(lifecycle, "settings", loaded)
 
     lifecycle._validate_required_settings()
-    assert loaded.keycloak_admin_redirect_uri == (
-        "https://akb.example.com/api/v1/admin/auth/keycloak/callback"
-    )
-    assert loaded.keycloak_admin_post_logout_redirect_uri == (
-        "https://akb.example.com/admin"
+    assert loaded.keycloak_admin_redirect_uri == ("https://akb.example.com/api/v1/admin/auth/keycloak/callback")
+    assert loaded.keycloak_admin_post_logout_redirect_uri == ("https://akb.example.com/admin")
+    assert loaded.keycloak_backchannel_logout_uri_effective == (
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
     )
     assert "akb-admin" not in loaded.keycloak_human_client_ids
+
+
+def test_sso_backchannel_logout_uri_defaults_public_and_rejects_non_callback_targets(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from app.services import lifecycle
+
+    common = {
+        "auth_mode": "sso",
+        "keycloak_enabled": True,
+        "keycloak_server_url": "https://auth.example.com",
+        "keycloak_client_id": "akb-web",
+        "keycloak_admin_client_id": "akb-admin",
+        "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+        "system_hmac_secret": "test-system-hmac-secret",  # pragma: allowlist secret
+        "db_password": "test-db-password",  # pragma: allowlist secret
+        "public_base_url": "https://akb.example.com",
+    }
+    defaulted = _load(monkeypatch, tmp_path, common)
+    monkeypatch.setattr(lifecycle, "settings", defaulted)
+    lifecycle._validate_required_settings()
+    assert defaulted.keycloak_backchannel_logout_uri_effective == (
+        "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"
+    )
+
+    for invalid in (
+        "\nhttp://backend:8000/api/v1/auth/keycloak/backchannel-logout",
+        "http://back end:8000/api/v1/auth/keycloak/backchannel-logout",
+        "http://backend:/api/v1/auth/keycloak/backchannel-logout",
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout?",
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout#",
+        "http://backend:8000/wrong",
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout?redirect=unsafe",
+        "file:///api/v1/auth/keycloak/backchannel-logout",
+        "http://user@backend:8000/api/v1/auth/keycloak/backchannel-logout",
+    ):
+        configured = _load(
+            monkeypatch,
+            tmp_path,
+            {**common, "keycloak_backchannel_logout_uri": invalid},
+        )
+        monkeypatch.setattr(lifecycle, "settings", configured)
+        with pytest.raises(RuntimeError, match="back-channel logout URI"):
+            lifecycle._validate_required_settings()
 
 
 def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -34,7 +34,7 @@ def _dsn_for_database(dsn: str, database: str) -> str:
 async def _can_connect(dsn: str) -> bool:
     try:
         conn = await asyncpg.connect(dsn, timeout=2.0)
-    except (OSError, asyncpg.PostgresError):
+    except OSError, asyncpg.PostgresError:
         return False
     await conn.close()
     return True
@@ -69,8 +69,7 @@ async def _fresh_database():
         if pool is not None:
             await pool.close()
         await admin.execute(
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-            "WHERE datname = $1 AND pid <> pg_backend_pid()",
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
             database,
         )
         await admin.execute(f'DROP DATABASE "{database}"')
@@ -454,9 +453,7 @@ async def test_migration_upgrades_old_schema_and_is_idempotent(services):
 
     async with pool.acquire() as conn:
         await conn.execute("DROP INDEX users_one_recovery_admin")
-        await conn.execute(
-            "ALTER TABLE users DROP CONSTRAINT users_recovery_admin_requires_admin"
-        )
+        await conn.execute("ALTER TABLE users DROP CONSTRAINT users_recovery_admin_requires_admin")
         await conn.execute("ALTER TABLE users DROP COLUMN is_recovery_admin")
         await conn.execute("ALTER TABLE external_identities DROP COLUMN username_snapshot")
 
@@ -542,9 +539,13 @@ async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(
     async with pool.acquire() as conn:
         await conn.execute("DROP TABLE standalone_sso_bootstrap_retirements")
         migration = _load_migration("073_sso_bootstrap_receipt.py")
+        callback_migration = _load_migration("075_sso_callback_receipt.py")
         assert migration is not None
+        assert callback_migration is not None
         await migration.migrate(conn)
         await migration.migrate(conn)
+        await callback_migration.migrate(conn)
+        await callback_migration.migrate(conn)
 
     async def _get_pool():
         return pool
@@ -560,6 +561,7 @@ async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(
         api_client_uuid="api-client-uuid",
         product_admin_subject="00000000-0000-4000-8000-000000000001",
         akb_user_id="11111111-1111-4111-8111-111111111111",
+        backchannel_logout_uri=("https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"),
     )
 
     assert await receipt_service.load_standalone_sso_retirement_receipt() is None
@@ -567,12 +569,21 @@ async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(
     await receipt_service.record_standalone_sso_retirement_receipt(expected)
     assert await receipt_service.load_standalone_sso_retirement_receipt() == expected
 
+    migrated = replace(
+        expected,
+        bootstrap_client_id="akb-bootstrap-upgrade-v2",
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+    )
+    await receipt_service.record_standalone_sso_retirement_receipt(
+        migrated,
+        previous_receipt=expected,
+    )
+    assert await receipt_service.load_standalone_sso_retirement_receipt() == migrated
+
     with pytest.raises(StandaloneSSOBootstrapError):
         await receipt_service.record_standalone_sso_retirement_receipt(
-            replace(expected, issuer="https://other.example.com/realms/akb")
+            replace(migrated, issuer="https://other.example.com/realms/akb")
         )
 
     async with pool.acquire() as conn:
-        assert await conn.fetchval(
-            "SELECT COUNT(*) FROM standalone_sso_bootstrap_retirements"
-        ) == 1
+        assert await conn.fetchval("SELECT COUNT(*) FROM standalone_sso_bootstrap_retirements") == 1

--- a/backend/tests/test_standalone_sso_bootstrap_unit.py
+++ b/backend/tests/test_standalone_sso_bootstrap_unit.py
@@ -140,9 +140,14 @@ class _Control:
         self.events.append("readback-keycloak-v1")
         return self._readback
 
-    async def upgrade_v1_to_v2(self, _spec, *, upgrade_token: str):
+    async def readback_legacy_v2(self, _spec, *, management_token: str):
+        assert management_token == "manager-token"
+        self.events.append("readback-keycloak-v2")
+        return self._readback
+
+    async def upgrade_legacy_to_current(self, _spec, *, upgrade_token: str):
         assert upgrade_token == "upgrade-token"
-        self.events.append("upgrade-keycloak-v1-to-v2")
+        self.events.append("upgrade-keycloak-to-current")
         return self._readback
 
     async def retire_bootstrap(self, _spec, *, bootstrap_token: str):
@@ -321,7 +326,7 @@ async def test_legacy_v1_receipt_uses_one_time_upgrade_authority_then_retires_it
         "acquire-upgrade",
         "readback-keycloak-v1",
         "provision-akb-admin",
-        "upgrade-keycloak-v1-to-v2",
+        "upgrade-keycloak-to-current",
         "acquire-management",
         "readback-keycloak",
         "retire-upgrade",
@@ -332,10 +337,138 @@ async def test_legacy_v1_receipt_uses_one_time_upgrade_authority_then_retires_it
     assert receipts.receipt == _receipt(
         retired_client_id=_spec().upgrade_client_id,
     )
-    assert report["mode"] == "upgrade-v1-to-v2"
+    assert report["mode"] == "upgrade-v1-to-v3"
     assert report["keycloak_mutated"] is True
-    assert report["receipt_profile"] == "bundled-keycloak-v2"
+    assert report["receipt_profile"] == "bundled-keycloak-v3"
     assert control.upgrade_available is False
+
+
+async def test_legacy_v2_public_callback_promotes_receipt_without_mutation_authority():
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(
+        control.events,
+        _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V2),
+    )
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    report = await bootstrap_standalone_sso(
+        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert control.events == [
+        "load-retirement-receipt",
+        "acquire-management",
+        "acquire-bootstrap",
+        "readback-keycloak-v2",
+        "provision-akb-admin",
+        "acquire-management",
+        "readback-keycloak",
+        "record-retirement-receipt",
+        "load-retirement-receipt",
+    ]
+    assert receipts.receipt == _receipt()
+    assert report["mode"] == "upgrade-v2-to-v3-readback"
+    assert report["keycloak_mutated"] is False
+    assert report["receipt_profile"] == "bundled-keycloak-v3"
+
+
+async def test_legacy_v2_internal_callback_uses_bounded_upgrade_authority():
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(
+        manager_available=True,
+        bootstrap_available=False,
+        upgrade_available=True,
+    )
+    receipts = _ReceiptStore(
+        control.events,
+        _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V2),
+    )
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    report = await bootstrap_standalone_sso(
+        replace(
+            _spec(),
+            bootstrap_client_secret="",
+            product_admin_password="",
+            backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+            upgrade_client_secret=_UPGRADE_SECRET,
+        ),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert "readback-keycloak-v2" in control.events
+    assert "upgrade-keycloak-to-current" in control.events
+    assert "retire-upgrade" in control.events
+    assert report["mode"] == "upgrade-v2-to-v3"
+    assert report["keycloak_mutated"] is True
+    assert report["receipt_profile"] == "bundled-keycloak-v3"
+
+
+async def test_legacy_v2_internal_callback_without_authority_fails_before_projection():
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(
+        control.events,
+        _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V2),
+    )
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("metadata migration requires its bounded authority")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(
+                _spec(),
+                bootstrap_client_secret="",
+                product_admin_password="",
+                backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+            ),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_upgrade_credential_required"
+    assert "provision-akb-admin" not in control.events
+    assert "upgrade-keycloak-to-current" not in control.events
 
 
 async def test_legacy_v1_receipt_without_upgrade_authority_fails_before_mutation():
@@ -369,7 +502,7 @@ async def test_legacy_v1_receipt_without_upgrade_authority_fails_before_mutation
         )
 
     assert captured.value.code == "keycloak_upgrade_credential_required"
-    assert "upgrade-keycloak-v1-to-v2" not in control.events
+    assert "upgrade-keycloak-to-current" not in control.events
     assert "provision-akb-admin" not in control.events
 
 
@@ -397,9 +530,7 @@ async def test_partial_bootstrap_uses_remaining_temp_admin_then_retires_it():
     )
 
     assert "reconcile-keycloak" in control.events
-    assert control.events.index("retire-bootstrap") > control.events.index(
-        "provision-akb-admin"
-    )
+    assert control.events.index("retire-bootstrap") > control.events.index("provision-akb-admin")
     assert report["mode"] == "recovery"
 
 
@@ -497,6 +628,31 @@ async def test_invalid_bootstrap_client_id_stops_before_external_calls():
         )
 
     assert captured.value.code == "keycloak_bootstrap_client_id_invalid"
+    assert control.events == []
+
+
+async def test_invalid_backchannel_logout_uri_stops_before_external_calls():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=False, bootstrap_available=True)
+    receipts = _ReceiptStore(control.events)
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("invalid callback must fail before reconciliation")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(_spec(), backchannel_logout_uri="http://backend:8000/wrong"),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_backchannel_logout_uri_invalid"
     assert control.events == []
 
 

--- a/backend/tests/test_standalone_sso_bootstrap_unit.py
+++ b/backend/tests/test_standalone_sso_bootstrap_unit.py
@@ -84,9 +84,10 @@ def _receipt(
         StandaloneSSORetirementReceipt,
     )
 
+    selected_profile = profile or STANDALONE_SSO_RECEIPT_PROFILE
     readback = _readback()
     return StandaloneSSORetirementReceipt(
-        profile=profile or STANDALONE_SSO_RECEIPT_PROFILE,
+        profile=selected_profile,
         issuer=_spec().issuer,
         realm_id=readback.realm_id,
         bootstrap_client_id=retired_client_id or _spec().bootstrap_client_id,
@@ -95,6 +96,9 @@ def _receipt(
         api_client_uuid=readback.api_client_uuid,
         product_admin_subject=readback.product_admin_subject,
         akb_user_id=user_id,
+        backchannel_logout_uri=(
+            _spec().backchannel_logout_uri_effective if selected_profile == STANDALONE_SSO_RECEIPT_PROFILE else None
+        ),
     )
 
 
@@ -105,10 +109,13 @@ class _Control:
         manager_available: bool,
         bootstrap_available: bool,
         upgrade_available: bool = False,
+        callback_uri: str | None = None,
     ):
         self.manager_available = manager_available
         self.bootstrap_available = bootstrap_available
         self.upgrade_available = upgrade_available
+        self.callback_uri = callback_uri or _spec().backchannel_logout_uri_effective
+        self.crash_after_callback_update = False
         self.events: list[str] = []
         self._readback = _readback()
 
@@ -124,30 +131,75 @@ class _Control:
         self.events.append("acquire-upgrade")
         return "upgrade-token" if self.upgrade_available else None
 
-    async def reconcile(self, _spec, *, bootstrap_token: str):
+    async def reconcile(self, spec, *, bootstrap_token: str):
         assert bootstrap_token == "bootstrap-token"
         self.events.append("reconcile-keycloak")
         self.manager_available = True
+        self.callback_uri = spec.backchannel_logout_uri_effective
         return self._readback
 
-    async def readback(self, _spec, *, management_token: str):
+    async def readback(self, spec, *, management_token: str):
         assert management_token == "manager-token"
+        assert self.callback_uri == spec.backchannel_logout_uri_effective
         self.events.append("readback-keycloak")
         return self._readback
 
-    async def readback_legacy_v1(self, _spec, *, management_token: str):
+    async def readback_legacy_v1(self, spec, *, management_token: str):
         assert management_token == "manager-token"
+        assert self.callback_uri in {
+            spec.legacy_backchannel_logout_uri,
+            spec.backchannel_logout_uri_effective,
+        }
         self.events.append("readback-keycloak-v1")
         return self._readback
 
-    async def readback_legacy_v2(self, _spec, *, management_token: str):
+    async def readback_legacy_v2(self, spec, *, management_token: str):
         assert management_token == "manager-token"
+        assert self.callback_uri in {
+            spec.legacy_backchannel_logout_uri,
+            spec.backchannel_logout_uri_effective,
+        }
         self.events.append("readback-keycloak-v2")
         return self._readback
 
-    async def upgrade_legacy_to_current(self, _spec, *, upgrade_token: str):
+    async def readback_callback_migration(
+        self,
+        spec,
+        *,
+        source_backchannel_logout_uri: str,
+        management_token: str,
+    ):
+        assert management_token == "manager-token"
+        assert self.callback_uri in {
+            source_backchannel_logout_uri,
+            spec.backchannel_logout_uri_effective,
+        }
+        self.events.append("readback-keycloak-callback-migration")
+        return self._readback
+
+    async def upgrade_legacy_to_current(self, spec, *, upgrade_token: str):
         assert upgrade_token == "upgrade-token"
         self.events.append("upgrade-keycloak-to-current")
+        self.callback_uri = spec.backchannel_logout_uri_effective
+        return self._readback
+
+    async def upgrade_callback_to_current(
+        self,
+        spec,
+        *,
+        source_backchannel_logout_uri: str,
+        upgrade_token: str,
+    ):
+        assert upgrade_token == "upgrade-token"
+        assert self.callback_uri in {
+            source_backchannel_logout_uri,
+            spec.backchannel_logout_uri_effective,
+        }
+        self.events.append("upgrade-keycloak-callback-to-current")
+        self.callback_uri = spec.backchannel_logout_uri_effective
+        if self.crash_after_callback_update:
+            self.crash_after_callback_update = False
+            raise RuntimeError("simulated crash after callback update")
         return self._readback
 
     async def retire_bootstrap(self, _spec, *, bootstrap_token: str):
@@ -180,8 +232,10 @@ class _ReceiptStore:
         self.events.append("load-retirement-receipt")
         return self.receipt
 
-    async def record(self, receipt):
+    async def record(self, receipt, *, previous_receipt=None):
         self.events.append("record-retirement-receipt")
+        if previous_receipt is not None:
+            assert self.receipt == previous_receipt
         self.receipt = receipt
 
 
@@ -387,6 +441,119 @@ async def test_legacy_v2_public_callback_promotes_receipt_without_mutation_autho
     assert report["mode"] == "upgrade-v2-to-v3-readback"
     assert report["keycloak_mutated"] is False
     assert report["receipt_profile"] == "bundled-keycloak-v3"
+
+
+async def test_v2_readback_promotion_preserves_later_exact_callback_migration_retry():
+    from app.services.standalone_sso_bootstrap import (
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
+        bootstrap_standalone_sso,
+    )
+
+    public_uri = _spec().backchannel_logout_uri_effective
+    internal_uri = "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(
+        control.events,
+        _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V2),
+    )
+
+    async def _provision(**_kwargs):
+        control.events.append("provision-akb-admin")
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": False,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
+
+    promoted = await bootstrap_standalone_sso(
+        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert promoted["mode"] == "upgrade-v2-to-v3-readback"
+    assert receipts.receipt.backchannel_logout_uri == public_uri
+
+    migration_spec = replace(
+        _spec(),
+        bootstrap_client_secret="",
+        product_admin_password="",
+        backchannel_logout_uri=internal_uri,
+        upgrade_client_secret=_UPGRADE_SECRET,
+    )
+    control.upgrade_available = True
+    control.crash_after_callback_update = True
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        await bootstrap_standalone_sso(
+            migration_spec,
+            control=control,
+            provision_admin=_provision,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert control.callback_uri == internal_uri
+    assert control.upgrade_available is True
+    assert receipts.receipt.backchannel_logout_uri == public_uri
+
+    report = await bootstrap_standalone_sso(
+        migration_spec,
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+
+    assert report["mode"] == "upgrade-v3-callback"
+    assert report["keycloak_mutated"] is True
+    assert control.upgrade_available is False
+    assert receipts.receipt.backchannel_logout_uri == internal_uri
+    assert receipts.receipt.bootstrap_client_id == migration_spec.upgrade_client_id
+    assert control.events.count("upgrade-keycloak-callback-to-current") == 2
+
+    settled = await bootstrap_standalone_sso(
+        migration_spec,
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
+    )
+    assert settled["mode"] == "readback"
+    assert settled["keycloak_mutated"] is False
+
+
+async def test_v3_callback_migration_without_one_time_authority_fails_closed():
+    from app.services.standalone_sso_bootstrap import (
+        StandaloneSSOBootstrapError,
+        bootstrap_standalone_sso,
+    )
+
+    control = _Control(manager_available=True, bootstrap_available=False)
+    receipts = _ReceiptStore(control.events, _receipt())
+
+    async def _should_not_run(**_kwargs):
+        raise AssertionError("callback migration requires bounded authority")
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await bootstrap_standalone_sso(
+            replace(
+                _spec(),
+                bootstrap_client_secret="",
+                product_admin_password="",
+                backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+            ),
+            control=control,
+            provision_admin=_should_not_run,
+            load_retirement_receipt=receipts.load,
+            record_retirement_receipt=receipts.record,
+        )
+
+    assert captured.value.code == "keycloak_upgrade_credential_required"
+    assert "readback-keycloak-callback-migration" not in control.events
 
 
 async def test_legacy_v2_internal_callback_uses_bounded_upgrade_authority():

--- a/backend/tests/test_standalone_sso_cli_unit.py
+++ b/backend/tests/test_standalone_sso_cli_unit.py
@@ -43,6 +43,9 @@ def _patch_sso_settings(monkeypatch) -> None:
         "keycloak_enabled": True,
         "keycloak_server_url": "https://auth.akb.example.com",
         "keycloak_internal_url": "http://keycloak:8080",
+        "keycloak_backchannel_logout_uri": (
+            "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
+        ),
         "keycloak_realm": "akb",
         "keycloak_client_id": "akb-web",
         "keycloak_client_secret": _API_SECRET,
@@ -157,6 +160,9 @@ async def test_bootstrap_cli_reads_only_secret_files_and_emits_allowlisted_repor
     assert spec.management_client_secret == _MANAGEMENT_SECRET
     assert spec.api_client_secret == _API_SECRET
     assert spec.admin_client_secret == _ADMIN_SECRET
+    assert spec.backchannel_logout_uri == (
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
+    )
     assert observed["verify_ssl"] is True
     assert observed["closed"] is True
     assert callable(observed["load_retirement_receipt"])

--- a/backend/tests/test_standalone_sso_deployment_unit.py
+++ b/backend/tests/test_standalone_sso_deployment_unit.py
@@ -23,8 +23,7 @@ def _one(name: str, *, kind: str, resource_name: str | None) -> dict:
     matches = [
         item
         for item in _documents(name)
-        if item.get("kind") == kind
-        and item.get("metadata", {}).get("name") == resource_name
+        if item.get("kind") == kind and item.get("metadata", {}).get("name") == resource_name
     ]
     assert len(matches) == 1
     return matches[0]
@@ -54,26 +53,15 @@ def test_overlay_owns_dedicated_keycloak_and_database_without_committed_secrets(
         kind="StatefulSet",
         resource_name="keycloak-postgres",
     )
-    assert keycloak["spec"]["template"]["spec"]["containers"][0]["image"].count(
-        "@sha256:"
-    ) == 1
-    assert keycloak_postgres["spec"]["template"]["spec"]["containers"][0][
-        "image"
-    ].count("@sha256:") == 1
+    assert keycloak["spec"]["template"]["spec"]["containers"][0]["image"].count("@sha256:") == 1
+    assert keycloak_postgres["spec"]["template"]["spec"]["containers"][0]["image"].count("@sha256:") == 1
 
 
 def test_keycloak_bootstrap_secret_is_required_for_first_boot_and_not_a_human_admin():
     keycloak = _one("keycloak.yaml", kind="StatefulSet", resource_name="keycloak")
-    env = {
-        item["name"]: item
-        for item in keycloak["spec"]["template"]["spec"]["containers"][0]["env"]
-    }
-    assert env["KC_BOOTSTRAP_ADMIN_CLIENT_ID"]["value"] == (
-        "akb-bootstrap-temporary"
-    )
-    reference = env["KC_BOOTSTRAP_ADMIN_CLIENT_SECRET"]["valueFrom"][
-        "secretKeyRef"
-    ]
+    env = {item["name"]: item for item in keycloak["spec"]["template"]["spec"]["containers"][0]["env"]}
+    assert env["KC_BOOTSTRAP_ADMIN_CLIENT_ID"]["value"] == ("akb-bootstrap-temporary")
+    reference = env["KC_BOOTSTRAP_ADMIN_CLIENT_SECRET"]["valueFrom"]["secretKeyRef"]
     assert reference == {
         "name": "akb-keycloak-bootstrap",
         "key": "client-secret",
@@ -116,18 +104,18 @@ def test_backend_patch_removes_local_key_authority_and_mounts_one_time_inputs_on
     assert "--upgrade-client-secret-file" in init["args"]
 
 
-def test_legacy_v1_upgrade_job_is_explicit_opt_in_and_uses_temporary_service_admin():
+def test_legacy_profile_upgrade_job_is_explicit_opt_in_and_uses_temporary_service_admin():
     kustomization = _one(
         "kustomization.yaml",
         kind="Kustomization",
         resource_name=None,
     )
-    assert "legacy-v1-upgrade-job.yaml" not in kustomization["resources"]
+    assert "legacy-profile-upgrade-job.yaml" not in kustomization["resources"]
 
     job = _one(
-        "legacy-v1-upgrade-job.yaml",
+        "legacy-profile-upgrade-job.yaml",
         kind="Job",
-        resource_name="akb-keycloak-v1-to-v2-authority",
+        resource_name="akb-keycloak-profile-upgrade-authority",
     )
     container = job["spec"]["template"]["spec"]["containers"][0]
     assert container["image"].count("@sha256:") == 1
@@ -136,9 +124,7 @@ def test_legacy_v1_upgrade_job_is_explicit_opt_in_and_uses_temporary_service_adm
     assert "akb-bootstrap-upgrade-v2" in container["args"]
     assert "--client-secret:env=AKB_KEYCLOAK_UPGRADE_SECRET" in container["args"]
     secret_refs = [
-        item["valueFrom"]["secretKeyRef"]
-        for item in container["env"]
-        if "secretKeyRef" in item.get("valueFrom", {})
+        item["valueFrom"]["secretKeyRef"] for item in container["env"] if "secretKeyRef" in item.get("valueFrom", {})
     ]
     assert {
         "name": "akb-keycloak-upgrade",
@@ -166,6 +152,7 @@ def test_sso_runtime_config_has_one_mode_and_three_distinct_confidential_clients
     }
     assert clients == {"akb-web", "akb-admin", "akb-sso-manager"}
     assert config["keycloak_internal_url"] == "http://keycloak:8080"
+    assert config["keycloak_backchannel_logout_uri"] == ("http://backend:8000/api/v1/auth/keycloak/backchannel-logout")
     assert config["keycloak_server_url"].startswith("https://")
 
 

--- a/backend/tests/test_standalone_sso_keycloak_unit.py
+++ b/backend/tests/test_standalone_sso_keycloak_unit.py
@@ -107,9 +107,13 @@ async def test_upgrade_authority_authenticates_only_against_master_realm():
         await control.aclose()
 
 
-async def test_v1_upgrade_mutates_only_the_signed_provider_mapper(monkeypatch):
+async def test_legacy_upgrade_updates_api_client_and_signed_provider_mapper(monkeypatch):
     control = KeycloakStandaloneSSOControl()
-    spec = replace(_spec(), upgrade_client_secret=_SECRETS[5])
+    spec = replace(
+        _spec(),
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+        upgrade_client_secret=_SECRETS[5],
+    )
     events: list[tuple[str, object]] = []
     expected_readback = object()
 
@@ -121,15 +125,20 @@ async def test_v1_upgrade_mutates_only_the_signed_provider_mapper(monkeypatch):
         events.append(("reconcile-mapper", (client_uuid, desired, token)))
         return desired
 
+    async def _reconcile_client(_spec, desired, *, token):
+        events.append(("reconcile-client", (desired, token)))
+        return {**desired, "id": "api-client-uuid"}
+
     async def _readback(_spec, *, management_token):
         events.append(("readback", management_token))
         return expected_readback
 
     monkeypatch.setattr(control, "_exact_client", _exact_client)
+    monkeypatch.setattr(control, "_reconcile_client", _reconcile_client)
     monkeypatch.setattr(control, "_reconcile_mapper", _reconcile_mapper)
     monkeypatch.setattr(control, "readback", _readback)
 
-    result = await control.upgrade_v1_to_v2(
+    result = await control.upgrade_legacy_to_current(
         spec,
         upgrade_token="opaque-upgrade-token",  # pragma: allowlist secret
     )
@@ -137,10 +146,16 @@ async def test_v1_upgrade_mutates_only_the_signed_provider_mapper(monkeypatch):
     assert result is expected_readback
     assert [name for name, _value in events] == [
         "exact-client",
+        "reconcile-client",
         "reconcile-mapper",
         "readback",
     ]
-    client_uuid, desired, token = events[1][1]
+    desired_client, client_token = events[1][1]
+    assert desired_client["attributes"]["backchannel.logout.url"] == (
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
+    )
+    assert client_token == "opaque-upgrade-token"  # pragma: allowlist secret
+    client_uuid, desired, token = events[2][1]
     assert client_uuid == "api-client-uuid"
     assert desired == control._api_identity_provider_mapper()  # noqa: SLF001
     assert token == "opaque-upgrade-token"  # pragma: allowlist secret
@@ -623,7 +638,10 @@ async def test_realm_sets_a_lean_product_admin_password_policy_from_creation():
 
 
 async def test_client_profiles_separate_user_admin_and_management_authorities():
-    spec = _spec()
+    spec = replace(
+        _spec(),
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+    )
     api = KeycloakStandaloneSSOControl._api_client(spec)  # noqa: SLF001
     admin = KeycloakStandaloneSSOControl._admin_client(spec)  # noqa: SLF001
     management = KeycloakStandaloneSSOControl._management_client(spec)  # noqa: SLF001
@@ -638,7 +656,7 @@ async def test_client_profiles_separate_user_admin_and_management_authorities():
     assert api["attributes"]["pkce.code.challenge.method"] == "S256"
     assert api["frontchannelLogout"] is False
     assert api["attributes"]["backchannel.logout.url"] == (
-        "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout"
     )
     assert api["attributes"]["backchannel.logout.session.required"] == "true"
     assert admin["attributes"]["pkce.code.challenge.method"] == "S256"
@@ -648,6 +666,14 @@ async def test_client_profiles_separate_user_admin_and_management_authorities():
     assert management["serviceAccountsEnabled"] is True
     assert management["defaultClientScopes"] == ["service_account"]
     assert management["redirectUris"] == []
+
+
+async def test_api_client_defaults_backchannel_logout_to_the_public_origin():
+    api = KeycloakStandaloneSSOControl._api_client(_spec())  # noqa: SLF001
+
+    assert api["attributes"]["backchannel.logout.url"] == (
+        "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"
+    )
 
 
 async def test_api_client_maps_signed_broker_provenance_into_both_token_profiles():

--- a/backend/tests/test_standalone_sso_keycloak_unit.py
+++ b/backend/tests/test_standalone_sso_keycloak_unit.py
@@ -161,6 +161,95 @@ async def test_legacy_upgrade_updates_api_client_and_signed_provider_mapper(monk
     assert token == "opaque-upgrade-token"  # pragma: allowlist secret
 
 
+@pytest.mark.parametrize(
+    "actual_callback",
+    [
+        "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout",
+        "http://backend:8000/api/v1/auth/keycloak/backchannel-logout",
+    ],
+)
+async def test_callback_upgrade_accepts_only_exact_receipt_source_or_target(
+    monkeypatch,
+    actual_callback: str,
+):
+    control = KeycloakStandaloneSSOControl()
+    source_callback = "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"
+    spec = replace(
+        _spec(),
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+        upgrade_client_secret=_SECRETS[5],
+    )
+    reconciled: list[dict[str, object]] = []
+    expected_readback = object()
+
+    async def _exact_client(_spec, _realm, _client_id, *, token):
+        assert token == "opaque-upgrade-token"  # pragma: allowlist secret
+        return {
+            **control._api_client(  # noqa: SLF001
+                spec,
+                backchannel_logout_uri=actual_callback,
+            ),
+            "id": "api-client-uuid",
+        }
+
+    async def _reconcile_client(_spec, desired, *, token):
+        assert token == "opaque-upgrade-token"  # pragma: allowlist secret
+        reconciled.append(desired)
+        return {**desired, "id": "api-client-uuid"}
+
+    async def _readback(_spec, *, management_token):
+        assert management_token == "opaque-upgrade-token"  # pragma: allowlist secret
+        return expected_readback
+
+    monkeypatch.setattr(control, "_exact_client", _exact_client)
+    monkeypatch.setattr(control, "_reconcile_client", _reconcile_client)
+    monkeypatch.setattr(control, "readback", _readback)
+
+    result = await control.upgrade_callback_to_current(
+        spec,
+        source_backchannel_logout_uri=source_callback,
+        upgrade_token="opaque-upgrade-token",  # pragma: allowlist secret
+    )
+
+    assert result is expected_readback
+    assert len(reconciled) == 1
+    assert reconciled[0]["attributes"]["backchannel.logout.url"] == (spec.backchannel_logout_uri_effective)
+
+
+async def test_callback_upgrade_rejects_callback_outside_receipt_transition(monkeypatch):
+    control = KeycloakStandaloneSSOControl()
+    spec = replace(
+        _spec(),
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+        upgrade_client_secret=_SECRETS[5],
+    )
+
+    async def _exact_client(_spec, _realm, _client_id, *, token):
+        assert token == "opaque-upgrade-token"  # pragma: allowlist secret
+        return {
+            **control._api_client(  # noqa: SLF001
+                spec,
+                backchannel_logout_uri=("https://other.example.com/api/v1/auth/keycloak/backchannel-logout"),
+            ),
+            "id": "api-client-uuid",
+        }
+
+    async def _should_not_reconcile(*_args, **_kwargs):
+        raise AssertionError("callback drift must not be reconciled")
+
+    monkeypatch.setattr(control, "_exact_client", _exact_client)
+    monkeypatch.setattr(control, "_reconcile_client", _should_not_reconcile)
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await control.upgrade_callback_to_current(
+            spec,
+            source_backchannel_logout_uri=("https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"),
+            upgrade_token="opaque-upgrade-token",  # pragma: allowlist secret
+        )
+
+    assert captured.value.code == "keycloak_client_readback_failed"
+
+
 async def test_keycloak_internal_base_path_is_preserved():
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/auth/realms/master/protocol/openid-connect/token"

--- a/backend/tests/test_standalone_sso_receipt_unit.py
+++ b/backend/tests/test_standalone_sso_receipt_unit.py
@@ -10,14 +10,19 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-def _receipt(*, profile: str | None = None):
+def _receipt(
+    *,
+    profile: str | None = None,
+    backchannel_logout_uri: str | None = None,
+):
     from app.services.standalone_sso_bootstrap import (
         STANDALONE_SSO_RECEIPT_PROFILE,
         StandaloneSSORetirementReceipt,
     )
 
+    selected_profile = profile or STANDALONE_SSO_RECEIPT_PROFILE
     return StandaloneSSORetirementReceipt(
-        profile=profile or STANDALONE_SSO_RECEIPT_PROFILE,
+        profile=selected_profile,
         issuer="https://auth.akb.example.com/realms/akb",
         realm_id="akb-realm-id",
         bootstrap_client_id="akb-bootstrap-temporary",
@@ -26,6 +31,15 @@ def _receipt(*, profile: str | None = None):
         api_client_uuid="api-client-uuid",
         product_admin_subject="00000000-0000-4000-8000-000000000001",
         akb_user_id="11111111-1111-4111-8111-111111111111",
+        backchannel_logout_uri=(
+            backchannel_logout_uri
+            if backchannel_logout_uri is not None
+            else (
+                "https://akb.example.com/api/v1/auth/keycloak/backchannel-logout"
+                if selected_profile == STANDALONE_SSO_RECEIPT_PROFILE
+                else None
+            )
+        ),
     )
 
 
@@ -48,23 +62,30 @@ class _Connection:
     async def execute(self, sql: str, *args):
         if "pg_advisory_xact_lock" in sql:
             return "SELECT 1"
-        assert "INSERT INTO standalone_sso_bootstrap_retirements" in sql
+        assert (
+            "INSERT INTO standalone_sso_bootstrap_retirements" in sql
+            or "UPDATE standalone_sso_bootstrap_retirements" in sql
+        )
         self.writes += 1
         profile = args[0]
-        if profile not in self.rows:
-            fields = (
-                "profile",
-                "issuer",
-                "realm_id",
-                "bootstrap_client_id",
-                "management_client_uuid",
-                "admin_client_uuid",
-                "api_client_uuid",
-                "product_admin_subject",
-                "akb_user_id",
-            )
+        fields = (
+            "profile",
+            "issuer",
+            "realm_id",
+            "bootstrap_client_id",
+            "management_client_uuid",
+            "admin_client_uuid",
+            "api_client_uuid",
+            "product_admin_subject",
+            "akb_user_id",
+            "backchannel_logout_uri",
+        )
+        if "UPDATE" in sql:
+            assert self.rows[profile]["backchannel_logout_uri"] == args[-1]
+            self.rows[profile] = dict(zip(fields, args[: len(fields)], strict=True))
+        elif profile not in self.rows:
             self.rows[profile] = dict(zip(fields, args, strict=True))
-        return "INSERT 0 1"
+        return "UPDATE 1" if "UPDATE" in sql else "INSERT 0 1"
 
     async def fetchrow(self, sql: str, profile: str):
         assert "FROM standalone_sso_bootstrap_retirements" in sql
@@ -115,6 +136,41 @@ async def test_receipt_round_trip_is_exact_idempotent_and_conflict_safe(monkeypa
     assert conn.writes == 1
 
 
+async def test_current_callback_receipt_replacement_is_an_exact_compare_and_swap(monkeypatch):
+    from app.services import standalone_sso_receipt as service
+    from app.services.standalone_sso_bootstrap import StandaloneSSOBootstrapError
+
+    conn = _Connection()
+
+    async def _get_pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(service, "get_pool", _get_pool)
+    source = _receipt()
+    target = replace(
+        source,
+        bootstrap_client_id="akb-bootstrap-upgrade-v2",
+        backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
+    )
+    await service.record_standalone_sso_retirement_receipt(source)
+    await service.record_standalone_sso_retirement_receipt(
+        target,
+        previous_receipt=source,
+    )
+
+    assert await service.load_standalone_sso_retirement_receipt() == target
+
+    with pytest.raises(StandaloneSSOBootstrapError) as captured:
+        await service.record_standalone_sso_retirement_receipt(
+            replace(target, backchannel_logout_uri=source.backchannel_logout_uri),
+            previous_receipt=source,
+        )
+
+    assert captured.value.code == "keycloak_bootstrap_retirement_receipt_mismatch"
+    assert await service.load_standalone_sso_retirement_receipt() == target
+    assert conn.writes == 2
+
+
 async def test_loader_prefers_current_v3_then_v2_then_v1(monkeypatch):
     from app.services import standalone_sso_receipt as service
     from app.services.standalone_sso_bootstrap import (
@@ -138,6 +194,7 @@ async def test_loader_prefers_current_v3_then_v2_then_v1(monkeypatch):
             "api_client_uuid": receipt.api_client_uuid,
             "product_admin_subject": receipt.product_admin_subject,
             "akb_user_id": receipt.akb_user_id,
+            "backchannel_logout_uri": receipt.backchannel_logout_uri,
         }
 
     for receipt in (legacy, v2, current):
@@ -163,8 +220,12 @@ async def test_receipt_schema_is_present_for_fresh_and_upgraded_databases():
     backend = Path(__file__).resolve().parents[1]
     init_sql = (backend / "app" / "db" / "init.sql").read_text()
     migration = backend / "app" / "db" / "migrations" / "073_sso_bootstrap_receipt.py"
+    callback_migration = backend / "app" / "db" / "migrations" / "075_sso_callback_receipt.py"
     registry = (backend / "app" / "db" / "postgres.py").read_text()
 
     assert "CREATE TABLE IF NOT EXISTS standalone_sso_bootstrap_retirements" in init_sql
+    assert "backchannel_logout_uri TEXT" in init_sql
     assert migration.is_file()
+    assert callback_migration.is_file()
     assert '"073_sso_bootstrap_receipt.py"' in registry
+    assert '"075_sso_callback_receipt.py"' in registry

--- a/backend/tests/test_standalone_sso_receipt_unit.py
+++ b/backend/tests/test_standalone_sso_receipt_unit.py
@@ -108,23 +108,23 @@ async def test_receipt_round_trip_is_exact_idempotent_and_conflict_safe(monkeypa
     await service.record_standalone_sso_retirement_receipt(expected)
 
     with pytest.raises(StandaloneSSOBootstrapError) as captured:
-        await service.record_standalone_sso_retirement_receipt(
-            replace(expected, realm_id="other-realm-id")
-        )
+        await service.record_standalone_sso_retirement_receipt(replace(expected, realm_id="other-realm-id"))
 
     assert captured.value.code == "keycloak_bootstrap_retirement_receipt_mismatch"
     assert await service.load_standalone_sso_retirement_receipt() == expected
     assert conn.writes == 1
 
 
-async def test_loader_reads_legacy_v1_until_current_v2_receipt_exists(monkeypatch):
+async def test_loader_prefers_current_v3_then_v2_then_v1(monkeypatch):
     from app.services import standalone_sso_receipt as service
     from app.services.standalone_sso_bootstrap import (
         STANDALONE_SSO_RECEIPT_PROFILE_V1,
+        STANDALONE_SSO_RECEIPT_PROFILE_V2,
     )
 
     conn = _Connection()
     legacy = _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V1)
+    v2 = _receipt(profile=STANDALONE_SSO_RECEIPT_PROFILE_V2)
     current = _receipt()
 
     def _row(receipt):
@@ -140,7 +140,7 @@ async def test_loader_reads_legacy_v1_until_current_v2_receipt_exists(monkeypatc
             "akb_user_id": receipt.akb_user_id,
         }
 
-    for receipt in (legacy, current):
+    for receipt in (legacy, v2, current):
         conn.rows[receipt.profile] = _row(receipt)
 
     async def _get_pool():
@@ -148,6 +148,9 @@ async def test_loader_reads_legacy_v1_until_current_v2_receipt_exists(monkeypatc
 
     monkeypatch.setattr(service, "get_pool", _get_pool)
     del conn.rows[current.profile]
+    assert await service.load_standalone_sso_retirement_receipt() == v2
+
+    del conn.rows[v2.profile]
     assert await service.load_standalone_sso_retirement_receipt() == legacy
 
     conn.rows[current.profile] = _row(current)

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -200,6 +200,8 @@ app_credential_overlap_seconds: 300
 # keycloak_enrollment_mode: open           # open | invite_only | disabled
 # keycloak_server_url: "https://auth.example.com"   # no /realms suffix; HTTPS outside loopback
 # keycloak_internal_url: ""          # optional backchannel URL (server→Keycloak); blank → use server_url
+# keycloak_backchannel_logout_uri: "" # Keycloak→AKB callback; blank → public_base_url callback.
+#                                       # In Kubernetes, use the exact backend Service URL.
 # keycloak_realm: "akb"
 # keycloak_client_id: "akb-web"
 # keycloak_public_client: false      # true → no client_secret; both profiles require PKCE

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -110,7 +110,7 @@ pod's `bootstrap-standalone-sso` init container and main container to complete,
 then inspect the init log. Its JSON report contains only IDs, key metadata, and
 the exact role names; it never contains credential values.
 
-## Upgrade an existing v1 or v2 receipt
+## Upgrade an existing receipt
 
 An installation that already recorded `bundled-keycloak-v1` retired its
 original master-realm bootstrap client before the signed broker-provenance
@@ -122,10 +122,13 @@ change either client resource cannot widen the manager's standing authority.
 If a v2 installation keeps the same public callback (the effective setting is
 still `https://<public-akb>/api/v1/auth/keycloak/backchannel-logout`), the init
 container proves the exact v2 and v3 read-backs and promotes the durable receipt
-without mutation or an upgrade credential. It reports
-`mode=upgrade-v2-to-v3-readback`. A v1 receipt always needs the one-time
+without mutation or an upgrade credential. The v3 receipt retains that effective
+callback, so a later callback change remains an exact, supported migration. It
+reports `mode=upgrade-v2-to-v3-readback`. A v1 receipt always needs the one-time
 authority to add the mapper. A v2 receipt needs it only when moving to a
-different callback, including this overlay's in-cluster backend URL.
+different callback, including this overlay's in-cluster backend URL. A v3
+receipt needs the same bounded authority when its recorded callback differs
+from the newly configured callback.
 
 Before rolling this version onto such an installation, create exactly one
 temporary upgrade service account named `akb-bootstrap-upgrade-v2`. Keycloak's
@@ -154,16 +157,18 @@ kubectl -n akb rollout status statefulset/keycloak --timeout=300s
 ```
 
 Then deploy the new AKB overlay. Its init container must report
-`mode=upgrade-v1-to-v3` or `mode=upgrade-v2-to-v3` and
+`mode=upgrade-v1-to-v3`, `mode=upgrade-v2-to-v3`, or
+`mode=upgrade-v3-callback` and
 `receipt_profile=bundled-keycloak-v3`. The lifecycle first validates the exact
-legacy read-back using the permanent manager, reconciles only the `akb-web`
-client metadata and signed broker-provenance mapper, revalidates the complete
+receipt-bound source read-back using the permanent manager, reconciles only the
+`akb-web` client metadata and, when required, signed broker-provenance mapper,
+revalidates the complete
 v3 profile through the permanent manager, deletes the temporary upgrade client,
 proves both its old and newly requested tokens are rejected, and only then
-writes the v3 receipt. Retrying after a partial client update accepts only the
-exact old or exact target metadata, so the process is convergent without
-accepting arbitrary drift. It does not require or reset the existing
-product-admin password.
+writes or compare-and-swaps the v3 receipt. Retrying after a partial client
+update accepts only the exact receipt source or exact target metadata, so the
+process is convergent without accepting arbitrary drift. It does not require
+or reset the existing product-admin password.
 
 Delete `akb-keycloak-upgrade` only after that report and a subsequent
 `mode=readback` restart succeed. If the init container reports

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -16,7 +16,7 @@ The bundle implements the product-administrator bootstrap and recovery slice:
    projection.
 3. It proves the permanent management credential, deletes the temporary
    bootstrap client, verifies that credential is rejected, and records a
-   non-secret `bundled-keycloak-v2` retirement receipt in the AKB database.
+   non-secret `bundled-keycloak-v3` retirement receipt in the AKB database.
 4. A subsequent init-container run is read-only and succeeds without either
    original one-time value only when its current Keycloak and AKB identities
    exactly match that durable receipt.
@@ -31,6 +31,15 @@ It becomes ready only after the browser-session encryption key is supplied and
 an upstream provider is enabled. `/admin` uses the dedicated confidential
 client and requires a fresh native Keycloak password ceremony; a brokered
 upstream identity is not accepted as the recovery administrator.
+
+The browser-facing AKB origin and Keycloak-to-AKB back-channel are separate
+deployment concerns. `keycloak_backchannel_logout_uri` is registered on the
+`akb-web` client and defaults to the public AKB callback for simple installs.
+This Kubernetes overlay sets it to the exact in-cluster backend Service URL so
+Keycloak never tries to deliver a signed logout token to its own loopback
+interface. Changing this client metadata on an existing standalone v2 install
+requires a bounded client-update authority; the permanent provider manager is
+intentionally unable to mutate clients.
 
 ## Required operator inputs
 
@@ -54,7 +63,7 @@ commit their values.
 | `akb-keycloak-db-credentials` | `POSTGRES_DB=keycloak`, `POSTGRES_USER=keycloak`, `POSTGRES_PASSWORD` | durable |
 | `akb-secret-config` | `secret.yaml` | durable |
 | `akb-keycloak-bootstrap` | `client-secret` | one-time |
-| `akb-keycloak-upgrade` | `client-secret` | optional; one-time v1-to-v2 upgrade only |
+| `akb-keycloak-upgrade` | `client-secret` | optional; one-time legacy-profile upgrade only |
 | `akb-product-admin-bootstrap` | `password` | one-time |
 
 The mounted `secret.yaml` must include the AKB database password, an
@@ -101,21 +110,32 @@ pod's `bootstrap-standalone-sso` init container and main container to complete,
 then inspect the init log. Its JSON report contains only IDs, key metadata, and
 the exact role names; it never contains credential values.
 
-## Upgrade an existing v1 receipt
+## Upgrade an existing v1 or v2 receipt
 
 An installation that already recorded `bundled-keycloak-v1` retired its
 original master-realm bootstrap client before the signed broker-provenance
-mapper existed. The permanent `akb-sso-manager` deliberately lacks
-`manage-clients`, so a normal rollout cannot add that mapper and must not widen
-the manager's standing authority.
+mapper existed. A `bundled-keycloak-v2` installation has that mapper but records
+the original public-origin back-channel callback. The permanent
+`akb-sso-manager` deliberately lacks `manage-clients`, so a rollout that must
+change either client resource cannot widen the manager's standing authority.
+
+If a v2 installation keeps the same public callback (the effective setting is
+still `https://<public-akb>/api/v1/auth/keycloak/backchannel-logout`), the init
+container proves the exact v2 and v3 read-backs and promotes the durable receipt
+without mutation or an upgrade credential. It reports
+`mode=upgrade-v2-to-v3-readback`. A v1 receipt always needs the one-time
+authority to add the mapper. A v2 receipt needs it only when moving to a
+different callback, including this overlay's in-cluster backend URL.
 
 Before rolling this version onto such an installation, create exactly one
 temporary upgrade service account named `akb-bootstrap-upgrade-v2`. Keycloak's
 supported recovery command requires every Keycloak node to be stopped. Follow
 the upstream [temporary admin service account procedure](https://www.keycloak.org/server/bootstrap-admin-recovery)
 and use the same database settings as the server. The opt-in
-`legacy-v1-upgrade-job.yaml` captures those settings but is intentionally not a
-Kustomize resource, so a fresh install never creates this authority.
+`legacy-profile-upgrade-job.yaml` captures those settings but is intentionally
+not a Kustomize resource, so a fresh install never creates this authority. The
+historical client ID `akb-bootstrap-upgrade-v2` remains stable so an interrupted
+older migration can be recovered without creating a second identity.
 
 For the default `akb` namespace, the bounded sequence is:
 
@@ -125,28 +145,32 @@ openssl rand -base64 48 | tr -d '\n' | kubectl -n akb create secret generic \
   --from-file=client-secret=/dev/stdin
 kubectl -n akb scale statefulset/keycloak --replicas=0
 kubectl -n akb wait --for=delete pod -l app=akb-keycloak --timeout=180s
-kubectl apply -f deploy/k8s/standalone-sso/legacy-v1-upgrade-job.yaml
+kubectl apply -f deploy/k8s/standalone-sso/legacy-profile-upgrade-job.yaml
 kubectl -n akb wait --for=condition=complete \
-  job/akb-keycloak-v1-to-v2-authority --timeout=180s
-kubectl -n akb delete job akb-keycloak-v1-to-v2-authority
+  job/akb-keycloak-profile-upgrade-authority --timeout=180s
+kubectl -n akb delete job akb-keycloak-profile-upgrade-authority
 kubectl -n akb scale statefulset/keycloak --replicas=1
 kubectl -n akb rollout status statefulset/keycloak --timeout=300s
 ```
 
 Then deploy the new AKB overlay. Its init container must report
-`mode=upgrade-v1-to-v2` and `receipt_profile=bundled-keycloak-v2`. The lifecycle
-first validates every v1 read-back using the permanent manager, changes only
-the `akb-browser-identity-provider` mapper, revalidates the complete v2 profile
-through the permanent manager, deletes the temporary upgrade client, proves
-both its old and newly requested tokens are rejected, and only then writes the
-v2 receipt. It does not require or reset the existing product-admin password.
+`mode=upgrade-v1-to-v3` or `mode=upgrade-v2-to-v3` and
+`receipt_profile=bundled-keycloak-v3`. The lifecycle first validates the exact
+legacy read-back using the permanent manager, reconciles only the `akb-web`
+client metadata and signed broker-provenance mapper, revalidates the complete
+v3 profile through the permanent manager, deletes the temporary upgrade client,
+proves both its old and newly requested tokens are rejected, and only then
+writes the v3 receipt. Retrying after a partial client update accepts only the
+exact old or exact target metadata, so the process is convergent without
+accepting arbitrary drift. It does not require or reset the existing
+product-admin password.
 
 Delete `akb-keycloak-upgrade` only after that report and a subsequent
 `mode=readback` restart succeed. If the init container reports
 `keycloak_upgrade_credential_required`, do not grant `manage-clients` to
 `akb-sso-manager`; complete this one-time procedure instead. A failed migration
 deliberately leaves the temporary authority available for repair. If deletion
-succeeds but the v2 receipt write does not, use the same official recovery
+succeeds but the v3 receipt write does not, use the same official recovery
 procedure to create the exact upgrade client again before retrying.
 
 ## Retire one-time material

--- a/deploy/k8s/standalone-sso/backend-config-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-config-patch.yaml
@@ -25,6 +25,7 @@ data:
     keycloak_enabled: true
     keycloak_server_url: https://auth.akb.example.com
     keycloak_internal_url: http://keycloak:8080
+    keycloak_backchannel_logout_uri: http://backend:8000/api/v1/auth/keycloak/backchannel-logout
     keycloak_realm: akb
     keycloak_client_id: akb-web
     keycloak_public_client: false

--- a/deploy/k8s/standalone-sso/legacy-profile-upgrade-job.yaml
+++ b/deploy/k8s/standalone-sso/legacy-profile-upgrade-job.yaml
@@ -1,17 +1,17 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: akb-keycloak-v1-to-v2-authority
+  name: akb-keycloak-profile-upgrade-authority
   namespace: akb
   labels:
-    app.kubernetes.io/name: akb-keycloak-v1-to-v2-authority
+    app.kubernetes.io/name: akb-keycloak-profile-upgrade-authority
     app.kubernetes.io/part-of: akb
 spec:
   backoffLimit: 0
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: akb-keycloak-v1-to-v2-authority
+        app.kubernetes.io/name: akb-keycloak-profile-upgrade-authority
     spec:
       restartPolicy: Never
       securityContext:
@@ -25,6 +25,8 @@ spec:
           args:
             - bootstrap-admin
             - service
+            # Kept stable so an interrupted v1-to-v2 migration receipt and a
+            # v2-to-v3 migration use one exact, already documented identity.
             - --client-id
             - akb-bootstrap-upgrade-v2
             - --client-secret:env=AKB_KEYCLOAK_UPGRADE_SECRET


### PR DESCRIPTION
## Summary

- separate the public browser origin from the internal Keycloak backchannel logout callback
- bind the effective callback URI into the current standalone SSO retirement receipt
- preserve a bounded, one-time upgrade path for legacy and callback-only migrations without granting manage-clients to the permanent manager
- reject non-canonical and legacy numeric IPv4 callback targets while preserving valid DNS names

## Verification

- 104 focused standalone SSO/configuration/receipt tests passed
- backend Ruff, focused mypy, formatting, and git diff --check passed
- independent exact-head security review reported no High or Medium findings

Refs #357
