### PR TITLE
fix(auth): fence SSO sessions with runtime generations

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -215,6 +215,7 @@ jobs:
           tests/test_admin_auth_postgres.py
           tests/test_sso_identity_migration_postgres.py
           tests/test_sso_browser_session_postgres.py
+          tests/test_sso_session_epoch_upgrade_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           -v --tb=short

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -798,6 +798,14 @@ class Settings(BaseModel):
     keycloak_management_client_id: str = "akb-sso-manager"
     keycloak_management_client_secret: str = ""
     admin_browser_session_ttl_secs: int = Field(default=900, ge=60, le=3600)
+    # Installation-owned SSO authority generation. Every ordinary and admin
+    # browser session, plus each back-channel logout fence, is bound to this
+    # UUID. It remains stable across normal SSO restarts and must change when
+    # an operator deliberately starts a new SSO authority epoch. AKB also
+    # records the last running auth mode in PostgreSQL, so an observed
+    # sso -> local -> sso transition revokes old handles even if an operator
+    # accidentally reuses the same UUID.
+    sso_session_epoch: uuid.UUID | None = None
     # Ordinary SSO browsers receive only an opaque AKB handle. The Keycloak
     # refresh/ID token set is encrypted at rest with this independent,
     # installation-owned AES-256-GCM key. Blank keeps the capability

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -734,6 +734,14 @@ class Settings(BaseModel):
     # allowed only so unrelated tests can construct Settings directly; the real
     # YAML loader rejects a missing mode before the runtime can start.
     auth_mode: AuthMode | None = None
+    # Monotonic installation-owned generation for auth runtime transitions.
+    # Keep it stable for an exact restart and increase it for every mode or SSO
+    # epoch change. PostgreSQL rejects stale or conflicting generations.
+    auth_runtime_generation: int = Field(default=1, ge=1)
+    # One-release acknowledgement for the pre-epoch schema bridge. Existing
+    # installations must stop every old backend before setting this value and
+    # running the executable preflight. Fresh databases do not require it.
+    sso_session_epoch_upgrade: Literal["stop-the-world-v1"] | None = None
 
     # App principals use a separate exchange-only carrier. Keeping a distinct
     # signing secret makes an app token cryptographically unusable as a user
@@ -798,13 +806,12 @@ class Settings(BaseModel):
     keycloak_management_client_id: str = "akb-sso-manager"
     keycloak_management_client_secret: str = ""
     admin_browser_session_ttl_secs: int = Field(default=900, ge=60, le=3600)
-    # Installation-owned SSO authority generation. Every ordinary and admin
+    # Installation-owned SSO authority epoch. Every ordinary and admin
     # browser session, plus each back-channel logout fence, is bound to this
     # UUID. It remains stable across normal SSO restarts and must change when
     # an operator deliberately starts a new SSO authority epoch. AKB also
-    # records the last running auth mode in PostgreSQL, so an observed
-    # sso -> local -> sso transition revokes old handles even if an operator
-    # accidentally reuses the same UUID.
+    # binds it to auth_runtime_generation in PostgreSQL, so sso -> local -> sso
+    # cannot revive old handles even if an operator reuses the same UUID.
     sso_session_epoch: uuid.UUID | None = None
     # Ordinary SSO browsers receive only an opaque AKB handle. The Keycloak
     # refresh/ID token set is encrypted at rest with this independent,

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -81,12 +81,15 @@ CREATE INDEX IF NOT EXISTS idx_external_identities_user
 CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
     ON external_identities(id, user_id);
 
--- Singleton observation of the last runtime auth boundary. Startup holds this
--- row FOR UPDATE and revokes every SSO browser handle/fence whenever the mode
--- or explicit epoch changes. Local mode never carries an SSO epoch.
+-- Singleton authority for the last accepted runtime auth boundary. The
+-- installation generation is monotonic: an exact restart is accepted, a
+-- greater generation performs one transition, and stale/conflicting starts
+-- fail closed. Local mode never carries an SSO epoch.
 CREATE TABLE IF NOT EXISTS auth_runtime_state (
     singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
         CHECK (singleton),
+    runtime_generation BIGINT NOT NULL
+        CHECK (runtime_generation > 0),
     auth_mode TEXT NOT NULL
         CHECK (auth_mode IN ('local', 'sso')),
     sso_session_epoch UUID,
@@ -101,13 +104,33 @@ CREATE TABLE IF NOT EXISTS auth_runtime_state (
         )
 );
 
+-- Machine-readable state for the one-time pre-epoch stop-the-world bridge.
+-- `required` blocks normal startup until the explicit upgrade acknowledgement;
+-- `enforced` makes legacy NULL writes fail; `rollback_ready` is written only
+-- after every epoch-bound row and runtime authority row has been purged.
+CREATE TABLE IF NOT EXISTS auth_runtime_epoch_upgrade (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
+        CHECK (singleton),
+    state TEXT NOT NULL
+        CHECK (state IN ('ready', 'required', 'enforced', 'rollback_ready')),
+    runtime_generation_floor BIGINT NOT NULL DEFAULT 0
+        CHECK (runtime_generation_floor >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO auth_runtime_epoch_upgrade (singleton, state)
+VALUES (TRUE, 'ready')
+ON CONFLICT (singleton) DO NOTHING;
+
 -- Dedicated product-admin browser sessions. These rows contain only hashes
 -- of opaque AKB session/CSRF values, an exact external-identity FK, and the
 -- issuer/subject snapshot used to invalidate a changed binding. No Keycloak
 -- access, refresh, or ID token is stored here.
 CREATE TABLE IF NOT EXISTS admin_browser_sessions (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    session_epoch UUID NOT NULL,
+    -- Nullable only for pre-epoch image rollback compatibility. Migration 076
+    -- installs a database guard that rejects NULL while current code is active.
+    session_epoch UUID,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -144,7 +167,7 @@ CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
 -- exact row and AKB user. Access tokens are verified and discarded.
 CREATE TABLE IF NOT EXISTS sso_browser_sessions (
     id UUID PRIMARY KEY,
-    session_epoch UUID NOT NULL,
+    session_epoch UUID,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -197,7 +220,7 @@ CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_subject
 -- logout. Session creation and logout also share a transaction advisory lock;
 -- this row rejects a callback that resumes only after logout committed.
 CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
-    session_epoch UUID NOT NULL,
+    session_epoch UUID,
     identity_issuer TEXT NOT NULL
         CHECK (char_length(identity_issuer) BETWEEN 1 AND 2048),
     keycloak_sid TEXT NOT NULL
@@ -210,7 +233,9 @@ CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
     logout_issued_at TIMESTAMPTZ NOT NULL,
     expires_at TIMESTAMPTZ NOT NULL,
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid),
+    -- Retain the pre-epoch key so an explicitly prepared rollback image can
+    -- still execute its original ON CONFLICT target.
+    PRIMARY KEY (identity_issuer, keycloak_sid),
     CONSTRAINT sso_browser_logout_fence_epoch_fk
         FOREIGN KEY (session_epoch)
         REFERENCES auth_runtime_state(sso_session_epoch),

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -81,12 +81,33 @@ CREATE INDEX IF NOT EXISTS idx_external_identities_user
 CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
     ON external_identities(id, user_id);
 
+-- Singleton observation of the last runtime auth boundary. Startup holds this
+-- row FOR UPDATE and revokes every SSO browser handle/fence whenever the mode
+-- or explicit epoch changes. Local mode never carries an SSO epoch.
+CREATE TABLE IF NOT EXISTS auth_runtime_state (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
+        CHECK (singleton),
+    auth_mode TEXT NOT NULL
+        CHECK (auth_mode IN ('local', 'sso')),
+    sso_session_epoch UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT auth_runtime_state_sso_session_epoch_key
+        UNIQUE (sso_session_epoch),
+    CONSTRAINT auth_runtime_state_epoch_shape
+        CHECK (
+            (auth_mode = 'local' AND sso_session_epoch IS NULL)
+            OR
+            (auth_mode = 'sso' AND sso_session_epoch IS NOT NULL)
+        )
+);
+
 -- Dedicated product-admin browser sessions. These rows contain only hashes
 -- of opaque AKB session/CSRF values, an exact external-identity FK, and the
 -- issuer/subject snapshot used to invalidate a changed binding. No Keycloak
 -- access, refresh, or ID token is stored here.
 CREATE TABLE IF NOT EXISTS admin_browser_sessions (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    session_epoch UUID NOT NULL,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -105,6 +126,9 @@ CREATE TABLE IF NOT EXISTS admin_browser_sessions (
     CONSTRAINT admin_browser_session_external_user_fk
         FOREIGN KEY (external_identity_id, user_id)
         REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
+    CONSTRAINT admin_browser_session_epoch_fk
+        FOREIGN KEY (session_epoch)
+        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT admin_browser_session_positive_lifetime
         CHECK (expires_at > created_at)
 );
@@ -120,6 +144,7 @@ CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
 -- exact row and AKB user. Access tokens are verified and discarded.
 CREATE TABLE IF NOT EXISTS sso_browser_sessions (
     id UUID PRIMARY KEY,
+    session_epoch UUID NOT NULL,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -144,6 +169,9 @@ CREATE TABLE IF NOT EXISTS sso_browser_sessions (
     CONSTRAINT sso_browser_session_external_user_fk
         FOREIGN KEY (external_identity_id, user_id)
         REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
+    CONSTRAINT sso_browser_session_epoch_fk
+        FOREIGN KEY (session_epoch)
+        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT sso_browser_session_positive_lifetime
         CHECK (
             access_expires_at > created_at
@@ -161,14 +189,15 @@ CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_absolute_expiry
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_user
     ON sso_browser_sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_sid
-    ON sso_browser_sessions(identity_issuer, keycloak_sid);
+    ON sso_browser_sessions(session_epoch, identity_issuer, keycloak_sid);
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_subject
-    ON sso_browser_sessions(identity_issuer, identity_subject);
+    ON sso_browser_sessions(session_epoch, identity_issuer, identity_subject);
 
 -- Durable, short-lived ordering fence for verified Keycloak back-channel
 -- logout. Session creation and logout also share a transaction advisory lock;
 -- this row rejects a callback that resumes only after logout committed.
 CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
+    session_epoch UUID NOT NULL,
     identity_issuer TEXT NOT NULL
         CHECK (char_length(identity_issuer) BETWEEN 1 AND 2048),
     keycloak_sid TEXT NOT NULL
@@ -181,7 +210,10 @@ CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
     logout_issued_at TIMESTAMPTZ NOT NULL,
     expires_at TIMESTAMPTZ NOT NULL,
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (identity_issuer, keycloak_sid),
+    PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid),
+    CONSTRAINT sso_browser_logout_fence_epoch_fk
+        FOREIGN KEY (session_epoch)
+        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT sso_browser_logout_fence_positive_lifetime
         CHECK (expires_at > logout_issued_at)
 );

--- a/backend/app/db/migrations/076_sso_session_epoch.py
+++ b/backend/app/db/migrations/076_sso_session_epoch.py
@@ -1,9 +1,11 @@
-"""Bind all SSO browser authority to one explicit runtime epoch.
+"""Add the rollback-compatible SSO runtime-generation boundary.
 
-This migration intentionally revokes existing ordinary/admin browser sessions
-and logout fences. Rows created before the epoch contract cannot be attributed
-to a safe authority generation, so trying to backfill them would recreate the
-mode-transition resurrection this migration closes.
+This is an explicit ``stop-the-world-v1`` bridge, not a rolling mixed-writer
+cutover.  Existing tables gain nullable epoch columns so the pre-epoch image
+can still be used after a prepared rollback.  Startup later purges all legacy
+rows and changes the machine-readable upgrade state to ``enforced``; database
+triggers then reject every legacy NULL write.  Migration itself never deletes
+browser authority and never makes the bridge columns NOT NULL.
 """
 
 from __future__ import annotations
@@ -11,11 +13,37 @@ from __future__ import annotations
 
 async def migrate(conn) -> None:
     async with conn.transaction():
+        # Multiple replicas may all observe migration 076 as pending. Serialize
+        # this idempotent DDL before either one acquires catalog/relation locks;
+        # reconciliation then shares the explicit authority-first table order.
+        await conn.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                hashtextextended('akb-migration-076-sso-session-epoch', 0)
+            )
+            """
+        )
+        pre_epoch_schema = await conn.fetchval(
+            """
+            SELECT COUNT(*) < 3
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND column_name = 'session_epoch'
+               AND table_name = ANY($1::TEXT[])
+            """,
+            [
+                "admin_browser_sessions",
+                "sso_browser_sessions",
+                "sso_browser_logout_fences",
+            ],
+        )
         await conn.execute(
             """
             CREATE TABLE IF NOT EXISTS auth_runtime_state (
                 singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
                     CHECK (singleton),
+                runtime_generation BIGINT NOT NULL
+                    CHECK (runtime_generation > 0),
                 auth_mode TEXT NOT NULL
                     CHECK (auth_mode IN ('local', 'sso')),
                 sso_session_epoch UUID,
@@ -33,11 +61,87 @@ async def migrate(conn) -> None:
         )
         await conn.execute(
             """
-            CREATE UNIQUE INDEX IF NOT EXISTS
-                auth_runtime_state_sso_session_epoch_key
-                ON auth_runtime_state(sso_session_epoch)
+            CREATE TABLE IF NOT EXISTS auth_runtime_epoch_upgrade (
+                singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
+                    CHECK (singleton),
+                state TEXT NOT NULL
+                    CHECK (
+                        state IN (
+                            'ready', 'required', 'enforced', 'rollback_ready'
+                        )
+                    ),
+                runtime_generation_floor BIGINT NOT NULL DEFAULT 0
+                    CHECK (runtime_generation_floor >= 0),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
             """
         )
+        await conn.execute(
+            """
+            INSERT INTO auth_runtime_epoch_upgrade (singleton, state)
+            VALUES (TRUE, 'ready')
+            ON CONFLICT (singleton) DO NOTHING
+            """
+        )
+
+        # Every migration/reconciliation path takes relations in this order.
+        # The authority relation is acquired before any session relation, so a
+        # request already holding the authority row can finish before DDL waits
+        # on a session table. Whole-migration deadlock retry lives in the
+        # migration runner, where transaction rollback makes replay sound.
+        await conn.execute("LOCK TABLE auth_runtime_state IN ACCESS EXCLUSIVE MODE")
+        await conn.execute(
+            """
+            ALTER TABLE auth_runtime_state
+                ADD COLUMN IF NOT EXISTS runtime_generation BIGINT
+            """
+        )
+        # Development databases that ran the unmerged pre-review migration may
+        # already have this singleton without a generation. Zero is a dormant
+        # migration sentinel: current config is strictly positive, so startup
+        # must advance and purge rather than accepting the old state as exact.
+        await conn.execute(
+            """
+            UPDATE auth_runtime_state
+               SET runtime_generation = 0
+             WHERE runtime_generation IS NULL
+            """
+        )
+        await conn.execute(
+            """
+            ALTER TABLE auth_runtime_state
+                ALTER COLUMN runtime_generation SET NOT NULL
+            """
+        )
+        generation_check_exists = await conn.fetchval(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                  FROM pg_constraint
+                 WHERE conname = 'auth_runtime_state_runtime_generation_check'
+                   AND conrelid = 'auth_runtime_state'::regclass
+            )
+            """
+        )
+        if not generation_check_exists:
+            await conn.execute(
+                """
+                ALTER TABLE auth_runtime_state
+                    ADD CONSTRAINT auth_runtime_state_runtime_generation_check
+                    CHECK (runtime_generation >= 0)
+                """
+            )
+        await conn.execute(
+            """
+            ALTER TABLE auth_runtime_epoch_upgrade
+                ADD COLUMN IF NOT EXISTS runtime_generation_floor BIGINT
+                NOT NULL DEFAULT 0
+            """
+        )
+        await conn.execute("LOCK TABLE admin_browser_sessions IN ACCESS EXCLUSIVE MODE")
+        await conn.execute("LOCK TABLE sso_browser_sessions IN ACCESS EXCLUSIVE MODE")
+        await conn.execute("LOCK TABLE sso_browser_logout_fences IN ACCESS EXCLUSIVE MODE")
+
         for table in (
             "admin_browser_sessions",
             "sso_browser_sessions",
@@ -50,20 +154,13 @@ async def migrate(conn) -> None:
                 """
             )
 
-        # No pre-epoch row has a trustworthy authority-generation binding.
-        # Delete in the same transaction before making the new columns strict.
-        await conn.execute("DELETE FROM admin_browser_sessions")
-        await conn.execute("DELETE FROM sso_browser_sessions")
-        await conn.execute("DELETE FROM sso_browser_logout_fences")
-        for table in (
-            "admin_browser_sessions",
-            "sso_browser_sessions",
-            "sso_browser_logout_fences",
-        ):
-            await conn.execute(
-                f"ALTER TABLE {table} ALTER COLUMN session_epoch SET NOT NULL"
-            )
-
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                auth_runtime_state_sso_session_epoch_key
+                ON auth_runtime_state(sso_session_epoch)
+            """
+        )
         for table, constraint_name in (
             ("admin_browser_sessions", "admin_browser_session_epoch_fk"),
             ("sso_browser_sessions", "sso_browser_session_epoch_fk"),
@@ -94,6 +191,9 @@ async def migrate(conn) -> None:
                     """
                 )
 
+        # Preserve the pre-epoch conflict target for a prepared rollback.
+        # Current code includes session_epoch in values and predicates, while
+        # the post-cutover trigger prevents a legacy NULL from occupying it.
         await conn.execute(
             """
             ALTER TABLE sso_browser_logout_fences
@@ -104,7 +204,7 @@ async def migrate(conn) -> None:
             """
             ALTER TABLE sso_browser_logout_fences
                 ADD CONSTRAINT sso_browser_logout_fences_pkey
-                PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)
+                PRIMARY KEY (identity_issuer, keycloak_sid)
             """
         )
         await conn.execute("DROP INDEX IF EXISTS idx_sso_browser_sessions_sid")
@@ -125,3 +225,45 @@ async def migrate(conn) -> None:
                 )
             """
         )
+
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION reject_legacy_sso_session_epoch()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                IF NEW.session_epoch IS NULL AND EXISTS (
+                    SELECT 1
+                      FROM auth_runtime_epoch_upgrade
+                     WHERE singleton = TRUE AND state = 'enforced'
+                ) THEN
+                    RAISE EXCEPTION 'legacy SSO session writes are disabled'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+        for table in (
+            "admin_browser_sessions",
+            "sso_browser_sessions",
+            "sso_browser_logout_fences",
+        ):
+            trigger = f"{table}_epoch_guard"
+            await conn.execute(f"DROP TRIGGER IF EXISTS {trigger} ON {table}")
+            await conn.execute(
+                f"""
+                CREATE TRIGGER {trigger}
+                BEFORE INSERT OR UPDATE OF session_epoch ON {table}
+                FOR EACH ROW EXECUTE FUNCTION reject_legacy_sso_session_epoch()
+                """
+            )
+
+        if pre_epoch_schema:
+            await conn.execute(
+                """
+                UPDATE auth_runtime_epoch_upgrade
+                   SET state = 'required', updated_at = NOW()
+                 WHERE singleton = TRUE AND state = 'ready'
+                """
+            )

--- a/backend/app/db/migrations/076_sso_session_epoch.py
+++ b/backend/app/db/migrations/076_sso_session_epoch.py
@@ -1,0 +1,127 @@
+"""Bind all SSO browser authority to one explicit runtime epoch.
+
+This migration intentionally revokes existing ordinary/admin browser sessions
+and logout fences. Rows created before the epoch contract cannot be attributed
+to a safe authority generation, so trying to backfill them would recreate the
+mode-transition resurrection this migration closes.
+"""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS auth_runtime_state (
+                singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
+                    CHECK (singleton),
+                auth_mode TEXT NOT NULL
+                    CHECK (auth_mode IN ('local', 'sso')),
+                sso_session_epoch UUID,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT auth_runtime_state_sso_session_epoch_key
+                    UNIQUE (sso_session_epoch),
+                CONSTRAINT auth_runtime_state_epoch_shape
+                    CHECK (
+                        (auth_mode = 'local' AND sso_session_epoch IS NULL)
+                        OR
+                        (auth_mode = 'sso' AND sso_session_epoch IS NOT NULL)
+                    )
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                auth_runtime_state_sso_session_epoch_key
+                ON auth_runtime_state(sso_session_epoch)
+            """
+        )
+        for table in (
+            "admin_browser_sessions",
+            "sso_browser_sessions",
+            "sso_browser_logout_fences",
+        ):
+            await conn.execute(
+                f"""
+                ALTER TABLE {table}
+                    ADD COLUMN IF NOT EXISTS session_epoch UUID
+                """
+            )
+
+        # No pre-epoch row has a trustworthy authority-generation binding.
+        # Delete in the same transaction before making the new columns strict.
+        await conn.execute("DELETE FROM admin_browser_sessions")
+        await conn.execute("DELETE FROM sso_browser_sessions")
+        await conn.execute("DELETE FROM sso_browser_logout_fences")
+        for table in (
+            "admin_browser_sessions",
+            "sso_browser_sessions",
+            "sso_browser_logout_fences",
+        ):
+            await conn.execute(
+                f"ALTER TABLE {table} ALTER COLUMN session_epoch SET NOT NULL"
+            )
+
+        for table, constraint_name in (
+            ("admin_browser_sessions", "admin_browser_session_epoch_fk"),
+            ("sso_browser_sessions", "sso_browser_session_epoch_fk"),
+            (
+                "sso_browser_logout_fences",
+                "sso_browser_logout_fence_epoch_fk",
+            ),
+        ):
+            exists = await conn.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                      FROM pg_constraint
+                     WHERE conname = $1
+                       AND conrelid = $2::regclass
+                )
+                """,
+                constraint_name,
+                table,
+            )
+            if not exists:
+                await conn.execute(
+                    f"""
+                    ALTER TABLE {table}
+                        ADD CONSTRAINT {constraint_name}
+                        FOREIGN KEY (session_epoch)
+                        REFERENCES auth_runtime_state(sso_session_epoch)
+                    """
+                )
+
+        await conn.execute(
+            """
+            ALTER TABLE sso_browser_logout_fences
+                DROP CONSTRAINT IF EXISTS sso_browser_logout_fences_pkey
+            """
+        )
+        await conn.execute(
+            """
+            ALTER TABLE sso_browser_logout_fences
+                ADD CONSTRAINT sso_browser_logout_fences_pkey
+                PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)
+            """
+        )
+        await conn.execute("DROP INDEX IF EXISTS idx_sso_browser_sessions_sid")
+        await conn.execute(
+            """
+            CREATE INDEX idx_sso_browser_sessions_sid
+                ON sso_browser_sessions(
+                    session_epoch, identity_issuer, keycloak_sid
+                )
+            """
+        )
+        await conn.execute("DROP INDEX IF EXISTS idx_sso_browser_sessions_subject")
+        await conn.execute(
+            """
+            CREATE INDEX idx_sso_browser_sessions_subject
+                ON sso_browser_sessions(
+                    session_epoch, identity_issuer, identity_subject
+                )
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -258,6 +258,7 @@ async def _apply_migrations() -> None:
         "073_sso_bootstrap_receipt.py",  # durable proof that the temporary bundled-Keycloak client was retired
         "074_sso_browser_sessions.py",  # encrypted ordinary-user SSO browser-session custody
         "075_sso_callback_receipt.py",  # bind current SSO receipts to the effective back-channel callback
+        "076_sso_session_epoch.py",  # revoke on auth-mode/epoch change; bind ordinary/admin SSO sessions and logout fences
     ):
         if filename in applied:
             continue

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -157,7 +157,11 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
                     filename,
                 )
             return
-        except (asyncpg.LockNotAvailableError, asyncpg.QueryCanceledError) as e:
+        except (
+            asyncpg.DeadlockDetectedError,
+            asyncpg.LockNotAvailableError,
+            asyncpg.QueryCanceledError,
+        ) as e:
             if attempt < retries - 1:
                 log.warning(
                     "Migration %s blocked on a lock (attempt %d/%d): %s — retrying in %.0fs",
@@ -258,7 +262,7 @@ async def _apply_migrations() -> None:
         "073_sso_bootstrap_receipt.py",  # durable proof that the temporary bundled-Keycloak client was retired
         "074_sso_browser_sessions.py",  # encrypted ordinary-user SSO browser-session custody
         "075_sso_callback_receipt.py",  # bind current SSO receipts to the effective back-channel callback
-        "076_sso_session_epoch.py",  # revoke on auth-mode/epoch change; bind ordinary/admin SSO sessions and logout fences
+        "076_sso_session_epoch.py",  # monotonic auth boundary + rollback-compatible epoch bridge/legacy-write guard
     ):
         if filename in applied:
             continue

--- a/backend/app/services/admin_auth_service.py
+++ b/backend/app/services/admin_auth_service.py
@@ -29,7 +29,7 @@ from app.services.auth_service import (
     resolve_delegated_human_authorization,
 )
 from app.services.sso_session_epoch import (
-    current_sso_session_epoch,
+    current_sso_session_authority,
     lock_active_sso_session_epoch,
 )
 
@@ -174,11 +174,12 @@ async def create_sso_admin_browser_session(
     csrf_token = secrets.token_urlsafe(32)
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(csrf_token)
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
                 f"admin-browser-session:{identity.user_id}",
@@ -258,7 +259,8 @@ async def create_sso_admin_browser_session(
 async def resolve_sso_admin_browser_session(
     raw_token: str,
 ) -> ProductAdminIdentity:
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     token = _bounded_credential(raw_token)
     if token is None:
         raise AuthenticationError()
@@ -266,7 +268,7 @@ async def resolve_sso_admin_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.user_id, s.external_identity_id,
@@ -330,13 +332,14 @@ async def validate_sso_admin_browser_session_csrf(
     ):
         raise AuthenticationError("Invalid admin CSRF token")
 
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(cookie)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.csrf_token_hash,
@@ -386,13 +389,14 @@ async def revoke_sso_admin_browser_session(
     if token is None or cookie is None or header is None or not secrets.compare_digest(cookie, header):
         raise AuthenticationError("Invalid admin CSRF token")
 
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(cookie)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.csrf_token_hash,

--- a/backend/app/services/admin_auth_service.py
+++ b/backend/app/services/admin_auth_service.py
@@ -28,6 +28,10 @@ from app.services.auth_service import (
     login,
     resolve_delegated_human_authorization,
 )
+from app.services.sso_session_epoch import (
+    current_sso_session_epoch,
+    lock_active_sso_session_epoch,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,9 +174,11 @@ async def create_sso_admin_browser_session(
     csrf_token = secrets.token_urlsafe(32)
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(csrf_token)
+    session_epoch = current_sso_session_epoch()
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
                 f"admin-browser-session:{identity.user_id}",
@@ -210,20 +216,23 @@ async def create_sso_admin_browser_session(
                     SELECT id
                       FROM admin_browser_sessions
                      WHERE user_id = $1
+                       AND session_epoch = $2
                      ORDER BY created_at DESC, id DESC
                     OFFSET 7
                  )
                 """,
                 identity.user_id,
+                session_epoch,
             )
             await conn.execute(
                 """
                 INSERT INTO admin_browser_sessions (
-                    token_hash, csrf_token_hash, user_id,
+                    session_epoch, token_hash, csrf_token_hash, user_id,
                     external_identity_id, identity_issuer, identity_subject,
                     keycloak_sid, expires_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 """,
+                session_epoch,
                 token_hash,
                 csrf_hash,
                 identity.user_id,
@@ -249,6 +258,7 @@ async def create_sso_admin_browser_session(
 async def resolve_sso_admin_browser_session(
     raw_token: str,
 ) -> ProductAdminIdentity:
+    session_epoch = current_sso_session_epoch()
     token = _bounded_credential(raw_token)
     if token is None:
         raise AuthenticationError()
@@ -256,6 +266,7 @@ async def resolve_sso_admin_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.user_id, s.external_identity_id,
@@ -265,8 +276,9 @@ async def resolve_sso_admin_browser_session(
                   JOIN external_identities e
                     ON e.id = s.external_identity_id AND e.user_id = s.user_id
                  WHERE s.token_hash = $1
+                   AND s.session_epoch = $2
                    AND s.expires_at > NOW()
-                   AND s.identity_issuer = $2
+                   AND s.identity_issuer = $3
                    AND e.issuer = s.identity_issuer
                    AND e.subject = s.identity_subject
                    AND u.is_admin
@@ -276,6 +288,7 @@ async def resolve_sso_admin_browser_session(
                  FOR UPDATE OF s
                 """,
                 token_hash,
+                session_epoch,
                 settings.keycloak_issuer,
             )
             if row is None:
@@ -317,11 +330,13 @@ async def validate_sso_admin_browser_session_csrf(
     ):
         raise AuthenticationError("Invalid admin CSRF token")
 
+    session_epoch = current_sso_session_epoch()
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(cookie)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.csrf_token_hash,
@@ -332,8 +347,9 @@ async def validate_sso_admin_browser_session_csrf(
                   JOIN external_identities e
                     ON e.id = s.external_identity_id AND e.user_id = s.user_id
                  WHERE s.token_hash = $1
+                   AND s.session_epoch = $2
                    AND s.expires_at > NOW()
-                   AND s.identity_issuer = $2
+                   AND s.identity_issuer = $3
                    AND e.issuer = s.identity_issuer
                    AND e.subject = s.identity_subject
                    AND u.is_admin
@@ -343,6 +359,7 @@ async def validate_sso_admin_browser_session_csrf(
                  FOR UPDATE OF s
                 """,
                 token_hash,
+                session_epoch,
                 settings.keycloak_issuer,
             )
             if (
@@ -369,11 +386,13 @@ async def revoke_sso_admin_browser_session(
     if token is None or cookie is None or header is None or not secrets.compare_digest(cookie, header):
         raise AuthenticationError("Invalid admin CSRF token")
 
+    session_epoch = current_sso_session_epoch()
     token_hash = _hash_credential(token)
     csrf_hash = _hash_credential(cookie)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             row = await conn.fetchrow(
                 """
                 SELECT s.id AS session_id, s.csrf_token_hash,
@@ -381,10 +400,13 @@ async def revoke_sso_admin_browser_session(
                        u.username, u.email, u.display_name
                   FROM admin_browser_sessions s
                   JOIN users u ON u.id = s.user_id
-                 WHERE s.token_hash = $1 AND s.expires_at > NOW()
+                 WHERE s.token_hash = $1
+                   AND s.session_epoch = $2
+                   AND s.expires_at > NOW()
                  FOR UPDATE OF s
                 """,
                 token_hash,
+                session_epoch,
             )
             if row is None or not secrets.compare_digest(row["csrf_token_hash"], csrf_hash):
                 raise AuthenticationError("Invalid admin CSRF token")

--- a/backend/app/services/auth_policy.py
+++ b/backend/app/services/auth_policy.py
@@ -19,6 +19,7 @@ def sso_browser_session_ready() -> bool:
     if (
         settings.require_auth_mode() != "sso"
         or not settings.keycloak_enabled
+        or settings.sso_session_epoch is None
         or not settings.keycloak_client_id.strip()
         or not settings.sso_browser_session_encryption_key
         or (not settings.keycloak_public_client and not settings.keycloak_client_secret)

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -110,6 +110,10 @@ def _validate_required_settings() -> None:
         if not settings.keycloak_realm.strip():
             missing.append("keycloak_realm (keycloak_enabled is true)")
         if settings.sso_human_auth_enabled:
+            if settings.sso_session_epoch is None:
+                missing.append(
+                    "sso_session_epoch (auth_mode is sso — generate and persist one UUID per SSO authority epoch)"
+                )
             if not settings.keycloak_human_client_ids:
                 missing.append(
                     "keycloak_client_id or companion client ID (auth_mode is sso — human API client allowlist is empty)"
@@ -177,6 +181,16 @@ async def init_storage() -> None:
     await pre_migration_revision_authority_guard()
     await init_db()
     logger.info("Database initialized")
+    from app.services.sso_session_epoch import reconcile_sso_session_epoch
+
+    epoch_result = await reconcile_sso_session_epoch()
+    if epoch_result.changed:
+        logger.warning(
+            "Authentication runtime boundary changed; revoked ordinary=%d admin=%d logout_fences=%d",
+            epoch_result.ordinary_sessions_revoked,
+            epoch_result.admin_sessions_revoked,
+            epoch_result.logout_fences_revoked,
+        )
     authority_status = await startup_revision_authority_preflight()
     logger.info(
         "Document revision authority ready: backend=%s status=%s",

--- a/backend/app/services/sso_browser_session_service.py
+++ b/backend/app/services/sso_browser_session_service.py
@@ -31,7 +31,7 @@ from app.services.sso_browser_session_crypto import (
     BrowserSessionPayloadError,
 )
 from app.services.sso_session_epoch import (
-    current_sso_session_epoch,
+    current_sso_session_authority,
     lock_active_sso_session_epoch,
 )
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError, validate_alias
@@ -251,7 +251,8 @@ async def create_sso_browser_session(
         absolute_expiry=absolute_expiry,
     )
     scope = _scope(principal.claims)
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
 
     try:
         user_id = uuid.UUID(user.user_id)
@@ -273,7 +274,7 @@ async def create_sso_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
                 f"sso-browser-session:{session_epoch}:{user_id}",
@@ -439,7 +440,7 @@ async def resolve_sso_browser_session(
 
 async def _sso_browser_session_needs_refresh(token_hash: str) -> bool:
     """Probe expiry without waiting on a concurrent refresh row lock."""
-    session_epoch = current_sso_session_epoch()
+    session_epoch = current_sso_session_authority().session_epoch
     pool = await get_pool()
     async with pool.acquire() as conn:
         access_expires_at = await conn.fetchval(
@@ -466,7 +467,8 @@ async def _resolve_sso_browser_session_pass(
     allow_refresh: bool,
 ) -> tuple[AuthenticatedUser | None, bool]:
     """Run one locked resolution pass, optionally performing remote refresh."""
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     invalid = False
     result: AuthenticatedUser | None = None
     needs_refresh = False
@@ -474,7 +476,7 @@ async def _resolve_sso_browser_session_pass(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             row = await conn.fetchrow(
                 """
                 SELECT s.*, e.issuer AS current_issuer,
@@ -738,7 +740,8 @@ async def revoke_sso_browser_session(
     csrf_header: str,
 ) -> RevokedSsoBrowserSession:
     """Delete one local handle and return its encrypted revocation material."""
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
     token = _bounded_credential(raw_token)
     cookie = _bounded_credential(csrf_cookie)
     header = _bounded_credential(csrf_header)
@@ -750,7 +753,7 @@ async def revoke_sso_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             row = await conn.fetchrow(
                 """
                 SELECT id, user_id, csrf_token_hash, token_envelope
@@ -821,12 +824,13 @@ async def revoke_sso_browser_sessions_from_logout_token(
     if event_expires_at <= event_issued_at or event_expires_at <= now:
         raise AuthenticationError("Invalid back-channel logout token")
     fence_expires_at = max(event_expires_at, now + _LOGOUT_FENCE_TTL)
-    session_epoch = current_sso_session_epoch()
+    authority = current_sso_session_authority()
+    session_epoch = authority.session_epoch
 
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await lock_active_sso_session_epoch(conn, session_epoch)
+            await lock_active_sso_session_epoch(conn, authority)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
                 f"sso-browser-sid:{session_epoch}:{issuer}:{sid}",
@@ -838,8 +842,9 @@ async def revoke_sso_browser_sessions_from_logout_token(
                     session_epoch, identity_issuer, keycloak_sid, identity_subject,
                     logout_issued_at, expires_at
                 ) VALUES ($1, $2, $3, $4, $5, $6)
-                ON CONFLICT (session_epoch, identity_issuer, keycloak_sid) DO UPDATE
-                   SET identity_subject = CASE
+                ON CONFLICT (identity_issuer, keycloak_sid) DO UPDATE
+                   SET session_epoch = EXCLUDED.session_epoch,
+                       identity_subject = CASE
                            WHEN EXCLUDED.logout_issued_at >=
                                 sso_browser_logout_fences.logout_issued_at
                            THEN EXCLUDED.identity_subject

--- a/backend/app/services/sso_browser_session_service.py
+++ b/backend/app/services/sso_browser_session_service.py
@@ -30,6 +30,10 @@ from app.services.sso_browser_session_crypto import (
     BrowserSessionKeyError,
     BrowserSessionPayloadError,
 )
+from app.services.sso_session_epoch import (
+    current_sso_session_epoch,
+    lock_active_sso_session_epoch,
+)
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError, validate_alias
 
 
@@ -247,6 +251,7 @@ async def create_sso_browser_session(
         absolute_expiry=absolute_expiry,
     )
     scope = _scope(principal.claims)
+    session_epoch = current_sso_session_epoch()
 
     try:
         user_id = uuid.UUID(user.user_id)
@@ -268,16 +273,17 @@ async def create_sso_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                f"sso-browser-session:{user_id}",
+                f"sso-browser-session:{session_epoch}:{user_id}",
             )
             # Session creation and back-channel logout share this exact lock.
             # The durable fence below then rejects a callback that resumes
             # after a verified logout event has already committed.
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                f"sso-browser-sid:{issuer}:{sid}",
+                f"sso-browser-sid:{session_epoch}:{issuer}:{sid}",
             )
             await conn.execute("DELETE FROM sso_browser_logout_fences WHERE expires_at <= NOW()")
             fenced = await conn.fetchval(
@@ -285,13 +291,15 @@ async def create_sso_browser_session(
                 SELECT EXISTS (
                     SELECT 1
                       FROM sso_browser_logout_fences
-                     WHERE identity_issuer = $1
-                       AND keycloak_sid = $2
-                       AND (identity_subject IS NULL OR identity_subject = $3)
-                       AND logout_issued_at >= $4
+                     WHERE session_epoch = $1
+                       AND identity_issuer = $2
+                       AND keycloak_sid = $3
+                       AND (identity_subject IS NULL OR identity_subject = $4)
+                       AND logout_issued_at >= $5
                        AND expires_at > NOW()
                 )
                 """,
+                session_epoch,
                 issuer,
                 sid,
                 subject,
@@ -336,24 +344,27 @@ async def create_sso_browser_session(
                     SELECT id
                       FROM sso_browser_sessions
                      WHERE user_id = $1
+                       AND session_epoch = $2
                      ORDER BY created_at DESC, id DESC
                     OFFSET 7
                  )
                 """,
                 user_id,
+                session_epoch,
             )
             await conn.execute(
                 """
                 INSERT INTO sso_browser_sessions (
-                    id, token_hash, csrf_token_hash, user_id,
+                    id, session_epoch, token_hash, csrf_token_hash, user_id,
                     external_identity_id, identity_issuer, identity_subject,
                     keycloak_sid, token_envelope, access_expires_at,
                     refresh_expires_at, idle_expires_at, absolute_expires_at
                 ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
                 )
                 """,
                 session_id,
+                session_epoch,
                 _hash_credential(token),
                 _hash_credential(csrf_token),
                 user_id,
@@ -428,6 +439,7 @@ async def resolve_sso_browser_session(
 
 async def _sso_browser_session_needs_refresh(token_hash: str) -> bool:
     """Probe expiry without waiting on a concurrent refresh row lock."""
+    session_epoch = current_sso_session_epoch()
     pool = await get_pool()
     async with pool.acquire() as conn:
         access_expires_at = await conn.fetchval(
@@ -435,8 +447,10 @@ async def _sso_browser_session_needs_refresh(token_hash: str) -> bool:
             SELECT access_expires_at
               FROM sso_browser_sessions
              WHERE token_hash = $1
+               AND session_epoch = $2
             """,
             token_hash,
+            session_epoch,
         )
     if not isinstance(access_expires_at, datetime):
         return False
@@ -452,6 +466,7 @@ async def _resolve_sso_browser_session_pass(
     allow_refresh: bool,
 ) -> tuple[AuthenticatedUser | None, bool]:
     """Run one locked resolution pass, optionally performing remote refresh."""
+    session_epoch = current_sso_session_epoch()
     invalid = False
     result: AuthenticatedUser | None = None
     needs_refresh = False
@@ -459,6 +474,7 @@ async def _resolve_sso_browser_session_pass(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             row = await conn.fetchrow(
                 """
                 SELECT s.*, e.issuer AS current_issuer,
@@ -470,9 +486,11 @@ async def _resolve_sso_browser_session_pass(
                   JOIN external_identities e
                     ON e.id = s.external_identity_id AND e.user_id = s.user_id
                  WHERE s.token_hash = $1
+                   AND s.session_epoch = $2
                  FOR UPDATE OF s
                 """,
                 token_hash,
+                session_epoch,
             )
             now = datetime.now(timezone.utc)
             if row is None:
@@ -720,6 +738,7 @@ async def revoke_sso_browser_session(
     csrf_header: str,
 ) -> RevokedSsoBrowserSession:
     """Delete one local handle and return its encrypted revocation material."""
+    session_epoch = current_sso_session_epoch()
     token = _bounded_credential(raw_token)
     cookie = _bounded_credential(csrf_cookie)
     header = _bounded_credential(csrf_header)
@@ -731,14 +750,17 @@ async def revoke_sso_browser_session(
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             row = await conn.fetchrow(
                 """
                 SELECT id, user_id, csrf_token_hash, token_envelope
                   FROM sso_browser_sessions
                  WHERE token_hash = $1
+                   AND session_epoch = $2
                  FOR UPDATE
                 """,
                 token_hash,
+                session_epoch,
             )
             if (
                 row is None
@@ -799,22 +821,24 @@ async def revoke_sso_browser_sessions_from_logout_token(
     if event_expires_at <= event_issued_at or event_expires_at <= now:
         raise AuthenticationError("Invalid back-channel logout token")
     fence_expires_at = max(event_expires_at, now + _LOGOUT_FENCE_TTL)
+    session_epoch = current_sso_session_epoch()
 
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
+            await lock_active_sso_session_epoch(conn, session_epoch)
             await conn.execute(
                 "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
-                f"sso-browser-sid:{issuer}:{sid}",
+                f"sso-browser-sid:{session_epoch}:{issuer}:{sid}",
             )
             await conn.execute("DELETE FROM sso_browser_logout_fences WHERE expires_at <= NOW()")
             await conn.execute(
                 """
                 INSERT INTO sso_browser_logout_fences (
-                    identity_issuer, keycloak_sid, identity_subject,
+                    session_epoch, identity_issuer, keycloak_sid, identity_subject,
                     logout_issued_at, expires_at
-                ) VALUES ($1, $2, $3, $4, $5)
-                ON CONFLICT (identity_issuer, keycloak_sid) DO UPDATE
+                ) VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT (session_epoch, identity_issuer, keycloak_sid) DO UPDATE
                    SET identity_subject = CASE
                            WHEN EXCLUDED.logout_issued_at >=
                                 sso_browser_logout_fences.logout_issued_at
@@ -831,6 +855,7 @@ async def revoke_sso_browser_sessions_from_logout_token(
                        ),
                        received_at = NOW()
                 """,
+                session_epoch,
                 issuer,
                 sid,
                 subject,
@@ -840,10 +865,12 @@ async def revoke_sso_browser_sessions_from_logout_token(
             result = await conn.execute(
                 """
                 DELETE FROM sso_browser_sessions
-                 WHERE identity_issuer = $1
-                   AND keycloak_sid = $2
-                   AND ($3::TEXT IS NULL OR identity_subject = $3)
+                 WHERE session_epoch = $1
+                   AND identity_issuer = $2
+                   AND keycloak_sid = $3
+                   AND ($4::TEXT IS NULL OR identity_subject = $4)
                 """,
+                session_epoch,
                 issuer,
                 sid,
                 subject,

--- a/backend/app/services/sso_session_epoch.py
+++ b/backend/app/services/sso_session_epoch.py
@@ -1,0 +1,157 @@
+"""Runtime authority generation for all SSO browser sessions.
+
+The configured UUID is intentionally not a credential. It is an installation-
+owned generation marker: normal SSO restarts reuse it, while an explicit epoch
+change invalidates every ordinary/admin browser handle and logout fence. AKB
+also persists the last observed auth mode, so a real sso -> local -> sso
+transition cannot revive rows that were merely ignored while local mode ran.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import AuthenticationError
+from app.repositories.events_repo import emit_event
+
+
+@dataclass(frozen=True, slots=True)
+class SsoSessionEpochReconcileResult:
+    changed: bool
+    auth_mode_changed: bool
+    epoch_changed: bool
+    ordinary_sessions_revoked: int
+    admin_sessions_revoked: int
+    logout_fences_revoked: int
+
+
+def current_sso_session_epoch() -> uuid.UUID:
+    """Return the validated current epoch or fail closed at request time."""
+    value = settings.sso_session_epoch
+    if not isinstance(value, uuid.UUID):
+        raise AuthenticationError("SSO session authority is unavailable")
+    return value
+
+
+async def lock_active_sso_session_epoch(
+    conn,
+    expected_epoch: uuid.UUID,
+) -> None:
+    """Pin one request to the database-observed active SSO generation.
+
+    The share lock serializes with startup reconciliation's row update. A
+    draining replica with stale mode/config therefore fails before touching
+    browser-session state, while the FK remains the database-level backstop.
+    """
+    active = await conn.fetchval(
+        """
+        SELECT sso_session_epoch
+          FROM auth_runtime_state
+         WHERE singleton = TRUE
+           AND auth_mode = 'sso'
+           AND sso_session_epoch = $1
+         FOR SHARE
+        """,
+        expected_epoch,
+    )
+    if active != expected_epoch:
+        raise AuthenticationError("SSO session authority is unavailable")
+
+
+def _command_count(result: object) -> int:
+    try:
+        return int(str(result).rsplit(" ", 1)[-1])
+    except ValueError:
+        return 0
+
+
+async def reconcile_sso_session_epoch() -> SsoSessionEpochReconcileResult:
+    """Atomically observe the runtime boundary and revoke stale SSO state."""
+    mode = settings.require_auth_mode()
+    desired_epoch = current_sso_session_epoch() if mode == "sso" else None
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            insert_result = await conn.execute(
+                """
+                INSERT INTO auth_runtime_state (
+                    singleton, auth_mode, sso_session_epoch
+                ) VALUES (TRUE, $1, $2)
+                ON CONFLICT (singleton) DO NOTHING
+                """,
+                mode,
+                desired_epoch,
+            )
+            inserted = _command_count(insert_result) == 1
+            observed = await conn.fetchrow(
+                """
+                SELECT auth_mode, sso_session_epoch
+                  FROM auth_runtime_state
+                 WHERE singleton = TRUE
+                 FOR UPDATE
+                """
+            )
+            if observed is None:
+                raise RuntimeError("auth runtime state is unavailable")
+
+            auth_mode_changed = not inserted and observed["auth_mode"] != mode
+            epoch_changed = (
+                not inserted and observed["sso_session_epoch"] != desired_epoch
+            )
+            changed = inserted or auth_mode_changed or epoch_changed
+            if not changed:
+                return SsoSessionEpochReconcileResult(
+                    changed=False,
+                    auth_mode_changed=False,
+                    epoch_changed=False,
+                    ordinary_sessions_revoked=0,
+                    admin_sessions_revoked=0,
+                    logout_fences_revoked=0,
+                )
+
+            ordinary = _command_count(
+                await conn.execute("DELETE FROM sso_browser_sessions")
+            )
+            admin = _command_count(
+                await conn.execute("DELETE FROM admin_browser_sessions")
+            )
+            fences = _command_count(
+                await conn.execute("DELETE FROM sso_browser_logout_fences")
+            )
+            if not inserted:
+                await conn.execute(
+                    """
+                    UPDATE auth_runtime_state
+                       SET auth_mode = $1,
+                           sso_session_epoch = $2,
+                           updated_at = NOW()
+                     WHERE singleton = TRUE
+                    """,
+                    mode,
+                    desired_epoch,
+                )
+            await emit_event(
+                conn,
+                "auth.runtime_boundary_changed",
+                actor_id="system",
+                payload={
+                    "auth_mode": mode,
+                    "initialized": inserted,
+                    "auth_mode_changed": auth_mode_changed,
+                    "sso_session_epoch_changed": epoch_changed,
+                    "ordinary_sessions_revoked": ordinary,
+                    "admin_sessions_revoked": admin,
+                    "logout_fences_revoked": fences,
+                },
+            )
+    return SsoSessionEpochReconcileResult(
+        changed=True,
+        auth_mode_changed=auth_mode_changed,
+        epoch_changed=epoch_changed,
+        ordinary_sessions_revoked=ordinary,
+        admin_sessions_revoked=admin,
+        logout_fences_revoked=fences,
+    )

--- a/backend/app/services/sso_session_epoch.py
+++ b/backend/app/services/sso_session_epoch.py
@@ -1,21 +1,44 @@
-"""Runtime authority generation for all SSO browser sessions.
+"""Monotonic runtime authority for all SSO browser sessions.
 
-The configured UUID is intentionally not a credential. It is an installation-
-owned generation marker: normal SSO restarts reuse it, while an explicit epoch
-change invalidates every ordinary/admin browser handle and logout fence. AKB
-also persists the last observed auth mode, so a real sso -> local -> sso
-transition cannot revive rows that were merely ignored while local mode ran.
+``auth_runtime_generation`` is installation-owned and monotonic. An ordinary
+restart must present the exact stored generation/mode/epoch tuple. A deliberate
+transition presents a greater generation; stale or conflicting replicas fail
+closed and can never restore an older authority boundary.
 """
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
+
+import asyncpg
 
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import AuthenticationError
 from app.repositories.events_repo import emit_event
+
+
+@dataclass(frozen=True, slots=True)
+class AuthRuntimeBoundary:
+    runtime_generation: int
+    auth_mode: str
+    sso_session_epoch: uuid.UUID | None
+
+    def __post_init__(self) -> None:
+        valid_generation = type(self.runtime_generation) is int and self.runtime_generation > 0
+        valid_shape = (self.auth_mode == "local" and self.sso_session_epoch is None) or (
+            self.auth_mode == "sso" and isinstance(self.sso_session_epoch, uuid.UUID)
+        )
+        if not valid_generation or not valid_shape:
+            raise RuntimeError("Invalid authentication runtime boundary")
+
+
+@dataclass(frozen=True, slots=True)
+class SsoSessionAuthority:
+    runtime_generation: int
+    session_epoch: uuid.UUID
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,36 +51,55 @@ class SsoSessionEpochReconcileResult:
     logout_fences_revoked: int
 
 
+def configured_auth_runtime_boundary() -> AuthRuntimeBoundary:
+    mode = settings.require_auth_mode()
+    epoch = current_sso_session_epoch() if mode == "sso" else None
+    return AuthRuntimeBoundary(settings.auth_runtime_generation, mode, epoch)
+
+
 def current_sso_session_epoch() -> uuid.UUID:
-    """Return the validated current epoch or fail closed at request time."""
+    """Return the configured epoch or fail closed without disclosing it."""
     value = settings.sso_session_epoch
     if not isinstance(value, uuid.UUID):
         raise AuthenticationError("SSO session authority is unavailable")
     return value
 
 
+def current_sso_session_authority() -> SsoSessionAuthority:
+    """Snapshot the exact configured generation/epoch request boundary."""
+    if settings.require_auth_mode() != "sso":
+        raise AuthenticationError("SSO session authority is unavailable")
+    generation = settings.auth_runtime_generation
+    epoch = current_sso_session_epoch()
+    if type(generation) is not int or generation <= 0:
+        raise AuthenticationError("SSO session authority is unavailable")
+    return SsoSessionAuthority(generation, epoch)
+
+
 async def lock_active_sso_session_epoch(
     conn,
-    expected_epoch: uuid.UUID,
+    authority: SsoSessionAuthority,
 ) -> None:
-    """Pin one request to the database-observed active SSO generation.
+    """Pin one request to the exact database-observed SSO authority.
 
-    The share lock serializes with startup reconciliation's row update. A
-    draining replica with stale mode/config therefore fails before touching
-    browser-session state, while the FK remains the database-level backstop.
+    Every browser operation takes this row lock before touching a session
+    relation. Reconciliation takes the same authority-first order, so a stale
+    replica either finishes before the transition purge or fails afterward.
     """
     active = await conn.fetchval(
         """
-        SELECT sso_session_epoch
+        SELECT TRUE
           FROM auth_runtime_state
          WHERE singleton = TRUE
+           AND runtime_generation = $1
            AND auth_mode = 'sso'
-           AND sso_session_epoch = $1
+           AND sso_session_epoch = $2
          FOR SHARE
         """,
-        expected_epoch,
+        authority.runtime_generation,
+        authority.session_epoch,
     )
-    if active != expected_epoch:
+    if active is not True:
         raise AuthenticationError("SSO session authority is unavailable")
 
 
@@ -68,77 +110,127 @@ def _command_count(result: object) -> int:
         return 0
 
 
-async def reconcile_sso_session_epoch() -> SsoSessionEpochReconcileResult:
-    """Atomically observe the runtime boundary and revoke stale SSO state."""
-    mode = settings.require_auth_mode()
-    desired_epoch = current_sso_session_epoch() if mode == "sso" else None
+async def _lock_session_relations(conn, mode: str) -> None:
+    # Keep this exact order aligned with migration 076. The auth relation and
+    # authority row are always acquired by the caller first.
+    await conn.execute(f"LOCK TABLE admin_browser_sessions IN {mode} MODE")
+    await conn.execute(f"LOCK TABLE sso_browser_sessions IN {mode} MODE")
+    await conn.execute(f"LOCK TABLE sso_browser_logout_fences IN {mode} MODE")
+
+
+async def _reconcile_once(
+    boundary: AuthRuntimeBoundary,
+    *,
+    upgrade_preflight: bool,
+) -> SsoSessionEpochReconcileResult:
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            insert_result = await conn.execute(
-                """
-                INSERT INTO auth_runtime_state (
-                    singleton, auth_mode, sso_session_epoch
-                ) VALUES (TRUE, $1, $2)
-                ON CONFLICT (singleton) DO NOTHING
-                """,
-                mode,
-                desired_epoch,
-            )
-            inserted = _command_count(insert_result) == 1
+            # Relation and row order: authority relation -> authority row ->
+            # admin sessions -> ordinary sessions -> logout fences.
+            await conn.execute("LOCK TABLE auth_runtime_state IN SHARE ROW EXCLUSIVE MODE")
             observed = await conn.fetchrow(
                 """
-                SELECT auth_mode, sso_session_epoch
+                SELECT runtime_generation, auth_mode, sso_session_epoch
                   FROM auth_runtime_state
                  WHERE singleton = TRUE
                  FOR UPDATE
                 """
             )
-            if observed is None:
-                raise RuntimeError("auth runtime state is unavailable")
-
-            auth_mode_changed = not inserted and observed["auth_mode"] != mode
-            epoch_changed = (
-                not inserted and observed["sso_session_epoch"] != desired_epoch
+            upgrade = await conn.fetchrow(
+                """
+                SELECT state, runtime_generation_floor
+                  FROM auth_runtime_epoch_upgrade
+                 WHERE singleton = TRUE
+                """
             )
-            changed = inserted or auth_mode_changed or epoch_changed
-            if not changed:
-                return SsoSessionEpochReconcileResult(
-                    changed=False,
-                    auth_mode_changed=False,
-                    epoch_changed=False,
-                    ordinary_sessions_revoked=0,
-                    admin_sessions_revoked=0,
-                    logout_fences_revoked=0,
+            if upgrade is None:
+                raise RuntimeError("Authentication runtime upgrade state is unavailable")
+            upgrade_state = upgrade["state"]
+            generation_floor = upgrade["runtime_generation_floor"]
+            if upgrade_state in {"required", "rollback_ready"} and (
+                settings.sso_session_epoch_upgrade != "stop-the-world-v1" or not upgrade_preflight
+            ):
+                raise RuntimeError(
+                    "SSO session epoch upgrade requires the executable stop-the-world-v1 quiescent preflight"
                 )
 
-            ordinary = _command_count(
-                await conn.execute("DELETE FROM sso_browser_sessions")
-            )
-            admin = _command_count(
-                await conn.execute("DELETE FROM admin_browser_sessions")
-            )
-            fences = _command_count(
-                await conn.execute("DELETE FROM sso_browser_logout_fences")
-            )
+            inserted = observed is None
+            if inserted and boundary.runtime_generation <= generation_floor:
+                raise RuntimeError("Authentication runtime generation is stale")
+            if observed is not None:
+                observed_generation = observed["runtime_generation"]
+                exact = (
+                    observed_generation == boundary.runtime_generation
+                    and observed["auth_mode"] == boundary.auth_mode
+                    and observed["sso_session_epoch"] == boundary.sso_session_epoch
+                )
+                if exact and upgrade_state == "enforced":
+                    return SsoSessionEpochReconcileResult(
+                        changed=False,
+                        auth_mode_changed=False,
+                        epoch_changed=False,
+                        ordinary_sessions_revoked=0,
+                        admin_sessions_revoked=0,
+                        logout_fences_revoked=0,
+                    )
+                if boundary.runtime_generation < observed_generation:
+                    raise RuntimeError("Authentication runtime generation is stale")
+                if boundary.runtime_generation == observed_generation and not exact:
+                    raise RuntimeError("Authentication runtime generation conflicts with the active boundary")
+
+            auth_mode_changed = bool(observed is not None and observed["auth_mode"] != boundary.auth_mode)
+            epoch_changed = bool(observed is not None and observed["sso_session_epoch"] != boundary.sso_session_epoch)
+
+            if inserted:
+                await conn.execute(
+                    """
+                    INSERT INTO auth_runtime_state (
+                        singleton, runtime_generation, auth_mode,
+                        sso_session_epoch
+                    ) VALUES (TRUE, $1, $2, $3)
+                    """,
+                    boundary.runtime_generation,
+                    boundary.auth_mode,
+                    boundary.sso_session_epoch,
+                )
+
+            await _lock_session_relations(conn, "SHARE ROW EXCLUSIVE")
+            admin = _command_count(await conn.execute("DELETE FROM admin_browser_sessions"))
+            ordinary = _command_count(await conn.execute("DELETE FROM sso_browser_sessions"))
+            fences = _command_count(await conn.execute("DELETE FROM sso_browser_logout_fences"))
             if not inserted:
                 await conn.execute(
                     """
                     UPDATE auth_runtime_state
-                       SET auth_mode = $1,
-                           sso_session_epoch = $2,
+                       SET runtime_generation = $1,
+                           auth_mode = $2,
+                           sso_session_epoch = $3,
                            updated_at = NOW()
                      WHERE singleton = TRUE
                     """,
-                    mode,
-                    desired_epoch,
+                    boundary.runtime_generation,
+                    boundary.auth_mode,
+                    boundary.sso_session_epoch,
                 )
+            await conn.execute(
+                """
+                UPDATE auth_runtime_epoch_upgrade
+                   SET state = 'enforced',
+                       runtime_generation_floor = GREATEST(
+                           runtime_generation_floor, $1
+                       ),
+                       updated_at = NOW()
+                 WHERE singleton = TRUE
+                """,
+                boundary.runtime_generation,
+            )
             await emit_event(
                 conn,
                 "auth.runtime_boundary_changed",
                 actor_id="system",
                 payload={
-                    "auth_mode": mode,
+                    "auth_mode": boundary.auth_mode,
                     "initialized": inserted,
                     "auth_mode_changed": auth_mode_changed,
                     "sso_session_epoch_changed": epoch_changed,
@@ -155,3 +247,57 @@ async def reconcile_sso_session_epoch() -> SsoSessionEpochReconcileResult:
         admin_sessions_revoked=admin,
         logout_fences_revoked=fences,
     )
+
+
+async def reconcile_sso_session_epoch(
+    boundary: AuthRuntimeBoundary | None = None,
+    *,
+    upgrade_preflight: bool = False,
+) -> SsoSessionEpochReconcileResult:
+    """Accept an exact restart or atomically advance one monotonic boundary."""
+    desired = boundary or configured_auth_runtime_boundary()
+    for attempt in range(3):
+        try:
+            return await _reconcile_once(
+                desired,
+                upgrade_preflight=upgrade_preflight,
+            )
+        except asyncpg.DeadlockDetectedError:
+            # PostgreSQL rolled back the whole transaction. Replaying the same
+            # immutable desired boundary is therefore safe and idempotent.
+            if attempt == 2:
+                raise
+            await asyncio.sleep(0.05 * (attempt + 1))
+    raise AssertionError("unreachable")
+
+
+async def prepare_sso_session_epoch_rollback() -> None:
+    """Purge current authority and reopen only the legacy rollback bridge.
+
+    The executable preflight checks that all current backends are stopped before
+    calling this transaction. No epoch or generation value is logged or emitted.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("LOCK TABLE auth_runtime_state IN SHARE ROW EXCLUSIVE MODE")
+            await conn.fetchrow(
+                """
+                SELECT runtime_generation
+                  FROM auth_runtime_state
+                 WHERE singleton = TRUE
+                 FOR UPDATE
+                """
+            )
+            await _lock_session_relations(conn, "SHARE ROW EXCLUSIVE")
+            await conn.execute("DELETE FROM admin_browser_sessions")
+            await conn.execute("DELETE FROM sso_browser_sessions")
+            await conn.execute("DELETE FROM sso_browser_logout_fences")
+            await conn.execute("DELETE FROM auth_runtime_state")
+            await conn.execute(
+                """
+                UPDATE auth_runtime_epoch_upgrade
+                   SET state = 'rollback_ready', updated_at = NOW()
+                 WHERE singleton = TRUE
+                """
+            )

--- a/backend/scripts/sso_session_epoch_preflight.py
+++ b/backend/scripts/sso_session_epoch_preflight.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Machine-check the stop-the-world SSO epoch upgrade/rollback contract."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+import asyncpg
+
+from app.config import settings
+from app.db.postgres import close_pool, init_db
+from app.services.sso_session_epoch import (
+    prepare_sso_session_epoch_rollback,
+    reconcile_sso_session_epoch,
+)
+
+
+async def _status(conn) -> dict[str, object]:
+    marker_exists = await conn.fetchval("SELECT to_regclass('auth_runtime_epoch_upgrade') IS NOT NULL")
+    if not marker_exists:
+        return {
+            "contract": "stop-the-world-v1",
+            "state": "migration_pending",
+            "legacy_rows_present": None,
+        }
+    state = await conn.fetchval("SELECT state FROM auth_runtime_epoch_upgrade WHERE singleton = TRUE")
+    legacy_rows_present = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM admin_browser_sessions WHERE session_epoch IS NULL
+            UNION ALL
+            SELECT 1 FROM sso_browser_sessions WHERE session_epoch IS NULL
+            UNION ALL
+            SELECT 1 FROM sso_browser_logout_fences WHERE session_epoch IS NULL
+        )
+        """
+    )
+    return {
+        "contract": "stop-the-world-v1",
+        "state": state,
+        "legacy_rows_present": legacy_rows_present,
+    }
+
+
+async def _connect():
+    return await asyncpg.connect(
+        settings.asyncpg_dsn,
+        server_settings={"application_name": "akb-auth-runtime-preflight"},
+    )
+
+
+async def _assert_quiescent(conn) -> None:
+    others = await conn.fetchval(
+        """
+        SELECT COUNT(*)
+          FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND pid <> pg_backend_pid()
+           AND backend_type = 'client backend'
+        """
+    )
+    if others:
+        raise RuntimeError("stop-the-world-v1 requires every backend and database client to be stopped")
+
+
+async def _run(command: str) -> dict[str, object]:
+    conn = await _connect()
+    try:
+        if command == "status":
+            return await _status(conn)
+        await _assert_quiescent(conn)
+    finally:
+        await conn.close()
+
+    try:
+        if command == "prepare-upgrade":
+            await init_db()
+            await reconcile_sso_session_epoch(upgrade_preflight=True)
+        elif command == "prepare-rollback":
+            await prepare_sso_session_epoch_rollback()
+        else:
+            raise ValueError("unknown command")
+    finally:
+        await close_pool()
+
+    conn = await _connect()
+    try:
+        return await _status(conn)
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("status", "prepare-upgrade", "prepare-rollback"),
+    )
+    args = parser.parse_args()
+    result = asyncio.run(_run(args.command))
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/fixtures/sso_session_epoch/exact_base_0860a0e_init.sql
+++ b/backend/tests/fixtures/sso_session_epoch/exact_base_0860a0e_init.sql
@@ -81,56 +81,12 @@ CREATE INDEX IF NOT EXISTS idx_external_identities_user
 CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
     ON external_identities(id, user_id);
 
--- Singleton authority for the last accepted runtime auth boundary. The
--- installation generation is monotonic: an exact restart is accepted, a
--- greater generation performs one transition, and stale/conflicting starts
--- fail closed. Local mode never carries an SSO epoch.
-CREATE TABLE IF NOT EXISTS auth_runtime_state (
-    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
-        CHECK (singleton),
-    runtime_generation BIGINT NOT NULL
-        CHECK (runtime_generation > 0),
-    auth_mode TEXT NOT NULL
-        CHECK (auth_mode IN ('local', 'sso')),
-    sso_session_epoch UUID,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT auth_runtime_state_sso_session_epoch_key
-        UNIQUE (sso_session_epoch),
-    CONSTRAINT auth_runtime_state_epoch_shape
-        CHECK (
-            (auth_mode = 'local' AND sso_session_epoch IS NULL)
-            OR
-            (auth_mode = 'sso' AND sso_session_epoch IS NOT NULL)
-        )
-);
-
--- Machine-readable state for the one-time pre-epoch stop-the-world bridge.
--- `required` blocks normal startup until the explicit upgrade acknowledgement;
--- `enforced` makes legacy NULL writes fail; `rollback_ready` is written only
--- after every epoch-bound row and runtime authority row has been purged.
-CREATE TABLE IF NOT EXISTS auth_runtime_epoch_upgrade (
-    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE
-        CHECK (singleton),
-    state TEXT NOT NULL
-        CHECK (state IN ('ready', 'required', 'enforced', 'rollback_ready')),
-    runtime_generation_floor BIGINT NOT NULL DEFAULT 0
-        CHECK (runtime_generation_floor >= 0),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-INSERT INTO auth_runtime_epoch_upgrade (singleton, state)
-VALUES (TRUE, 'ready')
-ON CONFLICT (singleton) DO NOTHING;
-
 -- Dedicated product-admin browser sessions. These rows contain only hashes
 -- of opaque AKB session/CSRF values, an exact external-identity FK, and the
 -- issuer/subject snapshot used to invalidate a changed binding. No Keycloak
 -- access, refresh, or ID token is stored here.
 CREATE TABLE IF NOT EXISTS admin_browser_sessions (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    -- Nullable only for pre-epoch image rollback compatibility. Migration 076
-    -- installs a database guard that rejects NULL while current code is active.
-    session_epoch UUID,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -149,9 +105,6 @@ CREATE TABLE IF NOT EXISTS admin_browser_sessions (
     CONSTRAINT admin_browser_session_external_user_fk
         FOREIGN KEY (external_identity_id, user_id)
         REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
-    CONSTRAINT admin_browser_session_epoch_fk
-        FOREIGN KEY (session_epoch)
-        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT admin_browser_session_positive_lifetime
         CHECK (expires_at > created_at)
 );
@@ -167,7 +120,6 @@ CREATE INDEX IF NOT EXISTS idx_admin_browser_sessions_user
 -- exact row and AKB user. Access tokens are verified and discarded.
 CREATE TABLE IF NOT EXISTS sso_browser_sessions (
     id UUID PRIMARY KEY,
-    session_epoch UUID,
     token_hash TEXT NOT NULL UNIQUE
         CHECK (token_hash ~ '^[0-9a-f]{64}$'),
     csrf_token_hash TEXT NOT NULL
@@ -192,9 +144,6 @@ CREATE TABLE IF NOT EXISTS sso_browser_sessions (
     CONSTRAINT sso_browser_session_external_user_fk
         FOREIGN KEY (external_identity_id, user_id)
         REFERENCES external_identities(id, user_id) ON DELETE CASCADE,
-    CONSTRAINT sso_browser_session_epoch_fk
-        FOREIGN KEY (session_epoch)
-        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT sso_browser_session_positive_lifetime
         CHECK (
             access_expires_at > created_at
@@ -211,9 +160,6 @@ CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_absolute_expiry
     ON sso_browser_sessions(absolute_expires_at);
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_user
     ON sso_browser_sessions(user_id);
--- init.sql runs before migrations on every startup, including against tables
--- created by a pre-epoch image. Migration 076 replaces these two compatible
--- definitions with epoch-leading indexes after it adds session_epoch.
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_sid
     ON sso_browser_sessions(identity_issuer, keycloak_sid);
 CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_subject
@@ -223,7 +169,6 @@ CREATE INDEX IF NOT EXISTS idx_sso_browser_sessions_subject
 -- logout. Session creation and logout also share a transaction advisory lock;
 -- this row rejects a callback that resumes only after logout committed.
 CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
-    session_epoch UUID,
     identity_issuer TEXT NOT NULL
         CHECK (char_length(identity_issuer) BETWEEN 1 AND 2048),
     keycloak_sid TEXT NOT NULL
@@ -236,12 +181,7 @@ CREATE TABLE IF NOT EXISTS sso_browser_logout_fences (
     logout_issued_at TIMESTAMPTZ NOT NULL,
     expires_at TIMESTAMPTZ NOT NULL,
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    -- Retain the pre-epoch key so an explicitly prepared rollback image can
-    -- still execute its original ON CONFLICT target.
     PRIMARY KEY (identity_issuer, keycloak_sid),
-    CONSTRAINT sso_browser_logout_fence_epoch_fk
-        FOREIGN KEY (session_epoch)
-        REFERENCES auth_runtime_state(sso_session_epoch),
     CONSTRAINT sso_browser_logout_fence_positive_lifetime
         CHECK (expires_at > logout_issued_at)
 );

--- a/backend/tests/test_admin_auth_postgres.py
+++ b/backend/tests/test_admin_auth_postgres.py
@@ -123,10 +123,18 @@ async def _fresh_database():
             await conn.execute(
                 """
                 INSERT INTO auth_runtime_state (
-                    singleton, auth_mode, sso_session_epoch
-                ) VALUES (TRUE, 'sso', $1)
+                    singleton, runtime_generation, auth_mode,
+                    sso_session_epoch
+                ) VALUES (TRUE, 1, 'sso', $1)
                 """,
                 _SSO_SESSION_EPOCH,
+            )
+            await conn.execute(
+                """
+                UPDATE auth_runtime_epoch_upgrade
+                   SET state = 'enforced'
+                 WHERE singleton = TRUE
+                """
             )
         finally:
             await conn.close()
@@ -158,6 +166,7 @@ async def test_sso_admin_is_exact_prebound_opaque_and_live_rechecked(
         monkeypatch.setattr(admin_auth_service, "get_pool", get_test_pool)
         monkeypatch.setattr(keycloak_oidc, "get_pool", get_test_pool)
         monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+        monkeypatch.setattr(settings, "auth_runtime_generation", 1, raising=False)
         monkeypatch.setattr(
             settings,
             "keycloak_server_url",

--- a/backend/tests/test_admin_auth_postgres.py
+++ b/backend/tests/test_admin_auth_postgres.py
@@ -27,6 +27,7 @@ _DSN = os.environ.get(
     "AKB_TEST_DSN",
     "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
 )
+_SSO_SESSION_EPOCH = uuid.UUID("80af20c6-6f9e-452e-9693-98b6ae0ea213")
 
 
 def _dsn_for_database(dsn: str, database: str) -> str:
@@ -51,7 +52,7 @@ async def _admin_schema_shape(conn) -> dict[str, tuple[tuple[object, ...], ...]]
           FROM information_schema.columns
          WHERE table_schema = 'public'
            AND table_name = 'admin_browser_sessions'
-         ORDER BY ordinal_position
+         ORDER BY column_name
         """
     )
     constraints = await conn.fetch(
@@ -107,11 +108,26 @@ async def _fresh_database():
             assert admin_session_migration is not None
             await admin_session_migration.migrate(conn=conn)
             await admin_session_migration.migrate(conn=conn)
+            ordinary_session_migration = _load_migration("074_sso_browser_sessions.py")
+            assert ordinary_session_migration is not None
+            await ordinary_session_migration.migrate(conn=conn)
+            epoch_migration = _load_migration("076_sso_session_epoch.py")
+            assert epoch_migration is not None
+            await epoch_migration.migrate(conn=conn)
+            await epoch_migration.migrate(conn=conn)
             assert await _admin_schema_shape(conn) == fresh_admin_shape
 
             events_migration = _load_migration("015_events_outbox.py")
             assert events_migration is not None
             await events_migration.migrate(conn=conn)
+            await conn.execute(
+                """
+                INSERT INTO auth_runtime_state (
+                    singleton, auth_mode, sso_session_epoch
+                ) VALUES (TRUE, 'sso', $1)
+                """,
+                _SSO_SESSION_EPOCH,
+            )
         finally:
             await conn.close()
         pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=4)
@@ -152,6 +168,7 @@ async def test_sso_admin_is_exact_prebound_opaque_and_live_rechecked(
         monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
         monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
         monkeypatch.setattr(settings, "admin_browser_session_ttl_secs", 300, raising=False)
+        monkeypatch.setattr(settings, "sso_session_epoch", _SSO_SESSION_EPOCH, raising=False)
 
         oidc = keycloak_oidc.KeycloakOIDC()
         rejected_request = await oidc.begin_admin_login()
@@ -246,14 +263,15 @@ async def test_sso_admin_is_exact_prebound_opaque_and_live_rechecked(
                 await conn.execute(
                     """
                     INSERT INTO admin_browser_sessions (
-                        token_hash, csrf_token_hash, user_id,
+                        session_epoch, token_hash, csrf_token_hash, user_id,
                         external_identity_id, identity_issuer, identity_subject,
                         keycloak_sid, expires_at
                     ) VALUES (
-                        $1, $2, $3, $4, $5, $6,
+                        $1, $2, $3, $4, $5, $6, $7,
                         'sid', NOW() + INTERVAL '5 minutes'
                     )
                     """,
+                    _SSO_SESSION_EPOCH,
                     "a" * 64,
                     "b" * 64,
                     admin_user_id,

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -10,6 +10,9 @@ import yaml
 from app import config as app_config
 
 
+_VALID_SSO_EPOCH = "b71eb45d-1091-4673-a4bc-e3646d4dd279"
+
+
 def _load(
     monkeypatch,
     tmp_path: Path,
@@ -284,6 +287,7 @@ def test_sso_startup_requires_active_human_api_verifier_config_only(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "",
@@ -314,6 +318,7 @@ def test_sso_startup_defers_ordinary_browser_inputs_but_requires_admin_client(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "akb-web",
@@ -341,6 +346,7 @@ def test_sso_admin_client_is_dedicated_and_callback_is_deployment_bound(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "akb-web",
@@ -371,6 +377,7 @@ def test_sso_backchannel_logout_uri_defaults_public_and_rejects_non_callback_tar
 
     common = {
         "auth_mode": "sso",
+        "sso_session_epoch": _VALID_SSO_EPOCH,
         "keycloak_enabled": True,
         "keycloak_server_url": "https://auth.example.com",
         "keycloak_client_id": "akb-web",
@@ -433,6 +440,7 @@ def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "akb-web",
@@ -452,6 +460,7 @@ def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_client_id": "akb-web",
@@ -471,6 +480,7 @@ def test_sso_startup_rejects_admin_client_reuse_and_non_tls_public_origin(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "http://auth.example.com",
             "keycloak_client_id": "akb-web",
@@ -497,6 +507,7 @@ def test_sso_startup_rejects_missing_system_hmac_secret(
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_redirect_uri": "https://akb.example.com/auth/keycloak/callback",
@@ -525,6 +536,7 @@ def test_sso_startup_accepts_legacy_jwt_secret_only_as_system_hmac_migration_inp
         tmp_path,
         {
             "auth_mode": "sso",
+            "sso_session_epoch": _VALID_SSO_EPOCH,
             "keycloak_enabled": True,
             "keycloak_server_url": "https://auth.example.com",
             "keycloak_redirect_uri": "https://akb.example.com/auth/keycloak/callback",

--- a/backend/tests/test_auth_mode_config_unit.py
+++ b/backend/tests/test_auth_mode_config_unit.py
@@ -64,6 +64,40 @@ def test_runtime_load_accepts_explicit_sso_auth_mode(
     assert loaded.keycloak_sso_only is True
 
 
+def test_runtime_generation_is_positive_and_upgrade_ack_is_versioned(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    loaded = _load(
+        monkeypatch,
+        tmp_path,
+        {
+            "auth_mode": "local",
+            "auth_runtime_generation": 7,
+            "sso_session_epoch_upgrade": "stop-the-world-v1",
+        },
+    )
+
+    assert loaded.auth_runtime_generation == 7
+    assert loaded.sso_session_epoch_upgrade == "stop-the-world-v1"
+
+    with pytest.raises(ValueError):
+        _load(
+            monkeypatch,
+            tmp_path,
+            {"auth_mode": "local", "auth_runtime_generation": 0},
+        )
+    with pytest.raises(ValueError):
+        _load(
+            monkeypatch,
+            tmp_path,
+            {
+                "auth_mode": "local",
+                "sso_session_epoch_upgrade": "rolling",
+            },
+        )
+
+
 def test_programmatic_settings_construction_does_not_require_runtime_mode() -> None:
     configured = app_config.Settings()
 

--- a/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
+++ b/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
@@ -30,6 +30,9 @@ def _settings(tmp_path, backend: str | None = None) -> Settings:
 
 
 def _stub_init_storage_dependencies(monkeypatch, lifecycle, settings, events: list[str]) -> None:
+    from app.services import sso_session_epoch
+    from app.services.sso_session_epoch import SsoSessionEpochReconcileResult
+
     monkeypatch.setattr(lifecycle, "settings", settings)
     monkeypatch.setattr(lifecycle, "_validate_required_settings", lambda: None)
 
@@ -40,8 +43,24 @@ def _stub_init_storage_dependencies(monkeypatch, lifecycle, settings, events: li
         events.append("authority_preflight")
         return "ready"
 
+    async def reconcile_epoch() -> SsoSessionEpochReconcileResult:
+        events.append("reconcile_sso_session_epoch")
+        return SsoSessionEpochReconcileResult(
+            changed=False,
+            auth_mode_changed=False,
+            epoch_changed=False,
+            ordinary_sessions_revoked=0,
+            admin_sessions_revoked=0,
+            logout_fences_revoked=0,
+        )
+
     monkeypatch.setattr(lifecycle, "pre_migration_revision_authority_guard", no_op)
     monkeypatch.setattr(lifecycle, "init_db", no_op)
+    monkeypatch.setattr(
+        sso_session_epoch,
+        "reconcile_sso_session_epoch",
+        reconcile_epoch,
+    )
     monkeypatch.setattr(lifecycle, "startup_revision_authority_preflight", authority_preflight)
 
     class _VectorStore:
@@ -107,6 +126,7 @@ async def test_init_storage_default_and_explicit_bare_git_clean_stale_locks(
 
     assert _TrackingGit.constructed == 1
     assert _TrackingGit.cleanups == 1
+    assert "reconcile_sso_session_epoch" in events
     assert "RoleSync.reconcile_from_catalog" in events
 
 

--- a/backend/tests/test_sso_browser_session_config_unit.py
+++ b/backend/tests/test_sso_browser_session_config_unit.py
@@ -13,6 +13,9 @@ from app.services import auth_policy, lifecycle, sso_browser_session_service
 from app.services.auth_service import AuthenticatedUser
 
 
+_SSO_SESSION_EPOCH = uuid.UUID("3ddfa3a1-d577-4cb4-9596-c4688fa42b17")
+
+
 def _encoded_key(byte: int = 7) -> str:
     return base64.urlsafe_b64encode(bytes([byte]) * 32).decode("ascii").rstrip("=")
 
@@ -26,6 +29,7 @@ def _sso_settings(**changes: object) -> Settings:
         "keycloak_client_secret": "browser-client-secret",  # pragma: allowlist secret
         "keycloak_admin_client_id": "akb-admin",
         "keycloak_admin_client_secret": "admin-client-secret",  # pragma: allowlist secret
+        "sso_session_epoch": _SSO_SESSION_EPOCH,
         "system_hmac_secret": "system-hmac-secret",  # pragma: allowlist secret
         "db_password": "database-secret",  # pragma: allowlist secret
         "public_base_url": "https://akb.example.com",
@@ -37,6 +41,13 @@ def _sso_settings(**changes: object) -> Settings:
 def test_browser_session_capability_requires_complete_server_custody(monkeypatch):
     missing_key = _sso_settings()
     monkeypatch.setattr(auth_policy, "settings", missing_key)
+    assert auth_policy.sso_browser_session_ready() is False
+
+    missing_epoch = _sso_settings(
+        sso_session_epoch=None,
+        sso_browser_session_encryption_key=_encoded_key(),
+    )
+    monkeypatch.setattr(auth_policy, "settings", missing_epoch)
     assert auth_policy.sso_browser_session_ready() is False
 
     ready = _sso_settings(sso_browser_session_encryption_key=_encoded_key())
@@ -79,6 +90,16 @@ def test_missing_key_keeps_expand_contract_deployment_staged(monkeypatch):
     monkeypatch.setattr(lifecycle, "settings", configured)
 
     lifecycle._validate_required_settings()
+
+
+def test_sso_session_epoch_is_required_even_while_browser_custody_is_staged(
+    monkeypatch,
+):
+    configured = _sso_settings(sso_session_epoch=None)
+    monkeypatch.setattr(lifecycle, "settings", configured)
+
+    with pytest.raises(RuntimeError, match="sso_session_epoch"):
+        lifecycle._validate_required_settings()
 
 
 def test_session_lifetime_must_fit_inside_absolute_lifetime():

--- a/backend/tests/test_sso_browser_session_postgres.py
+++ b/backend/tests/test_sso_browser_session_postgres.py
@@ -94,14 +94,15 @@ async def _fresh_database():
             await conn.execute(_INIT_SQL)
             from app.db.postgres import _load_migration
 
+            epoch_migration = _load_migration("076_sso_session_epoch.py")
+            assert epoch_migration is not None
+            await epoch_migration.migrate(conn=conn)
             fresh_shape = await _schema_shape(conn)
             await conn.execute("DROP TABLE sso_browser_sessions, sso_browser_logout_fences")
             migration = _load_migration("074_sso_browser_sessions.py")
             assert migration is not None
             await migration.migrate(conn=conn)
             await migration.migrate(conn=conn)
-            epoch_migration = _load_migration("076_sso_session_epoch.py")
-            assert epoch_migration is not None
             await epoch_migration.migrate(conn=conn)
             await epoch_migration.migrate(conn=conn)
             assert await _schema_shape(conn) == fresh_shape

--- a/backend/tests/test_sso_browser_session_postgres.py
+++ b/backend/tests/test_sso_browser_session_postgres.py
@@ -112,10 +112,18 @@ async def _fresh_database():
             await conn.execute(
                 """
                 INSERT INTO auth_runtime_state (
-                    singleton, auth_mode, sso_session_epoch
-                ) VALUES (TRUE, 'sso', $1)
+                    singleton, runtime_generation, auth_mode,
+                    sso_session_epoch
+                ) VALUES (TRUE, 1, 'sso', $1)
                 """,
                 _SSO_SESSION_EPOCH,
+            )
+            await conn.execute(
+                """
+                UPDATE auth_runtime_epoch_upgrade
+                   SET state = 'enforced'
+                 WHERE singleton = TRUE
+                """
             )
         finally:
             await conn.close()
@@ -229,6 +237,7 @@ def _configure(monkeypatch, service, pool) -> None:
 
     monkeypatch.setattr(service, "get_pool", get_test_pool)
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "auth_runtime_generation", 1, raising=False)
     monkeypatch.setattr(settings, "sso_session_epoch", _SSO_SESSION_EPOCH, raising=False)
     monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example", raising=False)
     monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
@@ -664,6 +673,7 @@ async def test_runtime_epoch_reconcile_prevents_mode_transition_resurrection(
         assert (await service.resolve_sso_browser_session(original.token)).user_id == str(user_id)
 
         monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+        monkeypatch.setattr(settings, "auth_runtime_generation", 2, raising=False)
         local = await epoch_service.reconcile_sso_session_epoch()
         assert local.auth_mode_changed is True
         assert (
@@ -698,6 +708,7 @@ async def test_runtime_epoch_reconcile_prevents_mode_transition_resurrection(
 
         # Returning to SSO remains an explicit mode boundary even when the
         # operator reuses the same UUID. No stale row can survive or be added.
+        monkeypatch.setattr(settings, "auth_runtime_generation", 3, raising=False)
         resumed = await epoch_service.reconcile_sso_session_epoch()
         assert resumed.auth_mode_changed is True
         assert (
@@ -711,6 +722,7 @@ async def test_runtime_epoch_reconcile_prevents_mode_transition_resurrection(
         prior_epoch = await issue_ordinary()
         await seed_admin_and_fence(_SSO_SESSION_EPOCH, "rotation")
         next_epoch = uuid.UUID("f243032e-8f74-42af-93e9-911222e4e748")
+        monkeypatch.setattr(settings, "auth_runtime_generation", 4, raising=False)
         monkeypatch.setattr(settings, "sso_session_epoch", next_epoch, raising=False)
         rotated = await epoch_service.reconcile_sso_session_epoch()
         assert rotated.auth_mode_changed is False

--- a/backend/tests/test_sso_browser_session_postgres.py
+++ b/backend/tests/test_sso_browser_session_postgres.py
@@ -23,6 +23,7 @@ _DSN = os.environ.get(
     "AKB_TEST_DSN",
     "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
 )
+_SSO_SESSION_EPOCH = uuid.UUID("8db8b1f8-5f70-43ec-b9c6-039effe26b38")
 
 
 def _dsn_for_database(dsn: str, database: str) -> str:
@@ -47,7 +48,7 @@ async def _schema_shape(conn) -> dict[str, tuple[tuple[object, ...], ...]]:
             SELECT column_name, data_type, is_nullable, column_default
               FROM information_schema.columns
              WHERE table_schema = 'public' AND table_name = $1
-             ORDER BY ordinal_position
+             ORDER BY column_name
             """,
             table,
         )
@@ -99,11 +100,23 @@ async def _fresh_database():
             assert migration is not None
             await migration.migrate(conn=conn)
             await migration.migrate(conn=conn)
+            epoch_migration = _load_migration("076_sso_session_epoch.py")
+            assert epoch_migration is not None
+            await epoch_migration.migrate(conn=conn)
+            await epoch_migration.migrate(conn=conn)
             assert await _schema_shape(conn) == fresh_shape
 
             events_migration = _load_migration("015_events_outbox.py")
             assert events_migration is not None
             await events_migration.migrate(conn=conn)
+            await conn.execute(
+                """
+                INSERT INTO auth_runtime_state (
+                    singleton, auth_mode, sso_session_epoch
+                ) VALUES (TRUE, 'sso', $1)
+                """,
+                _SSO_SESSION_EPOCH,
+            )
         finally:
             await conn.close()
         pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=8)
@@ -216,6 +229,7 @@ def _configure(monkeypatch, service, pool) -> None:
 
     monkeypatch.setattr(service, "get_pool", get_test_pool)
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "sso_session_epoch", _SSO_SESSION_EPOCH, raising=False)
     monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example", raising=False)
     monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
     monkeypatch.setattr(settings, "keycloak_client_id", "akb-web", raising=False)
@@ -557,3 +571,173 @@ async def test_identity_state_and_verified_backchannel_selector_revoke_immediate
         newer = _principal(issued_at=principal.claims["iat"] + 1)
         replacement = await issue(newer)
         assert (await service.resolve_sso_browser_session(replacement.token)).user_id == str(user_id)
+
+
+async def test_runtime_epoch_reconcile_prevents_mode_transition_resurrection(
+    monkeypatch,
+) -> None:
+    from app.config import settings
+    from app.exceptions import AuthenticationError
+    from app.services import sso_browser_session_service as service
+    from app.services import sso_session_epoch as epoch_service
+
+    async with _fresh_database() as pool:
+        _configure(monkeypatch, service, pool)
+
+        async def get_test_pool():
+            return pool
+
+        monkeypatch.setattr(epoch_service, "get_pool", get_test_pool)
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM auth_runtime_state")
+        first = await epoch_service.reconcile_sso_session_epoch()
+        assert first.changed is True
+        assert first.auth_mode_changed is False
+        assert first.epoch_changed is False
+        assert (
+            first.ordinary_sessions_revoked,
+            first.admin_sessions_revoked,
+            first.logout_fences_revoked,
+        ) == (0, 0, 0)
+
+        user_id, identity_id = await _seed_identity(pool)
+        principal = _principal()
+
+        async def issue_ordinary():
+            return await service.create_sso_browser_session(
+                _actor(user_id),
+                principal,
+                {
+                    "iss": principal.issuer,
+                    "sub": principal.subject,
+                    "sid": principal.claims["sid"],
+                    "identity_provider": "workforce",
+                },
+                _tokens(),
+            )
+
+        async def seed_admin_and_fence(epoch: uuid.UUID, suffix: str) -> None:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE users SET is_admin = TRUE WHERE id = $1",
+                    user_id,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO admin_browser_sessions (
+                        session_epoch, token_hash, csrf_token_hash, user_id,
+                        external_identity_id, identity_issuer, identity_subject,
+                        keycloak_sid, expires_at
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8,
+                        NOW() + INTERVAL '5 minutes'
+                    )
+                    """,
+                    epoch,
+                    uuid.uuid4().hex * 2,
+                    uuid.uuid4().hex * 2,
+                    user_id,
+                    identity_id,
+                    principal.issuer,
+                    principal.subject,
+                    f"admin-{suffix}",
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO sso_browser_logout_fences (
+                        session_epoch, identity_issuer, keycloak_sid,
+                        identity_subject, logout_issued_at, expires_at
+                    ) VALUES (
+                        $1, $2, $3, $4, NOW(), NOW() + INTERVAL '5 minutes'
+                    )
+                    """,
+                    epoch,
+                    principal.issuer,
+                    f"fence-{suffix}",
+                    principal.subject,
+                )
+
+        original = await issue_ordinary()
+        await seed_admin_and_fence(_SSO_SESSION_EPOCH, "initial")
+        unchanged = await epoch_service.reconcile_sso_session_epoch()
+        assert unchanged.changed is False
+        assert (await service.resolve_sso_browser_session(original.token)).user_id == str(user_id)
+
+        monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+        local = await epoch_service.reconcile_sso_session_epoch()
+        assert local.auth_mode_changed is True
+        assert (
+            local.ordinary_sessions_revoked,
+            local.admin_sessions_revoked,
+            local.logout_fences_revoked,
+        ) == (1, 1, 1)
+
+        # Model one draining old SSO replica using its prior generation after
+        # the local-mode startup transaction committed. The runtime-state
+        # share lock rejects it before a write, and the FK independently
+        # prevents that epoch from being reintroduced while local mode owns
+        # the singleton row.
+        monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+        with pytest.raises(AuthenticationError, match="authority"):
+            await issue_ordinary()
+        async with pool.acquire() as conn:
+            with pytest.raises(asyncpg.ForeignKeyViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO sso_browser_logout_fences (
+                        session_epoch, identity_issuer, keycloak_sid,
+                        logout_issued_at, expires_at
+                    ) VALUES (
+                        $1, $2, 'stale-draining-sid',
+                        NOW(), NOW() + INTERVAL '5 minutes'
+                    )
+                    """,
+                    _SSO_SESSION_EPOCH,
+                    principal.issuer,
+                )
+
+        # Returning to SSO remains an explicit mode boundary even when the
+        # operator reuses the same UUID. No stale row can survive or be added.
+        resumed = await epoch_service.reconcile_sso_session_epoch()
+        assert resumed.auth_mode_changed is True
+        assert (
+            resumed.ordinary_sessions_revoked,
+            resumed.admin_sessions_revoked,
+            resumed.logout_fences_revoked,
+        ) == (0, 0, 0)
+        with pytest.raises(AuthenticationError):
+            await service.resolve_sso_browser_session(original.token)
+
+        prior_epoch = await issue_ordinary()
+        await seed_admin_and_fence(_SSO_SESSION_EPOCH, "rotation")
+        next_epoch = uuid.UUID("f243032e-8f74-42af-93e9-911222e4e748")
+        monkeypatch.setattr(settings, "sso_session_epoch", next_epoch, raising=False)
+        rotated = await epoch_service.reconcile_sso_session_epoch()
+        assert rotated.auth_mode_changed is False
+        assert rotated.epoch_changed is True
+        assert (
+            rotated.ordinary_sessions_revoked,
+            rotated.admin_sessions_revoked,
+            rotated.logout_fences_revoked,
+        ) == (1, 1, 1)
+        with pytest.raises(AuthenticationError):
+            await service.resolve_sso_browser_session(prior_epoch.token)
+
+        async with pool.acquire() as conn:
+            state = await conn.fetchrow(
+                "SELECT auth_mode, sso_session_epoch FROM auth_runtime_state"
+            )
+            assert tuple(state) == ("sso", next_epoch)
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_sessions") == 0
+            assert await conn.fetchval("SELECT COUNT(*) FROM admin_browser_sessions") == 0
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_logout_fences") == 0
+            audit_payload = await conn.fetchval(
+                """
+                SELECT string_agg(payload::TEXT, ' ' ORDER BY id)
+                  FROM events
+                 WHERE kind = 'auth.runtime_boundary_changed'
+                """
+            )
+        assert audit_payload is not None
+        assert str(_SSO_SESSION_EPOCH) not in audit_payload
+        assert str(next_epoch) not in audit_payload

--- a/backend/tests/test_sso_browser_session_schema_unit.py
+++ b/backend/tests/test_sso_browser_session_schema_unit.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import asyncpg
+import pytest
+
 
 _BACKEND = Path(__file__).resolve().parents[1]
 
@@ -32,10 +35,13 @@ def test_fresh_and_migrated_schema_share_the_custody_invariants():
         assert "idx_sso_browser_logout_fences_expiry" in source
 
     assert "CREATE TABLE IF NOT EXISTS auth_runtime_state" in init_sql
+    assert "runtime_generation BIGINT NOT NULL" in init_sql
     assert "sso_session_epoch UUID" in init_sql
-    assert init_sql.count("session_epoch UUID NOT NULL") >= 3
-    assert "PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)" in init_sql
+    assert init_sql.count("session_epoch UUID,") >= 3
+    assert "PRIMARY KEY (identity_issuer, keycloak_sid)" in init_sql
     assert init_sql.count("REFERENCES auth_runtime_state(sso_session_epoch)") == 3
+    assert "CREATE TABLE IF NOT EXISTS auth_runtime_epoch_upgrade" in init_sql
+    assert "runtime_generation_floor BIGINT NOT NULL" in init_sql
 
     for table in (
         "admin_browser_sessions",
@@ -43,14 +49,26 @@ def test_fresh_and_migrated_schema_share_the_custody_invariants():
         "sso_browser_logout_fences",
     ):
         assert f'"{table}",' in epoch_migration
-        assert f"DELETE FROM {table}" in epoch_migration
+        assert f"LOCK TABLE {table}" in epoch_migration
     assert "ALTER TABLE {table}" in epoch_migration
     assert "ADD COLUMN IF NOT EXISTS session_epoch UUID" in epoch_migration
-    assert "ALTER COLUMN session_epoch SET NOT NULL" in epoch_migration
+    assert "ALTER COLUMN session_epoch SET NOT NULL" not in epoch_migration
     assert "auth_runtime_state_sso_session_epoch_key" in epoch_migration
     assert "REFERENCES auth_runtime_state(sso_session_epoch)" in epoch_migration
     assert "CREATE TABLE IF NOT EXISTS auth_runtime_state" in epoch_migration
-    assert "PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)" in epoch_migration
+    assert "PRIMARY KEY (identity_issuer, keycloak_sid)" in epoch_migration
+    assert "reject_legacy_sso_session_epoch" in epoch_migration
+    assert "stop-the-world-v1" in epoch_migration
+
+
+def test_runtime_epoch_preflight_is_executable_and_public_safe():
+    preflight = (_BACKEND / "scripts" / "sso_session_epoch_preflight.py").read_text()
+
+    assert "prepare-upgrade" in preflight
+    assert "prepare-rollback" in preflight
+    assert "status" in preflight
+    assert '"runtime_generation":' not in preflight
+    assert '"sso_session_epoch":' not in preflight
 
 
 def test_browser_session_migration_is_registered():
@@ -58,3 +76,55 @@ def test_browser_session_migration_is_registered():
 
     assert '"074_sso_browser_sessions.py"' in registry
     assert '"076_sso_session_epoch.py"' in registry
+
+
+@pytest.mark.asyncio
+async def test_migration_runner_retries_a_fully_rolled_back_deadlock(
+    monkeypatch,
+):
+    from app.db import postgres
+
+    calls: list[str] = []
+
+    class Connection:
+        async def execute(self, sql, *args):
+            del args
+            calls.append(sql)
+
+    connection = Connection()
+
+    class Acquire:
+        async def __aenter__(self):
+            return connection
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            del exc_type, exc, traceback
+
+    class Pool:
+        def acquire(self):
+            return Acquire()
+
+    class Migration:
+        attempts = 0
+
+        async def migrate(self, *, conn):
+            assert conn is connection
+            self.attempts += 1
+            if self.attempts == 1:
+                raise asyncpg.DeadlockDetectedError("deadlock detected")
+
+    async def no_sleep(delay):
+        assert delay == 0
+
+    migration = Migration()
+    monkeypatch.setattr(postgres.asyncio, "sleep", no_sleep)
+    await postgres._run_one_migration(
+        Pool(),
+        "076_sso_session_epoch.py",
+        migration,
+        retries=2,
+        backoff=0,
+    )
+
+    assert migration.attempts == 2
+    assert sum("INSERT INTO schema_migrations" in sql for sql in calls) == 1

--- a/backend/tests/test_sso_browser_session_schema_unit.py
+++ b/backend/tests/test_sso_browser_session_schema_unit.py
@@ -1,4 +1,4 @@
-"""Static guard for the ordinary SSO browser-session schema rollout."""
+"""Static guard for the SSO browser-session epoch boundary."""
 
 from pathlib import Path
 
@@ -8,9 +8,14 @@ _BACKEND = Path(__file__).resolve().parents[1]
 
 def test_fresh_and_migrated_schema_share_the_custody_invariants():
     init_sql = (_BACKEND / "app" / "db" / "init.sql").read_text()
-    migration = (_BACKEND / "app" / "db" / "migrations" / "074_sso_browser_sessions.py").read_text()
+    custody_migration = (
+        _BACKEND / "app" / "db" / "migrations" / "074_sso_browser_sessions.py"
+    ).read_text()
+    epoch_migration = (
+        _BACKEND / "app" / "db" / "migrations" / "076_sso_session_epoch.py"
+    ).read_text()
 
-    for source in (init_sql, migration):
+    for source in (init_sql, custody_migration):
         assert "CREATE TABLE IF NOT EXISTS sso_browser_sessions" in source
         assert "token_hash TEXT NOT NULL UNIQUE" in source
         assert "csrf_token_hash TEXT NOT NULL" in source
@@ -24,11 +29,32 @@ def test_fresh_and_migrated_schema_share_the_custody_invariants():
         assert "identity_issuer, identity_subject" in source
         assert "CREATE TABLE IF NOT EXISTS sso_browser_logout_fences" in source
         assert "logout_issued_at TIMESTAMPTZ NOT NULL" in source
-        assert "PRIMARY KEY (identity_issuer, keycloak_sid)" in source
         assert "idx_sso_browser_logout_fences_expiry" in source
+
+    assert "CREATE TABLE IF NOT EXISTS auth_runtime_state" in init_sql
+    assert "sso_session_epoch UUID" in init_sql
+    assert init_sql.count("session_epoch UUID NOT NULL") >= 3
+    assert "PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)" in init_sql
+    assert init_sql.count("REFERENCES auth_runtime_state(sso_session_epoch)") == 3
+
+    for table in (
+        "admin_browser_sessions",
+        "sso_browser_sessions",
+        "sso_browser_logout_fences",
+    ):
+        assert f'"{table}",' in epoch_migration
+        assert f"DELETE FROM {table}" in epoch_migration
+    assert "ALTER TABLE {table}" in epoch_migration
+    assert "ADD COLUMN IF NOT EXISTS session_epoch UUID" in epoch_migration
+    assert "ALTER COLUMN session_epoch SET NOT NULL" in epoch_migration
+    assert "auth_runtime_state_sso_session_epoch_key" in epoch_migration
+    assert "REFERENCES auth_runtime_state(sso_session_epoch)" in epoch_migration
+    assert "CREATE TABLE IF NOT EXISTS auth_runtime_state" in epoch_migration
+    assert "PRIMARY KEY (session_epoch, identity_issuer, keycloak_sid)" in epoch_migration
 
 
 def test_browser_session_migration_is_registered():
     registry = (_BACKEND / "app" / "db" / "postgres.py").read_text()
 
     assert '"074_sso_browser_sessions.py"' in registry
+    assert '"076_sso_session_epoch.py"' in registry

--- a/backend/tests/test_sso_browser_session_schema_unit.py
+++ b/backend/tests/test_sso_browser_session_schema_unit.py
@@ -71,6 +71,33 @@ def test_runtime_epoch_preflight_is_executable_and_public_safe():
     assert '"sso_session_epoch":' not in preflight
 
 
+def test_epoch_bridge_has_named_migration_only_retirement_contract():
+    contract = (_BACKEND.parent / "docs" / "sso" / "README.md").read_text()
+    heading = "## SSO session epoch migration bridge retirement gate"
+
+    assert heading in contract
+    section = contract.split(heading, 1)[1].split("\n## ", 1)[0]
+    normalized = " ".join(section.replace("`", "").split()).casefold()
+    for required_condition in (
+        "all supported AKB rollback artifacts are epoch-capable",
+        "pre-epoch image rollback support is formally ended",
+        "deployment and fleet inventory shows no pre-epoch artifact",
+        "upgrade and rollback rehearsal receipts exist for every supported deployment profile",
+    ):
+        assert required_condition.casefold() in normalized
+    for atomic_removal in (
+        "sso_session_epoch_upgrade",
+        "prepare-rollback",
+        "rollback_ready",
+        "legacy NULL trigger and state",
+        "make every session_epoch column NOT NULL",
+        "remove or replace the legacy bridge tests",
+    ):
+        assert atomic_removal.casefold() in normalized
+    assert "migration-only compatibility bridge, not a permanent feature" in normalized
+    assert "all three conditions are evidenced" in normalized
+
+
 def test_browser_session_migration_is_registered():
     registry = (_BACKEND / "app" / "db" / "postgres.py").read_text()
 

--- a/backend/tests/test_sso_session_epoch_upgrade_postgres.py
+++ b/backend/tests/test_sso_session_epoch_upgrade_postgres.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -18,6 +19,15 @@ pytestmark = pytest.mark.asyncio
 
 _BACKEND = Path(__file__).resolve().parents[1]
 _INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_EXACT_BASE_INIT_SQL = (
+    _BACKEND / "tests" / "fixtures" / "sso_session_epoch" / "exact_base_0860a0e_init.sql"
+).read_text()
+_EXACT_BASE_INIT_SHA256 = "410c67e62b63f254004430cd3bb2ab72ff0fc9e4af3415ac8218fec6137696b1"
+_MIGRATION_REGISTRY = (_BACKEND / "app" / "db" / "postgres.py").read_text().split("for filename in (", 1)[1]
+_MIGRATION_REGISTRY = _MIGRATION_REGISTRY.split("    ):", 1)[0]
+_CURRENT_MIGRATIONS = re.findall(r'"([0-9]{3}_[^"]+\.py)"', _MIGRATION_REGISTRY)
+_EPOCH_MIGRATION_POSITION = _CURRENT_MIGRATIONS.index("076_sso_session_epoch.py")
+_EXACT_BASE_MIGRATIONS = _CURRENT_MIGRATIONS[:_EPOCH_MIGRATION_POSITION]
 _DSN = os.environ.get(
     "AKB_TEST_DSN",
     "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
@@ -39,6 +49,112 @@ async def _can_connect(dsn: str) -> bool:
         return False
     await conn.close()
     return True
+
+
+@asynccontextmanager
+async def _init_db_regression_database(*, exact_base: bool):
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_sso_epoch_init_{uuid.uuid4().hex[:10]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        if exact_base:
+            conn = await asyncpg.connect(target_dsn)
+            try:
+                await conn.execute(_EXACT_BASE_INIT_SQL)
+                await conn.executemany(
+                    "INSERT INTO schema_migrations (filename) VALUES ($1)",
+                    [(filename,) for filename in _EXACT_BASE_MIGRATIONS],
+                )
+            finally:
+                await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=4)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+async def _run_current_init_db(monkeypatch, pool) -> None:
+    from app.db import postgres
+
+    async def get_test_pool():
+        return pool
+
+    monkeypatch.setattr(postgres, "get_pool", get_test_pool)
+    await postgres.init_db(max_retries=1, delay=0)
+
+
+async def _browser_session_index_columns(pool) -> dict[str, list[str]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT indexname, indexdef
+              FROM pg_indexes
+             WHERE schemaname = 'public'
+               AND indexname = ANY($1::TEXT[])
+            """,
+            ["idx_sso_browser_sessions_sid", "idx_sso_browser_sessions_subject"],
+        )
+    columns: dict[str, list[str]] = {}
+    for row in rows:
+        column_list = row["indexdef"].rsplit("(", 1)[1].removesuffix(")")
+        columns[row["indexname"]] = column_list.split(", ")
+    return columns
+
+
+async def test_current_init_db_upgrades_exact_base_schema_and_replaces_indexes(
+    monkeypatch,
+) -> None:
+    assert hashlib.sha256(_EXACT_BASE_INIT_SQL.encode()).hexdigest() == _EXACT_BASE_INIT_SHA256
+    assert _EXACT_BASE_MIGRATIONS[-1] == "075_sso_callback_receipt.py"
+
+    async with _init_db_regression_database(exact_base=True) as pool:
+        async with pool.acquire() as conn:
+            assert not await conn.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                      FROM information_schema.columns
+                     WHERE table_schema = 'public'
+                       AND table_name = 'sso_browser_sessions'
+                       AND column_name = 'session_epoch'
+                )
+                """
+            )
+        assert await _browser_session_index_columns(pool) == {
+            "idx_sso_browser_sessions_sid": ["identity_issuer", "keycloak_sid"],
+            "idx_sso_browser_sessions_subject": ["identity_issuer", "identity_subject"],
+        }
+
+        await _run_current_init_db(monkeypatch, pool)
+
+        assert await _browser_session_index_columns(pool) == {
+            "idx_sso_browser_sessions_sid": ["session_epoch", "identity_issuer", "keycloak_sid"],
+            "idx_sso_browser_sessions_subject": ["session_epoch", "identity_issuer", "identity_subject"],
+        }
+
+
+async def test_current_init_db_fresh_schema_finishes_with_epoch_indexes(monkeypatch) -> None:
+    async with _init_db_regression_database(exact_base=False) as pool:
+        await _run_current_init_db(monkeypatch, pool)
+
+        assert await _browser_session_index_columns(pool) == {
+            "idx_sso_browser_sessions_sid": ["session_epoch", "identity_issuer", "keycloak_sid"],
+            "idx_sso_browser_sessions_subject": ["session_epoch", "identity_issuer", "identity_subject"],
+        }
 
 
 @asynccontextmanager

--- a/backend/tests/test_sso_session_epoch_upgrade_postgres.py
+++ b/backend/tests/test_sso_session_epoch_upgrade_postgres.py
@@ -1,0 +1,471 @@
+"""PostgreSQL regressions for the SSO runtime-generation upgrade boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_EPOCH_0 = uuid.UUID("09f2df7b-8658-45f1-b82d-a244279e3c24")
+_EPOCH_1 = uuid.UUID("db123b46-ed25-4939-909e-79ae61f729e3")
+_EPOCH_2 = uuid.UUID("b57ee773-a9c2-427a-b1ba-b7f171d08f45")
+
+
+def _dsn_for_database(dsn: str, database: str) -> str:
+    parsed = urlsplit(dsn)
+    return urlunsplit(parsed._replace(path=f"/{database}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+@asynccontextmanager
+async def _pre_epoch_bridge_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_sso_epoch_upgrade_{uuid.uuid4().hex[:10]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        conn = await asyncpg.connect(target_dsn)
+        try:
+            await conn.execute(_INIT_SQL)
+            await conn.execute(
+                """
+                DROP TABLE sso_browser_sessions, sso_browser_logout_fences,
+                           admin_browser_sessions, auth_runtime_state
+                """
+            )
+            await conn.execute("DROP TABLE IF EXISTS auth_runtime_epoch_upgrade")
+            from app.db.postgres import _load_migration
+
+            admin_migration = _load_migration("072_admin_browser_sessions.py")
+            browser_migration = _load_migration("074_sso_browser_sessions.py")
+            epoch_migration = _load_migration("076_sso_session_epoch.py")
+            events_migration = _load_migration("015_events_outbox.py")
+            assert admin_migration is not None
+            assert browser_migration is not None
+            assert epoch_migration is not None
+            assert events_migration is not None
+            await events_migration.migrate(conn=conn)
+            await admin_migration.migrate(conn=conn)
+            await browser_migration.migrate(conn=conn)
+            await epoch_migration.migrate(conn=conn)
+        finally:
+            await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=12)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+async def _seed_identity(pool) -> tuple[uuid.UUID, uuid.UUID]:
+    user_id = uuid.uuid4()
+    identity_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES (
+                $1, $2, $3, '!sso!', TRUE,
+                'keycloak', 'active', 'human'
+            )
+            """,
+            user_id,
+            f"user-{user_id.hex[:8]}",
+            f"{user_id.hex[:8]}@example.com",
+        )
+        await conn.execute(
+            """
+            INSERT INTO external_identities (id, user_id, issuer, subject)
+            VALUES ($1, $2, 'https://id.example/realms/akb', $3)
+            """,
+            identity_id,
+            user_id,
+            f"subject-{user_id.hex[:8]}",
+        )
+    return user_id, identity_id
+
+
+async def _insert_legacy_admin(
+    pool,
+    user_id: uuid.UUID,
+    identity_id: uuid.UUID,
+    *,
+    token: str,
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO admin_browser_sessions (
+                token_hash, csrf_token_hash, user_id, external_identity_id,
+                identity_issuer, identity_subject, keycloak_sid, expires_at
+            ) VALUES (
+                $1, $2, $3, $4, 'https://id.example/realms/akb', $5, $6,
+                NOW() + INTERVAL '5 minutes'
+            )
+            """,
+            hashlib.sha256(token.encode()).hexdigest(),
+            "a" * 64,
+            user_id,
+            identity_id,
+            f"subject-{user_id.hex[:8]}",
+            f"admin-{token[-8:]}",
+        )
+
+
+async def _insert_legacy_browser(
+    pool,
+    user_id: uuid.UUID,
+    identity_id: uuid.UUID,
+    *,
+    token: str,
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO sso_browser_sessions (
+                id, token_hash, csrf_token_hash, user_id, external_identity_id,
+                identity_issuer, identity_subject, keycloak_sid, token_envelope,
+                access_expires_at, refresh_expires_at, idle_expires_at,
+                absolute_expires_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, 'https://id.example/realms/akb', $6, $7,
+                $8, NOW() + INTERVAL '5 minutes', NOW() + INTERVAL '5 minutes',
+                NOW() + INTERVAL '5 minutes', NOW() + INTERVAL '5 minutes'
+            )
+            """,
+            uuid.uuid4(),
+            hashlib.sha256(token.encode()).hexdigest(),
+            "b" * 64,
+            user_id,
+            identity_id,
+            f"subject-{user_id.hex[:8]}",
+            f"browser-{token[-8:]}",
+            "legacy-envelope-is-never-accepted-0000",
+        )
+
+
+async def _insert_legacy_fence(pool, *, suffix: str) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO sso_browser_logout_fences (
+                identity_issuer, keycloak_sid, logout_issued_at, expires_at
+            ) VALUES (
+                'https://id.example/realms/akb', $1, NOW(),
+                NOW() + INTERVAL '5 minutes'
+            )
+            """,
+            f"legacy-fence-{suffix}",
+        )
+
+
+async def _legacy_admin_resolves(pool, token: str) -> bool:
+    """Mirror the pre-epoch image's token-only lookup."""
+    async with pool.acquire() as conn:
+        return bool(
+            await conn.fetchval(
+                """
+                SELECT TRUE
+                  FROM admin_browser_sessions
+                 WHERE token_hash = $1 AND expires_at > NOW()
+                """,
+                hashlib.sha256(token.encode()).hexdigest(),
+            )
+        )
+
+
+def _configure(monkeypatch, epoch_service, pool) -> None:
+    from app.config import settings
+
+    async def get_test_pool():
+        return pool
+
+    monkeypatch.setattr(epoch_service, "get_pool", get_test_pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "auth_runtime_generation", 1, raising=False)
+    monkeypatch.setattr(settings, "sso_session_epoch", _EPOCH_0, raising=False)
+    monkeypatch.setattr(settings, "sso_session_epoch_upgrade", None, raising=False)
+
+
+async def test_mixed_version_upgrade_guard_and_rollback_are_executable(
+    monkeypatch,
+) -> None:
+    from app.config import settings
+    from app.exceptions import AuthenticationError
+    from app.services import admin_auth_service
+    from app.services import sso_session_epoch as epoch_service
+
+    async with _pre_epoch_bridge_database() as pool:
+        _configure(monkeypatch, epoch_service, pool)
+        user_id, identity_id = await _seed_identity(pool)
+        legacy_admin_token = "legacy-admin-session-token-value"
+        await _insert_legacy_admin(
+            pool,
+            user_id,
+            identity_id,
+            token=legacy_admin_token,
+        )
+        await _insert_legacy_browser(
+            pool,
+            user_id,
+            identity_id,
+            token="legacy-browser-session-token-value",
+        )
+        await _insert_legacy_fence(pool, suffix="before-upgrade")
+        assert await _legacy_admin_resolves(pool, legacy_admin_token) is True
+
+        async def get_test_pool():
+            return pool
+
+        monkeypatch.setattr(admin_auth_service, "get_pool", get_test_pool)
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(legacy_admin_token)
+
+        async with pool.acquire() as conn:
+            nullable = await conn.fetch(
+                """
+                SELECT table_name, is_nullable
+                  FROM information_schema.columns
+                 WHERE column_name = 'session_epoch'
+                   AND table_name = ANY($1::TEXT[])
+                 ORDER BY table_name
+                """,
+                [
+                    "admin_browser_sessions",
+                    "sso_browser_logout_fences",
+                    "sso_browser_sessions",
+                ],
+            )
+            assert [tuple(row) for row in nullable] == [
+                ("admin_browser_sessions", "YES"),
+                ("sso_browser_logout_fences", "YES"),
+                ("sso_browser_sessions", "YES"),
+            ]
+
+        with pytest.raises(RuntimeError, match="stop-the-world-v1"):
+            await epoch_service.reconcile_sso_session_epoch()
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT COUNT(*) FROM admin_browser_sessions") == 1
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_sessions") == 1
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_logout_fences") == 1
+
+        monkeypatch.setattr(
+            settings,
+            "sso_session_epoch_upgrade",
+            "stop-the-world-v1",
+            raising=False,
+        )
+        with pytest.raises(RuntimeError, match="quiescent preflight"):
+            await epoch_service.reconcile_sso_session_epoch()
+        activated = await epoch_service.reconcile_sso_session_epoch(upgrade_preflight=True)
+        assert activated.changed is True
+        assert (
+            activated.admin_sessions_revoked,
+            activated.ordinary_sessions_revoked,
+            activated.logout_fences_revoked,
+        ) == (1, 1, 1)
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT state FROM auth_runtime_epoch_upgrade WHERE singleton") == "enforced"
+
+        for legacy_write in (
+            _insert_legacy_admin(
+                pool,
+                user_id,
+                identity_id,
+                token="legacy-admin-after-cutover-value",
+            ),
+            _insert_legacy_browser(
+                pool,
+                user_id,
+                identity_id,
+                token="legacy-browser-after-cutover-value",
+            ),
+            _insert_legacy_fence(pool, suffix="after-cutover"),
+        ):
+            with pytest.raises(asyncpg.CheckViolationError):
+                await legacy_write
+
+        await epoch_service.prepare_sso_session_epoch_rollback()
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval("SELECT state FROM auth_runtime_epoch_upgrade WHERE singleton") == "rollback_ready"
+            )
+            assert await conn.fetchval("SELECT COUNT(*) FROM auth_runtime_state") == 0
+            assert await conn.fetchval("SELECT COUNT(*) FROM admin_browser_sessions") == 0
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_sessions") == 0
+            assert await conn.fetchval("SELECT COUNT(*) FROM sso_browser_logout_fences") == 0
+
+        await _insert_legacy_admin(
+            pool,
+            user_id,
+            identity_id,
+            token=legacy_admin_token,
+        )
+        assert await _legacy_admin_resolves(pool, legacy_admin_token) is True
+        with pytest.raises(AuthenticationError):
+            await admin_auth_service.resolve_sso_admin_browser_session(legacy_admin_token)
+        with pytest.raises(RuntimeError, match="stale"):
+            await epoch_service.reconcile_sso_session_epoch(upgrade_preflight=True)
+
+
+async def test_runtime_generation_is_monotonic_exact_and_stale_proof(
+    monkeypatch,
+) -> None:
+    from app.config import settings
+    from app.services import sso_session_epoch as epoch_service
+    from app.services.sso_session_epoch import AuthRuntimeBoundary
+
+    async with _pre_epoch_bridge_database() as pool:
+        _configure(monkeypatch, epoch_service, pool)
+        monkeypatch.setattr(
+            settings,
+            "sso_session_epoch_upgrade",
+            "stop-the-world-v1",
+            raising=False,
+        )
+        first = await epoch_service.reconcile_sso_session_epoch(upgrade_preflight=True)
+        assert first.changed is True
+
+        exact = await epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(1, "sso", _EPOCH_0))
+        assert exact.changed is False
+
+        local = await epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(2, "local", None))
+        assert local.auth_mode_changed is True
+
+        for stale_or_conflicting in (
+            AuthRuntimeBoundary(1, "sso", _EPOCH_0),
+            AuthRuntimeBoundary(2, "sso", _EPOCH_0),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await epoch_service.reconcile_sso_session_epoch(stale_or_conflicting)
+            assert str(_EPOCH_0) not in str(exc_info.value)
+
+        resumed = await epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(3, "sso", _EPOCH_0))
+        assert resumed.auth_mode_changed is True
+        rotated = await epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(4, "sso", _EPOCH_1))
+        assert rotated.epoch_changed is True
+
+        out_of_order = await asyncio.gather(
+            epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(5, "local", None)),
+            epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(6, "sso", _EPOCH_2)),
+            return_exceptions=True,
+        )
+        assert not any(isinstance(item, asyncpg.DeadlockDetectedError) for item in out_of_order)
+        async with pool.acquire() as conn:
+            state = await conn.fetchrow(
+                """
+                SELECT runtime_generation, auth_mode, sso_session_epoch
+                  FROM auth_runtime_state
+                """
+            )
+        assert tuple(state) == (6, "sso", _EPOCH_2)
+
+        simultaneous_conflict = await asyncio.gather(
+            epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(7, "local", None)),
+            epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(7, "sso", _EPOCH_1)),
+            return_exceptions=True,
+        )
+        assert sum(isinstance(item, RuntimeError) for item in simultaneous_conflict) == 1
+        async with pool.acquire() as conn:
+            state = await conn.fetchrow(
+                """
+                SELECT runtime_generation, auth_mode, sso_session_epoch
+                  FROM auth_runtime_state
+                """
+            )
+            payloads = await conn.fetch(
+                """
+                SELECT payload
+                  FROM events
+                 WHERE kind = 'auth.runtime_boundary_changed'
+                """
+            )
+        assert state["runtime_generation"] == 7
+        assert (state["auth_mode"], state["sso_session_epoch"]) in {
+            ("local", None),
+            ("sso", _EPOCH_1),
+        }
+        assert all("runtime_generation" not in row["payload"] for row in payloads)
+        serialized_payloads = " ".join(str(row["payload"]) for row in payloads)
+        for epoch in (_EPOCH_0, _EPOCH_1, _EPOCH_2):
+            assert str(epoch) not in serialized_payloads
+
+
+async def test_concurrent_migration_and_runtime_starts_do_not_deadlock(
+    monkeypatch,
+) -> None:
+    from app.config import settings
+    from app.db.postgres import _load_migration
+    from app.services import sso_session_epoch as epoch_service
+    from app.services.sso_session_epoch import AuthRuntimeBoundary
+
+    async with _pre_epoch_bridge_database() as pool:
+        _configure(monkeypatch, epoch_service, pool)
+        monkeypatch.setattr(
+            settings,
+            "sso_session_epoch_upgrade",
+            "stop-the-world-v1",
+            raising=False,
+        )
+        await epoch_service.reconcile_sso_session_epoch(upgrade_preflight=True)
+        migration = _load_migration("076_sso_session_epoch.py")
+        assert migration is not None
+
+        async def rerun_migration() -> None:
+            async with pool.acquire() as conn:
+                await migration.migrate(conn=conn)
+
+        outcomes = await asyncio.wait_for(
+            asyncio.gather(
+                rerun_migration(),
+                rerun_migration(),
+                *(
+                    epoch_service.reconcile_sso_session_epoch(AuthRuntimeBoundary(1, "sso", _EPOCH_0))
+                    for _ in range(12)
+                ),
+                return_exceptions=True,
+            ),
+            timeout=15,
+        )
+        assert not any(isinstance(item, asyncpg.DeadlockDetectedError) for item in outcomes), outcomes
+        assert not any(isinstance(item, BaseException) for item in outcomes), outcomes

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -57,14 +57,22 @@ async def services(monkeypatch):
         await conn.execute(
             """
             INSERT INTO auth_runtime_state (
-                singleton, auth_mode, sso_session_epoch
-            ) VALUES (TRUE, 'sso', $1)
+                singleton, runtime_generation, auth_mode, sso_session_epoch
+            ) VALUES (TRUE, 1, 'sso', $1)
             ON CONFLICT (singleton) DO UPDATE
-               SET auth_mode = EXCLUDED.auth_mode,
+               SET runtime_generation = EXCLUDED.runtime_generation,
+                   auth_mode = EXCLUDED.auth_mode,
                    sso_session_epoch = EXCLUDED.sso_session_epoch,
                    updated_at = NOW()
             """,
             _SSO_SESSION_EPOCH,
+        )
+        await conn.execute(
+            """
+            UPDATE auth_runtime_epoch_upgrade
+               SET state = 'enforced'
+             WHERE singleton = TRUE
+            """
         )
 
     role_sync = RecordingRoleSync()

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -14,6 +14,7 @@ import pytest
 pytestmark = pytest.mark.asyncio
 _DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
 _ISSUER = "https://id.example.com/realms/akb"
+_SSO_SESSION_EPOCH = uuid.UUID("8dbce581-ea57-47ca-ae8f-3c3ddb05e787")
 
 
 class RecordingRoleSync:
@@ -47,10 +48,24 @@ async def services(monkeypatch):
             "043_workspace_account_governance.py",
             "071_recovery_admin.py",
             "072_admin_browser_sessions.py",
+            "074_sso_browser_sessions.py",
+            "076_sso_session_epoch.py",
         ):
             migration = _load_migration(filename)
             assert migration is not None
             await migration.migrate(conn=conn)
+        await conn.execute(
+            """
+            INSERT INTO auth_runtime_state (
+                singleton, auth_mode, sso_session_epoch
+            ) VALUES (TRUE, 'sso', $1)
+            ON CONFLICT (singleton) DO UPDATE
+               SET auth_mode = EXCLUDED.auth_mode,
+                   sso_session_epoch = EXCLUDED.sso_session_epoch,
+                   updated_at = NOW()
+            """,
+            _SSO_SESSION_EPOCH,
+        )
 
     role_sync = RecordingRoleSync()
 
@@ -732,10 +747,11 @@ async def test_role_projection_preserves_user_id(services):
         await conn.execute(
             """
             INSERT INTO admin_browser_sessions (
-                token_hash, csrf_token_hash, user_id, external_identity_id,
+                session_epoch, token_hash, csrf_token_hash, user_id, external_identity_id,
                 identity_issuer, identity_subject, keycloak_sid, expires_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + INTERVAL '5 minutes')
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() + INTERVAL '5 minutes')
             """,
+            _SSO_SESSION_EPOCH,
             uuid.uuid4().hex * 2,
             uuid.uuid4().hex * 2,
             uuid.UUID(ensured["user_id"]),

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -210,6 +210,12 @@ app_credential_overlap_seconds: 300
 # keycloak_management_client_id: "akb-sso-manager" # standalone bundle only:
 #                                         # permanent least-privilege IdP control client
 # admin_browser_session_ttl_secs: 900     # also capped by the verified ID-token expiry
+# Required for every SSO-mode start, including a staged ordinary-browser
+# rollout. Generate one UUID per installation, persist it across normal
+# restarts, and change it only to revoke all ordinary/admin SSO browser
+# sessions and logout fences. It is a generation marker, not a credential,
+# and may instead live in the durable secret.yaml operational input.
+# sso_session_epoch: "<installation-owned UUID>"
 # keycloak_verify_ssl: true          # false only for local self-signed Keycloak
 # keycloak_require_verified_email: true   # refuse unverified email for open-mode JIT.
 #                                         # Exact subject bindings need no email claim.

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -152,6 +152,13 @@ document_asset_upload_body_timeout_secs: 60
 # Provision the designated administrator explicitly with
 # `python -m app.cli provision-recovery-admin`; ordinary registration is never admin.
 auth_mode: local
+# Installation-owned monotonic boundary. Keep it unchanged for an exact
+# restart. Increase it for every auth_mode or sso_session_epoch transition;
+# PostgreSQL rejects stale, replayed, or same-generation conflicting starts.
+auth_runtime_generation: 1
+# Existing installations upgrading from a pre-epoch image use this temporary
+# acknowledgement only while running the documented quiescent preflight:
+# sso_session_epoch_upgrade: stop-the-world-v1
 jwt_algorithm: RS256
 jwt_expire_hours: 24
 # Generate once before the first local-mode start:
@@ -211,10 +218,11 @@ app_credential_overlap_seconds: 300
 #                                         # permanent least-privilege IdP control client
 # admin_browser_session_ttl_secs: 900     # also capped by the verified ID-token expiry
 # Required for every SSO-mode start, including a staged ordinary-browser
-# rollout. Generate one UUID per installation, persist it across normal
-# restarts, and change it only to revoke all ordinary/admin SSO browser
-# sessions and logout fences. It is a generation marker, not a credential,
-# and may instead live in the durable secret.yaml operational input.
+# rollout. Generate one UUID per installation and persist it across normal
+# restarts. To revoke all ordinary/admin SSO browser sessions and logout
+# fences, change it and increase auth_runtime_generation in the same config
+# revision. It is an authority epoch, not a credential, and may instead live
+# in the durable secret.yaml operational input.
 # sso_session_epoch: "<installation-owned UUID>"
 # keycloak_verify_ssl: true          # false only for local self-signed Keycloak
 # keycloak_require_verified_email: true   # refuse unverified email for open-mode JIT.

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -34,11 +34,12 @@ keycloak_admin_client_secret: ""
 # performs mutations.
 keycloak_management_client_secret: ""
 
-# Required in SSO mode. This is a non-secret, installation-owned generation
+# Required in SSO mode. This is a non-secret, installation-owned authority
 # marker kept here because this file is normally the durable deployment input.
 # Generate with `python -c 'import uuid; print(uuid.uuid4())'`, keep it stable
 # across normal restarts, and change it only to force every ordinary/admin SSO
-# browser session and logout fence into a new authority generation.
+# browser session and logout fence into a new authority epoch. Increase the
+# non-secret app.yaml auth_runtime_generation in the same change.
 sso_session_epoch: null
 
 # Required before ordinary-user browser SSO can be enabled. This independent

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -34,6 +34,13 @@ keycloak_admin_client_secret: ""
 # performs mutations.
 keycloak_management_client_secret: ""
 
+# Required in SSO mode. This is a non-secret, installation-owned generation
+# marker kept here because this file is normally the durable deployment input.
+# Generate with `python -c 'import uuid; print(uuid.uuid4())'`, keep it stable
+# across normal restarts, and change it only to force every ordinary/admin SSO
+# browser session and logout fence into a new authority generation.
+sso_session_epoch: null
+
 # Required before ordinary-user browser SSO can be enabled. This independent
 # AES-256-GCM key encrypts the server-custodied Keycloak refresh/ID token set;
 # it must differ from every HMAC/client secret and persist across restarts.

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -89,13 +89,39 @@ is not the product-admin password.
 
 `sso_session_epoch` is not a credential. Generate it once with
 `python -c 'import uuid; print(uuid.uuid4())'` and keep it stable across normal
-restarts. Changing it is an explicit global SSO-session revocation: AKB removes
-ordinary and product-admin browser handles plus back-channel logout fences.
-AKB also records the last active auth mode, so a later `sso` start revokes rows
-that predate an intervening `local` start, even if the same UUID was
-accidentally reused. A draining replica cannot reintroduce its prior generation
-after the boundary because session writes also bind to the database-owned
-active epoch.
+restarts. The ConfigMap's positive `auth_runtime_generation` is also stable for
+an exact restart. Increase that generation for every auth-mode transition or
+epoch rotation. PostgreSQL rejects stale and same-generation conflicting
+starts; an accepted greater generation removes ordinary and product-admin
+browser handles plus back-channel logout fences before readiness.
+
+### Upgrade from a pre-epoch backend
+
+This first cutover is an explicit stop-the-world operation, not a rolling
+upgrade. Use the new backend image for the preflight, in this exact order:
+
+1. Scale the backend to zero and stop every other client of the AKB database.
+2. Set `auth_runtime_generation: 1`, persist `sso_session_epoch`, and temporarily
+   add `sso_session_epoch_upgrade: stop-the-world-v1` to `app.yaml`.
+3. Run `cd backend && uv run python
+   scripts/sso_session_epoch_preflight.py prepare-upgrade`. It exits nonzero if
+   another database client is connected. On success it applies the compatible
+   nullable-column bridge, purges pre-epoch sessions/fences, and enables the
+   database legacy-write guard. Starting the application directly cannot
+   activate a required bridge, even with the acknowledgement configured.
+4. Remove `sso_session_epoch_upgrade`, then start only the new backend at the
+   exact prepared generation/mode/epoch tuple.
+
+For an image rollback, first scale the new backend to zero and stop every other
+database client. With the new image and its current config, run `cd backend &&
+uv run python scripts/sso_session_epoch_preflight.py prepare-rollback`. Only
+after it succeeds, remove `auth_runtime_generation`,
+`sso_session_epoch_upgrade`, and `sso_session_epoch` from the old image's
+configuration and start the old backend. The preparation purges all current
+SSO browser authority and reopens legacy writes while retaining a generation
+floor; a later re-upgrade must use a greater generation. No browser session
+survives rollback. The preflight `status` command reports only contract state
+and legacy-row presence, never epoch/generation values or credentials.
 
 Generate the browser-session key as an unpadded 32-byte base64url value:
 

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -73,6 +73,7 @@ confidential-client secrets:
 ```yaml
 db_password: <same value as akb-postgres-credentials>
 system_hmac_secret: <independent random value>
+sso_session_epoch: <installation-owned UUID>
 sso_browser_session_encryption_key: <independent 32-byte base64url value>
 keycloak_client_secret: <akb-web secret>
 keycloak_admin_client_secret: <akb-admin secret>
@@ -86,15 +87,27 @@ email, and Keycloak forces `UPDATE_PASSWORD` on first login. The realm enforces
 the same lean policy for the replacement password. The bootstrap client secret
 is not the product-admin password.
 
+`sso_session_epoch` is not a credential. Generate it once with
+`python -c 'import uuid; print(uuid.uuid4())'` and keep it stable across normal
+restarts. Changing it is an explicit global SSO-session revocation: AKB removes
+ordinary and product-admin browser handles plus back-channel logout fences.
+AKB also records the last active auth mode, so a later `sso` start revokes rows
+that predate an intervening `local` start, even if the same UUID was
+accidentally reused. A draining replica cannot reintroduce its prior generation
+after the boundary because session writes also bind to the database-owned
+active epoch.
+
 Generate the browser-session key as an unpadded 32-byte base64url value:
 
 ```bash
 python -c 'import base64,secrets; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip("="))'
 ```
 
-Keep it stable across backend restarts. Replacing this single key intentionally
-invalidates every outstanding ordinary-user SSO browser session and requires a
-fresh login; it does not rotate a Keycloak realm signing key.
+Keep the encryption key stable across backend restarts. Replacing this single
+key makes ordinary-user envelopes unreadable and requires a fresh login; use
+the epoch change above when the intended operation is a complete, auditable
+ordinary/admin SSO-session revocation. Neither operation rotates a Keycloak
+realm signing key.
 
 Render and validate the public overlay before applying:
 

--- a/deploy/k8s/standalone-sso/backend-config-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-config-patch.yaml
@@ -21,6 +21,7 @@ data:
     s3_bucket: akb-files
 
     auth_mode: sso
+    auth_runtime_generation: 1
     jwt_algorithm: RS256
     keycloak_enabled: true
     keycloak_server_url: https://auth.akb.example.com

--- a/deploy/keycloak-dev/broker-chain/run.sh
+++ b/deploy/keycloak-dev/broker-chain/run.sh
@@ -68,6 +68,7 @@ mkdir -p "$fixture_run_dir/config"
 sso_session_epoch="$(python3 -c 'import uuid; print(uuid.uuid4())')"
 cat >"$fixture_run_dir/config/app.yaml" <<YAML
 auth_mode: sso
+auth_runtime_generation: 1
 sso_session_epoch: "$sso_session_epoch"
 keycloak_enabled: true
 keycloak_server_url: https://broker.localhost:19443

--- a/deploy/keycloak-dev/broker-chain/run.sh
+++ b/deploy/keycloak-dev/broker-chain/run.sh
@@ -65,8 +65,10 @@ openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
 chmod 600 "$cert_dir/tls.key"
 
 mkdir -p "$fixture_run_dir/config"
-cat >"$fixture_run_dir/config/app.yaml" <<'YAML'
+sso_session_epoch="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+cat >"$fixture_run_dir/config/app.yaml" <<YAML
 auth_mode: sso
+sso_session_epoch: "$sso_session_epoch"
 keycloak_enabled: true
 keycloak_server_url: https://broker.localhost:19443
 keycloak_realm: akb

--- a/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
+++ b/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
@@ -2,7 +2,7 @@
 status: accepted
 stage: implementation
 created: 2026-08-13
-updated: 2026-08-13
+updated: 2026-08-14
 ---
 
 # Authentication Mode Boundary
@@ -78,15 +78,22 @@ migration persists the derived canonical mode before normal startup; ambiguous
 legacy state fails closed and requires an explicit operator choice.
 
 An SSO runtime binds every ordinary browser session, product-admin browser
-session, and logout fence to one installation-owned authority generation.
-Normal restarts preserve that generation. An explicit generation change or
-any observed transition between `local` and `sso` revokes those rows
-transactionally before authentication traffic is accepted. Returning to SSO
-must not revive state ignored during local mode, and a draining replica must
-not reintroduce its prior generation after the mode-transition transaction.
-The concrete
-configuration field and storage layout are versioned implementation details;
-the no-resurrection boundary is permanent.
+session, and logout fence to one installation-owned epoch. A separate positive
+runtime generation is monotonic across both auth modes. Normal restarts present
+the exact persisted generation/mode/epoch tuple; every mode or epoch transition
+presents a greater generation. Stale and same-generation conflicting starts
+fail closed, while an accepted transition transactionally revokes all SSO
+browser authority before authentication traffic is accepted. Returning to SSO
+must not revive state ignored during local mode, and replica start order cannot
+restore an older boundary. The concrete configuration and storage layout are
+versioned implementation details; the no-resurrection boundary is permanent.
+
+The first pre-epoch upgrade uses an executable stop-the-world bridge. Epoch
+columns remain nullable only for image rollback compatibility; current code
+always writes/resolves an exact non-null epoch, and a database guard rejects
+legacy writes after cutover. Upgrade and rollback both require a quiescent
+preflight and purge all SSO browser authority. Rollback retains the monotonic
+generation floor so a later upgrade cannot replay the prior boundary.
 
 ### Credential authority
 
@@ -223,7 +230,9 @@ failing test.
 Browser-session cutover also owns executable coverage that a same-generation
 restart preserves sessions, while an epoch change or `sso → local → sso`
 transition revokes ordinary/admin sessions and logout fences without recording
-the generation value in audit payloads.
+authority values in audit payloads. It also owns real PostgreSQL coverage for
+pre-epoch writes, cutover rejection, prepared image rollback, stale and
+out-of-order starts, and concurrent migration/startup lock ordering.
 
 Mode-boundary acceptance requires:
 

--- a/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
+++ b/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
@@ -77,6 +77,17 @@ settings, and only when those settings identify one mode unambiguously. The
 migration persists the derived canonical mode before normal startup; ambiguous
 legacy state fails closed and requires an explicit operator choice.
 
+An SSO runtime binds every ordinary browser session, product-admin browser
+session, and logout fence to one installation-owned authority generation.
+Normal restarts preserve that generation. An explicit generation change or
+any observed transition between `local` and `sso` revokes those rows
+transactionally before authentication traffic is accepted. Returning to SSO
+must not revive state ignored during local mode, and a draining replica must
+not reintroduce its prior generation after the mode-transition transaction.
+The concrete
+configuration field and storage layout are versioned implementation details;
+the no-resurrection boundary is permanent.
+
 ### Credential authority
 
 In `local` mode, AKB remains the human login authority and continues to issue
@@ -171,7 +182,7 @@ following.
 
 | Class | Contracts fixed by this ADR | Change or retirement rule |
 | --- | --- | --- |
-| Permanent | One required canonical mode with no silent default; no hybrid or failure fallback; mode-selected verification; exact OIDC issuer, AKB audience/resource, and credential/token type validation before projection; no AKB user session minted in `sso`; common principal-to-actor authorization; separate ordinary and product-admin surfaces; PAT/service orthogonality | Changing one requires an ADR that explicitly supersedes this record. |
+| Permanent | One required canonical mode with no silent default; no hybrid or failure fallback; no SSO browser-state resurrection across mode/authority-generation boundaries; mode-selected verification; exact OIDC issuer, AKB audience/resource, and credential/token type validation before projection; no AKB user session minted in `sso`; common principal-to-actor authorization; separate ordinary and product-admin surfaces; PAT/service orthogonality | Changing one requires an ADR that explicitly supersedes this record. |
 | Versioned | Local asymmetric session profile; OIDC access-token profile; public login-options and admin-control schemas | Introduce a new named version with compatibility, migration, and retirement rules. Do not silently widen an existing verifier profile. |
 | Migration-only | Acceptance of legacy symmetric AKB sessions and any compatibility for legacy hybrid configuration | Must have a bounded entry condition and the retirement criteria below. Remove its code, configuration, and tests when retired. |
 
@@ -208,6 +219,11 @@ failing test.
 | Installation and admin bootstrap | Fresh-install rejection of missing or unknown `auth_mode`; explicit unambiguous legacy derivation and persistence; rejection of ambiguous legacy state; key persistence and rollover for the selected local profile; explicit product-admin provisioning; mode-appropriate admin recovery; any bounded legacy-hybrid migration. |
 | Login and IdP control | UI and API capability agreement by mode; enabled-provider projection; fail-closed login-options behavior; disabled-provider and secret redaction; separation of ordinary login from product-admin control. |
 | Browser session cutover | OIDC access, refresh, expiry, logout, revocation, and account suspension across AKB and first-party clients; proof that the `sso` path does not issue, store, or forward an AKB user session token. |
+
+Browser-session cutover also owns executable coverage that a same-generation
+restart preserves sessions, while an epoch change or `sso → local → sso`
+transition revokes ordinary/admin sessions and logout fences without recording
+the generation value in audit payloads.
 
 Mode-boundary acceptance requires:
 

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -157,6 +157,15 @@ deployment; a malformed configured key fails startup. Replacing the only key
 forces ordinary SSO reauthentication. Key-ring rotation is not part of this
 MVP.
 
+All ordinary sessions, product-admin sessions, and logout fences are also
+bound to the required non-secret `sso_session_epoch` UUID. Normal restarts keep
+the UUID. Changing it transactionally revokes every row in those three
+classes. Startup separately persists the observed auth mode, so any real mode
+change is also a revocation boundary; returning from `local` to `sso` cannot
+resurrect stale rows even when the configured UUID is reused. This generation
+binding is intentionally separate from encryption-key custody: it covers the
+admin session class, which stores no encrypted Keycloak token.
+
 | Route | `local` | ready `sso` |
 | --- | --- | --- |
 | `GET /auth/sso/{alias}/login` | `404` | starts only an enabled provider |

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -157,14 +157,16 @@ deployment; a malformed configured key fails startup. Replacing the only key
 forces ordinary SSO reauthentication. Key-ring rotation is not part of this
 MVP.
 
-All ordinary sessions, product-admin sessions, and logout fences are also
-bound to the required non-secret `sso_session_epoch` UUID. Normal restarts keep
-the UUID. Changing it transactionally revokes every row in those three
-classes. Startup separately persists the observed auth mode, so any real mode
-change is also a revocation boundary; returning from `local` to `sso` cannot
-resurrect stale rows even when the configured UUID is reused. This generation
-binding is intentionally separate from encryption-key custody: it covers the
-admin session class, which stores no encrypted Keycloak token.
+All ordinary sessions, product-admin sessions, and logout fences are bound to
+the required non-secret `sso_session_epoch` UUID. The complete runtime boundary
+also includes a positive, monotonic `auth_runtime_generation`. Normal restarts
+must present the exact persisted generation/mode/epoch tuple; every mode change
+or epoch rotation must increase the generation. PostgreSQL rejects stale and
+same-generation conflicting starts, while an accepted greater generation
+transactionally revokes every row in those three classes. Returning from
+`local` to `sso` therefore cannot resurrect stale rows even when the UUID is
+reused. This binding is separate from encryption-key custody and also covers
+the admin session class, which stores no encrypted Keycloak token.
 
 | Route | `local` | ready `sso` |
 | --- | --- | --- |

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -14,14 +14,54 @@ Product administration remains separate at `/admin`. A product administrator
 can configure an upstream provider while it is disabled, inspect the exact
 redirect URI, and then enable or disable it without redeploying AKB.
 
-Every SSO installation also owns a required UUID `sso_session_epoch`. It is a
-non-secret authority-generation marker: keep it stable for normal restarts and
-change it only to revoke all ordinary and product-admin browser sessions plus
-back-channel logout fences. AKB persists the last observed auth mode and
-reconciles it transactionally at startup. Consequently, `sso → local → sso`
-cannot revive ignored SSO rows; the database rejects a draining replica that
-tries to reintroduce the prior generation after the local-mode boundary, and
-returning to SSO remains a revocation boundary even if the UUID is reused.
+Every installation owns a positive `auth_runtime_generation`; SSO mode also
+requires the non-secret UUID `sso_session_epoch`. Keep the exact
+generation/mode/epoch tuple stable for normal restarts. Increase the generation
+for every mode change or epoch rotation. PostgreSQL accepts only an exact
+restart or a greater generation, so stale and same-generation conflicting
+replicas cannot reverse `sso → local → sso` or restore an older epoch. Every
+accepted transition transactionally purges ordinary and product-admin browser
+sessions plus back-channel logout fences. Audit and startup output contain
+transition booleans and row counts, never epoch or generation values.
+
+## Pre-epoch upgrade and rollback
+
+The first upgrade from a build without session epochs is deliberately
+stop-the-world; it is not a rolling mixed-writer upgrade. The schema bridge
+keeps `session_epoch` nullable so the old image remains usable after a prepared
+rollback, while current code always writes and resolves an exact non-null
+epoch. A database trigger rejects legacy NULL writes as soon as the current
+authority is activated.
+
+Upgrade in this exact order:
+
+1. Stop every backend and other database client.
+2. Configure `auth_runtime_generation: 1`, the installation epoch, and the
+   temporary `sso_session_epoch_upgrade: stop-the-world-v1` acknowledgement.
+3. From the new image's `backend/` directory, run
+   `uv run python scripts/sso_session_epoch_preflight.py prepare-upgrade`.
+   It fails while another client is connected, applies the bridge, purges all
+   pre-epoch sessions/fences, and enables the legacy-write guard atomically.
+   Ordinary application startup cannot activate a required bridge, even when
+   the acknowledgement is present.
+4. Remove the temporary acknowledgement and start only the new image with the
+   exact prepared generation/mode/epoch tuple.
+
+Rollback in this exact order:
+
+1. Stop every current backend and other database client.
+2. Using the current image and config, run
+   `uv run python scripts/sso_session_epoch_preflight.py prepare-rollback`.
+   It fails while another client is connected, purges all current SSO browser
+   authority, preserves the monotonic generation floor, and reopens legacy
+   NULL writes.
+3. Remove `auth_runtime_generation`, `sso_session_epoch_upgrade`, and
+   `sso_session_epoch` from the old image's configuration, then start the old
+   image. No SSO browser session survives the rollback.
+
+A later re-upgrade must use a generation greater than the last current-image
+generation; the retained floor rejects replay. `status` prints only the
+contract state and whether legacy rows exist, never authority values.
 
 ## Provider lifecycle
 

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -14,6 +14,15 @@ Product administration remains separate at `/admin`. A product administrator
 can configure an upstream provider while it is disabled, inspect the exact
 redirect URI, and then enable or disable it without redeploying AKB.
 
+Every SSO installation also owns a required UUID `sso_session_epoch`. It is a
+non-secret authority-generation marker: keep it stable for normal restarts and
+change it only to revoke all ordinary and product-admin browser sessions plus
+back-channel logout fences. AKB persists the last observed auth mode and
+reconciles it transactionally at startup. Consequently, `sso → local → sso`
+cannot revive ignored SSO rows; the database rejects a draining replica that
+tries to reintroduce the prior generation after the local-mode boundary, and
+returning to SSO remains a revocation boundary even if the UUID is reused.
+
 ## Provider lifecycle
 
 ```text

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -63,6 +63,23 @@ A later re-upgrade must use a generation greater than the last current-image
 generation; the retained floor rejects replay. `status` prints only the
 contract state and whether legacy rows exist, never authority values.
 
+## SSO session epoch migration bridge retirement gate
+
+This is a migration-only compatibility bridge, not a permanent feature.
+Retire it only after all three conditions are evidenced:
+
+1. All supported AKB rollback artifacts are epoch-capable, and pre-epoch image
+   rollback support is formally ended.
+2. Deployment and fleet inventory shows no pre-epoch artifact.
+3. Upgrade and rollback rehearsal receipts exist for every supported
+   deployment profile.
+
+Then remove the bridge in one atomic schema/runtime change: remove the
+`sso_session_epoch_upgrade` acknowledgement and the `prepare-rollback`
+command/path; remove `rollback_ready` and the legacy NULL trigger and state;
+make every `session_epoch` column NOT NULL; and remove or replace the legacy
+bridge tests.
+
 ## Provider lifecycle
 
 ```text


### PR DESCRIPTION
## Summary

- bind ordinary and product-admin SSO browser sessions, plus back-channel logout fences, to an installation-owned epoch and monotonic runtime generation
- preserve sessions on an exact restart, revoke them on an intentional mode or epoch transition, and reject stale or conflicting replicas
- add an executable stop-the-world upgrade and rollback bridge for pre-epoch installations without making legacy compatibility permanent
- keep local authentication and local AKB session-token semantics unchanged

## Upgrade safety

The schema bridge remains compatible with the prior image only during the documented rollback window. Existing backends must be stopped before the upgrade preflight runs. Upgrade and rollback both revoke SSO browser authority. A checked-in exact-base fixture proves that the prior schema reaches the current migration and that the final indexes are epoch-aware.

The bridge has an explicit retirement gate: it is removed once supported rollback artifacts are epoch-capable, fleet inventory contains no pre-epoch artifact, and upgrade and rollback rehearsals exist for every supported deployment profile.

## Verification

- focused real-PostgreSQL auth and upgrade suite: 80 passed
- backend non-E2E suite: 2326 passed, 236 skipped, 47 deselected
- frontend suite: 471 passed
- client SDK suite: 48 passed
- Ruff, mypy, Bandit, manifest checks, generated-code drift, packed-consumer proof, and secret scan passed
- independent exact-head review: 0 High, 0 Medium, 0 Low

Part of #357.
