### PR TITLE
fix(auth): reject noncanonical SSO session envelopes

### DIFF
--- a/backend/app/services/sso_browser_session_crypto.py
+++ b/backend/app/services/sso_browser_session_crypto.py
@@ -41,13 +41,19 @@ def _decode_base64url(value: str, *, error: type[ValueError]) -> bytes:
     if not isinstance(value, str) or not value or not value.isascii():
         raise error("Invalid browser-session cryptographic material")
     try:
-        return base64.b64decode(
+        decoded = base64.b64decode(
             value + "=" * ((4 - len(value) % 4) % 4),
             altchars=b"-_",
             validate=True,
         )
     except ValueError, binascii.Error:
         raise error("Invalid browser-session cryptographic material") from None
+    # Base64 decoders may accept aliases whose unused pad bits are non-zero.
+    # Reject every representation except our exact unpadded Base64URL profile so
+    # one encrypted envelope has one wire representation on every Python version.
+    if _encode_base64url(decoded) != value:
+        raise error("Invalid browser-session cryptographic material")
+    return decoded
 
 
 def _encode_base64url(value: bytes) -> str:

--- a/backend/tests/test_sso_browser_session_crypto_unit.py
+++ b/backend/tests/test_sso_browser_session_crypto_unit.py
@@ -17,6 +17,21 @@ def _key(byte: int) -> str:
     return base64.urlsafe_b64encode(bytes([byte]) * 32).decode("ascii").rstrip("=")
 
 
+def _noncanonical_base64url_alias(value: str) -> str:
+    """Change only unused pad bits while preserving the decoded bytes."""
+    # RFC 4648 URL-safe alphabet, not credential material.
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"  # pragma: allowlist secret
+    remainder = len(value) % 4
+    assert remainder in {2, 3}
+    unused_bits = 4 if remainder == 2 else 2
+    index = alphabet.index(value[-1])
+    assert index & ((1 << unused_bits) - 1) == 0
+    alias = f"{value[:-1]}{alphabet[index | 0b01]}"
+    padding = "=" * ((4 - len(value) % 4) % 4)
+    assert base64.urlsafe_b64decode(value + padding) == base64.urlsafe_b64decode(alias + padding)
+    return alias
+
+
 def test_v1_cipher_round_trips_without_putting_plaintext_in_the_envelope():
     cipher = BrowserSessionCipher.from_encoded_key(_key(7))
     payload = {
@@ -80,8 +95,15 @@ def test_cipher_rejects_wrong_key_tampering_and_noncanonical_payloads_without_ec
         context="session:one:user-1",
     )
     tampered = f"{envelope[:-1]}{'A' if envelope[-1] != 'A' else 'B'}"
+    version, nonce, ciphertext = envelope.split(".")
+    noncanonical = f"{version}.{nonce}.{_noncanonical_base64url_alias(ciphertext)}"
 
-    for candidate, cipher in ((envelope, second), (tampered, first), ("v2.abc", first)):
+    for candidate, cipher in (
+        (envelope, second),
+        (tampered, first),
+        (noncanonical, first),
+        ("v2.abc", first),
+    ):
         with pytest.raises(BrowserSessionPayloadError) as captured:
             cipher.open(candidate, context="session:one:user-1")
         assert "never-echo-this" not in str(captured.value)

--- a/backend/tests/test_sso_session_epoch_upgrade_postgres.py
+++ b/backend/tests/test_sso_session_epoch_upgrade_postgres.py
@@ -22,7 +22,8 @@ _INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
 _EXACT_BASE_INIT_SQL = (
     _BACKEND / "tests" / "fixtures" / "sso_session_epoch" / "exact_base_0860a0e_init.sql"
 ).read_text()
-_EXACT_BASE_INIT_SHA256 = "410c67e62b63f254004430cd3bb2ab72ff0fc9e4af3415ac8218fec6137696b1"
+# Public fixture integrity digest, not credential material.
+_EXACT_BASE_INIT_SHA256 = "410c67e62b63f254004430cd3bb2ab72ff0fc9e4af3415ac8218fec6137696b1"  # pragma: allowlist secret
 _MIGRATION_REGISTRY = (_BACKEND / "app" / "db" / "postgres.py").read_text().split("for filename in (", 1)[1]
 _MIGRATION_REGISTRY = _MIGRATION_REGISTRY.split("    ):", 1)[0]
 _CURRENT_MIGRATIONS = re.findall(r'"([0-9]{3}_[^"]+\.py)"', _MIGRATION_REGISTRY)


### PR DESCRIPTION
## Summary

- require one exact unpadded Base64URL representation for browser-session cryptographic material
- add a deterministic non-zero pad-bit alias regression for Python 3.14
- mark the public fixture digest and RFC 4648 alphabet as detect-secrets false positives

## Why

Follow-up to #370. Python 3.14 accepts Base64URL spellings with non-zero unused pad bits, so changing the final character can still decode to the original authenticated ciphertext. Canonical round-trip validation makes the wire profile unambiguous across runtime versions.

## Validation

- Python 3.14 focused crypto tests: 16 passed
- CI-equivalent backend unit selection: 2329 passed, 236 skipped, 47 deselected
- Ruff and format checks
- Mypy: 298 source files
- Bandit medium-severity gate
- tracked-file detect-secrets scan
- E2E suite manifest