### PR TITLE
fix: preserve backend mounts in SSO overlay

### DIFF
--- a/backend/tests/test_standalone_sso_deployment_unit.py
+++ b/backend/tests/test_standalone_sso_deployment_unit.py
@@ -172,6 +172,22 @@ def test_kustomize_render_has_no_local_session_mount_when_kubectl_is_available()
         text=True,
         timeout=30,
     )
+    rendered = [item for item in yaml.safe_load_all(result.stdout) if isinstance(item, dict)]
+    backend = next(
+        item
+        for item in rendered
+        if item.get("kind") == "Deployment" and item.get("metadata", {}).get("name") == "backend"
+    )
+    main = next(
+        item
+        for item in backend["spec"]["template"]["spec"]["containers"]
+        if item["name"] == "backend"
+    )
+    assert {mount["name"] for mount in main["volumeMounts"]} == {
+        "app-config",
+        "secret-config",
+        "vaultdata",
+    }
     assert "local-session-keys" not in result.stdout
     assert "auth_mode: sso" in result.stdout
     assert "kind: Secret" not in result.stdout

--- a/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
@@ -80,6 +80,7 @@ spec:
         - name: backend
           volumeMounts:
             - name: local-session-keys
+              mountPath: /etc/akb/local-session
               $patch: delete
       volumes:
         - name: local-session-keys


### PR DESCRIPTION
## Summary

- identify the local-session VolumeMount by its Kubernetes strategic-merge key (mountPath)
- preserve the application config, secret config, and vault data mounts in rendered standalone SSO deployments
- strengthen the existing rendered-manifest regression test

## Validation

- focused standalone SSO deployment unit suite: 6 passed
- rendered backend mount set: app-config, secret-config, vaultdata

Relates to #357.