### PR TITLE
fix(auth): make epoch preflight directly executable

### DIFF
--- a/backend/scripts/sso_session_epoch_preflight.py
+++ b/backend/scripts/sso_session_epoch_preflight.py
@@ -6,6 +6,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+from pathlib import Path
+import sys
+
+# Kubernetes and the documented rollback procedure execute this file directly.
+# Python then puts only ``scripts/`` on sys.path, so make the backend package
+# root explicit instead of relying on a caller-provided PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import asyncpg
 

--- a/backend/tests/test_sso_browser_session_schema_unit.py
+++ b/backend/tests/test_sso_browser_session_schema_unit.py
@@ -1,6 +1,9 @@
 """Static guard for the SSO browser-session epoch boundary."""
 
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import asyncpg
 import pytest
@@ -62,13 +65,25 @@ def test_fresh_and_migrated_schema_share_the_custody_invariants():
 
 
 def test_runtime_epoch_preflight_is_executable_and_public_safe():
-    preflight = (_BACKEND / "scripts" / "sso_session_epoch_preflight.py").read_text()
+    preflight_path = _BACKEND / "scripts" / "sso_session_epoch_preflight.py"
+    preflight = preflight_path.read_text()
 
     assert "prepare-upgrade" in preflight
     assert "prepare-rollback" in preflight
     assert "status" in preflight
     assert '"runtime_generation":' not in preflight
     assert '"sso_session_epoch":' not in preflight
+
+    env = {**os.environ, "PYTHONPATH": ""}
+    result = subprocess.run(
+        [sys.executable, str(preflight_path), "--help"],
+        cwd=_BACKEND,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_epoch_bridge_has_named_migration_only_retirement_contract():


### PR DESCRIPTION
## Summary
- Make the SSO epoch preflight resolve the backend package from its own location.
- Add a subprocess regression that clears PYTHONPATH and runs the documented direct invocation.

## Root cause
Running the script directly sets the import root to the scripts directory, so app.config was unavailable unless the caller injected PYTHONPATH.

## Validation
- Reproduced the direct-invocation failure against the prior Python 3.14 artifact.
- Verified direct invocation succeeds with an empty PYTHONPATH against the fixed source and rebuilt artifact.