### PR TITLE
fix(auth): release recovery admin on service adoption

### DIFF
--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -366,7 +366,7 @@ async def adopt_current_admin_as_service(
             current = await conn.fetchrow(
                 """
                 SELECT id, username, email, password_hash, display_name, is_admin,
-                       auth_provider, account_status, account_kind,
+                       is_recovery_admin, auth_provider, account_status, account_kind,
                        EXISTS (
                            SELECT 1 FROM external_identities e
                             WHERE e.user_id = users.id
@@ -412,6 +412,7 @@ async def adopt_current_admin_as_service(
                 current["account_kind"] != "service"
                 or current["auth_provider"] != "service"
                 or current["password_hash"] != _SERVICE_SENTINEL_HASH
+                or current["is_recovery_admin"]
             )
             wanted_scopes = ["read", "write", "admin"]
             token_changed = token["key_class"] != "service" or list(token["scopes"] or []) != wanted_scopes
@@ -422,6 +423,7 @@ async def adopt_current_admin_as_service(
                        SET account_kind = 'service',
                            auth_provider = 'service',
                            password_hash = $2,
+                           is_recovery_admin = false,
                            tokens_revoked_before = CASE
                                WHEN account_kind = 'human' THEN NOW()
                                ELSE tokens_revoked_before

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -449,9 +449,15 @@ async def test_create_pat_uses_caller_selected_token_id(services):
 
 async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     services,
+    monkeypatch,
 ):
     pool, role_sync, service = services
-    from app.services import auth_service
+    from app.config import settings
+    from app.services import auth_service, recovery_admin_service
+
+    monkeypatch.setattr(recovery_admin_service, "get_pool", service.get_pool)
+    monkeypatch.setattr(recovery_admin_service, "get_role_sync", lambda: role_sync)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
 
     user_id = uuid.uuid4()
     current_token_id = uuid.uuid4()
@@ -465,9 +471,9 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
             """
             INSERT INTO users (
                 id, username, email, password_hash, display_name, is_admin,
-                auth_provider, account_status, account_kind
+                is_recovery_admin, auth_provider, account_status, account_kind
             ) VALUES ($1, $2, $3, $4, 'Platform Bot', true,
-                      'local', 'active', 'human')
+                      true, 'local', 'active', 'human')
             """,
             user_id,
             username,
@@ -516,7 +522,7 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT u.password_hash, u.tokens_revoked_before,
+            SELECT u.password_hash, u.tokens_revoked_before, u.is_recovery_admin,
                    t.key_class, t.scopes,
                    (SELECT count(*) FROM tokens WHERE user_id = u.id) AS token_count
               FROM users u
@@ -528,6 +534,7 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
         )
     assert row["password_hash"].startswith("!service-account:")
     assert row["tokens_revoked_before"] is not None
+    assert row["is_recovery_admin"] is False
     assert row["key_class"] == "service"
     assert list(row["scopes"]) == ["read", "write", "admin"]
     assert row["token_count"] == 1
@@ -561,6 +568,16 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
             str(user_id),
         )
     assert retried_event_count == event_count
+
+    sso_recovery = await recovery_admin_service.provision_sso_recovery_admin(
+        username=f"governance-sso-recovery-{uuid.uuid4().hex[:8]}",
+        email=f"governance-sso-recovery-{uuid.uuid4().hex[:8]}@example.com",
+        issuer=_ISSUER,
+        subject=f"recovery-{uuid.uuid4().hex}",
+    )
+    assert sso_recovery["created"] is True
+    assert sso_recovery["is_recovery_admin"] is True
+    assert sso_recovery["user_id"] != str(user_id)
 
 
 async def test_adopt_bootstrap_admin_rejects_identity_mismatch_atomically(services):


### PR DESCRIPTION
## Summary

- clear the recovery-administrator designation when an administrator is adopted as a non-human service identity
- keep the adoption update atomic with the service account kind, provider, and sentinel password transition
- prove the recovery singleton can subsequently be claimed by the SSO recovery administrator

## Root cause

Service adoption changed the account kind and authentication provider but left `is_recovery_admin` set. That made a non-human service account retain the singleton recovery designation and blocked a later SSO recovery administrator from being provisioned.

## Validation

- independent exact-head review: 0 findings
- backend ruff, mypy, and bandit: passed
- account-service PostgreSQL tests: 22 passed
- recovery-admin PostgreSQL tests: 12 passed
- full non-E2E backend suite: 2342 passed, 236 skipped, 51 deselected
- scoped secret scan and `git diff --check`: passed
