### PR TITLE
fix(auth): prove recovery singleton release

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -1,5 +1,7 @@
 """REST API routes for vault access management."""
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import Field, SecretStr
 
@@ -122,6 +124,21 @@ class EnsureServiceUserRequest(NFCModel):
 class AdoptCurrentServiceUserRequest(NFCModel):
     expected_username: str
     expected_email: str
+
+
+class AdoptCurrentServiceUserResponse(NFCModel):
+    user_id: str
+    username: str
+    email: str
+    display_name: str | None
+    is_admin: bool
+    is_recovery_admin: Literal[False]
+    account_status: str
+    account_kind: str
+    auth_provider: str
+    token_id: str
+    key_class: str
+    revoked_token_ids: list[str]
 
 
 class SetUserRoleRequest(NFCModel):
@@ -445,6 +462,7 @@ async def admin_ensure_service_user(
 @router.post(
     "/admin/service-users/adopt-current",
     summary="[admin] Adopt the current bootstrap administrator as a service identity",
+    response_model=AdoptCurrentServiceUserResponse,
 )
 async def admin_adopt_current_service_user(
     req: AdoptCurrentServiceUserRequest,

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -61,7 +61,7 @@ def _user_result(row) -> dict:
 async def _fetch_user(conn, user_id: uuid.UUID):
     return await conn.fetchrow(
         """
-        SELECT id, username, email, display_name, is_admin,
+        SELECT id, username, email, display_name, is_admin, is_recovery_admin,
                auth_provider, account_status, account_kind
           FROM users WHERE id = $1
         """,
@@ -485,10 +485,13 @@ async def adopt_current_admin_as_service(
                     },
                 )
             adopted = await _fetch_user(conn, user_uuid)
+            if adopted is None or adopted["is_recovery_admin"] is not False:
+                raise ServiceIdentityAdoptionError()
 
     await _cleanup_token_roles(pool, user_uuid, pending_token_ids)
     return {
         **_user_result(adopted),
+        "is_recovery_admin": adopted["is_recovery_admin"],
         "token_id": token_id,
         "key_class": "service",
         "revoked_token_ids": [str(value) for value in pending_token_ids],

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -272,7 +272,11 @@ async def test_adopt_current_service_requires_exact_admin_pat_and_forwards_ids(m
 
     async def _adopt(**kwargs):
         observed.update(kwargs)
-        return {"account_kind": "service", "key_class": "service"}
+        return {
+            "account_kind": "service",
+            "key_class": "service",
+            "is_recovery_admin": False,
+        }
 
     monkeypatch.setattr(access, "adopt_current_admin_as_service", _adopt)
     request = access.AdoptCurrentServiceUserRequest(
@@ -291,7 +295,11 @@ async def test_adopt_current_service_requires_exact_admin_pat_and_forwards_ids(m
     token_id = str(uuid.uuid4())
     actor = _bootstrap_user(token_id=token_id)
     result = await access.admin_adopt_current_service_user(request, actor)
-    assert result == {"account_kind": "service", "key_class": "service"}
+    assert result == {
+        "account_kind": "service",
+        "key_class": "service",
+        "is_recovery_admin": False,
+    }
     assert observed == {
         "user_id": actor.user_id,
         "token_id": token_id,
@@ -336,3 +344,17 @@ async def test_governance_routes_are_explicit_in_openapi(monkeypatch, tmp_path):
     }
     assert expected <= set(paths)
     assert "/api/v1/admin/users/proxy" not in paths
+
+    operation = paths["/api/v1/admin/service-users/adopt-current"]["post"]
+    response_schema = operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert response_schema == {
+        "$ref": "#/components/schemas/AdoptCurrentServiceUserResponse"
+    }
+    adoption_schema = app.openapi()["components"]["schemas"][
+        "AdoptCurrentServiceUserResponse"
+    ]
+    assert "is_recovery_admin" in adoption_schema["required"]
+    assert adoption_schema["properties"]["is_recovery_admin"]["const"] is False
+    assert "default" not in adoption_schema["properties"]["is_recovery_admin"]

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -515,6 +515,7 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
     assert adopted["account_kind"] == "service"
     assert adopted["auth_provider"] == "service"
     assert adopted["is_admin"] is True
+    assert adopted["is_recovery_admin"] is False
     assert adopted["token_id"] == str(current_token_id)
     assert adopted["key_class"] == "service"
     assert adopted["revoked_token_ids"] == [str(stale_token_id)]
@@ -560,6 +561,7 @@ async def test_adopt_bootstrap_admin_preserves_current_token_and_revokes_others(
         expected_email=email,
         actor_id=str(user_id),
     )
+    assert retried["is_recovery_admin"] is False
     assert retried["revoked_token_ids"] == []
     assert role_sync.revoked_tokens == [stale_token_id]
     async with pool.acquire() as conn:


### PR DESCRIPTION
## Summary

- expose the post-adoption recovery-admin state in the `adopt-current` response
- require that state to be `false` in the public response contract
- re-read the updated database row and abort the transaction unless the recovery singleton was actually released

## Why

PR #376 clears `is_recovery_admin` while adopting the bootstrap administrator as a service identity. Automation performing a mode transition also needs a presence-sensitive proof that the live backend implements that behavior; an HTTP success from an older backend is not sufficient.

## Validation

- focused account-service and route tests: 32 passed
- scoped Ruff and mypy: passed
- scoped secret scan and `git diff --check`: passed
