### PR TITLE
fix(auth): ensure service user admin state

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -119,6 +119,7 @@ class EnsureServiceUserRequest(NFCModel):
     username: str
     email: str
     display_name: str | None = None
+    is_admin: bool = False
 
 
 class AdoptCurrentServiceUserRequest(NFCModel):
@@ -455,6 +456,7 @@ async def admin_ensure_service_user(
         username=req.username,
         email=req.email,
         display_name=req.display_name,
+        is_admin=req.is_admin,
         actor_id=user.user_id,
     )
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -264,6 +264,7 @@ async def ensure_service_user(
     email: str,
     display_name: str | None,
     actor_id: str,
+    is_admin: bool = False,
 ) -> dict:
     username = _required(username, "username")
     email = _required(email, "email").lower()
@@ -279,10 +280,15 @@ async def ensure_service_user(
                 )
                 rows = await conn.fetch(
                     """
-                    SELECT id, username, email, account_kind
-                      FROM users
-                     WHERE username = $1 OR email = $2
-                     FOR UPDATE
+                    SELECT u.id, u.username, u.email, u.account_kind,
+                           u.auth_provider, u.account_status,
+                           EXISTS (
+                               SELECT 1 FROM external_identities e
+                                WHERE e.user_id = u.id
+                           ) AS has_external_identity
+                      FROM users u
+                     WHERE u.username = $1 OR u.email = $2
+                     FOR UPDATE OF u
                     """,
                     username,
                     email,
@@ -293,18 +299,24 @@ async def ensure_service_user(
                         or rows[0]["username"] != username
                         or rows[0]["email"] != email
                         or rows[0]["account_kind"] != "service"
+                        or rows[0]["auth_provider"] != "service"
+                        or rows[0]["has_external_identity"]
                     ):
                         raise ExternalIdentityConflictError()
+                    if rows[0]["account_status"] != "active":
+                        raise AccountSuspendedError()
                     user_id = rows[0]["id"]
                     await conn.execute(
                         """
                         UPDATE users
                            SET display_name = COALESCE($2, display_name),
+                               is_admin = $3,
                                updated_at = NOW()
                          WHERE id = $1
                         """,
                         user_id,
                         display_name,
+                        is_admin,
                     )
                 else:
                     user_id = uuid.uuid4()
@@ -313,7 +325,7 @@ async def ensure_service_user(
                         INSERT INTO users (
                             id, username, email, password_hash, display_name,
                             is_admin, auth_provider, account_status, account_kind
-                        ) VALUES ($1, $2, $3, $4, $5, false, 'service',
+                        ) VALUES ($1, $2, $3, $4, $5, $6, 'service',
                                   'active', 'service')
                         """,
                         user_id,
@@ -321,6 +333,7 @@ async def ensure_service_user(
                         email,
                         _SERVICE_SENTINEL_HASH,
                         display_name,
+                        is_admin,
                     )
                     new_user_id = user_id
 
@@ -328,7 +341,7 @@ async def ensure_service_user(
                     conn,
                     "auth.service_user_ensured",
                     actor_id=actor_id,
-                    payload={"user_id": str(user_id)},
+                    payload={"user_id": str(user_id), "is_admin": is_admin},
                 )
         except asyncpg.UniqueViolationError:
             raise ExternalIdentityConflictError() from None

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -130,6 +130,46 @@ async def test_ensure_external_identity_forwards_verified_actor(monkeypatch):
     }
 
 
+async def test_ensure_service_user_is_admin_only_and_forwards_requested_role(monkeypatch):
+    from app.api.routes import access
+
+    observed = {}
+
+    async def _ensure(**kwargs):
+        observed.update(kwargs)
+        return {"user_id": "runtime-user", "is_admin": kwargs["is_admin"]}
+
+    monkeypatch.setattr(access, "ensure_service_user", _ensure)
+    default_request = access.EnsureServiceUserRequest(
+        username="runtime-agent",
+        email="runtime-agent@service.akb.invalid",
+    )
+    assert default_request.is_admin is False
+
+    with pytest.raises(HTTPException) as exc_info:
+        await access.admin_ensure_service_user(default_request, _user(admin=False))
+    assert exc_info.value.status_code == 403
+    assert observed == {}
+
+    admin = _user(admin=True)
+    request = access.EnsureServiceUserRequest(
+        username="runtime-agent",
+        email="runtime-agent@service.akb.invalid",
+        display_name="Runtime agent",
+        is_admin=True,
+    )
+    result = await access.admin_ensure_service_user(request, admin)
+
+    assert result == {"user_id": "runtime-user", "is_admin": True}
+    assert observed == {
+        "username": request.username,
+        "email": request.email,
+        "display_name": request.display_name,
+        "is_admin": True,
+        "actor_id": admin.user_id,
+    }
+
+
 async def test_exact_human_email_lookup_is_admin_only(monkeypatch):
     from app.api.routes import access
 
@@ -358,3 +398,8 @@ async def test_governance_routes_are_explicit_in_openapi(monkeypatch, tmp_path):
     assert "is_recovery_admin" in adoption_schema["required"]
     assert adoption_schema["properties"]["is_recovery_admin"]["const"] is False
     assert "default" not in adoption_schema["properties"]["is_recovery_admin"]
+
+    ensure_schema = app.openapi()["components"]["schemas"]["EnsureServiceUserRequest"]
+    assert "is_admin" not in ensure_schema["required"]
+    assert ensure_schema["properties"]["is_admin"]["type"] == "boolean"
+    assert ensure_schema["properties"]["is_admin"]["default"] is False

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -419,6 +419,134 @@ async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
     assert password_hash.startswith("!service-account:")
 
 
+async def test_ensure_service_user_converges_admin_state_with_live_token_and_audit(
+    services,
+):
+    pool, role_sync, service = services
+    username = f"governance-admin-runtime-{uuid.uuid4().hex[:10]}"
+    email = f"{username}@service.akb.invalid"
+
+    promoted = await service.ensure_service_user(
+        username=username,
+        email=email,
+        display_name="Administrative runtime",
+        is_admin=True,
+        actor_id="bootstrap-admin",
+    )
+
+    from app.services.auth_service import create_pat, resolve_token
+
+    credential = await create_pat(
+        promoted["user_id"],
+        "runtime-key",
+        key_class="service",
+        scopes=["read", "write", "admin"],
+    )
+    resolved_promoted = await resolve_token(f"Bearer {credential['token']}")
+
+    from app.exceptions import NotFoundError
+
+    with pytest.raises(NotFoundError):
+        await service.set_user_admin(
+            promoted["user_id"],
+            is_admin=False,
+            actor_id="bootstrap-admin",
+        )
+
+    demoted = await service.ensure_service_user(
+        username=username,
+        email=email,
+        display_name=None,
+        is_admin=False,
+        actor_id="bootstrap-admin",
+    )
+    resolved_demoted = await resolve_token(f"Bearer {credential['token']}")
+
+    assert promoted["user_id"] == demoted["user_id"]
+    assert promoted["is_admin"] is True
+    assert demoted["is_admin"] is False
+    assert resolved_promoted is not None and resolved_promoted.is_admin is True
+    assert resolved_demoted is not None and resolved_demoted.is_admin is False
+    assert role_sync.created_users == [uuid.UUID(promoted["user_id"])]
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT account_kind, auth_provider, account_status, is_admin
+              FROM users WHERE id = $1
+            """,
+            uuid.UUID(promoted["user_id"]),
+        )
+        events = await conn.fetch(
+            """
+            SELECT actor_id, payload->>'is_admin' AS is_admin
+              FROM events
+             WHERE kind = 'auth.service_user_ensured'
+               AND payload->>'user_id' = $1
+             ORDER BY id
+            """,
+            promoted["user_id"],
+        )
+
+    assert dict(row) == {
+        "account_kind": "service",
+        "auth_provider": "service",
+        "account_status": "active",
+        "is_admin": False,
+    }
+    assert [dict(event) for event in events] == [
+        {"actor_id": "bootstrap-admin", "is_admin": "true"},
+        {"actor_id": "bootstrap-admin", "is_admin": "false"},
+    ]
+
+
+async def test_ensure_service_user_fails_closed_for_suspended_or_conflicting_identity(
+    services,
+):
+    pool, _, service = services
+    username = f"governance-guarded-runtime-{uuid.uuid4().hex[:10]}"
+    email = f"{username}@service.akb.invalid"
+    ensured = await service.ensure_service_user(
+        username=username,
+        email=email,
+        display_name=None,
+        actor_id="bootstrap-admin",
+    )
+    user_id = uuid.UUID(ensured["user_id"])
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE users SET account_status = 'suspended' WHERE id = $1",
+            user_id,
+        )
+
+    from app.exceptions import AccountSuspendedError, ExternalIdentityConflictError
+
+    with pytest.raises(AccountSuspendedError):
+        await service.ensure_service_user(
+            username=username,
+            email=email,
+            display_name=None,
+            is_admin=True,
+            actor_id="bootstrap-admin",
+        )
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE users SET account_status = 'active', auth_provider = 'local' WHERE id = $1",
+            user_id,
+        )
+
+    with pytest.raises(ExternalIdentityConflictError):
+        await service.ensure_service_user(
+            username=username,
+            email=email,
+            display_name=None,
+            is_admin=True,
+            actor_id="bootstrap-admin",
+        )
+
+
 async def test_create_pat_uses_caller_selected_token_id(services):
     pool, _, service = services
     requested_token_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

- let the admin-only service-user ensure contract atomically converge an optional admin state
- preserve the existing non-admin default and the human-only role endpoint
- reject suspended or conflicting identities before mutation
- cover route schema, live PAT authorization, audit, promotion, and demotion behavior

## Verification

- focused backend regression suite: 35 passed
- ruff and mypy checks passed
- independent exact-head auth/security review: no findings