### PR TITLE
fix(auth): expose account kind at credential boundary

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -583,6 +583,7 @@ async def me(user: AuthenticatedUser = Depends(get_current_user)):
         "display_name": user.display_name,
         "is_admin": user.is_admin,
         "auth_method": user.auth_method,
+        "account_kind": user.account_kind,
         "key_class": user.key_class,
     }
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -62,6 +62,10 @@ class AuthenticatedUser:
     display_name: str | None
     is_admin: bool
     auth_method: str  # "jwt" | "pat" | "oauth" | "browser_session"
+    # Human is the only account kind reachable through local/OIDC sessions.
+    # Token-store credentials override this from the authoritative users row
+    # so service callers remain distinguishable at the request boundary.
+    account_kind: str = "human"
     # Per-PAT vault scope (Option B). None = unscoped: JWT logins, and PATs
     # minted without a scope. A concrete scope gates mutating vault access.
     vault_scope: VaultScope | None = None
@@ -1130,7 +1134,8 @@ async def _resolve_pat(raw_token: str) -> AuthenticatedUser | None:
                AND (t.expires_at IS NULL OR t.expires_at > NOW())
                AND u.account_status = 'active'
             RETURNING t.id AS token_id, t.user_id, t.scopes, t.vault_scope, t.key_class,
-                      t.expires_at, u.username, u.email, u.display_name, u.is_admin
+                      t.expires_at, u.username, u.email, u.display_name, u.is_admin,
+                      u.account_kind
             """,
             token_hash,
         )
@@ -1165,6 +1170,7 @@ async def _resolve_pat(raw_token: str) -> AuthenticatedUser | None:
             display_name=row["display_name"],
             is_admin=row["is_admin"],
             auth_method="pat",
+            account_kind=row["account_kind"],
             vault_scope=scope,
             token_id=token_id,
             key_class=key_class,

--- a/backend/tests/test_workspace_account_admin_routes.py
+++ b/backend/tests/test_workspace_account_admin_routes.py
@@ -21,6 +21,7 @@ def _user(*, admin: bool) -> AuthenticatedUser:
         display_name=None,
         is_admin=admin,
         auth_method="pat",
+        account_kind="service",
         key_class="service",
     )
 
@@ -36,6 +37,14 @@ def _bootstrap_user(*, auth_method: str = "pat", token_id: str | None = None) ->
         token_id=token_id,
         key_class="pat",
     )
+
+
+async def test_auth_me_exposes_the_authenticated_account_kind():
+    from app.api.routes import auth
+
+    result = await auth.me(_user(admin=True))
+
+    assert result["account_kind"] == "service"
 
 
 async def test_non_admin_is_rejected_before_account_service(monkeypatch):

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -466,7 +466,9 @@ async def test_ensure_service_user_converges_admin_state_with_live_token_and_aud
     assert promoted["is_admin"] is True
     assert demoted["is_admin"] is False
     assert resolved_promoted is not None and resolved_promoted.is_admin is True
+    assert resolved_promoted is not None and resolved_promoted.account_kind == "service"
     assert resolved_demoted is not None and resolved_demoted.is_admin is False
+    assert resolved_demoted is not None and resolved_demoted.account_kind == "service"
     assert role_sync.created_users == [uuid.UUID(promoted["user_id"])]
 
     async with pool.acquire() as conn:


### PR DESCRIPTION
## Summary

- carry the authoritative users.account_kind through PAT and service-key authentication
- expose account_kind from /api/v1/auth/me for credential-boundary verification
- preserve human as the default for local, OIDC, and browser-session principals
- add route and live token regression coverage for service principals

## Verification

- RED-first route contract reproduced the missing field
- focused account route/service suite: 36 passed
- ruff and mypy passed