### PR TITLE
fix(auth): retire local recovery admin during SSO cutover

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -3,7 +3,7 @@
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import Field, SecretStr
+from pydantic import ConfigDict, Field, SecretStr
 
 from app.api.deps import get_current_user
 from app.services.auth_service import (
@@ -12,6 +12,7 @@ from app.services.auth_service import (
     revoke_all_sessions,
 )
 from app.services.auth_policy import require_local_auth_enabled
+from app.services.recovery_admin_service import retire_local_recovery_admin
 from app.services.account_service import (
     activate_user,
     adopt_current_admin_as_service,
@@ -158,6 +159,26 @@ class ExpectedManagedHuman(NFCModel):
 class ManagedAccountStateRequest(NFCModel):
     issuer: str
     expected_humans: list[ExpectedManagedHuman] = Field(min_length=1, max_length=10_000)
+
+
+class RetireRecoveryAdminRequest(NFCModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_username: str = Field(min_length=1, max_length=255)
+    expected_email: str = Field(min_length=1, max_length=320)
+
+
+class RetireRecoveryAdminResponse(NFCModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    username: str
+    email: str
+    account_status: Literal["suspended"]
+    is_admin: Literal[False]
+    is_recovery_admin: Literal[False]
+    account_kind: Literal["human"]
+    auth_provider: Literal["local"]
 
 
 @router.get("/my/vaults", summary="List vaults accessible to me")
@@ -350,6 +371,37 @@ async def admin_remove_vault_write_grant(
 async def admin_list_users(user: AuthenticatedUser = Depends(get_current_user)):
     _require_admin(user)
     return {"users": await list_all_users_admin()}
+
+
+@router.post(
+    "/admin/recovery-admin/retire",
+    summary="[admin] Retire the exact local recovery administrator",
+    response_model=RetireRecoveryAdminResponse,
+)
+async def admin_retire_recovery_admin(
+    req: RetireRecoveryAdminRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    if not (
+        user.is_admin
+        and user.account_kind == "service"
+        and user.auth_method == "pat"
+        and user.token_id is not None
+        and user.key_class in {"pat", "service"}
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "Recovery administrator retirement requires an independent service administrator token",
+                "code": "recovery_admin_retirement_requires_service_admin",
+            },
+        )
+    return await retire_local_recovery_admin(
+        expected_username=req.expected_username,
+        expected_email=req.expected_email,
+        actor_user_id=user.user_id,
+        actor_token_id=user.token_id,
+    )
 
 
 @router.post(

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -156,6 +156,28 @@ class RecoveryAdminProtectedError(AKBError):
         )
 
 
+class RecoveryAdminRetirementAuthorizationError(AKBError):
+    """The retirement caller is not an independent service administrator."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator retirement requires an independent service administrator token",
+            status_code=403,
+            code="recovery_admin_retirement_requires_service_admin",
+        )
+
+
+class RecoveryAdminRetirementConflictError(AKBError):
+    """The expected recovery identity does not match one safe retirement state."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator does not match the retirement contract",
+            status_code=409,
+            code="recovery_admin_retirement_conflict",
+        )
+
+
 class ExternalAuthDisabledError(AKBError):
     """External authentication is disabled by deployment policy."""
 

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -21,6 +21,7 @@ from app.models.vault_scope import VaultScope, current_token_uuid, current_vault
 from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
 from app.repositories.vault_files_repo import confirmed_file_predicate
+from app.services.account_markers import is_retired_recovery_admin_password
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
 from app.services.write_lane import run_compensation, run_git_write
@@ -1683,9 +1684,13 @@ async def delete_user_account(user_id: str) -> dict:
     pool = await get_pool()
 
     async with pool.acquire() as conn:
-        if await conn.fetchval(
-            "SELECT is_recovery_admin FROM users WHERE id = $1",
+        protected = await conn.fetchrow(
+            "SELECT is_recovery_admin, password_hash FROM users WHERE id = $1",
             uid,
+        )
+        if protected is not None and (
+            protected["is_recovery_admin"]
+            or is_retired_recovery_admin_password(protected["password_hash"])
         ):
             raise RecoveryAdminProtectedError()
         owned_vault_names = [

--- a/backend/app/services/account_markers.py
+++ b/backend/app/services/account_markers.py
@@ -1,0 +1,14 @@
+"""Persistent account-state markers shared by lifecycle services."""
+
+from __future__ import annotations
+
+
+# An intentionally invalid credential tombstone, never a usable password.
+RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL = (  # nosec B105
+    "!retired-recovery-admin:no-local-login!"
+)
+
+
+def is_retired_recovery_admin_password(password_hash: str | None) -> bool:
+    """Return whether an account is the durable retired-recovery tombstone."""
+    return password_hash == RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -18,6 +18,10 @@ from app.exceptions import (
     ValidationError,
 )
 from app.repositories.events_repo import emit_event
+from app.services.account_markers import (
+    RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+    is_retired_recovery_admin_password,
+)
 from app.services.auth_service import (
     REVOKE_REASON_ADMIN,
     _hash_token,
@@ -96,7 +100,7 @@ async def ensure_human_external_identity(
                 )
                 bound = await conn.fetchrow(
                     """
-                    SELECT u.id, u.account_kind
+                    SELECT u.id, u.account_kind, u.password_hash
                       FROM external_identities e
                       JOIN users u ON u.id = e.user_id
                      WHERE e.issuer = $1 AND e.subject = $2
@@ -106,6 +110,8 @@ async def ensure_human_external_identity(
                     subject,
                 )
                 if bound is not None:
+                    if is_retired_recovery_admin_password(bound["password_hash"]):
+                        raise RecoveryAdminProtectedError()
                     if bound["account_kind"] != "human" or (
                         existing_user_uuid is not None and bound["id"] != existing_user_uuid
                     ):
@@ -138,7 +144,7 @@ async def ensure_human_external_identity(
                     if existing_user_uuid is not None:
                         target = await conn.fetchrow(
                             """
-                            SELECT id, account_kind
+                            SELECT id, account_kind, password_hash
                               FROM users WHERE id = $1
                              FOR UPDATE
                             """,
@@ -146,6 +152,8 @@ async def ensure_human_external_identity(
                         )
                         if target is None:
                             raise NotFoundError("User", str(existing_user_uuid))
+                        if is_retired_recovery_admin_password(target["password_hash"]):
+                            raise RecoveryAdminProtectedError()
                         if target["account_kind"] != "human":
                             raise ExternalIdentityConflictError()
                         email_owner = await conn.fetchval(
@@ -170,7 +178,7 @@ async def ensure_human_external_identity(
                     else:
                         rows = await conn.fetch(
                             """
-                            SELECT id, account_kind
+                            SELECT id, account_kind, password_hash
                               FROM users WHERE email = $1
                              FOR UPDATE
                             """,
@@ -180,6 +188,8 @@ async def ensure_human_external_identity(
                             raise ExternalIdentityConflictError()
                         if rows:
                             user_id = rows[0]["id"]
+                            if is_retired_recovery_admin_password(rows[0]["password_hash"]):
+                                raise RecoveryAdminProtectedError()
                             if rows[0]["account_kind"] != "human":
                                 raise ExternalIdentityConflictError()
                             has_identity = await conn.fetchval(
@@ -254,7 +264,7 @@ async def ensure_human_external_identity(
     if new_user_id is not None:
         await get_role_sync().on_user_create(new_user_id)
     if prepare_suspended:
-        await _cleanup_token_roles(pool, user_id, token_ids)
+        await cleanup_token_roles(pool, user_id, token_ids)
     return _user_result(row)
 
 
@@ -501,7 +511,7 @@ async def adopt_current_admin_as_service(
             if adopted is None or adopted["is_recovery_admin"] is not False:
                 raise ServiceIdentityAdoptionError()
 
-    await _cleanup_token_roles(pool, user_uuid, pending_token_ids)
+    await cleanup_token_roles(pool, user_uuid, pending_token_ids)
     return {
         **_user_result(adopted),
         "is_recovery_admin": adopted["is_recovery_admin"],
@@ -710,7 +720,8 @@ async def set_user_admin(user_id: str, *, is_admin: bool, actor_id: str) -> dict
     return _user_result(row)
 
 
-async def _cleanup_token_roles(pool, user_id: uuid.UUID, token_ids: list[uuid.UUID]) -> None:
+async def cleanup_token_roles(pool, user_id: uuid.UUID, token_ids: list[uuid.UUID]) -> None:
+    """Strictly finish durable token-role cleanup before reporting success."""
     failed: list[str] = []
     for token_id in token_ids:
         try:
@@ -830,7 +841,7 @@ async def suspend_user(user_id: str, *, actor_id: str) -> dict:
                 actor_id=actor_id,
             )
 
-    await _cleanup_token_roles(pool, user_uuid, token_ids)
+    await cleanup_token_roles(pool, user_uuid, token_ids)
     return {
         "user_id": user_id,
         "account_status": "suspended",
@@ -847,13 +858,22 @@ async def activate_user(user_id: str, *, actor_id: str) -> dict:
                 """
                 UPDATE users
                    SET account_status = 'active', updated_at = NOW()
-                 WHERE id = $1
+                 WHERE id = $1 AND password_hash <> $2
              RETURNING id, username, email, display_name, is_admin,
                        auth_provider, account_status, account_kind
                 """,
                 user_uuid,
+                RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
             )
             if row is None:
+                current = await conn.fetchrow(
+                    "SELECT password_hash FROM users WHERE id = $1 FOR UPDATE",
+                    user_uuid,
+                )
+                if current is None:
+                    raise NotFoundError("User", user_id)
+                if is_retired_recovery_admin_password(current["password_hash"]):
+                    raise RecoveryAdminProtectedError()
                 raise NotFoundError("User", user_id)
             await emit_event(
                 conn,
@@ -914,7 +934,7 @@ async def revoke_user_token(user_id: str, token_id: str, *, actor_id: str) -> di
                 needs_cleanup = True
 
     if needs_cleanup:
-        await _cleanup_token_roles(pool, user_uuid, [token_uuid])
+        await cleanup_token_roles(pool, user_uuid, [token_uuid])
     return {"user_id": user_id, "token_id": token_id, "revoked": True}
 
 

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -12,9 +12,13 @@ from app.db.postgres import get_pool
 from app.exceptions import (
     RecoveryAdminConflictError,
     RecoveryAdminModeError,
+    RecoveryAdminRetirementAuthorizationError,
+    RecoveryAdminRetirementConflictError,
     ValidationError,
 )
 from app.repositories.events_repo import emit_event
+from app.services.account_markers import RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+from app.services.account_service import cleanup_token_roles
 from app.services.auth_service import hash_password_async
 from app.services.role_sync import get_role_sync
 
@@ -22,7 +26,8 @@ from app.services.role_sync import get_role_sync
 # Fixed signed-bigint key: stable across processes and PostgreSQL upgrades,
 # unlike a runtime hash whose implementation could change.
 _PROVISIONING_LOCK_ID = 0x414B425245434F56  # "AKBRECOV"
-_SSO_PASSWORD_SENTINEL = "!keycloak-sso:no-local-login!"
+# These fixed strings are intentionally invalid credential tombstones, not passwords.
+_SSO_PASSWORD_SENTINEL = "!keycloak-sso:no-local-login!"  # nosec B105
 
 
 def _required(value: str, field: str) -> str:
@@ -269,3 +274,292 @@ async def provision_sso_recovery_admin(
     if created:
         await get_role_sync().on_user_create(row["id"])
     return _result(row, mode="sso", created=created)
+
+
+def _exact_expected(value: str, field: str) -> str:
+    if not value or not value.strip():
+        raise ValidationError(f"{field} is required")
+    return value
+
+
+def _retirement_proof(row) -> dict:
+    return {
+        "user_id": str(row["id"]),
+        "username": row["username"],
+        "email": row["email"],
+        "account_status": row["account_status"],
+        "is_admin": bool(row["is_admin"]),
+        "is_recovery_admin": bool(row["is_recovery_admin"]),
+        "account_kind": row["account_kind"],
+        "auth_provider": row["auth_provider"],
+    }
+
+
+async def _require_retirement_actor(
+    conn,
+    *,
+    actor_user_id: str,
+    actor_token_id: str,
+) -> uuid.UUID:
+    try:
+        user_id = uuid.UUID(actor_user_id)
+        token_id = uuid.UUID(actor_token_id)
+    except (AttributeError, TypeError, ValueError):
+        raise RecoveryAdminRetirementAuthorizationError() from None
+
+    row = await conn.fetchrow(
+        """
+        SELECT u.id, u.is_admin, u.is_recovery_admin, u.auth_provider,
+               u.account_status, u.account_kind, t.key_class, t.scopes,
+               NOT EXISTS (
+                   SELECT 1 FROM external_identities e WHERE e.user_id = u.id
+               ) AS has_no_external_identity
+          FROM users u
+          JOIN tokens t ON t.user_id = u.id
+         WHERE u.id = $1 AND t.id = $2
+           AND (t.expires_at IS NULL OR t.expires_at > NOW())
+         FOR SHARE OF u, t
+        """,
+        user_id,
+        token_id,
+    )
+    scopes = set(row["scopes"] or ("read", "write")) if row is not None else set()
+    if (
+        row is None
+        or not row["is_admin"]
+        or row["is_recovery_admin"]
+        or row["auth_provider"] != "service"
+        or row["account_status"] != "active"
+        or row["account_kind"] != "service"
+        or row["key_class"] not in {"pat", "service"}
+        or not row["has_no_external_identity"]
+        or not scopes.intersection({"write", "admin"})
+    ):
+        raise RecoveryAdminRetirementAuthorizationError()
+    return user_id
+
+
+async def _locked_recovery_rows(conn):
+    return await conn.fetch(
+        """
+        SELECT u.id, u.username, u.email, u.password_hash, u.is_admin,
+               u.is_recovery_admin, u.auth_provider, u.account_status,
+               u.account_kind, u.tokens_revoked_before,
+               EXISTS (
+                   SELECT 1 FROM external_identities e WHERE e.user_id = u.id
+               ) AS has_external_identity,
+               EXISTS (
+                   SELECT 1 FROM tokens t WHERE t.user_id = u.id
+               ) AS has_tokens,
+               EXISTS (
+                   SELECT 1 FROM admin_browser_sessions s WHERE s.user_id = u.id
+               ) AS has_admin_browser_sessions,
+               EXISTS (
+                   SELECT 1 FROM sso_browser_sessions s WHERE s.user_id = u.id
+               ) AS has_sso_browser_sessions
+          FROM users u
+         WHERE u.is_recovery_admin
+         ORDER BY u.id
+         FOR UPDATE OF u
+        """
+    )
+
+
+async def _locked_retirement_collisions(
+    conn,
+    *,
+    expected_username: str,
+    expected_email: str,
+):
+    return await conn.fetch(
+        """
+        SELECT u.id, u.username, u.email, u.password_hash, u.is_admin,
+               u.is_recovery_admin, u.auth_provider, u.account_status,
+               u.account_kind, u.tokens_revoked_before,
+               EXISTS (
+                   SELECT 1 FROM external_identities e WHERE e.user_id = u.id
+               ) AS has_external_identity,
+               EXISTS (
+                   SELECT 1 FROM tokens t WHERE t.user_id = u.id
+               ) AS has_tokens,
+               EXISTS (
+                   SELECT 1 FROM admin_browser_sessions s WHERE s.user_id = u.id
+               ) AS has_admin_browser_sessions,
+               EXISTS (
+                   SELECT 1 FROM sso_browser_sessions s WHERE s.user_id = u.id
+               ) AS has_sso_browser_sessions
+          FROM users u
+         WHERE u.username = $1 OR u.email = $2
+         ORDER BY u.id
+         FOR UPDATE OF u
+        """,
+        expected_username,
+        expected_email,
+    )
+
+
+def _is_exact_active_local_recovery(
+    row,
+    *,
+    expected_username: str,
+    expected_email: str,
+) -> bool:
+    return bool(
+        row["username"] == expected_username
+        and row["email"] == expected_email
+        and row["is_admin"]
+        and row["is_recovery_admin"]
+        and row["auth_provider"] == "local"
+        and row["account_status"] == "active"
+        and row["account_kind"] == "human"
+        and not row["has_external_identity"]
+    )
+
+
+def _is_exact_retired_tombstone(
+    row,
+    *,
+    expected_username: str,
+    expected_email: str,
+) -> bool:
+    return bool(
+        row["username"] == expected_username
+        and row["email"] == expected_email
+        and row["password_hash"] == RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+        and not row["is_admin"]
+        and not row["is_recovery_admin"]
+        and row["auth_provider"] == "local"
+        and row["account_status"] == "suspended"
+        and row["account_kind"] == "human"
+        and not row["has_external_identity"]
+        and not row["has_tokens"]
+        and not row["has_admin_browser_sessions"]
+        and not row["has_sso_browser_sessions"]
+    )
+
+
+async def _pending_token_cleanup(conn, user_id: uuid.UUID) -> list[uuid.UUID]:
+    pending = await conn.fetch(
+        """
+        SELECT token_id
+          FROM account_token_cleanup
+         WHERE user_id = $1 AND completed_at IS NULL
+         ORDER BY requested_at, token_id
+        """,
+        user_id,
+    )
+    return [record["token_id"] for record in pending]
+
+
+async def retire_local_recovery_admin(
+    *,
+    expected_username: str,
+    expected_email: str,
+    actor_user_id: str,
+    actor_token_id: str,
+) -> dict:
+    """Retire the exact local recovery administrator after an SSO cutover.
+
+    Credential rows and account denial commit together. Derived PostgreSQL
+    token roles are then removed strictly through the durable cleanup ledger;
+    an incomplete cleanup returns 503 and an exact retry resumes it without
+    restoring credentials or emitting a duplicate retirement event.
+    """
+    _require_mode("sso")
+    expected_username = _exact_expected(expected_username, "expected_username")
+    expected_email = _exact_expected(expected_email, "expected_email")
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            actor_id = await _require_retirement_actor(
+                conn,
+                actor_user_id=actor_user_id,
+                actor_token_id=actor_token_id,
+            )
+            await _lock_provisioning(conn)
+            designated = await _locked_recovery_rows(conn)
+            if len(designated) > 1:
+                raise RecoveryAdminRetirementConflictError()
+
+            if designated:
+                current = designated[0]
+                if current["id"] == actor_id or not _is_exact_active_local_recovery(
+                    current,
+                    expected_username=expected_username,
+                    expected_email=expected_email,
+                ):
+                    raise RecoveryAdminRetirementConflictError()
+
+                deleted = await conn.fetch(
+                    "DELETE FROM tokens WHERE user_id = $1 RETURNING id",
+                    current["id"],
+                )
+                token_ids = [record["id"] for record in deleted]
+                if token_ids:
+                    await conn.executemany(
+                        """
+                        INSERT INTO account_token_cleanup (token_id, user_id)
+                        VALUES ($1, $2)
+                        ON CONFLICT (token_id) DO NOTHING
+                        """,
+                        [(token_id, current["id"]) for token_id in token_ids],
+                    )
+                await conn.execute(
+                    "DELETE FROM admin_browser_sessions WHERE user_id = $1",
+                    current["id"],
+                )
+                await conn.execute(
+                    "DELETE FROM sso_browser_sessions WHERE user_id = $1",
+                    current["id"],
+                )
+                retired = await conn.fetchrow(
+                    """
+                    UPDATE users
+                       SET is_recovery_admin = false,
+                           is_admin = false,
+                           account_status = 'suspended',
+                           password_hash = $2,
+                           tokens_revoked_before = NOW(),
+                           updated_at = NOW()
+                     WHERE id = $1
+                 RETURNING id, username, email, is_admin, is_recovery_admin,
+                           auth_provider, account_status, account_kind
+                    """,
+                    current["id"],
+                    RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+                )
+                await emit_event(
+                    conn,
+                    "auth.recovery_admin_retired",
+                    actor_id=str(actor_id),
+                    payload={
+                        "user_id": str(current["id"]),
+                        "account_status": "suspended",
+                        "is_admin": False,
+                        "is_recovery_admin": False,
+                        "revoked_token_ids": [str(token_id) for token_id in token_ids],
+                    },
+                )
+            else:
+                collisions = await _locked_retirement_collisions(
+                    conn,
+                    expected_username=expected_username,
+                    expected_email=expected_email,
+                )
+                if (
+                    len(collisions) != 1
+                    or collisions[0]["id"] == actor_id
+                    or not _is_exact_retired_tombstone(
+                        collisions[0],
+                        expected_username=expected_username,
+                        expected_email=expected_email,
+                    )
+                ):
+                    raise RecoveryAdminRetirementConflictError()
+                retired = collisions[0]
+
+            pending_token_ids = await _pending_token_cleanup(conn, retired["id"])
+
+    await cleanup_token_roles(pool, retired["id"], pending_token_ids)
+    return _retirement_proof(retired)

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -406,10 +406,26 @@ class RoleSync:
         role = token_role_name(token_id)
         try:
             async with self.pool.acquire() as conn:
-                await self._create_role_if_missing(conn, role)
-                accessible = await self._fetch_user_accessible(conn, user_id)
-                for group in wanted_token_group_roles(accessible, scope):
-                    await self._grant_membership(conn, group, role)
+                async with conn.transaction():
+                    rows = await self._locked_live_scoped_tokens(
+                        conn,
+                        token_id=token_id,
+                        user_id=user_id,
+                    )
+                    if len(rows) != 1:
+                        return
+                    live = rows[0]
+                    try:
+                        stored_scope = VaultScope.from_db_json(live["vault_scope"])
+                    except ValueError:
+                        return
+                    if stored_scope is None:
+                        return
+                    scope = stored_scope
+                    await self._create_role_if_missing(conn, role)
+                    accessible = await self._fetch_user_accessible(conn, live["user_id"])
+                    for group in wanted_token_group_roles(accessible, scope):
+                        await self._grant_membership(conn, group, role)
         except Exception as e:  # noqa: BLE001
             self._record_failure("on_token_create", e, token_id)
 
@@ -906,6 +922,37 @@ class RoleSync:
         )
         return {r["group_role"] for r in rows}
 
+    async def _locked_live_scoped_tokens(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        user_id: uuid.UUID | str | None = None,
+        token_id: uuid.UUID | str | None = None,
+    ):
+        """Lock exact catalog authority before any scoped-token role creation."""
+        conditions: list[str] = []
+        values: list[uuid.UUID] = []
+        if user_id is not None:
+            values.append(uuid.UUID(str(user_id)))
+            conditions.append(f"t.user_id = ${len(values)}")
+        if token_id is not None:
+            values.append(uuid.UUID(str(token_id)))
+            conditions.append(f"t.id = ${len(values)}")
+        filters = "" if not conditions else " AND " + " AND ".join(conditions)
+        return await conn.fetch(
+            """
+            SELECT t.id, t.user_id, t.vault_scope
+              FROM tokens t
+              JOIN users u ON u.id = t.user_id
+             WHERE t.vault_scope IS NOT NULL
+               AND (t.expires_at IS NULL OR t.expires_at > NOW())
+               AND u.account_status = 'active'
+            """
+            + filters
+            + " ORDER BY t.id FOR SHARE OF t, u",
+            *values,
+        )
+
     async def _sync_user_scoped_tokens(
         self, conn: asyncpg.Connection, user_id: uuid.UUID | str,
     ) -> None:
@@ -919,15 +966,14 @@ class RoleSync:
         reconcile (the token role would be missing the just-created vault's
         group). A no-op for users with no scoped tokens. Runs inside the
         caller hook's connection + best-effort try/except."""
+        async with conn.transaction():
+            await self._sync_user_scoped_tokens_locked(conn, user_id)
+
+    async def _sync_user_scoped_tokens_locked(
+        self, conn: asyncpg.Connection, user_id: uuid.UUID | str,
+    ) -> None:
         uid = user_id if isinstance(user_id, uuid.UUID) else uuid.UUID(str(user_id))
-        token_rows = await conn.fetch(
-            """
-            SELECT id, vault_scope FROM tokens
-             WHERE user_id = $1 AND vault_scope IS NOT NULL
-               AND (expires_at IS NULL OR expires_at > NOW())
-            """,
-            uid,
-        )
+        token_rows = await self._locked_live_scoped_tokens(conn, user_id=uid)
         if not token_rows:
             return
         accessible = await self._fetch_user_accessible(conn, uid)
@@ -959,14 +1005,13 @@ class RoleSync:
         joins, and a revoked/downgraded owner grant is withdrawn from the
         token. A malformed scope is logged and skipped (it never widens —
         the token role just keeps its current, already-narrow membership)."""
-        token_rows = await conn.fetch(
-            """
-            SELECT id, user_id, vault_scope
-              FROM tokens
-             WHERE vault_scope IS NOT NULL
-               AND (expires_at IS NULL OR expires_at > NOW())
-            """
-        )
+        async with conn.transaction():
+            await self._reconcile_token_roles_locked(conn, report)
+
+    async def _reconcile_token_roles_locked(
+        self, conn: asyncpg.Connection, report: ReconcileReport,
+    ) -> None:
+        token_rows = await self._locked_live_scoped_tokens(conn)
         live: list[tuple[str, uuid.UUID, VaultScope]] = []
         for r in token_rows:
             try:
@@ -987,13 +1032,17 @@ class RoleSync:
         }
         for role in wanted_roles - existing:
             try:
-                await conn.execute(f'CREATE ROLE "{role}" NOLOGIN')
+                async with conn.transaction():
+                    await self._create_role_if_missing(conn, role)
+                # Count only after the savepoint committed.
                 report.token_roles_created += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"CREATE ROLE {role}: {e}")
         for orphan in existing - wanted_roles:
             try:
-                await self._drop_role_if_present(conn, orphan)
+                async with conn.transaction():
+                    await self._drop_role_if_present(conn, orphan)
+                # Count only after the savepoint committed.
                 report.token_roles_dropped += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"DROP ROLE {orphan}: {e}")
@@ -1015,18 +1064,25 @@ class RoleSync:
             actual.setdefault(r["token_role"], set()).add(r["group_role"])
 
         for role, uid, scope in live:
+            added = 0
+            removed = 0
             try:
-                accessible = await self._fetch_user_accessible(conn, uid)
-                wanted = wanted_token_group_roles(accessible, scope)
-                have = actual.get(role, set())
-                for group in wanted - have:
-                    await self._grant_membership(conn, group, role)
-                    report.grants_added += 1
-                for group in have - wanted:
-                    await self._revoke_membership_if_present(conn, group, role)
-                    report.grants_removed += 1
+                async with conn.transaction():
+                    accessible = await self._fetch_user_accessible(conn, uid)
+                    wanted = wanted_token_group_roles(accessible, scope)
+                    have = actual.get(role, set())
+                    for group in wanted - have:
+                        await self._grant_membership(conn, group, role)
+                        added += 1
+                    for group in have - wanted:
+                        await self._revoke_membership_if_present(conn, group, role)
+                        removed += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"token role {role} membership: {e}")
+            else:
+                # Report only effects whose savepoint committed.
+                report.grants_added += added
+                report.grants_removed += removed
 
     # ── Drift inspection (read-only) ──
 

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -80,12 +80,20 @@ class _RoleSync:
     def __init__(self):
         self.created: list[uuid.UUID] = []
         self.deleted: list[uuid.UUID] = []
+        self.revoked_tokens: list[uuid.UUID] = []
+        self.fail_token: uuid.UUID | None = None
 
     async def on_user_create(self, user_id):
         self.created.append(uuid.UUID(str(user_id)))
 
     async def on_user_delete(self, user_id):
         self.deleted.append(uuid.UUID(str(user_id)))
+
+    async def revoke_token_role_strict(self, token_id):
+        token_uuid = uuid.UUID(str(token_id))
+        if token_uuid == self.fail_token:
+            raise RuntimeError("role cleanup failed")
+        self.revoked_tokens.append(token_uuid)
 
 
 @pytest.fixture
@@ -445,6 +453,632 @@ async def test_normal_admin_can_still_be_demoted_and_deleted(services):
     assert role_sync.deleted == [user_id]
     async with pool.acquire() as conn:
         assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE id = $1", user_id) == 0
+
+
+async def _create_retirement_actor(pool) -> tuple[uuid.UUID, uuid.UUID]:
+    user_id = uuid.uuid4()
+    token_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, $2, $3, '!service:no-local-login!', true,
+                      'service', 'active', 'service')
+            """,
+            user_id,
+            f"retirement-service-{user_id.hex}",
+            f"retirement-service-{user_id.hex}@service.invalid",
+        )
+        await conn.execute(
+            """
+            INSERT INTO tokens (
+                id, user_id, name, token_hash, token_prefix, scopes, key_class
+            ) VALUES ($1, $2, 'retirement', $3, 'akb_secret_',
+                      ARRAY['read', 'write', 'admin'], 'service')
+            """,
+            token_id,
+            user_id,
+            uuid.uuid4().hex,
+        )
+    return user_id, token_id
+
+
+async def test_retirement_is_disabled_in_local_mode_without_mutation(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminModeError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    recovery_user_id = uuid.UUID(provisioned["user_id"])
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+
+    with pytest.raises(RecoveryAdminModeError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="local-recovery-admin@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            "SELECT account_status, is_admin, is_recovery_admin FROM users WHERE id = $1",
+            recovery_user_id,
+        )
+    assert dict(state) == {
+        "account_status": "active",
+        "is_admin": True,
+        "is_recovery_admin": True,
+    }
+
+
+async def test_retirement_is_exact_atomic_and_idempotent(services, monkeypatch):
+    pool, role_sync, service, account_service, access_service, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminProtectedError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    recovery_user_id = uuid.UUID(provisioned["user_id"])
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    target_token_ids = [uuid.uuid4(), uuid.uuid4()]
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT tokens_revoked_before FROM users WHERE id = $1",
+            recovery_user_id,
+        )
+        await conn.executemany(
+            """
+            INSERT INTO tokens (
+                id, user_id, name, token_hash, token_prefix, scopes, key_class
+            ) VALUES ($1, $2, $3, $4, 'akb_recover', ARRAY['read', 'write'], $5)
+            """,
+            [
+                (
+                    target_token_ids[0],
+                    recovery_user_id,
+                    "legacy-pat",
+                    uuid.uuid4().hex,
+                    "pat",
+                ),
+                (
+                    target_token_ids[1],
+                    recovery_user_id,
+                    "legacy-service-key",
+                    uuid.uuid4().hex,
+                    "service",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    first = await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+    repeated = await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+
+    with pytest.raises(RecoveryAdminProtectedError):
+        await account_service.activate_user(
+            str(recovery_user_id),
+            actor_id=str(actor_user_id),
+        )
+    with pytest.raises(RecoveryAdminProtectedError):
+        await access_service.delete_user_account(str(recovery_user_id))
+
+    expected_proof = {
+        "user_id": str(recovery_user_id),
+        "username": "local-recovery-admin",
+        "email": "local-recovery-admin@example.com",
+        "account_status": "suspended",
+        "is_admin": False,
+        "is_recovery_admin": False,
+        "account_kind": "human",
+        "auth_provider": "local",
+    }
+    assert first == expected_proof
+    assert repeated == expected_proof
+    assert set(role_sync.revoked_tokens) == set(target_token_ids)
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            """
+            SELECT password_hash, account_status, is_admin, is_recovery_admin,
+                   account_kind, auth_provider, tokens_revoked_before,
+                   (SELECT COUNT(*) FROM tokens WHERE user_id = users.id) AS token_count,
+                   (SELECT COUNT(*) FROM external_identities WHERE user_id = users.id) AS identity_count
+              FROM users WHERE id = $1
+            """,
+            recovery_user_id,
+        )
+        cleanup_count = await conn.fetchval(
+            """
+            SELECT COUNT(*) FROM account_token_cleanup
+             WHERE user_id = $1 AND completed_at IS NOT NULL
+            """,
+            recovery_user_id,
+        )
+        audit = await conn.fetchrow(
+            """
+            SELECT kind, actor_id, payload->>'user_id' AS user_id
+              FROM events
+             WHERE kind = 'auth.recovery_admin_retired'
+            """
+        )
+        audit_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE kind = 'auth.recovery_admin_retired'"
+        )
+        actor_token_exists = await conn.fetchval(
+            "SELECT EXISTS (SELECT 1 FROM tokens WHERE id = $1 AND user_id = $2)",
+            actor_token_id,
+            actor_user_id,
+        )
+
+    assert state["password_hash"].startswith("!retired-recovery-admin:")
+    assert state["account_status"] == "suspended"
+    assert state["is_admin"] is False
+    assert state["is_recovery_admin"] is False
+    assert state["account_kind"] == "human"
+    assert state["auth_provider"] == "local"
+    assert state["tokens_revoked_before"] > before
+    assert state["token_count"] == 0
+    assert state["identity_count"] == 0
+    assert cleanup_count == len(target_token_ids)
+    assert dict(audit) == {
+        "kind": "auth.recovery_admin_retired",
+        "actor_id": str(actor_user_id),
+        "user_id": str(recovery_user_id),
+    }
+    assert audit_count == 1
+    assert actor_token_exists is True
+
+
+async def test_retirement_denial_survives_failed_role_cleanup_and_retry_finishes(
+    services,
+    monkeypatch,
+):
+    pool, role_sync, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import CredentialCleanupIncompleteError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    recovery_user_id = uuid.UUID(provisioned["user_id"])
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    target_token_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, key_class)
+            VALUES ($1, $2, 'legacy', $3, 'akb_recover', 'pat')
+            """,
+            target_token_id,
+            recovery_user_id,
+            uuid.uuid4().hex,
+        )
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    role_sync.fail_token = target_token_id
+    with pytest.raises(CredentialCleanupIncompleteError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="local-recovery-admin@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        denied = await conn.fetchrow(
+            """
+            SELECT account_status, is_admin, is_recovery_admin,
+                   EXISTS (SELECT 1 FROM tokens WHERE id = $2) AS token_exists,
+                   EXISTS (
+                       SELECT 1 FROM account_token_cleanup
+                        WHERE token_id = $2 AND completed_at IS NULL
+                   ) AS cleanup_pending
+              FROM users WHERE id = $1
+            """,
+            recovery_user_id,
+            target_token_id,
+        )
+    assert dict(denied) == {
+        "account_status": "suspended",
+        "is_admin": False,
+        "is_recovery_admin": False,
+        "token_exists": False,
+        "cleanup_pending": True,
+    }
+
+    role_sync.fail_token = None
+    retried = await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+
+    assert retried["user_id"] == str(recovery_user_id)
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT completed_at IS NOT NULL FROM account_token_cleanup WHERE token_id = $1",
+            target_token_id,
+        ) is True
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE kind = 'auth.recovery_admin_retired'"
+        ) == 1
+
+
+@pytest.mark.parametrize("creator", ["on_create", "sync_user", "reconcile"])
+async def test_retirement_serializes_delayed_scoped_token_role_creation(
+    services,
+    monkeypatch,
+    creator,
+):
+    pool, _, service, account_service, _, _ = services
+    from app.config import settings
+    from app.models.vault_scope import VaultScope
+    from app.services.role_sync import ReconcileReport, RoleSync, token_role_name
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    recovery_user_id = uuid.UUID(provisioned["user_id"])
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    target_token_id = uuid.uuid4()
+    scope = VaultScope(prefixes=("managed-",), extra_vaults=frozenset())
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO tokens (
+                id, user_id, name, token_hash, token_prefix, scopes,
+                vault_scope, key_class
+            ) VALUES ($1, $2, 'delayed-scoped', $3, 'akb_delayed_',
+                      ARRAY['read', 'write'], $4::jsonb, 'pat')
+            """,
+            target_token_id,
+            recovery_user_id,
+            uuid.uuid4().hex,
+            '{"prefixes":["managed-"],"extra_vaults":[]}',
+        )
+
+    actual_role_sync = RoleSync(pool)
+    monkeypatch.setattr(account_service, "get_role_sync", lambda: actual_role_sync)
+    role_name = token_role_name(target_token_id)
+    create_entered = asyncio.Event()
+    release_create = asyncio.Event()
+    original_create = actual_role_sync._create_role_if_missing
+
+    async def delayed_create(conn, role):
+        if role == role_name:
+            create_entered.set()
+            await release_create.wait()
+        await original_create(conn, role)
+
+    monkeypatch.setattr(actual_role_sync, "_create_role_if_missing", delayed_create)
+    async def create_role_path():
+        if creator == "on_create":
+            await actual_role_sync.on_token_create(
+                target_token_id,
+                recovery_user_id,
+                scope,
+            )
+        elif creator == "sync_user":
+            async with pool.acquire() as conn:
+                await actual_role_sync._sync_user_scoped_tokens(conn, recovery_user_id)
+        else:
+            async with pool.acquire() as conn:
+                await actual_role_sync._reconcile_token_roles(conn, ReconcileReport())
+
+    create_task = asyncio.create_task(create_role_path())
+    retire_task = None
+    try:
+        await asyncio.wait_for(create_entered.wait(), timeout=2)
+        monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+        retire_task = asyncio.create_task(
+            service.retire_local_recovery_admin(
+                expected_username="local-recovery-admin",
+                expected_email="local-recovery-admin@example.com",
+                actor_user_id=str(actor_user_id),
+                actor_token_id=str(actor_token_id),
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert not retire_task.done()
+        release_create.set()
+        await asyncio.wait_for(asyncio.gather(create_task, retire_task), timeout=5)
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM tokens WHERE id = $1)",
+                target_token_id,
+            ) is False
+            assert await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1)",
+                role_name,
+            ) is False
+    finally:
+        release_create.set()
+        if not create_task.done():
+            create_task.cancel()
+        if retire_task is not None and not retire_task.done():
+            retire_task.cancel()
+        await asyncio.gather(
+            create_task,
+            *(tuple() if retire_task is None else (retire_task,)),
+            return_exceptions=True,
+        )
+        async with pool.acquire() as conn:
+            await actual_role_sync._drop_role_if_present(conn, role_name)
+
+
+@pytest.mark.parametrize("target_by_id", [True, False], ids=["explicit-id", "email"])
+async def test_retired_tombstone_rejects_external_identity_adoption(
+    services,
+    monkeypatch,
+    target_by_id,
+):
+    pool, _, service, account_service, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminProtectedError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+
+    with pytest.raises(RecoveryAdminProtectedError):
+        await account_service.ensure_human_external_identity(
+            issuer="https://identity.example.com/realms/example",
+            subject=f"subject-{target_by_id}",
+            email="local-recovery-admin@example.com",
+            display_name="Retired recovery admin",
+            actor_id=str(actor_user_id),
+            existing_user_id=provisioned["user_id"] if target_by_id else None,
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            """
+            SELECT auth_provider, account_status, is_admin, is_recovery_admin,
+                   (SELECT COUNT(*) FROM external_identities WHERE user_id = users.id)
+                       AS identity_count
+              FROM users WHERE id = $1
+            """,
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert dict(state) == {
+        "auth_provider": "local",
+        "account_status": "suspended",
+        "is_admin": False,
+        "is_recovery_admin": False,
+        "identity_count": 0,
+    }
+
+
+async def test_token_role_reconcile_savepoint_isolates_one_ddl_failure(
+    services,
+    monkeypatch,
+):
+    pool, _, _, _, _, _ = services
+    from app.services.role_sync import ReconcileReport, RoleSync, token_role_name
+
+    user_id = uuid.uuid4()
+    failed_token_id = uuid.uuid4()
+    healthy_token_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash)
+            VALUES ($1, $2, $3, '!hash!')
+            """,
+            user_id,
+            f"reconcile-{user_id.hex}",
+            f"reconcile-{user_id.hex}@example.test",
+        )
+        await conn.executemany(
+            """
+            INSERT INTO tokens (
+                id, user_id, name, token_hash, token_prefix, vault_scope
+            ) VALUES ($1, $2, $3, $4, 'akb_scope_', $5::jsonb)
+            """,
+            [
+                (
+                    failed_token_id,
+                    user_id,
+                    "failed-role",
+                    uuid.uuid4().hex,
+                    '{"prefixes":["managed-"],"extra_vaults":[]}',
+                ),
+                (
+                    healthy_token_id,
+                    user_id,
+                    "healthy-role",
+                    uuid.uuid4().hex,
+                    '{"prefixes":["managed-"],"extra_vaults":[]}',
+                ),
+            ],
+        )
+
+    role_sync = RoleSync(pool)
+    failed_role = token_role_name(failed_token_id)
+    healthy_role = token_role_name(healthy_token_id)
+    original_create = role_sync._create_role_if_missing
+
+    async def fail_one_create(conn, role):
+        if role == failed_role:
+            await conn.execute("SELECT 1 / 0")
+            return
+        await original_create(conn, role)
+
+    monkeypatch.setattr(role_sync, "_create_role_if_missing", fail_one_create)
+    report = ReconcileReport()
+    try:
+        async with pool.acquire() as conn:
+            await role_sync._reconcile_token_roles(conn, report)
+            roles = {
+                row["rolname"]
+                for row in await conn.fetch(
+                    "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[])",
+                    [failed_role, healthy_role],
+                )
+            }
+        assert roles == {healthy_role}
+        assert report.token_roles_created == 1
+        assert len(report.errors) == 1
+        assert failed_role in report.errors[0]
+    finally:
+        async with pool.acquire() as conn:
+            await role_sync._drop_role_if_present(conn, failed_role)
+            await role_sync._drop_role_if_present(conn, healthy_role)
+
+
+async def test_retirement_mismatch_external_binding_and_collisions_fail_closed(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminRetirementConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    recovery_user_id = uuid.UUID(provisioned["user_id"])
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+
+    with pytest.raises(RecoveryAdminRetirementConflictError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="wrong@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO external_identities (user_id, issuer, subject, email_snapshot)
+            VALUES ($1, 'https://identity.example.com/realms/example', $2, $3)
+            """,
+            recovery_user_id,
+            f"subject-{uuid.uuid4()}",
+            "local-recovery-admin@example.com",
+        )
+
+    with pytest.raises(RecoveryAdminRetirementConflictError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="local-recovery-admin@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            "SELECT account_status, is_admin, is_recovery_admin FROM users WHERE id = $1",
+            recovery_user_id,
+        )
+    assert dict(state) == {
+        "account_status": "active",
+        "is_admin": True,
+        "is_recovery_admin": True,
+    }
+
+
+async def test_retirement_revalidates_service_actor_and_split_collision(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import (
+        RecoveryAdminRetirementAuthorizationError,
+        RecoveryAdminRetirementConflictError,
+    )
+
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    human_actor_id = uuid.uuid4()
+    human_actor_token_id = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (
+                id, username, email, password_hash, is_admin,
+                auth_provider, account_status, account_kind
+            ) VALUES ($1, 'human-admin', 'human-admin@example.com', '!hash!', true,
+                      'local', 'active', 'human')
+            """,
+            human_actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, key_class)
+            VALUES ($1, $2, 'human-admin', $3, 'akb_human_', 'pat')
+            """,
+            human_actor_token_id,
+            human_actor_id,
+            uuid.uuid4().hex,
+        )
+        await conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash)
+            VALUES ('split-username', 'other@example.com', '!hash!'),
+                   ('other-username', 'split-email@example.com', '!hash!')
+            """
+        )
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    with pytest.raises(RecoveryAdminRetirementAuthorizationError):
+        await service.retire_local_recovery_admin(
+            expected_username="split-username",
+            expected_email="split-email@example.com",
+            actor_user_id=str(human_actor_id),
+            actor_token_id=str(human_actor_token_id),
+        )
+
+    with pytest.raises(RecoveryAdminRetirementConflictError):
+        await service.retire_local_recovery_admin(
+            expected_username="split-username",
+            expected_email="split-email@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
 
 
 async def test_migration_upgrades_old_schema_and_is_idempotent(services):

--- a/backend/tests/test_recovery_admin_retirement_routes_unit.py
+++ b/backend/tests/test_recovery_admin_retirement_routes_unit.py
@@ -1,0 +1,115 @@
+"""HTTP authorization contract for recovery-admin retirement."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.api.routes import access
+from app.services.auth_service import AuthenticatedUser
+
+
+def _actor(**changes) -> AuthenticatedUser:
+    values = {
+        "user_id": str(uuid.uuid4()),
+        "username": "retirement-controller",
+        "email": "retirement-controller@service.invalid",
+        "display_name": "Retirement controller",
+        "is_admin": True,
+        "auth_method": "pat",
+        "account_kind": "service",
+        "token_id": str(uuid.uuid4()),
+        "key_class": "service",
+        "token_scopes": frozenset({"write"}),
+    }
+    values.update(changes)
+    return AuthenticatedUser(**values)
+
+
+def _client(monkeypatch, actor: AuthenticatedUser, calls: list[dict[str, str]]) -> TestClient:
+    async def _retire(**values):
+        calls.append(values)
+        return {
+            "user_id": "00000000-0000-0000-0000-000000000071",
+            "username": values["expected_username"],
+            "email": values["expected_email"],
+            "account_status": "suspended",
+            "is_admin": False,
+            "is_recovery_admin": False,
+            "account_kind": "human",
+            "auth_provider": "local",
+        }
+
+    monkeypatch.setattr(access, "retire_local_recovery_admin", _retire, raising=False)
+    app = FastAPI()
+    app.include_router(access.router, prefix="/api/v1")
+    app.dependency_overrides[access.get_current_user] = lambda: actor
+    return TestClient(app)
+
+
+def test_service_admin_token_can_retire_only_the_exact_expected_identity(monkeypatch):
+    actor = _actor()
+    calls: list[dict[str, str]] = []
+
+    response = _client(monkeypatch, actor, calls).post(
+        "/api/v1/admin/recovery-admin/retire",
+        json={
+            "expected_username": "local-recovery-admin",
+            "expected_email": "local-recovery-admin@example.com",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": "00000000-0000-0000-0000-000000000071",
+        "username": "local-recovery-admin",
+        "email": "local-recovery-admin@example.com",
+        "account_status": "suspended",
+        "is_admin": False,
+        "is_recovery_admin": False,
+        "account_kind": "human",
+        "auth_provider": "local",
+    }
+    assert calls == [
+        {
+            "expected_username": "local-recovery-admin",
+            "expected_email": "local-recovery-admin@example.com",
+            "actor_user_id": actor.user_id,
+            "actor_token_id": actor.token_id,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "actor",
+    [
+        _actor(auth_method="jwt", account_kind="human", token_id=None, key_class=None),
+        _actor(account_kind="human", key_class="pat"),
+        _actor(auth_method="browser_session", token_id=None, key_class=None),
+        _actor(is_admin=False),
+        _actor(token_id=None),
+        _actor(key_class="publishable"),
+    ],
+)
+def test_human_session_and_non_service_admin_carriers_fail_before_retirement(
+    monkeypatch,
+    actor,
+):
+    calls: list[dict[str, str]] = []
+
+    response = _client(monkeypatch, actor, calls).post(
+        "/api/v1/admin/recovery-admin/retire",
+        json={
+            "expected_username": "local-recovery-admin",
+            "expected_email": "local-recovery-admin@example.com",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == (
+        "recovery_admin_retirement_requires_service_admin"
+    )
+    assert calls == []


### PR DESCRIPTION
## Summary

- add an SSO-only administrative endpoint that retires the bootstrapped local recovery administrator
- require an independently authenticated active service-admin PAT and atomically revoke the recovery account credentials
- preserve a suspended tombstone so the retired identity cannot be reactivated or adopted
- make scoped-token role reconciliation resilient to recoverable PostgreSQL errors via nested savepoints

## Validation

- 71 focused backend tests
- real-PostgreSQL concurrency and savepoint regression tests
- ruff, mypy, bandit, and diff-check
- repository-native full check at the frozen candidate head