### PR TITLE
fix(auth): hand over recovery authority during SSO cutover

### DIFF
--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -55,11 +55,13 @@ CREATE TABLE IF NOT EXISTS users (
         CONSTRAINT users_account_kind_check
         CHECK (account_kind IN ('human', 'service')),
     CONSTRAINT users_recovery_admin_requires_admin
-        CHECK (NOT is_recovery_admin OR is_admin)
+        CHECK (NOT is_recovery_admin OR is_admin),
+    CONSTRAINT users_recovery_admin_provider_check
+        CHECK (NOT is_recovery_admin OR auth_provider IN ('local', 'keycloak'))
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin
-    ON users ((is_recovery_admin))
+CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin_per_provider
+    ON users (auth_provider)
     WHERE is_recovery_admin;
 
 -- Stable external identity binding. Email is a mutable snapshot; verified

--- a/backend/app/db/migrations/078_recovery_admin_authority_handover.py
+++ b/backend/app/db/migrations/078_recovery_admin_authority_handover.py
@@ -1,0 +1,34 @@
+"""Allow one local and one Keycloak recovery admin during auth handover."""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute("DROP INDEX IF EXISTS users_one_recovery_admin")
+        await conn.execute(
+            """
+            DO $$
+            BEGIN
+              IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                 WHERE conname = 'users_recovery_admin_provider_check'
+                   AND conrelid = 'users'::regclass
+              ) THEN
+                ALTER TABLE users
+                  ADD CONSTRAINT users_recovery_admin_provider_check
+                  CHECK (
+                    NOT is_recovery_admin
+                    OR auth_provider IN ('local', 'keycloak')
+                  );
+              END IF;
+            END $$;
+            """
+        )
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin_per_provider
+                ON users (auth_provider)
+                WHERE is_recovery_admin
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -265,6 +265,7 @@ async def _apply_migrations() -> None:
         "075_sso_callback_receipt.py",  # bind current SSO receipts to the effective back-channel callback
         "076_sso_session_epoch.py",  # monotonic auth boundary + rollback-compatible epoch bridge/legacy-write guard
         "077_legacy_adoptions.py",  # immutable legacy app adoption plans, targets, and bounded audit
+        "078_recovery_admin_authority_handover.py",  # provider-scoped recovery authority during local-to-SSO cutover
     ):
         if filename in applied:
             continue

--- a/backend/app/services/admin_auth_service.py
+++ b/backend/app/services/admin_auth_service.py
@@ -28,6 +28,10 @@ from app.services.auth_service import (
     login,
     resolve_delegated_human_authorization,
 )
+from app.services.external_identity_contract import (
+    OIDC_SUBJECT_MAX_LENGTH,
+    bounded_nonempty_claim,
+)
 from app.services.sso_session_epoch import (
     current_sso_session_authority,
     lock_active_sso_session_epoch,
@@ -70,10 +74,10 @@ def _required_claim(
     claims: Mapping[str, object],
     name: str,
     *,
-    max_length: int = 1024,
+    max_length: int = OIDC_SUBJECT_MAX_LENGTH,
 ) -> str:
-    value = claims.get(name)
-    if not isinstance(value, str) or not value.strip() or len(value) > max_length:
+    value = bounded_nonempty_claim(claims.get(name), maximum=max_length)
+    if value is None:
         raise AuthenticationError("Invalid admin identity token")
     return value
 

--- a/backend/app/services/external_identity_contract.py
+++ b/backend/app/services/external_identity_contract.py
@@ -1,0 +1,12 @@
+"""Shared bounds for identity-provider claims used as durable account keys."""
+
+from __future__ import annotations
+
+
+OIDC_SUBJECT_MAX_LENGTH = 1024
+
+
+def bounded_nonempty_claim(value: object, *, maximum: int) -> str | None:
+    if not isinstance(value, str) or not value.strip() or len(value) > maximum:
+        return None
+    return value

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -20,6 +20,10 @@ from app.repositories.events_repo import emit_event
 from app.services.account_markers import RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
 from app.services.account_service import cleanup_token_roles
 from app.services.auth_service import hash_password_async
+from app.services.external_identity_contract import (
+    OIDC_SUBJECT_MAX_LENGTH,
+    bounded_nonempty_claim,
+)
 from app.services.role_sync import get_role_sync
 
 
@@ -60,15 +64,16 @@ async def _lock_provisioning(conn) -> None:
     )
 
 
-async def _designated_user(conn):
+async def _designated_user(conn, *, auth_provider: Literal["local", "keycloak"]):
     return await conn.fetchrow(
         """
         SELECT id, username, email, password_hash, is_admin, is_recovery_admin,
                auth_provider, account_status, account_kind
           FROM users
-         WHERE is_recovery_admin
+         WHERE is_recovery_admin AND auth_provider = $1
          FOR UPDATE
-        """
+        """,
+        auth_provider,
     )
 
 
@@ -112,7 +117,7 @@ async def provision_local_recovery_admin(
         async with pool.acquire() as conn:
             async with conn.transaction():
                 await _lock_provisioning(conn)
-                row = await _designated_user(conn)
+                row = await _designated_user(conn, auth_provider="local")
                 if row is not None:
                     identity_count = await conn.fetchval(
                         "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
@@ -180,6 +185,8 @@ async def provision_sso_recovery_admin(
     email = _email(email)
     issuer = _required(issuer, "issuer")
     subject = _required(subject, "subject")
+    if bounded_nonempty_claim(subject, maximum=OIDC_SUBJECT_MAX_LENGTH) is None:
+        raise ValidationError("subject exceeds maximum length")
     pool = await get_pool()
     created = False
 
@@ -187,7 +194,7 @@ async def provision_sso_recovery_admin(
         async with pool.acquire() as conn:
             async with conn.transaction():
                 await _lock_provisioning(conn)
-                row = await _designated_user(conn)
+                row = await _designated_user(conn, auth_provider="keycloak")
                 if row is not None:
                     identities = await conn.fetch(
                         """
@@ -345,9 +352,8 @@ async def _locked_recovery_rows(conn):
         SELECT u.id, u.username, u.email, u.password_hash, u.is_admin,
                u.is_recovery_admin, u.auth_provider, u.account_status,
                u.account_kind, u.tokens_revoked_before,
-               EXISTS (
-                   SELECT 1 FROM external_identities e WHERE e.user_id = u.id
-               ) AS has_external_identity,
+               (SELECT COUNT(*) FROM external_identities e WHERE e.user_id = u.id)
+                   AS external_identity_count,
                EXISTS (
                    SELECT 1 FROM tokens t WHERE t.user_id = u.id
                ) AS has_tokens,
@@ -365,6 +371,23 @@ async def _locked_recovery_rows(conn):
     )
 
 
+async def _locked_sso_recovery_identities(conn):
+    rows = await conn.fetch(
+        """
+        SELECT e.user_id, e.issuer, e.subject
+          FROM external_identities e
+          JOIN users u ON u.id = e.user_id
+         WHERE u.is_recovery_admin AND u.auth_provider = 'keycloak'
+         ORDER BY e.user_id, e.issuer, e.subject
+         FOR UPDATE OF e /* recovery-successor-authority-lock */
+        """
+    )
+    identities: dict[uuid.UUID, list] = {}
+    for row in rows:
+        identities.setdefault(row["user_id"], []).append(row)
+    return identities
+
+
 async def _locked_retirement_collisions(
     conn,
     *,
@@ -376,9 +399,8 @@ async def _locked_retirement_collisions(
         SELECT u.id, u.username, u.email, u.password_hash, u.is_admin,
                u.is_recovery_admin, u.auth_provider, u.account_status,
                u.account_kind, u.tokens_revoked_before,
-               EXISTS (
-                   SELECT 1 FROM external_identities e WHERE e.user_id = u.id
-               ) AS has_external_identity,
+               (SELECT COUNT(*) FROM external_identities e WHERE e.user_id = u.id)
+                   AS external_identity_count,
                EXISTS (
                    SELECT 1 FROM tokens t WHERE t.user_id = u.id
                ) AS has_tokens,
@@ -412,7 +434,25 @@ def _is_exact_active_local_recovery(
         and row["auth_provider"] == "local"
         and row["account_status"] == "active"
         and row["account_kind"] == "human"
-        and not row["has_external_identity"]
+        and row["external_identity_count"] == 0
+    )
+
+
+def _is_exact_active_sso_recovery(row, identities) -> bool:
+    return bool(
+        row["password_hash"] == _SSO_PASSWORD_SENTINEL
+        and row["is_admin"]
+        and row["is_recovery_admin"]
+        and row["auth_provider"] == "keycloak"
+        and row["account_status"] == "active"
+        and row["account_kind"] == "human"
+        and row["external_identity_count"] == 1
+        and len(identities) == 1
+        and identities[0]["issuer"] == settings.keycloak_issuer
+        and bounded_nonempty_claim(
+            identities[0]["subject"], maximum=OIDC_SUBJECT_MAX_LENGTH
+        )
+        is not None
     )
 
 
@@ -431,7 +471,7 @@ def _is_exact_retired_tombstone(
         and row["auth_provider"] == "local"
         and row["account_status"] == "suspended"
         and row["account_kind"] == "human"
-        and not row["has_external_identity"]
+        and row["external_identity_count"] == 0
         and not row["has_tokens"]
         and not row["has_admin_browser_sessions"]
         and not row["has_sso_browser_sessions"]
@@ -478,12 +518,27 @@ async def retire_local_recovery_admin(
                 actor_token_id=actor_token_id,
             )
             await _lock_provisioning(conn)
+            sso_identities = await _locked_sso_recovery_identities(conn)
             designated = await _locked_recovery_rows(conn)
-            if len(designated) > 1:
+            local_designated = [
+                row for row in designated if row["auth_provider"] == "local"
+            ]
+            sso_successors = []
+            for row in designated:
+                if row["auth_provider"] != "keycloak":
+                    continue
+                identities = sso_identities.get(row["id"], [])
+                if _is_exact_active_sso_recovery(row, identities):
+                    sso_successors.append(row)
+            if (
+                len(local_designated) > 1
+                or len(sso_successors) != 1
+                or len(designated) != len(local_designated) + len(sso_successors)
+            ):
                 raise RecoveryAdminRetirementConflictError()
 
-            if designated:
-                current = designated[0]
+            if local_designated:
+                current = local_designated[0]
                 if current["id"] == actor_id or not _is_exact_active_local_recovery(
                     current,
                     expected_username=expected_username,

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -322,6 +322,183 @@ async def test_sso_prebinding_is_exact_idempotent_and_has_no_local_password(serv
     assert auth_service.verify_password("any-local-password", row["password_hash"]) is False
 
 
+async def test_sso_prebinding_rejects_oversized_subject_without_mutation(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import ValidationError
+    from app.services.external_identity_contract import OIDC_SUBJECT_MAX_LENGTH
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+
+    with pytest.raises(ValidationError):
+        await service.provision_sso_recovery_admin(
+            username="sso-recovery-admin",
+            email="sso-recovery-admin@example.com",
+            issuer=settings.keycloak_issuer,
+            subject="s" * (OIDC_SUBJECT_MAX_LENGTH + 1),
+        )
+
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 0
+        assert await conn.fetchval("SELECT COUNT(*) FROM external_identities") == 0
+
+
+async def test_sso_prebinding_overlaps_local_recovery_until_exact_retirement(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    local = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    sso = await service.provision_sso_recovery_admin(
+        username="admin",
+        email="admin@example.com",
+        issuer=settings.keycloak_issuer,
+        subject="stable-admin-subject",
+    )
+
+    async with pool.acquire() as conn:
+        providers = await conn.fetch(
+            "SELECT auth_provider FROM users WHERE is_recovery_admin ORDER BY auth_provider"
+        )
+    assert [row["auth_provider"] for row in providers] == ["keycloak", "local"]
+
+    retired = await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+    repeated = await service.retire_local_recovery_admin(
+        expected_username="local-recovery-admin",
+        expected_email="local-recovery-admin@example.com",
+        actor_user_id=str(actor_user_id),
+        actor_token_id=str(actor_token_id),
+    )
+
+    assert retired["user_id"] == local["user_id"]
+    assert repeated == retired
+    async with pool.acquire() as conn:
+        active_recovery = await conn.fetchrow(
+            "SELECT id, auth_provider FROM users WHERE is_recovery_admin"
+        )
+        local_state = await conn.fetchrow(
+            "SELECT is_admin, is_recovery_admin, account_status FROM users WHERE id = $1",
+            uuid.UUID(local["user_id"]),
+        )
+    assert dict(active_recovery) == {
+        "id": uuid.UUID(sso["user_id"]),
+        "auth_provider": "keycloak",
+    }
+    assert dict(local_state) == {
+        "is_admin": False,
+        "is_recovery_admin": False,
+        "account_status": "suspended",
+    }
+
+
+async def test_retirement_rejects_sso_successor_bound_to_stale_issuer(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminRetirementConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    local = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    stale_issuer = settings.keycloak_issuer + "-stale"
+    await service.provision_sso_recovery_admin(
+        username="admin",
+        email="admin@example.com",
+        issuer=stale_issuer,
+        subject="stale-admin-subject",
+    )
+
+    with pytest.raises(RecoveryAdminRetirementConflictError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="local-recovery-admin@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            "SELECT is_admin, is_recovery_admin, account_status FROM users WHERE id = $1",
+            uuid.UUID(local["user_id"]),
+        )
+    assert dict(state) == {
+        "is_admin": True,
+        "is_recovery_admin": True,
+        "account_status": "active",
+    }
+
+
+async def test_retirement_rejects_legacy_oversized_sso_subject(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminRetirementConflictError
+    from app.services.external_identity_contract import OIDC_SUBJECT_MAX_LENGTH
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    local = await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    successor = await _create_sso_recovery_successor(service)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE external_identities SET subject = $2 WHERE user_id = $1",
+            uuid.UUID(successor["user_id"]),
+            "s" * (OIDC_SUBJECT_MAX_LENGTH + 1),
+        )
+
+    with pytest.raises(RecoveryAdminRetirementConflictError):
+        await service.retire_local_recovery_admin(
+            expected_username="local-recovery-admin",
+            expected_email="local-recovery-admin@example.com",
+            actor_user_id=str(actor_user_id),
+            actor_token_id=str(actor_token_id),
+        )
+
+    async with pool.acquire() as conn:
+        state = await conn.fetchrow(
+            "SELECT is_admin, is_recovery_admin, account_status FROM users WHERE id = $1",
+            uuid.UUID(local["user_id"]),
+        )
+    assert dict(state) == {
+        "is_admin": True,
+        "is_recovery_admin": True,
+        "account_status": "active",
+    }
+
+
 async def test_sso_prebinding_never_links_an_email_or_existing_binding(services, monkeypatch):
     pool, _, service, _, _, _ = services
     from app.config import settings
@@ -485,6 +662,102 @@ async def _create_retirement_actor(pool) -> tuple[uuid.UUID, uuid.UUID]:
     return user_id, token_id
 
 
+async def _create_sso_recovery_successor(service) -> dict:
+    from app.config import settings
+
+    return await service.provision_sso_recovery_admin(
+        username="sso-recovery-admin",
+        email="sso-recovery-admin@example.com",
+        issuer=settings.keycloak_issuer,
+        subject="stable-sso-recovery-subject",
+    )
+
+
+async def test_retirement_locks_external_identity_before_successor_user(
+    services,
+    monkeypatch,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    await service.provision_local_recovery_admin(
+        username="local-recovery-admin",
+        email="local-recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_user_id, actor_token_id = await _create_retirement_actor(pool)
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    successor = await _create_sso_recovery_successor(service)
+    successor_id = uuid.UUID(successor["user_id"])
+
+    blocker = await pool.acquire()
+    blocker_tx = blocker.transaction()
+    await blocker_tx.start()
+    blocker_tx_finished = False
+    retire_task: asyncio.Task | None = None
+    try:
+        await blocker.execute(
+            """
+            UPDATE external_identities
+               SET last_seen_at = last_seen_at
+             WHERE user_id = $1
+            """,
+            successor_id,
+        )
+        retire_task = asyncio.create_task(
+            service.retire_local_recovery_admin(
+                expected_username="local-recovery-admin",
+                expected_email="local-recovery-admin@example.com",
+                actor_user_id=str(actor_user_id),
+                actor_token_id=str(actor_token_id),
+            )
+        )
+
+        observed_identity_wait = False
+        for _ in range(100):
+            async with pool.acquire() as observer:
+                observed_identity_wait = bool(
+                    await observer.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1
+                              FROM pg_stat_activity
+                             WHERE datname = current_database()
+                               AND pid <> pg_backend_pid()
+                               AND query LIKE '%recovery-successor-authority-lock%'
+                               AND wait_event_type = 'Lock'
+                        )
+                        """
+                    )
+                )
+            if observed_identity_wait:
+                break
+            await asyncio.sleep(0.01)
+        assert observed_identity_wait
+
+        await blocker.execute(
+            "UPDATE users SET updated_at = NOW() WHERE id = $1",
+            successor_id,
+        )
+        await blocker_tx.commit()
+        blocker_tx_finished = True
+        await asyncio.wait_for(retire_task, timeout=5)
+    finally:
+        if not blocker_tx_finished:
+            await blocker_tx.rollback()
+        await pool.release(blocker)
+        if retire_task is not None and not retire_task.done():
+            retire_task.cancel()
+            await asyncio.gather(retire_task, return_exceptions=True)
+
+    async with pool.acquire() as conn:
+        active = await conn.fetchrow(
+            "SELECT id, auth_provider FROM users WHERE is_recovery_admin"
+        )
+    assert dict(active) == {"id": successor_id, "auth_provider": "keycloak"}
+
+
 async def test_retirement_is_disabled_in_local_mode_without_mutation(services, monkeypatch):
     pool, _, service, _, _, _ = services
     from app.config import settings
@@ -563,6 +836,7 @@ async def test_retirement_is_exact_atomic_and_idempotent(services, monkeypatch):
         )
 
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
     first = await service.retire_local_recovery_admin(
         expected_username="local-recovery-admin",
         expected_email="local-recovery-admin@example.com",
@@ -680,6 +954,7 @@ async def test_retirement_denial_survives_failed_role_cleanup_and_retry_finishes
         )
 
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
     role_sync.fail_token = target_token_id
     with pytest.raises(CredentialCleanupIncompleteError):
         await service.retire_local_recovery_admin(
@@ -794,11 +1069,12 @@ async def test_retirement_serializes_delayed_scoped_token_role_creation(
             async with pool.acquire() as conn:
                 await actual_role_sync._reconcile_token_roles(conn, ReconcileReport())
 
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
     create_task = asyncio.create_task(create_role_path())
     retire_task = None
     try:
         await asyncio.wait_for(create_entered.wait(), timeout=2)
-        monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
         retire_task = asyncio.create_task(
             service.retire_local_recovery_admin(
                 expected_username="local-recovery-admin",
@@ -854,6 +1130,7 @@ async def test_retired_tombstone_rejects_external_identity_adoption(
     )
     actor_user_id, actor_token_id = await _create_retirement_actor(pool)
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
     await service.retire_local_recovery_admin(
         expected_username="local-recovery-admin",
         expected_email="local-recovery-admin@example.com",
@@ -984,6 +1261,7 @@ async def test_retirement_mismatch_external_binding_and_collisions_fail_closed(
     recovery_user_id = uuid.UUID(provisioned["user_id"])
     actor_user_id, actor_token_id = await _create_retirement_actor(pool)
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
 
     with pytest.raises(RecoveryAdminRetirementConflictError):
         await service.retire_local_recovery_admin(
@@ -1064,6 +1342,7 @@ async def test_retirement_revalidates_service_actor_and_split_collision(services
         )
 
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
     with pytest.raises(RecoveryAdminRetirementAuthorizationError):
         await service.retire_local_recovery_admin(
             expected_username="split-username",
@@ -1086,7 +1365,7 @@ async def test_migration_upgrades_old_schema_and_is_idempotent(services):
     from app.db.postgres import _load_migration
 
     async with pool.acquire() as conn:
-        await conn.execute("DROP INDEX users_one_recovery_admin")
+        await conn.execute("DROP INDEX users_one_recovery_admin_per_provider")
         await conn.execute("ALTER TABLE users DROP CONSTRAINT users_recovery_admin_requires_admin")
         await conn.execute("ALTER TABLE users DROP COLUMN is_recovery_admin")
         await conn.execute("ALTER TABLE external_identities DROP COLUMN username_snapshot")
@@ -1150,11 +1429,83 @@ async def test_migration_upgrades_old_schema_and_is_idempotent(services):
                           'migration-recovery-two@example.com', '!hash!', true, true)
                 """
             )
-
     assert user_column is True
     assert snapshot_column is True
     assert constraint == 1
     assert unique_index == 1
+
+
+async def test_recovery_handover_migration_allows_one_recovery_per_provider(services):
+    pool, _, _, _, _, _ = services
+    from app.db.postgres import _load_migration
+
+    async with pool.acquire() as conn:
+        await conn.execute("DROP INDEX users_one_recovery_admin_per_provider")
+        await conn.execute(
+            "ALTER TABLE users DROP CONSTRAINT users_recovery_admin_provider_check"
+        )
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX users_one_recovery_admin
+                ON users ((is_recovery_admin))
+                WHERE is_recovery_admin
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO users (
+                username, email, password_hash, is_admin, is_recovery_admin,
+                auth_provider
+            ) VALUES ('migration-local', 'migration-local@example.com',
+                      '!local!', true, true, 'local')
+            """
+        )
+        migration = _load_migration("078_recovery_admin_authority_handover.py")
+        assert migration is not None
+        await migration.migrate(conn)
+        await migration.migrate(conn)
+
+        await conn.execute(
+            """
+            INSERT INTO users (
+                username, email, password_hash, is_admin, is_recovery_admin,
+                auth_provider
+            ) VALUES ('migration-sso', 'migration-sso@example.com',
+                      '!sso!', true, true, 'keycloak')
+            """
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO users (
+                    username, email, password_hash, is_admin, is_recovery_admin,
+                    auth_provider
+                ) VALUES ('migration-local-two', 'migration-local-two@example.com',
+                          '!local-two!', true, true, 'local')
+                """
+            )
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                """
+                INSERT INTO users (
+                    username, email, password_hash, is_admin, is_recovery_admin,
+                    auth_provider
+                ) VALUES ('migration-foreign', 'migration-foreign@example.com',
+                          '!foreign!', true, true, 'foreign')
+                """
+            )
+        indexes = await conn.fetch(
+            """
+            SELECT indexname FROM pg_indexes
+             WHERE schemaname = 'public' AND tablename = 'users'
+               AND indexname LIKE 'users_one_recovery_admin%'
+             ORDER BY indexname
+            """
+        )
+
+    assert [row["indexname"] for row in indexes] == [
+        "users_one_recovery_admin_per_provider"
+    ]
 
 
 async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(


### PR DESCRIPTION
## Summary
- allow one designated recovery administrator per supported auth provider during a local-to-SSO handover
- require an exact active Keycloak successor before retiring the local recovery administrator
- migrate the singleton recovery-admin index without weakening provider or admin constraints
- preserve exact, atomic, idempotent local retirement after the SSO successor exists

## Verification
- PostgreSQL recovery-admin suite: 25 passed
- SSO/recovery/admin related suites: 101 passed
- focused Ruff, mypy, and Bandit checks passed
