### PR TITLE
feat: isolate durable workers from API runtime

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3509
+        "line_number": 3524
       }
     ],
     "backend/mcp_server/help.py": [
@@ -321,7 +321,7 @@
         "filename": "deploy/k8s/backend.yaml",
         "hashed_secret": "e2c600c1584e7714abc8f7267aaf28fd288c1cc2",
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 233,
         "is_secret": false
       }
     ],
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T04:31:57Z"
+  "generated_at": "2026-08-18T07:22:45Z"
 }

--- a/README.md
+++ b/README.md
@@ -297,9 +297,13 @@ docker compose exec -T backend python -m app.cli provision-recovery-admin local 
 open http://localhost:3000
 ```
 
-`config/app.yaml` and `config/secret.yaml` are the **single source of runtime
-configuration** — no environment variables are read by the backend. Mount the
-`config/` directory at `/etc/akb/` in any deployment.
+`config/app.yaml` and `config/secret.yaml` are the **single source of
+application configuration**. Mount the `config/` directory at `/etc/akb/` in
+any deployment. Process composition is the narrow exception:
+`AKB_PROCESS_ROLE=all|api|worker` selects the entrypoint role and
+`AKB_TOKENIZER_PROCESSES=1..4` can lower the per-process tokenizer pool for a
+deployment container. The Kubernetes base owns those two operational values;
+business, auth, storage, and provider settings remain in the YAML files.
 
 Ordinary registration always creates a non-admin account, including on an
 empty database. Administrator bootstrap is available only through the

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,21 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added crash-safe worker runtime isolation
+
+Kubernetes now composes the serving API and durable background workers as
+separate processes in one RWO-backed Pod, while the default local entrypoint
+retains the all-in-one runtime. Worker shutdown broadcasts every stop signal
+before a shared bounded join, tokenizer process counts are explicit, and the
+worker sidecar has an event-loop heartbeat probe.
+
+Durable queues now count attempts in their claim transaction, record explicit
+claim/abandon state, credit back unattempted batch rows, and use a singleton
+rescuer to close final claims left by process death. Shared Bare-Git worktrees
+are guarded across processes with storage-backed locks and ref compare-and-
+swap. Migration and role-reconciliation startup are serialized for the
+two-process topology.
+
 ### Added metadata-only legacy app adoption
 
 System administrators and target Vault administrators can now create immutable,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -402,6 +402,15 @@ class Settings(BaseModel):
     pg_pool_min_size: int = 2
     pg_pool_max_size: int = 30
 
+    # Runtime safety budgets. Kiwi keeps a large model resident in every child,
+    # so an implicit CPU-count-sized pool can exhaust a 4 GiB pod as workers
+    # warm up. Keep the production-safe default explicit and bounded.
+    tokenizer_processes: int = Field(default=2, ge=1, le=4)
+    # All background workers share this one absolute shutdown budget. Kubernetes
+    # grants 45 seconds in the base manifest, leaving ten seconds for storage
+    # clients, audit draining, and interpreter teardown after workers quiesce.
+    worker_shutdown_timeout_secs: float = Field(default=35.0, gt=0.0, le=300.0)
+
     # `akb_sql` / REST SQL: rows are coerced to JSON dicts on the single event
     # loop. A huge SELECT (`SELECT * FROM generate_series(1, 2e6)`) coerced in
     # one pass blocks the loop for seconds → /livez probe timeout → 503. We

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -60,9 +60,22 @@ CREATE TABLE IF NOT EXISTS users (
         CHECK (NOT is_recovery_admin OR auth_provider IN ('local', 'keycloak'))
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin_per_provider
-    ON users (auth_provider)
-    WHERE is_recovery_admin;
+-- Guarded: `is_recovery_admin` arrives with migration 071 on existing
+-- installations. init.sql runs before migrations, so an unconditional index
+-- here would abort the upgrade before migration 071 can add the column.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'users'
+           AND column_name = 'is_recovery_admin'
+    ) THEN
+        CREATE UNIQUE INDEX IF NOT EXISTS users_one_recovery_admin_per_provider
+            ON users (auth_provider)
+            WHERE is_recovery_admin;
+    END IF;
+END $$;
 
 -- Stable external identity binding. Email is a mutable snapshot; verified
 -- OIDC issuer + subject is the permanent key.
@@ -445,6 +458,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     vector_next_attempt_at TIMESTAMPTZ,
     vector_retry_count INTEGER NOT NULL DEFAULT 0,
     vector_last_error TEXT,
+    vector_claimed_at TIMESTAMPTZ,
+    vector_abandoned_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/backend/app/db/migrations/079_worker_claim_lifecycle.py
+++ b/backend/app/db/migrations/079_worker_claim_lifecycle.py
@@ -1,0 +1,140 @@
+"""Migration 079: crash-safe claim lifecycle for durable worker queues.
+
+Every retry counter now represents work *claimed*, not only failures that
+managed to reach their exception handler.  The companion ``*_claimed_at`` and
+``*_abandoned_at`` timestamps let an operator distinguish an active lease from
+a terminal row and let the queue rescuer close a claim whose process died on
+its final attempt.
+
+Idempotent and additive.  Existing completed rows are normalised to retry=0;
+pending rows retain their historical retry count.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.079")
+
+
+_TABLE_STEPS = (
+    (
+        "chunks",
+        ("vector_indexed_at", "vector_retry_count", "vector_next_attempt_at"),
+        """
+        ALTER TABLE chunks
+            ADD COLUMN IF NOT EXISTS vector_claimed_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS vector_abandoned_at TIMESTAMPTZ;
+        UPDATE chunks
+           SET vector_retry_count = 0,
+               vector_claimed_at = NULL,
+               vector_abandoned_at = NULL
+         WHERE vector_indexed_at IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_chunks_vector_claim_lifecycle
+            ON chunks (vector_next_attempt_at, created_at DESC, id)
+         WHERE vector_indexed_at IS NULL AND vector_abandoned_at IS NULL;
+        """,
+    ),
+    (
+        "vector_delete_outbox",
+        ("processed_at", "retry_count", "next_attempt_at"),
+        """
+        ALTER TABLE vector_delete_outbox
+            ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS abandoned_at TIMESTAMPTZ;
+        UPDATE vector_delete_outbox
+           SET retry_count = 0, claimed_at = NULL, abandoned_at = NULL
+         WHERE processed_at IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_vector_delete_claim_lifecycle
+            ON vector_delete_outbox (next_attempt_at, id)
+         WHERE processed_at IS NULL AND abandoned_at IS NULL;
+        """,
+    ),
+    (
+        "s3_delete_outbox",
+        ("processed_at", "retry_count", "next_attempt_at"),
+        """
+        ALTER TABLE s3_delete_outbox
+            ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS abandoned_at TIMESTAMPTZ;
+        UPDATE s3_delete_outbox
+           SET retry_count = 0, claimed_at = NULL, abandoned_at = NULL
+         WHERE processed_at IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_s3_delete_claim_lifecycle
+            ON s3_delete_outbox (next_attempt_at, id)
+         WHERE processed_at IS NULL AND abandoned_at IS NULL;
+        """,
+    ),
+    (
+        "events",
+        ("redis_published_at", "attempts", "next_attempt_at"),
+        """
+        ALTER TABLE events
+            ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS abandoned_at TIMESTAMPTZ;
+        UPDATE events
+           SET attempts = 0, claimed_at = NULL, abandoned_at = NULL
+         WHERE redis_published_at IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_events_claim_lifecycle
+            ON events (next_attempt_at, id)
+         WHERE redis_published_at IS NULL AND abandoned_at IS NULL;
+        """,
+    ),
+    (
+        "documents",
+        ("llm_metadata_at", "llm_retry_count", "llm_next_attempt_at"),
+        """
+        ALTER TABLE documents
+            ADD COLUMN IF NOT EXISTS llm_claimed_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS llm_abandoned_at TIMESTAMPTZ;
+        UPDATE documents
+           SET llm_retry_count = 0,
+               llm_claimed_at = NULL,
+               llm_abandoned_at = NULL
+         WHERE llm_metadata_at IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_documents_llm_claim_lifecycle
+            ON documents (llm_next_attempt_at, id)
+         WHERE source = 'external_git'
+           AND llm_metadata_at IS NULL
+           AND llm_abandoned_at IS NULL;
+        """,
+    ),
+)
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    # Some supported upgrade fixtures have a complete migration ledger but do
+    # not materialize optional historical subsystems. Apply the lifecycle only
+    # to queues that actually exist instead of making an unrelated upgrade
+    # recreate or depend on those tables.
+    for table_name, required_columns, sql in _TABLE_STEPS:
+        columns = await conn.fetch(
+            """
+            SELECT column_name
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name = $1
+               AND column_name = ANY($2::text[])
+            """,
+            table_name,
+            list(required_columns),
+        )
+        if {row["column_name"] for row in columns} != set(required_columns):
+            logger.info(
+                "Migration 079: optional queue %s is unavailable; skipping",
+                table_name,
+            )
+            continue
+        await conn.execute(sql)
+    logger.info("Migration 079 applied: crash-safe worker claim lifecycle")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import asyncpg
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from app.config import settings
@@ -9,6 +10,7 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _pool: asyncpg.Pool | None = None
+_MIGRATION_LOCK_KEY = 0x414B425F4D494752  # ``AKB_MIGR``
 
 
 def _pool_sizes() -> tuple[int, int]:
@@ -131,7 +133,17 @@ def _load_migration(filename: str):
     return module
 
 
-async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, backoff: float = 4.0) -> None:
+@asynccontextmanager
+async def _migration_connection(pool_or_conn):
+    """Accept a pool for direct tests or the applier's leader connection."""
+    if hasattr(pool_or_conn, "acquire"):
+        async with pool_or_conn.acquire() as conn:
+            yield conn
+    else:
+        yield pool_or_conn
+
+
+async def _run_one_migration(pool_or_conn, filename: str, module, *, retries: int = 10, backoff: float = 4.0) -> None:
     """Apply one migration under a bounded lock_timeout, retrying on a lock
     conflict, then record it in the ledger.
 
@@ -149,18 +161,28 @@ async def _run_one_migration(pool, filename: str, module, *, retries: int = 10, 
     log = logging.getLogger("akb.migrations")
     for attempt in range(retries):
         try:
-            async with pool.acquire() as conn:
+            async with _migration_connection(pool_or_conn) as conn:
                 await conn.execute("SET lock_timeout = '5s'")
-                await module.migrate(conn=conn)
-                await conn.execute(
-                    "INSERT INTO schema_migrations (filename) VALUES ($1) ON CONFLICT (filename) DO NOTHING",
-                    filename,
-                )
+                if hasattr(conn, "transaction"):
+                    # Migration effects and their ledger receipt are one unit.
+                    # Nested transaction blocks in individual migrations become
+                    # savepoints under asyncpg and remain compatible.
+                    async with conn.transaction():
+                        await module.migrate(conn=conn)
+                        await conn.execute(
+                            "INSERT INTO schema_migrations (filename) VALUES ($1) ON CONFLICT (filename) DO NOTHING",
+                            filename,
+                        )
+                else:  # minimal connection fakes used by unit tests
+                    await module.migrate(conn=conn)
+                    await conn.execute(
+                        "INSERT INTO schema_migrations (filename) VALUES ($1) ON CONFLICT (filename) DO NOTHING",
+                        filename,
+                    )
             return
         except (
             asyncpg.DeadlockDetectedError,
             asyncpg.LockNotAvailableError,
-            asyncpg.QueryCanceledError,
         ) as e:
             if attempt < retries - 1:
                 log.warning(
@@ -187,7 +209,20 @@ async def _apply_migrations() -> None:
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
-        applied = {r["filename"] for r in await conn.fetch("SELECT filename FROM schema_migrations")}
+        # Session lock serializes the read-of-ledger + apply + ledger-write
+        # sequence across API/worker pods during a rolling deployment.
+        await conn.execute("SELECT pg_advisory_lock($1)", _MIGRATION_LOCK_KEY)
+        try:
+            applied = {
+                r["filename"]
+                for r in await conn.fetch("SELECT filename FROM schema_migrations")
+            }
+            await _apply_pending_migrations(conn, applied)
+        finally:
+            await conn.execute("SELECT pg_advisory_unlock($1)", _MIGRATION_LOCK_KEY)
+
+
+async def _apply_pending_migrations(conn, applied: set[str]) -> None:
     for filename in (
         "002_public_shares.py",  # legacy is_public/public_slug → public_shares
         "003_rename_public_shares.py",  # public_shares → publications
@@ -266,10 +301,11 @@ async def _apply_migrations() -> None:
         "076_sso_session_epoch.py",  # monotonic auth boundary + rollback-compatible epoch bridge/legacy-write guard
         "077_legacy_adoptions.py",  # immutable legacy app adoption plans, targets, and bounded audit
         "078_recovery_admin_authority_handover.py",  # provider-scoped recovery authority during local-to-SSO cutover
+        "079_worker_claim_lifecycle.py",  # attempt-at-claim + explicit claimed/abandoned timestamps for durable queues
     ):
         if filename in applied:
             continue
         module = _load_migration(filename)
         if module is None:
             continue
-        await _run_one_migration(pool, filename, module)
+        await _run_one_migration(conn, filename, module)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError
 from app.logging_redaction import install_secret_redaction
 from app.openapi_contract import install_openapi_contract
+from app.process_role import runtime_process_role
 from app.services import (
     asset_gc_worker,
     audit_log,
@@ -57,7 +58,15 @@ from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
 from app.services.external_git_capability import check_external_git_capability
 from app.services.health import vault_health
-from app.services.lifecycle import init_storage, shutdown_storage, start_workers, stop_workers
+from app.services.lifecycle import (
+    init_storage,
+    shutdown_storage,
+    start_workers,
+    start_api_runtime,
+    stop_api_runtime,
+    stop_workers,
+    worker_lifecycle_snapshot,
+)
 from app.services.revision_backend import selected_document_revision_backend
 from app.services.vector_store import get_vector_store
 from app.util.errors import (
@@ -91,40 +100,61 @@ async def lifespan(app: FastAPI):
     # loggers/handlers (uvicorn.access/error don't propagate to the root handler).
     # Idempotent — already-covered handlers are skipped.
     install_secret_redaction()
-    await init_storage()
-    bare_git_selected = selected_document_revision_backend() == "bare_git"
-    if bare_git_selected:
-        # Stamp the external-mirror marker on any mirror whose
-        # bare repo predates it, so its reads route through the hermetic runner
-        # (fail-closed) rather than GitPython. Runs AFTER the DB is up (authoritative
-        # mirror list) and BEFORE workers/requests. This remains unconditional
-        # within Bare-Git mode, even when external_git is disabled, because the
-        # marker is the fail-closed safety net that makes the read paths correctly
-        # REFUSE a disabled mirror (503) rather than serve it via GitPython. The
-        # backfill is not composed for PostgreSQL Native, whose vault storage is
-        # PostgreSQL-only and may have no Git write authority. FAIL-FAST: if a
-        # marker cannot be written onto an existing mirror bare (disk/permission),
-        # or the mirror list can't be read, this raises and startup ABORTS rather
-        # than serving mirrors that would fall open. No serving has begun yet, so
-        # the fail-open window is zero.
-        marked = await external_git_service.backfill_mirror_markers()
-        if marked:
-            logger.info("Backfilled external-git mirror marker on %d vault(s)", marked)
-        # When the mirror feature is enabled, prove at boot (in a
-        # thread; it runs a git subprocess + loopback socket) that this git build
-        # actually enforces the network controls the hermetic runner depends on
-        # (http.curloptResolve DNS-pin, proxy-off, --config-env) and meets the git
-        # >= 2.37 floor. Fast-fails the boot BEFORE workers/serving start if not; a
-        # no-op when external_git is disabled. No real network (uses a *.invalid host).
-        await asyncio.to_thread(check_external_git_capability, settings)
-    start_workers()
-    yield
-    await stop_workers()
-    await shutdown_storage()
-    # Drain the audit writer's queue so a rollout doesn't drop its tail. Off the
-    # loop since shutdown() blocks on the queue join.
-    await asyncio.to_thread(audit_log.shutdown)
-    logger.info("Server shutdown")
+    role = runtime_process_role()
+    if role == "worker":
+        raise RuntimeError(
+            "AKB_PROCESS_ROLE=worker must use `python -m app.worker_main`, not uvicorn"
+        )
+    storage_initialized = False
+    runtime_started = False
+    try:
+        await init_storage()
+        storage_initialized = True
+        bare_git_selected = selected_document_revision_backend() == "bare_git"
+        if bare_git_selected:
+            # Stamp the external-mirror marker on any mirror whose
+            # bare repo predates it, so its reads route through the hermetic runner
+            # (fail-closed) rather than GitPython. Runs AFTER the DB is up (authoritative
+            # mirror list) and BEFORE workers/requests. This remains unconditional
+            # within Bare-Git mode, even when external_git is disabled, because the
+            # marker is the fail-closed safety net that makes the read paths correctly
+            # REFUSE a disabled mirror (503) rather than serve it via GitPython. The
+            # backfill is not composed for PostgreSQL Native, whose vault storage is
+            # PostgreSQL-only and may have no Git write authority. FAIL-FAST: if a
+            # marker cannot be written onto an existing mirror bare (disk/permission),
+            # or the mirror list can't be read, this raises and startup ABORTS rather
+            # than serving mirrors that would fall open. No serving has begun yet, so
+            # the fail-open window is zero.
+            marked = await external_git_service.backfill_mirror_markers()
+            if marked:
+                logger.info("Backfilled external-git mirror marker on %d vault(s)", marked)
+            # When the mirror feature is enabled, prove at boot (in a
+            # thread; it runs a git subprocess + loopback socket) that this git build
+            # actually enforces the network controls the hermetic runner depends on
+            # (http.curloptResolve DNS-pin, proxy-off, --config-env) and meets the git
+            # >= 2.37 floor. Fast-fails the boot BEFORE workers/serving start if not; a
+            # no-op when external_git is disabled. No real network (uses a *.invalid host).
+            await asyncio.to_thread(check_external_git_capability, settings)
+        # Mark this before synchronous composition so a partial start is still
+        # unwound if a later component raises.
+        runtime_started = True
+        if role == "all":
+            start_workers()
+        else:
+            start_api_runtime()
+        yield
+    finally:
+        if runtime_started:
+            if role == "all":
+                await stop_workers()
+            else:
+                await stop_api_runtime()
+        if storage_initialized:
+            await shutdown_storage()
+        # Drain the audit writer's queue so a rollout doesn't drop its tail. Off the
+        # loop since shutdown() blocks on the queue join.
+        await asyncio.to_thread(audit_log.shutdown)
+        logger.info("Server shutdown (role=%s)", role)
 
 
 app = FastAPI(
@@ -436,7 +466,7 @@ async def health(user: AuthenticatedUser | None = Depends(get_optional_user)):
     `vector_store.backfill` and `embed_backfill` is gone — they were
     reporting the same `chunks.vector_indexed_at IS NULL` count.
     """
-    from app.services import sparse_encoder, vault_backfill
+    from app.services import queue_rescuer, sparse_encoder, vault_backfill
 
     store = get_vector_store()
     vs_info: dict = {"reachable": await store.health()}
@@ -466,6 +496,8 @@ async def health(user: AuthenticatedUser | None = Depends(get_optional_user)):
     result: dict = {
         "status": "ok",
         "service": "akb",
+        "workers": worker_lifecycle_snapshot(),
+        "queue_claims": queue_rescuer.snapshot(),
         "external_git": await _safe(external_git_poller.pending_stats),
         "asset_gc": await _safe(asset_gc_worker.pending_stats),
         "metadata_backfill": await _safe(metadata_worker.pending_stats),

--- a/backend/app/process_role.py
+++ b/backend/app/process_role.py
@@ -1,0 +1,18 @@
+"""Process composition selector for all-in-one, API, and worker entrypoints."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, cast
+
+ProcessRole = Literal["all", "api", "worker"]
+
+
+def runtime_process_role() -> ProcessRole:
+    value = os.getenv("AKB_PROCESS_ROLE", "all").strip().lower()
+    if value not in {"all", "api", "worker"}:
+        raise RuntimeError(
+            "AKB_PROCESS_ROLE must be one of all, api, worker; "
+            f"got {value!r}"
+        )
+    return cast(ProcessRole, value)

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -784,6 +784,11 @@ class DocumentRepository:
                     doc_type = COALESCE(NULLIF(doc_type, ''), $4, doc_type),
                     domain   = COALESCE(NULLIF(domain, ''), $5, domain),
                     llm_metadata_at = $6,
+                    llm_retry_count = 0,
+                    llm_last_error = NULL,
+                    llm_next_attempt_at = NULL,
+                    llm_claimed_at = NULL,
+                    llm_abandoned_at = NULL,
                     updated_at = $6
                 WHERE id = $1
             """

--- a/backend/app/services/_backfill.py
+++ b/backend/app/services/_backfill.py
@@ -19,6 +19,9 @@ import logging
 import time
 from typing import Awaitable, Callable, Optional
 
+
+_RUNNERS: list["BackfillRunner"] = []
+
 # Retry backoff shared by every backfill worker. Index is retry_count (0-based).
 # After MAX_RETRIES the row stays in 'abandoned' until operator intervention.
 BACKOFF_SECS: list[int] = [60, 300, 900, 1800, 3600, 7200, 14400, 21600]
@@ -75,6 +78,33 @@ class BackfillRunner:
         self._inflight: set[asyncio.Task] = set()
         self._stop_event: Optional[asyncio.Event] = None
         self._log = logging.getLogger(f"akb.{name}")
+        _RUNNERS.append(self)
+
+    def request_stop(self) -> None:
+        """Stop claiming new work without waiting for the current iteration."""
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+    def snapshot(self) -> dict:
+        return {
+            "name": self._name,
+            "loop_tasks": len([task for task in self._tasks if not task.done()]),
+            "inflight": len([task for task in self._inflight if not task.done()]),
+            "abandoned": self.abandoned(),
+            "stop_requested": bool(
+                self._stop_event is not None and self._stop_event.is_set()
+            ),
+        }
+
+    def is_running(self) -> bool:
+        """Return whether this runner currently owns a live loop task."""
+        return any(not task.done() for task in self._tasks)
+
+    def configure_idle_secs(self, idle_secs: int) -> None:
+        """Set the idle cadence before starting or restarting the runner."""
+        if self.is_running():
+            return
+        self._idle_secs = idle_secs
 
     def abandoned(self) -> int:
         """Iterations that ignored cancellation and outlived a `stop()`.
@@ -87,7 +117,7 @@ class BackfillRunner:
         return len([t for t in self._inflight if not t.done()])
 
     def start(self) -> None:
-        if self._tasks and any(not t.done() for t in self._tasks):
+        if self.is_running():
             return
         # A previous `stop()` may have abandoned an iteration that ignored
         # cancellation. Starting a second loop over the same queue while that
@@ -122,8 +152,7 @@ class BackfillRunner:
         `_inflight` rather than forgotten, so `start()` can refuse to run a
         second loop over the same queue.
         """
-        if self._stop_event:
-            self._stop_event.set()
+        self.request_stop()
         deadline = time.monotonic() + max(0.0, timeout)
 
         await self._join(self._tasks, deadline, "loop task")
@@ -207,3 +236,14 @@ class BackfillRunner:
                 await asyncio.sleep(0)
 
         log.info("%s loop stopped", task_name)
+
+
+def request_stop_all() -> None:
+    """Broadcast stop before lifecycle starts waiting on any one worker."""
+    for runner in tuple(_RUNNERS):
+        runner.request_stop()
+
+
+def runner_snapshots() -> list[dict]:
+    """Operator-facing state for every runner constructed in this process."""
+    return [runner.snapshot() for runner in _RUNNERS]

--- a/backend/app/services/delete_worker.py
+++ b/backend/app/services/delete_worker.py
@@ -51,15 +51,19 @@ async def _claim_delete_batch(conn) -> list[dict]:
              WHERE processed_at IS NULL
                AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
                AND retry_count < $2
+               AND abandoned_at IS NULL
              ORDER BY next_attempt_at NULLS FIRST, id
              LIMIT $1
              FOR UPDATE SKIP LOCKED
         )
         UPDATE vector_delete_outbox o
-           SET next_attempt_at = NOW() + INTERVAL '10 minutes'
+           SET next_attempt_at = NOW() + INTERVAL '10 minutes',
+               claimed_at = NOW(),
+               retry_count = retry_count + 1
           FROM pending p
          WHERE o.id = p.id
-        RETURNING o.id, o.chunk_id, o.source_type, o.source_id, o.retry_count
+        RETURNING o.id, o.chunk_id, o.source_type, o.source_id,
+                  o.retry_count, o.claimed_at
         """,
         BATCH_SIZE, MAX_RETRIES,
     )
@@ -68,24 +72,51 @@ async def _claim_delete_batch(conn) -> list[dict]:
 
 async def _mark_delete_success(conn, outbox_id) -> None:
     await conn.execute(
-        "UPDATE vector_delete_outbox SET processed_at = NOW(), last_error = NULL WHERE id = $1",
+        """
+        UPDATE vector_delete_outbox
+           SET processed_at = NOW(), retry_count = 0, last_error = NULL,
+               next_attempt_at = NULL, claimed_at = NULL, abandoned_at = NULL
+         WHERE id = $1
+        """,
         outbox_id,
     )
 
 
-async def _mark_delete_failure(conn, outbox_id, retry_count: int, error: str) -> None:
-    delay = next_attempt_delay(retry_count)
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+async def _mark_delete_failure(conn, outbox_id, attempt_count: int, error: str) -> None:
+    terminal = attempt_count >= MAX_RETRIES
+    delay = next_attempt_delay(max(0, attempt_count - 1))
+    next_at = None if terminal else datetime.now(timezone.utc) + timedelta(seconds=delay)
     await conn.execute(
         """
         UPDATE vector_delete_outbox
-           SET retry_count = retry_count + 1,
-               last_error = $2,
-               next_attempt_at = $3
+           SET last_error = $2,
+               next_attempt_at = $3,
+               claimed_at = NULL,
+               abandoned_at = CASE WHEN $4 THEN NOW() ELSE NULL END
          WHERE id = $1
         """,
-        outbox_id, (error or "")[:500], next_at,
+        outbox_id, (error or "")[:500], next_at, terminal,
     )
+
+
+async def _release_unattempted(pool, rows: list[dict]) -> None:
+    if not rows:
+        return
+    claimed_at = rows[0]["claimed_at"]
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE vector_delete_outbox
+               SET retry_count = GREATEST(retry_count - 1, 0),
+                   next_attempt_at = NOW(), claimed_at = NULL
+             WHERE id = ANY($1::bigint[])
+               AND processed_at IS NULL
+               AND abandoned_at IS NULL
+               AND claimed_at = $2
+            """,
+            [row["id"] for row in rows],
+            claimed_at,
+        )
 
 
 async def _process_deletes_once() -> int:
@@ -104,7 +135,7 @@ async def _process_deletes_once() -> int:
     # outbox mark — outer rollback can no longer leave a dangling
     # vector_index row.
     succeeded = 0
-    for row in batch:
+    for position, row in enumerate(batch):
         try:
             async with pool.acquire() as conn:
                 async with conn.transaction():
@@ -114,6 +145,7 @@ async def _process_deletes_once() -> int:
             async with pool.acquire() as conn:
                 async with conn.transaction():
                     await _mark_delete_failure(conn, row["id"], row["retry_count"], str(e))
+            await _release_unattempted(pool, batch[position + 1:])
             return succeeded
         except Exception as e:  # noqa: BLE001
             async with pool.acquire() as conn:
@@ -194,7 +226,7 @@ async def _sweep_outbox_once() -> int:
 
 # ── Abandoned-chunk reaper ────────────────────────────────────────
 
-# A chunk is "abandoned" once vector_retry_count has hit MAX_RETRIES:
+# A chunk is "abandoned" once vector_abandoned_at is stamped:
 # the indexing worker has stopped picking it and it will sit in
 # `vector_indexed_at IS NULL` forever. Operators see them as a stuck
 # `indexing N` counter on the UI. After this grace window we delete
@@ -210,8 +242,7 @@ _last_reap_at: float = 0.0
 
 
 async def _reap_abandoned_chunks_once() -> int:
-    """Delete chunks whose `vector_retry_count >= MAX_RETRIES` and whose
-    last retry attempt was more than REAP_GRACE_INTERVAL ago. Enqueues
+    """Delete chunks abandoned for more than REAP_GRACE_INTERVAL. Enqueues
     them to `vector_delete_outbox` so this worker's normal delete pass
     removes them from the vector store too. Rate-limited."""
     global _last_reap_at
@@ -227,13 +258,10 @@ async def _reap_abandoned_chunks_once() -> int:
                 """
                 WITH abandoned AS (
                     SELECT id, source_type, source_id
-                      FROM chunks
+                     FROM chunks
                      WHERE vector_indexed_at IS NULL
-                       AND vector_retry_count >= $1
-                       AND (
-                           vector_next_attempt_at IS NULL
-                        OR vector_next_attempt_at < NOW() - $2::interval
-                       )
+                       AND vector_abandoned_at IS NOT NULL
+                       AND vector_abandoned_at < NOW() - $1::interval
                      FOR UPDATE SKIP LOCKED
                 ),
                 enqueued AS (
@@ -260,7 +288,7 @@ async def _reap_abandoned_chunks_once() -> int:
                 )
                 SELECT COUNT(*) FROM deleted
                 """,
-                MAX_RETRIES, REAP_GRACE_INTERVAL,
+                REAP_GRACE_INTERVAL,
             )
     n = int(n or 0)
     if n:
@@ -309,11 +337,10 @@ async def delete_outbox_stats() -> dict:
         row = await conn.fetchrow(
             """
             SELECT
-                COUNT(*) FILTER (WHERE processed_at IS NULL AND retry_count < $1)     AS pending,
-                COUNT(*) FILTER (WHERE processed_at IS NULL AND retry_count >= $1)    AS abandoned
+                COUNT(*) FILTER (WHERE processed_at IS NULL AND abandoned_at IS NULL)     AS pending,
+                COUNT(*) FILTER (WHERE processed_at IS NULL AND abandoned_at IS NOT NULL) AS abandoned
               FROM vector_delete_outbox
-            """,
-            MAX_RETRIES,
+            """
         )
     return {
         "pending":   int(row["pending"]),

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -348,6 +348,51 @@ class DocumentService:
         pool = await get_pool()
         return VaultRepository(pool), DocumentRepository(pool), CollectionRepository(pool)
 
+    @asynccontextmanager
+    async def _vault_creation_lock(self, name: str):
+        """Hold the storage-wide create/rollback mutex without blocking loop."""
+        acquire_task = asyncio.create_task(
+            asyncio.to_thread(self.git.acquire_vault_creation_lock, name),
+            name=f"vault-create-lock:{name}",
+        )
+        try:
+            fd = await asyncio.shield(acquire_task)
+        except BaseException:
+            # A thread blocked in flock cannot be cancelled. Settle it, then
+            # release the acquired fd before propagating cancellation/error.
+            while not acquire_task.done():
+                try:
+                    await asyncio.shield(acquire_task)
+                except asyncio.CancelledError:
+                    continue
+                except BaseException:
+                    break
+            if not acquire_task.cancelled() and acquire_task.exception() is None:
+                await asyncio.to_thread(
+                    self.git.release_vault_creation_lock,
+                    acquire_task.result(),
+                )
+            raise
+        try:
+            yield
+        finally:
+            # Unlock is tiny but still a filesystem operation on the mounted
+            # lock file; settle it even if shutdown cancellation is repeated.
+            release_task = asyncio.create_task(
+                asyncio.to_thread(self.git.release_vault_creation_lock, fd),
+                name=f"vault-create-unlock:{name}",
+            )
+            pending_cancel: asyncio.CancelledError | None = None
+            while not release_task.done():
+                try:
+                    await asyncio.shield(release_task)
+                except asyncio.CancelledError as exc:
+                    pending_cancel = exc
+                    continue
+            release_task.result()
+            if pending_cancel is not None:
+                raise pending_cancel
+
     async def _resolve_author_name(self, created_by: str | None) -> str | None:
         """Resolve a `created_by` token to a human display name for the UI.
 
@@ -1983,8 +2028,9 @@ class DocumentService:
         # vaults row exists. BaseException so SIGTERM and
         # KeyboardInterrupt also unwind cleanly.
         #
-        # `_create_lock(name)` serializes same-name creates in-process for
-        # the WHOLE section including rollback. Without it the ownership
+        # `_create_lock(name)` is the cheap in-process gate; the nested
+        # storage-backed creation lock serializes the WHOLE section including
+        # rollback across API/worker processes. Without the outer ownership
         # probe below is unsound: A and B race the same name, A's init
         # wins, B's fails, and B's rollback would see the dir "appear
         # during its attempt" and delete A's repo. (Distinct from the
@@ -1998,20 +2044,21 @@ class DocumentService:
         # vault's repo. Only ever clean up a directory this request
         # itself brought into existence — and under the create lock,
         # "appeared during this section and wasn't there before" implies
-        # exactly that.
+        # exactly that. Both gates are intentionally held through compensation.
         async with _create_lock(name):
-            return await self._create_vault_standard(
-                name=name, description=description, template=template,
-                public_access=public_access, owner_id=owner_id, uid=uid,
-                external_git=external_git, vault_repo=vault_repo,
-                coll_repo=coll_repo,
-            )
+            async with self._vault_creation_lock(name):
+                return await self._create_vault_standard(
+                    name=name, description=description, template=template,
+                    public_access=public_access, owner_id=owner_id, uid=uid,
+                    external_git=external_git, vault_repo=vault_repo,
+                    coll_repo=coll_repo,
+                )
 
     async def _create_vault_standard(
         self, *, name, description, template, public_access, owner_id, uid,
         external_git, vault_repo, coll_repo,
     ) -> str:
-        existed_before = self.git.vault_exists(name)
+        existed_before = await asyncio.to_thread(self.git.vault_exists, name)
         git_path: str | None = None
         created_vault_id: uuid.UUID | None = None
         try:
@@ -2139,10 +2186,13 @@ class DocumentService:
         `git_path is not None` covers the normal case; the extra
         vault_exists() probe covers an absorbed-cancel during init where
         the thread completed but the coroutine never received git_path —
-        sound only because `_create_lock(name)` excludes concurrent
-        same-name creates.
+        sound because `_vault_creation_lock(name)` excludes concurrent
+        same-name creates across every process sharing the storage volume.
         """
-        if existed_before or (git_path is None and not self.git.vault_exists(name)):
+        if existed_before or (
+            git_path is None
+            and not await asyncio.to_thread(self.git.vault_exists, name)
+        ):
             return
         try:
             # Commit executor: cleanup blocks on the vault threading.Lock

--- a/backend/app/services/embed_worker.py
+++ b/backend/app/services/embed_worker.py
@@ -65,17 +65,20 @@ async def _claim_batch(conn) -> list[dict]:
              WHERE vector_indexed_at IS NULL
                AND (vector_next_attempt_at IS NULL OR vector_next_attempt_at <= NOW())
                AND vector_retry_count < $2
+               AND vector_abandoned_at IS NULL
              ORDER BY created_at DESC, id
              LIMIT $1
              FOR UPDATE SKIP LOCKED
         )
         UPDATE chunks c
-           SET vector_next_attempt_at = NOW() + INTERVAL '10 minutes'
+           SET vector_next_attempt_at = NOW() + INTERVAL '10 minutes',
+               vector_claimed_at = NOW(),
+               vector_retry_count = vector_retry_count + 1
           FROM pending p
          WHERE c.id = p.id
         RETURNING c.id, c.source_type, c.source_id, c.vault_id,
                   c.content, c.section_path, c.chunk_index,
-                  c.vector_retry_count
+                  c.vector_retry_count, c.vector_claimed_at
         """,
         _batch_size(), MAX_RETRIES,
     )
@@ -87,32 +90,59 @@ async def _mark_success(conn, chunk_id) -> None:
         """
         UPDATE chunks
            SET vector_indexed_at = NOW(),
+               vector_retry_count = 0,
                vector_last_error = NULL,
-               vector_next_attempt_at = NULL
+               vector_next_attempt_at = NULL,
+               vector_claimed_at = NULL,
+               vector_abandoned_at = NULL
          WHERE id = $1
         """,
         chunk_id,
     )
 
 
-async def _mark_failure(pool, chunk_id, retry_count: int, error: str) -> None:
+async def _mark_failure(pool, chunk_id, attempt_count: int, error: str) -> None:
     """Failures own a tiny transaction of their own. Done outside the
     upsert path so a single chunk's failure can't poison the rest of
     the batch."""
-    delay = next_attempt_delay(retry_count)
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+    terminal = attempt_count >= MAX_RETRIES
+    delay = next_attempt_delay(max(0, attempt_count - 1))
+    next_at = None if terminal else datetime.now(timezone.utc) + timedelta(seconds=delay)
     async with pool.acquire() as c:
         async with c.transaction():
             await c.execute(
                 """
                 UPDATE chunks
-                   SET vector_retry_count = vector_retry_count + 1,
-                       vector_last_error = $2,
-                       vector_next_attempt_at = $3
+                   SET vector_last_error = $2,
+                       vector_next_attempt_at = $3,
+                       vector_claimed_at = NULL,
+                       vector_abandoned_at = CASE WHEN $4 THEN NOW() ELSE NULL END
                  WHERE id = $1
                 """,
-                chunk_id, (error or "")[:500], next_at,
+                chunk_id, (error or "")[:500], next_at, terminal,
             )
+
+
+async def _release_unattempted(pool, rows: list[dict]) -> None:
+    """Return claim budget for rows skipped after a batch-wide outage."""
+    if not rows:
+        return
+    claimed_at = rows[0]["vector_claimed_at"]
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE chunks
+               SET vector_retry_count = GREATEST(vector_retry_count - 1, 0),
+                   vector_next_attempt_at = NOW(),
+                   vector_claimed_at = NULL
+             WHERE id = ANY($1::uuid[])
+               AND vector_indexed_at IS NULL
+               AND vector_abandoned_at IS NULL
+               AND vector_claimed_at = $2
+            """,
+            [row["id"] for row in rows],
+            claimed_at,
+        )
 
 
 async def _process_once() -> int:
@@ -202,7 +232,7 @@ async def _process_once() -> int:
     # longer leave the vector store with an unmarked row.
     store = get_vector_store()
     succeeded = 0
-    for row, dense in zip(batch, embeddings_padded):
+    for position, (row, dense) in enumerate(zip(batch, embeddings_padded)):
         content = row["content"] or ""
         try:
             sparse_idx, sparse_vals = await sparse_encoder.encode_document(content)
@@ -271,6 +301,7 @@ async def _process_once() -> int:
             # so we don't hammer it. Remaining rows already have
             # next_attempt_at set by _claim_batch.
             logger.info("vector store unavailable; backing off batch: %s", e)
+            await _release_unattempted(pool, batch[position + 1:])
             return native_processed + succeeded
         except Exception as e:  # noqa: BLE001
             await _mark_failure(
@@ -318,28 +349,29 @@ async def pending_stats(vault_id=None) -> dict:
             chunk_row = await conn.fetchrow(
                 """
                 SELECT
-                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL)                                          AS pending,
+                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_abandoned_at IS NULL)          AS pending,
                     COUNT(*) FILTER (WHERE vector_indexed_at IS NULL
-                                     AND vector_retry_count > 0 AND vector_retry_count < $1)                    AS retrying,
-                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_retry_count >= $1)             AS abandoned,
+                                     AND vector_abandoned_at IS NULL
+                                     AND vector_retry_count > 0)                                                AS retrying,
+                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_abandoned_at IS NOT NULL)       AS abandoned,
                     COUNT(*) FILTER (WHERE vector_indexed_at IS NOT NULL)                                       AS indexed
                   FROM chunks
                 """,
-                MAX_RETRIES,
             )
         else:
             chunk_row = await conn.fetchrow(
                 """
                 SELECT
-                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL)                                          AS pending,
+                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_abandoned_at IS NULL)          AS pending,
                     COUNT(*) FILTER (WHERE vector_indexed_at IS NULL
-                                     AND vector_retry_count > 0 AND vector_retry_count < $1)                    AS retrying,
-                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_retry_count >= $1)             AS abandoned,
+                                     AND vector_abandoned_at IS NULL
+                                     AND vector_retry_count > 0)                                                AS retrying,
+                    COUNT(*) FILTER (WHERE vector_indexed_at IS NULL AND vector_abandoned_at IS NOT NULL)       AS abandoned,
                     COUNT(*) FILTER (WHERE vector_indexed_at IS NOT NULL)                                       AS indexed
                   FROM chunks
-                 WHERE vault_id = $2
+                 WHERE vault_id = $1
                 """,
-                MAX_RETRIES, vault_id,
+                vault_id,
             )
 
     stats = {

--- a/backend/app/services/events_publisher.py
+++ b/backend/app/services/events_publisher.py
@@ -95,16 +95,20 @@ async def _claim_batch(conn) -> list[dict]:
              WHERE redis_published_at IS NULL
                AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
                AND attempts < $2
+               AND abandoned_at IS NULL
              ORDER BY next_attempt_at NULLS FIRST, id
              LIMIT $1
              FOR UPDATE SKIP LOCKED
         )
         UPDATE events e
-           SET next_attempt_at = NOW() + INTERVAL '10 minutes'
+           SET next_attempt_at = NOW() + INTERVAL '10 minutes',
+               claimed_at = NOW(),
+               attempts = attempts + 1
           FROM pending p
          WHERE e.id = p.id
         RETURNING e.id, e.occurred_at, e.vault_id, e.kind,
-                  e.resource_uri, e.actor_id, e.payload, e.attempts
+                  e.resource_uri, e.actor_id, e.payload, e.attempts,
+                  e.claimed_at
         """,
         BATCH_SIZE, MAX_RETRIES,
     )
@@ -116,26 +120,49 @@ async def _mark_published(conn, event_id: int) -> None:
         """
         UPDATE events
            SET redis_published_at = NOW(),
+               attempts = 0,
                last_error = NULL,
-               next_attempt_at = NULL
+               next_attempt_at = NULL,
+               claimed_at = NULL,
+               abandoned_at = NULL
          WHERE id = $1
         """,
         event_id,
     )
 
 
-async def _mark_failure(conn, event_id: int, attempts: int, error: str) -> None:
-    delay = next_attempt_delay(attempts)
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+async def _mark_failure(conn, event_id: int, attempt_count: int, error: str) -> None:
+    terminal = attempt_count >= MAX_RETRIES
+    delay = next_attempt_delay(max(0, attempt_count - 1))
+    next_at = None if terminal else datetime.now(timezone.utc) + timedelta(seconds=delay)
     await conn.execute(
         """
         UPDATE events
-           SET attempts = attempts + 1,
-               last_error = $2,
-               next_attempt_at = $3
+           SET last_error = $2,
+               next_attempt_at = $3,
+               claimed_at = NULL,
+               abandoned_at = CASE WHEN $4 THEN NOW() ELSE NULL END
          WHERE id = $1
         """,
-        event_id, (error or "")[:500], next_at,
+        event_id, (error or "")[:500], next_at, terminal,
+    )
+
+
+async def _release_unattempted(conn, rows: list[dict]) -> None:
+    if not rows:
+        return
+    await conn.execute(
+        """
+        UPDATE events
+           SET attempts = GREATEST(attempts - 1, 0),
+               next_attempt_at = NOW(), claimed_at = NULL
+         WHERE id = ANY($1::bigint[])
+           AND redis_published_at IS NULL
+           AND abandoned_at IS NULL
+           AND claimed_at = $2
+        """,
+        [row["id"] for row in rows],
+        rows[0]["claimed_at"],
     )
 
 
@@ -190,12 +217,18 @@ async def _process_once() -> int:
         try:
             client = await _client()
         except Exception as e:  # noqa: BLE001
-            for row in batch:
-                await _mark_failure(conn, row["id"], row["attempts"], f"redis client init: {e}")
+            # The connection attempt represents work on one row, not all rows
+            # claimed with it. Preserve the first row's failure/backoff and
+            # return claim credit for the untouched remainder.
+            first, *unattempted = batch
+            await _mark_failure(
+                conn, first["id"], first["attempts"], f"redis client init: {e}",
+            )
+            await _release_unattempted(conn, unattempted)
             return 0
 
         succeeded = 0
-        for row in batch:
+        for position, row in enumerate(batch):
             fields = _xadd_fields(row)
             try:
                 # redis-py's xadd stub takes the wider
@@ -215,6 +248,7 @@ async def _process_once() -> int:
                 # one and short-circuit so we don't hammer a downed
                 # broker. Loop's idle backoff then kicks in.
                 await _mark_failure(conn, row["id"], row["attempts"], str(e))
+                await _release_unattempted(conn, batch[position + 1:])
                 logger.warning("XADD failed for event %s: %s", row["id"], e)
                 # Drop the cached client so the next tick reconnects;
                 # otherwise a dead connection sticks around.
@@ -291,14 +325,14 @@ async def pending_stats() -> dict:
         row = await conn.fetchrow(
             """
             SELECT
-                COUNT(*) FILTER (WHERE redis_published_at IS NULL AND attempts < $1)     AS pending,
+                COUNT(*) FILTER (WHERE redis_published_at IS NULL AND abandoned_at IS NULL) AS pending,
                 COUNT(*) FILTER (WHERE redis_published_at IS NULL
-                                 AND attempts > 0 AND attempts < $1)                      AS retrying,
-                COUNT(*) FILTER (WHERE redis_published_at IS NULL AND attempts >= $1)     AS abandoned,
+                                 AND abandoned_at IS NULL AND attempts > 0)                AS retrying,
+                COUNT(*) FILTER (WHERE redis_published_at IS NULL
+                                 AND abandoned_at IS NOT NULL)                             AS abandoned,
                 COUNT(*) FILTER (WHERE redis_published_at IS NOT NULL)                    AS published
               FROM events
-            """,
-            MAX_RETRIES,
+            """
         )
     return {
         "pending":   int(row["pending"]),

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1157,8 +1157,13 @@ async def index_file_metadata(
     )
     pool = await get_pool()
     async with pool.acquire() as conn:
-        await write_source_chunks(
-            conn, "file", file_id,
-            vault_id=vault_id,
-            chunks=[chunk],
-        )
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"akb:index:file:{file_id}",
+            )
+            await write_source_chunks(
+                conn, "file", file_id,
+                vault_id=vault_id,
+                chunks=[chunk],
+            )

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -11,7 +11,8 @@ Writes go through a persistent per-vault worktree linked to the bare repo
 (`git worktree add`). No clone-per-commit, no push. The worktree shares
 the object store with bare, so commits in the worktree update the bare's
 refs directly. Concurrent writes against the same worktree are serialized
-by a per-vault threading lock.
+by both a per-process threading lock and a storage-backed ``flock``; the final
+ref update is compare-and-swap against the exact parent commit.
 
 Every external-mirror git command — the three network sinks (clone_mirror /
 fetch_remote / ls_remote_head) *and* every local read on a mirror bare repo
@@ -25,6 +26,7 @@ environment, pins DNS, and blocks non-https transports. See
 
 from __future__ import annotations
 
+import fcntl
 import logging
 import os
 import re
@@ -35,6 +37,8 @@ import subprocess
 import threading
 import time
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -54,6 +58,30 @@ from app.util.errors import (
 )
 
 logger = logging.getLogger("akb.git")
+
+
+@contextmanager
+def _managed_repo(repo: Repo) -> Iterator[Repo]:
+    """Deterministically release GitPython's persistent command processes.
+
+    GitPython keeps ``git cat-file --batch`` helpers in each ``Repo`` object.
+    Relying on ``Repo.__del__`` leaves those helpers alive until cyclic garbage
+    collection happens, which is unbounded in a long-running API process.  A
+    cleanup failure is logged instead of replacing the result of a completed
+    mutation with an ambiguous error response.
+    """
+    try:
+        yield repo
+    finally:
+        try:
+            repo.close()
+        except Exception:  # noqa: BLE001 - cleanup must not mask the operation
+            logger.warning(
+                "Failed to close GitPython repository handle for %s",
+                getattr(repo, "working_dir", None) or getattr(repo, "git_dir", "unknown"),
+                exc_info=True,
+            )
+
 
 # Sentinel file dropped at the bare-repo root by ``clone_mirror`` to mark a vault
 # as an external-git mirror. It is written by us — never by upstream
@@ -247,6 +275,10 @@ class GitService:
         self.storage_path.mkdir(parents=True, exist_ok=True)
         self.worktrees_path = self.storage_path / "_worktrees"
         self.worktrees_path.mkdir(parents=True, exist_ok=True)
+        self.write_locks_path = self.storage_path / ".akb-write-locks"
+        self.write_locks_path.mkdir(parents=True, exist_ok=True)
+        self.creation_locks_path = self.storage_path / ".akb-create-locks"
+        self.creation_locks_path.mkdir(parents=True, exist_ok=True)
         # The sole hermetic execution boundary for external-mirror git commands.
         # Injectable so tests can supply a policy/resolver that
         # accepts a local fixture host.
@@ -267,6 +299,51 @@ class GitService:
         # Same universal name guard as ``_bare_path``.
         self._require_safe_vault_name(vault_name)
         return self.worktrees_path / vault_name
+
+    @contextmanager
+    def _vault_write_lock(self, vault_name: str):
+        """Serialize one shared worktree across threads and processes.
+
+        Ref CAS cannot protect files or the shared index between ``reset`` and
+        ``write-tree``. The lock file lives on the same mounted storage as the
+        worktree, making that full interval mutually exclusive for every AKB
+        process with write access to the volume.
+        """
+        self._require_safe_vault_name(vault_name)
+        lock_path = self.write_locks_path / f"{vault_name}.lock"
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        with _vault_lock(vault_name):
+            fd = os.open(lock_path, flags, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                yield
+            finally:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                finally:
+                    os.close(fd)
+
+    def acquire_vault_creation_lock(self, vault_name: str) -> int:
+        """Acquire the cross-process lock spanning create *and rollback*."""
+        self._require_safe_vault_name(vault_name)
+        lock_path = self.creation_locks_path / f"{vault_name}.lock"
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(lock_path, flags, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except BaseException:
+            os.close(fd)
+            raise
+        return fd
+
+    @staticmethod
+    def release_vault_creation_lock(fd: int) -> None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
     def _mirror_bare(self, vault_name: str) -> Path:
         """Resolve a mirror's bare path for a READ, fail-CLOSED on a symlinked
@@ -420,7 +497,7 @@ class GitService:
         unforgeable.
         """
         bare = self._bare_path(vault_name)
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             # Absent bare → nothing to do; a bare that exists but is NOT a real
             # directory (a symlink, or a plain file) is fail-closed — a
             # symlinked bare could redirect the marker write out of storage.
@@ -494,9 +571,20 @@ class GitService:
         """
         tree_sha = work_repo.git.write_tree(**_write_kt())
         parent_args: list[str] = []
+        expected_old = "0" * 40
         if parent_required:
-            work_repo.git.rev_parse("--verify", "HEAD", **_write_kt())
-            parent_args = ["-p", "HEAD"]
+            expected_old = work_repo.git.rev_parse(
+                "--verify",
+                "HEAD",
+                **_write_kt(),
+            ).strip()
+            parent_tree = work_repo.git.rev_parse(
+                f"{expected_old}^{{tree}}",
+                **_write_kt(),
+            ).strip()
+            if tree_sha.strip() == parent_tree:
+                return expected_old
+            parent_args = ["-p", expected_old]
 
         with work_repo.git.custom_environment(**self._git_author_env(author_name, author_email)):
             commit_sha = work_repo.git.commit_tree(
@@ -507,8 +595,10 @@ class GitService:
                 message,
                 **_write_kt(),
             ).strip()
-        work_repo.git.update_ref("HEAD", commit_sha, **_write_kt())
-        return work_repo.git.rev_parse("HEAD", **_write_kt()).strip()
+        # Compare-and-swap the branch tip. A concurrent writer that advanced
+        # HEAD after the parent snapshot makes this command fail loudly.
+        work_repo.git.update_ref("HEAD", commit_sha, expected_old, **_write_kt())
+        return commit_sha
 
     def _ensure_worktree(self, vault_name: str) -> Path | None:
         """Create a persistent worktree for this vault if one doesn't exist.
@@ -521,44 +611,52 @@ class GitService:
         wt = self._worktree_path(vault_name)
         if (wt / ".git").exists():
             return wt
-        bare_repo = Repo(str(bare))
-        try:
-            # Touch HEAD to see if there's at least one commit.
-            _ = bare_repo.head.commit
-            branch_name = bare_repo.head.ref.name
-        except (ValueError, TypeError, GitError):
-            return None  # empty repo; caller falls back to the clone path
-        wt.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
-        except GitError as e:
-            # A previous `worktree add` killed mid-write (SIGKILL, OOM,
-            # container restart) can leave the bare's
-            # `.git/worktrees/<name>/` metadata half-written. The next
-            # call fails with "<name> is already registered" even though
-            # the on-disk worktree dir is gone. `git worktree prune`
-            # reaps those stale registrations; retry once after pruning.
-            msg = str(e)
-            if "already registered" not in msg:
-                raise
-            logger.warning(
-                "worktree add for vault %s tripped stale registration; pruning and retrying: %s",
-                vault_name, msg,
+        with _managed_repo(Repo(str(bare))) as bare_repo:
+            try:
+                # Touch HEAD to see if there's at least one commit.
+                _ = bare_repo.head.commit
+                branch_name = bare_repo.head.ref.name
+            except (ValueError, TypeError, GitError):
+                return None  # empty repo; caller falls back to the clone path
+            wt.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
+            except GitError as e:
+                # A previous `worktree add` killed mid-write (SIGKILL, OOM,
+                # container restart) can leave the bare's
+                # `.git/worktrees/<name>/` metadata half-written. The next
+                # call fails with "<name> is already registered" even though
+                # the on-disk worktree dir is gone. `git worktree prune`
+                # reaps those stale registrations; retry once after pruning.
+                msg = str(e)
+                if "already registered" not in msg:
+                    raise
+                logger.warning(
+                    "worktree add for vault %s tripped stale registration; pruning and retrying: %s",
+                    vault_name,
+                    msg,
+                )
+                bare_repo.git.worktree("prune", **_write_kt())
+                bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
+            logger.info(
+                "Worktree created for vault %s at %s (branch=%s)",
+                vault_name,
+                wt,
+                branch_name,
             )
-            bare_repo.git.worktree("prune", **_write_kt())
-            bare_repo.git.worktree("add", str(wt), branch_name, **_write_kt())
-        logger.info("Worktree created for vault %s at %s (branch=%s)", vault_name, wt, branch_name)
-        return wt
+            return wt
 
     # ── Vault lifecycle ──────────────────────────────────────
 
     def init_vault(self, vault_name: str) -> str:
         """Initialize a new bare repo for a vault. Returns the repo path."""
-        bare_path = self._bare_path(vault_name)
-        if bare_path.exists():
-            raise FileExistsError(f"Vault already exists: {vault_name}")
-        Repo.init(str(bare_path), bare=True)
-        return str(bare_path)
+        with self._vault_write_lock(vault_name):
+            bare_path = self._bare_path(vault_name)
+            if bare_path.exists():
+                raise FileExistsError(f"Vault already exists: {vault_name}")
+            with _managed_repo(Repo.init(str(bare_path), bare=True)):
+                pass
+            return str(bare_path)
 
     def vault_exists(self, vault_name: str) -> bool:
         return self._bare_path(vault_name).exists()
@@ -587,7 +685,7 @@ class GitService:
         if not bare.exists():
             return False
         try:
-            with _vault_lock(vault_name):
+            with self._vault_write_lock(vault_name):
                 # Through the hermetic runner so GIT_NO_REPLACE_OBJECTS / sealed
                 # env apply on the mirror path — never a raw
                 # GitPython Repo on an external mirror. HEAD must resolve to a real
@@ -713,8 +811,8 @@ class GitService:
         own try/except so a rollback failure doesn't hide the
         original exception.
 
-        Held under `_vault_lock(vault_name)` so teardown serializes with
-        any in-flight clone/fetch/commit on the same vault. This is the
+        Held under `_vault_write_lock(vault_name)` so teardown serializes with
+        any in-flight clone/fetch/commit on the same vault across processes. This is the
         only git-touching op that mutates the on-disk repo outside the
         lock, so without it a `delete_vault` rmtree can race a poller
         `clone_mirror` writing the same bare dir — leaving a partial /
@@ -732,7 +830,7 @@ class GitService:
         possibly outside the storage root); the link itself is removed instead.
         """
         self._require_safe_vault_name(vault_name)
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             for path in (self._bare_path(vault_name), self._worktree_path(vault_name)):
                 # lstat (never stat): classify the artefact WITHOUT following a
                 # symlink at the final component.
@@ -779,7 +877,7 @@ class GitService:
         bare_path = self._bare_path(vault_name)
         if bare_path.exists():
             raise FileExistsError(f"Vault already exists: {vault_name}")
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             # Age-qualified sweep INSIDE the lock: only reap leftover
             # temp clone dirs older than the clone timeout, so a concurrent
             # same-vault clone's ACTIVE temp is never deleted. Same-vault clones
@@ -850,7 +948,7 @@ class GitService:
         )
 
         # Brief critical section: promote tmp ref → branch ref, read the sha.
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             self._ext_runner.update_ref(bare_path, f"refs/heads/{vbranch}", tmp_ref)
             self._ext_runner.delete_ref_quiet(bare_path, tmp_ref)
             return self._ext_runner.rev_parse(bare_path, f"refs/heads/{vbranch}")
@@ -1062,27 +1160,26 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._read_file_mirror(vault_name, file_path, commit)
-        repo = self._get_repo(vault_name)
-        from git.exc import BadName, BadObject
-        try:
-            ref = repo.commit(commit) if commit else repo.head.commit
-        except (ValueError, BadName, BadObject):
-            # Empty repo, malformed hash, or hash unknown to this repo.
-            return None
-        try:
-            blob = ref.tree / file_path
-            return blob.data_stream.read().decode("utf-8")
-        except (KeyError, TypeError):
-            if commit is None:
+        with _managed_repo(self._get_repo(vault_name)) as repo:
+            try:
+                ref = repo.commit(commit) if commit else repo.head.commit
+            except (ValueError, BadName, BadObject):
+                # Empty repo, malformed hash, or hash unknown to this repo.
                 return None
-            historical_path = self.path_at_revision(vault_name, file_path, commit)
-            if historical_path and historical_path != file_path:
-                try:
-                    blob = ref.tree / historical_path
-                    return blob.data_stream.read().decode("utf-8")
-                except (KeyError, TypeError):
-                    pass
-            return None
+            try:
+                blob = ref.tree / file_path
+                return blob.data_stream.read().decode("utf-8")
+            except (KeyError, TypeError):
+                if commit is None:
+                    return None
+                historical_path = self.path_at_revision(vault_name, file_path, commit)
+                if historical_path and historical_path != file_path:
+                    try:
+                        blob = ref.tree / historical_path
+                        return blob.data_stream.read().decode("utf-8")
+                    except (KeyError, TypeError):
+                        pass
+                return None
 
     @staticmethod
     def _parse_follow_path_log(output: str) -> list[dict]:
@@ -1326,12 +1423,12 @@ class GitService:
         if self._use_mirror_reader(vault_name):
             return None
         try:
-            repo = self._get_repo(vault_name)
-            target = repo.commit(commit).hexsha
-            fixed_ref = repo.head.commit.hexsha
+            with _managed_repo(self._get_repo(vault_name)) as repo:
+                target = repo.commit(commit).hexsha
+                fixed_ref = repo.head.commit.hexsha
+                return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
         except (BadName, BadObject, FileNotFoundError, ValueError):
             return None
-        return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
 
     def manual_fixed_ref_history(
         self,
@@ -1363,7 +1460,30 @@ class GitService:
             raise FixedRefHistoryError("fixed-ref history is limited to manual vaults")
 
         try:
-            repo = self._get_repo(vault_name)
+            with _managed_repo(self._get_repo(vault_name)) as repo:
+                return self._manual_fixed_ref_history_with_repo(
+                    repo,
+                    fixed_ref,
+                    file_path,
+                    current_commit=current_commit,
+                    since_epoch=since_epoch,
+                )
+        except FileNotFoundError as exc:
+            raise FixedRefHistoryError(
+                "fixed-ref history could not resolve the requested commit or body"
+            ) from exc
+
+    def _manual_fixed_ref_history_with_repo(
+        self,
+        repo: Repo,
+        fixed_ref: str,
+        file_path: str,
+        *,
+        current_commit: str,
+        since_epoch: int | None,
+    ) -> dict:
+        """Implementation kept inside ``manual_fixed_ref_history``'s Repo scope."""
+        try:
             repo.commit(fixed_ref)
             current = repo.commit(current_commit)
             repo.git.merge_base("--is-ancestor", current_commit, fixed_ref)
@@ -1669,21 +1789,21 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._list_files_mirror(vault_name, directory, extension)
-        repo = self._get_repo(vault_name)
-        try:
-            tree = repo.head.commit.tree
-        except ValueError:
-            return []
-
-        if directory:
+        with _managed_repo(self._get_repo(vault_name)) as repo:
             try:
-                tree = tree / directory
-            except KeyError:
+                tree = repo.head.commit.tree
+            except ValueError:
                 return []
 
-        results: list[str] = []
-        self._walk_tree(tree, directory, extension, results)
-        return results
+            if directory:
+                try:
+                    tree = tree / directory
+                except KeyError:
+                    return []
+
+            results: list[str] = []
+            self._walk_tree(tree, directory, extension, results)
+            return results
 
     def _walk_tree(self, tree, prefix: str, extension: str, results: list[str]) -> None:
         for item in tree:
@@ -1724,23 +1844,23 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._list_directories_mirror(vault_name, parent)
-        repo = self._get_repo(vault_name)
-        try:
-            tree = repo.head.commit.tree
-        except ValueError:
-            return []
-
-        if parent:
+        with _managed_repo(self._get_repo(vault_name)) as repo:
             try:
-                tree = tree / parent
-            except KeyError:
+                tree = repo.head.commit.tree
+            except ValueError:
                 return []
 
-        return [
-            item.name
-            for item in tree
-            if item.type == "tree" and not item.name.startswith(".")
-        ]
+            if parent:
+                try:
+                    tree = tree / parent
+                except KeyError:
+                    return []
+
+            return [
+                item.name
+                for item in tree
+                if item.type == "tree" and not item.name.startswith(".")
+            ]
 
     def _list_directories_mirror(self, vault_name: str, parent: str) -> list[str]:
         """Hermetic-runner equivalent of ``list_directories`` for a mirror: the
@@ -1785,30 +1905,30 @@ class GitService:
         back to clone-and-push only when the bare is empty (no HEAD to
         attach the worktree to — happens once at vault creation).
         """
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 return self._commit_via_clone(vault_name, file_path, content, message, author_name, author_email)
 
-            work_repo = Repo(str(wt))
-            # Defensive: if anything left the worktree dirty or behind the
-            # bare ref (e.g., a previous crash mid-commit), sync to HEAD
-            # before writing. With a single writer this is a no-op in the
-            # steady state.
-            work_repo.git.reset("--hard", "HEAD", **_write_kt())
+            with _managed_repo(Repo(str(wt))) as work_repo:
+                # Defensive: if anything left the worktree dirty or behind the
+                # bare ref (e.g., a previous crash mid-commit), sync to HEAD
+                # before writing. With a single writer this is a no-op in the
+                # steady state.
+                work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
-            full_path = wt / file_path
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_text(content, encoding="utf-8")
+                full_path = wt / file_path
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text(content, encoding="utf-8")
 
-            work_repo.git.add("--", file_path, **_write_kt())
-            return self._stage_and_commit(
-                work_repo,
-                message,
-                author_name,
-                author_email,
-                parent_required=True,
-            )
+                work_repo.git.add("--", file_path, **_write_kt())
+                return self._stage_and_commit(
+                    work_repo,
+                    message,
+                    author_name,
+                    author_email,
+                    parent_required=True,
+                )
 
     def delete_file(
         self,
@@ -1819,26 +1939,26 @@ class GitService:
         author_email: str = "akb@system",
     ) -> str:
         """Delete a file and commit. Returns the commit hash."""
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 raise FileNotFoundError(f"File not found in vault: {file_path}")
 
-            work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD", **_write_kt())
+            with _managed_repo(Repo(str(wt))) as work_repo:
+                work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
-            full_path = wt / file_path
-            if not full_path.exists():
-                raise FileNotFoundError(f"File not found in vault: {file_path}")
+                full_path = wt / file_path
+                if not full_path.exists():
+                    raise FileNotFoundError(f"File not found in vault: {file_path}")
 
-            work_repo.git.rm("--", file_path, **_write_kt())
-            return self._stage_and_commit(
-                work_repo,
-                message,
-                author_name,
-                author_email,
-                parent_required=True,
-            )
+                work_repo.git.rm("--", file_path, **_write_kt())
+                return self._stage_and_commit(
+                    work_repo,
+                    message,
+                    author_name,
+                    author_email,
+                    parent_required=True,
+                )
 
     def move_file(
         self,
@@ -1858,34 +1978,34 @@ class GitService:
         """
         if old_path == new_path:
             raise ValueError("move_file: old_path and new_path are identical")
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 raise FileNotFoundError(f"File not found in vault: {old_path}")
 
-            work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD", **_write_kt())
+            with _managed_repo(Repo(str(wt))) as work_repo:
+                work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
-            src = wt / old_path
-            if not src.exists():
-                raise FileNotFoundError(f"File not found in vault: {old_path}")
-            dst = wt / new_path
-            # A case-only rename ("File.md" -> "file.md") on a case-INSENSITIVE
-            # filesystem (macOS APFS/HFS+) makes dst.exists() report True even
-            # though src and dst are the SAME inode. Allow that; only a genuine
-            # different file at the destination is a conflict.
-            if dst.exists() and not src.samefile(dst):
-                raise FileExistsError(f"Destination already exists in vault: {new_path}")
-            dst.parent.mkdir(parents=True, exist_ok=True)
+                src = wt / old_path
+                if not src.exists():
+                    raise FileNotFoundError(f"File not found in vault: {old_path}")
+                dst = wt / new_path
+                # A case-only rename ("File.md" -> "file.md") on a case-INSENSITIVE
+                # filesystem (macOS APFS/HFS+) makes dst.exists() report True even
+                # though src and dst are the SAME inode. Allow that; only a genuine
+                # different file at the destination is a conflict.
+                if dst.exists() and not src.samefile(dst):
+                    raise FileExistsError(f"Destination already exists in vault: {new_path}")
+                dst.parent.mkdir(parents=True, exist_ok=True)
 
-            work_repo.git.mv("--", old_path, new_path, **_write_kt())
-            return self._stage_and_commit(
-                work_repo,
-                message,
-                author_name,
-                author_email,
-                parent_required=True,
-            )
+                work_repo.git.mv("--", old_path, new_path, **_write_kt())
+                return self._stage_and_commit(
+                    work_repo,
+                    message,
+                    author_name,
+                    author_email,
+                    parent_required=True,
+                )
 
     def current_commit(self, vault_name: str) -> str | None:
         """Return the vault's current HEAD commit hash, or None if the bare repo
@@ -1903,7 +2023,8 @@ class GitService:
             except Exception:  # noqa: BLE001 — no HEAD yet / unreadable
                 return None
         try:
-            return self._get_repo(vault_name).head.commit.hexsha
+            with _managed_repo(self._get_repo(vault_name)) as repo:
+                return repo.head.commit.hexsha
         except Exception:  # noqa: BLE001 — repo missing or no HEAD yet (empty repo)
             return None
 
@@ -1928,35 +2049,35 @@ class GitService:
         Mirrors `delete_file`'s lock + worktree-prep + commit shape.
         Returns the new commit's hex SHA, or `None` when no commit was made.
         """
-        with _vault_lock(vault_name):
+        with self._vault_write_lock(vault_name):
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 # Empty bare repo or missing vault — nothing to delete.
                 return None
 
-            work_repo = Repo(str(wt))
-            work_repo.git.reset("--hard", "HEAD", **_write_kt())
+            with _managed_repo(Repo(str(wt))) as work_repo:
+                work_repo.git.reset("--hard", "HEAD", **_write_kt())
 
-            # Dedupe while preserving caller order so log output is stable
-            # and so a doubled path doesn't make `git rm` fail on
-            # the second occurrence.
-            unique_paths = list(dict.fromkeys(file_paths))
-            present = [p for p in unique_paths if (wt / p).exists()]
-            if not present:
-                logger.debug(
-                    "delete_paths_bulk: all paths already absent for vault=%s (%d requested)",
-                    vault_name, len(unique_paths),
+                # Dedupe while preserving caller order so log output is stable
+                # and so a doubled path doesn't make `git rm` fail on
+                # the second occurrence.
+                unique_paths = list(dict.fromkeys(file_paths))
+                present = [p for p in unique_paths if (wt / p).exists()]
+                if not present:
+                    logger.debug(
+                        "delete_paths_bulk: all paths already absent for vault=%s (%d requested)",
+                        vault_name, len(unique_paths),
+                    )
+                    return None
+
+                work_repo.git.rm("--", *present, **_write_kt())
+                return self._stage_and_commit(
+                    work_repo,
+                    message,
+                    author_name,
+                    author_email,
+                    parent_required=True,
                 )
-                return None
-
-            work_repo.git.rm("--", *present, **_write_kt())
-            return self._stage_and_commit(
-                work_repo,
-                message,
-                author_name,
-                author_email,
-                parent_required=True,
-            )
 
     def _commit_via_clone(
         self,
@@ -2005,27 +2126,27 @@ class GitService:
                 raise GitError(
                     f"git clone timed out after {clone_timeout:.0f}s for vault {vault_name}"
                 ) from e
-            work_repo = Repo(tmp)
-            full_path = Path(tmp) / file_path
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_text(content, encoding="utf-8")
-            work_repo.git.add("--", file_path, **_write_kt())
-            commit_hash = self._stage_and_commit(
-                work_repo,
-                message,
-                author_name,
-                author_email,
-                parent_required=False,
-            )
-            # Push is local-to-local (bare repo on the same disk), so the
-            # standard write timeout is generous; if it hangs the timeout
-            # still releases the vault lock for the next caller.
-            try:
-                work_repo.git.push("origin", **_write_kt())
-            except GitError as e:
-                raise GitError(
-                    f"git push failed for vault {vault_name}: {e}"
-                ) from e
+            with _managed_repo(Repo(tmp)) as work_repo:
+                full_path = Path(tmp) / file_path
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text(content, encoding="utf-8")
+                work_repo.git.add("--", file_path, **_write_kt())
+                commit_hash = self._stage_and_commit(
+                    work_repo,
+                    message,
+                    author_name,
+                    author_email,
+                    parent_required=False,
+                )
+                # Push is local-to-local (bare repo on the same disk), so the
+                # standard write timeout is generous; if it hangs the timeout
+                # still releases the vault lock for the next caller.
+                try:
+                    work_repo.git.push("origin", **_write_kt())
+                except GitError as e:
+                    raise GitError(
+                        f"git push failed for vault {vault_name}: {e}"
+                    ) from e
         return commit_hash
 
     # ── History operations ───────────────────────────────────
@@ -2049,7 +2170,16 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._file_log_mirror(vault_name, file_path, max_count, since_epoch)
-        repo = self._get_repo(vault_name)
+        with _managed_repo(self._get_repo(vault_name)) as repo:
+            return self._file_log_with_repo(repo, file_path, max_count, since_epoch)
+
+    def _file_log_with_repo(
+        self,
+        repo: Repo,
+        file_path: str,
+        max_count: int,
+        since_epoch: int | None,
+    ) -> list[dict]:
         try:
             entries = self._follow_path_history(
                 repo,
@@ -2105,7 +2235,16 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._vault_log_mirror(vault_name, max_count, since, path)
-        repo = self._get_repo(vault_name)
+        with _managed_repo(self._get_repo(vault_name)) as repo:
+            return self._vault_log_with_repo(repo, max_count, since, path)
+
+    def _vault_log_with_repo(
+        self,
+        repo: Repo,
+        max_count: int,
+        since: str | None,
+        path: str | None,
+    ) -> list[dict]:
         try:
             # gitpython's iter_commits stub forbids **kwargs splatting
             # (each named param is typed individually). Two branches by
@@ -2186,10 +2325,23 @@ class GitService:
         """
         if self._use_mirror_reader(vault_name):
             return self._file_diff_mirror(vault_name, file_path, commit_hash)
-        from git.exc import BadName, BadObject
         historical_path = self.path_at_revision(vault_name, file_path, commit_hash)
         lookup_path = historical_path or file_path
-        repo = self._get_repo(vault_name)
+        with _managed_repo(self._get_repo(vault_name)) as repo:
+            return self._file_diff_with_repo(
+                repo,
+                file_path,
+                lookup_path,
+                commit_hash,
+            )
+
+    def _file_diff_with_repo(
+        self,
+        repo: Repo,
+        file_path: str,
+        lookup_path: str,
+        commit_hash: str,
+    ) -> dict:
         try:
             commit = repo.commit(commit_hash)
         except (ValueError, BadName, BadObject):
@@ -2248,7 +2400,7 @@ class GitService:
                 status_code=400,
                 code="external_git_mirror_diff_unsupported",
             )
-        repo = self._get_repo(vault_name)
-        base = repo.commit(from_commit)
-        head = repo.commit(to_commit) if to_commit else repo.head.commit
-        return base.diff(head, create_patch=True).__str__()
+        with _managed_repo(self._get_repo(vault_name)) as repo:
+            base = repo.commit(from_commit)
+            head = repo.commit(to_commit) if to_commit else repo.head.commit
+            return base.diff(head, create_patch=True).__str__()

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -1,17 +1,21 @@
-"""Shared startup/shutdown for the indexing/embedding background workers.
+"""Shared process composition for serving support and durable workers.
 
-Both `app.main` (when AKB_DISABLE_WORKERS is unset) and `app.worker_main`
-import these so the start/stop order stays consistent across entrypoints.
+``AKB_PROCESS_ROLE=all`` preserves the local all-in-one runtime. Kubernetes
+uses ``api`` for FastAPI and ``worker`` for :mod:`app.worker_main`; both
+entrypoints import this module so pool and worker ordering cannot drift.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from urllib.parse import urlsplit
 
-from app.config import settings
 from app.db.postgres import close_pool, get_pool, init_db
+from app.config import settings
+from app.process_role import runtime_process_role
+from app.services._backfill import request_stop_all, runner_snapshots
 from app.services import (
     asset_gc_worker,
     audit_log,
@@ -23,6 +27,7 @@ from app.services import (
     http_pool,
     m1_file_transfer_reaper,
     metadata_worker,
+    queue_rescuer,
     s3_delete_worker,
     sparse_encoder,
     tool_usage,
@@ -211,7 +216,7 @@ async def init_storage() -> None:
     # fail silently until an operator removes the lock by hand.
     if selected_document_revision_backend() == "bare_git":
         try:
-            cleared = GitService().cleanup_stale_locks()
+            cleared = await asyncio.to_thread(GitService().cleanup_stale_locks)
             if cleared:
                 logger.info("Cleared %d stale git lock(s) at startup", cleared)
         except Exception as e:  # noqa: BLE001 — never block startup on best-effort cleanup
@@ -247,7 +252,56 @@ async def init_storage() -> None:
         logger.error("RoleSync reconcile failed at startup: %s", e)
 
 
-def start_workers() -> None:
+def start_runtime_pools() -> None:
+    """Start process-local CPU/Git executors needed by API and workers."""
+    raw_processes = os.getenv("AKB_TOKENIZER_PROCESSES", "").strip()
+    processes = settings.tokenizer_processes
+    if raw_processes:
+        try:
+            processes = int(raw_processes)
+        except ValueError:
+            raise RuntimeError("AKB_TOKENIZER_PROCESSES must be an integer") from None
+        if not 1 <= processes <= 4:
+            raise RuntimeError("AKB_TOKENIZER_PROCESSES must be between 1 and 4")
+    sparse_encoder.start_tokenizer_pool(processes)
+    write_lane.start_commit_pool()
+
+
+def stop_runtime_pools() -> None:
+    sparse_encoder.stop_tokenizer_pool()
+    write_lane.stop_commit_pool()
+
+
+def _start_api_local(started: list[str]) -> None:
+    """Start sinks whose queues live in the serving process's memory."""
+    if settings.audit.enabled:
+        audit_log.init()
+        if settings.audit.bucket:
+            audit_log.start_uploader()
+            started.append("audit_uploader")
+        else:
+            logger.info("audit enabled file-only (audit.bucket not set; no uploader)")
+    else:
+        logger.info("audit disabled (audit.enabled=false)")
+
+    tool_usage.start()
+    started.append("tool_usage_maintenance")
+    if settings.tool_usage.enabled:
+        started.append("tool_usage_flusher")
+    else:
+        logger.info("tool_usage collection disabled (tool_usage.enabled=false)")
+
+
+def start_api_runtime() -> None:
+    """Start only process-local serving support, never durable queue workers."""
+    start_runtime_pools()
+    started = ["tokenizer_pool", "git_commit_pool"]
+    _start_api_local(started)
+    logger.info("API runtime started: %s", ", ".join(started))
+
+
+def start_workers(*, include_api_local: bool = True) -> None:
+    start_runtime_pools()
     embed_worker.start()
     delete_worker.start()
     # ``start_workers`` is normally called from the FastAPI lifespan loop.
@@ -271,6 +325,7 @@ def start_workers() -> None:
     # reports ready (until then the source-id path runs unchanged). No-op for
     # other drivers / separate-instance / fully-backfilled corpora.
     vault_backfill.start()
+    queue_rescuer.start()
     # BM25 corpus stats (total_docs, avgdl, per-term df) only become
     # non-degenerate after `recompute_stats()` runs. The refresher fires
     # once at startup and then on a configurable cadence so the sparse
@@ -282,12 +337,10 @@ def start_workers() -> None:
     # event loop → probe timeouts → 503. Run it off-process. Start it BEFORE the
     # stats refresher, which tokenizes the whole corpus on first tick. (Serving
     # also depends on it — move to the always-run path if API/worker tiers split.)
-    sparse_encoder.start_tokenizer_pool()
     sparse_encoder.start_stats_refresher(settings.bm25_recompute_interval_secs)
     # Dedicated git-commit executor (write-lane, command-lane round-05).
     # Git mutations run here so blocked/slow commits can never crowd git
     # READS out of asyncio.to_thread's shared default executor.
-    write_lane.start_commit_pool()
     started = [
         "tokenizer_pool",
         "git_commit_pool",
@@ -296,6 +349,7 @@ def start_workers() -> None:
         "app_rollout_worker",
         "bm25_stats_refresher",
         "vault_backfill",
+        "queue_rescuer",
     ]
     if bare_git_selected and settings.external_git_enabled:
         started.append("external_git_poller")
@@ -339,29 +393,8 @@ def start_workers() -> None:
         started.append("events_publisher")
     else:
         logger.info("events_publisher disabled (redis_url not configured)")
-    # Audit log — producer-only. `init` seeds the per-file hash chain;
-    # the uploader (daily handoff to the WORM bucket) only runs when a
-    # bucket is configured. File-only mode (no bucket) still writes the
-    # JSON-lines stream for a co-located SIEM/Logstash to tail.
-    if settings.audit.enabled:
-        audit_log.init()
-        if settings.audit.bucket:
-            audit_log.start_uploader()
-            started.append("audit_uploader")
-        else:
-            logger.info("audit enabled file-only (audit.bucket not set; no uploader)")
-    else:
-        logger.info("audit disabled (audit.enabled=false)")
-    # MCP tool-usage analytics — a separate sink from audit (queryable PG rows
-    # rather than a hash-chained ledger) with its own flag. The maintenance
-    # runner starts either way so that disabling collection still rolls up and
-    # prunes what was already gathered.
-    tool_usage.start()
-    started.append("tool_usage_maintenance")
-    if settings.tool_usage.enabled:
-        started.append("tool_usage_flusher")
-    else:
-        logger.info("tool_usage collection disabled (tool_usage.enabled=false)")
+    if include_api_local:
+        _start_api_local(started)
     # PG-RBAC periodic reconcile — converges drift caused by silent
     # lifecycle-hook failures (counted in role_sync.metrics_snapshot).
     # Set role_sync_reconcile_interval_secs <= 0 in config to disable.
@@ -373,25 +406,117 @@ def start_workers() -> None:
     logger.info("Workers started: %s", ", ".join(started))
 
 
-async def stop_workers() -> None:
-    await get_role_sync().stop_reconcile_timer()
-    await m1_file_transfer_reaper.stop()
-    await audit_log.stop_uploader()
-    await tool_usage.stop()
-    await events_publisher.stop()
-    await metadata_worker.stop()
-    await external_git_poller.stop()
-    # Stop producers before the S3 outbox consumer so shutdown cannot leave a
-    # freshly-enqueued object waiting solely because the consumer exited first.
-    await asset_gc_worker.stop()
-    await s3_delete_worker.stop()
-    await app_rollout_worker.stop()
-    await delete_worker.stop()
-    await embed_worker.stop()
-    await vault_backfill.stop()
-    await sparse_encoder.stop_stats_refresher()
-    sparse_encoder.stop_tokenizer_pool()
-    write_lane.stop_commit_pool()
+async def _stop_component(name: str, stop) -> None:
+    """Stop one component without letting it skip the rest of shutdown."""
+    try:
+        await stop()
+    except asyncio.CancelledError:
+        # A component may use cancellation as its normal stop mechanism. The
+        # lifecycle already broadcast the global stop request, so one such
+        # outcome must not prevent siblings from joining.
+        logger.warning("worker shutdown cancelled for %s", name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("worker shutdown failed for %s: %s", name, exc)
+
+
+async def stop_workers(*, include_api_local: bool = True) -> None:
+    """Signal every worker first, then join them under one absolute budget."""
+    # BackfillRunner.stop used to be called sequentially. A slow first worker
+    # therefore left every later worker claiming new rows until Kubernetes sent
+    # SIGKILL. Broadcast first so all queue consumers become quiescent together.
+    request_stop_all()
+    components = [
+        ("role_sync", lambda: get_role_sync().stop_reconcile_timer()),
+        ("m1_file_transfer_reaper", m1_file_transfer_reaper.stop),
+        ("events_publisher", events_publisher.stop),
+        ("metadata_worker", metadata_worker.stop),
+        ("external_git_poller", external_git_poller.stop),
+        ("asset_gc_worker", asset_gc_worker.stop),
+        ("s3_delete_worker", s3_delete_worker.stop),
+        ("app_rollout_worker", app_rollout_worker.stop),
+        ("delete_worker", delete_worker.stop),
+        ("embed_worker", embed_worker.stop),
+        ("vault_backfill", vault_backfill.stop),
+        ("queue_rescuer", queue_rescuer.stop),
+        ("bm25_stats_refresher", sparse_encoder.stop_stats_refresher),
+    ]
+    if include_api_local:
+        components.extend([
+            ("audit_uploader", audit_log.stop_uploader),
+            ("tool_usage", lambda: tool_usage.stop()),
+        ])
+    tasks = [
+        asyncio.create_task(_stop_component(name, stop), name=f"stop:{name}")
+        for name, stop in components
+    ]
+    try:
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=settings.worker_shutdown_timeout_secs,
+        )
+        for task in done:
+            # Retrieve exceptions even though _stop_component should contain
+            # ordinary failures. Cancellation remains visible to this caller.
+            task.result()
+        if pending:
+            logger.error(
+                "worker shutdown deadline exceeded; %d component(s) still running: %s",
+                len(pending),
+                ", ".join(sorted(task.get_name() for task in pending)),
+            )
+            for task in pending:
+                task.cancel()
+            # Do not wait beyond the shared deadline. Consume eventual task
+            # outcomes so an uncooperative callback cannot emit warnings later.
+            for task in pending:
+                task.add_done_callback(
+                    lambda finished: None
+                    if finished.cancelled()
+                    else finished.exception()
+                )
+    finally:
+        stop_runtime_pools()
+
+
+async def stop_api_runtime() -> None:
+    """Stop only serving-process sinks and process-local executors."""
+    request_stop_all()
+    tasks = [
+        asyncio.create_task(
+            _stop_component("audit_uploader", audit_log.stop_uploader),
+            name="stop:audit_uploader",
+        ),
+        asyncio.create_task(
+            _stop_component("tool_usage", lambda: tool_usage.stop()),
+            name="stop:tool_usage",
+        ),
+    ]
+    try:
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=settings.worker_shutdown_timeout_secs,
+        )
+        for task in done:
+            task.result()
+        for task in pending:
+            task.cancel()
+            task.add_done_callback(
+                lambda finished: None
+                if finished.cancelled()
+                else finished.exception()
+            )
+    finally:
+        stop_runtime_pools()
+
+
+def worker_lifecycle_snapshot() -> dict:
+    runners = runner_snapshots()
+    return {
+        "process_role": runtime_process_role(),
+        "shutdown_timeout_secs": settings.worker_shutdown_timeout_secs,
+        "runners": runners,
+        "abandoned_total": sum(item["abandoned"] for item in runners),
+    }
 
 
 async def shutdown_storage() -> None:

--- a/backend/app/services/metadata_worker.py
+++ b/backend/app/services/metadata_worker.py
@@ -66,17 +66,20 @@ async def _claim_batch(conn) -> list[dict]:
                AND llm_metadata_at IS NULL
                AND (llm_next_attempt_at IS NULL OR llm_next_attempt_at <= NOW())
                AND llm_retry_count < $2
+               AND llm_abandoned_at IS NULL
              ORDER BY llm_next_attempt_at NULLS FIRST, id
              LIMIT $1
              FOR UPDATE SKIP LOCKED
         )
         UPDATE documents d
-           SET llm_next_attempt_at = NOW() + ($3 || ' seconds')::interval
+           SET llm_next_attempt_at = NOW() + ($3 || ' seconds')::interval,
+               llm_claimed_at = NOW(),
+               llm_retry_count = llm_retry_count + 1
           FROM pending p
          WHERE d.id = p.id
         RETURNING d.id, d.vault_id, d.path, d.external_blob, d.title,
                   d.summary, d.tags, d.doc_type, d.domain,
-                  d.llm_retry_count,
+                  d.llm_retry_count, d.llm_claimed_at,
                   (SELECT name FROM vaults v WHERE v.id = d.vault_id) AS vault_name
         """,
         BATCH_SIZE, MAX_RETRIES, str(settings.external_git_claim_lookahead_secs),
@@ -84,18 +87,27 @@ async def _claim_batch(conn) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-async def _mark_failure(conn, doc_id, retry_count: int, error: str) -> None:
-    delay = next_attempt_delay(retry_count)
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+async def _mark_failure(
+    conn,
+    doc_id,
+    attempt_count: int,
+    error: str,
+    *,
+    permanent: bool = False,
+) -> None:
+    terminal = permanent or attempt_count >= MAX_RETRIES
+    delay = next_attempt_delay(max(0, attempt_count - 1))
+    next_at = None if terminal else datetime.now(timezone.utc) + timedelta(seconds=delay)
     await conn.execute(
         """
         UPDATE documents
-           SET llm_retry_count     = llm_retry_count + 1,
-               llm_last_error      = $2,
-               llm_next_attempt_at = $3
+           SET llm_last_error      = $2,
+               llm_next_attempt_at = $3,
+               llm_claimed_at      = NULL,
+               llm_abandoned_at    = CASE WHEN $4 THEN NOW() ELSE NULL END
          WHERE id = $1
         """,
-        doc_id, error[:500], next_at,
+        doc_id, error[:500], next_at, terminal,
     )
 
 
@@ -172,10 +184,12 @@ async def _process_once() -> int:
         vault_name = row["vault_name"]
         if not blob_sha or not vault_name:
             # Either field missing means this row can never make progress
-            # — burn retries to MAX in one go so the worker stops picking it.
+            # — mark it terminal without inventing attempts that never ran.
             reason = "no external_blob" if not blob_sha else "vault gone"
             async with pool.acquire() as conn:
-                await _mark_failure(conn, doc_id, MAX_RETRIES - 1, reason)
+                await _mark_failure(
+                    conn, doc_id, row["llm_retry_count"], reason, permanent=True,
+                )
             continue
 
         try:
@@ -186,9 +200,11 @@ async def _process_once() -> int:
             fields = await _resolve_metadata(vault_name, body)
         except LLMPermanentError as e:
             # Deterministic LLM failure — retrying will produce the same
-            # result. Burn straight to MAX so the worker stops picking it.
+            # result. Mark terminal immediately so the worker stops picking it.
             async with pool.acquire() as conn:
-                await _mark_failure(conn, doc_id, MAX_RETRIES - 1, str(e))
+                await _mark_failure(
+                    conn, doc_id, row["llm_retry_count"], str(e), permanent=True,
+                )
             continue
         except (LLMError, RuntimeError, OSError) as e:
             async with pool.acquire() as conn:
@@ -216,7 +232,14 @@ async def _process_once() -> int:
         )
         async with pool.acquire() as conn:
             await conn.execute(
-                "UPDATE documents SET llm_next_attempt_at = NULL WHERE id = $1",
+                """
+                UPDATE documents
+                   SET llm_retry_count = 0,
+                       llm_next_attempt_at = NULL,
+                       llm_claimed_at = NULL,
+                       llm_abandoned_at = NULL
+                 WHERE id = $1
+                """,
                 doc_id,
             )
 
@@ -241,30 +264,33 @@ async def pending_stats(vault_id: "uuid.UUID | None" = None) -> dict:
             row = await conn.fetchrow(
                 """
                 SELECT
-                    COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL)
+                    COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
+                                     AND llm_abandoned_at IS NULL)
                                                                                       AS pending,
                     COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
-                                     AND llm_retry_count > 0 AND llm_retry_count < $1) AS retrying,
+                                     AND llm_abandoned_at IS NULL
+                                     AND llm_retry_count > 0)                          AS retrying,
                     COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
-                                     AND llm_retry_count >= $1)                        AS abandoned
+                                     AND llm_abandoned_at IS NOT NULL)                 AS abandoned
                   FROM documents
-                """,
-                MAX_RETRIES,
+                """
             )
         else:
             row = await conn.fetchrow(
                 """
                 SELECT
-                    COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL)
+                    COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
+                                     AND llm_abandoned_at IS NULL)
                                                                                       AS pending,
                     COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
-                                     AND llm_retry_count > 0 AND llm_retry_count < $1) AS retrying,
+                                     AND llm_abandoned_at IS NULL
+                                     AND llm_retry_count > 0)                          AS retrying,
                     COUNT(*) FILTER (WHERE source='external_git' AND llm_metadata_at IS NULL
-                                     AND llm_retry_count >= $1)                        AS abandoned
+                                     AND llm_abandoned_at IS NOT NULL)                 AS abandoned
                   FROM documents
-                 WHERE vault_id = $2
+                 WHERE vault_id = $1
                 """,
-                MAX_RETRIES, vault_id,
+                vault_id,
             )
     return {
         "pending":   int(row["pending"]),

--- a/backend/app/services/native_derived_worker.py
+++ b/backend/app/services/native_derived_worker.py
@@ -149,6 +149,9 @@ class NativeDerivedWorker:
                        SET completed_at = NOW(),
                            delivery_outcome = 'superseded',
                            selected_delivery = $1,
+                           retry_count = 0,
+                           claimed_at = NULL,
+                           next_attempt_at = NULL,
                            last_error = NULL
                       FROM ranked r
                      WHERE i.intent_id = r.intent_id AND r.position > 1
@@ -173,18 +176,22 @@ class NativeDerivedWorker:
                 )
                 if row is None:
                     return None
-                await conn.execute(
+                claimed = await conn.fetchrow(
                     """
                     UPDATE native_invalidation_intents
                        SET claimed_at = NOW(),
                            next_attempt_at = NOW() + INTERVAL '10 minutes',
+                           retry_count = retry_count + 1,
                            selected_delivery = $2
                      WHERE intent_id = $1
+                    RETURNING retry_count, claimed_at
                     """,
                     row["intent_id"],
                     SELECTED_DELIVERY,
                 )
-                return dict(row)
+                intent = dict(row)
+                intent.update(dict(claimed))
+                return intent
 
     async def _complete(
         self,
@@ -199,6 +206,7 @@ class NativeDerivedWorker:
                 UPDATE native_invalidation_intents
                    SET completed_at = NOW(), delivery_outcome = $2,
                        selected_delivery = $3,
+                       retry_count = 0, claimed_at = NULL,
                        next_attempt_at = NULL, last_error = NULL
                  WHERE intent_id = $1
                 """,
@@ -208,33 +216,31 @@ class NativeDerivedWorker:
             )
 
     async def _failure(self, intent: dict, error: Exception) -> None:
-        next_retry_count = int(intent["retry_count"]) + 1
-        delay = next_attempt_delay(int(intent["retry_count"]))
+        attempt_count = int(intent["retry_count"])
+        delay = next_attempt_delay(max(0, attempt_count - 1))
         next_at = datetime.now(UTC) + timedelta(seconds=delay)
         async with self.pool.acquire() as conn:
-            if next_retry_count >= MAX_RETRIES:
+            if attempt_count >= MAX_RETRIES:
                 await conn.execute(
                     """
                     UPDATE native_invalidation_intents
-                       SET claimed_at = NULL, retry_count = $2,
+                       SET claimed_at = NULL,
                            completed_at = NOW(), delivery_outcome = 'abandoned',
-                           next_attempt_at = NULL, last_error = $3
+                           next_attempt_at = NULL, last_error = $2
                      WHERE intent_id = $1 AND completed_at IS NULL
                     """,
                     intent["intent_id"],
-                    next_retry_count,
                     type(error).__name__,
                 )
             else:
                 await conn.execute(
                     """
                     UPDATE native_invalidation_intents
-                       SET claimed_at = NULL, retry_count = $2,
-                           next_attempt_at = $3, last_error = $4
+                       SET claimed_at = NULL,
+                           next_attempt_at = $2, last_error = $3
                      WHERE intent_id = $1 AND completed_at IS NULL
                     """,
                     intent["intent_id"],
-                    next_retry_count,
                     next_at,
                     type(error).__name__,
                 )
@@ -291,6 +297,7 @@ class NativeDerivedWorker:
                         """
                         UPDATE native_invalidation_intents
                            SET completed_at = NOW(), delivery_outcome = 'superseded',
+                               retry_count = 0, claimed_at = NULL,
                                next_attempt_at = NULL, last_error = NULL
                          WHERE intent_id = $1
                         """,
@@ -302,6 +309,7 @@ class NativeDerivedWorker:
                         """
                         UPDATE native_invalidation_intents
                            SET completed_at = NOW(), delivery_outcome = 'superseded',
+                               retry_count = 0, claimed_at = NULL,
                                next_attempt_at = NULL, last_error = NULL
                          WHERE intent_id = $1
                         """,
@@ -321,6 +329,7 @@ class NativeDerivedWorker:
                     """
                     UPDATE native_invalidation_intents
                        SET completed_at = NOW(), delivery_outcome = 'deleted',
+                           retry_count = 0, claimed_at = NULL,
                            next_attempt_at = NULL, last_error = NULL
                      WHERE intent_id = $1
                     """,
@@ -370,6 +379,7 @@ class NativeDerivedWorker:
                         """
                         UPDATE native_invalidation_intents
                            SET completed_at = NOW(), delivery_outcome = 'superseded',
+                               retry_count = 0, claimed_at = NULL,
                                next_attempt_at = NULL, last_error = NULL
                          WHERE intent_id = $1
                         """,
@@ -435,6 +445,7 @@ class NativeDerivedWorker:
                     """
                     UPDATE native_invalidation_intents
                        SET completed_at = NOW(), delivery_outcome = 'applied',
+                           retry_count = 0, claimed_at = NULL,
                            next_attempt_at = NULL, last_error = NULL
                      WHERE intent_id = $1
                     """,

--- a/backend/app/services/queue_rescuer.py
+++ b/backend/app/services/queue_rescuer.py
@@ -1,0 +1,146 @@
+"""Close durable queue claims that died on their final attempt.
+
+Workers stamp terminal state in their ordinary exception path.  A SIGKILL,
+OOM, or host loss has no exception path, though, so a claim whose counter was
+incremented to ``MAX_RETRIES`` would otherwise remain an ambiguous lease
+forever.  This singleton rescuer waits for the lease to expire and then stamps
+the queue's explicit terminal state.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from app.db.postgres import get_pool
+from app.services._backfill import BackfillRunner, MAX_RETRIES
+
+logger = logging.getLogger("akb.queue_rescuer")
+
+_ADVISORY_LOCK_KEY = 0x414B425F51524553  # ``AKB_QRES``
+_last_run_at: datetime | None = None
+_last_rescued = 0
+_last_error: str | None = None
+
+_RESCUE_STATEMENTS = (
+    """
+    WITH rescued AS (
+        UPDATE chunks
+           SET vector_abandoned_at = NOW(), vector_claimed_at = NULL,
+               vector_next_attempt_at = NULL,
+               vector_last_error = COALESCE(
+                   vector_last_error, 'claim lease expired after final attempt'
+               )
+         WHERE vector_indexed_at IS NULL
+           AND vector_abandoned_at IS NULL
+           AND vector_retry_count >= $1
+           AND (vector_next_attempt_at IS NULL OR vector_next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+    """
+    WITH rescued AS (
+        UPDATE vector_delete_outbox
+           SET abandoned_at = NOW(), claimed_at = NULL, next_attempt_at = NULL,
+               last_error = COALESCE(
+                   last_error, 'claim lease expired after final attempt'
+               )
+         WHERE processed_at IS NULL AND abandoned_at IS NULL
+           AND retry_count >= $1
+           AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+    """
+    WITH rescued AS (
+        UPDATE s3_delete_outbox
+           SET abandoned_at = NOW(), claimed_at = NULL, next_attempt_at = NULL,
+               last_error = COALESCE(
+                   last_error, 'claim lease expired after final attempt'
+               )
+         WHERE processed_at IS NULL AND abandoned_at IS NULL
+           AND retry_count >= $1
+           AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+    """
+    WITH rescued AS (
+        UPDATE events
+           SET abandoned_at = NOW(), claimed_at = NULL, next_attempt_at = NULL,
+               last_error = COALESCE(
+                   last_error, 'claim lease expired after final attempt'
+               )
+         WHERE redis_published_at IS NULL AND abandoned_at IS NULL
+           AND attempts >= $1
+           AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+    """
+    WITH rescued AS (
+        UPDATE documents
+           SET llm_abandoned_at = NOW(), llm_claimed_at = NULL,
+               llm_next_attempt_at = NULL,
+               llm_last_error = COALESCE(
+                   llm_last_error, 'claim lease expired after final attempt'
+               )
+         WHERE source = 'external_git' AND llm_metadata_at IS NULL
+           AND llm_abandoned_at IS NULL AND llm_retry_count >= $1
+           AND (llm_next_attempt_at IS NULL OR llm_next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+    """
+    WITH rescued AS (
+        UPDATE native_invalidation_intents
+           SET completed_at = NOW(), delivery_outcome = 'abandoned',
+               claimed_at = NULL, next_attempt_at = NULL,
+               last_error = COALESCE(
+                   last_error, 'claim lease expired after final attempt'
+               )
+         WHERE completed_at IS NULL AND retry_count >= $1
+           AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+        RETURNING 1
+    ) SELECT COUNT(*) FROM rescued
+    """,
+)
+
+
+async def _rescue_once() -> int:
+    global _last_run_at, _last_rescued, _last_error
+    pool = await get_pool()
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                leader = await conn.fetchval(
+                    "SELECT pg_try_advisory_xact_lock($1)",
+                    _ADVISORY_LOCK_KEY,
+                )
+                if not leader:
+                    return 0
+                rescued = 0
+                for statement in _RESCUE_STATEMENTS:
+                    rescued += int(await conn.fetchval(statement, MAX_RETRIES) or 0)
+        _last_run_at = datetime.now(timezone.utc)
+        _last_rescued = rescued
+        _last_error = None
+        if rescued:
+            logger.warning("rescued %d expired final worker claim(s)", rescued)
+        return rescued
+    except Exception as exc:
+        _last_error = str(exc)[:500]
+        raise
+
+
+def snapshot() -> dict:
+    return {
+        "last_run_at": _last_run_at.isoformat() if _last_run_at else None,
+        "last_rescued": _last_rescued,
+        "last_error": _last_error,
+    }
+
+
+_runner = BackfillRunner("queue_rescuer", _rescue_once, idle_secs=60)
+start = _runner.start
+stop = _runner.stop

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -702,15 +702,25 @@ class RoleSync:
 
         report = ReconcileReport()
         async with self.pool.acquire() as conn:
-            await self._create_role_if_missing(conn, AUTHENTICATED_ROLE)
-            await self._reconcile_user_roles(conn, report)
-            await self._reconcile_vault_roles(conn, report)
-            await self._reconcile_memberships(conn, report)
-            await self._reconcile_table_grants(conn, report)
-            await self._reconcile_public_access(conn, report)
-            # Token roles depend on user + vault group roles + memberships
-            # existing, so converge them LAST.
-            await self._reconcile_token_roles(conn, report)
+            # One catalog snapshot prevents an online signup/vault-create from
+            # appearing in the role scan but not the application-table scan (or
+            # vice versa), which could make the orphan pass drop a live role.
+            # The xact advisory lock also keeps API/worker process startups from
+            # running two destructive convergence passes simultaneously.
+            async with conn.transaction(isolation="repeatable_read"):
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    "akb:role-sync:reconcile",
+                )
+                await self._create_role_if_missing(conn, AUTHENTICATED_ROLE)
+                await self._reconcile_user_roles(conn, report)
+                await self._reconcile_vault_roles(conn, report)
+                await self._reconcile_memberships(conn, report)
+                await self._reconcile_table_grants(conn, report)
+                await self._reconcile_public_access(conn, report)
+                # Token roles depend on user + vault group roles + memberships
+                # existing, so converge them LAST.
+                await self._reconcile_token_roles(conn, report)
 
         self.metrics.last_reconcile_errors = len(report.errors)
         self.metrics.last_reconcile_at = datetime.now(timezone.utc).isoformat()
@@ -734,7 +744,8 @@ class RoleSync:
         }
         for role in wanted - existing:
             try:
-                await conn.execute(f'CREATE ROLE "{role}" NOLOGIN')
+                async with conn.transaction():
+                    await self._create_role_if_missing(conn, role)
                 report.user_roles_created += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"CREATE ROLE {role}: {e}")
@@ -742,12 +753,14 @@ class RoleSync:
         # Idempotent GRANT re-applies are no-ops.
         for role in wanted:
             try:
-                await self._grant_membership(conn, AUTHENTICATED_ROLE, role)
+                async with conn.transaction():
+                    await self._grant_membership(conn, AUTHENTICATED_ROLE, role)
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"GRANT {AUTHENTICATED_ROLE}→{role}: {e}")
         for orphan in existing - wanted:
             try:
-                await self._drop_role_if_present(conn, orphan)
+                async with conn.transaction():
+                    await self._drop_role_if_present(conn, orphan)
                 report.user_roles_dropped += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"DROP ROLE {orphan}: {e}")
@@ -777,7 +790,8 @@ class RoleSync:
         }
         for role in wanted - existing:
             try:
-                await conn.execute(f'CREATE ROLE "{role}" NOLOGIN')
+                async with conn.transaction():
+                    await self._create_role_if_missing(conn, role)
                 report.vault_roles_created += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"CREATE ROLE {role}: {e}")
@@ -788,21 +802,24 @@ class RoleSync:
             writer = vault_group_role_name(r["id"], "writer")
             admin = vault_group_role_name(r["id"], "admin")
             try:
-                await self._grant_membership(conn, reader, writer)
-                await self._grant_membership(conn, writer, admin)
+                async with conn.transaction():
+                    await self._grant_membership(conn, reader, writer)
+                    await self._grant_membership(conn, writer, admin)
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"hierarchy {r['id']}: {e}")
             if r["owner_id"]:
                 owner_role = user_role_name(r["owner_id"])
                 try:
-                    await self._create_role_if_missing(conn, owner_role)
-                    await self._grant_membership(conn, admin, owner_role)
+                    async with conn.transaction():
+                        await self._create_role_if_missing(conn, owner_role)
+                        await self._grant_membership(conn, admin, owner_role)
                 except Exception as e:  # noqa: BLE001
                     report.errors.append(f"owner grant {r['id']}: {e}")
 
         for orphan in existing - wanted:
             try:
-                await self._drop_role_if_present(conn, orphan)
+                async with conn.transaction():
+                    await self._drop_role_if_present(conn, orphan)
                 report.vault_roles_dropped += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"DROP ROLE {orphan}: {e}")
@@ -817,7 +834,8 @@ class RoleSync:
             user = user_role_name(ar["user_id"])
             group = vault_group_role_name(ar["vault_id"], ar["role"])
             try:
-                await self._grant_membership(conn, group, user)
+                async with conn.transaction():
+                    await self._grant_membership(conn, group, user)
                 report.grants_added += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"GRANT {group}→{user}: {e}")
@@ -836,17 +854,18 @@ class RoleSync:
         for r in rows:
             target = _public_access_scope(r["public_access"])
             try:
-                for scope in ("reader", "writer", "admin"):
-                    if scope == target:
-                        continue
-                    group = vault_group_role_name(r["id"], scope)
-                    await self._revoke_membership_if_present(
-                        conn, group, AUTHENTICATED_ROLE,
-                    )
-                if target is not None:
-                    group = vault_group_role_name(r["id"], target)
-                    await self._grant_membership(conn, group, AUTHENTICATED_ROLE)
-                    report.public_grants_applied += 1
+                async with conn.transaction():
+                    for scope in ("reader", "writer", "admin"):
+                        if scope == target:
+                            continue
+                        group = vault_group_role_name(r["id"], scope)
+                        await self._revoke_membership_if_present(
+                            conn, group, AUTHENTICATED_ROLE,
+                        )
+                    if target is not None:
+                        group = vault_group_role_name(r["id"], target)
+                        await self._grant_membership(conn, group, AUTHENTICATED_ROLE)
+                        report.public_grants_applied += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(
                     f"public access {r['id']} ({r['public_access']}): {e}"
@@ -871,7 +890,8 @@ class RoleSync:
                 report.errors.append(f"unsafe pg_name: {pg_name}")
                 continue
             try:
-                await self._grant_table(conn, tr["vault_id"], pg_name)
+                async with conn.transaction():
+                    await self._grant_table(conn, tr["vault_id"], pg_name)
                 report.table_grants_applied += 1
             except Exception as e:  # noqa: BLE001
                 report.errors.append(f"GRANT on {pg_name}: {e}")
@@ -1348,13 +1368,15 @@ class RoleSync:
         # DROP ROLE attempt; PG will still refuse if dependencies
         # remain and surface a clearer error there.
         try:
-            await conn.execute(f'DROP OWNED BY "{role}"')
+            async with conn.transaction():
+                await conn.execute(f'DROP OWNED BY "{role}"')
         except asyncpg.exceptions.UndefinedObjectError:
             return
         except Exception as e:  # noqa: BLE001
             logger.warning("DROP OWNED BY %s failed (continuing to DROP ROLE): %s", role, e)
         try:
-            await conn.execute(f'DROP ROLE IF EXISTS "{role}"')
+            async with conn.transaction():
+                await conn.execute(f'DROP ROLE IF EXISTS "{role}"')
         except asyncpg.exceptions.UndefinedObjectError:
             pass
 

--- a/backend/app/services/s3_delete_worker.py
+++ b/backend/app/services/s3_delete_worker.py
@@ -81,7 +81,8 @@ async def cancel_delete(conn, outbox_id: int) -> None:
     await conn.execute(
         """
         UPDATE s3_delete_outbox
-           SET processed_at = NOW(), last_error = NULL
+           SET processed_at = NOW(), retry_count = 0, last_error = NULL,
+               next_attempt_at = NULL, claimed_at = NULL, abandoned_at = NULL
          WHERE id = $1 AND processed_at IS NULL
         """,
         outbox_id,
@@ -100,15 +101,18 @@ async def _claim_batch(conn, limit: int = BATCH_SIZE) -> list[dict]:
              WHERE processed_at IS NULL
                AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
                AND retry_count < $2
+               AND abandoned_at IS NULL
              ORDER BY next_attempt_at NULLS FIRST, id
              LIMIT $1
              FOR UPDATE SKIP LOCKED
         )
         UPDATE s3_delete_outbox o
-           SET next_attempt_at = NOW() + INTERVAL '10 minutes'
+           SET next_attempt_at = NOW() + INTERVAL '10 minutes',
+               claimed_at = NOW(),
+               retry_count = retry_count + 1
           FROM pending p
          WHERE o.id = p.id
-        RETURNING o.id, o.s3_key, o.retry_count
+        RETURNING o.id, o.s3_key, o.retry_count, o.claimed_at
         """,
         limit, MAX_RETRIES,
     )
@@ -117,23 +121,30 @@ async def _claim_batch(conn, limit: int = BATCH_SIZE) -> list[dict]:
 
 async def _mark_success(conn, outbox_id) -> None:
     await conn.execute(
-        "UPDATE s3_delete_outbox SET processed_at = NOW(), last_error = NULL WHERE id = $1",
+        """
+        UPDATE s3_delete_outbox
+           SET processed_at = NOW(), retry_count = 0, last_error = NULL,
+               next_attempt_at = NULL, claimed_at = NULL, abandoned_at = NULL
+         WHERE id = $1
+        """,
         outbox_id,
     )
 
 
-async def _mark_failure(conn, outbox_id, retry_count: int, error: str) -> None:
-    delay = next_attempt_delay(retry_count)
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+async def _mark_failure(conn, outbox_id, attempt_count: int, error: str) -> None:
+    terminal = attempt_count >= MAX_RETRIES
+    delay = next_attempt_delay(max(0, attempt_count - 1))
+    next_at = None if terminal else datetime.now(timezone.utc) + timedelta(seconds=delay)
     await conn.execute(
         """
         UPDATE s3_delete_outbox
-           SET retry_count = retry_count + 1,
-               last_error = $2,
-               next_attempt_at = $3
+           SET last_error = $2,
+               next_attempt_at = $3,
+               claimed_at = NULL,
+               abandoned_at = CASE WHEN $4 THEN NOW() ELSE NULL END
          WHERE id = $1
         """,
-        outbox_id, (error or "")[:500], next_at,
+        outbox_id, (error or "")[:500], next_at, terminal,
     )
 
 
@@ -141,8 +152,10 @@ async def _release_claim(conn, outbox_id, *, delay_seconds: int = 1) -> None:
     await conn.execute(
         """
         UPDATE s3_delete_outbox
-           SET next_attempt_at = NOW() + ($2 * INTERVAL '1 second')
-         WHERE id = $1 AND processed_at IS NULL
+           SET retry_count = GREATEST(retry_count - 1, 0),
+               next_attempt_at = NOW() + ($2 * INTERVAL '1 second'),
+               claimed_at = NULL
+         WHERE id = $1 AND processed_at IS NULL AND abandoned_at IS NULL
         """,
         outbox_id,
         delay_seconds,
@@ -308,11 +321,10 @@ async def pending_stats() -> dict:
         row = await conn.fetchrow(
             """
             SELECT
-                COUNT(*) FILTER (WHERE processed_at IS NULL AND retry_count < $1)  AS pending,
-                COUNT(*) FILTER (WHERE processed_at IS NULL AND retry_count >= $1) AS abandoned
+                COUNT(*) FILTER (WHERE processed_at IS NULL AND abandoned_at IS NULL)     AS pending,
+                COUNT(*) FILTER (WHERE processed_at IS NULL AND abandoned_at IS NOT NULL) AS abandoned
               FROM s3_delete_outbox
-            """,
-            MAX_RETRIES,
+            """
         )
     return {
         "pending":   int(row["pending"]),

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -215,7 +215,10 @@ def _english_token_variants(token: str) -> list[str]:
 def _get_kiwi() -> Kiwi:
     global _kiwi
     if _kiwi is None:
-        _kiwi = Kiwi()
+        # One native Kiwi worker per process-pool child. Letting Kiwi size its
+        # own native pool from host CPU count multiplies memory and threads by
+        # the outer ProcessPoolExecutor size and ignores the pod budget.
+        _kiwi = Kiwi(num_workers=1)
         logger.info("Kiwi tokenizer initialized (version=%s)", _kiwi_version)
     return _kiwi
 
@@ -738,6 +741,7 @@ async def _refresh_tick() -> int:
 from app.services._backfill import BackfillRunner  # noqa: E402
 
 _refresher = BackfillRunner("bm25_stats_refresher", _refresh_tick, idle_secs=1)
+_bootstrap_task: asyncio.Task | None = None
 
 
 def start_stats_refresher(interval_secs: int = 1800) -> None:
@@ -747,15 +751,16 @@ def start_stats_refresher(interval_secs: int = 1800) -> None:
     gate) so a fresh install isn't stuck at total_docs=0; subsequent
     ticks honour the gate.
     """
-    global _refresher
-    _refresher = BackfillRunner(
-        "bm25_stats_refresher", _refresh_tick, idle_secs=interval_secs,
-    )
+    global _bootstrap_task
+    if _refresher.is_running():
+        return
+    _refresher.configure_idle_secs(interval_secs)
     # Bootstrap: force one recompute on startup regardless of delta so
     # a brand-new DB doesn't have to wait `interval_secs` for usable
     # sparse weights. Wrapped in a task so startup isn't blocked.
-    import asyncio as _asyncio
-    _asyncio.create_task(_bootstrap_recompute(), name="bm25_stats_bootstrap")
+    _bootstrap_task = asyncio.create_task(
+        _bootstrap_recompute(), name="bm25_stats_bootstrap",
+    )
     _refresher.start()
 
 
@@ -768,6 +773,14 @@ async def _bootstrap_recompute() -> None:
 
 async def stop_stats_refresher() -> None:
     """Signal stop and await the runner. Safe to call when not started."""
+    global _bootstrap_task
+    task, _bootstrap_task = _bootstrap_task, None
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
     if _refresher is not None:
         await _refresher.stop()
 

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -542,18 +542,28 @@ async def index_table_metadata(
     )
     pool = await get_pool()
     async with pool.acquire() as conn:
-        await write_source_chunks(
-            conn, "table", table_id,
-            vault_id=vault_id,
-            chunks=[chunk],
-        )
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"akb:index:table:{table_id}",
+            )
+            await write_source_chunks(
+                conn, "table", table_id,
+                vault_id=vault_id,
+                chunks=[chunk],
+            )
 
 
 async def delete_table_index(table_id: str) -> None:
     """Drop the metadata chunk for a table (outbox-driven vector-store delete)."""
     pool = await get_pool()
     async with pool.acquire() as conn:
-        await delete_table_chunks(conn, table_id)
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                f"akb:index:table:{table_id}",
+            )
+            await delete_table_chunks(conn, table_id)
 
 
 # ── CRUD ─────────────────────────────────────────────────────────
@@ -1879,7 +1889,6 @@ async def execute_sql(
                 "request.jwt.claims is reserved for service-key claim injection.",
                 code=METHOD_NOT_ALLOWED,
             )
-
         # Archived vaults are READ-ONLY. PG ACL has no archive concept
         # (write grants are intentionally preserved so unarchive is
         # instant), so the write block lives here: a non-read statement

--- a/backend/app/services/vault_backfill.py
+++ b/backend/app/services/vault_backfill.py
@@ -139,6 +139,7 @@ async def _process_once() -> int:
                   ) src ON src.id = vi.source_id
                   WHERE vi.vault_id IS NULL
                   LIMIT {_BATCH}
+                  FOR UPDATE OF vi SKIP LOCKED
                 )
                 UPDATE "{schema}".chunks vi
                 SET vault_id = batch.vid

--- a/backend/app/worker_health.py
+++ b/backend/app/worker_health.py
@@ -1,0 +1,24 @@
+"""Kubernetes exec probe for the dedicated worker event loop heartbeat."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    path = Path(
+        os.getenv("AKB_WORKER_HEARTBEAT_PATH", "/run/akb/worker-heartbeat")
+    )
+    max_age = float(os.getenv("AKB_WORKER_HEARTBEAT_MAX_AGE_SECS", "30"))
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError as exc:
+        raise SystemExit(f"worker heartbeat unavailable: {exc}") from exc
+    if age < 0 or age > max_age:
+        raise SystemExit(f"worker heartbeat stale: {age:.1f}s (max {max_age:.1f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/worker_main.py
+++ b/backend/app/worker_main.py
@@ -1,0 +1,128 @@
+"""Dedicated background-worker process entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from contextlib import suppress
+from pathlib import Path
+
+from app.config import settings
+from app.logging_redaction import install_secret_redaction
+from app.process_role import runtime_process_role
+from app.services import external_git_service
+from app.services.external_git_capability import check_external_git_capability
+from app.services.lifecycle import (
+    init_storage,
+    shutdown_storage,
+    start_workers,
+    stop_workers,
+)
+from app.services.revision_backend import (
+    get_revision_backend,
+    selected_document_revision_backend,
+)
+
+logger = logging.getLogger("akb.worker_main")
+_HEARTBEAT_PATH = Path(
+    os.getenv("AKB_WORKER_HEARTBEAT_PATH", "/run/akb/worker-heartbeat")
+)
+
+
+async def _heartbeat(stop_event: asyncio.Event) -> None:
+    while not stop_event.is_set():
+        # This file is intentionally touched on the worker event loop. It lives
+        # on the container-local runtime directory, so the operation is tiny.
+        # A fresh mtime proves the loop itself is scheduling rather than merely
+        # proving that a shared/default executor thread is still alive.
+        _HEARTBEAT_PATH.touch(mode=0o600, exist_ok=True)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=5.0)
+        except TimeoutError:
+            pass
+
+
+def _select_revision_backend() -> str:
+    """Compose the process-scoped revision backend before worker startup.
+
+    API imports select the backend through their route composition, but the
+    standalone worker entrypoint does not import those routes.  Without this
+    explicit composition step ``selected_document_revision_backend()`` remains
+    ``None`` and Bare-Git-only workers are incorrectly omitted.
+    """
+    get_revision_backend()
+    selected = selected_document_revision_backend()
+    if selected is None:
+        raise RuntimeError("worker revision backend selection did not complete")
+    return selected
+
+
+async def run() -> None:
+    if runtime_process_role() != "worker":
+        raise RuntimeError(
+            "app.worker_main requires AKB_PROCESS_ROLE=worker (fail-closed against duplicate workers)"
+        )
+
+    install_secret_redaction()
+    # Never let a heartbeat written by a previous process make startup/readiness
+    # pass before this process is ready. The default directory is container-local
+    # and owner-only so another local process cannot forge the probe signal.
+    _HEARTBEAT_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _HEARTBEAT_PATH.unlink(missing_ok=True)
+    stop_event = asyncio.Event()
+    heartbeat_task: asyncio.Task | None = None
+    storage_initialized = False
+    workers_started = False
+    revision_backend = _select_revision_backend()
+    loop = asyncio.get_running_loop()
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(signum, stop_event.set)
+
+    try:
+        await init_storage()
+        storage_initialized = True
+        if revision_backend == "bare_git":
+            marked = await external_git_service.backfill_mirror_markers()
+            if marked:
+                logger.info(
+                    "Backfilled external-git mirror marker on %d vault(s)", marked,
+                )
+            await asyncio.to_thread(check_external_git_capability, settings)
+
+        # Mark this before the synchronous call so a partial start is still
+        # unwound if a later component raises during composition.
+        workers_started = True
+        start_workers(include_api_local=False)
+        heartbeat_task = asyncio.create_task(
+            _heartbeat(stop_event), name="worker-heartbeat",
+        )
+        logger.info("AKB worker process ready")
+        await stop_event.wait()
+    finally:
+        stop_event.set()
+        if heartbeat_task is not None:
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
+        _HEARTBEAT_PATH.unlink(missing_ok=True)
+        if workers_started:
+            await stop_workers(include_api_local=False)
+        if storage_initialized:
+            await shutdown_storage()
+        logger.info("AKB worker process stopped")
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/concurrency/test_git_multiprocess_race.py
+++ b/backend/tests/concurrency/test_git_multiprocess_race.py
@@ -1,0 +1,68 @@
+"""Two OS processes may never corrupt one vault's shared worktree."""
+
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+from git import Repo
+
+from app.services.git_service import GitService
+
+
+def _commit_in_process(
+    storage: str,
+    ready,
+    results,
+    path: str,
+    content: str,
+) -> None:
+    try:
+        service = GitService(storage)
+        ready.wait(timeout=10)
+        commit = service.commit_file(
+            "shared",
+            path,
+            content,
+            f"write {path}",
+        )
+        results.put(("ok", commit))
+    except BaseException as exc:  # noqa: BLE001 — child reports to parent
+        results.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def test_shared_worktree_serializes_across_processes(tmp_path: Path):
+    service = GitService(str(tmp_path))
+    service.init_vault("shared")
+    service.commit_file("shared", "seed.md", "seed", "seed")
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_commit_in_process,
+            args=(str(tmp_path), ready, results, "a.md", "alpha"),
+        ),
+        context.Process(
+            target=_commit_in_process,
+            args=(str(tmp_path), ready, results, "b.md", "bravo"),
+        ),
+    ]
+    for process in processes:
+        process.start()
+    ready.set()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    outcomes = [results.get(timeout=2) for _ in processes]
+    assert [status for status, _ in outcomes] == ["ok", "ok"]
+    assert service.read_file("shared", "a.md") == "alpha"
+    assert service.read_file("shared", "b.md") == "bravo"
+
+    bare = Repo(str(tmp_path / "shared.git"))
+    head = bare.git.rev_parse("HEAD").strip()
+    for _status, commit in outcomes:
+        bare.git.merge_base("--is-ancestor", commit, head)
+    assert bare.git.fsck("--full").strip() == ""

--- a/backend/tests/concurrency/test_native_derived_pipeline.py
+++ b/backend/tests/concurrency/test_native_derived_pipeline.py
@@ -487,7 +487,7 @@ async def test_failed_intent_retries_then_reclaims_and_applies(monkeypatch):
                 "SELECT retry_count, delivery_outcome, completed_at, last_error FROM native_invalidation_intents WHERE revision_id = $1",
                 created.revision_id,
             )
-            assert recovered["retry_count"] == 1
+            assert recovered["retry_count"] == 0
             assert recovered["delivery_outcome"] == "applied"
             assert recovered["completed_at"] is not None
             assert recovered["last_error"] is None
@@ -580,7 +580,7 @@ async def test_expired_claim_lease_is_reclaimed_by_another_worker():
         reclaimed = await NativeDerivedWorker(pool)._claim_one()
         assert reclaimed is not None
         assert reclaimed["intent_id"] == first["intent_id"]
-        assert reclaimed["retry_count"] == 0
+        assert reclaimed["retry_count"] == 2
 
 
 async def test_direct_pg_grep_default_and_additive_modes_preserve_acl_and_collection_boundaries():

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -11,9 +11,12 @@ import os
 import shutil
 import subprocess
 import threading
+import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from git import Repo
 
 from app.services.external_git_service import ExternalGitService
 from app.services.git_service import GitService
@@ -68,6 +71,30 @@ def _block_chdir(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(os, "chdir", fail_chdir)
 
 
+def _direct_cat_file_children() -> set[int]:
+    """Return this pytest process's persistent GitPython cat-file children."""
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError, subprocess.SubprocessError:
+        pytest.skip("process-table inspection is unavailable")
+
+    children: set[int] = set()
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(maxsplit=2)
+        if len(fields) != 3:
+            continue
+        pid, parent_pid, command = fields
+        if parent_pid == str(os.getpid()) and command.startswith("git cat-file --batch"):
+            children.add(int(pid))
+    return children
+
+
 def test_commit_file_creates_initial_commit(git_service: GitService) -> None:
     name = f"test_vault_{uuid.uuid4().hex[:8]}"
     git_service.init_vault(name)
@@ -84,6 +111,52 @@ def test_commit_file_creates_initial_commit(git_service: GitService) -> None:
     assert len(sha) == 40
     assert git_service.read_file(name, "first.md") == "first\n"
     assert _vault_commit_count(git_service, name) == 1
+
+
+def test_read_file_closes_repo_while_caller_still_references_it(
+    git_service: GitService,
+    vault: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hot read path must not depend on ``Repo.__del__`` or cyclic GC."""
+    bare_repo = Repo(str(git_service._bare_path(vault)))
+    original_close = bare_repo.close
+    close_calls = 0
+
+    def close() -> None:
+        nonlocal close_calls
+        close_calls += 1
+        original_close()
+
+    monkeypatch.setattr(bare_repo, "close", close)
+    monkeypatch.setattr(git_service, "_get_repo", lambda _vault_name: bare_repo)
+
+    assert git_service.read_file(vault, "seed.md") == "seed\n"
+    assert close_calls == 1
+
+
+def test_parallel_reads_leave_no_cat_file_children(
+    git_service: GitService,
+    vault: str,
+) -> None:
+    """Concurrent reads release GitPython's two persistent helper processes."""
+    before = _direct_cat_file_children()
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        results = list(
+            executor.map(
+                lambda _index: git_service.read_file(vault, "seed.md"),
+                range(96),
+            )
+        )
+
+    assert results == ["seed\n"] * 96
+    deadline = time.monotonic() + 2
+    after = _direct_cat_file_children()
+    while after - before and time.monotonic() < deadline:
+        time.sleep(0.02)
+        after = _direct_cat_file_children()
+    assert after - before == set()
 
 
 def test_commit_file_existing_worktree_preserves_author_and_message(git_service: GitService, vault: str) -> None:

--- a/backend/tests/test_lifecycle_shutdown.py
+++ b/backend/tests/test_lifecycle_shutdown.py
@@ -1,0 +1,168 @@
+"""Runtime safety contracts for the all-in-one backend lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+
+
+def test_runtime_safety_defaults_are_explicit_and_bounded():
+    configured = Settings()
+
+    assert configured.tokenizer_processes == 2
+    assert configured.worker_shutdown_timeout_secs == 35.0
+    with pytest.raises(ValueError):
+        Settings(tokenizer_processes=0)
+    with pytest.raises(ValueError):
+        Settings(tokenizer_processes=5)
+
+
+def test_kiwi_uses_one_native_worker_inside_each_process(monkeypatch):
+    from app.services import sparse_encoder
+
+    created: list[dict] = []
+
+    class FakeKiwi:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+
+    monkeypatch.setattr(sparse_encoder, "Kiwi", FakeKiwi)
+    monkeypatch.setattr(sparse_encoder, "_kiwi", None)
+
+    sparse_encoder._get_kiwi()
+
+    assert created == [{"num_workers": 1}]
+
+
+async def test_stop_workers_broadcasts_then_joins_every_component(monkeypatch):
+    from app.services import lifecycle
+
+    entered: list[str] = []
+    release = asyncio.Event()
+
+    async def stop(name: str) -> None:
+        entered.append(name)
+        await release.wait()
+
+    class RoleSync:
+        async def stop_reconcile_timer(self) -> None:
+            await stop("role_sync")
+
+    names = {
+        lifecycle.m1_file_transfer_reaper: "m1",
+        lifecycle.events_publisher: "events",
+        lifecycle.metadata_worker: "metadata",
+        lifecycle.external_git_poller: "external_git",
+        lifecycle.asset_gc_worker: "asset_gc",
+        lifecycle.s3_delete_worker: "s3_delete",
+        lifecycle.app_rollout_worker: "rollout",
+        lifecycle.delete_worker: "vector_delete",
+        lifecycle.embed_worker: "embed",
+        lifecycle.vault_backfill: "vault_backfill",
+        lifecycle.queue_rescuer: "queue_rescuer",
+    }
+    for module, name in names.items():
+        monkeypatch.setattr(module, "stop", lambda name=name: stop(name))
+    monkeypatch.setattr(lifecycle.audit_log, "stop_uploader", lambda: stop("audit"))
+    monkeypatch.setattr(lifecycle.tool_usage, "stop", lambda: stop("tool_usage"))
+    monkeypatch.setattr(
+        lifecycle.sparse_encoder,
+        "stop_stats_refresher",
+        lambda: stop("bm25"),
+    )
+    monkeypatch.setattr(lifecycle, "get_role_sync", lambda: RoleSync())
+    monkeypatch.setattr(lifecycle.settings, "worker_shutdown_timeout_secs", 1.0)
+
+    ordering: list[str] = []
+    monkeypatch.setattr(lifecycle, "request_stop_all", lambda: ordering.append("broadcast"))
+    monkeypatch.setattr(
+        lifecycle.sparse_encoder,
+        "stop_tokenizer_pool",
+        lambda: ordering.append("tokenizer_pool"),
+    )
+    monkeypatch.setattr(
+        lifecycle.write_lane,
+        "stop_commit_pool",
+        lambda: ordering.append("commit_pool"),
+    )
+
+    task = asyncio.create_task(lifecycle.stop_workers())
+    expected = len(names) + 4
+    for _ in range(100):
+        if len(entered) == expected:
+            break
+        await asyncio.sleep(0)
+
+    assert ordering == ["broadcast"]
+    assert len(entered) == expected
+    release.set()
+    await task
+    assert ordering == ["broadcast", "tokenizer_pool", "commit_pool"]
+
+
+async def test_one_stop_failure_does_not_skip_siblings(monkeypatch):
+    from app.services import lifecycle
+
+    called: list[str] = []
+
+    async def ok(name: str) -> None:
+        called.append(name)
+
+    async def fail() -> None:
+        called.append("failed")
+        raise RuntimeError("boom")
+
+    class RoleSync:
+        async def stop_reconcile_timer(self) -> None:
+            await ok("role_sync")
+
+    modules = [
+        lifecycle.m1_file_transfer_reaper,
+        lifecycle.events_publisher,
+        lifecycle.metadata_worker,
+        lifecycle.external_git_poller,
+        lifecycle.asset_gc_worker,
+        lifecycle.s3_delete_worker,
+        lifecycle.app_rollout_worker,
+        lifecycle.delete_worker,
+        lifecycle.embed_worker,
+        lifecycle.vault_backfill,
+        lifecycle.queue_rescuer,
+    ]
+    for index, module in enumerate(modules):
+        monkeypatch.setattr(module, "stop", lambda index=index: ok(f"module-{index}"))
+    monkeypatch.setattr(lifecycle.audit_log, "stop_uploader", lambda: ok("audit"))
+    monkeypatch.setattr(lifecycle.tool_usage, "stop", fail)
+    monkeypatch.setattr(
+        lifecycle.sparse_encoder,
+        "stop_stats_refresher",
+        lambda: ok("bm25"),
+    )
+    monkeypatch.setattr(lifecycle, "get_role_sync", lambda: RoleSync())
+    monkeypatch.setattr(lifecycle, "request_stop_all", lambda: None)
+    monkeypatch.setattr(lifecycle.sparse_encoder, "stop_tokenizer_pool", lambda: None)
+    monkeypatch.setattr(lifecycle.write_lane, "stop_commit_pool", lambda: None)
+
+    await lifecycle.stop_workers()
+
+    assert "failed" in called
+    assert "bm25" in called
+    assert "module-9" in called
+
+
+def test_kubernetes_timeout_contract_is_explicit():
+    manifest = (
+        Path(__file__).resolve().parents[2] / "deploy/k8s/backend.yaml"
+    ).read_text()
+
+    assert "terminationGracePeriodSeconds: 45" in manifest
+    assert 'name: AKB_PROCESS_ROLE' in manifest
+    assert 'value: "api"' in manifest
+    assert '- name: worker' in manifest
+    assert 'command: ["python", "-m", "app.worker_main"]' in manifest
+    assert 'value: "worker"' in manifest
+    assert 'command: ["python", "-m", "app.worker_health"]' in manifest

--- a/backend/tests/test_lifecycle_workers.py
+++ b/backend/tests/test_lifecycle_workers.py
@@ -50,6 +50,7 @@ def _stub_workers(monkeypatch, lifecycle, started: list[str]) -> None:
     monkeypatch.setattr(lifecycle.external_git_poller, "start", rec("external_git_poller"))
     monkeypatch.setattr(lifecycle.metadata_worker, "start", rec("metadata_worker"))
     monkeypatch.setattr(lifecycle.vault_backfill, "start", rec("vault_backfill"))
+    monkeypatch.setattr(lifecycle.queue_rescuer, "start", rec("queue_rescuer"))
     monkeypatch.setattr(lifecycle.sparse_encoder, "start_tokenizer_pool", rec("tokenizer_pool"))
     monkeypatch.setattr(lifecycle.sparse_encoder, "start_stats_refresher", rec("stats_refresher"))
     monkeypatch.setattr(lifecycle.write_lane, "start_commit_pool", rec("git_commit_pool"))
@@ -68,6 +69,7 @@ def _settings(
     external_git gate."""
     return types.SimpleNamespace(
         external_git_enabled=external_git_enabled,
+        tokenizer_processes=2,
         bm25_recompute_interval_secs=3600,
         s3_endpoint_url=None,
         llm_base_url="http://llm.local/v1" if llm_configured else None,
@@ -103,6 +105,31 @@ def test_start_workers_skips_poller_when_disabled(monkeypatch, tmp_path):
     # … but the always-on workers still start (the gate is surgical).
     assert "embed_worker" in started
     assert "delete_worker" in started
+
+
+def test_worker_role_excludes_api_local_in_memory_sinks(monkeypatch, tmp_path):
+    lifecycle = _import_lifecycle(monkeypatch, tmp_path)
+    started: list[str] = []
+    _stub_workers(monkeypatch, lifecycle, started)
+    monkeypatch.setattr(lifecycle, "settings", _settings(external_git_enabled=False))
+
+    lifecycle.start_workers(include_api_local=False)
+
+    assert "embed_worker" in started
+    assert "tool_usage_maintenance" not in started
+
+
+def test_api_role_starts_no_durable_queue_consumer(monkeypatch, tmp_path):
+    lifecycle = _import_lifecycle(monkeypatch, tmp_path)
+    started: list[str] = []
+    _stub_workers(monkeypatch, lifecycle, started)
+    monkeypatch.setattr(lifecycle, "settings", _settings(external_git_enabled=False))
+
+    lifecycle.start_api_runtime()
+
+    assert "tool_usage_maintenance" in started
+    assert "embed_worker" not in started
+    assert "delete_worker" not in started
 
 
 def test_start_workers_starts_metadata_worker_when_enabled_and_llm(monkeypatch, tmp_path):

--- a/backend/tests/test_process_roles.py
+++ b/backend/tests/test_process_roles.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from app import worker_health
+from app import worker_main
+from app.process_role import runtime_process_role
+
+
+def test_process_role_defaults_to_all(monkeypatch):
+    monkeypatch.delenv("AKB_PROCESS_ROLE", raising=False)
+    assert runtime_process_role() == "all"
+
+
+def test_process_role_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("AKB_PROCESS_ROLE", "surprise")
+    with pytest.raises(RuntimeError, match="all, api, worker"):
+        runtime_process_role()
+
+
+def test_worker_health_accepts_fresh_and_rejects_stale_heartbeat(monkeypatch, tmp_path):
+    heartbeat = tmp_path / "heartbeat"
+    heartbeat.touch()
+    monkeypatch.setenv("AKB_WORKER_HEARTBEAT_PATH", str(heartbeat))
+    monkeypatch.setenv("AKB_WORKER_HEARTBEAT_MAX_AGE_SECS", "30")
+
+    worker_health.main()
+
+    old = time.time() - 60
+    os.utime(heartbeat, (old, old))
+    with pytest.raises(SystemExit, match="stale"):
+        worker_health.main()
+
+
+def test_worker_entrypoint_selects_revision_backend_before_composition(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        worker_main,
+        "get_revision_backend",
+        lambda: calls.append("selected"),
+    )
+    monkeypatch.setattr(
+        worker_main,
+        "selected_document_revision_backend",
+        lambda: "bare_git" if calls else None,
+    )
+
+    assert worker_main._select_revision_backend() == "bare_git"
+    assert calls == ["selected"]
+
+
+def test_worker_entrypoint_fails_closed_when_selection_does_not_complete(monkeypatch):
+    monkeypatch.setattr(worker_main, "get_revision_backend", lambda: None)
+    monkeypatch.setattr(
+        worker_main,
+        "selected_document_revision_backend",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="selection did not complete"):
+        worker_main._select_revision_backend()

--- a/backend/tests/test_sparse_encoder.py
+++ b/backend/tests/test_sparse_encoder.py
@@ -1,3 +1,7 @@
+import asyncio
+
+import pytest
+
 from app.services.sparse_encoder import _english_token_variants
 
 
@@ -34,3 +38,37 @@ def test_english_token_variants_stem_plural_once_no_es_s_overlap():
     assert "study" in studies
     assert "studi" not in studies
     assert "studie" not in studies
+
+
+@pytest.mark.asyncio
+async def test_stats_refresher_start_is_idempotent_and_keeps_one_health_runner(
+    monkeypatch,
+):
+    from app.services import sparse_encoder
+    from app.services._backfill import runner_snapshots
+
+    await sparse_encoder.stop_stats_refresher()
+
+    async def no_work() -> int:
+        return 0
+
+    async def bootstrap() -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(sparse_encoder._refresher, "_process_once", no_work)
+    monkeypatch.setattr(sparse_encoder, "_bootstrap_recompute", bootstrap)
+    before = sum(
+        item["name"] == "bm25_stats_refresher" for item in runner_snapshots()
+    )
+
+    sparse_encoder.start_stats_refresher(3600)
+    sparse_encoder.start_stats_refresher(3600)
+    await asyncio.sleep(0)
+
+    after = sum(
+        item["name"] == "bm25_stats_refresher" for item in runner_snapshots()
+    )
+    assert before == after == 1
+    assert sparse_encoder._refresher.is_running()
+
+    await sparse_encoder.stop_stats_refresher()

--- a/backend/tests/test_standalone_sso_deployment_unit.py
+++ b/backend/tests/test_standalone_sso_deployment_unit.py
@@ -95,6 +95,9 @@ def test_backend_patch_removes_local_key_authority_and_mounts_one_time_inputs_on
     assert "keycloak-upgrade" not in main_mounts
     assert "product-admin-bootstrap" not in main_mounts
     assert pod["containers"][0]["volumeMounts"][0]["$patch"] == "delete"
+    worker = next(item for item in pod["containers"] if item["name"] == "worker")
+    assert worker["volumeMounts"][0]["name"] == "local-session-keys"
+    assert worker["volumeMounts"][0]["$patch"] == "delete"
     volumes = {item["name"]: item for item in pod["volumes"]}
     assert volumes["local-session-keys"]["$patch"] == "delete"
     assert "optional" not in volumes["keycloak-bootstrap"]["secret"]

--- a/backend/tests/test_tool_usage_unit.py
+++ b/backend/tests/test_tool_usage_unit.py
@@ -1028,7 +1028,13 @@ def test_lifecycle_starts_and_stops_the_workers():
             for c in calls
         )
 
-    assert _has(_calls("start_workers"), "start"), "lifecycle must start the workers"
+    assert _has(_calls("_start_api_local"), "start"), (
+        "the API-local lifecycle must start tool-usage maintenance"
+    )
+    assert any(
+        isinstance(call.func, ast.Name) and call.func.id == "_start_api_local"
+        for call in _calls("start_workers")
+    ), "all-in-one lifecycle must compose the API-local sinks"
     assert _has(_calls("stop_workers"), "stop"), "lifecycle must stop the workers"
 
     # `start()` must be unconditional — find it and check no enclosing `if`.

--- a/backend/tests/test_worker_claim_lifecycle.py
+++ b/backend/tests/test_worker_claim_lifecycle.py
@@ -1,0 +1,155 @@
+"""Crash-safe retry accounting contracts shared by durable workers."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from app.services import (
+    delete_worker,
+    embed_worker,
+    events_publisher,
+    metadata_worker,
+    queue_rescuer,
+    s3_delete_worker,
+)
+from app.services._backfill import MAX_RETRIES
+
+
+@pytest.mark.parametrize(
+    ("claim", "counter", "claimed", "abandoned"),
+    [
+        (embed_worker._claim_batch, "vector_retry_count", "vector_claimed_at", "vector_abandoned_at"),
+        (delete_worker._claim_delete_batch, "retry_count", "claimed_at", "abandoned_at"),
+        (s3_delete_worker._claim_batch, "retry_count", "claimed_at", "abandoned_at"),
+        (metadata_worker._claim_batch, "llm_retry_count", "llm_claimed_at", "llm_abandoned_at"),
+        (events_publisher._claim_batch, "attempts", "claimed_at", "abandoned_at"),
+    ],
+)
+def test_claims_burn_attempt_before_external_work(claim, counter, claimed, abandoned):
+    source = inspect.getsource(claim)
+
+    assert f"{counter} = {counter} + 1" in source
+    assert f"{claimed} = NOW()" in source
+    assert f"{abandoned} IS NULL" in source
+    assert counter in source.split("RETURNING", 1)[1]
+    assert claimed in source.split("RETURNING", 1)[1]
+
+
+class _RecordingConn:
+    def __init__(self):
+        self.calls: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, *args):
+        self.calls.append((sql, args))
+        return "UPDATE 1"
+
+
+async def test_failure_does_not_increment_twice_and_stamps_terminal(monkeypatch):
+    conn = _RecordingConn()
+    delays: list[int] = []
+
+    def delay(index: int) -> int:
+        delays.append(index)
+        return 123
+
+    monkeypatch.setattr(delete_worker, "next_attempt_delay", delay)
+    await delete_worker._mark_delete_failure(
+        conn, 7, MAX_RETRIES, "terminal",
+    )
+
+    sql, args = conn.calls[0]
+    assert "retry_count = retry_count + 1" not in sql
+    assert delays == [MAX_RETRIES - 1]
+    assert args[2] is None
+    assert args[3] is True
+    assert "abandoned_at" in sql
+
+
+async def test_events_client_init_failure_credits_unattempted_batch(monkeypatch):
+    batch = [
+        {"id": index, "attempts": 1, "claimed_at": "same-claim"}
+        for index in range(1, 4)
+    ]
+
+    class Context:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def transaction(self):
+            return self
+
+    class Pool:
+        def acquire(self):
+            return Context()
+
+    async def get_pool():
+        return Pool()
+
+    async def claim(_conn):
+        return batch
+
+    async def unavailable():
+        raise OSError("redis unavailable")
+
+    failed: list[int] = []
+    released: list[list[int]] = []
+
+    async def mark_failure(_conn, event_id, _attempts, _error):
+        failed.append(event_id)
+
+    async def release(_conn, rows):
+        released.append([row["id"] for row in rows])
+
+    monkeypatch.setattr(events_publisher.settings, "redis_url", "redis://test")
+    monkeypatch.setattr(events_publisher, "get_pool", get_pool)
+    monkeypatch.setattr(events_publisher, "_claim_batch", claim)
+    monkeypatch.setattr(events_publisher, "_client", unavailable)
+    monkeypatch.setattr(events_publisher, "_mark_failure", mark_failure)
+    monkeypatch.setattr(events_publisher, "_release_unattempted", release)
+
+    assert await events_publisher._process_once() == 0
+    assert failed == [1]
+    assert released == [[2, 3]]
+
+
+def test_rescuer_covers_every_attempt_at_claim_queue():
+    sql = "\n".join(queue_rescuer._RESCUE_STATEMENTS)
+
+    for table in (
+        "chunks",
+        "vector_delete_outbox",
+        "s3_delete_outbox",
+        "events",
+        "documents",
+        "native_invalidation_intents",
+    ):
+        assert f"UPDATE {table}" in sql
+    assert sql.count(">= $1") == 6
+    assert "delivery_outcome = 'abandoned'" in sql
+
+
+def test_migration_is_registered_and_adds_claim_lifecycle_columns():
+    backend = Path(__file__).resolve().parents[1]
+    postgres = (backend / "app/db/postgres.py").read_text()
+    migration = (backend / "app/db/migrations/079_worker_claim_lifecycle.py").read_text()
+
+    assert '"079_worker_claim_lifecycle.py"' in postgres
+    for column in (
+        "vector_claimed_at",
+        "vector_abandoned_at",
+        "claimed_at",
+        "abandoned_at",
+        "llm_claimed_at",
+        "llm_abandoned_at",
+    ):
+        assert column in migration
+    assert "native_invalidation_intents" in inspect.getsource(
+        __import__("app.services.native_derived_worker", fromlist=["NativeDerivedWorker"])
+        .NativeDerivedWorker._claim_one
+    )

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -14,6 +14,12 @@ db_user: akb
 # pg_pool_min_size: 2
 # pg_pool_max_size: 30
 
+# Runtime safety budgets. Each Kiwi child holds its own model in memory, so do
+# not derive this from host CPU count. Kubernetes grants 45 seconds for pod
+# termination; workers share 35 seconds and leave the remainder for teardown.
+tokenizer_processes: 2
+worker_shutdown_timeout_secs: 35
+
 # === Git storage (bare repos per vault live under this path) ===
 git_storage_path: /data/vaults
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -45,6 +45,26 @@ inside the Postgres pod. Other options:
 The `internal/` overlay shows the Qdrant pattern for the production
 cluster.
 
+## Backend process topology
+
+The base Deployment keeps one `Recreate` Pod and one RWO Git PVC, but runs two
+containers from the same backend image:
+
+- `backend` uses `AKB_PROCESS_ROLE=api` and serves FastAPI/MCP. It owns only
+  serving-process sinks and one query-tokenizer child.
+- `worker` runs `python -m app.worker_main` with
+  `AKB_PROCESS_ROLE=worker`. It owns durable queue consumers, external-Git
+  reconciliation, and periodic maintenance. Its exec probe checks an
+  event-loop heartbeat.
+
+This separation prevents a worker stall from blocking the serving loop. It is
+not the final horizontally scalable topology: both containers still mount the
+RWO PVC because synchronous Bare-Git reads/writes remain in the API path.
+Keep `replicas: 1`, `strategy: Recreate`, and the API PVC mount until the
+single-writer gitd, MCP session, audit/throttle, and drift-recovery gates in
+[`docs/design/accepted/2026-08-18-worker-runtime-safety-foundation`](../../docs/design/accepted/2026-08-18-worker-runtime-safety-foundation/README.md)
+are complete.
+
 For a standalone installation whose canonical human-auth mode is `sso`, use
 [`standalone-sso/README.md`](standalone-sso/README.md). That overlay owns its
 Keycloak lifecycle and dedicated database. Do not apply it to a managed tenant

--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -14,6 +14,8 @@ data:
     db_name: akb
     db_user: akbuser
     git_storage_path: /data/vaults
+    tokenizer_processes: 2
+    worker_shutdown_timeout_secs: 35
 
     # Embedding (required) — any OpenAI-compatible /v1/embeddings endpoint.
     # embed_dimensions MUST match the model.
@@ -100,12 +102,23 @@ spec:
       labels:
         app: akb-backend
     spec:
+      # All worker stop signals are broadcast together and joined under the
+      # 35-second application deadline. The remaining 10 seconds cover DB/HTTP
+      # client close, audit drain, and interpreter teardown before SIGKILL.
+      terminationGracePeriodSeconds: 45
       containers:
         - name: backend
           image: akb-backend:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
+          env:
+            - name: AKB_PROCESS_ROLE
+              value: "api"
+            # Serving only tokenizes queries; one child avoids duplicating the
+            # worker sidecar's corpus-indexing memory footprint.
+            - name: AKB_TOKENIZER_PROCESSES
+              value: "1"
           volumeMounts:
             - name: app-config
               mountPath: /etc/akb/app.yaml
@@ -148,11 +161,12 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 8
             failureThreshold: 3
-          # Liveness RESTARTS the pod (SIGKILL) — with replicas=1 that is a
-          # total outage, so it must fire ONLY on a genuinely dead loop, never
-          # on a transient multi-second stall (a big akb_sql, an indexing
-          # burst). The single event loop can be briefly unschedulable while
-          # still healthy, so tolerate ~6×30s = 3min before assuming deadlock.
+          # Liveness restarts the serving container — with one API replica that
+          # is a total serving outage, so it must fire ONLY on a genuinely dead
+          # loop, never on a transient multi-second stall (for example a large
+          # akb_sql response). Durable indexing now lives in the sidecar. The
+          # API loop can still be briefly unschedulable while healthy, so
+          # tolerate ~6×30s = 3min before assuming deadlock.
           # (Do NOT rely on a runtime `kubectl patch` — deploy-internal.sh
           # re-applies this manifest and clobbers it; the value must live here.)
           livenessProbe:
@@ -162,6 +176,54 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 8
             failureThreshold: 6
+        - name: worker
+          image: akb-backend:latest
+          imagePullPolicy: Always
+          command: ["python", "-m", "app.worker_main"]
+          env:
+            - name: AKB_PROCESS_ROLE
+              value: "worker"
+            - name: AKB_TOKENIZER_PROCESSES
+              value: "2"
+          volumeMounts:
+            - name: app-config
+              mountPath: /etc/akb/app.yaml
+              subPath: app.yaml
+              readOnly: true
+            - name: secret-config
+              mountPath: /etc/akb/secret.yaml
+              subPath: secret.yaml
+              readOnly: true
+            - name: local-session-keys
+              mountPath: /etc/akb/local-session
+              readOnly: true
+            - name: vaultdata
+              mountPath: /data/vaults
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "4Gi"
+          startupProbe:
+            exec:
+              command: ["python", "-m", "app.worker_health"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: ["python", "-m", "app.worker_health"]
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["python", "-m", "app.worker_health"]
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
       volumes:
         - name: app-config
           configMap:

--- a/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-deployment-patch.yaml
@@ -82,6 +82,11 @@ spec:
             - name: local-session-keys
               mountPath: /etc/akb/local-session
               $patch: delete
+        - name: worker
+          volumeMounts:
+            - name: local-session-keys
+              mountPath: /etc/akb/local-session
+              $patch: delete
       volumes:
         - name: local-session-keys
           $patch: delete

--- a/docs/design/accepted/2026-08-18-worker-runtime-safety-foundation/README.md
+++ b/docs/design/accepted/2026-08-18-worker-runtime-safety-foundation/README.md
@@ -1,0 +1,111 @@
+---
+status: accepted
+stage: implementation
+created: 2026-08-18
+updated: 2026-08-18
+---
+
+# Worker Runtime Safety Foundation
+
+## Decision
+
+AKB now supports three explicit process roles:
+
+| `AKB_PROCESS_ROLE` | Entrypoint | Responsibility |
+|---|---|---|
+| `all` (default) | `uvicorn app.main:app` | Local/development compatibility: API and durable workers together |
+| `api` | `uvicorn app.main:app` | HTTP/MCP serving, API-local audit/tool-usage sinks, query tokenizer |
+| `worker` | `python -m app.worker_main` | Durable queue workers, external-git reconciliation, periodic maintenance |
+
+The Kubernetes base runs `api` and `worker` as separate containers in the same
+Pod. This is an intentional intermediate topology: it isolates the serving
+event loop immediately while preserving the current RWO PVC and synchronous
+Bare-Git write contract. It does **not** authorize additional API replicas or
+removal of the API container's PVC mount. Those changes still require the
+single-writer gitd boundary and the remaining gates listed below.
+
+```text
+one Recreate Pod, one RWO PVC
+
+  API container                         worker sidecar
+  AKB_PROCESS_ROLE=api                  AKB_PROCESS_ROLE=worker
+  FastAPI + MCP                         durable workers
+  query tokenizer (1 child)             corpus tokenizer (2 children)
+  API-local audit/tool queues           queue rescuer + periodic reconcile
+            \                              /
+             +---- PostgreSQL + shared Git PVC ----+
+                    storage flock + ref CAS
+```
+
+## Correctness changes that make the split safe
+
+### Shutdown
+
+All durable runners receive their stop signal before any runner is awaited.
+They then share one 35-second absolute join budget. Kubernetes grants 45
+seconds, leaving ten seconds for DB/HTTP closure, audit draining, and process
+teardown. Kiwi uses one native worker inside each bounded tokenizer child so
+memory use cannot multiply by host CPU count.
+
+The worker exec probe checks a container-local heartbeat written by the worker
+event loop. A stale heartbeat is deleted before startup, so an old process
+cannot make a new one ready prematurely.
+
+### Durable queue claims
+
+The vector-index, vector-delete, S3-delete, metadata, event, and native-derived
+queues increment their attempt counter in the claim transaction. A process
+death therefore consumes an attempt even when no exception handler runs.
+Claims carry explicit claimed and abandoned timestamps; successful work resets
+the retry epoch; batch consumers credit back rows they did not attempt.
+
+A singleton PostgreSQL-advisory-lock rescuer stamps final claims abandoned once
+their visibility timeout expires. It never deletes vector/S3 outbox evidence.
+Queue and runner state is exposed by `/health` under `queue_claims` and
+`workers`.
+
+### Shared Git writes
+
+The API and worker containers can both reach Bare Git during this intermediate
+phase. A storage-backed per-vault `flock`, paired with the existing process
+lock, now covers the shared worktree mutation interval. Commits capture their
+exact parent, skip empty trees, and advance `HEAD` with `update-ref` compare-and-
+swap. Same-name vault creation holds a second storage lock across creation and
+rollback so one process cannot compensate by deleting another process's repo.
+
+The race regression test starts two spawned processes against the same linked
+worktree and verifies both files, ancestry, and `git fsck`.
+
+### Multi-process startup
+
+Schema migrations are serialized by a PostgreSQL session advisory lock. Each
+migration and its ledger receipt commit in the same transaction. Role
+reconciliation runs from one repeatable-read snapshot under an advisory lock;
+each recoverable DDL unit has a savepoint so one failure cannot poison the
+entire convergence transaction.
+
+## Deployment and rollback
+
+The local/default behavior remains `all`. Kubernetes selects `api` and
+`worker` explicitly; `app.worker_main` refuses to run without the `worker`
+role, and Uvicorn refuses the `worker` role. This fail-closed composition
+prevents accidental duplicate durable workers.
+
+Rollback is a manifest rollback to the previous single-container Pod. The
+claim-lifecycle migration is additive, and the default all-in-one entrypoint
+understands the new columns, so no destructive schema rollback is required.
+
+## Remaining gates before the target topology
+
+This foundation deliberately keeps `replicas: 1`, `strategy: Recreate`, and
+the API PVC mount. The following are not claimed complete:
+
+1. a networked single-writer gitd and fail-closed `gitd_url` composition;
+2. removal of every API-side Bare-Git write/read dependency and the API PVC;
+3. drift detector and operator repair/restore drill;
+4. MCP multi-replica session ownership or routing;
+5. publication throttling and audit-chain authority suitable for API replicas;
+6. API `RollingUpdate` and horizontal replica increase.
+
+Until those gates are implemented and exercised, raising Uvicorn workers or
+Deployment replicas remains unsupported.


### PR DESCRIPTION
## Summary

- add explicit `all`, `api`, and `worker` process roles while preserving the local all-in-one default
- run Kubernetes API serving and durable workers as separate containers in the same single-replica, RWO-backed Pod
- make shutdown bounded with broadcast-first stop signals, a shared deadline, and a worker heartbeat probe
- make durable queue claims crash-safe with claim-time attempt accounting, explicit claim/abandon state, batch credit-back, and a singleton rescuer
- protect shared Bare-Git writes with storage-backed per-vault locks, exact-parent commits, and ref compare-and-swap
- serialize migrations and role reconciliation for multi-process startup

## Deployment shape

The Kubernetes base remains deliberately conservative:

- `replicas: 1`
- `strategy: Recreate`
- one Pod and one RWO Git PVC
- `backend`: `AKB_PROCESS_ROLE=api`
- `worker`: `AKB_PROCESS_ROLE=worker`

Docker Compose keeps the default `AKB_PROCESS_ROLE=all`. This change does not enable horizontal API scaling or remove the API PVC mount.

## Remaining gates

Horizontal scaling still requires a networked single-writer Git service, removal of API-side Git/PVC access, multi-replica MCP session ownership, and distributed audit/throttling authority.