### PR TITLE
feat(auth): create the recovery administrator without a credential

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -47,7 +47,8 @@ REPAIR_RESOURCE_HASHES_USAGE = (
 PROVISION_RECOVERY_ADMIN_USAGE = (
     "Usage: python -m app.cli provision-recovery-admin "
     "{local|sso} --username USER --email EMAIL [profile options]\n"
-    "  local: (--password-file PATH|- | --generate-password-file PATH)\n"
+    "  local: [--password-file PATH|- | --generate-password-file PATH]\n"
+    "         omit both to create the account without a credential\n"
     "  sso:   --issuer ISSUER --subject SUBJECT"
 )
 
@@ -61,7 +62,7 @@ STANDALONE_SSO_BOOTSTRAP_USAGE = (
     "--bootstrap-client-id ID --bootstrap-client-secret-file PATH "
     "[--upgrade-client-id ID --upgrade-client-secret-file PATH] "
     "--product-admin-username USER --product-admin-email EMAIL "
-    "--product-admin-password-file PATH"
+    "[--product-admin-password-file PATH  (accepted, ignored)]"
 )
 
 
@@ -123,7 +124,9 @@ def _recovery_admin_parser() -> argparse.ArgumentParser:
     local = profiles.add_parser("local", add_help=False)
     local.add_argument("--username", required=True)
     local.add_argument("--email", required=True)
-    password_source = local.add_mutually_exclusive_group(required=True)
+    # Neither source is required: with both omitted the account is created
+    # holding no credential at all, and one is issued for it separately.
+    password_source = local.add_mutually_exclusive_group()
     password_source.add_argument("--password-file")
     password_source.add_argument("--generate-password-file")
 
@@ -235,18 +238,20 @@ async def _provision_recovery_admin(args: list[str]) -> int:
     try:
         await _initialize_operator_database()
         if parsed.profile == "local":
+            credential: dict[str, str] = {}
             if parsed.generate_password_file is not None:
                 password = secrets.token_urlsafe(32)
                 generated_path = _write_generated_password(
                     parsed.generate_password_file,
                     password,
                 )
-            else:
-                password = _read_password_source(parsed.password_file)
+                credential["password"] = password
+            elif parsed.password_file is not None:
+                credential["password"] = _read_password_source(parsed.password_file)
             report = await provision_local_recovery_admin(
                 username=parsed.username,
                 email=parsed.email,
-                password=password,
+                **credential,
             )
         else:
             report = await provision_sso_recovery_admin(
@@ -314,7 +319,11 @@ def _standalone_sso_parser() -> argparse.ArgumentParser:
     parser.add_argument("--upgrade-client-secret-file")
     parser.add_argument("--product-admin-username", required=True)
     parser.add_argument("--product-admin-email", required=True)
-    parser.add_argument("--product-admin-password-file", required=True)
+    # Retired input, still accepted so a deployment whose init container
+    # passes it keeps starting. The value is deliberately never read: the
+    # product admin is installed with no credential at all, and honouring a
+    # supplied password here would put a stored one back on the account.
+    parser.add_argument("--product-admin-password-file")
     return parser
 
 
@@ -351,9 +360,6 @@ async def _bootstrap_standalone_sso(args: list[str]) -> int:
             if parsed.upgrade_client_secret_file is not None
             else ""
         )
-        product_admin_password = _read_optional_bootstrap_secret_file(
-            parsed.product_admin_password_file
-        )
         if settings.require_auth_mode() != "sso" or not settings.keycloak_enabled:
             raise _ProvisioningInputError(
                 "Standalone SSO bootstrap requires auth_mode=sso and Keycloak enabled"
@@ -389,7 +395,6 @@ async def _bootstrap_standalone_sso(args: list[str]) -> int:
             settings.keycloak_management_client_secret,
             bootstrap_secret,
             upgrade_secret,
-            product_admin_password,
         ]
         configured_credentials = [value for value in credentials if value]
         if len(set(configured_credentials)) != len(configured_credentials):
@@ -424,7 +429,6 @@ async def _bootstrap_standalone_sso(args: list[str]) -> int:
             admin_client_secret=settings.keycloak_admin_client_secret,
             product_admin_username=parsed.product_admin_username,
             product_admin_email=parsed.product_admin_email,
-            product_admin_password=product_admin_password,
             backchannel_logout_uri=(
                 settings.keycloak_backchannel_logout_uri_effective
             ),

--- a/backend/app/services/account_markers.py
+++ b/backend/app/services/account_markers.py
@@ -8,7 +8,21 @@ RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL = (  # nosec B105
     "!retired-recovery-admin:no-local-login!"
 )
 
+# The designated recovery administrator can be created before any credential
+# exists for it. This marker records that state: it is not a bcrypt hash, so
+# no candidate can ever verify against it and the account cannot be entered
+# until a credential is issued on demand. Distinct from the retirement
+# tombstone above — this account is live and holds recovery authority.
+UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL = (  # nosec B105
+    "!unissued-recovery-admin:no-local-login!"
+)
+
 
 def is_retired_recovery_admin_password(password_hash: str | None) -> bool:
     """Return whether an account is the durable retired-recovery tombstone."""
     return password_hash == RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+
+
+def is_unissued_recovery_admin_password(password_hash: str | None) -> bool:
+    """Return whether a recovery administrator has no issued credential yet."""
+    return password_hash == UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Literal
 
@@ -17,7 +18,11 @@ from app.exceptions import (
     ValidationError,
 )
 from app.repositories.events_repo import emit_event
-from app.services.account_markers import RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+from app.services.account_markers import (
+    RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+    UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+    is_unissued_recovery_admin_password,
+)
 from app.services.account_service import cleanup_token_roles
 from app.services.auth_service import hash_password_async
 from app.services.external_identity_contract import (
@@ -32,6 +37,9 @@ from app.services.role_sync import get_role_sync
 _PROVISIONING_LOCK_ID = 0x414B425245434F56  # "AKBRECOV"
 # These fixed strings are intentionally invalid credential tombstones, not passwords.
 _SSO_PASSWORD_SENTINEL = "!keycloak-sso:no-local-login!"  # nosec B105
+# Every bcrypt hash starts with a versioned "$2x$<cost>$" prefix, so this
+# distinguishes a real credential from any marker string.
+_BCRYPT_HASH_PREFIX = re.compile(r"^\$2[aby]\$\d{2}\$")
 
 
 def _required(value: str, field: str) -> str:
@@ -48,6 +56,19 @@ def _email(value: str) -> str:
 def _require_mode(expected: Literal["local", "sso"]) -> None:
     if settings.require_auth_mode() != expected:
         raise RecoveryAdminModeError()
+
+
+def _is_local_recovery_credential(password_hash: str | None) -> bool:
+    """Return whether a local recovery admin holds a credential state we set.
+
+    Exactly two are legitimate: a bcrypt hash (a credential has been issued)
+    and the unissued marker (none has). Anything else is an account state this
+    service did not produce, so converging on it would adopt an identity of
+    unknown provenance as the one account that can recover the installation.
+    """
+    if password_hash is None:
+        return False
+    return bool(_BCRYPT_HASH_PREFIX.match(password_hash)) or is_unissued_recovery_admin_password(password_hash)
 
 
 def _validate_password(password: str) -> None:
@@ -102,14 +123,22 @@ async def provision_local_recovery_admin(
     *,
     username: str,
     email: str,
-    password: str,
+    password: str | None = None,
 ) -> dict:
-    """Create the one local recovery admin, or converge on its exact identity."""
+    """Create the one local recovery admin, or converge on its exact identity.
+
+    Without ``password`` the account is created holding the unissued marker
+    instead of a hash, so it exists and carries recovery authority but cannot
+    be authenticated until a credential is issued for it.
+    """
     _require_mode("local")
     username = _required(username, "username")
     email = _email(email)
-    _validate_password(password)
-    password_hash = await hash_password_async(password)
+    if password is None:
+        password_hash = UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+    else:
+        _validate_password(password)
+        password_hash = await hash_password_async(password)
     pool = await get_pool()
     created = False
 
@@ -123,9 +152,13 @@ async def provision_local_recovery_admin(
                         "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
                         row["id"],
                     )
+                    # Convergence deliberately never touches the credential
+                    # column: an issued password is not reset, and an unissued
+                    # account is not silently given one.
                     if not (
                         row["username"] == username
                         and row["email"].lower() == email
+                        and _is_local_recovery_credential(row["password_hash"])
                         and row["is_admin"]
                         and row["is_recovery_admin"]
                         and row["auth_provider"] == "local"

--- a/backend/app/services/standalone_sso_bootstrap.py
+++ b/backend/app/services/standalone_sso_bootstrap.py
@@ -62,7 +62,6 @@ class StandaloneSSOBootstrapSpec:
     admin_client_secret: str = field(repr=False)
     product_admin_username: str
     product_admin_email: str
-    product_admin_password: str = field(repr=False)
     backchannel_logout_uri: str = ""
     upgrade_client_id: str = "akb-bootstrap-upgrade-v2"
     upgrade_client_secret: str = field(default="", repr=False)
@@ -388,17 +387,9 @@ async def bootstrap_standalone_sso(
             raise StandaloneSSOBootstrapError("keycloak_bootstrap_retirement_receipt_missing")
         if upgrade_token is not None:
             raise StandaloneSSOBootstrapError("keycloak_upgrade_client_unexpected")
-        if not spec.product_admin_password:
-            # Validate the one-time recovery input before reconcile creates or
-            # changes any realm resource. Readback and profile-upgrade runs do
-            # not need the original product-admin password.
-            raise StandaloneSSOBootstrapError("keycloak_product_admin_password_unavailable")
-        if (
-            len(spec.product_admin_password) < 12
-            or spec.product_admin_password == spec.product_admin_username
-            or spec.product_admin_password == spec.product_admin_email
-        ):
-            raise StandaloneSSOBootstrapError("keycloak_product_admin_password_policy")
+        # Installation carries no product-admin password. The account is
+        # created unable to authenticate, and a credential is issued for it
+        # separately; the realm's own password policy governs that credential.
         mode = "fresh" if management_token is None else "recovery"
         keycloak_mutated = True
         readback = await control.reconcile(

--- a/backend/app/services/standalone_sso_keycloak.py
+++ b/backend/app/services/standalone_sso_keycloak.py
@@ -978,8 +978,6 @@ class KeycloakStandaloneSSOControl:
         token: str,
     ) -> dict[str, Any]:
         existing = await self._exact_user(spec, token=token)
-        if not spec.product_admin_password:
-            raise _fail("keycloak_product_admin_password_unavailable")
         if existing is None:
             desired = {
                 "username": spec.product_admin_username,
@@ -988,14 +986,14 @@ class KeycloakStandaloneSSOControl:
                 "emailVerified": True,
                 "firstName": "AKB",
                 "lastName": "Product Administrator",
-                "requiredActions": ["UPDATE_PASSWORD"],
-                "credentials": [
-                    {
-                        "type": "password",
-                        "value": spec.product_admin_password,
-                        "temporary": True,
-                    }
-                ],
+                # No credential, and therefore no required action. Keycloak
+                # evaluates required actions at the end of a successful
+                # authentication; on an account nobody can authenticate to,
+                # UPDATE_PASSWORD can never fire, and asking for it would
+                # advertise a password that does not exist. Requiring a change
+                # belongs to whatever issues the credential later, which is
+                # also the moment the action first becomes reachable.
+                "requiredActions": [],
             }
             await self._request(
                 spec,
@@ -1015,43 +1013,27 @@ class KeycloakStandaloneSSOControl:
             raise _fail("keycloak_admin_identity_is_federated")
         if not self._product_admin_matches(spec, user):
             raise _fail("keycloak_product_admin_readback_failed")
-        if existing is not None:
-            user_id = _required_string(
-                user,
-                "id",
-                "keycloak_product_admin_readback_failed",
-            )
-            if await self._federated_identity_count(
-                spec,
-                user_id,
-                token=token,
-            ):
-                # Never add a local recovery credential to a brokered user.
-                # The dedicated product admin must remain realm-native.
-                raise _fail("keycloak_admin_identity_is_federated")
-            await self._request(
-                spec,
-                "PUT",
-                (f"/admin/realms/{_path(spec.realm)}/users/{_path(user_id)}/reset-password"),
-                token=token,
-                json_body={
-                    "type": "password",
-                    "value": spec.product_admin_password,
-                    "temporary": True,
-                },
-                expected=frozenset({204}),
-                code="keycloak_product_admin_password_reset_failed",
-            )
-            user = await self._exact_user(spec, token=token)
-            if user is None:
-                raise _fail("keycloak_product_admin_readback_failed")
-            if not self._product_admin_is_native(user):
-                raise _fail("keycloak_admin_identity_is_federated")
-            if not self._product_admin_matches(spec, user):
-                raise _fail("keycloak_product_admin_readback_failed")
-        if user.get("requiredActions") != ["UPDATE_PASSWORD"]:
-            raise _fail("keycloak_product_admin_update_password_missing")
-        await self._require_product_admin_password(spec, user, token=token)
+        if existing is None:
+            # Read back the account we just created: it must be un-enterable.
+            if user.get("requiredActions"):
+                raise _fail("keycloak_product_admin_required_action_unexpected")
+            await self._require_product_admin_has_no_password(spec, user, token=token)
+            return user
+        # An account an operator already installed keeps whatever credential
+        # state it holds; convergence neither writes nor removes one.
+        user_id = _required_string(
+            user,
+            "id",
+            "keycloak_product_admin_readback_failed",
+        )
+        if await self._federated_identity_count(
+            spec,
+            user_id,
+            token=token,
+        ):
+            # Never add a local recovery credential to a brokered user.
+            # The dedicated product admin must remain realm-native.
+            raise _fail("keycloak_admin_identity_is_federated")
         return user
 
     @staticmethod
@@ -1069,13 +1051,18 @@ class KeycloakStandaloneSSOControl:
             and user.get("emailVerified") is True
         )
 
-    async def _require_product_admin_password(
+    async def _require_product_admin_has_no_password(
         self,
         spec: StandaloneSSOBootstrapSpec,
         user: Mapping[str, object],
         *,
         token: str,
     ) -> None:
+        """Prove a freshly created product admin holds no password credential.
+
+        This is a read-back of our own create, not a standing realm invariant:
+        a recovery credential issued later is expected to show up here.
+        """
         user_id = _required_string(user, "id", "keycloak_product_admin_readback_failed")
         credentials = _objects(
             await self._json(
@@ -1086,8 +1073,8 @@ class KeycloakStandaloneSSOControl:
             ),
             "keycloak_product_admin_credential_read_failed",
         )
-        if not any(item.get("type") == "password" for item in credentials):
-            raise _fail("keycloak_product_admin_password_missing")
+        if any(item.get("type") == "password" for item in credentials):
+            raise _fail("keycloak_product_admin_password_present")
 
     async def _federated_identity_count(
         self,
@@ -1394,11 +1381,10 @@ class KeycloakStandaloneSSOControl:
             product_admin,
         ):
             raise _fail("keycloak_product_admin_readback_failed")
-        await self._require_product_admin_password(
-            spec,
-            product_admin,
-            token=management_token,
-        )
+        # Steady-state read-back deliberately does not inspect the credential
+        # list. It runs on every re-install, and by then a recovery credential
+        # may have been issued on demand; whether one exists is not evidence
+        # about this installation's shape.
         product_admin_id = _required_string(
             product_admin,
             "id",

--- a/backend/tests/test_recovery_admin_cli_unit.py
+++ b/backend/tests/test_recovery_admin_cli_unit.py
@@ -299,3 +299,41 @@ async def test_sso_profile_accepts_only_external_identity_and_usage_errors_hide_
     captured = capsys.readouterr()
     assert _SECRET not in captured.out
     assert _SECRET not in captured.err
+
+
+async def test_local_profile_provisions_without_any_password_source(monkeypatch, capsys):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    observed = {}
+
+    async def _provision(**kwargs):
+        observed.update(kwargs)
+        return _result(mode="local")
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "provision_local_recovery_admin",
+        _provision,
+    )
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # No password is generated, read, or handed to the service: the account is
+    # created unable to authenticate until a credential is issued on demand.
+    assert observed == {
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+    }
+    assert json.loads(captured.out)["password_file_written"] is False

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -189,6 +189,152 @@ async def test_local_provisioning_empty_database_and_exact_repeat_converge(servi
     assert identity_count == 0
 
 
+async def test_local_provisioning_without_a_password_cannot_authenticate(services, monkeypatch):
+    pool, role_sync, service, _, _, auth_service = services
+    from app.config import settings
+    from app.exceptions import AuthenticationError
+    from app.services.account_markers import (
+        UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+    )
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+    )
+
+    assert provisioned["created"] is True
+    assert provisioned["is_admin"] is True
+    assert provisioned["is_recovery_admin"] is True
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT password_hash, is_admin, is_recovery_admin, auth_provider,
+                   account_status, account_kind
+              FROM users WHERE id = $1
+            """,
+            uuid.UUID(provisioned["user_id"]),
+        )
+        identity_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert row["password_hash"] == UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+    assert row["is_admin"] is True
+    assert row["is_recovery_admin"] is True
+    assert row["auth_provider"] == "local"
+    assert row["account_status"] == "active"
+    assert row["account_kind"] == "human"
+    assert identity_count == 0
+    assert role_sync.created == [uuid.UUID(provisioned["user_id"])]
+
+    # The stored marker is not a bcrypt hash, so no candidate can verify
+    # against it: the account is created already unable to authenticate.
+    assert auth_service.verify_password("", row["password_hash"]) is False
+    assert (
+        auth_service.verify_password(
+            UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+            row["password_hash"],
+        )
+        is False
+    )
+    with pytest.raises(AuthenticationError):
+        await auth_service.login("recovery-admin", UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL)
+    with pytest.raises(AuthenticationError):
+        await auth_service.login("recovery-admin", _LOCAL_PASSWORD)
+
+
+async def test_local_provisioning_without_a_password_converges_without_issuing_one(
+    services,
+    monkeypatch,
+):
+    pool, role_sync, service, _, _, _ = services
+    from app.config import settings
+    from app.services.account_markers import (
+        UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+    )
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    kwargs = {"username": "recovery-admin", "email": "recovery-admin@example.com"}
+
+    first = await service.provision_local_recovery_admin(**kwargs)
+    repeated = await service.provision_local_recovery_admin(**kwargs)
+
+    assert first["created"] is True
+    assert repeated["created"] is False
+    assert repeated["user_id"] == first["user_id"]
+    assert len(role_sync.created) == 1
+    async with pool.acquire() as conn:
+        assert (
+            await conn.fetchval(
+                "SELECT password_hash FROM users WHERE id = $1",
+                uuid.UUID(first["user_id"]),
+            )
+            == UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+        )
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 1
+
+
+async def test_local_provisioning_converges_over_an_issued_credential(services, monkeypatch):
+    pool, _, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    issued = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(issued["user_id"]),
+        )
+
+    # A later passwordless run must converge on the same row: provisioning is
+    # create-or-converge and never resets an issued credential.
+    converged = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+    )
+
+    assert converged["created"] is False
+    assert converged["user_id"] == issued["user_id"]
+    async with pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(issued["user_id"]),
+        )
+    assert after == before
+    assert auth_service.verify_password(_LOCAL_PASSWORD, after)
+    assert (await auth_service.login("recovery-admin", _LOCAL_PASSWORD))["user"]["id"] == issued["user_id"]
+
+
+async def test_local_provisioning_rejects_an_unrecognised_credential_marker(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash, is_admin,
+                               is_recovery_admin, auth_provider,
+                               account_status, account_kind)
+            VALUES ('recovery-admin', 'recovery-admin@example.com',
+                    '!some-other-marker!', true, true, 'local', 'active', 'human')
+            """
+        )
+
+    with pytest.raises(RecoveryAdminConflictError):
+        await service.provision_local_recovery_admin(
+            username="recovery-admin",
+            email="recovery-admin@example.com",
+        )
+
+
 async def test_local_provisioning_never_adopts_an_existing_email(services, monkeypatch):
     pool, _, service, _, _, _ = services
     from app.config import settings

--- a/backend/tests/test_standalone_sso_bootstrap_unit.py
+++ b/backend/tests/test_standalone_sso_bootstrap_unit.py
@@ -13,7 +13,6 @@ _BOOTSTRAP_SECRET = "temporary-bootstrap-secret-must-not-leak"  # pragma: allowl
 _UPGRADE_SECRET = "temporary-upgrade-secret-must-not-leak"  # pragma: allowlist secret
 _MANAGEMENT_SECRET = "permanent-management-secret-must-not-leak"  # pragma: allowlist secret
 _ADMIN_CLIENT_SECRET = "admin-browser-secret-must-not-leak"  # pragma: allowlist secret
-_PRODUCT_ADMIN_PASSWORD = "one-time-product-admin-password"  # pragma: allowlist secret
 
 
 def _spec():
@@ -34,7 +33,6 @@ def _spec():
         admin_client_secret=_ADMIN_CLIENT_SECRET,
         product_admin_username="product-admin",
         product_admin_email="product-admin@example.com",
-        product_admin_password=_PRODUCT_ADMIN_PASSWORD,
         upgrade_client_id="akb-bootstrap-upgrade-v2",
         upgrade_client_secret="",
     )
@@ -292,7 +290,6 @@ async def test_fresh_bootstrap_retires_temporary_admin_only_after_akb_projection
         _BOOTSTRAP_SECRET,
         _MANAGEMENT_SECRET,
         _ADMIN_CLIENT_SECRET,
-        _PRODUCT_ADMIN_PASSWORD,
         "api-browser-secret-must-not-leak",
     ):
         assert secret not in serialized
@@ -314,7 +311,7 @@ async def test_completed_bootstrap_rerun_is_read_only_and_does_not_need_temp_adm
         }
 
     report = await bootstrap_standalone_sso(
-        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        replace(_spec(), bootstrap_client_secret=""),
         control=control,
         provision_admin=_provision,
         load_retirement_receipt=receipts.load,
@@ -364,7 +361,6 @@ async def test_legacy_v1_receipt_uses_one_time_upgrade_authority_then_retires_it
         replace(
             _spec(),
             bootstrap_client_secret="",
-            product_admin_password="",
             upgrade_client_secret=_UPGRADE_SECRET,
         ),
         control=control,
@@ -419,7 +415,7 @@ async def test_legacy_v2_public_callback_promotes_receipt_without_mutation_autho
         }
 
     report = await bootstrap_standalone_sso(
-        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        replace(_spec(), bootstrap_client_secret=""),
         control=control,
         provision_admin=_provision,
         load_retirement_receipt=receipts.load,
@@ -467,7 +463,7 @@ async def test_v2_readback_promotion_preserves_later_exact_callback_migration_re
         }
 
     promoted = await bootstrap_standalone_sso(
-        replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+        replace(_spec(), bootstrap_client_secret=""),
         control=control,
         provision_admin=_provision,
         load_retirement_receipt=receipts.load,
@@ -480,7 +476,6 @@ async def test_v2_readback_promotion_preserves_later_exact_callback_migration_re
     migration_spec = replace(
         _spec(),
         bootstrap_client_secret="",
-        product_admin_password="",
         backchannel_logout_uri=internal_uri,
         upgrade_client_secret=_UPGRADE_SECRET,
     )
@@ -543,7 +538,6 @@ async def test_v3_callback_migration_without_one_time_authority_fails_closed():
             replace(
                 _spec(),
                 bootstrap_client_secret="",
-                product_admin_password="",
                 backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
             ),
             control=control,
@@ -585,7 +579,6 @@ async def test_legacy_v2_internal_callback_uses_bounded_upgrade_authority():
         replace(
             _spec(),
             bootstrap_client_secret="",
-            product_admin_password="",
             backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
             upgrade_client_secret=_UPGRADE_SECRET,
         ),
@@ -624,7 +617,6 @@ async def test_legacy_v2_internal_callback_without_authority_fails_before_projec
             replace(
                 _spec(),
                 bootstrap_client_secret="",
-                product_admin_password="",
                 backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
             ),
             control=control,
@@ -659,7 +651,6 @@ async def test_legacy_v1_receipt_without_upgrade_authority_fails_before_mutation
             replace(
                 _spec(),
                 bootstrap_client_secret="",
-                product_admin_password="",
                 upgrade_client_secret="",
             ),
             control=control,
@@ -831,7 +822,7 @@ async def test_removed_bootstrap_secret_without_retirement_receipt_fails_closed(
 
     control = _Control(manager_available=True, bootstrap_available=False)
     receipts = _ReceiptStore(control.events)
-    spec = replace(_spec(), bootstrap_client_secret="", product_admin_password="")
+    spec = replace(_spec(), bootstrap_client_secret="")
 
     async def _should_not_run(**_kwargs):
         raise AssertionError("AKB projection must not run without retirement evidence")
@@ -853,62 +844,36 @@ async def test_removed_bootstrap_secret_without_retirement_receipt_fails_closed(
     ]
 
 
-async def test_missing_product_admin_password_stops_before_keycloak_mutation():
-    from app.services.standalone_sso_bootstrap import (
-        StandaloneSSOBootstrapError,
-        bootstrap_standalone_sso,
-    )
+async def test_fresh_bootstrap_reconciles_without_any_product_admin_password():
+    from app.services.standalone_sso_bootstrap import bootstrap_standalone_sso
 
     control = _Control(manager_available=False, bootstrap_available=True)
     receipts = _ReceiptStore(control.events)
+    spec = _spec()
 
-    async def _should_not_run(**_kwargs):
-        raise AssertionError("projection must not run without the one-time password")
+    # The installation never carries a product-admin password: the account is
+    # created unable to authenticate and a credential is issued later.
+    assert not hasattr(spec, "product_admin_password")
 
-    with pytest.raises(StandaloneSSOBootstrapError) as captured:
-        await bootstrap_standalone_sso(
-            replace(_spec(), product_admin_password=""),
-            control=control,
-            provision_admin=_should_not_run,
-            load_retirement_receipt=receipts.load,
-            record_retirement_receipt=receipts.record,
-        )
+    async def _provision(**_kwargs):
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "created": True,
+            "is_admin": True,
+            "is_recovery_admin": True,
+        }
 
-    assert captured.value.code == "keycloak_product_admin_password_unavailable"
-    assert control.events == [
-        "load-retirement-receipt",
-        "acquire-management",
-        "acquire-bootstrap",
-    ]
-
-
-@pytest.mark.parametrize(
-    "password",
-    ["short", "product-admin", "product-admin@example.com"],
-)
-async def test_invalid_product_admin_password_stops_before_keycloak_mutation(password):
-    from app.services.standalone_sso_bootstrap import (
-        StandaloneSSOBootstrapError,
-        bootstrap_standalone_sso,
+    report = await bootstrap_standalone_sso(
+        spec,
+        control=control,
+        provision_admin=_provision,
+        load_retirement_receipt=receipts.load,
+        record_retirement_receipt=receipts.record,
     )
 
-    control = _Control(manager_available=False, bootstrap_available=True)
-    receipts = _ReceiptStore(control.events)
-
-    async def _should_not_run(**_kwargs):
-        raise AssertionError("invalid password must fail before reconciliation")
-
-    with pytest.raises(StandaloneSSOBootstrapError) as captured:
-        await bootstrap_standalone_sso(
-            replace(_spec(), product_admin_password=password),
-            control=control,
-            provision_admin=_should_not_run,
-            load_retirement_receipt=receipts.load,
-            record_retirement_receipt=receipts.record,
-        )
-
-    assert captured.value.code == "keycloak_product_admin_password_policy"
-    assert "reconcile-keycloak" not in control.events
+    assert report["mode"] == "fresh"
+    assert report["keycloak_mutated"] is True
+    assert "reconcile-keycloak" in control.events
 
 
 async def test_readback_rejects_receipt_bound_to_another_installation():
@@ -934,7 +899,7 @@ async def test_readback_rejects_receipt_bound_to_another_installation():
 
     with pytest.raises(StandaloneSSOBootstrapError) as captured:
         await bootstrap_standalone_sso(
-            replace(_spec(), bootstrap_client_secret="", product_admin_password=""),
+            replace(_spec(), bootstrap_client_secret=""),
             control=control,
             provision_admin=_provision,
             load_retirement_receipt=receipts.load,
@@ -1010,7 +975,6 @@ async def test_spec_repr_and_mapping_never_expose_secret_values():
         _UPGRADE_SECRET,
         _MANAGEMENT_SECRET,
         _ADMIN_CLIENT_SECRET,
-        _PRODUCT_ADMIN_PASSWORD,
         "api-browser-secret-must-not-leak",
     ):
         assert secret not in rendered

--- a/backend/tests/test_standalone_sso_cli_unit.py
+++ b/backend/tests/test_standalone_sso_cli_unit.py
@@ -156,7 +156,7 @@ async def test_bootstrap_cli_reads_only_secret_files_and_emits_allowlisted_repor
     assert spec.bootstrap_client_secret == _BOOTSTRAP_SECRET
     assert spec.upgrade_client_id == "akb-bootstrap-upgrade-v2"
     assert spec.upgrade_client_secret == _UPGRADE_SECRET
-    assert spec.product_admin_password == _PRODUCT_PASSWORD
+    assert not hasattr(spec, "product_admin_password")
     assert spec.management_client_secret == _MANAGEMENT_SECRET
     assert spec.api_client_secret == _API_SECRET
     assert spec.admin_client_secret == _ADMIN_SECRET
@@ -250,7 +250,6 @@ async def test_bootstrap_cli_rerun_allows_removed_one_time_secret_files(
 
     async def _readback(spec, **_kwargs):
         observed["bootstrap_secret"] = spec.bootstrap_client_secret
-        observed["product_password"] = spec.product_admin_password
         return {
             "mode": "readback",
             "keycloak_mutated": False,
@@ -273,7 +272,7 @@ async def test_bootstrap_cli_rerun_allows_removed_one_time_secret_files(
     assert await cli._bootstrap_standalone_sso(
         _arguments(str(missing_bootstrap), str(missing_password))
     ) == 0
-    assert observed == {"bootstrap_secret": "", "product_password": ""}
+    assert observed == {"bootstrap_secret": ""}
     assert json.loads(capsys.readouterr().out)["mode"] == "readback"
 
 
@@ -317,3 +316,112 @@ def _all_secrets() -> tuple[str, ...]:
         _API_SECRET,
         _ADMIN_SECRET,
     )
+
+
+async def test_bootstrap_cli_accepts_but_ignores_a_supplied_product_admin_password(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    caplog,
+):
+    """The deployed init container still passes the retired flag.
+
+    Accepting it and discarding the value is what lets the current manifests
+    be redeployed unchanged: honouring it would put a stored credential back
+    on the account this change is meant to leave un-enterable.
+    """
+    from app import cli
+    from app.services import standalone_sso_bootstrap, standalone_sso_keycloak
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    bootstrap_file = tmp_path / "bootstrap-client-secret"
+    product_password_file = tmp_path / "product-admin-password"
+    bootstrap_file.write_text(f"{_BOOTSTRAP_SECRET}\n")
+    product_password_file.write_text(f"{_PRODUCT_PASSWORD}\n")
+    observed: dict[str, object] = {}
+
+    class _Control:
+        def __init__(self, *, verify_ssl: bool) -> None:
+            assert verify_ssl is True
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _bootstrap(spec, **_kwargs):
+        observed["spec"] = spec
+        return {"mode": "fresh", "bootstrap_admin_retired": True}
+
+    monkeypatch.setattr(
+        standalone_sso_keycloak,
+        "KeycloakStandaloneSSOControl",
+        _Control,
+    )
+    monkeypatch.setattr(
+        standalone_sso_bootstrap,
+        "bootstrap_standalone_sso",
+        _bootstrap,
+    )
+
+    exit_code = await cli._bootstrap_standalone_sso(
+        _arguments(str(bootstrap_file), str(product_password_file))
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    spec = observed["spec"]
+    assert not hasattr(spec, "product_admin_password")
+    assert _PRODUCT_PASSWORD not in repr(spec)
+    rendered = captured.out + captured.err + caplog.text
+    assert all(secret not in rendered for secret in _all_secrets())
+
+
+async def test_bootstrap_cli_accepts_an_omitted_product_admin_password_flag(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from app import cli
+    from app.services import standalone_sso_bootstrap, standalone_sso_keycloak
+
+    _patch_database(monkeypatch)
+    _patch_sso_settings(monkeypatch)
+    bootstrap_file = tmp_path / "bootstrap-client-secret"
+    bootstrap_file.write_text(f"{_BOOTSTRAP_SECRET}\n")
+
+    class _Control:
+        def __init__(self, *, verify_ssl: bool) -> None:
+            assert verify_ssl is True
+
+        async def aclose(self) -> None:
+            return None
+
+    async def _bootstrap(_spec, **_kwargs):
+        return {"mode": "fresh", "bootstrap_admin_retired": True}
+
+    monkeypatch.setattr(
+        standalone_sso_keycloak,
+        "KeycloakStandaloneSSOControl",
+        _Control,
+    )
+    monkeypatch.setattr(
+        standalone_sso_bootstrap,
+        "bootstrap_standalone_sso",
+        _bootstrap,
+    )
+
+    exit_code = await cli._bootstrap_standalone_sso(
+        [
+            "--bootstrap-client-id",
+            "akb-bootstrap-temporary",
+            "--bootstrap-client-secret-file",
+            str(bootstrap_file),
+            "--product-admin-username",
+            "product-admin",
+            "--product-admin-email",
+            "product-admin@example.com",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["mode"] == "fresh"

--- a/backend/tests/test_standalone_sso_keycloak_unit.py
+++ b/backend/tests/test_standalone_sso_keycloak_unit.py
@@ -25,7 +25,6 @@ _SECRETS = (
     "permanent-management-secret-must-not-leak",  # pragma: allowlist secret
     "api-browser-secret-must-not-leak",  # pragma: allowlist secret
     "admin-browser-secret-must-not-leak",  # pragma: allowlist secret
-    "one-time-product-admin-password",  # pragma: allowlist secret
     "one-time-upgrade-secret-must-not-leak",  # pragma: allowlist secret
 )
 
@@ -46,7 +45,6 @@ def _spec() -> StandaloneSSOBootstrapSpec:
         admin_client_secret=_SECRETS[3],
         product_admin_username="product-admin",
         product_admin_email="product-admin@example.com",
-        product_admin_password=_SECRETS[4],
     )
 
 
@@ -100,7 +98,7 @@ async def test_upgrade_authority_authenticates_only_against_master_realm():
         return httpx.Response(200, json={"access_token": "opaque-upgrade-token"})
 
     control, spec = _control(httpx.MockTransport(handler))
-    spec = replace(spec, upgrade_client_secret=_SECRETS[5])
+    spec = replace(spec, upgrade_client_secret=_SECRETS[4])
     try:
         assert await control.acquire_upgrade(spec) == "opaque-upgrade-token"
     finally:
@@ -112,7 +110,7 @@ async def test_legacy_upgrade_updates_api_client_and_signed_provider_mapper(monk
     spec = replace(
         _spec(),
         backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
-        upgrade_client_secret=_SECRETS[5],
+        upgrade_client_secret=_SECRETS[4],
     )
     events: list[tuple[str, object]] = []
     expected_readback = object()
@@ -177,7 +175,7 @@ async def test_callback_upgrade_accepts_only_exact_receipt_source_or_target(
     spec = replace(
         _spec(),
         backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
-        upgrade_client_secret=_SECRETS[5],
+        upgrade_client_secret=_SECRETS[4],
     )
     reconciled: list[dict[str, object]] = []
     expected_readback = object()
@@ -221,7 +219,7 @@ async def test_callback_upgrade_rejects_callback_outside_receipt_transition(monk
     spec = replace(
         _spec(),
         backchannel_logout_uri=("http://backend:8000/api/v1/auth/keycloak/backchannel-logout"),
-        upgrade_client_secret=_SECRETS[5],
+        upgrade_client_secret=_SECRETS[4],
     )
 
     async def _exact_client(_spec, _realm, _client_id, *, token):
@@ -432,7 +430,7 @@ async def test_upgrade_retirement_deletes_only_exact_master_client_and_reauth_de
         raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
 
     control, spec = _control(httpx.MockTransport(handler))
-    spec = replace(spec, upgrade_client_secret=_SECRETS[5])
+    spec = replace(spec, upgrade_client_secret=_SECRETS[4])
     try:
         await control.retire_upgrade(
             spec,
@@ -448,88 +446,18 @@ async def test_upgrade_retirement_deletes_only_exact_master_client_and_reauth_de
     assert deleted_paths == ["/admin/realms/master/clients/upgrade-client-uuid"]
 
 
-async def test_missing_one_time_password_cannot_create_product_admin():
+async def test_created_product_admin_carries_no_credential_and_no_required_action():
     requests: list[str] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(f"{request.method} {request.url.path}")
-        assert request.method == "GET"
-        assert request.url.path == "/admin/realms/akb/users"
-        return httpx.Response(200, json=[])
-
-    control, spec = _control(httpx.MockTransport(handler))
-    spec = replace(spec, product_admin_password="")
-    try:
-        with pytest.raises(StandaloneSSOBootstrapError) as captured:
-            await control._reconcile_product_admin(  # noqa: SLF001
-                spec,
-                token="opaque-token",  # pragma: allowlist secret
-            )
-    finally:
-        await control.aclose()
-
-    assert captured.value.code == "keycloak_product_admin_password_unavailable"
-    assert requests == ["GET /admin/realms/akb/users"]
-
-
-async def test_existing_product_admin_password_is_reset_to_the_operator_input():
-    requests: list[str] = []
+    created: dict[str, object] = {}
     user_reads = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal user_reads
         requests.append(f"{request.method} {request.url.path}")
-        if request.url.path == "/admin/realms/akb/users":
+        if request.url.path == "/admin/realms/akb/users" and request.method == "GET":
             user_reads += 1
-            return httpx.Response(
-                200,
-                json=[
-                    {
-                        "id": "product-admin-uuid",
-                        "username": "product-admin",
-                        "email": "product-admin@example.com",
-                        "enabled": True,
-                        "emailVerified": True,
-                        "requiredActions": (["UPDATE_PASSWORD"] if user_reads > 1 else []),
-                    }
-                ],
-            )
-        if request.url.path.endswith("/reset-password"):
-            assert request.method == "PUT"
-            assert json.loads(request.content) == {
-                "type": "password",
-                "value": _SECRETS[4],
-                "temporary": True,
-            }
-            return httpx.Response(204)
-        if request.url.path.endswith("/federated-identity"):
-            return httpx.Response(200, json=[])
-        if request.url.path.endswith("/credentials"):
-            return httpx.Response(200, json=[{"type": "password"}])
-        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
-
-    control, spec = _control(httpx.MockTransport(handler))
-    try:
-        user = await control._reconcile_product_admin(  # noqa: SLF001
-            spec,
-            token="opaque-token",  # pragma: allowlist secret
-        )
-    finally:
-        await control.aclose()
-
-    assert user["id"] == "product-admin-uuid"
-    assert requests == [
-        "GET /admin/realms/akb/users",
-        "GET /admin/realms/akb/users/product-admin-uuid/federated-identity",
-        "PUT /admin/realms/akb/users/product-admin-uuid/reset-password",
-        "GET /admin/realms/akb/users",
-        "GET /admin/realms/akb/users/product-admin-uuid/credentials",
-    ]
-
-
-async def test_product_admin_password_change_requirement_must_read_back():
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/admin/realms/akb/users":
+            if user_reads == 1:
+                return httpx.Response(200, json=[])
             return httpx.Response(
                 200,
                 json=[
@@ -543,10 +471,62 @@ async def test_product_admin_password_change_requirement_must_read_back():
                     }
                 ],
             )
-        if request.url.path.endswith("/federated-identity"):
+        if request.url.path == "/admin/realms/akb/users" and request.method == "POST":
+            created.update(json.loads(request.content))
+            return httpx.Response(201)
+        if request.url.path.endswith("/credentials"):
             return httpx.Response(200, json=[])
-        if request.url.path.endswith("/reset-password"):
-            return httpx.Response(204)
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    try:
+        user = await control._reconcile_product_admin(  # noqa: SLF001
+            spec,
+            token="opaque-token",  # pragma: allowlist secret
+        )
+    finally:
+        await control.aclose()
+
+    assert user["id"] == "product-admin-uuid"
+    assert "credentials" not in created
+    assert created["requiredActions"] == []
+    assert created["enabled"] is True
+    assert created["emailVerified"] is True
+    assert created["username"] == "product-admin"
+    assert created["email"] == "product-admin@example.com"
+    assert requests == [
+        "GET /admin/realms/akb/users",
+        "POST /admin/realms/akb/users",
+        "GET /admin/realms/akb/users",
+        "GET /admin/realms/akb/users/product-admin-uuid/credentials",
+    ]
+    assert all(secret not in json.dumps(created) for secret in _SECRETS)
+
+
+async def test_created_product_admin_readback_rejects_a_present_password_credential():
+    user_reads = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal user_reads
+        if request.url.path == "/admin/realms/akb/users" and request.method == "GET":
+            user_reads += 1
+            if user_reads == 1:
+                return httpx.Response(200, json=[])
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                        "requiredActions": [],
+                    }
+                ],
+            )
+        if request.url.path == "/admin/realms/akb/users" and request.method == "POST":
+            return httpx.Response(201)
         if request.url.path.endswith("/credentials"):
             return httpx.Response(200, json=[{"type": "password"}])
         raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
@@ -561,31 +541,35 @@ async def test_product_admin_password_change_requirement_must_read_back():
     finally:
         await control.aclose()
 
-    assert captured.value.code == "keycloak_product_admin_update_password_missing"
+    assert captured.value.code == "keycloak_product_admin_password_present"
 
 
-async def test_product_admin_federation_race_after_password_reset_is_rejected():
+async def test_created_product_admin_readback_rejects_an_unexpected_required_action():
     user_reads = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal user_reads
-        if request.url.path == "/admin/realms/akb/users":
+        if request.url.path == "/admin/realms/akb/users" and request.method == "GET":
             user_reads += 1
-            user = {
-                "id": "product-admin-uuid",
-                "username": "product-admin",
-                "email": "product-admin@example.com",
-                "enabled": True,
-                "emailVerified": True,
-                "requiredActions": ["UPDATE_PASSWORD"],
-            }
-            if user_reads > 1:
-                user["federationLink"] = "racing-storage-provider"
-            return httpx.Response(200, json=[user])
-        if request.url.path.endswith("/federated-identity"):
+            if user_reads == 1:
+                return httpx.Response(200, json=[])
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                        "requiredActions": ["UPDATE_PASSWORD"],
+                    }
+                ],
+            )
+        if request.url.path == "/admin/realms/akb/users" and request.method == "POST":
+            return httpx.Response(201)
+        if request.url.path.endswith("/credentials"):
             return httpx.Response(200, json=[])
-        if request.url.path.endswith("/reset-password"):
-            return httpx.Response(204)
         raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
 
     control, spec = _control(httpx.MockTransport(handler))
@@ -598,41 +582,166 @@ async def test_product_admin_federation_race_after_password_reset_is_rejected():
     finally:
         await control.aclose()
 
-    assert captured.value.code == "keycloak_admin_identity_is_federated"
+    assert captured.value.code == "keycloak_product_admin_required_action_unexpected"
 
 
-async def test_existing_product_admin_cannot_be_adopted_without_one_time_password():
+async def test_existing_product_admin_credentials_are_never_written_or_removed():
     requests: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(f"{request.method} {request.url.path}")
-        assert request.url.path == "/admin/realms/akb/users"
-        return httpx.Response(
-            200,
-            json=[
-                {
-                    "id": "product-admin-uuid",
-                    "username": "product-admin",
-                    "email": "product-admin@example.com",
-                    "enabled": True,
-                    "emailVerified": True,
-                }
-            ],
-        )
+        if request.url.path == "/admin/realms/akb/users":
+            assert request.method == "GET"
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "product-admin-uuid",
+                        "username": "product-admin",
+                        "email": "product-admin@example.com",
+                        "enabled": True,
+                        "emailVerified": True,
+                        "requiredActions": ["UPDATE_PASSWORD"],
+                    }
+                ],
+            )
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(200, json=[])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
 
     control, spec = _control(httpx.MockTransport(handler))
-    spec = replace(spec, product_admin_password="")
     try:
-        with pytest.raises(StandaloneSSOBootstrapError) as captured:
-            await control._reconcile_product_admin(  # noqa: SLF001
-                spec,
-                token="opaque-token",  # pragma: allowlist secret
-            )
+        user = await control._reconcile_product_admin(  # noqa: SLF001
+            spec,
+            token="opaque-token",  # pragma: allowlist secret
+        )
     finally:
         await control.aclose()
 
-    assert captured.value.code == "keycloak_product_admin_password_unavailable"
-    assert requests == ["GET /admin/realms/akb/users"]
+    # An account an operator is already using keeps whatever credential state
+    # it holds: convergence never resets it and never takes it away.
+    assert user["id"] == "product-admin-uuid"
+    assert requests == [
+        "GET /admin/realms/akb/users",
+        "GET /admin/realms/akb/users/product-admin-uuid/federated-identity",
+    ]
+
+
+async def test_readback_tolerates_a_product_admin_credential_issued_on_demand(monkeypatch):
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(f"{request.method} {request.url.path}")
+        if request.url.path.endswith("/federated-identity"):
+            return httpx.Response(200, json=[])
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    control, spec = _control(httpx.MockTransport(handler))
+    clients = {
+        "akb-web": ("api-client-uuid", control._api_client(spec)),  # noqa: SLF001
+        "akb-admin": ("admin-client-uuid", control._admin_client(spec)),  # noqa: SLF001
+        "akb-sso-manager": (
+            "management-client-uuid",
+            control._management_client(spec),  # noqa: SLF001
+        ),
+    }
+    mappers = {
+        "api-client-uuid": [
+            {
+                "name": "akb-api-audience",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": False,
+                "config": {
+                    "included.custom.audience": "https://akb.example.com/api",
+                    "id.token.claim": "false",
+                    "access.token.claim": "true",
+                },
+            },
+            control._api_identity_provider_mapper(),  # noqa: SLF001
+        ],
+        "admin-client-uuid": [
+            {
+                "name": "akb-admin-native-amr",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-amr-mapper",
+                "consentRequired": False,
+                "config": {
+                    "id.token.claim": "true",
+                    "access.token.claim": "false",
+                },
+            }
+        ],
+    }
+    roles = (
+        "manage-identity-providers",
+        "query-clients",
+        "query-users",
+        "view-clients",
+        "view-realm",
+        "view-users",
+    )
+
+    async def _realm(_spec, *, token):
+        return {**control._realm_profile(spec), "id": "akb-realm-id"}  # noqa: SLF001
+
+    async def _exact_client(_spec, _realm, client_id, *, token):
+        uuid_value, profile = clients[client_id]
+        # Keycloak always renders an attributes object, even when empty.
+        return {**profile, "id": uuid_value, "attributes": profile.get("attributes", {})}
+
+    async def _protocol_mappers(_spec, client_uuid, *, token):
+        return mappers[client_uuid]
+
+    async def _exact_user(_spec, *, token):
+        # A recovery credential was issued on demand after installation, so
+        # the realm now reports a password for the product admin.
+        return {
+            "id": "product-admin-uuid",
+            "username": "product-admin",
+            "email": "product-admin@example.com",
+            "enabled": True,
+            "emailVerified": True,
+            "requiredActions": ["UPDATE_PASSWORD"],
+        }
+
+    async def _key_readback(_spec, *, token):
+        return ("rsa-3072-active-kid", 3072, 1)
+
+    async def _native_amr_readback(_spec, *, token):
+        return "pwd"
+
+    async def _management_roles(_spec, _uuid, *, token):
+        return roles
+
+    async def _management_scope_roles(_spec, _uuid, *, token):
+        return roles
+
+    monkeypatch.setattr(control, "_realm", _realm)
+    monkeypatch.setattr(control, "_exact_client", _exact_client)
+    monkeypatch.setattr(control, "_protocol_mappers", _protocol_mappers)
+    monkeypatch.setattr(control, "_exact_user", _exact_user)
+    monkeypatch.setattr(control, "_key_readback", _key_readback)
+    monkeypatch.setattr(control, "_native_amr_readback", _native_amr_readback)
+    monkeypatch.setattr(control, "_management_roles", _management_roles)
+    monkeypatch.setattr(control, "_management_scope_roles", _management_scope_roles)
+
+    try:
+        readback = await control.readback(
+            spec,
+            management_token="opaque-token",  # pragma: allowlist secret
+        )
+    finally:
+        await control.aclose()
+
+    assert readback.product_admin_subject == "product-admin-uuid"
+    assert readback.product_admin_federated_identities == 0
+    # Steady-state readback proves the account is realm-native. Whether a
+    # credential currently exists is not its business — one may have been
+    # issued on demand since installation.
+    assert requests == [
+        "GET /admin/realms/akb/users/product-admin-uuid/federated-identity",
+    ]
 
 
 async def test_existing_federated_identity_is_rejected_before_password_mutation():

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -64,7 +64,7 @@ commit their values.
 | `akb-secret-config` | `secret.yaml` | durable |
 | `akb-keycloak-bootstrap` | `client-secret` | one-time |
 | `akb-keycloak-upgrade` | `client-secret` | optional; one-time legacy-profile upgrade only |
-| `akb-product-admin-bootstrap` | `password` | one-time |
+| `akb-product-admin-bootstrap` | `password` | unused; kept because the current init container still mounts it |
 
 The mounted `secret.yaml` must include the AKB database password, an
 independent browser-session encryption key, and three independently generated
@@ -81,11 +81,14 @@ keycloak_management_client_secret: <akb-sso-manager secret>
 embed_api_key: <provider key, if required>
 ```
 
-Generate each credential independently. The product-admin password is
-temporary, must be at least 12 characters, must differ from its username and
-email, and Keycloak forces `UPDATE_PASSWORD` on first login. The realm enforces
-the same lean policy for the replacement password. The bootstrap client secret
-is not the product-admin password.
+Generate each credential independently. Installation does not create a
+product-admin password. The account is created holding no credential at all,
+so nobody can sign in as it until one is issued, and nothing about it is
+stored ahead of that. The realm keeps its lean policy — at least 12
+characters, and different from the username and email — for whatever
+credential is issued later. The `akb-product-admin-bootstrap` value is read by
+nothing; the init container still mounts it, and still accepts
+`--product-admin-password-file`, only so the current manifests keep starting.
 
 `sso_session_epoch` is not a credential. Generate it once with
 `python -c 'import uuid; print(uuid.uuid4())'` and keep it stable across normal
@@ -224,8 +227,9 @@ durable recovery paths and the AKB administrator projection have been read
 back. Its successful report also means the exact retirement receipt was
 written and read back from AKB PostgreSQL. After that report succeeds:
 
-1. Preserve the product-admin password through an approved installer handoff;
-   the administrator needs it for the forced first-login password change.
+1. There is no product-admin password to hand over. The account exists with
+   recovery authority and no credential; one is issued when an administrator
+   actually needs to sign in.
 2. Replace both first-install Secret values with fresh, unrelated retirement
    sentinels. Keep
    the Secret objects because the default first-boot manifest deliberately


### PR DESCRIPTION
## Why

The designated recovery administrator is provisioned today with a password
generated ahead of time and stored at rest. This is the first half of moving to a
model where the account is created in a state that **cannot authenticate at all**
and a usable credential is minted later, on demand, and never stored.

This PR makes the un-enterable creation possible and stops requiring a password
at bootstrap. The on-demand issue path is a separate change.

## What changed

**Local provisioning.** `provision_local_recovery_admin` takes `password` as
optional. Without it the row is created holding a new
`UNISSUED_RECOVERY_ADMIN_PASSWORD_SENTINEL` instead of a hash. That marker lives
in `account_markers` next to the existing retirement tombstone, because both are
lifecycle markers other services read. It is not a bcrypt hash, so no candidate
can verify against it — `verify_password` already catches the `ValueError` from a
malformed hash and returns `False`, which is what makes the account return 401
rather than 500.

The two markers mean different things and are kept distinct: the retirement
tombstone is a dead account; the unissued marker is a **live** account that holds
recovery authority and has no credential yet.

**Converge is now an explicit predicate.** `_is_local_recovery_credential`
accepts exactly two states — a bcrypt hash (a credential was issued) or the
unissued marker (none was). Before this, local converge ignored `password_hash`
entirely, so a designated row bearing any other string was adopted as the one
account that can recover the installation. Safe for existing installs: the only
value in the wild is a bcrypt hash.

**Keycloak product admin.** The user is created with no `credentials` and with
`requiredActions: []`, sent explicitly. A required action is evaluated at the end
of a successful authentication; on an account with no credential it can never
fire, and asking for `UPDATE_PASSWORD` advertises a password that does not exist.
It belongs with whatever mints the credential.

**Read-back polarity.** The create-time read-back now asserts the account has
**no** password credential, which is the inverse of what it asserted before. Both
create-time assertions are scoped to the fresh-create branch, and the credential
read was removed from the steady-state read-back. That second part is deliberate
and worth stating plainly: the steady-state path runs on every init-container
redeploy, so once the issue path lands, an operator who minted a credential and
then redeployed would hard-fail on a "no credential" assertion and crash-loop.
"Bootstrap did not mint one" is an invariant this code can keep; "nobody ever
minted one" is not.

The federated-identity guard is unchanged — a brokered user must still never
receive a local recovery credential.

**Password input removed.** `product_admin_password` is gone from the bootstrap
spec, and the CLI no longer opens `--product-admin-password-file`. The flag is
still accepted and is now optional, so the current deployment manifests keep
working unchanged; the value simply never enters the process. Honouring it would
recreate the stored credential, and the create's own read-back would then refuse
it — a crash-loop on the first redeploy.

`provision-recovery-admin local` accepts no password source, which is what gives
the new capability a caller.

Three now-false statements in the standalone-SSO deployment guide were corrected.
The root README's local examples were deliberately left alone: documenting the
un-enterable state without the issue path is a dead end for an operator, so that
belongs with the next change.

## Tests

RED first, then implementation, then mutation. Baseline on this file set was 95
passed / 0 failed; tests-only ran 14 failed / 85 passed; after implementation 99
passed / 0 failed.

Eight mutations, one at a time, each restored before the next:

| mutation | red |
|---|---|
| credential-shape guard forced true | 1 |
| passwordless branch hashes anyway | 2 (both assert the marker) |
| no-password read-back neutralised | 1 |
| required-action read-back neutralised | 1 |
| federated guard neutralised (probe preserved) | 1 |
| credentials re-added to the create body | 1 |
| password file back to required | 1 |
| local password argument back to required | 1 |

## Gate

`scripts/check.sh` is green end to end. Note it is by its own header a
**static-analysis** entry point and does not run backend pytest, so it was run
alongside the backend suite rather than instead of it.

Backend suite against a real database
(`pytest tests/ -k 'not _e2e'`, `REQUIRE_REAL_PG=1`):

```
this branch      58 failed   2555 passed
pristine main    58 failed   2551 passed     <- same 58, +4 are the new tests
```

The 58 are pre-existing and environmental, proven by stash-and-rerun on the same
tip: the host's git is 2.34.1 and the external-git tests require 2.37 or newer,
which the failure output states directly. Grouped: 35 `test_git_service`, 14
`test_external_git_runner`, plus external-git cascade and capability files.

Without a database DSN the whole postgres provisioning file skips, including the
strongest assertion here — passwordless provisioning cannot authenticate. Run it
with one.
