### PR TITLE
feat(auth): rotate the recovery administrator credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,26 @@ command stores no usable local password and does not contact the identity
 provider. Generated output files are create-only and never overwritten; for a
 retry after the file exists, pass that file back with `--password-file`.
 
+If that credential later leaks, is lost, or has to be taken back, rotate it
+rather than reprovisioning the account:
+
+```bash
+# Break-glass: replace the credential and print the new one once. Nothing
+# stores or logs the value, and the machine-readable report omits it.
+python -m app.cli issue-recovery-admin-credential \
+  --expected-username recovery-admin \
+  --expected-email recovery-admin@example.com
+```
+
+Rotation names the account it expects and refuses any mismatch, so it cannot
+act on the wrong one. The credential it replaces stops working immediately,
+including one currently in use, and sessions held before the rotation are
+revoked — both are what a compromise response requires. The same operation is
+available at `POST /admin/recovery-admin/issue-credential`, which requires an
+independent service-administrator token rather than a human session. Rotation
+is not available in `sso` mode: the identity provider holds the credential,
+and nothing in a running AKB can replace it.
+
 Open `/admin` for the separate product-administration surface. In `local`
 mode it accepts the provisioned local administrator and returns the same
 `local-session-rs256-v2` profile used by local human authentication, but it

--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -12,7 +12,10 @@ from app.services.auth_service import (
     revoke_all_sessions,
 )
 from app.services.auth_policy import require_local_auth_enabled
-from app.services.recovery_admin_service import retire_local_recovery_admin
+from app.services.recovery_admin_service import (
+    issue_recovery_admin_credential,
+    retire_local_recovery_admin,
+)
 from app.services.account_service import (
     activate_user,
     adopt_current_admin_as_service,
@@ -179,6 +182,25 @@ class RetireRecoveryAdminResponse(NFCModel):
     is_recovery_admin: Literal[False]
     account_kind: Literal["human"]
     auth_provider: Literal["local"]
+
+
+class IssueRecoveryAdminCredentialRequest(NFCModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_username: str = Field(min_length=1, max_length=255)
+    expected_email: str = Field(min_length=1, max_length=320)
+
+
+class IssueRecoveryAdminCredentialResponse(NFCModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    username: str
+    email: str
+    auth_mode: Literal["local", "sso"]
+    # The only copy of the replacement. Nothing stores, logs, or audits it,
+    # and the credential it replaced no longer works.
+    credential: str
 
 
 @router.get("/my/vaults", summary="List vaults accessible to me")
@@ -399,6 +421,40 @@ async def admin_retire_recovery_admin(
     return await retire_local_recovery_admin(
         expected_username=req.expected_username,
         expected_email=req.expected_email,
+        actor_user_id=user.user_id,
+        actor_token_id=user.token_id,
+    )
+
+
+@router.post(
+    "/admin/recovery-admin/issue-credential",
+    summary="[admin] Replace the designated recovery administrator's credential",
+    response_model=IssueRecoveryAdminCredentialResponse,
+)
+async def admin_issue_recovery_admin_credential(
+    req: IssueRecoveryAdminCredentialRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    if not (
+        user.is_admin
+        and user.account_kind == "service"
+        and user.auth_method == "pat"
+        and user.token_id is not None
+        and user.key_class in {"pat", "service"}
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "Recovery administrator credential issue requires an independent service administrator token",
+                "code": "recovery_admin_credential_requires_service_admin",
+            },
+        )
+    # `method` is fixed by the route. The break-glass discriminator belongs to
+    # the unauthenticated CLI path and must not be reachable over HTTP.
+    return await issue_recovery_admin_credential(
+        expected_username=req.expected_username,
+        expected_email=req.expected_email,
+        method="recovery_admin_api",
         actor_user_id=user.user_id,
         actor_token_id=user.token_id,
     )

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -16,6 +16,11 @@ Subcommands:
                                SSO recovery administrator. Password material
                                is accepted only by file/stdin and is never
                                printed.
+    issue-recovery-admin-credential
+                               Break-glass: replace the exact designated
+                               recovery administrator's credential and print
+                               the new one once. The credential it replaces
+                               stops working. Nothing stores or logs the value.
     bootstrap-standalone-sso   Converge the bundled Keycloak realm, clients,
                                signing profile, and exact AKB recovery-admin
                                projection; then retire the temporary bootstrap
@@ -54,6 +59,11 @@ PROVISION_RECOVERY_ADMIN_USAGE = (
 GENERATE_LOCAL_SESSION_KEYSET_USAGE = (
     "Usage: python -m app.cli generate-local-session-keyset "
     "--output-dir DIR [--retain-jwks PATH ...]"
+)
+
+ISSUE_RECOVERY_ADMIN_CREDENTIAL_USAGE = (
+    "Usage: python -m app.cli issue-recovery-admin-credential "
+    "--expected-username USER --expected-email EMAIL"
 )
 
 STANDALONE_SSO_BOOTSTRAP_USAGE = (
@@ -300,6 +310,78 @@ async def _provision_recovery_admin(args: list[str]) -> int:
         "password_file_written": keep_generated,
     }
     print(json.dumps(public_report, sort_keys=True))
+    return 0
+
+
+async def _issue_recovery_admin_credential(args: list[str]) -> int:
+    parser = _SafeArgumentParser(add_help=False)
+    parser.add_argument("--expected-username", required=True)
+    parser.add_argument("--expected-email", required=True)
+    try:
+        parsed = parser.parse_args(args)
+    except _CLIUsageError:
+        print(ISSUE_RECOVERY_ADMIN_CREDENTIAL_USAGE, file=sys.stderr)
+        return 2
+
+    from app.config import AuthModeConfigurationError
+    from app.db.postgres import close_pool
+    from app.exceptions import AKBError
+    from app.services.recovery_admin_service import issue_recovery_admin_credential
+
+    report: dict | None = None
+    error: tuple[str, str] | None = None
+    try:
+        await _initialize_operator_database()
+        # Same service function as the endpoint. Workspace shell access is the
+        # authority here, so there is no authenticated principal to pass. This
+        # replaces a credential the account already has; it is not a way in for
+        # an account that never had one.
+        report = await issue_recovery_admin_credential(
+            expected_username=parsed.expected_username,
+            expected_email=parsed.expected_email,
+            method="recovery_admin_cli",
+        )
+    except AKBError as exc:
+        error = (exc.code or "recovery_admin_credential_issue_failed", exc.message)
+    except AuthModeConfigurationError as exc:
+        error = ("recovery_admin_credential_mode_configuration", str(exc))
+    except Exception:
+        # Never render an unexpected exception: driver and HTTP libraries can
+        # retain request bodies, and this command handles credential material.
+        error = (
+            "recovery_admin_credential_issue_failed",
+            "Recovery administrator credential issue failed",
+        )
+    finally:
+        try:
+            await close_pool()
+        except Exception:
+            if error is None:
+                error = (
+                    "recovery_admin_credential_database_cleanup_failed",
+                    "Database connection cleanup failed",
+                )
+
+    if error is not None:
+        print(f"{error[0]}: {error[1]}", file=sys.stderr)
+        return 1
+    assert report is not None
+    # The one-time reveal of the replacement. It is deliberately not part of
+    # the JSON report so a caller piping stdout into a log or a file captures
+    # the identity, not the credential.
+    print(
+        json.dumps(
+            {
+                "user_id": report["user_id"],
+                "username": report["username"],
+                "email": report["email"],
+                "auth_mode": report["auth_mode"],
+            },
+            sort_keys=True,
+        )
+    )
+    print(f"Credential for {report['username']}: {report['credential']}")
+    print("Share this out-of-band. It cannot be retrieved again.")
     return 0
 
 
@@ -650,6 +732,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Subcommands: generate-local-session-keyset, "
             "provision-recovery-admin {local|sso}, "
+            "issue-recovery-admin-credential, "
             "bootstrap-standalone-sso, "
             "reset-password <username>, repair-resource-hashes, "
             "initialize-postgres-native, okf-validate <dir>, "
@@ -662,6 +745,8 @@ def main(argv: list[str] | None = None) -> int:
         return _generate_local_session_keyset(argv[1:])
     if cmd == "provision-recovery-admin":
         return asyncio.run(_provision_recovery_admin(argv[1:]))
+    if cmd == "issue-recovery-admin-credential":
+        return asyncio.run(_issue_recovery_admin_credential(argv[1:]))
     if cmd == "bootstrap-standalone-sso":
         return asyncio.run(_bootstrap_standalone_sso(argv[1:]))
     if cmd == "reset-password":

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -178,6 +178,40 @@ class RecoveryAdminRetirementConflictError(AKBError):
         )
 
 
+class RecoveryAdminCredentialAuthorizationError(AKBError):
+    """The credential-issue caller is not an independent service administrator."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator credential issue requires an independent service administrator token",
+            status_code=403,
+            code="recovery_admin_credential_requires_service_admin",
+        )
+
+
+class RecoveryAdminCredentialConflictError(AKBError):
+    """The expected recovery identity is not one that can be issued a credential."""
+
+    def __init__(self):
+        super().__init__(
+            "Recovery administrator does not match the credential-issue contract",
+            status_code=409,
+            code="recovery_admin_credential_conflict",
+        )
+
+
+class RecoveryAdminCredentialUnavailableError(AKBError):
+    """No authority in this installation can replace the stored credential."""
+
+    def __init__(self):
+        super().__init__(
+            "Cannot rotate the recovery administrator credential in the configured auth mode: "
+            "the identity provider holds it and nothing in a running AKB can replace it",
+            status_code=503,
+            code="recovery_admin_credential_rotation_unavailable",
+        )
+
+
 class ExternalAuthDisabledError(AKBError):
     """External authentication is disabled by deployment policy."""
 

--- a/backend/app/services/password_service.py
+++ b/backend/app/services/password_service.py
@@ -44,7 +44,16 @@ async def reset_password(
     *,
     username: str,
     actor_id: str | None,
-    method: Literal["admin_ui", "cli"],
+    method: Literal[
+        "admin_ui",
+        "cli",
+        # Recovery-administrator credential issue, which delegates here rather
+        # than reimplementing the reset. The discriminator keeps the two
+        # authorities apart in the audit trail: an independent service
+        # administrator token, or workspace shell access.
+        "recovery_admin_api",
+        "recovery_admin_cli",
+    ],
 ) -> tuple[str, str]:
     """Generate a temp password, replace the user's password_hash, emit audit.
 

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import re
 import uuid
 from typing import Literal
@@ -11,7 +12,11 @@ import asyncpg
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import (
+    AKBError,
     RecoveryAdminConflictError,
+    RecoveryAdminCredentialAuthorizationError,
+    RecoveryAdminCredentialConflictError,
+    RecoveryAdminCredentialUnavailableError,
     RecoveryAdminModeError,
     RecoveryAdminRetirementAuthorizationError,
     RecoveryAdminRetirementConflictError,
@@ -21,6 +26,7 @@ from app.repositories.events_repo import emit_event
 from app.services.account_markers import RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
 from app.services.account_service import cleanup_token_roles
 from app.services.auth_service import hash_password_async
+from app.services.password_service import reset_password
 from app.services.external_identity_contract import (
     OIDC_SUBJECT_MAX_LENGTH,
     bounded_nonempty_claim,
@@ -324,17 +330,24 @@ def _retirement_proof(row) -> dict:
     }
 
 
-async def _require_retirement_actor(
+async def _require_independent_service_admin(
     conn,
     *,
     actor_user_id: str,
     actor_token_id: str,
+    refusal: Callable[[], AKBError],
 ) -> uuid.UUID:
+    """Resolve the caller as an independent service administrator, or refuse.
+
+    Independent means it is not the designated recovery administrator and
+    holds no external identity: the one account that can recover the
+    installation must never be the authority over its own recovery.
+    """
     try:
         user_id = uuid.UUID(actor_user_id)
         token_id = uuid.UUID(actor_token_id)
     except (AttributeError, TypeError, ValueError):
-        raise RecoveryAdminRetirementAuthorizationError() from None
+        raise refusal() from None
 
     row = await conn.fetchrow(
         """
@@ -364,7 +377,7 @@ async def _require_retirement_actor(
         or not row["has_no_external_identity"]
         or not scopes.intersection({"write", "admin"})
     ):
-        raise RecoveryAdminRetirementAuthorizationError()
+        raise refusal()
     return user_id
 
 
@@ -534,10 +547,11 @@ async def retire_local_recovery_admin(
 
     async with pool.acquire() as conn:
         async with conn.transaction():
-            actor_id = await _require_retirement_actor(
+            actor_id = await _require_independent_service_admin(
                 conn,
                 actor_user_id=actor_user_id,
                 actor_token_id=actor_token_id,
+                refusal=RecoveryAdminRetirementAuthorizationError,
             )
             await _lock_provisioning(conn)
             sso_identities = await _locked_sso_recovery_identities(conn)
@@ -640,3 +654,130 @@ async def retire_local_recovery_admin(
 
     await cleanup_token_roles(pool, retired["id"], pending_token_ids)
     return _retirement_proof(retired)
+
+
+CredentialIssueMethod = Literal["recovery_admin_api", "recovery_admin_cli"]
+
+
+def _is_issuable_local_recovery(row, *, expected_username: str, expected_email: str) -> bool:
+    """Return whether this row is the exact live account we may rotate.
+
+    A retired administrator fails every clause: retirement clears both admin
+    flags, suspends the account, and leaves its own tombstone marker, so it
+    can never be re-entered through this path.
+    """
+    return bool(
+        row is not None
+        and row["username"] == expected_username
+        and (row["email"] or "").lower() == expected_email
+        and row["is_admin"]
+        and row["is_recovery_admin"]
+        and row["auth_provider"] == "local"
+        and row["account_status"] == "active"
+        and row["account_kind"] == "human"
+        and _is_local_recovery_credential(row["password_hash"])
+    )
+
+
+async def issue_recovery_admin_credential(
+    *,
+    expected_username: str,
+    expected_email: str,
+    method: CredentialIssueMethod,
+    actor_user_id: str | None = None,
+    actor_token_id: str | None = None,
+) -> dict:
+    """Replace the credential of the exact designated recovery administrator.
+
+    Installation leaves the account holding a credential, so this is rotation:
+    the response to one that leaked, was lost, or must be taken back. The
+    previous credential stops working, including one currently in use — that
+    is what a compromise response requires. The returned credential is the
+    only copy: it is bcrypt-hashed into the account and never stored, logged,
+    or placed in an audit payload. Audit records that a rotation happened, by
+    whom, and for which account.
+
+    ``method`` selects the authority. ``recovery_admin_api`` requires an
+    independent service administrator token and is re-validated here rather
+    than trusted from the route. ``recovery_admin_cli`` is the break-glass
+    path, whose authority is workspace shell access and which therefore has
+    no authenticated principal at all — supplying one is refused so an API
+    caller cannot borrow the unauthenticated route.
+    """
+    expected_username = _exact_expected(expected_username, "expected_username")
+    expected_email = _exact_expected(expected_email, "expected_email").lower()
+    if method == "recovery_admin_cli":
+        if actor_user_id is not None or actor_token_id is not None:
+            raise RecoveryAdminCredentialAuthorizationError()
+    elif actor_user_id is None or actor_token_id is None:
+        raise RecoveryAdminCredentialAuthorizationError()
+
+    mode = settings.require_auth_mode()
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            actor_id: uuid.UUID | None = None
+            if actor_user_id is not None and actor_token_id is not None:
+                actor_id = await _require_independent_service_admin(
+                    conn,
+                    actor_user_id=actor_user_id,
+                    actor_token_id=actor_token_id,
+                    refusal=RecoveryAdminCredentialAuthorizationError,
+                )
+            await _lock_provisioning(conn)
+            row = await _designated_user(
+                conn,
+                auth_provider="local" if mode == "local" else "keycloak",
+            )
+            if mode != "local":
+                # The account is reachable — installation wrote a credential
+                # into the identity provider and handed it over — but nothing
+                # in a running AKB can replace that credential. The permanent
+                # management client is deliberately without `manage-users`,
+                # and the temporary bootstrap client that created the product
+                # administrator is deleted and proven dead before the install
+                # writes its retirement receipt. Rotating here needs an
+                # authority an operator creates and destroys, which does not
+                # exist yet.
+                raise RecoveryAdminCredentialUnavailableError()
+            if not _is_issuable_local_recovery(
+                row,
+                expected_username=expected_username,
+                expected_email=expected_email,
+            ):
+                raise RecoveryAdminCredentialConflictError()
+            user_id = row["id"]
+            username = row["username"]
+            email = row["email"]
+
+    # The delegate opens its own transaction and takes its own row lock, so
+    # the verification above must have committed first. The window is safe:
+    # `users.username` is unique and retirement does not release it, and the
+    # delegate refuses a suspended account — which is exactly what a
+    # retirement landing in the window would have produced.
+    credential, issued_username = await reset_password(
+        username=username,
+        actor_id=str(actor_id) if actor_id is not None else None,
+        method=method,
+    )
+
+    async with pool.acquire() as conn:
+        await emit_event(
+            conn,
+            "auth.recovery_admin_credential_issued",
+            actor_id=str(actor_id) if actor_id is not None else None,
+            payload={
+                "user_id": str(user_id),
+                "username": issued_username,
+                "auth_mode": mode,
+                "method": method,
+            },
+        )
+    return {
+        "user_id": str(user_id),
+        "username": issued_username,
+        "email": email,
+        "auth_mode": mode,
+        "credential": credential,
+    }

--- a/backend/tests/test_recovery_admin_cli_unit.py
+++ b/backend/tests/test_recovery_admin_cli_unit.py
@@ -299,3 +299,110 @@ async def test_sso_profile_accepts_only_external_identity_and_usage_errors_hide_
     captured = capsys.readouterr()
     assert _SECRET not in captured.out
     assert _SECRET not in captured.err
+
+
+async def test_break_glass_issue_calls_the_shared_service_and_reveals_once(monkeypatch, capsys):
+    from app import cli
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+    observed = {}
+
+    async def _issue(**kwargs):
+        observed.update(kwargs)
+        return {
+            "user_id": "11111111-1111-4111-8111-111111111111",
+            "username": "recovery-admin",
+            "email": "recovery-admin@example.com",
+            "auth_mode": "local",
+            "credential": _SECRET,
+        }
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "issue_recovery_admin_credential",
+        _issue,
+    )
+
+    exit_code = await cli._issue_recovery_admin_credential(
+        [
+            "--expected-username",
+            "recovery-admin",
+            "--expected-email",
+            "recovery-admin@example.com",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # Same service function as the endpoint, distinguished only by method,
+    # and with no authenticated principal.
+    assert observed == {
+        "expected_username": "recovery-admin",
+        "expected_email": "recovery-admin@example.com",
+        "method": "recovery_admin_cli",
+    }
+    # The one-time reveal is the whole point of the command, so it is on
+    # stdout — but it must not be in the machine-readable report, which is
+    # what a caller piping stdout into a log or a file will keep.
+    assert _SECRET in captured.out
+    lines = captured.out.splitlines()
+    report = json.loads(lines[0])
+    assert report == {
+        "user_id": "11111111-1111-4111-8111-111111111111",
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "auth_mode": "local",
+    }
+    assert _SECRET not in lines[0]
+    assert any(_SECRET in line for line in lines[1:])
+
+
+async def test_break_glass_issue_hides_values_on_usage_and_service_errors(monkeypatch, capsys):
+    from app import cli
+    from app.exceptions import RecoveryAdminCredentialConflictError
+    from app.services import recovery_admin_service
+
+    _patch_database(monkeypatch)
+
+    async def _refuse(**_kwargs):
+        raise RecoveryAdminCredentialConflictError()
+
+    monkeypatch.setattr(
+        recovery_admin_service,
+        "issue_recovery_admin_credential",
+        _refuse,
+    )
+
+    assert await cli._issue_recovery_admin_credential(
+        [
+            "--expected-username",
+            "recovery-admin",
+            "--expected-email",
+            "recovery-admin@example.com",
+        ]
+    ) == 1
+    captured = capsys.readouterr()
+    assert "recovery_admin_credential_conflict" in captured.err
+    assert _SECRET not in captured.out + captured.err
+
+    assert await cli._issue_recovery_admin_credential(["--expected-username", "only"]) == 2
+    captured = capsys.readouterr()
+    assert _SECRET not in captured.out + captured.err
+
+
+async def test_break_glass_issue_is_registered_as_a_subcommand(capsys):
+    import asyncio
+
+    from app import cli
+
+    # `main` runs its own event loop, so drive it off this test's loop.
+    # It also returns 2 for an unknown subcommand, so the exit code alone
+    # cannot tell "registered but misused" from "not registered at all".
+    assert await asyncio.to_thread(cli.main, ["issue-recovery-admin-credential"]) == 2
+    captured = capsys.readouterr()
+    assert "Unknown subcommand" not in captured.err
+    assert "--expected-username" in captured.err
+
+    assert await asyncio.to_thread(cli.main, ["issue-recovery-admin-credentials"]) == 2
+    assert "Unknown subcommand" in capsys.readouterr().err

--- a/backend/tests/test_recovery_admin_credential_routes_unit.py
+++ b/backend/tests/test_recovery_admin_credential_routes_unit.py
@@ -1,0 +1,134 @@
+"""HTTP authorization contract for recovery-admin credential issue."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from app.api.routes import access
+from app.services.auth_service import AuthenticatedUser
+
+
+_CREDENTIAL = "issued-credential-must-not-be-logged"  # pragma: allowlist secret
+
+
+def _actor(**changes) -> AuthenticatedUser:
+    values = {
+        "user_id": str(uuid.uuid4()),
+        "username": "break-glass-controller",
+        "email": "break-glass-controller@service.invalid",
+        "display_name": "Break-glass controller",
+        "is_admin": True,
+        "auth_method": "pat",
+        "account_kind": "service",
+        "token_id": str(uuid.uuid4()),
+        "key_class": "service",
+        "token_scopes": frozenset({"write"}),
+    }
+    values.update(changes)
+    return AuthenticatedUser(**values)
+
+
+def _client(monkeypatch, actor: AuthenticatedUser, calls: list[dict[str, str]]) -> TestClient:
+    async def _issue(**values):
+        calls.append(values)
+        return {
+            "user_id": "00000000-0000-0000-0000-000000000072",
+            "username": values["expected_username"],
+            "email": values["expected_email"],
+            "auth_mode": "local",
+            "credential": _CREDENTIAL,
+        }
+
+    monkeypatch.setattr(
+        access,
+        "issue_recovery_admin_credential",
+        _issue,
+        raising=False,
+    )
+    app = FastAPI()
+    app.include_router(access.router, prefix="/api/v1")
+    app.dependency_overrides[access.get_current_user] = lambda: actor
+    return TestClient(app)
+
+
+def test_service_admin_token_issues_for_only_the_exact_expected_identity(monkeypatch):
+    actor = _actor()
+    calls: list[dict[str, str]] = []
+
+    response = _client(monkeypatch, actor, calls).post(
+        "/api/v1/admin/recovery-admin/issue-credential",
+        json={
+            "expected_username": "recovery-admin",
+            "expected_email": "recovery-admin@example.com",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": "00000000-0000-0000-0000-000000000072",
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "auth_mode": "local",
+        "credential": _CREDENTIAL,
+    }
+    # The route names the API path; it cannot borrow the unauthenticated
+    # break-glass discriminator.
+    assert calls == [
+        {
+            "expected_username": "recovery-admin",
+            "expected_email": "recovery-admin@example.com",
+            "method": "recovery_admin_api",
+            "actor_user_id": actor.user_id,
+            "actor_token_id": actor.token_id,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "actor",
+    [
+        _actor(auth_method="jwt", account_kind="human", token_id=None, key_class=None),
+        _actor(account_kind="human", key_class="pat"),
+        _actor(auth_method="browser_session", token_id=None, key_class=None),
+        _actor(is_admin=False),
+        _actor(token_id=None),
+        _actor(key_class="publishable"),
+    ],
+)
+def test_human_session_and_non_service_admin_carriers_fail_before_issue(monkeypatch, actor):
+    calls: list[dict[str, str]] = []
+
+    response = _client(monkeypatch, actor, calls).post(
+        "/api/v1/admin/recovery-admin/issue-credential",
+        json={
+            "expected_username": "recovery-admin",
+            "expected_email": "recovery-admin@example.com",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == (
+        "recovery_admin_credential_requires_service_admin"
+    )
+    assert _CREDENTIAL not in response.text
+    assert calls == []
+
+
+def test_issue_request_rejects_an_unexpected_field(monkeypatch):
+    calls: list[dict[str, str]] = []
+
+    response = _client(monkeypatch, _actor(), calls).post(
+        "/api/v1/admin/recovery-admin/issue-credential",
+        json={
+            "expected_username": "recovery-admin",
+            "expected_email": "recovery-admin@example.com",
+            "method": "recovery_admin_cli",
+        },
+    )
+
+    assert response.status_code == 422
+    assert calls == []

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -14,6 +14,7 @@ import asyncpg
 import pytest
 
 
+
 pytestmark = pytest.mark.asyncio
 
 _BACKEND = Path(__file__).resolve().parents[1]
@@ -103,6 +104,7 @@ async def services(monkeypatch):
             access_service,
             account_service,
             auth_service,
+            password_service,
             recovery_admin_service,
         )
 
@@ -115,6 +117,7 @@ async def services(monkeypatch):
             access_service,
             account_service,
             auth_service,
+            password_service,
             recovery_admin_service,
         ):
             monkeypatch.setattr(module, "get_pool", _get_pool)
@@ -1600,3 +1603,462 @@ async def test_sso_bootstrap_retirement_receipt_migrates_and_is_monotonic(
 
     async with pool.acquire() as conn:
         assert await conn.fetchval("SELECT COUNT(*) FROM standalone_sso_bootstrap_retirements") == 1
+
+
+async def test_credential_issue_replaces_the_credential_the_account_already_had(
+    services,
+    monkeypatch,
+):
+    """Rotation, not first issue: the old credential must stop working.
+
+    The account is installed enterable, so this endpoint replaces a credential
+    that already exists. It is the response to a credential that leaked or was
+    lost, which is only true if the previous one dies with the rotation — and
+    it rotates a credential currently in use, deliberately, because that is
+    what a compromise response has to do.
+    """
+    pool, _, service, _, _, auth_service = services
+    from app.config import settings
+    from app.exceptions import AuthenticationError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+    # The installed credential works before the rotation, and the session it
+    # mints is live.
+    signed_in = await auth_service.login("recovery-admin", _LOCAL_PASSWORD)
+    assert signed_in["user"]["id"] == provisioned["user_id"]
+    held_session = f"Bearer {signed_in['token']}"
+    assert await auth_service.resolve_rest_user_authorization(held_session) is not None
+
+    issued = await service.issue_recovery_admin_credential(
+        expected_username="recovery-admin",
+        expected_email="recovery-admin@example.com",
+        method="recovery_admin_api",
+        actor_user_id=str(actor_id),
+        actor_token_id=str(token_id),
+    )
+
+    assert issued["user_id"] == provisioned["user_id"]
+    assert issued["username"] == "recovery-admin"
+    assert issued["auth_mode"] == "local"
+    credential = issued["credential"]
+    assert isinstance(credential, str) and credential
+
+    async with pool.acquire() as conn:
+        stored = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert auth_service.verify_password(credential, stored)
+    login = await auth_service.login("recovery-admin", credential)
+    assert login["user"]["id"] == provisioned["user_id"]
+
+    # And the credential it replaced no longer opens the account.
+    assert not auth_service.verify_password(_LOCAL_PASSWORD, stored)
+    with pytest.raises(AuthenticationError):
+        await auth_service.login("recovery-admin", _LOCAL_PASSWORD)
+
+    # Nor does the session that credential had already minted. Replacing the
+    # credential without this would leave whoever held the old one signed in,
+    # which is the case the rotation exists for. The delegate does it; assert
+    # it here so the behaviour cannot be inherited silently.
+    assert await auth_service.resolve_rest_user_authorization(held_session) is None
+
+
+async def test_credential_issue_never_writes_the_value_into_any_audit_payload(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+
+    issued = await service.issue_recovery_admin_credential(
+        expected_username="recovery-admin",
+        expected_email="recovery-admin@example.com",
+        method="recovery_admin_api",
+        actor_user_id=str(actor_id),
+        actor_token_id=str(token_id),
+    )
+
+    async with pool.acquire() as conn:
+        every_payload = await conn.fetch("SELECT kind, payload::text AS body FROM events")
+        stored = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert every_payload
+    for record in every_payload:
+        assert issued["credential"] not in record["body"], record["kind"]
+    # Not recoverable from the row either: only the bcrypt hash is stored.
+    assert issued["credential"] not in stored
+
+    issued_events = [
+        record for record in every_payload
+        if record["kind"] == "auth.recovery_admin_credential_issued"
+    ]
+    assert len(issued_events) == 1
+    assert "recovery_admin_api" in issued_events[0]["body"]
+
+
+async def test_credential_issue_requires_an_independent_service_administrator(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialAuthorizationError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    # The designated recovery admin is not an independent authority over itself.
+    async with pool.acquire() as conn:
+        self_token = uuid.uuid4()
+        await conn.execute(
+            """
+            INSERT INTO tokens (id, user_id, name, token_hash, token_prefix, scopes, key_class)
+            VALUES ($1, $2, 'self', $3, 'akb_secret_', ARRAY['read','write','admin'], 'service')
+            """,
+            self_token,
+            uuid.UUID(provisioned["user_id"]),
+            uuid.uuid4().hex,
+        )
+
+    with pytest.raises(RecoveryAdminCredentialAuthorizationError):
+        await service.issue_recovery_admin_credential(
+            expected_username="recovery-admin",
+            expected_email="recovery-admin@example.com",
+            method="recovery_admin_api",
+            actor_user_id=provisioned["user_id"],
+            actor_token_id=str(self_token),
+        )
+
+    async with pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert after == before
+
+
+async def test_credential_issue_refuses_an_inexact_expected_identity(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+
+    for username, email in (
+        ("recovery-admin", "someone-else@example.com"),
+        ("someone-else", "recovery-admin@example.com"),
+    ):
+        with pytest.raises(RecoveryAdminCredentialConflictError):
+            await service.issue_recovery_admin_credential(
+                expected_username=username,
+                expected_email=email,
+                method="recovery_admin_api",
+                actor_user_id=str(actor_id),
+                actor_token_id=str(token_id),
+            )
+
+    async with pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert after == before
+
+
+async def test_credential_issue_refuses_a_retired_recovery_administrator(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialConflictError
+    from app.services.account_markers import RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+    # Exactly the durable state retirement leaves behind.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE users
+               SET is_recovery_admin = false, is_admin = false,
+                   account_status = 'suspended', password_hash = $2
+             WHERE id = $1
+            """,
+            uuid.UUID(provisioned["user_id"]),
+            RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL,
+        )
+
+    with pytest.raises(RecoveryAdminCredentialConflictError):
+        await service.issue_recovery_admin_credential(
+            expected_username="recovery-admin",
+            expected_email="recovery-admin@example.com",
+            method="recovery_admin_api",
+            actor_user_id=str(actor_id),
+            actor_token_id=str(token_id),
+        )
+
+    async with pool.acquire() as conn:
+        unchanged = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    assert unchanged == RETIRED_RECOVERY_ADMIN_PASSWORD_SENTINEL
+
+
+async def test_break_glass_cli_issue_carries_no_actor_and_is_audited_apart(services, monkeypatch):
+    pool, _, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+
+    issued = await service.issue_recovery_admin_credential(
+        expected_username="recovery-admin",
+        expected_email="recovery-admin@example.com",
+        method="recovery_admin_cli",
+    )
+
+    async with pool.acquire() as conn:
+        stored = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+        events = await conn.fetch(
+            """
+            SELECT kind, actor_id, payload::text AS body
+              FROM events
+             WHERE kind IN ('auth.recovery_admin_credential_issued', 'auth.password_reset')
+             ORDER BY kind
+            """
+        )
+    assert auth_service.verify_password(issued["credential"], stored)
+    by_type = {record["kind"]: record for record in events}
+    # Shell access is the authority, so there is no authenticated principal.
+    assert by_type["auth.recovery_admin_credential_issued"]["actor_id"] is None
+    assert "recovery_admin_cli" in by_type["auth.recovery_admin_credential_issued"]["body"]
+    # The delegated local reset stays visible and carries the same discriminator.
+    assert "recovery_admin_cli" in by_type["auth.password_reset"]["body"]
+
+
+async def test_break_glass_cli_method_refuses_a_supplied_actor(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialAuthorizationError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+
+    # The break-glass path has no authenticated principal by construction.
+    # Accepting one would let an API caller borrow the unauthenticated route.
+    with pytest.raises(RecoveryAdminCredentialAuthorizationError):
+        await service.issue_recovery_admin_credential(
+            expected_username="recovery-admin",
+            expected_email="recovery-admin@example.com",
+            method="recovery_admin_cli",
+            actor_user_id=str(actor_id),
+            actor_token_id=str(token_id),
+        )
+
+
+async def test_credential_issue_advances_the_session_revocation_cutoff(services, monkeypatch):
+    pool, _, service, _, _, auth_service = services
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT tokens_revoked_before FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+
+    await service.issue_recovery_admin_credential(
+        expected_username="recovery-admin",
+        expected_email="recovery-admin@example.com",
+        method="recovery_admin_api",
+        actor_user_id=str(actor_id),
+        actor_token_id=str(token_id),
+    )
+
+    async with pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT tokens_revoked_before FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    # The mechanism behind the rejection asserted end-to-end in
+    # test_credential_issue_replaces_the_credential_the_account_already_had.
+    # Kept separately because a cutoff that stops advancing is a different
+    # failure from a resolver that stops accepting anything.
+    assert after > before
+
+
+async def test_sso_credential_issue_fails_closed_without_a_minting_authority(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialUnavailableError
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    provisioned = await _create_sso_recovery_successor(service)
+    actor_id, token_id = await _create_retirement_actor(pool)
+
+    # A running AKB holds no authority that can mint a Keycloak credential:
+    # the management client has no manage-users, and the bootstrap client is
+    # deleted and proven dead before the install writes its receipt.
+    with pytest.raises(RecoveryAdminCredentialUnavailableError) as captured:
+        await service.issue_recovery_admin_credential(
+            expected_username="sso-recovery-admin",
+            expected_email="sso-recovery-admin@example.com",
+            method="recovery_admin_api",
+            actor_user_id=str(actor_id),
+            actor_token_id=str(token_id),
+        )
+
+    # The code and status are what an API caller sees, so pin them rather than
+    # only the class: renaming either is a contract change, not a refactor.
+    assert captured.value.code == "recovery_admin_credential_rotation_unavailable"
+    assert captured.value.status_code == 503
+
+    from app.services.recovery_admin_service import _SSO_PASSWORD_SENTINEL
+
+    async with pool.acquire() as conn:
+        unchanged = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+        issued = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE kind = 'auth.recovery_admin_credential_issued'"
+        )
+    assert unchanged == _SSO_PASSWORD_SENTINEL
+    assert issued == 0
+
+
+async def test_sso_credential_issue_still_refuses_an_unauthorized_caller_first(services, monkeypatch):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialAuthorizationError
+
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    await _create_sso_recovery_successor(service)
+
+    # Authorization is decided before capability, so an unauthorized caller
+    # never learns which modes can mint.
+    with pytest.raises(RecoveryAdminCredentialAuthorizationError):
+        await service.issue_recovery_admin_credential(
+            expected_username="sso-recovery-admin",
+            expected_email="sso-recovery-admin@example.com",
+            method="recovery_admin_api",
+            actor_user_id=str(uuid.uuid4()),
+            actor_token_id=str(uuid.uuid4()),
+        )
+
+
+@pytest.mark.parametrize(
+    "column, value",
+    [
+        # Still the designated administrator, but not in a state we may issue
+        # for. Retirement clears `is_recovery_admin`, so these are the states
+        # the designated-row lookup itself cannot filter out.
+        ("account_status", "suspended"),
+        ("account_kind", "service"),
+        ("password_hash", "!some-other-marker!"),
+    ],
+)
+async def test_credential_issue_refuses_a_designated_row_in_a_bad_state(
+    services,
+    monkeypatch,
+    column,
+    value,
+):
+    pool, _, service, _, _, _ = services
+    from app.config import settings
+    from app.exceptions import RecoveryAdminCredentialConflictError
+
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    provisioned = await service.provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_LOCAL_PASSWORD,
+    )
+    actor_id, token_id = await _create_retirement_actor(pool)
+    async with pool.acquire() as conn:
+        before = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            f"UPDATE users SET {column} = $2 WHERE id = $1",  # noqa: S608 - fixed test vocabulary
+            uuid.UUID(provisioned["user_id"]),
+            value,
+        )
+        assert await conn.fetchval(
+            "SELECT is_recovery_admin FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+
+    with pytest.raises(RecoveryAdminCredentialConflictError):
+        await service.issue_recovery_admin_credential(
+            expected_username="recovery-admin",
+            expected_email="recovery-admin@example.com",
+            method="recovery_admin_api",
+            actor_user_id=str(actor_id),
+            actor_token_id=str(token_id),
+        )
+
+    async with pool.acquire() as conn:
+        after = await conn.fetchval(
+            "SELECT password_hash FROM users WHERE id = $1",
+            uuid.UUID(provisioned["user_id"]),
+        )
+        issued = await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE kind = 'auth.recovery_admin_credential_issued'"
+        )
+    assert after == (value if column == "password_hash" else before)
+    assert issued == 0


### PR DESCRIPTION
## What this adds

An on-demand path to **replace** the designated recovery administrator's
credential, for the case where the installed one leaked or was lost.

One implementation, two callers:

- `POST /admin/recovery-admin/rotate-credential`, requiring an **independent
  service administrator token** — the same five-part conjunction the retirement
  endpoint uses, re-validated inside the transaction rather than trusted from the
  route, plus `expected_username` / `expected_email` exact-match confirmation so
  acting on the wrong account is not possible by slip.
- a break-glass CLI subcommand whose authority is workspace shell access, which
  therefore has no authenticated principal at all — and **refuses** a supplied
  one, so an API caller cannot borrow the unauthenticated path.

The `method` discriminator distinguishes the two wherever password resets are
already audited, and is fixed by the route so the break-glass value is not
reachable over HTTP. The request model forbids extra fields, so it cannot be
smuggled either.

Local delegates to the existing password-reset service rather than
reimplementing it, which is why session revocation comes for free.

Authorization is decided before capability, so an unauthorized caller cannot
probe which modes can rotate. A test pins that ordering.

## SSO fails closed, deliberately

SSO returns a named 503, `recovery_admin_credential_rotation_unavailable`. It is
not a stub: a running AKB holds no authority that can replace a credential in the
identity provider. The permanent management client is kept without
`manage-users`, and the temporary bootstrap client that created the account is
deleted and proven dead before the install completes. The account has a door —
the install created one — but nothing in the running system can give it a new
one. That design question is tracked separately.

The seam is in place, with the target binding recorded for whoever wires the
authority: the exact subject AKB stored at provisioning, with an issuer check,
rather than a username lookup — a username lookup would rotate whoever holds that
name now.

## Rotation semantics, pinned rather than implicit

Rotating a credential that is currently in use is **allowed**, with no additional
guard. That is what a compromise response has to do, and refusing would make the
endpoint useless for its main purpose: recovering a lost credential means one
exists and nobody knows it. The protection against a slip is the exact-identity
confirmation and the independent-service-admin authority, not a refusal.

The consequences are asserted rather than the permission:

- the new credential works
- the one it replaced no longer verifies and no longer logs in
- the session the **old** credential had already minted is dead, asserted
  end-to-end through session resolution rather than by reading a timestamp

That third assertion checks the held session resolves *before* the rotation and
returns nothing after. Without the before-check, a future refactor that broke
resolution entirely would make it pass for the wrong reason.

The narrower timestamp test is kept alongside it rather than deleted as a
duplicate: a revocation cutoff that stops advancing and a resolver that stops
accepting anything are different failures.

## A wire contract that was not pinned

The 503 was asserted only by exception class. Nothing pinned its code or its
status, so renaming the error changed the wire contract invisibly through a fully
green suite. Both are now asserted, and a mutation that renames it back reddens.

## Mutations

One at a time, restored after each: rotation returns a credential it never wrote
→ 3 red; rotation leaves the previous credential working → 2 red; the 503 code
renamed back → 1 red; session revocation removed from the delegate → 2 red, the
consequence test and the mechanism test.

## Gate

`scripts/check.sh`: all checks passed. Backend suite with both database DSNs on
separate databases: 61 failed / 2613 passed / 2 skipped. The failures are the
host's git being older than the external-git tests require, two pre-existing
file-measurement failures, and one known flake — the same population as the base
commit, with no new failures. ruff, mypy across 314 files, and detect-secrets are
clean.
