### PR TITLE
feat(auth): require a delivered local credential to be replaced

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -17,6 +17,7 @@ from app.models.vault_scope import (
 from app.services.auth_service import (
     AuthenticatedUser,
     resolve_delegated_human_authorization,
+    resolve_rest_credential_change_authorization,
     resolve_rest_user_authorization,
     token_has_scope,
 )
@@ -167,10 +168,23 @@ async def get_current_user(
     _credentials: HTTPAuthorizationCredentials | None = Security(bearer_auth),
 ) -> AuthenticatedUser:
     """Extract and validate user from Authorization header. Required."""
+    return await _authenticated_user(request)
+
+
+async def _authenticated_user(
+    request: Request,
+    *,
+    for_credential_change: bool = False,
+) -> AuthenticatedUser:
     current_request_jwt_claims.set(None)
     authorization = request.headers.get("authorization")
     if authorization:
-        user = await resolve_rest_user_authorization(authorization)
+        resolve = (
+            resolve_rest_credential_change_authorization
+            if for_credential_change
+            else resolve_rest_user_authorization
+        )
+        user = await resolve(authorization)
     else:
         user = await _resolve_cookie_user(request, optional=False)
         if user is None:
@@ -190,6 +204,22 @@ async def get_current_user(
         )
     _apply_claim_header(request, user)
     return user
+
+
+async def get_credential_change_user(
+    request: Request,
+    _credentials: HTTPAuthorizationCredentials | None = Security(bearer_auth),
+) -> AuthenticatedUser:
+    """``get_current_user`` for the one route a forced change must reach.
+
+    An account owing a credential change is refused everywhere else, which
+    would include the route that clears the requirement — so exactly one
+    dependency carries the exemption, and only the change-password route
+    depends on it. Everything else about the resolution is unchanged: an
+    invalid credential is still 401, and an insufficient token scope is
+    still 403.
+    """
+    return await _authenticated_user(request, for_credential_change=True)
 
 
 async def get_optional_user(

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, 
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import ConfigDict, Field, field_validator
 
-from app.api.deps import get_current_user
+from app.api.deps import get_credential_change_user, get_current_user
 from app.config import settings
 from app.exceptions import (
     AuthenticationError,
@@ -701,7 +701,10 @@ async def delete_token(token_id: str, user: AuthenticatedUser = Depends(get_curr
 @router.post("/auth/change-password", summary="Change own password")
 async def change_password_route(
     req: ChangePasswordRequest,
-    user: AuthenticatedUser = Depends(get_current_user),
+    # The only route reachable by an account that still owes a change for a
+    # credential it was issued. Every other route refuses that account until
+    # this one has succeeded.
+    user: AuthenticatedUser = Depends(get_credential_change_user),
 ):
     require_local_auth_enabled()
     from app.services.auth_service import change_password, BadPasswordChange

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -54,6 +54,15 @@ CREATE TABLE IF NOT EXISTS users (
     account_kind TEXT NOT NULL DEFAULT 'human'
         CONSTRAINT users_account_kind_check
         CHECK (account_kind IN ('human', 'service')),
+    -- Local counterpart to the identity provider's UPDATE_PASSWORD required
+    -- action. TRUE while a credential that was issued to this account and
+    -- handed over out-of-band has not yet been replaced by its holder; a
+    -- session projected from it may do nothing but change the password.
+    -- Set by password reset and local recovery-admin provisioning, cleared
+    -- by change_password. Self-service registration never sets it, so every
+    -- account that has never had a credential issued keeps this default.
+    -- See migration 080.
+    credential_change_required BOOLEAN NOT NULL DEFAULT false,
     CONSTRAINT users_recovery_admin_requires_admin
         CHECK (NOT is_recovery_admin OR is_admin),
     CONSTRAINT users_recovery_admin_provider_check

--- a/backend/app/db/migrations/080_local_forced_credential_change.py
+++ b/backend/app/db/migrations/080_local_forced_credential_change.py
@@ -1,0 +1,33 @@
+"""Mark a delivered local credential as owed a replacement.
+
+In SSO mode a credential handed to a person is temporary: the identity
+provider arms ``UPDATE_PASSWORD`` when the account is created with a supplied
+password and when that password is reset, so the first successful sign-in
+forces a replacement. Local mode had no equivalent — a delivered credential
+was simply the account's password until someone chose to change it.
+
+The column is the local marker for exactly that state. It is set only where a
+credential is issued to someone (administrative reset and local recovery-admin
+provisioning), and cleared only where the holder replaces it. Self-service
+registration never sets it: the person chose that password themselves, so
+there is nothing to replace, and every pre-existing account keeps the ``false``
+default.
+
+Deliberately no CHECK tying the marker to ``auth_provider = 'local'``. The
+services that set it already refuse non-local and non-human accounts, and a
+constraint here would turn a local-to-SSO provider cutover on a row still
+holding the marker into a migration failure.
+"""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE users
+              ADD COLUMN IF NOT EXISTS credential_change_required
+                  BOOLEAN NOT NULL DEFAULT false;
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -302,6 +302,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "077_legacy_adoptions.py",  # immutable legacy app adoption plans, targets, and bounded audit
         "078_recovery_admin_authority_handover.py",  # provider-scoped recovery authority during local-to-SSO cutover
         "079_worker_claim_lifecycle.py",  # attempt-at-claim + explicit claimed/abandoned timestamps for durable queues
+        "080_local_forced_credential_change.py",  # local parity for the identity provider's UPDATE_PASSWORD: a delivered credential is owed a replacement until its holder changes it
     ):
         if filename in applied:
             continue

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -101,6 +101,22 @@ class AccountSuspendedError(AKBError):
         )
 
 
+class CredentialChangeRequiredError(AKBError):
+    """A delivered local credential has not been replaced by its holder yet.
+
+    Local mode's counterpart to the identity provider's ``UPDATE_PASSWORD``
+    required action. The account authenticates, but the only thing the
+    resulting session may do is replace the credential it was issued.
+    """
+
+    def __init__(self):
+        super().__init__(
+            "This account must change its password before doing anything else",
+            status_code=403,
+            code="credential_change_required",
+        )
+
+
 class ExternalIdentityConflictError(AKBError):
     """Verified external claims conflict with an existing stable binding."""
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -27,6 +27,7 @@ from app.exceptions import (
     AccountSuspendedError,
     AuthenticationError,
     ConflictError,
+    CredentialChangeRequiredError,
     ExternalAuthDisabledError,
     ExternalIdentityConflictError,
     ExternalProfileReadOnlyError,
@@ -263,6 +264,11 @@ async def register(username: str, email: str, password: str, display_name: str |
         if existing:
             raise ConflictError("Username or email already exists")
 
+        # Self-service signup deliberately leaves credential_change_required
+        # at its false default: this password was chosen by the person who
+        # will use it, never delivered to them, so there is nothing to
+        # replace. Arming it here would force a change on an account that
+        # was never issued a credential.
         is_admin = await conn.fetchval(
             """
             INSERT INTO users (id, username, email, password_hash, display_name, is_admin)
@@ -596,10 +602,22 @@ async def _project_keycloak_principal(
 
 async def project_verified_principal(
     principal: VerifiedPrincipal,
+    *,
+    for_credential_change: bool = False,
 ) -> AuthenticatedUser | None:
-    """Common verified-human boundary before existing AKB authorization."""
+    """Common verified-human boundary before existing AKB authorization.
+
+    ``for_credential_change`` is the single exemption from the local
+    forced-credential-change refusal, and belongs to the change-password
+    route alone. Defaulting it to False is what keeps the refusal
+    fail-closed: a future caller of this boundary is gated unless it
+    deliberately asks not to be.
+    """
     if principal.profile_id == LOCAL_SESSION_RS256_V2:
-        return await _project_local_session_principal(principal)
+        return await _project_local_session_principal(
+            principal,
+            for_credential_change=for_credential_change,
+        )
     if principal.profile_id == KEYCLOAK_ACCESS_V1:
         return await _project_keycloak_principal(principal)
     return None
@@ -655,8 +673,17 @@ async def change_password(user_id: str, current: str, new: str) -> None:
             if await verify_password_async(new, row["password_hash"]):
                 raise BadPasswordChange("New password must differ from current")
 
+            # Clearing the marker belongs in the same statement as the new
+            # hash: the marker describes the credential in that column, so
+            # the two can never be observed disagreeing.
             await conn.execute(
-                "UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2",
+                """
+                UPDATE users
+                   SET password_hash = $1,
+                       credential_change_required = false,
+                       updated_at = NOW()
+                 WHERE id = $2
+                """,
                 await hash_password_async(new),
                 uuid.UUID(user_id),
             )
@@ -996,6 +1023,31 @@ async def resolve_rest_user_authorization(
     authorization: str,
 ) -> AuthenticatedUser | None:
     """Resolve the REST capability without token-directed verifier dispatch."""
+    return await _resolve_rest_authorization(authorization)
+
+
+async def resolve_rest_credential_change_authorization(
+    authorization: str,
+) -> AuthenticatedUser | None:
+    """Resolve the REST capability for the forced credential change alone.
+
+    Identical to ``resolve_rest_user_authorization`` except that this is the
+    one entry point exempt from the forced-credential-change refusal. A
+    separate name rather than a flag is what makes the exemption narrow:
+    the resolver every other route reaches cannot be asked to skip the
+    refusal at all.
+    """
+    return await _resolve_rest_authorization(
+        authorization,
+        for_credential_change=True,
+    )
+
+
+async def _resolve_rest_authorization(
+    authorization: str,
+    *,
+    for_credential_change: bool = False,
+) -> AuthenticatedUser | None:
     _reset_request_credential_context()
     token = _bearer_token(authorization)
     if token is None:
@@ -1009,7 +1061,10 @@ async def resolve_rest_user_authorization(
         principal = await verify_keycloak_access_v1(token, "api")
     if principal is None:
         return None
-    return await project_verified_principal(principal)
+    return await project_verified_principal(
+        principal,
+        for_credential_change=for_credential_change,
+    )
 
 
 async def resolve_mcp_authorization(authorization: str) -> AuthenticatedUser | None:
@@ -1057,6 +1112,8 @@ async def resolve_token(authorization: str) -> AuthenticatedUser | None:
 
 async def _project_local_session_principal(
     principal: VerifiedPrincipal,
+    *,
+    for_credential_change: bool = False,
 ) -> AuthenticatedUser | None:
     """Project a verified local session onto its active AKB account."""
     iat = principal.claims["iat"]
@@ -1066,6 +1123,7 @@ async def _project_local_session_principal(
             row = await conn.fetchrow(
                 """
                 SELECT id, username, email, display_name, is_admin,
+                       credential_change_required,
                        CEIL(EXTRACT(EPOCH FROM tokens_revoked_before))::bigint
                            AS revoked_epoch_ceil
                   FROM users
@@ -1094,6 +1152,16 @@ async def _project_local_session_principal(
             # issued in the same second as revoke would survive.
             if int(iat) < int(row["revoked_epoch_ceil"]):
                 return None
+
+            # A credential this account was handed, and has not replaced,
+            # buys exactly one capability: replacing it. The refusal is
+            # here rather than at each route because this is the only
+            # place a local password becomes request authority, so a route
+            # added later is covered without being told about it. It is a
+            # raise, not a None, so the caller can be told what to do
+            # instead of being told its credential is invalid.
+            if row["credential_change_required"] and not for_credential_change:
+                raise CredentialChangeRequiredError()
 
             return AuthenticatedUser(
                 user_id=str(row["id"]),

--- a/backend/app/services/password_service.py
+++ b/backend/app/services/password_service.py
@@ -57,6 +57,11 @@ async def reset_password(
 ) -> tuple[str, str]:
     """Generate a temp password, replace the user's password_hash, emit audit.
 
+    The account is left owing a credential change, so the delivered value
+    stops being a working password the moment its holder signs in with it —
+    the local equivalent of the identity provider's ``temporary`` credential
+    plus ``UPDATE_PASSWORD`` required action.
+
     Returns (temp_password, username). `actor_id` is None for CLI invocations
     (no authenticated principal); audit event carries `method` to distinguish.
     """
@@ -80,8 +85,26 @@ async def reset_password(
                 raise PasswordLifecycleUnavailableError()
 
             temp = generate_temp_password()
+            # The returned value is delivered to a person out-of-band, which
+            # is what makes it temporary: the marker is set in the same
+            # statement that installs the hash, so the account cannot be
+            # observed holding an issued credential without owing a
+            # replacement for it. change_password clears it.
+            #
+            # Only the sessions this credential can produce are limited.
+            # Personal Access Tokens the account already holds keep working,
+            # deliberately and consistently with the session revoke below:
+            # a PAT is not the credential that was just handed over, and
+            # breaking stored integrations on every administrative reset is
+            # a different (and larger) change than this one.
             await conn.execute(
-                "UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2",
+                """
+                UPDATE users
+                   SET password_hash = $1,
+                       credential_change_required = true,
+                       updated_at = NOW()
+                 WHERE id = $2
+                """,
                 await hash_password_async(temp),
                 row["id"],
             )

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -176,12 +176,23 @@ async def provision_local_recovery_admin(
                     if collision:
                         raise RecoveryAdminConflictError()
                     user_id = uuid.uuid4()
+                    # The operator supplied or generated this password in a
+                    # file and hands it to the administrator, so it is a
+                    # delivered credential and is owed a replacement. The SSO
+                    # profile creates its product administrator the same way:
+                    # a `temporary` credential plus the UPDATE_PASSWORD
+                    # required action. Only creation arms it — the
+                    # convergence branch above leaves the credential column
+                    # alone, so re-running provisioning must not re-arm a
+                    # marker the holder has already cleared.
                     row = await conn.fetchrow(
                         """
                         INSERT INTO users (
                             id, username, email, password_hash, is_admin,
-                            is_recovery_admin, auth_provider, account_status, account_kind
-                        ) VALUES ($1, $2, $3, $4, true, true, 'local', 'active', 'human')
+                            is_recovery_admin, auth_provider, account_status, account_kind,
+                            credential_change_required
+                        ) VALUES ($1, $2, $3, $4, true, true, 'local', 'active', 'human',
+                                  true)
                         RETURNING id, username, email, password_hash, is_admin,
                                   is_recovery_admin, auth_provider, account_status, account_kind
                         """,
@@ -611,6 +622,9 @@ async def retire_local_recovery_admin(
                            is_admin = false,
                            account_status = 'suspended',
                            password_hash = $2,
+                           -- The tombstone is not a credential anyone was
+                           -- handed, so there is nothing left to replace.
+                           credential_change_required = false,
                            tokens_revoked_before = NOW(),
                            updated_at = NOW()
                      WHERE id = $1

--- a/backend/tests/test_auth_verifier_profiles_unit.py
+++ b/backend/tests/test_auth_verifier_profiles_unit.py
@@ -184,7 +184,7 @@ async def test_rest_local_mode_selects_only_local_profile_without_fallback(monke
     async def forbidden_keycloak(*_args, **_kwargs):
         raise AssertionError("local REST must not try the Keycloak verifier")
 
-    async def project(value):
+    async def project(value, **_kwargs):
         assert value is principal
         return actor
 
@@ -217,7 +217,7 @@ async def test_rest_sso_mode_selects_only_api_access_profile_without_fallback(mo
         calls.append((token, route_profile))
         return principal
 
-    async def project(value):
+    async def project(value, **_kwargs):
         assert value is principal
         return actor
 

--- a/backend/tests/test_local_forced_credential_change.py
+++ b/backend/tests/test_local_forced_credential_change.py
@@ -1,0 +1,411 @@
+"""Local parity for the identity provider's forced credential change.
+
+In SSO mode a delivered credential is temporary: the provider arms
+``UPDATE_PASSWORD``, so the first successful sign-in has to replace it. These
+are the local-mode contracts for the same promise — including the one that
+says nothing changes for an account that was never issued a credential.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from app.config import settings
+from app.exceptions import AKBError, CredentialChangeRequiredError
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_CHOSEN_PASSWORD = "chosen-by-the-holder"  # pragma: allowlist secret
+_DELIVERED_PASSWORD = "delivered-out-of-band"  # pragma: allowlist secret
+_REPLACEMENT_PASSWORD = "replacement-chosen-now"  # pragma: allowlist secret
+
+
+def _dsn_for_database(dsn: str, database: str) -> str:
+    parsed = urlsplit(dsn)
+    return urlunsplit(parsed._replace(path=f"/{database}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_forced_change_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        conn = await asyncpg.connect(target_dsn)
+        try:
+            await conn.execute(_INIT_SQL)
+            from app.db.postgres import _load_migration
+
+            events_migration = _load_migration("015_events_outbox.py")
+            assert events_migration is not None
+            await events_migration.migrate(conn=conn)
+        finally:
+            await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=8)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity"
+            " WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+class _RoleSync:
+    """PG-native role hooks are best-effort lifecycle noise for these tests."""
+
+    async def on_user_create(self, user_id) -> None:
+        return None
+
+    async def on_user_delete(self, user_id) -> None:
+        return None
+
+    async def revoke_token_role_strict(self, token_id) -> None:
+        return None
+
+
+@pytest.fixture
+async def pool(monkeypatch):
+    async with _fresh_database() as pool:
+        from app.services import (
+            access_service,
+            account_service,
+            auth_service,
+            password_service,
+            recovery_admin_service,
+        )
+
+        async def _get_pool():
+            return pool
+
+        role_sync = _RoleSync()
+        for module in (
+            access_service,
+            account_service,
+            auth_service,
+            password_service,
+            recovery_admin_service,
+        ):
+            monkeypatch.setattr(module, "get_pool", _get_pool)
+        for module in (
+            access_service,
+            account_service,
+            auth_service,
+            recovery_admin_service,
+        ):
+            monkeypatch.setattr(module, "get_role_sync", lambda: role_sync)
+        monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+        yield pool
+
+
+async def _credential_change_required(pool, user_id) -> bool:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT credential_change_required FROM users WHERE id = $1",
+            uuid.UUID(str(user_id)),
+        )
+
+
+async def _signed_in(username: str, password: str) -> str:
+    """Sign in and hold until the returned session is usable.
+
+    ``login`` pins ``iat`` past the account's revocation cutoff, so a token
+    minted right after a reset carries an ``nbf`` up to a second ahead. That
+    is pre-existing revocation behavior; waiting it out here keeps these
+    tests about the credential-change marker.
+    """
+    from app.services.auth_service import login
+
+    session = await login(username, password)
+    await asyncio.sleep(1.1)
+    return session["token"]
+
+
+async def _registered(pool) -> dict:
+    """An ordinary account whose password its own holder chose."""
+    from app.services.auth_service import register
+
+    suffix = uuid.uuid4().hex[:10]
+    return await register(
+        f"holder-{suffix}",
+        f"holder-{suffix}@example.com",
+        _CHOSEN_PASSWORD,
+    )
+
+
+# ── Which paths arm the marker ──────────────────────────────────────
+
+
+async def test_self_service_registration_owes_no_credential_change(pool):
+    account = await _registered(pool)
+    assert await _credential_change_required(pool, account["user_id"]) is False
+
+
+async def test_password_reset_leaves_the_account_owing_a_change(pool):
+    from app.services.password_service import reset_password
+
+    account = await _registered(pool)
+    await reset_password(username=account["username"], actor_id=None, method="cli")
+    assert await _credential_change_required(pool, account["user_id"]) is True
+
+
+async def test_local_recovery_admin_provisioning_arms_the_marker(pool):
+    from app.services.recovery_admin_service import provision_local_recovery_admin
+
+    report = await provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_DELIVERED_PASSWORD,
+    )
+    assert report["created"] is True
+    assert await _credential_change_required(pool, report["user_id"]) is True
+
+
+async def test_repeat_provisioning_does_not_re_arm_a_cleared_requirement(pool):
+    from app.services.auth_service import change_password
+    from app.services.recovery_admin_service import provision_local_recovery_admin
+
+    kwargs = {
+        "username": "recovery-admin",
+        "email": "recovery-admin@example.com",
+        "password": _DELIVERED_PASSWORD,
+    }
+    report = await provision_local_recovery_admin(**kwargs)
+    await change_password(
+        report["user_id"], _DELIVERED_PASSWORD, _REPLACEMENT_PASSWORD
+    )
+
+    repeat = await provision_local_recovery_admin(**kwargs)
+
+    assert repeat["created"] is False
+    assert await _credential_change_required(pool, report["user_id"]) is False
+
+
+# ── An account that was never issued a credential is unaffected ─────
+
+
+async def test_an_account_that_never_had_a_credential_issued_is_unaffected(pool):
+    """The regression this whole change must not cause."""
+    from app.services.auth_service import resolve_rest_user_authorization
+
+    account = await _registered(pool)
+    token = await _signed_in(account["username"], _CHOSEN_PASSWORD)
+
+    resolved = await resolve_rest_user_authorization(f"Bearer {token}")
+
+    assert resolved is not None
+    assert resolved.user_id == account["user_id"]
+    assert await _credential_change_required(pool, account["user_id"]) is False
+
+
+async def test_migration_080_leaves_pre_existing_accounts_unaffected(pool):
+    """The upgrade path: existing rows must not acquire the requirement."""
+    from app.db.postgres import _load_migration
+    from app.services.auth_service import hash_password
+
+    migration = _load_migration("080_local_forced_credential_change.py")
+    assert migration is not None
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "ALTER TABLE users DROP COLUMN credential_change_required"
+        )
+        for index in range(2):
+            suffix = f"{uuid.uuid4().hex[:8]}-{index}"
+            await conn.execute(
+                "INSERT INTO users (username, email, password_hash)"
+                " VALUES ($1, $2, $3)",
+                f"pre-{suffix}",
+                f"pre-{suffix}@example.com",
+                hash_password(_CHOSEN_PASSWORD),
+            )
+        await migration.migrate(conn)
+
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 2
+        assert (
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM users WHERE credential_change_required"
+            )
+            == 0
+        )
+
+
+# ── While the marker is set ─────────────────────────────────────────
+
+
+async def _issued_session(pool) -> tuple[dict, str, str]:
+    """An account holding a credential someone else generated for it."""
+    from app.services.password_service import reset_password
+
+    account = await _registered(pool)
+    delivered, _ = await reset_password(
+        username=account["username"], actor_id=None, method="admin_ui"
+    )
+    return account, delivered, await _signed_in(account["username"], delivered)
+
+
+async def test_a_delivered_credential_still_signs_in(pool):
+    """Sign-in has to work, or there is no session to change the password."""
+    _, _, token = await _issued_session(pool)
+    assert token
+
+
+async def test_the_resulting_session_is_refused_off_the_change_route(pool):
+    from app.services.auth_service import resolve_rest_user_authorization
+
+    _, _, token = await _issued_session(pool)
+    with pytest.raises(CredentialChangeRequiredError):
+        await resolve_rest_user_authorization(f"Bearer {token}")
+
+
+async def test_delegated_human_authorization_is_refused_too(pool):
+    """The other boundary a local session becomes authority through."""
+    from app.services.auth_service import resolve_delegated_human_authorization
+
+    _, _, token = await _issued_session(pool)
+    with pytest.raises(CredentialChangeRequiredError):
+        await resolve_delegated_human_authorization(f"Bearer {token}")
+
+
+async def test_the_credential_change_resolution_is_the_one_exemption(pool):
+    from app.services.auth_service import (
+        resolve_rest_credential_change_authorization,
+    )
+
+    account, _, token = await _issued_session(pool)
+    resolved = await resolve_rest_credential_change_authorization(f"Bearer {token}")
+    assert resolved is not None
+    assert resolved.user_id == account["user_id"]
+
+
+async def test_a_personal_access_token_is_not_gated_by_the_marker(pool):
+    """A PAT is not the credential that was delivered.
+
+    Reset already leaves PATs working on purpose, so pin that boundary here
+    rather than letting a later change move it by accident.
+    """
+    from app.services.auth_service import (
+        create_pat,
+        resolve_rest_user_authorization,
+    )
+    from app.services.password_service import reset_password
+
+    account = await _registered(pool)
+    credential = await create_pat(account["user_id"], "integration")
+    await reset_password(username=account["username"], actor_id=None, method="cli")
+
+    resolved = await resolve_rest_user_authorization(f"Bearer {credential['token']}")
+
+    assert resolved is not None
+    assert resolved.user_id == account["user_id"]
+
+
+# ── Clearing it ─────────────────────────────────────────────────────
+
+
+async def test_changing_the_password_clears_the_requirement(pool):
+    from app.services.auth_service import change_password, resolve_rest_user_authorization
+    from app.services.password_service import reset_password
+
+    account = await _registered(pool)
+    delivered, _ = await reset_password(
+        username=account["username"], actor_id=None, method="admin_ui"
+    )
+
+    await change_password(account["user_id"], delivered, _REPLACEMENT_PASSWORD)
+
+    assert await _credential_change_required(pool, account["user_id"]) is False
+    token = await _signed_in(account["username"], _REPLACEMENT_PASSWORD)
+    resolved = await resolve_rest_user_authorization(f"Bearer {token}")
+    assert resolved is not None
+
+
+# ── The route seam ──────────────────────────────────────────────────
+
+
+def _app() -> FastAPI:
+    """The real auth router, with the application's own error envelope."""
+    from app.api.routes import auth as auth_routes
+
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix="/api/v1")
+
+    @app.exception_handler(AKBError)
+    async def _akb_error(request, exc: AKBError):
+        detail: object = exc.message
+        if exc.code:
+            detail = {"message": exc.message, "code": exc.code}
+        return JSONResponse(status_code=exc.status_code, content={"detail": detail})
+
+    return app
+
+
+async def test_every_other_route_refuses_and_the_change_route_escapes(pool):
+    account, delivered, token = await _issued_session(pool)
+    headers = {"Authorization": f"Bearer {token}"}
+    transport = httpx.ASGITransport(app=_app())
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://forced-change.test"
+    ) as client:
+        refused = await client.get("/api/v1/auth/me", headers=headers)
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["code"] == "credential_change_required"
+
+        changed = await client.post(
+            "/api/v1/auth/change-password",
+            headers=headers,
+            json={
+                "current_password": delivered,
+                "new_password": _REPLACEMENT_PASSWORD,
+            },
+        )
+        assert changed.status_code == 200
+
+        # Changing the password revokes the session that changed it, so the
+        # account signs in again — and then reaches the route it was refused.
+        replacement = await _signed_in(account["username"], _REPLACEMENT_PASSWORD)
+        allowed = await client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {replacement}"},
+        )
+        assert allowed.status_code == 200
+        assert allowed.json()["username"] == account["username"]

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -1629,11 +1629,17 @@ async def test_credential_issue_replaces_the_credential_the_account_already_had(
     )
     actor_id, token_id = await _create_retirement_actor(pool)
     # The installed credential works before the rotation, and the session it
-    # mints is live.
+    # mints is live. That credential was delivered, so the session it mints
+    # may do nothing but replace it — resolve it through the entry point that
+    # serves the forced credential change, which is the one thing this account
+    # can still reach.
     signed_in = await auth_service.login("recovery-admin", _LOCAL_PASSWORD)
     assert signed_in["user"]["id"] == provisioned["user_id"]
     held_session = f"Bearer {signed_in['token']}"
-    assert await auth_service.resolve_rest_user_authorization(held_session) is not None
+    assert (
+        await auth_service.resolve_rest_credential_change_authorization(held_session)
+        is not None
+    )
 
     issued = await service.issue_recovery_admin_credential(
         expected_username="recovery-admin",


### PR DESCRIPTION
Closes #389.

## What was missing

In SSO mode a delivered administrator credential is temporary — the identity
provider arms a required action, so the first successful sign-in forces a
replacement. Local mode had no equivalent: a delivered credential was simply the
password until someone chose to change it.

The two modes are meant to differ in **where the credential is stored**, not in
whether the person who receives it must replace it. A credential handed to
someone over any channel should stop being valid as soon as they have used it;
otherwise the delivery is a long-lived secret rather than a one-time handover.

## What this adds

A per-account marker that a credential change is owed, set when a credential is
issued or reset, and cleared when the holder changes it. While it is set the
account authenticates far enough to change its own credential and no further.

That is deliberately the same behaviour the identity provider already implements
on the other side, so both modes now make the same promise through different
mechanisms.

## The seam, which is the whole risk

Getting the boundary wrong in either direction is the failure mode: too broad
locks the account out of the very route that would clear the requirement, too
narrow leaves the promise unkept. Both directions are pinned by tests rather than
by reading:

- every other route refuses while the marker is set;
- the credential-change route escapes, and it is the **only** exemption;
- delegated human authorization is refused too, so the gate cannot be stepped
  around by a second entry point;
- a personal access token is not gated by it, because a service credential is not
  the human who owes a password change.

## Existing accounts are untouched

This is the regression that would matter most — a change that quietly required a
password change from every account already in a database. The column defaults to
not-owed and the migration adds nothing to existing rows.

Both halves are asserted: an account that never had a credential issued is
unaffected, and the migration itself leaves pre-existing accounts unaffected.
Flipping the migration's default to owed reddens the second one, counting the
accounts it wrongly armed.

Re-provisioning also does not re-arm a requirement someone has already cleared,
which is the subtler version of the same mistake.

## Gate

`scripts/check.sh` — the repository's static-analysis entry point — plus the
backend suite, which that script does not run:

```
new tests                    13 passed
backend suite, both DSNs     60 failed / 2627 passed / 2 skipped
```

The failures are the pre-existing population on this host: the external-git tests
require a newer git than the host provides, plus two file-measurement failures
and one concurrency group. No new failures. The database-backed tests need their
DSNs pointed at **separate** databases; without them a whole file skips silently.
