### PR TITLE
fix(auth): arm the forced credential change on delivery, not on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,16 @@ command stores no usable local password and does not contact the identity
 provider. Generated output files are create-only and never overwritten; for a
 retry after the file exists, pass that file back with `--password-file`.
 
+The two local forms differ in one further way. `--generate-password-file` is
+AKB producing a credential and handing it over, so the account it creates owes
+a replacement for it: the first session that credential opens can reach the
+password change and nothing else, exactly as a password reset behaves.
+`--password-file` installs a value the caller already holds — AKB delivers it
+to nobody — so it arms nothing, and an installation that signs in as this
+account to bootstrap its own service identity keeps working. To force a
+replacement for a credential supplied that way, rotate it afterwards with the
+command below; rotation always leaves the account owing a change.
+
 If that credential later leaks, is lost, or has to be taken back, rotate it
 rather than reprovisioning the account:
 

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -257,6 +257,12 @@ async def _provision_recovery_admin(args: list[str]) -> int:
                 username=parsed.username,
                 email=parsed.email,
                 password=password,
+                # True for exactly the branch above that produced the value
+                # and wrote it into an operator-owned file: that is AKB
+                # handing a credential to a person, so the account it creates
+                # owes a replacement for it. A caller-supplied password was
+                # never handed over by AKB.
+                credential_issued_by_akb=generated_path is not None,
             )
         else:
             report = await provision_sso_recovery_admin(

--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -127,8 +127,17 @@ async def provision_local_recovery_admin(
     username: str,
     email: str,
     password: str,
+    credential_issued_by_akb: bool = True,
 ) -> dict:
-    """Create the one local recovery admin, or converge on its exact identity."""
+    """Create the one local recovery admin, or converge on its exact identity.
+
+    ``credential_issued_by_akb`` says whether this password is one AKB
+    produced and handed back, which is the generated-output-file form of the
+    provisioning command. That is the only shape in which provisioning
+    delivers a credential to anybody, and delivery is what the forced
+    credential change is about. Defaulting it to True keeps the requirement
+    fail-closed for a caller that does not say.
+    """
     _require_mode("local")
     username = _required(username, "username")
     email = _email(email)
@@ -176,15 +185,26 @@ async def provision_local_recovery_admin(
                     if collision:
                         raise RecoveryAdminConflictError()
                     user_id = uuid.uuid4()
-                    # The operator supplied or generated this password in a
-                    # file and hands it to the administrator, so it is a
-                    # delivered credential and is owed a replacement. The SSO
-                    # profile creates its product administrator the same way:
-                    # a `temporary` credential plus the UPDATE_PASSWORD
-                    # required action. Only creation arms it — the
-                    # convergence branch above leaves the credential column
-                    # alone, so re-running provisioning must not re-arm a
-                    # marker the holder has already cleared.
+                    # A credential AKB produced here is one AKB hands over —
+                    # it leaves in the operator's output file — so it is
+                    # delivered, and is owed a replacement exactly like the
+                    # one `reset_password` issues. The SSO profile creates
+                    # its product administrator the same way: a `temporary`
+                    # credential plus the UPDATE_PASSWORD required action.
+                    #
+                    # A credential the caller supplied is a different event.
+                    # The value existed before this process saw it, nobody
+                    # received it from AKB, and whoever runs the installation
+                    # already holds it — including when that is a machine,
+                    # which then signs in as this account to establish the
+                    # service principal the installation runs as. Arming the
+                    # requirement there refuses the installer's own bootstrap
+                    # for a delivery that never happened.
+                    #
+                    # Only creation arms it — the convergence branch above
+                    # leaves the credential column alone, so re-running
+                    # provisioning must not re-arm a marker the holder has
+                    # already cleared.
                     row = await conn.fetchrow(
                         """
                         INSERT INTO users (
@@ -192,7 +212,7 @@ async def provision_local_recovery_admin(
                             is_recovery_admin, auth_provider, account_status, account_kind,
                             credential_change_required
                         ) VALUES ($1, $2, $3, $4, true, true, 'local', 'active', 'human',
-                                  true)
+                                  $5)
                         RETURNING id, username, email, password_hash, is_admin,
                                   is_recovery_admin, auth_provider, account_status, account_kind
                         """,
@@ -200,6 +220,7 @@ async def provision_local_recovery_admin(
                         username,
                         email,
                         password_hash,
+                        credential_issued_by_akb,
                     )
                     await _emit_provisioned(conn, user_id, "local")
                     created = True

--- a/backend/tests/test_local_forced_credential_change.py
+++ b/backend/tests/test_local_forced_credential_change.py
@@ -36,6 +36,7 @@ _DSN = os.environ.get(
 _CHOSEN_PASSWORD = "chosen-by-the-holder"  # pragma: allowlist secret
 _DELIVERED_PASSWORD = "delivered-out-of-band"  # pragma: allowlist secret
 _REPLACEMENT_PASSWORD = "replacement-chosen-now"  # pragma: allowlist secret
+_INSTALLER_PASSWORD = "the-installer-already-had-this"  # pragma: allowlist secret
 
 
 def _dsn_for_database(dsn: str, database: str) -> str:
@@ -187,7 +188,36 @@ async def test_password_reset_leaves_the_account_owing_a_change(pool):
     assert await _credential_change_required(pool, account["user_id"]) is True
 
 
-async def test_local_recovery_admin_provisioning_arms_the_marker(pool):
+async def test_provisioning_arms_the_marker_for_a_credential_it_issued(pool):
+    """The credential provisioning produced and handed back is delivered."""
+    from app.services.recovery_admin_service import provision_local_recovery_admin
+
+    report = await provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_DELIVERED_PASSWORD,
+        credential_issued_by_akb=True,
+    )
+    assert report["created"] is True
+    assert await _credential_change_required(pool, report["user_id"]) is True
+
+
+async def test_provisioning_arms_nothing_for_a_credential_it_was_given(pool):
+    """A value that existed before AKB saw it was delivered by nobody here."""
+    from app.services.recovery_admin_service import provision_local_recovery_admin
+
+    report = await provision_local_recovery_admin(
+        username="recovery-admin",
+        email="recovery-admin@example.com",
+        password=_INSTALLER_PASSWORD,
+        credential_issued_by_akb=False,
+    )
+    assert report["created"] is True
+    assert await _credential_change_required(pool, report["user_id"]) is False
+
+
+async def test_provisioning_treats_an_unstated_credential_as_delivered(pool):
+    """The default is the fail-closed one: a caller that does not say arms it."""
     from app.services.recovery_admin_service import provision_local_recovery_admin
 
     report = await provision_local_recovery_admin(
@@ -195,7 +225,6 @@ async def test_local_recovery_admin_provisioning_arms_the_marker(pool):
         email="recovery-admin@example.com",
         password=_DELIVERED_PASSWORD,
     )
-    assert report["created"] is True
     assert await _credential_change_required(pool, report["user_id"]) is True
 
 
@@ -362,11 +391,18 @@ async def test_changing_the_password_clears_the_requirement(pool):
 
 
 def _app() -> FastAPI:
-    """The real auth router, with the application's own error envelope."""
+    """The real routers, with the application's own error envelope.
+
+    Both are here because both sides of this contract are routes: the change
+    that clears the requirement is in ``auth``, and the administrative route
+    an installer's bootstrap reaches is in ``access``.
+    """
+    from app.api.routes import access as access_routes
     from app.api.routes import auth as auth_routes
 
     app = FastAPI()
     app.include_router(auth_routes.router, prefix="/api/v1")
+    app.include_router(access_routes.router, prefix="/api/v1")
 
     @app.exception_handler(AKBError)
     async def _akb_error(request, exc: AKBError):
@@ -409,3 +445,144 @@ async def test_every_other_route_refuses_and_the_change_route_escapes(pool):
         )
         assert allowed.status_code == 200
         assert allowed.json()["username"] == account["username"]
+
+
+# ── The installer's own bootstrap ───────────────────────────────────
+
+
+async def _provisioned_by_the_installer(monkeypatch, tmp_path) -> str:
+    """Provision through the operator CLI with a password the caller supplies.
+
+    This is the shape an installer actually runs: it holds the credential
+    already — in a file, an environment variable, or a mounted secret — and
+    AKB is told to install that value, not to produce one.
+    """
+    from app import cli
+    from app.db import postgres
+
+    async def _no_database_lifecycle() -> None:
+        return None
+
+    monkeypatch.setattr(cli, "_initialize_operator_database", _no_database_lifecycle)
+    monkeypatch.setattr(postgres, "close_pool", _no_database_lifecycle)
+
+    password_file = tmp_path / "recovery-admin.password"
+    password_file.write_text(f"{_INSTALLER_PASSWORD}\n", encoding="utf-8")
+
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--password-file",
+            str(password_file),
+        ]
+    )
+    assert exit_code == 0
+    return await _signed_in("recovery-admin", _INSTALLER_PASSWORD)
+
+
+async def test_the_installer_bootstrap_reaches_the_account_it_provisioned(
+    pool, monkeypatch, tmp_path
+):
+    """A machine signs in as the account the installer just created.
+
+    Nothing in this sequence hands a credential to anyone: the installer
+    supplied the value, and the session it opens is used to establish the
+    service principal the installation runs as. Refusing it leaves the
+    installation with no machine identity at all.
+    """
+    token = await _provisioned_by_the_installer(monkeypatch, tmp_path)
+    transport = httpx.ASGITransport(app=_app())
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://forced-change.test"
+    ) as client:
+        ensured = await client.post(
+            "/api/v1/admin/service-users/ensure",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "username": "installation-bot",
+                "email": "installation-bot@example.com",
+                "is_admin": True,
+            },
+        )
+
+    assert ensured.status_code == 200
+    assert ensured.json()["account_kind"] == "service"
+
+
+async def test_a_credential_provisioning_issued_must_still_be_replaced(pool, monkeypatch, tmp_path):
+    """The other installer shape, and the promise that must survive this fix.
+
+    When AKB produces the password itself it writes it into an operator-owned
+    file to be handed to the administrator. That is the same delivery a
+    password reset performs, so the account owes a replacement for it and
+    reaches nothing until it has made one.
+    """
+    from app import cli
+    from app.db import postgres
+
+    async def _no_database_lifecycle() -> None:
+        return None
+
+    monkeypatch.setattr(cli, "_initialize_operator_database", _no_database_lifecycle)
+    monkeypatch.setattr(postgres, "close_pool", _no_database_lifecycle)
+
+    password_file = tmp_path / "generated.password"
+    exit_code = await cli._provision_recovery_admin(
+        [
+            "local",
+            "--username",
+            "recovery-admin",
+            "--email",
+            "recovery-admin@example.com",
+            "--generate-password-file",
+            str(password_file),
+        ]
+    )
+    assert exit_code == 0
+
+    delivered = password_file.read_text(encoding="utf-8").rstrip("\n")
+    token = await _signed_in("recovery-admin", delivered)
+    headers = {"Authorization": f"Bearer {token}"}
+    transport = httpx.ASGITransport(app=_app())
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://forced-change.test"
+    ) as client:
+        refused = await client.post(
+            "/api/v1/admin/service-users/ensure",
+            headers=headers,
+            json={
+                "username": "installation-bot",
+                "email": "installation-bot@example.com",
+                "is_admin": True,
+            },
+        )
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["code"] == "credential_change_required"
+
+        changed = await client.post(
+            "/api/v1/auth/change-password",
+            headers=headers,
+            json={
+                "current_password": delivered,
+                "new_password": _REPLACEMENT_PASSWORD,
+            },
+        )
+        assert changed.status_code == 200
+
+        replacement = await _signed_in("recovery-admin", _REPLACEMENT_PASSWORD)
+        allowed = await client.post(
+            "/api/v1/admin/service-users/ensure",
+            headers={"Authorization": f"Bearer {replacement}"},
+            json={
+                "username": "installation-bot",
+                "email": "installation-bot@example.com",
+                "is_admin": True,
+            },
+        )
+        assert allowed.status_code == 200


### PR DESCRIPTION
Closes #391.

## The regression

An installation that provisions the local recovery administrator could not sign
in as that account afterwards. Provisioning armed the credential-change
requirement on creation, and the gate correctly refuses every route except the
one that clears it — including the one an installer needs to establish the
service principal it runs as. A freshly created workspace therefore never got a
machine identity at all, and never reached a serving state.

Both halves were right. The refusal asserts exactly what was asked of it and
knows nothing about a machine signing in as this account during installation.
Provisioning had no test that signs in against an armed account, because until
the marker existed nothing could arm one.

## Where the requirement belongs

The requirement is about a credential **somebody received**, so the question is
where this service hands one over. There are exactly two places, and only two:

- the reset path, which generates the value and returns it — the administrative
  reset, the command line, and the recovery-administrator rotation all delegate
  there. It was already the arming site;
- provisioning's generate-and-write form, which generates the value and writes it
  into an operator-owned file. That is now the only provisioning shape that arms.

**Supplying a password is not a delivery.** That value existed before this
process saw it, nobody received it from this service, and whoever runs the
installation already holds it — including when that is a machine, which then
signs in as the account it just created. Arming there was arming on installation
rather than on delivery, and it refused a bootstrap session for a handover that
never happened.

## Shape

Provisioning takes an explicit statement of whether the credential is one this
service issued, and writes the marker in the same statement that installs the
hash — so the marker and the credential it describes cannot drift apart.

It **defaults to treating the credential as delivered**, so a caller that does
not say is handled the safe way, and the command line passes the fact directly:
true for exactly the branch that generated the password.

Convergence still never touches the credential column, so re-running provisioning
neither arms nor clears an existing marker.

## What does not change

A credential this service issues must still be replaced before it can do anything
else. That was the point of the change being repaired, and dropping it quietly
would have been worse than the regression.

Both installer shapes are now driven end to end: the supplied-password one
reaches the administrative route it provisions with, and the generated one is
refused there until it has been replaced. The two halves stop being invisible to
each other, which is the gap that produced this.

An operator who wants the requirement on a supplied credential rotates it
afterwards — rotation always arms — and the documentation now says which form
leaves the account owing a change.

## Tests

Reproduced first: a provisioning sign-in against an armed account fails on the
unfixed tree.

Mutation on the non-negotiable: defaulting the credential to *not* issued reddens
`test_provisioning_treats_an_unstated_credential_as_delivered`, and nothing else
— so the safe default is asserted rather than assumed.

## Gate

Project interpreter (3.14), static analysis plus the backend suite, which the
static entry point does not run:

```
new file           17 passed
backend suite      61 failed / 2630 passed / 2 skipped
```

The failures are this host's pre-existing population — the external-git tests
require a newer git than it provides, plus file-measurement and concurrency
groups and one known flake. No new failures.
