### PR TITLE
feat(auth): admit one named identity-provider client as a service authority

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3524
+        "line_number": 3548
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-18T07:22:45Z"
+  "generated_at": "2026-08-19T14:28:47Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,30 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added a non-human service authority for identity-provider-only workspaces
+
+An installation whose accounts all come from an identity provider had no way to
+give a control plane a first credential: every administrative call needs a
+bearer, and obtaining one needs an account. `keycloak_service_admin_client_id`
+now names one OIDC client whose client-credentials service account is admitted
+as a non-human AKB administrator. Blank — the default, and every existing
+installation — keeps the capability inert: no service-account token authorizes
+anything.
+
+It is verified by its own `keycloak-service-authority-v1` profile rather than
+by relaxing the human one, because a client-credentials token genuinely is a
+different object: it carries no audience, no session id, and no profile claim.
+The profile pins the realm and the exact authorized party instead, requires
+Keycloak's own machine markers to agree with it, and refuses any token carrying
+a human profile claim or the MCP route audience. The named client can never
+authorize a human route on either profile, and a client that is also an
+ordinary, companion, or `/admin` client is refused at configuration load.
+
+The resulting principal is a `service` account bound through the new
+`service_identities` table, kept deliberately out of the human
+`external_identities` population. The product administrator's prebound
+identity, invite-only enrollment, and the human assertion are unchanged.
+
 ### Added crash-safe worker runtime isolation
 
 Kubernetes now composes the serving API and durable background workers as

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -814,6 +814,19 @@ class Settings(BaseModel):
     # the platform owns IdP changes out of band.
     keycloak_management_client_id: str = "akb-sso-manager"
     keycloak_management_client_secret: str = ""
+    # Exact OIDC client whose client-credentials service account is admitted as
+    # a non-human AKB administrator. This is a separate grant from managing the
+    # identity provider: naming a client here is what turns possession of its
+    # client secret into administrative authority over this AKB, so it must be
+    # stated deliberately rather than inherited from
+    # `keycloak_management_client_id`.
+    #
+    # Blank (the default) keeps the capability inert — no service-account token
+    # authorizes any route. A named client is verified by the separate
+    # `keycloak-service-authority-v1` profile and may never authorize a human
+    # route, so it is rejected outright when it collides with a browser,
+    # companion, or product-admin client.
+    keycloak_service_admin_client_id: str = ""
     admin_browser_session_ttl_secs: int = Field(default=900, ge=60, le=3600)
     # Installation-owned SSO authority epoch. Every ordinary and admin
     # browser session, plus each back-channel logout fence, is bound to this
@@ -1067,6 +1080,29 @@ class Settings(BaseModel):
     tool_usage: ToolUsageSettings = Field(default_factory=ToolUsageSettings)
 
     @model_validator(mode="after")
+    def validate_service_admin_client(self) -> "Settings":
+        """Refuse a service-authority client that is not exactly one non-human client."""
+        client_id = self.keycloak_service_admin_client_id.strip()
+        if not client_id:
+            return self
+        if not self.keycloak_enabled:
+            raise AuthModeConfigurationError(
+                "keycloak_service_admin_client_id requires keycloak_enabled=true; a "
+                "service-authority client is verified against the configured OIDC authority"
+            )
+        if client_id in self.keycloak_human_client_ids:
+            raise AuthModeConfigurationError(
+                "keycloak_service_admin_client_id must not name a human browser or "
+                "companion client; a machine principal is never reachable through a human route"
+            )
+        if client_id == self.keycloak_admin_client_id.strip():
+            raise AuthModeConfigurationError(
+                "keycloak_service_admin_client_id must not name the product-admin browser "
+                "client; that client is an authentication proof for a person"
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_sso_browser_session_lifetimes(self) -> "Settings":
         if self.sso_browser_session_idle_ttl_secs > self.sso_browser_session_absolute_ttl_secs:
             raise ValueError("sso_browser_session_idle_ttl_secs must be <= sso_browser_session_absolute_ttl_secs")
@@ -1157,6 +1193,22 @@ class Settings(BaseModel):
             )
             if client_id.strip()
         )
+
+    @property
+    def keycloak_service_admin_client_id_effective(self) -> str:
+        """The one non-human client admitted as an AKB administrator, or ''.
+
+        Blank means the capability is inert. The disjointness from every human
+        client is re-derived here rather than trusted from load time, so a
+        Settings object assembled outside the canonical loader still fails
+        closed instead of admitting a machine through a human client id.
+        """
+        client_id = self.keycloak_service_admin_client_id.strip()
+        if not client_id or not self.keycloak_enabled:
+            return ""
+        if client_id in self.keycloak_human_client_ids or client_id == self.keycloak_admin_client_id.strip():
+            return ""
+        return client_id
 
     @property
     def keycloak_end_session_endpoint(self) -> str:

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -105,6 +105,27 @@ CREATE INDEX IF NOT EXISTS idx_external_identities_user
 CREATE UNIQUE INDEX IF NOT EXISTS external_identities_id_user_key
     ON external_identities(id, user_id);
 
+-- Non-human counterpart, deliberately a separate population: the table above
+-- means "an identity provider identity belonging to a person here", and the
+-- human resolution path reads it that way. One row is one configured
+-- authority — an exact (issuer, client) pair resolved to one AKB service
+-- account. `subject` is that client's service-account user, recorded for
+-- audit rather than consulted as an authorization input. See migration 081.
+CREATE TABLE IF NOT EXISTS service_identities (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT service_identities_issuer_client_key UNIQUE (issuer, client_id),
+    CONSTRAINT service_identities_issuer_subject_key UNIQUE (issuer, subject)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS service_identities_user_key
+    ON service_identities(user_id);
+
 -- Singleton authority for the last accepted runtime auth boundary. The
 -- installation generation is monotonic: an exact restart is accepted, a
 -- greater generation performs one transition, and stale/conflicting starts

--- a/backend/app/db/migrations/081_service_identities.py
+++ b/backend/app/db/migrations/081_service_identities.py
@@ -1,0 +1,46 @@
+"""Bind a non-human identity-provider client to an AKB service account.
+
+``external_identities`` means "an identity provider identity that belongs to a
+person here". The whole human resolution path is built on that reading:
+enrollment policy, email snapshots, profile refresh on every request, the
+ordinary browser-session surface, and the product-admin surface all join it and
+expect a human on the other end. Putting a machine there would make every one
+of those a place where the invariant has to be re-established, forever.
+
+So machine principals get their own table. One row is one configured authority:
+an exact (issuer, client) pair, resolved to exactly one AKB service account.
+``subject`` is the client's service-account user in that realm — recorded and
+refreshed for audit and to keep a recreated client from silently becoming a
+second administrator, not consulted as an authorization input.
+"""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS service_identities (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                issuer TEXT NOT NULL,
+                client_id TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT service_identities_issuer_client_key
+                    UNIQUE (issuer, client_id),
+                CONSTRAINT service_identities_issuer_subject_key
+                    UNIQUE (issuer, subject)
+            )
+            """
+        )
+        # One AKB account is never shared by two authorities: a second binding
+        # onto the same account would make revoking one revoke both.
+        await conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS service_identities_user_key
+                ON service_identities(user_id)
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -303,6 +303,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "078_recovery_admin_authority_handover.py",  # provider-scoped recovery authority during local-to-SSO cutover
         "079_worker_claim_lifecycle.py",  # attempt-at-claim + explicit claimed/abandoned timestamps for durable queues
         "080_local_forced_credential_change.py",  # local parity for the identity provider's UPDATE_PASSWORD: a delivered credential is owed a replacement until its holder changes it
+        "081_service_identities.py",  # non-human (issuer, client) → AKB service account bindings, kept out of the human external_identities population
     ):
         if filename in applied:
             continue

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -41,13 +41,16 @@ from app.repositories.events_repo import emit_event
 from app.services.auth_policy import require_local_auth_enabled
 from app.services.auth_verifier_profiles import (
     KEYCLOAK_ACCESS_V1,
+    KEYCLOAK_SERVICE_AUTHORITY_V1,
     LOCAL_SESSION_RS256_V2,
     KeycloakRouteProfile,
     VerifiedPrincipal,
     verify_keycloak_access_v1,
+    verify_keycloak_service_authority_v1,
     verify_local_session_rs256_v2,
 )
 from app.services.role_sync import get_role_sync
+from app.services.service_authority_service import resolve_service_authority
 
 TOKEN_KEY_CLASSES = frozenset({"pat", "service", "publishable"})
 ISSUABLE_TOKEN_KEY_CLASSES = frozenset({"pat", "service"})
@@ -600,6 +603,45 @@ async def _project_keycloak_principal(
     )
 
 
+async def _project_service_authority_principal(
+    principal: VerifiedPrincipal,
+) -> AuthenticatedUser | None:
+    """Project the verified non-human authority onto its own AKB account.
+
+    Deliberately not routed through the human account path: no enrollment
+    decision, no external identity, and no profile claim is read here. The
+    verified ``azp`` is re-checked against configuration so a principal minted
+    while one client was named cannot be projected after the operator named a
+    different one.
+    """
+    claims = dict(principal.claims)
+    client_id = settings.keycloak_service_admin_client_id_effective
+    if not client_id or claims.get("azp") != client_id:
+        return None
+    try:
+        resolved = await resolve_service_authority(
+            issuer=principal.issuer,
+            client_id=client_id,
+            subject=principal.subject,
+        )
+    except AKBError as e:
+        logging.getLogger("akb.auth").info("Keycloak service authority: account projection rejected (%s)", e)
+        return None
+
+    scope_claim = claims.get("scope")
+    scopes = [scope for scope in scope_claim.split(" ") if scope] if isinstance(scope_claim, str) else []
+    return AuthenticatedUser(
+        user_id=str(resolved["user_id"]),
+        username=resolved["username"],
+        email=resolved["email"] or "",
+        display_name=resolved["display_name"],
+        is_admin=resolved["is_admin"],
+        auth_method="oauth",
+        account_kind="service",
+        oauth_scopes=scopes,
+    )
+
+
 async def project_verified_principal(
     principal: VerifiedPrincipal,
     *,
@@ -620,6 +662,8 @@ async def project_verified_principal(
         )
     if principal.profile_id == KEYCLOAK_ACCESS_V1:
         return await _project_keycloak_principal(principal)
+    if principal.profile_id == KEYCLOAK_SERVICE_AUTHORITY_V1:
+        return await _project_service_authority_principal(principal)
     return None
 
 
@@ -1058,13 +1102,50 @@ async def _resolve_rest_authorization(
     if settings.require_auth_mode() == "local":
         principal = verify_local_session_rs256_v2(token)
     else:
-        principal = await verify_keycloak_access_v1(token, "api")
+        principal = await _verify_sso_rest_bearer(token)
     if principal is None:
         return None
     return await project_verified_principal(
         principal,
         for_credential_change=for_credential_change,
     )
+
+
+def _unverified_authorized_party(token: str) -> str | None:
+    value = _unverified_claim(token, "azp")
+    return value if isinstance(value, str) else None
+
+
+def _unverified_claim(token: str, name: str):
+    try:
+        claims = jwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_exp": False,
+                "verify_aud": False,
+            },
+        )
+    except (jwt.PyJWTError, TypeError, ValueError):
+        return None
+    return claims.get(name) if isinstance(claims, dict) else None
+
+
+async def _verify_sso_rest_bearer(token: str) -> VerifiedPrincipal | None:
+    """Select exactly one SSO profile for a REST bearer — never a fallback.
+
+    The two profiles are disjoint by authorized party: the human profile pins
+    ``azp`` to a human client, the service-authority profile to the single
+    configured non-human client. The peek that selects between them is
+    unverified and is never an authorization input — whichever profile it
+    selects proves signature, issuer, and its own exact ``azp`` before
+    returning a principal, so a lying ``azp`` only picks the profile that will
+    refuse it. Exactly one profile is tried, and a refusal is final.
+    """
+    service_admin_client_id = settings.keycloak_service_admin_client_id_effective
+    if service_admin_client_id and _unverified_authorized_party(token) == service_admin_client_id:
+        return await verify_keycloak_service_authority_v1(token)
+    return await verify_keycloak_access_v1(token, "api")
 
 
 async def resolve_mcp_authorization(authorization: str) -> AuthenticatedUser | None:

--- a/backend/app/services/auth_verifier_profiles.py
+++ b/backend/app/services/auth_verifier_profiles.py
@@ -14,6 +14,7 @@ from app.config import AuthModeConfigurationError, settings
 
 LOCAL_SESSION_RS256_V2 = "local-session-rs256-v2"
 KEYCLOAK_ACCESS_V1 = "keycloak-access-v1"
+KEYCLOAK_SERVICE_AUTHORITY_V1 = "keycloak-service-authority-v1"
 
 CredentialType = Literal["session", "access_token"]
 KeycloakRouteProfile = Literal["api", "mcp"]
@@ -194,3 +195,28 @@ async def verify_keycloak_access_v1(
         audience,
         route_profile=route_profile,
     )
+
+
+async def verify_keycloak_service_authority_v1(token: str) -> VerifiedPrincipal | None:
+    """Verify the one configured non-human administrative credential.
+
+    Deliberately not a route profile: there is exactly one authority and one
+    route class (REST) that may present it. It carries no route audience, so
+    there is nothing for a route selector to choose between, and adding one
+    would only create a second way to reach the same principal.
+    """
+    if not settings.keycloak_enabled:
+        return None
+    if not settings.keycloak_service_admin_client_id_effective:
+        return None
+    try:
+        if not settings.sso_human_auth_enabled:
+            # The capability lives on the human REST surface. `local` mode
+            # resolves that surface with the local-session profile only.
+            return None
+    except AuthModeConfigurationError:
+        return None
+
+    from app.services.keycloak_oidc import get_keycloak_oidc
+
+    return await get_keycloak_oidc().verify_service_authority_token(token)

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -35,6 +35,7 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError, AuthenticationError
 from app.services.auth_verifier_profiles import (
     KEYCLOAK_ACCESS_V1,
+    KEYCLOAK_SERVICE_AUTHORITY_V1,
     KeycloakRouteProfile,
     VerifiedPrincipal,
 )
@@ -46,6 +47,9 @@ logger = logging.getLogger("akb.keycloak")
 _SCOPE = "openid profile email"
 _TOKEN_SUPPLIED_KEY_HEADERS = frozenset({"jku", "x5u", "jwk", "x5c"})
 _SERVICE_ACCOUNT_CLAIMS = frozenset({"client_id", "clientId", "clientHost", "clientAddress"})
+# Claims that describe a person. A client-credentials token has none of them,
+# so their presence means the bearer came from some other flow on the client.
+_HUMAN_PROFILE_CLAIMS = frozenset({"email", "email_verified", "name"})
 _JWKS_REFRESH_COOLDOWN_SECONDS = 30.0
 _BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openid.net/event/backchannel-logout"
 
@@ -906,6 +910,13 @@ class KeycloakOIDC:
         # even on the MCP profile where dynamic client IDs are otherwise valid.
         if claims["azp"] == settings.keycloak_admin_client_id:
             return None
+        # A client an operator named as the non-human service authority is
+        # never a human client, on either route, even if a misconfiguration
+        # also lists it among the human clients. The canonical loader refuses
+        # that combination; this is the runtime half of the same refusal.
+        service_admin_client_id = settings.keycloak_service_admin_client_id.strip()
+        if service_admin_client_id and claims["azp"] == service_admin_client_id:
+            return None
         if route_profile == "api" and claims["azp"] not in settings.keycloak_human_client_ids:
             return None
         if type(claims.get("iat")) is not int or type(claims.get("exp")) is not int:
@@ -937,6 +948,112 @@ class KeycloakOIDC:
             credential_type="access_token",
             claims=claims,
             audience=audience,
+        )
+
+    # ── Non-human service-authority verification ─────────────────────
+    async def verify_service_authority_token(self, token: str) -> VerifiedPrincipal | None:
+        """Verify the one configured non-human administrative credential.
+
+        This is a separate profile, not a relaxation of the human one. Keycloak
+        issues a client-credentials token with no ``aud``, no ``sid``, and an
+        empty ``scope``, so admitting it through ``keycloak-access-v1`` would
+        mean dropping three requirements every human bearer must keep. The
+        authority is instead pinned to what such a grant does establish: the
+        realm that signed the token and the exact client that obtained it.
+
+        ``keycloak_service_admin_client_id`` is what names that client. Blank
+        keeps the whole profile inert.
+        """
+        service_admin_client_id = settings.keycloak_service_admin_client_id_effective
+        if not service_admin_client_id:
+            return None
+        if not isinstance(token, str) or not 1 <= len(token) <= 16_384:
+            return None
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as e:
+            logger.debug("Keycloak service-authority token: malformed header (%s)", e)
+            return None
+
+        if header.get("alg") != "RS256" or header.get("typ") != "JWT":
+            return None
+        if _TOKEN_SUPPLIED_KEY_HEADERS.intersection(header):
+            return None
+        kid = header.get("kid")
+        if not isinstance(kid, str) or not kid:
+            return None
+        if not self._has_pinned_unverified_issuer(token):
+            return None
+
+        key = await self._resolve_signing_key(kid)
+        if key is None:
+            return None
+        if key.get("kty") != "RSA" or key.get("use") != "sig" or key.get("alg") != "RS256":
+            return None
+
+        try:
+            public_key = RSAAlgorithm.from_jwk(json.dumps(key))
+            claims = jwt.decode(
+                token,
+                cast(Any, public_key),
+                algorithms=["RS256"],
+                issuer=settings.keycloak_issuer,
+                options={
+                    "verify_aud": False,
+                    "require": ["exp", "iat", "jti", "iss", "sub", "typ", "azp"],
+                },
+            )
+        except (jwt.PyJWTError, TypeError, ValueError) as e:
+            logger.debug("Keycloak service-authority token verification failed: %s", e)
+            return None
+
+        required_strings = ("iss", "sub", "jti", "typ", "azp")
+        if any(not isinstance(claims.get(name), str) or not claims[name].strip() for name in required_strings):
+            return None
+        if claims["typ"] != "Bearer":
+            return None
+        if claims["azp"] != service_admin_client_id:
+            return None
+        if type(claims.get("iat")) is not int or type(claims.get("exp")) is not int:
+            return None
+        if claims["exp"] <= claims["iat"]:
+            return None
+        # Keycloak's own machine marker, and it must name the same client that
+        # obtained the token — an `azp` alone is not proof of the grant type.
+        if claims.get("client_id") != service_admin_client_id:
+            return None
+        preferred_username = claims.get("preferred_username")
+        if preferred_username is not None and preferred_username != f"service-account-{service_admin_client_id}":
+            return None
+        # No person is behind this principal, and nothing downstream may
+        # project a profile claim onto an account from it.
+        if not _HUMAN_PROFILE_CLAIMS.isdisjoint(claims):
+            return None
+        scope = claims.get("scope")
+        if scope is not None and not isinstance(scope, str):
+            return None
+        # A client-credentials token carries no audience unless an operator
+        # adds a mapper. Whatever it does carry must not be another AKB
+        # route's credential.
+        raw_audience = claims.get("aud")
+        if raw_audience is not None:
+            if isinstance(raw_audience, str):
+                audiences = {raw_audience}
+            elif isinstance(raw_audience, list) and all(isinstance(item, str) and item for item in raw_audience):
+                audiences = set(raw_audience)
+            else:
+                return None
+            mcp_audience = settings.mcp_oauth_audience_effective
+            if mcp_audience and mcp_audience in audiences:
+                return None
+
+        return VerifiedPrincipal(
+            profile_id=KEYCLOAK_SERVICE_AUTHORITY_V1,
+            issuer=claims["iss"],
+            subject=claims["sub"],
+            credential_type="access_token",
+            claims=claims,
+            audience=None,
         )
 
     # ── Logout URL construction ──────────────────────────────────────

--- a/backend/app/services/service_authority_service.py
+++ b/backend/app/services/service_authority_service.py
@@ -1,0 +1,181 @@
+"""Durable resolution of the one configured non-human administrative principal.
+
+The verifier proves that a bearer was minted by the exact identity-provider
+client an operator named as this workspace's service authority. This module
+turns that proof into an AKB account, and it does so without touching the human
+account path at any point: no ``external_identities`` row, no enrollment
+policy, no profile claims, no email.
+
+The binding lives in ``service_identities`` and is keyed by (issuer, client),
+not by subject. A client that is deleted and recreated gets a new
+service-account user in the realm; keying on the client is what makes that a
+refreshed binding instead of a second administrator.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import asyncpg
+
+from app.db.postgres import get_pool
+from app.exceptions import (
+    AccountSuspendedError,
+    ExternalIdentityConflictError,
+    ValidationError,
+)
+from app.repositories.events_repo import emit_event
+from app.services.role_sync import get_role_sync
+
+
+# Shared with account_service's service-user provisioning: an unusable value in
+# a NOT NULL column, never a hash of anything.
+_SERVICE_SENTINEL_HASH = "!service-account:no-local-login!"
+
+# RFC 2606 reserves `.invalid`, so the address this account carries in a NOT
+# NULL, UNIQUE column can never collide with, or be mistaken for, a mailbox.
+_SERVICE_EMAIL_DOMAIN = "service.invalid"
+
+
+def _required(value: str, field: str) -> str:
+    normalized = value.strip() if isinstance(value, str) else ""
+    if not normalized:
+        raise ValidationError(f"{field} is required")
+    return normalized
+
+
+def _assert_bindable(row) -> None:
+    """Refuse a binding whose account has stopped being this kind of principal.
+
+    Administrator status is deliberately not asserted here. Creating the
+    account grants it; an operator who later demotes it has made a decision,
+    and silently re-granting on the next token would erase that decision. The
+    demoted principal keeps authenticating and is refused by the routes that
+    require an administrator.
+    """
+    if row["account_status"] != "active":
+        raise AccountSuspendedError()
+    if (
+        row["account_kind"] != "service"
+        or row["auth_provider"] != "service"
+        or row["is_recovery_admin"]
+        or row["has_external_identity"]
+    ):
+        raise ExternalIdentityConflictError()
+
+
+def _result(row, *, newly_bound: bool) -> dict:
+    return {
+        "user_id": row["id"],
+        "username": row["username"],
+        "email": row["email"],
+        "display_name": row["display_name"],
+        "is_admin": row["is_admin"],
+        "newly_bound": newly_bound,
+    }
+
+
+async def resolve_service_authority(*, issuer: str, client_id: str, subject: str) -> dict:
+    """Resolve, or on first use create, the AKB account for one service authority."""
+    issuer = _required(issuer, "issuer")
+    client_id = _required(client_id, "client_id")
+    subject = _required(subject, "subject")
+
+    username = f"service-{client_id}"
+    email = f"{username}@{_SERVICE_EMAIL_DOMAIN}".lower()
+    display_name = f"{client_id} service authority"
+
+    pool = await get_pool()
+    new_user_id: uuid.UUID | None = None
+
+    async with pool.acquire() as conn:
+        try:
+            async with conn.transaction():
+                # Serialize concurrent first-use for one authority so two
+                # requests cannot race into two accounts before the unique
+                # constraints see either.
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+                    f"service-authority:{len(issuer)}:{issuer}{client_id}",
+                )
+                bound = await conn.fetchrow(
+                    """
+                    SELECT s.id AS service_identity_id,
+                           u.id, u.username, u.email, u.display_name, u.is_admin,
+                           u.is_recovery_admin, u.auth_provider, u.account_status,
+                           u.account_kind,
+                           EXISTS (
+                               SELECT 1 FROM external_identities e
+                                WHERE e.user_id = u.id
+                           ) AS has_external_identity
+                      FROM service_identities s
+                      JOIN users u ON u.id = s.user_id
+                     WHERE s.issuer = $1 AND s.client_id = $2
+                       FOR UPDATE OF u
+                    """,
+                    issuer,
+                    client_id,
+                )
+                if bound is not None:
+                    _assert_bindable(bound)
+                    await conn.execute(
+                        """
+                        UPDATE service_identities
+                           SET subject = $2, last_seen_at = NOW()
+                         WHERE id = $1
+                        """,
+                        bound["service_identity_id"],
+                        subject,
+                    )
+                    user_id = bound["id"]
+                else:
+                    user_id = uuid.uuid4()
+                    await conn.execute(
+                        """
+                        INSERT INTO users (
+                            id, username, email, password_hash, display_name,
+                            is_admin, auth_provider, account_status, account_kind
+                        ) VALUES ($1, $2, $3, $4, $5, true, 'service',
+                                  'active', 'service')
+                        """,
+                        user_id,
+                        username,
+                        email,
+                        _SERVICE_SENTINEL_HASH,
+                        display_name,
+                    )
+                    await conn.execute(
+                        """
+                        INSERT INTO service_identities (
+                            user_id, issuer, client_id, subject
+                        ) VALUES ($1, $2, $3, $4)
+                        """,
+                        user_id,
+                        issuer,
+                        client_id,
+                        subject,
+                    )
+                    await emit_event(
+                        conn,
+                        "auth.service_authority_bound",
+                        actor_id=str(user_id),
+                        payload={"issuer": issuer, "client_id": client_id},
+                    )
+                    new_user_id = user_id
+        except asyncpg.UniqueViolationError:
+            # A username, email, or identity collision with something this
+            # authority does not own needs explicit administrative resolution;
+            # it is never silently adopted.
+            raise ExternalIdentityConflictError() from None
+
+        row = await conn.fetchrow(
+            """
+            SELECT id, username, email, display_name, is_admin
+              FROM users WHERE id = $1
+            """,
+            user_id,
+        )
+
+    if new_user_id is not None:
+        await get_role_sync().on_user_create(new_user_id)
+    return _result(row, newly_bound=new_user_id is not None)

--- a/backend/tests/test_platform_service_authority_postgres.py
+++ b/backend/tests/test_platform_service_authority_postgres.py
@@ -1,0 +1,400 @@
+"""PostgreSQL contracts for the non-human service-authority binding.
+
+The point of these is the separation: the machine principal must be a real,
+durable AKB account and must be reachable by nothing on the human path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+ISSUER = "https://auth-workspace.example.com/realms/akb"
+CLIENT_ID = "akb-sso-manager"
+SUBJECT = "a9cf6dcd-46ec-42b6-94f4-b6f0312ec15f"
+
+
+def _dsn_for_database(dsn: str, database: str) -> str:
+    parsed = urlsplit(dsn)
+    return urlunsplit(parsed._replace(path=f"/{database}"))
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2.0)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    database = f"akb_service_authority_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    await admin.execute(f'CREATE DATABASE "{database}"')
+    pool: asyncpg.Pool | None = None
+    try:
+        target_dsn = _dsn_for_database(_DSN, database)
+        conn = await asyncpg.connect(target_dsn)
+        try:
+            await conn.execute(_INIT_SQL)
+            from app.db.postgres import _load_migration
+
+            events_migration = _load_migration("015_events_outbox.py")
+            assert events_migration is not None
+            await events_migration.migrate(conn=conn)
+        finally:
+            await conn.close()
+        pool = await asyncpg.create_pool(target_dsn, min_size=1, max_size=8)
+        yield pool
+    finally:
+        if pool is not None:
+            await pool.close()
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            database,
+        )
+        await admin.execute(f'DROP DATABASE "{database}"')
+        await admin.close()
+
+
+class _RoleSync:
+    def __init__(self):
+        self.created: list[uuid.UUID] = []
+
+    async def on_user_create(self, user_id):
+        self.created.append(uuid.UUID(str(user_id)))
+
+
+@pytest.fixture
+async def services(monkeypatch):
+    async with _fresh_database() as pool:
+        from app.services import account_service, auth_service, service_authority_service
+
+        role_sync = _RoleSync()
+
+        async def _get_pool():
+            return pool
+
+        for module in (account_service, auth_service, service_authority_service):
+            monkeypatch.setattr(module, "get_pool", _get_pool)
+            monkeypatch.setattr(module, "get_role_sync", lambda: role_sync)
+
+        yield pool, role_sync, service_authority_service, account_service, auth_service
+
+
+async def test_the_migration_reproduces_the_bundled_schema(services):
+    """081 on a database created before it must land the same shape init.sql has."""
+    pool, *_ = services
+    from app.db.postgres import _load_migration
+
+    async with pool.acquire() as conn:
+        await conn.execute("DROP TABLE service_identities")
+        migration = _load_migration("081_service_identities.py")
+        assert migration is not None
+        await migration.migrate(conn)
+
+        columns = {
+            row["column_name"]: row["is_nullable"]
+            for row in await conn.fetch(
+                """
+                SELECT column_name, is_nullable
+                  FROM information_schema.columns
+                 WHERE table_name = 'service_identities'
+                """
+            )
+        }
+        assert columns == {
+            "id": "NO",
+            "user_id": "NO",
+            "issuer": "NO",
+            "client_id": "NO",
+            "subject": "NO",
+            "created_at": "NO",
+            "last_seen_at": "NO",
+        }
+        # Applying it twice is a no-op, the way a restart applies it.
+        await migration.migrate(conn)
+
+
+async def test_first_use_creates_exactly_a_non_human_administrator(services):
+    pool, role_sync, service_authority_service, _, _ = services
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        subject=SUBJECT,
+    )
+
+    assert resolved["newly_bound"] is True
+    assert resolved["is_admin"] is True
+    assert resolved["username"] == f"service-{CLIENT_ID}"
+    assert role_sync.created == [uuid.UUID(str(resolved["user_id"]))]
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT account_kind, auth_provider, account_status, is_admin,
+                   is_recovery_admin, credential_change_required, password_hash
+              FROM users WHERE id = $1
+            """,
+            resolved["user_id"],
+        )
+        assert row["account_kind"] == "service"
+        assert row["auth_provider"] == "service"
+        assert row["account_status"] == "active"
+        assert row["is_admin"] is True
+        assert row["is_recovery_admin"] is False
+        assert row["credential_change_required"] is False
+        # No usable local credential exists for this account.
+        assert row["password_hash"].startswith("!")
+
+        # The machine is not in the human population.
+        assert await conn.fetchval("SELECT COUNT(*) FROM external_identities") == 0
+        binding = await conn.fetchrow("SELECT * FROM service_identities")
+        assert binding["issuer"] == ISSUER
+        assert binding["client_id"] == CLIENT_ID
+        assert binding["subject"] == SUBJECT
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM events WHERE kind = 'auth.service_authority_bound'"
+        ) == 1
+
+
+async def test_repeat_use_is_idempotent_and_concurrent_first_use_converges(services):
+    pool, role_sync, service_authority_service, _, _ = services
+
+    first = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    again = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    assert again["user_id"] == first["user_id"]
+    assert again["newly_bound"] is False
+
+    concurrent = await asyncio.gather(
+        *(
+            service_authority_service.resolve_service_authority(
+                issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+            )
+            for _ in range(6)
+        )
+    )
+    assert {str(result["user_id"]) for result in concurrent} == {str(first["user_id"])}
+    assert role_sync.created == [uuid.UUID(str(first["user_id"]))]
+
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users") == 1
+        assert await conn.fetchval("SELECT COUNT(*) FROM service_identities") == 1
+
+
+async def test_a_recreated_client_refreshes_the_binding_instead_of_adding_an_administrator(
+    services,
+):
+    """Deleting and recreating the client in the realm yields a new
+    service-account user. That is the same authority, not a second one."""
+    pool, _, service_authority_service, _, _ = services
+
+    first = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    recreated_subject = "0f0f0f0f-1111-4222-8333-444444444444"
+    after = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=recreated_subject
+    )
+
+    assert after["user_id"] == first["user_id"]
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM users WHERE is_admin") == 1
+        assert await conn.fetchval("SELECT subject FROM service_identities") == recreated_subject
+
+
+async def test_a_second_authority_is_a_second_account_and_never_shares_one(services):
+    pool, _, service_authority_service, _, _ = services
+
+    first = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    other = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER,
+        client_id="akb-other-authority",
+        subject="11111111-2222-4333-8444-555555555555",
+    )
+    assert other["user_id"] != first["user_id"]
+
+    async with pool.acquire() as conn:
+        # And the same realm subject can never be bound twice. A third,
+        # otherwise unbound account isolates this to the subject constraint —
+        # binding it to `first`'s account would collide on user_id instead.
+        third = await conn.fetchval(
+            """
+            INSERT INTO users (username, email, password_hash, auth_provider, account_kind)
+            VALUES ('service-akb-third-authority', 'third@service.invalid', '!x!', 'service', 'service')
+            RETURNING id
+            """
+        )
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await conn.execute(
+                """
+                INSERT INTO service_identities (user_id, issuer, client_id, subject)
+                VALUES ($1, $2, $3, $4)
+                """,
+                third,
+                ISSUER,
+                "akb-third-authority",
+                SUBJECT,
+            )
+
+
+async def test_suspension_revokes_the_authority(services):
+    from app.exceptions import AccountSuspendedError
+
+    pool, _, service_authority_service, account_service, _ = services
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    await account_service.suspend_user(str(resolved["user_id"]), actor_id=str(resolved["user_id"]))
+
+    with pytest.raises(AccountSuspendedError):
+        await service_authority_service.resolve_service_authority(
+            issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+        )
+
+
+async def test_an_operator_demotion_is_respected_rather_than_silently_re_granted(services):
+    pool, _, service_authority_service, _, _ = services
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE users SET is_admin = false WHERE id = $1", resolved["user_id"])
+
+    after = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    assert after["user_id"] == resolved["user_id"]
+    assert after["is_admin"] is False
+
+
+async def test_a_bound_account_that_stops_being_a_service_principal_is_refused(services):
+    from app.exceptions import ExternalIdentityConflictError
+
+    pool, _, service_authority_service, _, _ = services
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO external_identities (user_id, issuer, subject)
+            VALUES ($1, $2, $3)
+            """,
+            resolved["user_id"],
+            ISSUER,
+            "some-human-subject",
+        )
+
+    with pytest.raises(ExternalIdentityConflictError):
+        await service_authority_service.resolve_service_authority(
+            issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+        )
+
+
+async def test_a_username_collision_is_refused_rather_than_adopted(services):
+    from app.exceptions import ExternalIdentityConflictError
+
+    pool, _, service_authority_service, _, _ = services
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash, auth_provider, account_kind)
+            VALUES ($1, $2, 'x', 'local', 'human')
+            """,
+            f"service-{CLIENT_ID}",
+            "someone@example.com",
+        )
+
+    with pytest.raises(ExternalIdentityConflictError):
+        await service_authority_service.resolve_service_authority(
+            issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+        )
+    async with pool.acquire() as conn:
+        assert await conn.fetchval("SELECT COUNT(*) FROM service_identities") == 0
+
+
+async def test_the_human_path_cannot_see_the_bound_machine_identity(services):
+    """The measured token's subject stays unenrollable as a person: under
+    invite-only there is no prebound human identity for it, and the machine's
+    own binding is invisible to that lookup."""
+    from app.config import settings
+    from app.exceptions import MembershipRequiredError
+
+    _, _, service_authority_service, _, auth_service = services
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    assert resolved["user_id"] is not None
+
+    settings_backup = settings.keycloak_enrollment_mode
+    object.__setattr__(settings, "keycloak_enrollment_mode", "invite_only")
+    try:
+        async with (await auth_service.get_pool()).acquire() as conn:
+            assert await auth_service._bound_external_user(conn, ISSUER, SUBJECT) is None
+        with pytest.raises(MembershipRequiredError):
+            await auth_service._resolve_or_provision_keycloak_user(
+                {
+                    "iss": ISSUER,
+                    "sub": SUBJECT,
+                    "preferred_username": f"service-account-{CLIENT_ID}",
+                }
+            )
+    finally:
+        object.__setattr__(settings, "keycloak_enrollment_mode", settings_backup)
+
+
+async def test_the_bound_machine_is_not_an_independent_service_administrator(services):
+    """The recovery-administrator retirement authority requires a service PAT
+    that this principal does not have. Verified rather than assumed."""
+    pool, _, service_authority_service, _, _ = services
+    from app.exceptions import RecoveryAdminProtectedError
+    from app.services import recovery_admin_service
+
+    resolved = await service_authority_service.resolve_service_authority(
+        issuer=ISSUER, client_id=CLIENT_ID, subject=SUBJECT
+    )
+    async with pool.acquire() as conn:
+        with pytest.raises(RecoveryAdminProtectedError):
+            await recovery_admin_service._require_independent_service_admin(
+                conn,
+                actor_user_id=str(resolved["user_id"]),
+                actor_token_id=str(uuid.uuid4()),
+                refusal=RecoveryAdminProtectedError,
+            )

--- a/backend/tests/test_platform_service_authority_unit.py
+++ b/backend/tests/test_platform_service_authority_unit.py
@@ -1,0 +1,807 @@
+"""The non-human service-authority profile, and the human profile it cannot enter.
+
+The token fixtures here are not invented. They are the exact claim set a
+Keycloak realm emits for ``grant_type=client_credentials`` on the client this
+project's own SSO bootstrap creates (``serviceAccountsEnabled: true``,
+``fullScopeAllowed: false``, ``defaultClientScopes: ["service_account"]``,
+no protocol mappers) — measured against Keycloak 26.0 and 26.4:
+
+    iss, sub, iat, exp, jti, typ, azp, scope, client_id, clientHost, clientAddress
+
+with **no** ``aud``, **no** ``sid``, **no** ``preferred_username``, and an empty
+``scope`` string. That shape is why this is a separate profile rather than a
+relaxation of ``keycloak-access-v1``: the human profile requires ``aud``,
+``sid`` and a non-empty ``scope``, and must keep requiring them.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.config import settings
+
+
+ISSUER = "https://auth-workspace.example.com/realms/akb"
+API_AUDIENCE = "https://akb-workspace.example.com/api"
+MCP_AUDIENCE = "https://akb-workspace.example.com/mcp"
+SERVICE_ADMIN_CLIENT_ID = "akb-sso-manager"
+SERVICE_ACCOUNT_SUBJECT = "a9cf6dcd-46ec-42b6-94f4-b6f0312ec15f"
+
+_MISSING = object()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _replace_header(token: str, **updates: object) -> str:
+    encoded_header, payload, signature = token.split(".")
+    padded = encoded_header + "=" * (-len(encoded_header) % 4)
+    header = json.loads(base64.urlsafe_b64decode(padded))
+    header.update(updates)
+    return ".".join((_b64url(json.dumps(header, separators=(",", ":")).encode()), payload, signature))
+
+
+@pytest.fixture
+def rsa_keypair() -> dict[str, Any]:
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    numbers = private.public_key().public_numbers()
+
+    def encode_number(value: int) -> str:
+        return _b64url(value.to_bytes((value.bit_length() + 7) // 8, "big"))
+
+    return {
+        "private_pem": private.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        "jwk": {
+            "kty": "RSA",
+            "kid": "service-authority-key-1",
+            "use": "sig",
+            "alg": "RS256",
+            "n": encode_number(numbers.n),
+            "e": encode_number(numbers.e),
+        },
+    }
+
+
+def _configure_workspace(monkeypatch, *, service_admin_client_id: str = SERVICE_ADMIN_CLIENT_ID) -> None:
+    """The managed profile an operator renders for one workspace."""
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://auth-workspace.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "keycloak_client_id", "akb-workspace-web", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-workspace-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_management_client_id", SERVICE_ADMIN_CLIENT_ID, raising=False)
+    monkeypatch.setattr(settings, "keycloak_service_admin_client_id", service_admin_client_id, raising=False)
+    monkeypatch.setattr(settings, "keycloak_companion_client_ids_by_origin", {}, raising=False)
+    monkeypatch.setattr(settings, "keycloak_enrollment_mode", "invite_only", raising=False)
+    monkeypatch.setattr(settings, "keycloak_require_verified_email", True, raising=False)
+    monkeypatch.setattr(settings, "api_oauth_audience", API_AUDIENCE, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "mcp_oauth_audience", MCP_AUDIENCE, raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb-workspace.example.com", raising=False)
+
+
+def _service_authority_claims(*, client_id: str = SERVICE_ADMIN_CLIENT_ID) -> dict[str, object]:
+    """The measured client-credentials claim set — nothing added, nothing dropped."""
+    now = int(datetime.now(timezone.utc).timestamp())
+    return {
+        "iss": ISSUER,
+        "sub": SERVICE_ACCOUNT_SUBJECT,
+        "iat": now,
+        "exp": now + 60,
+        "jti": str(uuid.uuid4()),
+        "typ": "Bearer",
+        "azp": client_id,
+        "scope": "",
+        "client_id": client_id,
+        "clientHost": "10.42.0.11",
+        "clientAddress": "10.42.0.11",
+    }
+
+
+def _mint(
+    rsa_keypair: dict[str, Any],
+    claims: dict[str, object],
+    *,
+    overrides: dict[str, object] | None = None,
+    header_overrides: dict[str, object] | None = None,
+    key_pem: bytes | None = None,
+) -> str:
+    payload = dict(claims)
+    for name, value in (overrides or {}).items():
+        if value is _MISSING:
+            payload.pop(name, None)
+        else:
+            payload[name] = value
+    headers: dict[str, object] = {"kid": "service-authority-key-1", "typ": "JWT"}
+    headers.update(header_overrides or {})
+    return jwt.encode(
+        payload,
+        key_pem or rsa_keypair["private_pem"],
+        algorithm=str(headers.get("alg", "RS256")),
+        headers=headers,
+    )
+
+
+def _service_authority_token(
+    rsa_keypair: dict[str, Any],
+    *,
+    client_id: str = SERVICE_ADMIN_CLIENT_ID,
+    overrides: dict[str, object] | None = None,
+    header_overrides: dict[str, object] | None = None,
+) -> str:
+    return _mint(
+        rsa_keypair,
+        _service_authority_claims(client_id=client_id),
+        overrides=overrides,
+        header_overrides=header_overrides,
+    )
+
+
+def _human_claims() -> dict[str, object]:
+    now = int(datetime.now(timezone.utc).timestamp())
+    return {
+        "iss": ISSUER,
+        "aud": API_AUDIENCE,
+        "sub": "3d0d1a2b-0000-4000-8000-1111c0ffee00",
+        "iat": now,
+        "exp": now + 300,
+        "jti": str(uuid.uuid4()),
+        "typ": "Bearer",
+        "azp": "akb-workspace-web",
+        "sid": str(uuid.uuid4()),
+        "scope": "openid profile email",
+        "preferred_username": "alice",
+        "email": "alice@example.com",
+        "email_verified": True,
+        "name": "Alice",
+    }
+
+
+def _verifier(rsa_keypair: dict[str, Any]):
+    from app.services.keycloak_oidc import KeycloakOIDC
+
+    service = KeycloakOIDC()
+    service._jwks = {"keys": [rsa_keypair["jwk"]]}
+
+    def forbidden_client():
+        raise AssertionError("the pinned JWKS is already cached; no network call is expected")
+
+    service._client = forbidden_client  # type: ignore[method-assign]
+    return service
+
+
+# ── The capability itself ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_measured_management_client_token_verifies_as_service_authority(
+    monkeypatch,
+    rsa_keypair,
+):
+    from app.services.auth_verifier_profiles import KEYCLOAK_SERVICE_AUTHORITY_V1
+
+    _configure_workspace(monkeypatch)
+    principal = await _verifier(rsa_keypair).verify_service_authority_token(
+        _service_authority_token(rsa_keypair)
+    )
+
+    assert principal is not None
+    assert principal.profile_id == KEYCLOAK_SERVICE_AUTHORITY_V1
+    assert principal.issuer == ISSUER
+    assert principal.subject == SERVICE_ACCOUNT_SUBJECT
+    assert principal.credential_type == "access_token"
+    # The measured token carries no `aud`; the profile must not invent one.
+    assert principal.audience is None
+
+
+@pytest.mark.asyncio
+async def test_the_capability_is_inert_until_the_exact_client_is_named(monkeypatch, rsa_keypair):
+    """Default configuration admits no service-account token at all."""
+    _configure_workspace(monkeypatch, service_admin_client_id="")
+    assert settings.keycloak_service_admin_client_id_effective == ""
+
+    assert (
+        await _verifier(rsa_keypair).verify_service_authority_token(
+            _service_authority_token(rsa_keypair)
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_service_account_token_from_a_different_client_is_refused(monkeypatch, rsa_keypair):
+    """The boundary: this is one named authority, not "service accounts"."""
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    for other in ("akb-workspace-web", "akb-workspace-admin", "some-other-service", "akb-sso-manager-2"):
+        token = _service_authority_token(rsa_keypair, client_id=other)
+        assert await service.verify_service_authority_token(token) is None, other
+
+    # ... and a token that merely *claims* the right `client_id` while being
+    # issued to another party is refused too.
+    mismatched = _service_authority_token(
+        rsa_keypair,
+        client_id="some-other-service",
+        overrides={"client_id": SERVICE_ADMIN_CLIENT_ID},
+    )
+    assert await service.verify_service_authority_token(mismatched) is None
+
+
+@pytest.mark.asyncio
+async def test_the_service_account_marker_must_be_present_and_agree(monkeypatch, rsa_keypair):
+    """A bearer without Keycloak's own machine markers is not this credential."""
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    for overrides in (
+        {"client_id": _MISSING},
+        {"client_id": "akb-workspace-web"},
+        {"preferred_username": "alice"},
+        {"preferred_username": "service-account-akb-workspace-web"},
+    ):
+        token = _service_authority_token(rsa_keypair, overrides=overrides)
+        assert await service.verify_service_authority_token(token) is None, overrides
+
+    # Keycloak emits `service-account-<client>` whenever the `profile` scope is
+    # attached; the exact form stays acceptable.
+    accepted = _service_authority_token(
+        rsa_keypair,
+        overrides={"preferred_username": f"service-account-{SERVICE_ADMIN_CLIENT_ID}"},
+    )
+    assert await service.verify_service_authority_token(accepted) is not None
+
+
+@pytest.mark.asyncio
+async def test_a_token_carrying_human_profile_claims_is_not_this_credential(monkeypatch, rsa_keypair):
+    """A machine principal has no person behind it. Claims that describe one
+    mean the token came from some other flow on this client."""
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    for claim, value in (
+        ("email", "someone@example.com"),
+        ("email_verified", True),
+        ("name", "Someone"),
+    ):
+        token = _service_authority_token(rsa_keypair, overrides={claim: value})
+        assert await service.verify_service_authority_token(token) is None, claim
+
+
+@pytest.mark.asyncio
+async def test_the_pinned_signature_and_issuer_profile_is_unchanged(monkeypatch, rsa_keypair):
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    foreign = rsa.generate_private_key(public_exponent=65537, key_size=2048).private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    assert (
+        await service.verify_service_authority_token(
+            _mint(rsa_keypair, _service_authority_claims(), key_pem=foreign)
+        )
+        is None
+    )
+
+    # Another realm's identically shaped token.
+    assert (
+        await service.verify_service_authority_token(
+            _service_authority_token(
+                rsa_keypair,
+                overrides={"iss": "https://auth-other.example.com/realms/akb"},
+            )
+        )
+        is None
+    )
+
+    # Algorithm and JOSE-type pinning, and token-supplied key material.
+    assert (
+        await service.verify_service_authority_token(
+            jwt.encode(_service_authority_claims(), "secret", algorithm="HS256", headers={"kid": "x"})
+        )
+        is None
+    )
+    assert (
+        await service.verify_service_authority_token(
+            _service_authority_token(rsa_keypair, header_overrides={"typ": "at+jwt"})
+        )
+        is None
+    )
+    for header in ("jku", "x5u", "jwk", "x5c"):
+        token = _replace_header(_service_authority_token(rsa_keypair), **{header: "https://evil.example.com/keys"})
+        assert await service.verify_service_authority_token(token) is None, header
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_kid_is_an_availability_failure_not_an_acceptance(
+    monkeypatch,
+    rsa_keypair,
+):
+    """Same distinction the human profile makes: a key that cannot be resolved
+    is a bounded 502, never a verified principal."""
+    import time
+
+    from app.exceptions import AKBError
+
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+    service._jwks_refresh_attempt_at = time.monotonic()
+
+    with pytest.raises(AKBError):
+        await service.verify_service_authority_token(
+            _service_authority_token(rsa_keypair, header_overrides={"kid": "unknown-kid"})
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_claim_shape(monkeypatch, rsa_keypair):
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    for overrides in (
+        {"typ": "Refresh"},
+        {"typ": _MISSING},
+        {"sub": _MISSING},
+        {"sub": "   "},
+        {"jti": _MISSING},
+        {"azp": _MISSING},
+        {"iat": _MISSING},
+        {"exp": _MISSING},
+        {"scope": 7},
+    ):
+        token = _service_authority_token(rsa_keypair, overrides=overrides)
+        assert await service.verify_service_authority_token(token) is None, overrides
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    expired = _service_authority_token(rsa_keypair, overrides={"iat": now - 600, "exp": now - 300})
+    assert await service.verify_service_authority_token(expired) is None
+
+    inverted = _service_authority_token(rsa_keypair, overrides={"iat": now + 300, "exp": now + 60})
+    assert await service.verify_service_authority_token(inverted) is None
+
+
+@pytest.mark.asyncio
+async def test_audience_is_optional_but_another_route_audience_is_refused(monkeypatch, rsa_keypair):
+    """The measured token has no `aud` and this profile does not require one:
+    (issuer, azp) already names exactly one client in exactly one realm, and
+    Keycloak cannot add an audience to a client-credentials token without an
+    operator adding a mapper. What it must never be is another route's token."""
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    assert await service.verify_service_authority_token(_service_authority_token(rsa_keypair)) is not None
+
+    # An operator who does add an audience mapper stays compatible.
+    with_audience = _service_authority_token(rsa_keypair, overrides={"aud": API_AUDIENCE})
+    assert await service.verify_service_authority_token(with_audience) is not None
+
+    for audience in (MCP_AUDIENCE, [API_AUDIENCE, MCP_AUDIENCE]):
+        token = _service_authority_token(rsa_keypair, overrides={"aud": audience})
+        assert await service.verify_service_authority_token(token) is None, audience
+
+
+# ── The human profile it must never enter ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_human_api_profile_still_refuses_the_service_authority_token(
+    monkeypatch,
+    rsa_keypair,
+):
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    assert (
+        await service.verify_access_token(
+            _service_authority_token(rsa_keypair),
+            API_AUDIENCE,
+            route_profile="api",
+        )
+        is None
+    )
+    # Even shaped to satisfy every human requirement the measured token lacks.
+    now = int(datetime.now(timezone.utc).timestamp())
+    dressed = _service_authority_token(
+        rsa_keypair,
+        overrides={
+            "aud": API_AUDIENCE,
+            "sid": str(uuid.uuid4()),
+            "scope": "openid profile email",
+            "iat": now,
+            "exp": now + 300,
+        },
+    )
+    assert await service.verify_access_token(dressed, API_AUDIENCE, route_profile="api") is None
+
+
+@pytest.mark.asyncio
+async def test_naming_a_client_as_service_authority_never_makes_it_a_human_client(
+    monkeypatch,
+    rsa_keypair,
+):
+    """Misconfiguring the same client into the human allowlist must not open
+    the human route to it."""
+    _configure_workspace(monkeypatch)
+    monkeypatch.setattr(
+        settings,
+        "keycloak_companion_client_ids_by_origin",
+        {"https://platform.example.com": SERVICE_ADMIN_CLIENT_ID},
+        raising=False,
+    )
+    assert SERVICE_ADMIN_CLIENT_ID in settings.keycloak_human_client_ids
+    service = _verifier(rsa_keypair)
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    human_shaped = _service_authority_token(
+        rsa_keypair,
+        overrides={
+            "aud": API_AUDIENCE,
+            "sid": str(uuid.uuid4()),
+            "scope": "openid profile email",
+            "preferred_username": "not-a-service-account",
+            "client_id": _MISSING,
+            "clientHost": _MISSING,
+            "clientAddress": _MISSING,
+            "iat": now,
+            "exp": now + 300,
+        },
+    )
+    assert await service.verify_access_token(human_shaped, API_AUDIENCE, route_profile="api") is None
+
+
+@pytest.mark.asyncio
+async def test_a_colliding_configuration_makes_the_capability_inert_at_runtime_too(
+    monkeypatch,
+    rsa_keypair,
+):
+    """The canonical loader refuses the collision. A Settings object assembled
+    around it must still fail closed rather than admit the machine."""
+    _configure_workspace(monkeypatch)
+    monkeypatch.setattr(
+        settings,
+        "keycloak_companion_client_ids_by_origin",
+        {"https://platform.example.com": SERVICE_ADMIN_CLIENT_ID},
+        raising=False,
+    )
+    assert settings.keycloak_service_admin_client_id_effective == ""
+
+    assert (
+        await _verifier(rsa_keypair).verify_service_authority_token(
+            _service_authority_token(rsa_keypair)
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_human_token_is_refused_by_the_service_authority_profile(monkeypatch, rsa_keypair):
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    assert await service.verify_service_authority_token(_mint(rsa_keypair, _human_claims())) is None
+    # Even with the authorized party forced to the named client.
+    forced = _mint(rsa_keypair, _human_claims(), overrides={"azp": SERVICE_ADMIN_CLIENT_ID})
+    assert await service.verify_service_authority_token(forced) is None
+
+
+@pytest.mark.asyncio
+async def test_service_authority_is_not_reachable_on_the_mcp_route(monkeypatch, rsa_keypair):
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    mcp_shaped = _service_authority_token(
+        rsa_keypair,
+        overrides={
+            "aud": MCP_AUDIENCE,
+            "sid": str(uuid.uuid4()),
+            "scope": "akb:vault:read akb:vault:write",
+            "iat": now,
+            "exp": now + 300,
+        },
+    )
+    assert await service.verify_access_token(mcp_shaped, MCP_AUDIENCE, route_profile="mcp") is None
+
+
+# ── Selection, projection, and the resolvers that must not admit it ──
+
+
+@pytest.mark.asyncio
+async def test_rest_resolution_selects_the_service_authority_profile(monkeypatch, rsa_keypair):
+    from app.services import auth_service
+    from app.services.auth_verifier_profiles import KEYCLOAK_SERVICE_AUTHORITY_V1
+
+    _configure_workspace(monkeypatch)
+    service = _verifier(rsa_keypair)
+    token = _service_authority_token(rsa_keypair)
+
+    async def forbidden_human(*_args, **_kwargs):
+        raise AssertionError("a service-authority bearer must not enter the human profile")
+
+    async def verify_service(value: str):
+        return await service.verify_service_authority_token(value)
+
+    projected: list[object] = []
+
+    async def project(principal, **_kwargs):
+        projected.append(principal)
+        return "resolved-service-principal"
+
+    monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", forbidden_human)
+    monkeypatch.setattr(auth_service, "verify_keycloak_service_authority_v1", verify_service)
+    monkeypatch.setattr(auth_service, "project_verified_principal", project)
+
+    resolved = await auth_service.resolve_rest_user_authorization(f"Bearer {token}")
+
+    assert resolved == "resolved-service-principal"
+    assert [p.profile_id for p in projected] == [KEYCLOAK_SERVICE_AUTHORITY_V1]
+
+
+@pytest.mark.asyncio
+async def test_a_human_bearer_still_selects_only_the_human_profile(monkeypatch, rsa_keypair):
+    from app.services import auth_service
+
+    _configure_workspace(monkeypatch)
+    token = _mint(rsa_keypair, _human_claims())
+
+    async def forbidden_service(*_args, **_kwargs):
+        raise AssertionError("a human bearer must not enter the service-authority profile")
+
+    seen: list[tuple[str, str]] = []
+
+    async def verify_human(value: str, route_profile: str):
+        seen.append((value, route_profile))
+        return None
+
+    monkeypatch.setattr(auth_service, "verify_keycloak_service_authority_v1", forbidden_service)
+    monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", verify_human)
+
+    assert await auth_service.resolve_rest_user_authorization(f"Bearer {token}") is None
+    assert [route for _, route in seen] == ["api"]
+
+
+@pytest.mark.asyncio
+async def test_service_authority_is_not_a_delegated_human_and_not_an_mcp_credential(
+    monkeypatch,
+    rsa_keypair,
+):
+    from app.services import auth_service
+
+    _configure_workspace(monkeypatch)
+    token = _service_authority_token(rsa_keypair)
+
+    async def forbidden_service(*_args, **_kwargs):
+        raise AssertionError("only the REST capability may select the service-authority profile")
+
+    async def refuse_human(_token: str, _route_profile: str):
+        return None
+
+    monkeypatch.setattr(auth_service, "verify_keycloak_service_authority_v1", forbidden_service)
+    monkeypatch.setattr(auth_service, "verify_keycloak_access_v1", refuse_human)
+
+    assert await auth_service.resolve_delegated_human_authorization(f"Bearer {token}") is None
+    assert await auth_service.resolve_mcp_authorization(f"Bearer {token}") is None
+
+
+@pytest.mark.asyncio
+async def test_projection_never_reaches_the_human_account_path(monkeypatch, rsa_keypair):
+    from app.services import auth_service
+    from app.services.auth_verifier_profiles import KEYCLOAK_SERVICE_AUTHORITY_V1, VerifiedPrincipal
+
+    _configure_workspace(monkeypatch)
+
+    async def forbidden_human_resolution(_claims):
+        raise AssertionError("a machine principal must never enter human enrollment")
+
+    resolved: list[tuple[str, str, str]] = []
+
+    async def fake_resolve_service_authority(*, issuer: str, client_id: str, subject: str):
+        resolved.append((issuer, client_id, subject))
+        return {
+            "user_id": uuid.UUID("11111111-2222-4333-8444-555555555555"),
+            "username": f"service-{client_id}",
+            "email": f"service-{client_id}@service.invalid",
+            "display_name": None,
+            "is_admin": True,
+            "newly_bound": False,
+        }
+
+    monkeypatch.setattr(auth_service, "_resolve_or_provision_keycloak_user", forbidden_human_resolution)
+    monkeypatch.setattr(auth_service, "resolve_service_authority", fake_resolve_service_authority)
+
+    principal = VerifiedPrincipal(
+        profile_id=KEYCLOAK_SERVICE_AUTHORITY_V1,
+        issuer=ISSUER,
+        subject=SERVICE_ACCOUNT_SUBJECT,
+        credential_type="access_token",
+        claims=_service_authority_claims(),
+        audience=None,
+    )
+    user = await auth_service.project_verified_principal(principal)
+
+    assert user is not None
+    assert resolved == [(ISSUER, SERVICE_ADMIN_CLIENT_ID, SERVICE_ACCOUNT_SUBJECT)]
+    assert user.is_admin is True
+    assert user.account_kind == "service"
+    assert user.auth_method == "oauth"
+    # An empty `scope` string must not become a phantom OAuth scope.
+    assert user.oauth_scopes == []
+    assert user.token_scopes is None
+
+
+# ── Configuration ────────────────────────────────────────────────────
+
+
+def test_the_service_authority_client_may_not_be_a_human_or_admin_client():
+    from app.config import AuthModeConfigurationError, Settings
+
+    def build(**overrides):
+        values = {
+            "auth_mode": "sso",
+            "keycloak_enabled": True,
+            "keycloak_server_url": "https://auth-workspace.example.com",
+            "keycloak_realm": "akb",
+            "keycloak_client_id": "akb-workspace-web",
+            "keycloak_admin_client_id": "akb-workspace-admin",
+            "keycloak_companion_client_ids_by_origin": {"https://companion.example.com": "akb-companion"},
+            "public_base_url": "https://akb-workspace.example.com",
+        }
+        values.update(overrides)
+        return Settings(**values)
+
+    assert build().keycloak_service_admin_client_id_effective == ""
+    assert (
+        build(keycloak_service_admin_client_id=SERVICE_ADMIN_CLIENT_ID).keycloak_service_admin_client_id_effective
+        == SERVICE_ADMIN_CLIENT_ID
+    )
+
+    for collision in ("akb-workspace-web", "akb-workspace-admin", "akb-companion"):
+        with pytest.raises(AuthModeConfigurationError):
+            build(keycloak_service_admin_client_id=collision)
+
+
+def test_a_service_authority_client_requires_a_configured_keycloak_authority():
+    from app.config import AuthModeConfigurationError, Settings
+
+    with pytest.raises(AuthModeConfigurationError):
+        Settings(
+            auth_mode="local",
+            keycloak_enabled=False,
+            keycloak_service_admin_client_id=SERVICE_ADMIN_CLIENT_ID,
+            public_base_url="https://akb-workspace.example.com",
+        )
+
+
+# ── The request boundary the platform actually calls ─────────────────
+
+
+def _admin_app():
+    from fastapi import Depends, FastAPI
+
+    from app.api import deps
+    from app.api.routes.access import _require_admin
+    from app.services.auth_service import AuthenticatedUser
+
+    app = FastAPI()
+
+    @app.post("/admin/service-users/ensure")
+    async def ensure(user: AuthenticatedUser = Depends(deps.get_current_user)):
+        _require_admin(user)
+        return {
+            "user_id": user.user_id,
+            "is_admin": user.is_admin,
+            "account_kind": user.account_kind,
+            "auth_method": user.auth_method,
+        }
+
+    return app
+
+
+def _install_verifier(monkeypatch, rsa_keypair):
+    from app.services import keycloak_oidc
+
+    service = _verifier(rsa_keypair)
+    monkeypatch.setattr(keycloak_oidc, "get_keycloak_oidc", lambda: service)
+    return service
+
+
+def _install_binding(monkeypatch, *, is_admin: bool = True):
+    from app.services import auth_service
+
+    async def fake_resolve_service_authority(*, issuer: str, client_id: str, subject: str):
+        return {
+            "user_id": uuid.UUID("11111111-2222-4333-8444-555555555555"),
+            "username": f"service-{client_id}",
+            "email": f"service-{client_id}@service.invalid",
+            "display_name": None,
+            "is_admin": is_admin,
+            "newly_bound": False,
+        }
+
+    monkeypatch.setattr(auth_service, "resolve_service_authority", fake_resolve_service_authority)
+
+
+def test_the_measured_bearer_reaches_an_admin_route(monkeypatch, rsa_keypair):
+    """The whole boundary: bearer → verifier → binding → scope gate → admin gate."""
+    from fastapi.testclient import TestClient
+
+    _configure_workspace(monkeypatch)
+    _install_verifier(monkeypatch, rsa_keypair)
+    _install_binding(monkeypatch)
+
+    response = TestClient(_admin_app()).post(
+        "/admin/service-users/ensure",
+        headers={"Authorization": f"Bearer {_service_authority_token(rsa_keypair)}"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "user_id": "11111111-2222-4333-8444-555555555555",
+        "is_admin": True,
+        "account_kind": "service",
+        "auth_method": "oauth",
+    }
+
+
+def test_the_same_bearer_is_401_while_the_capability_is_inert(monkeypatch, rsa_keypair):
+    from fastapi.testclient import TestClient
+
+    _configure_workspace(monkeypatch, service_admin_client_id="")
+    _install_verifier(monkeypatch, rsa_keypair)
+    _install_binding(monkeypatch)
+
+    response = TestClient(_admin_app()).post(
+        "/admin/service-users/ensure",
+        headers={"Authorization": f"Bearer {_service_authority_token(rsa_keypair)}"},
+    )
+    assert response.status_code == 401
+
+
+def test_a_service_account_bearer_from_another_client_is_401(monkeypatch, rsa_keypair):
+    from fastapi.testclient import TestClient
+
+    _configure_workspace(monkeypatch)
+    _install_verifier(monkeypatch, rsa_keypair)
+    _install_binding(monkeypatch)
+
+    response = TestClient(_admin_app()).post(
+        "/admin/service-users/ensure",
+        headers={
+            "Authorization": f"Bearer {_service_authority_token(rsa_keypair, client_id='akb-other-service')}"
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_an_operator_demotion_reaches_the_route_as_a_refusal_not_an_acceptance(
+    monkeypatch,
+    rsa_keypair,
+):
+    from fastapi.testclient import TestClient
+
+    _configure_workspace(monkeypatch)
+    _install_verifier(monkeypatch, rsa_keypair)
+    _install_binding(monkeypatch, is_admin=False)
+
+    response = TestClient(_admin_app()).post(
+        "/admin/service-users/ensure",
+        headers={"Authorization": f"Bearer {_service_authority_token(rsa_keypair)}"},
+    )
+    assert response.status_code == 403

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -222,6 +222,14 @@ app_credential_overlap_seconds: 300
 #                                         # must differ from every ordinary human client
 # keycloak_management_client_id: "akb-sso-manager" # standalone bundle only:
 #                                         # permanent least-privilege IdP control client
+# keycloak_service_admin_client_id: ""    # blank (default) → no service-account
+#                                         # token authorizes anything. Naming a
+#                                         # client admits its client-credentials
+#                                         # service account as a NON-HUMAN AKB
+#                                         # administrator, so possession of that
+#                                         # client's secret becomes administrative
+#                                         # authority here. It must not be an
+#                                         # ordinary, companion, or /admin client.
 # admin_browser_session_ttl_secs: 900     # also capped by the verified ID-token expiry
 # Required for every SSO-mode start, including a staged ordinary-browser
 # rollout. Generate one UUID per installation and persist it across normal

--- a/docs/designs/keycloak-oidc/00-overview.md
+++ b/docs/designs/keycloak-oidc/00-overview.md
@@ -15,7 +15,10 @@ Human REST and delegated-human routes select exactly one verifier from the
 canonical `auth_mode`:
 
 - `local` selects `local-session-rs256-v2` only;
-- `sso` selects `keycloak-access-v1` only.
+- `sso` selects `keycloak-access-v1`, or — for the one configured non-human
+  client, and only when one is configured — `keycloak-service-authority-v1`.
+  The two are disjoint by authorized party and neither is a fallback for the
+  other; see [Non-human service authority](#non-human-service-authority).
 
 `keycloak-access-v1` is a Keycloak 26-compatible RS256 access-token profile.
 It pins the configured issuer and that issuer's JWKS, requires the selected
@@ -44,6 +47,67 @@ profile/token-use claims, `jti`, and numeric lifetime claims. The public-only
 keyset is available from `/api/v1/auth/jwks` in local mode. The Phase 2 cutover
 uses immediate reauthentication: the legacy HS256 verifier and issuance path
 are absent, so an old session fails rather than trying another profile.
+
+## Non-human service authority
+
+A workspace whose accounts all come from an identity provider has no way to
+hand a control plane a first credential: every administrative call needs a
+bearer, and obtaining one needs an account. `keycloak-service-authority-v1`
+closes that circle with the one credential such a workspace already owns — a
+client-credentials token from its own realm.
+
+`keycloak_service_admin_client_id` names the exact OIDC client whose service
+account is admitted. Blank, the default, keeps the profile inert: no
+service-account token authorizes anything. Naming a client is a deliberate
+grant, separate from `keycloak_management_client_id`, because it turns
+possession of that client's secret into administrative authority over this AKB.
+A client that is also an ordinary, companion, or `/admin` client is rejected at
+configuration load, and rejected again at verification time.
+
+It is a separate profile rather than a relaxation of `keycloak-access-v1`
+because a client-credentials token is a different object. Measured against
+Keycloak 26.0 and 26.4, the token this grant produces carries `iss`, `sub`,
+`iat`, `exp`, `jti`, `typ`, `azp`, an empty `scope`, and Keycloak's `client_id`
+/ `clientHost` / `clientAddress` markers — and **no `aud`, no `sid`, and no
+profile claim at all**. Admitting it through the human profile would mean
+dropping three requirements every human bearer must keep.
+
+So the authority is pinned to what such a grant does establish: the pinned
+realm signed it, and the named client obtained it. `aud` is not required —
+Keycloak cannot put one on a client-credentials token without an operator
+adding an audience mapper, and neither the `audience` nor the `scope` request
+parameter changes that. A token that does carry an audience is still refused if
+it carries the MCP route's. The profile further requires the `client_id` marker
+to name the same client as `azp`, admits `preferred_username` only in the exact
+`service-account-<client>` form, and refuses any token carrying `email`,
+`email_verified`, or `name`: a machine principal has no person behind it, so a
+bearer that describes one came from some other flow.
+
+Selection between the two SSO profiles is by authorized party, and is not a
+fallback: exactly one profile is tried, and its refusal is final. The peek that
+selects is unverified and never an authorization input — each profile proves
+signature, issuer, and its own exact `azp` before returning a principal.
+
+The principal is resolved by `service_identities`, a table deliberately
+separate from `external_identities`. That table means "an identity provider
+identity belonging to a person here", and enrollment policy, email snapshots,
+profile refresh, the browser-session surface, and the product-admin surface all
+read it that way; a machine row there would make every one of them a place
+where the invariant has to be re-established. One `service_identities` row is
+one authority — an exact (issuer, client) pair — resolved to one AKB account
+with `account_kind = 'service'`, `auth_provider = 'service'`, an unusable
+password sentinel, and administrator status granted at creation. The realm
+subject is recorded and refreshed for audit; keying on the client is what makes
+a deleted-and-recreated client a refreshed binding rather than a second
+administrator. A later demotion or suspension by an operator is respected on
+the next request rather than silently re-granted.
+
+Nothing about the human paths moves for this. The product administrator's exact
+prebound identity, the no-just-in-time rule under `invite_only`, and the human
+assertion are unchanged, and the named client can never authorize a human
+route on either profile. The principal holds no token-store credential, so it
+is also not the independent service administrator that recovery-administrator
+retirement requires.
 
 ## Exact AKB account projection
 


### PR DESCRIPTION
The identity-provider half of giving a control plane its first credential in a
workspace whose accounts all come from an identity provider.

## The circle

Every administrative call needs a bearer, obtaining a bearer needs an account,
and under invite-only enrollment an account needs an administrator to create it.
Nothing outside can break that: binding an external identity is itself an
administrative call needing the very bearer in question.

The one credential such an installation already owns is a client-credentials
token from its own realm. This admits exactly that, for exactly one client the
operator names.

## Named, not inferred

`keycloak_service_admin_client_id` is that name, and blank — the default, and
every existing installation — keeps the capability inert: no service-account
token authorizes anything, anywhere.

It is deliberately a **separate key** from the management client rather than
derived from it. Managing the identity provider and administering this service
are two different grants, and naming a client here is what turns possession of
its secret into administrative authority over the installation. A client that is
also an ordinary, companion, or administration client is refused at configuration
load, and refused again at verification time so a settings object assembled
outside the canonical loader still fails closed.

## A separate profile, because the token is a different object

Measured against two identity-provider versions: a client-credentials grant on a
service-account client with a limited scope yields issuer, subject, timestamps,
identifier, type, authorized party, an empty scope, and the client markers — and
**no audience, no session, and no profile claim at all.**

Admitting that through the human profile would mean dropping three requirements
every human bearer must keep. So it gets its own profile, which pins what such a
grant does establish — the pinned realm signed it, and the named client obtained
it — and additionally requires the client marker to agree with the authorized
party, admits the username only in its exact service-account form, and refuses
any token carrying a person's profile claims. A machine principal has no person
behind it, so a bearer describing one came from some other flow on that client.

**No audience requirement**, because an identity provider cannot put an audience
on a client-credentials token without an operator adding a mapper — neither
request parameter changes that — and because issuer plus authorized party already
names one client in one realm. A token that *does* carry the wrong audience is
still refused.

Selection between the two profiles is by authorized party and is **not a fallback
chain**: exactly one is tried and its refusal is final. The peek that selects is
unverified and is never an authorization input — whichever profile it picks
proves signature, issuer, and its own exact authorized party before returning a
principal, so a lying claim only chooses the profile that will refuse it.

## A separate table, for the same reason

The principal resolves through a new table kept deliberately apart from the
external identities one. That table means "an identity-provider identity
belonging to a person here", and enrollment policy, profile refresh, the browser
session surface and the administration surface all read it that way. A machine
row there would make every one of them a place where the invariant has to be
re-established, permanently.

One row is one authority — an exact issuer and client pair — resolved to one
account of service kind and service provider, with an unusable password sentinel
and administrator status granted at creation. Keying on the **client** rather
than the subject is what makes a deleted-and-recreated client a refreshed binding
instead of a second administrator; the realm subject is recorded and refreshed
for audit. A later demotion or suspension by an operator is respected on the next
request rather than silently re-granted.

## Nothing on the human paths moves

The administrator's exact pre-bound identity, the no-just-in-time rule under
invite-only enrollment, and the human assertion are unchanged.

## Tests

Boundary first: **a service-account token from a different client is refused**,
and removing the client-identity check reddens exactly that test.

## Gate

Project interpreter (3.14). New suites 35 passed; full backend suite 60 failed /
2662 passed, the failures being this host's pre-existing population — the
external-git tests require a newer git than it provides, plus file-measurement
and concurrency groups. No new failures.
