### PR TITLE
fix(check): refuse to run when the gate would examine less than the tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,43 @@ cleans child processes and dependency resources on exit, but leaves the
 private `RUNTIME_ROOT` and its logs for inspection; the caller owns removing
 that explicit temporary directory after collecting what it needs.
 
+## Static Analysis Gate
+
+`scripts/check.sh` is the single entry point CI runs (`.github/workflows/check.yml`)
+and the one to run before opening a PR. It has two prerequisites it now
+checks for itself and refuses to start without — both used to fail as
+something other than "you are missing a prerequisite":
+
+**1. Python analyzers on the version this repo requires.** `backend/pyproject.toml`
+declares `requires-python = ">=3.14"` and the code uses syntax older
+interpreters cannot parse. mypy and bandit build their AST with the
+interpreter they run on, so `--python-version` does not help: on an older
+one mypy stops after the first file it cannot parse and reports the other
+few hundred as unchecked, while bandit skips the file and still exits 0.
+Install them against the required version, at the versions CI pins:
+
+```bash
+uv tool install --python 3.14 --force 'mypy==2.1.0'
+uv tool install --python 3.14 --force 'bandit[toml]==1.9.4'
+uv tool install --python 3.14 --force 'ruff==0.15.16'
+uv tool install --python 3.14 --force 'detect-secrets==1.5.0'
+```
+
+**2. Node deps in both pnpm projects.** `frontend/` and `packages/akb-client/`
+are separate projects with separate lockfiles and separate `node_modules`,
+and the gate runs steps in each. Installing only one is the common mistake:
+
+```bash
+(cd frontend && pnpm install --frozen-lockfile)
+(cd packages/akb-client && pnpm install --frozen-lockfile)
+```
+
+Then:
+
+```bash
+bash scripts/check.sh
+```
+
 ## Code Style
 
 - **Python**: ruff (configured in `backend/pyproject.toml`, line length 120).
@@ -114,6 +151,7 @@ that explicit temporary directory after collecting what it needs.
 
 ## Pull Request Checklist
 
+- [ ] `bash scripts/check.sh` passes (see Static Analysis Gate above).
 - [ ] All E2E suites pass against your local stack.
 - [ ] Changes to the E2E runtime/bootstrap also pass the isolated full gate;
       see [`backend/scripts/ci/README.md`](backend/scripts/ci/README.md).

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -12,6 +12,131 @@ cd "${REPO_ROOT}"
 
 step() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
 
+# ─── preflight: this gate's own prerequisites ─────────────────────
+# Both classes below used to fail as something other than "you are missing
+# a prerequisite", which is the most expensive way for a gate to be wrong.
+step "preflight (analyzer parsers, node deps)"
+
+PREFLIGHT_TMP="$(mktemp -d)"
+trap 'rm -rf "${PREFLIGHT_TMP}"' EXIT
+
+# 1. The Python analyzers must be able to PARSE this repo.
+#
+# mypy and bandit both build their AST with the interpreter they are running
+# on, so the `--python-version 3.14` passed to mypy below selects typing
+# semantics — it is not a parser selector. An analyzer installed against an
+# older interpreter therefore cannot read a repo that uses newer syntax, and
+# the two fail in opposite, equally unhelpful ways:
+#
+#   mypy    stops at the first unparseable file with a `[syntax]` error that
+#           reads like a defect in the source. "errors prevented further
+#           checking" is the important half: on Python 3.13 that was 1 file
+#           reported and the other 316 never examined.
+#   bandit  skips the file, lists it under "Files skipped", and exits 0.
+#           `-q` suppressed that list, so the security scan reported success
+#           having silently skipped 11 files — among them auth_service,
+#           admin_auth_service, keycloak_oidc, local_session_keys and
+#           sso_browser_session_crypto. Exactly the surface it exists for.
+#
+# CI gets this right by construction (setup-python, then pip install into
+# it). Nothing asserted it locally, so whichever interpreter a contributor's
+# `mypy` happened to be installed against silently decided how much of the
+# repo got analysed. Assert it here instead, before any analyzer runs, so
+# the gate names the interpreter rather than blaming the source.
+#
+# The canary is the newest syntax this repo actually relies on. It is a
+# behavioural assertion on purpose: a version-string comparison would still
+# pass for a tool that cannot parse us, and this one cannot.
+cat >"${PREFLIGHT_TMP}/canary.py" <<'CANARY'
+def _canary() -> None:
+    try:
+        pass
+    except ValueError, TypeError:  # PEP 758 — Python 3.14
+        pass
+CANARY
+
+REQUIRED_PYTHON="$(sed -n 's/^requires-python *= *">=\([0-9.]*\)".*/\1/p' backend/pyproject.toml)"
+: "${REQUIRED_PYTHON:=3.14}"
+
+# Best effort, for the error message only: a pip/uv/pipx console script names
+# its interpreter in its shebang.
+analyzer_interpreter() {
+  local bin shebang
+  bin="$(command -v "$1" 2>/dev/null)" || return 0
+  shebang="$(head -c 256 "$bin" 2>/dev/null | sed -n '1s/^#!//p')" || return 0
+  [ -n "$shebang" ] || return 0
+  "${shebang%% *}" -c 'import sys; print("%d.%d.%d at %s" % (sys.version_info[:3] + (sys.executable,)))' 2>/dev/null
+}
+
+preflight_parser_fail() {
+  local tool="$1" running
+  running="$(analyzer_interpreter "$tool")"
+  echo >&2
+  echo "  ✗ ${tool} cannot parse Python ${REQUIRED_PYTHON} syntax." >&2
+  echo >&2
+  echo "    backend/pyproject.toml declares requires-python = \">=${REQUIRED_PYTHON}\" and this" >&2
+  echo "    repo uses syntax older interpreters cannot parse. ${tool} parses with the" >&2
+  echo "    interpreter it runs on, so --python-version does not help." >&2
+  echo "    Running on: ${running:-could not determine}" >&2
+  echo >&2
+  echo "    Reinstall it against Python ${REQUIRED_PYTHON} — the versions CI pins are in" >&2
+  echo "    .github/workflows/check.yml and backend/pyproject.toml [dev]:" >&2
+  echo "      uv tool install --python ${REQUIRED_PYTHON} --force mypy==2.1.0" >&2
+  echo "      uv tool install --python ${REQUIRED_PYTHON} --force 'bandit[toml]==1.9.4'" >&2
+  echo >&2
+  echo "    Refusing to run: on the wrong interpreter mypy examines one file and" >&2
+  echo "    bandit exits 0 having read nothing." >&2
+  exit 1
+}
+
+mypy --python-version "${REQUIRED_PYTHON}" --no-error-summary \
+  "${PREFLIGHT_TMP}/canary.py" >/dev/null 2>&1 || preflight_parser_fail mypy
+
+# bandit reports an unreadable file as a skip and still exits 0, so its
+# canary has to be read from the report, not the exit code.
+if ! bandit "${PREFLIGHT_TMP}/canary.py" 2>&1 | grep -q '^Files skipped (0):'; then
+  preflight_parser_fail bandit
+fi
+
+echo "  mypy + bandit parse Python ${REQUIRED_PYTHON}"
+
+# 2. Node deps must be installed in BOTH pnpm projects.
+#
+# frontend/ and packages/akb-client/ are separate pnpm projects with separate
+# lockfiles and separate node_modules, and this gate runs steps in each.
+# Installing only one died six steps later, inside the other, as:
+#
+#     undefined
+#      ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found
+#
+# — which names neither the package nor the missing install, and has already
+# been misread once. Worse, the two steps before it can PASS out of a global
+# tsc on PATH, so the run appears to get further than it did and to have
+# typechecked against a compiler nobody pinned. CI installs both explicitly
+# (.github/workflows/check.yml); nothing else said so, so a fresh clone could
+# not run this script. Say it here and in CONTRIBUTING.md.
+missing_installs=()
+for pnpm_project in frontend packages/akb-client; do
+  [ -d "${pnpm_project}/node_modules" ] || missing_installs+=("${pnpm_project}")
+done
+if [ "${#missing_installs[@]}" -ne 0 ]; then
+  echo >&2
+  echo "  ✗ node_modules missing in ${#missing_installs[@]} of the 2 pnpm projects this gate runs in:" >&2
+  for pnpm_project in "${missing_installs[@]}"; do
+    echo "      ${pnpm_project}" >&2
+  done
+  echo >&2
+  echo "    Both are required — they are separate projects with separate lockfiles:" >&2
+  for pnpm_project in "${missing_installs[@]}"; do
+    echo "      (cd ${pnpm_project} && pnpm install --frozen-lockfile)" >&2
+  done
+  echo >&2
+  echo "    Refusing to run: without them eslint/tsc/vitest either fail without" >&2
+  echo "    naming their package or silently resolve to a global toolchain." >&2
+  exit 1
+fi
+echo "  node deps present in frontend + packages/akb-client"
+
 # ─── E2E suite manifest ───────────────────────────────────────────
 # Fails fast when a new shell E2E suite is neither run by the hosted gate nor
 # deliberately deferred with a reviewed reason.
@@ -23,14 +148,17 @@ step "ruff (backend)"
 ruff check backend/
 
 # ─── backend: mypy (types) ─────────────────────────────────────────
-# `--python-version 3.11` matches both pyproject.toml's `requires-python`
-# and the CI runner's `actions/setup-python` pin. Without it the analyzer
-# picks up whatever Python the dev's `mypy` binary was installed against
-# (3.11 / 3.13 / 3.14 all currently in flight on team machines), and
-# different runtimes' typing modules can disagree on third-party stubs —
-# which is the bug shape we hit in 0.6.4 (local: 18 errors, CI: green).
-# Setting it explicitly here keeps `bash scripts/check.sh` deterministic
-# regardless of which venv is active.
+# `--python-version 3.14` matches pyproject.toml's `requires-python` and the
+# CI runner's `actions/setup-python` pin, so the typing semantics analysed
+# here are the ones we ship against — third-party stubs can otherwise
+# disagree between runtimes, which is the bug shape we hit in 0.6.4 (local:
+# 18 errors, CI: green).
+#
+# It does NOT make this step independent of the active interpreter, and the
+# comment that used to claim it did is why that went unnoticed for so long:
+# mypy parses with the running interpreter's `ast`, so on an older one this
+# flag is accepted and the file still fails to parse. The preflight above is
+# what actually pins the parser; this flag pins the type system.
 step "mypy (backend)"
 (cd backend && mypy --python-version 3.14 app/ mcp_server/)
 
@@ -38,8 +166,28 @@ step "mypy (backend)"
 # Gate at medium severity — low-level findings on `random`, `try/except
 # pass`, etc. would drown out the real signals. The pyproject [tool.bandit]
 # section explains the two skipped tests (B104, B608).
+#
+# Run without `-q` and assert the skip list is empty, rather than trusting
+# the exit code. bandit exits 0 for a file it could not read, so "found no
+# issues" and "read no files" are indistinguishable by status alone — and
+# `-q` suppressed the "Files skipped" line that was the only evidence. The
+# preflight above removes the syntax cause specifically; this removes the
+# whole class, because a file skipped for permissions or encoding is just
+# as unscanned. Any skip is a failure here: unscanned is not clean.
 step "bandit (backend)"
-(cd backend && bandit -r app/ mcp_server/ -c pyproject.toml --severity-level medium -q)
+bandit_report="$(cd backend && bandit -r app/ mcp_server/ -c pyproject.toml --severity-level medium 2>&1)" || {
+  printf '%s\n' "${bandit_report}" >&2
+  exit 1
+}
+bandit_skipped="$(printf '%s\n' "${bandit_report}" | sed -n 's/^Files skipped (\([0-9]*\)):.*/\1/p')"
+if [ "${bandit_skipped:-0}" != "0" ]; then
+  printf '%s\n' "${bandit_report}" >&2
+  echo >&2
+  echo "  ✗ bandit skipped ${bandit_skipped} file(s) and still exited 0 — listed above." >&2
+  echo "    A skipped file is unscanned, not clean." >&2
+  exit 1
+fi
+echo "  0 files skipped,$(printf '%s\n' "${bandit_report}" | sed -n 's/^[[:space:]]*Total lines of code:\(.*\)/\1/p') lines scanned"
 
 # ─── frontend: eslint (lint) ──────────────────────────────────────
 step "eslint (frontend)"


### PR DESCRIPTION
## What this fixes

Two prerequisites silently decided how much of this repository `scripts/check.sh`
actually analysed. Neither was asserted anywhere, and both failed as something
other than "you are missing a prerequisite" — so the run still looked like a run.

### 1. The analyzers' interpreter

`mypy` and `bandit` build their AST with the interpreter they are *running on*.
`--python-version` therefore selects typing semantics, not a parser. The comment
above that flag claimed it kept the step "deterministic regardless of which venv
is active" — that claim is false, and believing it is why this went unnoticed.

`backend/pyproject.toml` declares `requires-python = ">=3.14"` and the code uses
PEP 758 except clauses, so an analyzer installed against an older interpreter
cannot read this repo. The two tools hide that differently:

| tool | on Python 3.13 | on Python 3.14 |
|---|---|---|
| mypy | `Found 1 error in 1 file (errors prevented further checking)` — 316 files never examined | `Success: no issues found in 317 source files` |
| bandit | `Files skipped (11)`, **exit 0** — and `-q` suppressed the list | `Files skipped (0)`, 87125 lines scanned |

The eleven files bandit skipped in silence were `postgres`, `account_service`,
`admin_auth_service`, `auth_service`, `auth_verifier_profiles`, `keycloak_oidc`,
`local_session_keys`, `sso_browser_session_crypto`, `sso_browser_session_service`,
`sso_callback_urls`, `standalone_sso_receipt` — the security scanner was blind to
precisely the surface it exists for.

CI is correct here by construction (`setup-python`, then `pip install` into it).
Nothing carried that guarantee to anyone running the gate anywhere else.

### 2. Node deps in both pnpm projects

`frontend/` and `packages/akb-client/` are separate projects with separate
lockfiles, and this gate runs steps in each. Installing only one died six steps
later, *inside the other*, as:

```
undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found
```

which names neither the package nor the missing install. The two steps before it
can pass out of a global `tsc` on `PATH`, so the run appeared to get further than
it had, and to have typechecked against a compiler nobody pinned.

## What changed

- A preflight step asserts the parser **behaviourally**, with a canary carrying
  the newest syntax this repo relies on, and names the interpreter it found
  instead of blaming the source. A version-string comparison would still pass for
  a tool that cannot parse us.
- The bandit step drops `-q` and fails on any non-empty skip list. This covers the
  whole class rather than this one cause: a file skipped for permissions or
  encoding is equally unscanned, and exit status cannot distinguish "found no
  issues" from "read no files".
- The preflight names each missing pnpm project and its exact install command.
- `CONTRIBUTING.md` documents both prerequisites, which no file did before — a
  fresh clone could not run this script.
- The false comment above `--python-version` is replaced with what the flag
  actually does.

## Proof that each guard can fail

Guards are proved able to go red, not assumed to be.

| input | before | after |
|---|---|---|
| analyzers on 3.13 | mypy reports 1 file, 316 unchecked; bandit exit 0, silent | preflight refuses, prints `Running on: 3.13.7 at …` |
| analyzers on 3.14 | — | passes; mypy 317 files, bandit 0 skipped / 87125 lines |
| only `frontend/` installed | `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` six steps later | preflight names `packages/akb-client` |
| one unparseable file added | bandit exit 0, no output | bandit step exit 1, names the file and the reason |

Full gate on correct inputs, this branch: **exit 0** — ruff clean, mypy 317 files,
bandit 0 skipped across 87125 lines, `@akb/client` 5 files / 50 tests, frontend
65 files / 471 tests, generated-type drift and packed-SDK proof pass,
detect-secrets clean.
