### PR TITLE
test(sso): measure where the authority to mint an administrator credential lives

### DIFF
--- a/backend/app/services/recovery_admin_service.py
+++ b/backend/app/services/recovery_admin_service.py
@@ -772,9 +772,20 @@ async def issue_recovery_admin_credential(
                 # management client is deliberately without `manage-users`,
                 # and the temporary bootstrap client that created the product
                 # administrator is deleted and proven dead before the install
-                # writes its retirement receipt. Rotating here needs an
-                # authority an operator creates and destroys, which does not
-                # exist yet.
+                # writes its retirement receipt.
+                #
+                # Rotating needs an authority that is created and destroyed
+                # around the one operation, and that authority now exists —
+                # outside a running AKB, which is where it has to be. Creating
+                # one means reaching Keycloak's own database, so whoever
+                # performs the ceremony holds far more than `manage-users`
+                # for as long as it lasts. An AKB able to start it would hold
+                # a standing path to exactly that, which is a larger capability
+                # than the one this refusal exists to withhold.
+                #
+                # So this stays a refusal, and is not a gap: it is the boundary
+                # being kept from the inside while the deployment's own control
+                # plane serves the rotation from the outside.
                 raise RecoveryAdminCredentialUnavailableError()
             if not _is_issuable_local_recovery(
                 row,

--- a/deploy/keycloak-dev/broker-chain/README.md
+++ b/deploy/keycloak-dev/broker-chain/README.md
@@ -15,7 +15,34 @@ the AKB API audience and still must be rejected. Finally, the provider is
 disabled, the AKB identity binding is rolled back, the operator removes the
 Keycloak prelink/user, and a secret-free JSON receipt is printed.
 
-Requirements: Docker Compose, OpenSSL, curl, and `uv`.
+It also measures where the authority to mint the product administrator's
+credential actually lives, against the same realm. Three facts in one phase: the
+permanent management account is refused `403` when it tries to reset that
+password; an authority created for the purpose succeeds, and the credential it
+installs is one use, because the realm demands a replacement at first login;
+and once that authority is retired, neither the token it was holding nor a newly
+requested one is accepted. The replaced credential is then refused at a real
+login page, and the new one is accepted straight into the forced change — proved
+at the door an administrator uses, not read back out of the store that was just
+written.
+
+The transient authority is created the way a deployment creates one, with
+Keycloak's own `bootstrap-admin service` command in a separate process against
+the running broker's database. Nothing standing in the realm can create it,
+which is the point of the phase, so the fixture cannot mint it through the Admin
+REST API either. That is why the broker keeps its state in the fixture's
+PostgreSQL rather than an embedded H2 file: a second process cannot open H2, and
+faking the creation would leave the real path unexercised while the fixture
+reported it verified.
+
+Requirements: Docker Compose, OpenSSL, curl, and `uv`. Two host conditions are
+easy to miss because the runner can only report them as "Keycloak never became
+ready": `broker.localhost` and `upstream.localhost` must resolve to `127.0.0.1`
+(some resolvers do this for `*.localhost` and some do not — add them to
+`/etc/hosts` if `getent hosts broker.localhost` prints nothing), and a host
+HTTP proxy must not capture them. The runner names both hosts in `NO_PROXY` for
+the exercise itself; a proxy that intercepts them anyway surfaces as an
+"unreachable" Keycloak that `curl --insecure` can reach perfectly well.
 
 ```bash
 deploy/keycloak-dev/broker-chain/run.sh
@@ -29,6 +56,8 @@ credentials are explicitly fixture-only. The runner uses
 SSO must verify TLS.
 
 The fixed host ports are `19443` for the broker, `19444` for the upstream realm,
-and `19445` for PostgreSQL. All three bind to `127.0.0.1` only. Do not run this
+and `19445` for PostgreSQL. The one PostgreSQL process serves two databases —
+AKB's and the broker Keycloak's — on the same tmpfs volume, so teardown destroys
+both. All three bind to `127.0.0.1` only. Do not run this
 fixture against a shared Keycloak or reuse its realm files as production
 credentials.

--- a/deploy/keycloak-dev/broker-chain/compose.yaml
+++ b/deploy/keycloak-dev/broker-chain/compose.yaml
@@ -2,7 +2,21 @@ services:
   broker:
     image: quay.io/keycloak/keycloak@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
     command: ["start-dev", "--import-realm"]
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
+      # The broker keeps its state in PostgreSQL rather than the dev H2 file,
+      # for one reason: the transient-authority phase creates its authority the
+      # way a deployment does, with Keycloak's own `bootstrap-admin service`
+      # command in a separate process against the same database. An embedded H2
+      # file cannot be opened by a second process, so on H2 that phase could
+      # only be faked -- and a faked creation would leave the production path
+      # unexercised while the fixture reported it verified.
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: akb
+      KC_DB_PASSWORD: akb # pragma: allowlist secret
       KC_BOOTSTRAP_ADMIN_USERNAME: fixture-admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: fixture-only-admin-password # pragma: allowlist secret
       KC_HOSTNAME: https://broker.localhost:19443
@@ -45,5 +59,14 @@ services:
       POSTGRES_DB: akb
     ports:
       - "127.0.0.1:19445:5432"
+    healthcheck:
+      # The broker refuses to start against an unreachable database, so it waits
+      # for this rather than racing it.
+      test: ["CMD-SHELL", "pg_isready --username akb --dbname akb"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - ./keycloak-db-init.sql:/docker-entrypoint-initdb.d/10-keycloak.sql:ro
     tmpfs:
       - /var/lib/postgresql/data

--- a/deploy/keycloak-dev/broker-chain/exercise.py
+++ b/deploy/keycloak-dev/broker-chain/exercise.py
@@ -8,6 +8,7 @@ import hashlib
 from html import unescape
 from html.parser import HTMLParser
 import json
+import os
 import secrets
 from typing import Any
 from urllib.parse import parse_qs, urljoin, urlsplit
@@ -319,6 +320,286 @@ async def _assert_management_roles(
         raise _fail("fixture_management_manage_users_present")
 
 
+PRODUCT_ADMIN = "admin"
+PRODUCT_ADMIN_EMAIL = "admin@broker.localhost"
+INSTALLED_CREDENTIAL = "fixture-only-installed-admin-password"  # pragma: allowlist secret
+
+
+def _rotation_authority() -> tuple[str, str]:
+    """The transient authority the runner created, or a refusal."""
+    client_id = os.environ.get("AKB_FIXTURE_ROTATION_CLIENT_ID", "")
+    client_secret = os.environ.get("AKB_FIXTURE_ROTATION_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise _fail("fixture_rotation_authority_absent")
+    return client_id, client_secret
+
+
+async def _client_credentials_token(
+    client: httpx.AsyncClient,
+    *,
+    realm: str,
+    client_id: str,
+    client_secret: str,
+) -> str | None:
+    response = await client.post(
+        f"{BROKER}/realms/{realm}/protocol/openid-connect/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+    )
+    if response.status_code in {400, 401, 403, 404}:
+        return None
+    if response.status_code != 200:
+        raise _fail("fixture_client_credentials_failed")
+    token = _require_object(
+        response.json(),
+        "fixture_client_credentials_invalid",
+    ).get("access_token")
+    if not isinstance(token, str) or not token:
+        raise _fail("fixture_client_credentials_invalid")
+    return token
+
+
+async def _exact_realm_user(
+    client: httpx.AsyncClient,
+    *,
+    token: str,
+    username: str,
+) -> dict[str, Any]:
+    response = await client.get(
+        f"{BROKER}/admin/realms/akb/users",
+        params={"username": username, "exact": "true"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if response.status_code != 200:
+        raise _fail("fixture_product_admin_read_failed")
+    matches = [
+        item
+        for item in _require_objects(response.json(), "fixture_product_admin_read_failed")
+        if item.get("username") == username
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("id"), str):
+        raise _fail("fixture_product_admin_not_exact")
+    return matches[0]
+
+
+async def _login_outcome(password: str) -> str:
+    """Drive a real browser login and say what the realm did with it.
+
+    Three outcomes are distinguishable without reading a token: the credential
+    is refused and the login form comes back, the credential is accepted and
+    Keycloak demands the forced password change, or the credential is accepted
+    outright. The middle one is what a correctly delivered administrator
+    credential must produce -- it is one use, and Keycloak says so before it
+    lets anyone in.
+    """
+    params = {
+        "client_id": "fixture-browser",
+        "redirect_uri": "https://client.localhost/callback",
+        "response_type": "code",
+        "scope": "openid profile email",
+        "state": secrets.token_urlsafe(24),
+        "nonce": secrets.token_urlsafe(24),
+    }
+    verifier, challenge = _pkce()
+    params["code_challenge"] = challenge
+    params["code_challenge_method"] = "S256"
+    del verifier
+    async with httpx.AsyncClient(
+        verify=False,
+        follow_redirects=True,
+        timeout=httpx.Timeout(20.0, connect=10.0),
+    ) as client:
+        page = await client.get(
+            f"{BROKER_ISSUER}/protocol/openid-connect/auth",
+            params=params,
+        )
+        if page.status_code != 200:
+            raise _fail("fixture_login_page_unavailable")
+        action, data = _login_form(page)
+        data.update(
+            {
+                "username": PRODUCT_ADMIN,
+                "password": password,
+                "login": data.get("login") or "Sign In",
+            }
+        )
+        result = await client.post(action, data=data)
+        if result.status_code != 200:
+            raise _fail("fixture_login_post_failed")
+        parser = _FormParser()
+        parser.feed(result.text)
+        fields: set[str] = set()
+        for form in parser.forms:
+            inputs = form.get("inputs")
+            if isinstance(inputs, dict):
+                fields.update(inputs)
+    if {"password-new", "password-confirm"} & fields:
+        return "accepted_forced_change"
+    if {"username", "password"} & fields:
+        return "refused"
+    return "accepted"
+
+
+async def _prove_transient_authority_boundary() -> dict[str, object]:
+    """Prove where the authority to mint an administrator credential lives.
+
+    Three facts, and each one is only worth having with the other two:
+
+    1. the permanent management account CANNOT reset the product
+       administrator's password. Its six realm-management roles are asserted
+       elsewhere in this fixture; this is the consequence of them, measured
+       against a real realm rather than inferred from a role list;
+    2. an authority created for the purpose CAN, and the credential it installs
+       is one use -- the realm demands a replacement at first login;
+    3. once that authority is retired, neither the token it was holding nor a
+       newly requested one is accepted. The client is gone and cannot come back.
+
+    Fact 2 alone would read as a hole in the boundary. Facts 1 and 3 are what
+    make it a door: it exists only while someone is holding it open.
+    """
+    client_id, client_secret = _rotation_authority()
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        broker_admin = await _admin_token(client, BROKER)
+        create = await client.post(
+            f"{BROKER}/admin/realms/akb/users",
+            headers={"Authorization": f"Bearer {broker_admin}"},
+            json={
+                "username": PRODUCT_ADMIN,
+                "email": PRODUCT_ADMIN_EMAIL,
+                "emailVerified": True,
+                "enabled": True,
+                "firstName": "AKB",
+                "lastName": "Product Administrator",
+                "requiredActions": ["UPDATE_PASSWORD"],
+                "credentials": [
+                    {
+                        "type": "password",
+                        "value": INSTALLED_CREDENTIAL,
+                        "temporary": True,
+                    }
+                ],
+            },
+        )
+        if create.status_code != 201:
+            raise _fail("fixture_product_admin_create_failed")
+
+        management_token = await _client_credentials_token(
+            client,
+            realm="akb",
+            client_id="akb-sso-manager",
+            client_secret="fixture-only-management-secret",  # pragma: allowlist secret
+        )
+        if management_token is None:
+            raise _fail("fixture_management_token_failed")
+        product_admin = await _exact_realm_user(
+            client,
+            token=management_token,
+            username=PRODUCT_ADMIN,
+        )
+        product_admin_id = product_admin["id"]
+        # The permanent account can SEE the administrator -- query-users and
+        # view-users are in its six -- and must not be able to replace its
+        # credential.
+        standing_reset = await client.put(
+            f"{BROKER}/admin/realms/akb/users/{product_admin_id}/reset-password",
+            headers={"Authorization": f"Bearer {management_token}"},
+            json={"type": "password", "value": "would-be-a-standing-mint", "temporary": False},
+        )
+        if standing_reset.status_code != 403:
+            raise _fail("fixture_standing_client_can_mint")
+
+        authority_token = await _client_credentials_token(
+            client,
+            realm="master",
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        if authority_token is None:
+            raise _fail("fixture_rotation_authority_unusable")
+        rotated_credential = "fixture-only-rotated-admin-password"  # pragma: allowlist secret
+        minted = await client.put(
+            f"{BROKER}/admin/realms/akb/users/{product_admin_id}/reset-password",
+            headers={"Authorization": f"Bearer {authority_token}"},
+            json={"type": "password", "value": rotated_credential, "temporary": True},
+        )
+        if minted.status_code != 204:
+            raise _fail("fixture_transient_authority_mint_failed")
+        after = await _exact_realm_user(
+            client,
+            token=management_token,
+            username=PRODUCT_ADMIN,
+        )
+        if after.get("id") != product_admin_id:
+            raise _fail("fixture_product_admin_changed_under_rotation")
+        if after.get("requiredActions") != ["UPDATE_PASSWORD"]:
+            raise _fail("fixture_rotated_credential_is_not_one_use")
+        if after.get("federationLink"):
+            raise _fail("fixture_product_admin_is_federated")
+
+        authority_clients = await client.get(
+            f"{BROKER}/admin/realms/master/clients",
+            params={"clientId": client_id},
+            headers={"Authorization": f"Bearer {authority_token}"},
+        )
+        if authority_clients.status_code != 200:
+            raise _fail("fixture_rotation_authority_read_failed")
+        matches = [
+            item
+            for item in _require_objects(
+                authority_clients.json(),
+                "fixture_rotation_authority_read_failed",
+            )
+            if item.get("clientId") == client_id
+        ]
+        if len(matches) != 1 or not isinstance(matches[0].get("id"), str):
+            raise _fail("fixture_rotation_authority_not_exact")
+        retired = await client.delete(
+            f"{BROKER}/admin/realms/master/clients/{matches[0]['id']}",
+            headers={"Authorization": f"Bearer {authority_token}"},
+        )
+        if retired.status_code != 204:
+            raise _fail("fixture_rotation_authority_retire_failed")
+
+        # Both directions, because either alone can be true of a live client: a
+        # revoked session would fail the first, and a cached token would pass
+        # the second.
+        proven = False
+        for _attempt in range(5):
+            prior = await client.get(
+                f"{BROKER}/admin/realms/master",
+                headers={"Authorization": f"Bearer {authority_token}"},
+            )
+            fresh = await _client_credentials_token(
+                client,
+                realm="master",
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+            if prior.status_code in {401, 403} and fresh is None:
+                proven = True
+                break
+            await asyncio.sleep(0.5)
+        if not proven:
+            raise _fail("fixture_rotation_authority_still_active")
+
+    # The credential is proven at the door the owner actually uses, not by
+    # reading it back from the store that was just written.
+    if await _login_outcome(INSTALLED_CREDENTIAL) != "refused":
+        raise _fail("fixture_replaced_credential_still_works")
+    if await _login_outcome(rotated_credential) != "accepted_forced_change":
+        raise _fail("fixture_rotated_credential_rejected")
+
+    return {
+        "standing_client_mint": "refused-403",
+        "transient_authority_mint": "accepted-and-forced-change",
+        "replaced_credential": "refused-at-login",
+        "authority_retirement": "old-and-new-token-rejected",
+    }
+
+
 async def _operator_prelink() -> tuple[str, str]:
     async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
         upstream_admin = await _admin_token(client, UPSTREAM)
@@ -591,6 +872,12 @@ async def main() -> None:
     ):
         raise _fail("fixture_secret_preservation_failed")
 
+    # Prove where the authority to mint an administrator credential lives,
+    # before the broker chain adds a second realm to reason about. It touches
+    # only the product-administrator account and the temporary client the runner
+    # created, so it is independent of everything below it.
+    authority_boundary = await _prove_transient_authority_boundary()
+
     upstream_subject, broker_subject = await _operator_prelink()
     prelink = await control.verify_identity_prelink(
         "workforce",
@@ -734,7 +1021,7 @@ async def main() -> None:
     print(
         json.dumps(
             {
-                "schema_version": 2,
+                "schema_version": 3,
                 "provider_type": enabled.provider_type,
                 "alias": enabled.alias,
                 "configure_state": configured.state,
@@ -748,6 +1035,7 @@ async def main() -> None:
                 "vault_continuity": "owner-and-writer-verified",
                 "upstream_token_rejected": True,
                 "rollback": "binding-and-operator-cleanup-verified",
+                "authority_boundary": authority_boundary,
                 "client_secret_exposed": False,
             },
             sort_keys=True,

--- a/deploy/keycloak-dev/broker-chain/keycloak-db-init.sql
+++ b/deploy/keycloak-dev/broker-chain/keycloak-db-init.sql
@@ -1,0 +1,4 @@
+-- The broker Keycloak's own database, beside AKB's. One PostgreSQL process
+-- serves both so the fixture stays three containers, and both are on the
+-- same tmpfs volume that the runner destroys on teardown.
+CREATE DATABASE keycloak OWNER akb;

--- a/deploy/keycloak-dev/broker-chain/run.sh
+++ b/deploy/keycloak-dev/broker-chain/run.sh
@@ -62,7 +62,16 @@ openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 \
   -subj "/CN=AKB SSO broker-chain fixture" \
   -addext "subjectAltName=DNS:broker.localhost,DNS:upstream.localhost" \
   -keyout "$cert_dir/tls.key" -out "$cert_dir/tls.crt" >/dev/null 2>&1
-chmod 600 "$cert_dir/tls.key"
+# Keycloak runs as uid 1000 and reads both files through the bind mount, so
+# `mktemp -d`'s 0700 directory silently fails the fixture on every host whose
+# invoking user is not uid 1000 -- the server refuses to start with
+# "Failed to initialize truststore ... Permission denied" and the runner reports
+# only that Keycloak never became ready. 0711 lets the container traverse
+# without letting anyone list the directory; the files themselves are a one-day
+# self-signed certificate generated per run and destroyed on teardown, and the
+# runner already refuses to reuse them anywhere else.
+chmod 711 "$cert_dir"
+chmod 644 "$cert_dir/tls.key" "$cert_dir/tls.crt"
 
 mkdir -p "$fixture_run_dir/config"
 sso_session_epoch="$(python3 -c 'import uuid; print(uuid.uuid4())')"
@@ -122,6 +131,39 @@ if [[ "$postgres_ready" != true ]]; then
   exit 1
 fi
 
+# The transient authority the rotation phase uses is created the way a
+# deployment creates one: Keycloak's own `bootstrap-admin service` command, in a
+# separate short-lived process against the running broker's database. Nothing
+# standing in the realm can create it -- that is the boundary the phase exists
+# to prove -- so it cannot be minted through the Admin REST API here either.
+#
+# The client id carries a per-run nonce so a repeated run never inherits a
+# previous one, and the secret is generated here and never written to disk.
+rotation_nonce="$(openssl rand -hex 6)"
+rotation_client_id="akb-rotation-$rotation_nonce"
+rotation_client_secret="$(openssl rand -base64 32 | tr -d '\n')"
+if ! AKB_SSO_FIXTURE_CERT_DIR="$cert_dir" docker compose \
+  --project-name "$project_name" --file "$compose_file" \
+  run --rm --no-deps \
+  --env "AKB_FIXTURE_ROTATION_SECRET=$rotation_client_secret" \
+  broker bootstrap-admin service \
+  --client-id "$rotation_client_id" \
+  --client-secret:env=AKB_FIXTURE_ROTATION_SECRET \
+  --no-prompt >/dev/null 2>&1
+then
+  echo "Transient rotation authority could not be created" >&2
+  exit 1
+fi
+
 cd "$fixture_run_dir"
+# Every endpoint this fixture talks to is loopback. On a host with a proxy
+# configured, an HTTP client that honours the environment sends
+# broker.localhost through it and the run fails as "unreachable" -- a proxy's
+# 403 wearing the fixture's error message. Name the hosts explicitly rather
+# than relying on the ambient no_proxy list to already contain them.
+NO_PROXY="broker.localhost,upstream.localhost,localhost,127.0.0.1,::1${NO_PROXY:+,$NO_PROXY}" \
+no_proxy="broker.localhost,upstream.localhost,localhost,127.0.0.1,::1${no_proxy:+,$no_proxy}" \
+AKB_FIXTURE_ROTATION_CLIENT_ID="$rotation_client_id" \
+AKB_FIXTURE_ROTATION_CLIENT_SECRET="$rotation_client_secret" \
 PYTHONPATH="$repo_root/backend" uv run --project "$repo_root/backend" \
   --locked python "$fixture_root/exercise.py"


### PR DESCRIPTION
Closes the measurement gap behind #385, and corrects the refusal comment that
told a reader the authority a rotation needs did not exist yet.

## What the fixture proves now

The broker-chain fixture already asserted that the permanent management service
account holds an exact six realm-management roles and that `manage-users` is not
among them. That is a role list. What follows from it — that the account cannot
actually replace the product administrator's password — was never measured, and
the absence of a minting authority is the property the retirement ceremony
exists to produce.

Three facts now run against the same realm, in one phase:

1. the permanent management account is refused `403` when it resets that
   password, while still being able to read the account (`query-users` and
   `view-users` are in its six);
2. an authority created for the purpose succeeds, and the credential it installs
   is one use — the realm reinstates the forced password change;
3. once that authority is retired, neither the token it was already holding nor
   a newly requested one is accepted.

The replaced credential is then refused at a real login page and the new one is
accepted straight into the forced change, so the delivery is proved at the door
an administrator uses rather than read back out of the store just written.

Fact 2 alone would read as a hole in the boundary. Facts 1 and 3 are what make
it a door: it exists only while someone holds it open.

## Why the fixture had to change shape

The authority is created the way a deployment creates one: Keycloak's own
`bootstrap-admin service` command, in a separate process against the running
broker's database. Nothing standing in the realm can create it — that is the
point of the phase — so the fixture cannot mint it through the Admin REST API
either.

That is why the broker now keeps its state in the fixture's PostgreSQL rather
than an embedded H2 file: a second process cannot open H2, and faking the
creation would leave the real path unexercised while the fixture reported it
verified. One PostgreSQL process serves both databases, so this is still three
containers and teardown still destroys everything.

Measured against Keycloak 26.7 while writing this: `bootstrap-admin service`
completes against a *running* server, in about fifteen seconds, and whether or
not a permanent master administrator already exists.

## Two host conditions that could only surface as "never became ready"

Both are fixed in the runner rather than documented away:

- the generated certificate directory is `mktemp -d`'s `0700`, which Keycloak's
  uid 1000 cannot traverse on any host whose invoking user is not uid 1000. The
  server refuses to start with `Failed to initialize truststore … Permission
  denied` and the runner reports only that Keycloak never became ready. The
  directory is now `0711` — traversable, still not listable — and the one-day
  self-signed files inside it are readable.
- a host HTTP proxy captures the fixture's loopback hostnames, turning the
  proxy's `403` into an "unreachable" Keycloak that `curl --insecure` reaches
  perfectly well. The runner now names both fixture hosts in `NO_PROXY`.

The README also names the one host condition that cannot be fixed from inside
the fixture: both fixture hostnames must resolve to the loopback address, which
some resolvers do for the `.localhost` suffix and some do not.

## The refusal is unchanged

`issue_recovery_admin_credential` still fails closed for a non-local auth mode,
with the same error, code, and status; its test is untouched and still passes.

Only the comment changed. It said the authority a rotation needs "does not exist
yet". It exists now, and it lives outside a running AKB, which is where it has
to be: creating one means reaching the identity provider's own database, so
whoever performs the ceremony briefly holds far more than `manage-users`. An AKB
able to start that would hold a standing path to exactly that capability, which
is strictly larger than the one this refusal withholds.

So the refusal stays, and it is not a gap. It is the boundary being kept from
the inside while a deployment's own control plane serves the rotation from the
outside.

## The seven defences are all still there, and can all still go red

None of them is spent by this change:

- the exact six-role tuple, and the two fail-closed read-backs over the role set
  and the scope set;
- the unit test asserting `manage-users` is absent from that tuple;
- the fixture's existing role/scope assertion;
- the reachability-model assertion;
- the three documents;
- the refusal point itself.

## Verification

`scripts/check.sh` — exit 0. E2E suite manifest 25 curated / 34 deferred; ruff
clean; mypy 317 source files, no issues (Python 3.14); bandit clean; eslint and
`tsc --noEmit` clean; `@akb/client` 5 files / 50 tests; frontend 65 files / 471
tests; `detect-secrets` clean.

`deploy/keycloak-dev/broker-chain/run.sh` — exit 0 against real Keycloak 26.7,
with every pre-existing assertion still passing and the new phase reporting:

```
"authority_boundary": {
  "standing_client_mint": "refused-403",
  "transient_authority_mint": "accepted-and-forced-change",
  "replaced_credential": "refused-at-login",
  "authority_retirement": "old-and-new-token-rejected"
}
```

Both new assertions were proved by mutation, not by watching them pass:

- granting `manage-users` to the permanent management account in the fixture
  realm makes the run fail with `fixture_standing_client_can_mint`;
- skipping the authority's deletion makes it fail with
  `fixture_rotation_authority_still_active` — so the proof is the two token
  rejections, not the delete call returning 204.
