### PR TITLE
fix(auth): refuse a prelink under an issuer this runtime does not present

### DIFF
--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -128,6 +128,29 @@ class ExternalIdentityConflictError(AKBError):
         )
 
 
+class ExternalIdentityIssuerMismatchError(AKBError):
+    """A prelink named an issuer this runtime does not present.
+
+    The binding a control plane writes is only usable if its issuer is the one
+    this AKB will actually see on a token. Nothing downstream re-checks that:
+    ``invite_only`` matches an exact ``(issuer, subject)`` pair, so a binding
+    written under any other issuer is created successfully, reported as
+    success, and refuses its owner at sign-in with nothing recording why.
+
+    The expected issuer is included because it is public — it is the ``iss``
+    claim this deployment stamps and is published in its discovery document —
+    and because a caller that cannot see it cannot correct the call.
+    """
+
+    def __init__(self, expected: str):
+        super().__init__(
+            "External identity issuer does not match the one this AKB presents",
+            status_code=422,
+            code="external_identity_issuer_mismatch",
+            details={"expected_issuer": expected},
+        )
+
+
 class ServiceIdentityAdoptionError(AKBError):
     """A local bootstrap administrator cannot be safely adopted in place."""
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -11,7 +11,9 @@ from app.db.postgres import get_pool
 from app.exceptions import (
     AccountSuspendedError,
     CredentialCleanupIncompleteError,
+    ExternalAuthDisabledError,
     ExternalIdentityConflictError,
+    ExternalIdentityIssuerMismatchError,
     NotFoundError,
     RecoveryAdminProtectedError,
     ServiceIdentityAdoptionError,
@@ -29,6 +31,31 @@ from app.services.auth_service import (
     _unique_username,
 )
 from app.services.role_sync import get_role_sync
+
+
+def _presented_issuer(issuer: str) -> str:
+    """Refuse a binding under an issuer this runtime will never present.
+
+    ``get_managed_account_state`` already compares an issuer it is *given*
+    against ``settings.keycloak_issuer`` before it will read anything. The
+    write path had no such comparison, and that asymmetry is the whole defect:
+    a control plane could create an exact binding under its own issuer, be told
+    it succeeded, and leave the person it named unable to sign in — because
+    ``invite_only`` matches the exact pair and theirs is stored under an issuer
+    that never appears on a token here.
+
+    In local mode the answer is not "some other issuer" but "none". Writing an
+    external binding there is worse than inert: the same call sets
+    ``auth_provider = 'keycloak'``, and local sign-in requires ``'local'``, so
+    it locks the account out of the only credential it has.
+    """
+
+    if settings.require_auth_mode() != "sso" or not settings.keycloak_enabled:
+        raise ExternalAuthDisabledError()
+    expected = settings.keycloak_issuer
+    if issuer != expected:
+        raise ExternalIdentityIssuerMismatchError(expected)
+    return issuer
 
 
 _HUMAN_SENTINEL_HASH = "!keycloak-sso:no-local-login!"
@@ -83,7 +110,7 @@ async def ensure_human_external_identity(
     existing_user_id: str | None = None,
     prepare_suspended: bool = False,
 ) -> dict:
-    issuer = _required(issuer, "issuer")
+    issuer = _presented_issuer(_required(issuer, "issuer"))
     subject = _required(subject, "subject")
     email = _required(email, "email").lower()
     existing_user_uuid = _uuid(existing_user_id, "existing_user_id") if existing_user_id is not None else None

--- a/backend/tests/test_recovery_admin_provisioning_postgres.py
+++ b/backend/tests/test_recovery_admin_provisioning_postgres.py
@@ -1161,6 +1161,7 @@ async def test_retired_tombstone_rejects_external_identity_adoption(
     )
     actor_user_id, actor_token_id = await _create_retirement_actor(pool)
     monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
     await _create_sso_recovery_successor(service)
     await service.retire_local_recovery_admin(
         expected_username="local-recovery-admin",
@@ -1171,7 +1172,11 @@ async def test_retired_tombstone_rejects_external_identity_adoption(
 
     with pytest.raises(RecoveryAdminProtectedError):
         await account_service.ensure_human_external_identity(
-            issuer="https://identity.example.com/realms/example",
+            # The prelink refuses any issuer this runtime would not present,
+            # and that refusal now comes first. Naming ours is what lets the
+            # call reach the tombstone this test is actually about — otherwise
+            # it passes on the issuer check and proves nothing about adoption.
+            issuer=settings.keycloak_issuer,
             subject=f"subject-{target_by_id}",
             email="local-recovery-admin@example.com",
             display_name="Retired recovery admin",

--- a/backend/tests/test_workspace_account_admin_service.py
+++ b/backend/tests/test_workspace_account_admin_service.py
@@ -10,6 +10,12 @@ import uuid
 import asyncpg
 import pytest
 
+from app.config import settings
+from app.exceptions import (
+    ExternalAuthDisabledError,
+    ExternalIdentityIssuerMismatchError,
+)
+
 
 pytestmark = pytest.mark.asyncio
 _DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
@@ -79,6 +85,16 @@ async def services(monkeypatch):
 
     async def _get_pool():
         return pool
+
+    # The prelink write path now refuses an issuer this runtime would never
+    # present, so a fixture has to say what it presents. Until it did, every
+    # test here passed an issuer nobody had claimed was ours — which is the
+    # shape the defect hid in.
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    assert settings.keycloak_issuer == _ISSUER
 
     monkeypatch.setattr(account_service, "get_pool", _get_pool)
     monkeypatch.setattr(auth_service, "get_pool", _get_pool)
@@ -297,19 +313,29 @@ async def test_concurrent_human_ensure_converges_to_one_user(services):
         )
 
 
-async def test_explicit_user_id_allows_reviewed_issuer_migration(services):
+async def test_explicit_user_id_still_pins_the_account_on_a_second_binding(services):
+    """`existing_user_id` keeps its job: a second exact binding, same account.
+
+    This used to be written with two different issuers, because this route
+    would take any issuer at all. Crossing issuers now belongs to the
+    identity-migration API, which makes the caller name the exact old pair and
+    offers a preflight and a rollback. What must survive here is the narrower
+    property that route still owns — naming an existing user attaches the new
+    binding to that user rather than resolving one by email.
+    """
+
     pool, _, service = services
     email = f"governance-issuer-migration-{uuid.uuid4().hex[:10]}@example.com"
     first = await service.ensure_human_external_identity(
-        issuer="https://old-id.example.com/realms/akb",
+        issuer=_ISSUER,
         subject="stable-old-subject",
         email=email,
         display_name="Migrating member",
         actor_id="platform-service",
     )
 
-    migrated = await service.ensure_human_external_identity(
-        issuer="https://new-id.example.com/realms/akb",
+    rebound = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
         subject="stable-new-subject",
         email=email,
         display_name="Migrating member",
@@ -317,13 +343,96 @@ async def test_explicit_user_id_allows_reviewed_issuer_migration(services):
         existing_user_id=first["user_id"],
     )
 
-    assert migrated["user_id"] == first["user_id"]
+    assert rebound["user_id"] == first["user_id"]
     async with pool.acquire() as conn:
         bindings = await conn.fetchval(
             "SELECT COUNT(*) FROM external_identities WHERE user_id = $1",
             uuid.UUID(first["user_id"]),
         )
     assert bindings == 2
+
+
+async def test_a_binding_under_an_issuer_we_do_not_present_is_refused(services):
+    """The shape a control plane's member invitation actually sends.
+
+    It resolves the person in its own directory and posts that directory's
+    issuer here. Nothing downstream re-checks it: `invite_only` matches the
+    exact pair, so such a binding is written, reported as success, and refuses
+    its owner at sign-in with nothing recording why.
+    """
+
+    pool, _, service = services
+    email = f"governance-foreign-issuer-{uuid.uuid4().hex[:10]}@example.com"
+    with pytest.raises(ExternalIdentityIssuerMismatchError) as refused:
+        await service.ensure_human_external_identity(
+            issuer="https://control-plane.example.com/realms/platform",
+            subject="subject-from-another-directory",
+            email=email,
+            display_name="Invited member",
+            actor_id="platform-service",
+        )
+
+    # The caller cannot correct the call without being told what we present,
+    # and the issuer is public — it is the claim we stamp on every token.
+    assert refused.value.details == {"expected_issuer": _ISSUER}
+
+    async with pool.acquire() as conn:
+        written = await conn.fetchval(
+            "SELECT COUNT(*) FROM users WHERE email = $1",
+            email,
+        )
+    assert written == 0
+
+
+async def test_an_explicit_user_id_does_not_buy_a_foreign_issuer(services):
+    """Deliberateness is not the missing property — usability is.
+
+    A binding under an issuer that never appears on a token here is unusable
+    whether or not the caller meant it, so naming an existing user must not
+    unlock writing one.
+    """
+
+    _, _, service = services
+    email = f"governance-foreign-explicit-{uuid.uuid4().hex[:10]}@example.com"
+    existing = await service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject="stable-subject-we-present",
+        email=email,
+        display_name="Existing member",
+        actor_id="platform-service",
+    )
+
+    with pytest.raises(ExternalIdentityIssuerMismatchError):
+        await service.ensure_human_external_identity(
+            issuer="https://control-plane.example.com/realms/platform",
+            subject="subject-from-another-directory",
+            email=email,
+            display_name="Existing member",
+            actor_id="platform-service",
+            existing_user_id=existing["user_id"],
+        )
+
+
+async def test_local_mode_refuses_an_external_binding_outright(services, monkeypatch):
+    """In local mode the answer is not another issuer but none at all.
+
+    Writing the binding there is worse than inert: the same call sets
+    `auth_provider = 'keycloak'`, and local sign-in requires `'local'`, so it
+    would lock the account out of the only credential it has.
+    """
+
+    _, _, service = services
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", False, raising=False)
+
+    with pytest.raises(ExternalAuthDisabledError):
+        await service.ensure_human_external_identity(
+            issuer=_ISSUER,
+            subject="subject-that-cannot-apply-here",
+            email=f"governance-local-{uuid.uuid4().hex[:10]}@example.com",
+            display_name="Local member",
+            actor_id="platform-service",
+        )
 
 
 async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
@@ -372,6 +481,14 @@ async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
     assert row["account_status"] == "active"
     assert row["password_hash"].startswith("!service-account:")
 
+    # The refusals below are local-mode properties: they assert that a service
+    # account cannot use the password lifecycle that exists only in that mode.
+    # The fixture declares sso, so say so here rather than letting the refusal
+    # arrive from the mode instead of from the account kind — a test that
+    # passes because the whole path is switched off is not testing the account.
+    monkeypatch.setattr(settings, "auth_mode", "local", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", False, raising=False)
+
     from app.exceptions import AuthenticationError
     from app.services.auth_service import change_password, login
 
@@ -403,7 +520,6 @@ async def test_ensure_service_user_is_noninteractive_idempotent_and_non_admin(
         key_class="service",
         scopes=["read", "write"],
     )
-    from app.config import settings
 
     monkeypatch.setattr(settings, "local_auth_enabled", False, raising=False)
     resolved = await resolve_token(f"Bearer {credential['token']}")

--- a/scripts/check-workspace-account-governance.sh
+++ b/scripts/check-workspace-account-governance.sh
@@ -52,7 +52,6 @@ cd "$BACKEND"
   tests/test_account_status_auth_carriers.py \
   tests/test_workspace_account_admin_service.py \
   tests/test_workspace_account_admin_routes.py \
-  tests/test_keycloak_redirect_unit.py \
   tests/test_old_image_schema_compat_unit.py \
   tests/old_image_schema_compat.py
 "$PYTHON_BIN" -m mypy \
@@ -68,7 +67,6 @@ cd "$BACKEND"
   tests/test_account_status_auth_carriers.py \
   tests/test_workspace_account_admin_service.py \
   tests/test_workspace_account_admin_routes.py \
-  tests/test_keycloak_redirect_unit.py \
   tests/test_auth_change_password.py \
   tests/test_password_service.py \
   tests/test_mcp_oauth_unit.py \


### PR DESCRIPTION
The admin prelink took any issuer at all. It required the field to be non-empty and wrote the binding, while the comparison against the issuer this deployment actually stamps on tokens lived in the readiness read path and nowhere in the write path.

That asymmetry is the defect. Nothing downstream re-checks it: invite-only admission matches an exact issuer and subject pair, so a binding written under someone else's issuer is created, reported as success, and refuses its owner at sign-in with nothing recording why. A control plane that resolves an invitee in its own directory and posts that directory's issuer here does exactly this, and it is currently hidden only by every workspace happening to share an identity provider with the control plane. A workspace that owns its own no longer does.

In local mode the answer is not a different issuer but none. The refusal there is not pedantry: the same call sets the account's provider to keycloak, and local sign-in requires local, so writing the binding would lock the account out of the only credential it has.

## Crossing issuers already has a home

The identity-migration API makes the caller name the exact old pair, offers a preflight and a rollback, and requires the provider be disabled while it runs. The loose capability on this route predates it by a month. The test that asserted it is rewritten to keep the narrower property this route still owns — naming an existing user attaches the binding to that user rather than resolving one by email.

## Verification

Each half of the guard proven separately by mutation:

| mutation | reddens |
|---|---|
| delete the issuer comparison | only the two issuer tests |
| delete the mode branch | only the local-mode test |
| delete the guard entirely | all three |

Against the full backend suite the change adds three passes and no failures — 58 failures before and after, from an unrelated area, verified by running the suite with the change stashed.

Gate for this area: ruff, mypy and 131 tests green, plus the old-image schema compatibility check.

## Neighbouring tests that were passing for a reason they did not name

- The fixture never declared which issuer the runtime presents. That silence is where the defect lived, so it says so now.
- The service-account refusals assert a local-mode property and were inheriting the mode. They select it explicitly.
- The retired-tombstone test was reaching the new guard instead of the tombstone. It names our issuer, so it tests adoption again.

Also repairs the gate for this area, which has been unable to run since a test file it lists was deleted a week ago.
