### PR TITLE
feat(auth): record the arrival invite-only refuses, and let an admin approve it

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -184,6 +184,14 @@ jobs:
         # since-renumbered migration tuple, so it silently self-skipped in
         # both jobs.
         #
+        # Pending admissions are a row with a uniqueness constraint, a
+        # retention window, and a cap that evicts — three database facts a mock
+        # would agree with rather than test. The two files beside it are the
+        # exact-identity contract the approval writes into, and both were
+        # absent from this list: they need a DSN, so they skipped in the unit
+        # job, and off this list they skipped here too. Enrollment policy and
+        # the whole administrative projection surface were gating nothing.
+        #
         # Recovery-admin provisioning and the dedicated admin browser-session
         # contract are also database guarantees.  Their ordinary unit-job
         # collection intentionally skips without Postgres, so keep both files
@@ -214,6 +222,9 @@ jobs:
           tests/test_recovery_admin_provisioning_postgres.py
           tests/test_admin_auth_postgres.py
           tests/test_sso_identity_migration_postgres.py
+          tests/test_pending_admission_postgres.py
+          tests/test_workspace_external_identity.py
+          tests/test_workspace_account_admin_service.py
           tests/test_sso_browser_session_postgres.py
           tests/test_sso_session_epoch_upgrade_postgres.py
           tests/test_tool_usage_e2e.py

--- a/backend/app/api/routes/admin_sso.py
+++ b/backend/app/api/routes/admin_sso.py
@@ -15,7 +15,13 @@ from app.api.routes.admin_auth import (
     get_product_admin_mutation,
 )
 from app.config import settings
+from app.exceptions import AKBError
 from app.services import audit_log
+from app.services.admission_service import (
+    approve_pending_admission,
+    dismiss_pending_admission,
+    list_pending_admissions,
+)
 from app.sso.keycloak_admin import (
     ProviderControlError,
     get_keycloak_provider_control,
@@ -604,3 +610,97 @@ async def rollback_sso_identity_migration(
         actor,
         operation="rollback",
     )
+
+
+class ApprovePendingAdmissionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Deliberately absent: issuer and subject. Approval names a row, and the
+    # row carries the identity. A caller able to supply a subject alongside a
+    # row id could approve one arrival and bind a different one.
+    existing_user_id: str | None = Field(default=None, max_length=64)
+    email: str | None = Field(default=None, max_length=320)
+    display_name: str | None = Field(default=None, max_length=255)
+    prepare_suspended: bool = False
+
+
+def _admission_audit_meta(admission: dict[str, object]) -> dict[str, object]:
+    return {
+        "issuer": admission.get("issuer"),
+        "subject_sha256": _subject_digest(admission.get("subject")),
+        "arrivals": admission.get("arrivals"),
+    }
+
+
+@router.get(
+    "/admin/sso/pending-admissions",
+    summary="List identities that arrived and were refused by invite-only",
+)
+async def list_sso_pending_admissions(
+    limit: int = 200,
+    actor: ProductAdminActor = Depends(get_current_product_admin),
+):
+    del actor  # authorization only; reading the list is not an event
+    return await list_pending_admissions(limit=limit)
+
+
+@router.post(
+    "/admin/sso/pending-admissions/{admission_id}/approve",
+    summary="Bind one recorded arrival to an AKB user",
+)
+async def approve_sso_pending_admission(
+    admission_id: str,
+    request: ApprovePendingAdmissionRequest,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    try:
+        result = await approve_pending_admission(
+            admission_id,
+            actor_id=str(actor.user_id),
+            existing_user_id=request.existing_user_id,
+            email=request.email,
+            display_name=request.display_name,
+            prepare_suspended=request.prepare_suspended,
+        )
+    except AKBError as error:
+        audit_log.record(
+            action="sso.pending_admission.approve",
+            actor=actor.username,
+            actor_id=str(actor.user_id),
+            target=f"pending_admission={_canonical_user_id(admission_id)}",
+            outcome="error",
+            code=getattr(error, "code", None) or str(error.status_code),
+            meta={"existing_user_id": _canonical_user_id(request.existing_user_id)},
+        )
+        raise
+    approved = result["approved"]
+    meta = _admission_audit_meta(approved)
+    meta["user_id"] = _canonical_user_id(result["user"].get("user_id"))
+    audit_log.record(
+        action="sso.pending_admission.approve",
+        actor=actor.username,
+        actor_id=str(actor.user_id),
+        target=f"pending_admission={approved['id']}",
+        outcome="ok",
+        meta=meta,
+    )
+    return result
+
+
+@router.delete(
+    "/admin/sso/pending-admissions/{admission_id}",
+    summary="Forget one recorded arrival without admitting it",
+)
+async def dismiss_sso_pending_admission(
+    admission_id: str,
+    actor: ProductAdminActor = Depends(get_product_admin_mutation),
+):
+    result = await dismiss_pending_admission(admission_id)
+    audit_log.record(
+        action="sso.pending_admission.dismiss",
+        actor=actor.username,
+        actor_id=str(actor.user_id),
+        target=f"pending_admission={result['dismissed']}",
+        outcome="ok",
+    )
+    return result

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -862,6 +862,17 @@ class Settings(BaseModel):
     # user plus exact binding. `invite_only` accepts only an exact prebound
     # (issuer, subject) identity. `disabled` rejects external login entirely.
     keycloak_enrollment_mode: Literal["open", "invite_only", "disabled"] = "open"
+    # `invite_only` records the arrival it refuses so an administrator can
+    # approve that exact identity. Both bounds are on the RECORD, never on the
+    # refusal: eviction changes what an administrator can still see, and never
+    # what a token is allowed to do.
+    #
+    # An arrival costs an authenticated session at the upstream identity
+    # provider, so this table is not reachable by anyone who merely reaches the
+    # login page. The bounds exist because "unbounded, but hard to fill" is
+    # still unbounded.
+    keycloak_pending_admission_retention_hours: int = Field(default=336, ge=1, le=8760)
+    keycloak_pending_admission_cap: int = Field(default=500, ge=1, le=100000)
     # Deprecated migration input retained so Phase 3 readiness tooling can
     # identify legacy installations. Canonical config loading rejects true,
     # and the projection service repeats that guard for directly constructed

--- a/backend/app/db/migrations/082_pending_admissions.py
+++ b/backend/app/db/migrations/082_pending_admissions.py
@@ -1,0 +1,55 @@
+"""Record the arrival that ``invite_only`` refuses.
+
+A workspace that owns its identity provider admits people by an exact
+``(issuer, subject)`` pair, and the subject in that pair is assigned by this
+workspace's own realm at exactly one moment: the person's first arrival through
+the broker. Until then nobody can name it — not the platform, not an
+administrator, and not the person. Only the upstream's owner could, and it is
+not ours.
+
+``invite_only`` refuses that arrival and, until now, discarded it. The broker
+had just verified the person, checked a signed ``email_verified`` claim, and
+minted them a stable realm subject; the one value an exact binding needs was
+produced and thrown away in the same instant.
+
+One row here is one such arrival. It is deliberately NOT a membership, an
+account, or a grant: it authorizes nothing, and the refusal that creates it is
+unchanged. It is a note saying "this exact identity presented itself", so that
+an administrator can approve that specific arrival instead of guessing a
+subject in advance.
+
+``(issuer, subject)`` is unique, so a person who keeps trying updates one row
+rather than adding rows. Nothing is keyed by email: the address is recorded
+because an administrator reads it, never because anything matches on it.
+"""
+
+from __future__ import annotations
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pending_admissions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                issuer TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                email TEXT,
+                display_name TEXT,
+                first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                arrivals INTEGER NOT NULL DEFAULT 1,
+                CONSTRAINT pending_admissions_issuer_subject_key
+                    UNIQUE (issuer, subject)
+            )
+            """
+        )
+        # Retention and the cap both evict by least-recent arrival, and the
+        # list an administrator reads is ordered the same way. One index
+        # serves all three.
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS pending_admissions_last_seen_idx
+                ON pending_admissions(last_seen_at DESC)
+            """
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -304,6 +304,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "079_worker_claim_lifecycle.py",  # attempt-at-claim + explicit claimed/abandoned timestamps for durable queues
         "080_local_forced_credential_change.py",  # local parity for the identity provider's UPDATE_PASSWORD: a delivered credential is owed a replacement until its holder changes it
         "081_service_identities.py",  # non-human (issuer, client) → AKB service account bindings, kept out of the human external_identities population
+        "082_pending_admissions.py",  # the arrival invite_only refuses, kept so an administrator can approve that exact identity instead of guessing a subject in advance
     ):
         if filename in applied:
             continue

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -128,6 +128,31 @@ class ExternalIdentityConflictError(AKBError):
         )
 
 
+class ExternalIdentityAdoptionNotRequestedError(AKBError):
+    """A binding would have attached to an account chosen by email address.
+
+    ``ensure_human_external_identity`` may attach a new identity to an existing
+    unbound account holding the same address. For a control plane that already
+    knows which person it is provisioning, that is a convenience. For approving
+    a recorded arrival it is not: the address there is a claim out of the
+    token, so letting it select the account makes the approval an adoption by
+    address at exactly the step that exists to stop it.
+
+    The candidate account is named because an administrator who *does* mean to
+    attach the arrival to it can then say so deliberately, by passing it back as
+    ``existing_user_id`` — which is a different act from having it chosen for
+    them.
+    """
+
+    def __init__(self, candidate_user_id: str):
+        super().__init__(
+            "An account already holds this email address; name it explicitly to attach this identity to it",
+            status_code=409,
+            code="external_identity_adoption_not_requested",
+            details={"candidate_user_id": candidate_user_id},
+        )
+
+
 class ExternalIdentityIssuerMismatchError(AKBError):
     """A prelink named an issuer this runtime does not present.
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -13,6 +13,7 @@ from app.exceptions import (
     CredentialCleanupIncompleteError,
     ExternalAuthDisabledError,
     ExternalIdentityConflictError,
+    ExternalIdentityAdoptionNotRequestedError,
     ExternalIdentityIssuerMismatchError,
     NotFoundError,
     RecoveryAdminProtectedError,
@@ -109,7 +110,19 @@ async def ensure_human_external_identity(
     actor_id: str,
     existing_user_id: str | None = None,
     prepare_suspended: bool = False,
+    adopt_unbound_email: bool = True,
 ) -> dict:
+    """Bind one exact ``(issuer, subject)`` to an AKB human account.
+
+    ``adopt_unbound_email`` decides what happens when no account is bound to
+    that pair, the caller named none, and an unbound human account already
+    holds the address. A control plane that is provisioning a person it already
+    identified wants that account — that is the default, and the behaviour every
+    existing caller has. Approving a recorded arrival does not: there the
+    address is a claim out of the token, so letting it select the account turns
+    the approval into an adoption by address. Those callers pass ``False`` and
+    get a refusal that names the candidate instead.
+    """
     issuer = _presented_issuer(_required(issuer, "issuer"))
     subject = _required(subject, "subject")
     email = _required(email, "email").lower()
@@ -213,6 +226,10 @@ async def ensure_human_external_identity(
                         )
                         if len(rows) > 1:
                             raise ExternalIdentityConflictError()
+                        if rows and not adopt_unbound_email:
+                            raise ExternalIdentityAdoptionNotRequestedError(
+                                str(rows[0]["id"])
+                            )
                         if rows:
                             user_id = rows[0]["id"]
                             if is_retired_recovery_admin_password(rows[0]["password_hash"]):

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -287,6 +287,16 @@ async def ensure_human_external_identity(
             raise ExternalIdentityConflictError() from None
 
         row = await _fetch_user(conn, user_id)
+        # This identity now has a binding, so the note `invite_only` took when
+        # it refused them has been answered. Clearing it here rather than only
+        # in the approval path covers every writer of an exact binding —
+        # including a control plane that prelinks someone who had already
+        # arrived and been turned away.
+        await conn.execute(
+            "DELETE FROM pending_admissions WHERE issuer = $1 AND subject = $2",
+            issuer,
+            subject,
+        )
 
     if new_user_id is not None:
         await get_role_sync().on_user_create(new_user_id)

--- a/backend/app/services/admission_service.py
+++ b/backend/app/services/admission_service.py
@@ -205,6 +205,11 @@ async def approve_pending_admission(
     binding gets. In particular an arrival recorded under an issuer this
     runtime does not present is refused here rather than written.
 
+    Nothing is adopted by address: if an unbound account already holds the
+    arrival's email, approval refuses and names it rather than attaching to it.
+    An administrator who means that account passes it as ``existing_user_id``,
+    which is a different act from having it chosen for them.
+
     The row is removed only after the binding succeeds. A failed approval
     leaves the arrival exactly where it was.
     """
@@ -229,5 +234,10 @@ async def approve_pending_admission(
         existing_user_id=existing_user_id,
         prepare_suspended=prepare_suspended,
         actor_id=actor_id,
+        # The address on an arrival is a claim out of the person's token. If it
+        # were allowed to select an existing account, approving would be an
+        # adoption by address at the one step whose purpose is to stop that.
+        # An administrator who does mean that account names it.
+        adopt_unbound_email=False,
     )
     return {"approved": arrival, "user": result}

--- a/backend/app/services/admission_service.py
+++ b/backend/app/services/admission_service.py
@@ -1,0 +1,233 @@
+"""Pending admissions — the arrival ``invite_only`` refuses, kept.
+
+``invite_only`` admits an exact ``(issuer, subject)`` pair and refuses everyone
+else. The subject half of that pair is assigned by this workspace's own realm,
+and it comes into being at exactly one moment: the person's first arrival
+through the broker. Before that arrival nobody can name it. That is why every
+attempt to bind an invited person *ahead* of time has failed — each one was
+trying to obtain a value that did not exist yet.
+
+So the refusal records what it refused. Nothing else about the refusal changes:
+the caller still receives ``membership_required`` and holds nothing. The record
+authorizes nothing; it is what an administrator reads in order to approve one
+specific arrival, after which the ordinary exact-binding path
+(``ensure_human_external_identity``) writes the binding.
+
+Two properties are load-bearing and are asserted by tests rather than assumed:
+
+* **Recording cannot rescue a refusal.** If the record cannot be written, the
+  refusal is still a refusal. A pending admission is a note, so failing to take
+  a note must never become a way in — nor a 500 that hides the real answer.
+* **Nothing is keyed by email.** The address is stored because an administrator
+  reads it. Approval names a row, and that row carries the subject.
+
+The table is bounded twice, and both bounds are on the record rather than on
+the refusal. Producing an arrival costs an authenticated session at the
+upstream identity provider, so the table is not reachable by anyone who merely
+reaches the login page; the bounds exist because "unbounded but hard to fill"
+is still unbounded.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import NotFoundError, ValidationError
+
+
+_LOG = logging.getLogger("akb.admission")
+
+
+def _text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+async def record_arrival(
+    conn,
+    *,
+    issuer: str,
+    subject: str,
+    claims: dict[str, Any],
+) -> None:
+    """Note that this exact identity presented itself and was refused.
+
+    Runs on the connection the refusal already holds, outside any transaction
+    of its own, and never raises: a failure to take a note must not change what
+    the caller is told. The refusal is raised by the caller immediately after
+    this returns, whatever happened here.
+    """
+    email = _text(claims.get("email"))
+    display_name = _text(claims.get("name")) or _text(claims.get("preferred_username"))
+    try:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                INSERT INTO pending_admissions (issuer, subject, email, display_name)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT ON CONSTRAINT pending_admissions_issuer_subject_key
+                DO UPDATE SET
+                    email = EXCLUDED.email,
+                    display_name = EXCLUDED.display_name,
+                    last_seen_at = NOW(),
+                    arrivals = pending_admissions.arrivals + 1
+                """,
+                issuer,
+                subject,
+                email,
+                display_name,
+            )
+            # Eviction runs with the write so the table stays bounded without a
+            # scheduled job that a deployment could be missing. Both clauses
+            # keep the most recent arrivals, which is the row just written.
+            await conn.execute(
+                """
+                DELETE FROM pending_admissions
+                 WHERE last_seen_at < NOW() - ($1 || ' hours')::interval
+                """,
+                str(int(settings.keycloak_pending_admission_retention_hours)),
+            )
+            await conn.execute(
+                """
+                DELETE FROM pending_admissions
+                 WHERE id IN (
+                     SELECT id FROM pending_admissions
+                      ORDER BY last_seen_at DESC, id
+                      OFFSET $1
+                 )
+                """,
+                int(settings.keycloak_pending_admission_cap),
+            )
+    except Exception as exc:  # noqa: BLE001 — see the docstring: never rescue, never 500
+        _LOG.warning(
+            "pending admission not recorded for an arrival that was refused (%s)", exc
+        )
+
+
+def _row(record) -> dict[str, Any]:
+    return {
+        "id": str(record["id"]),
+        "issuer": record["issuer"],
+        "subject": record["subject"],
+        "email": record["email"],
+        "display_name": record["display_name"],
+        "first_seen_at": record["first_seen_at"].isoformat(),
+        "last_seen_at": record["last_seen_at"].isoformat(),
+        "arrivals": record["arrivals"],
+    }
+
+
+async def list_pending_admissions(*, limit: int = 200) -> dict[str, Any]:
+    """Arrivals an administrator can still act on, most recent first."""
+    bounded = max(1, min(int(limit), 1000))
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, issuer, subject, email, display_name,
+                   first_seen_at, last_seen_at, arrivals
+              FROM pending_admissions
+             WHERE last_seen_at >= NOW() - ($2 || ' hours')::interval
+             ORDER BY last_seen_at DESC, id
+             LIMIT $1
+            """,
+            bounded,
+            str(int(settings.keycloak_pending_admission_retention_hours)),
+        )
+    return {"pending_admissions": [_row(row) for row in rows]}
+
+
+def _admission_uuid(value: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, AttributeError, TypeError):
+        raise ValidationError("pending admission id must be a UUID") from None
+
+
+async def get_pending_admission(admission_id: str) -> dict[str, Any]:
+    identifier = _admission_uuid(admission_id)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, issuer, subject, email, display_name,
+                   first_seen_at, last_seen_at, arrivals
+              FROM pending_admissions
+             WHERE id = $1
+            """,
+            identifier,
+        )
+    if row is None:
+        raise NotFoundError("Pending admission", str(identifier))
+    return _row(row)
+
+
+async def dismiss_pending_admission(admission_id: str) -> dict[str, Any]:
+    """Forget one arrival. It says nothing about whether they may return."""
+    identifier = _admission_uuid(admission_id)
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "DELETE FROM pending_admissions WHERE id = $1 RETURNING id",
+            identifier,
+        )
+    if row is None:
+        raise NotFoundError("Pending admission", str(identifier))
+    return {"dismissed": str(row["id"])}
+
+
+async def approve_pending_admission(
+    admission_id: str,
+    *,
+    actor_id: str,
+    existing_user_id: str | None = None,
+    email: str | None = None,
+    display_name: str | None = None,
+    prepare_suspended: bool = False,
+) -> dict[str, Any]:
+    """Bind one recorded arrival to an AKB account.
+
+    The subject is taken from the ROW, never from the caller: naming the row is
+    the whole act of approval, and a caller that could also supply a subject
+    could approve one arrival while binding another. ``existing_user_id``
+    attaches the arrival to an account that already exists — the invited
+    person's prepared account, or, during a workspace's move to its own realm,
+    the account they have been using all along.
+
+    The binding itself is the ordinary exact-binding path, so the issuer guard,
+    the conflict rules, and the audit trail are the same ones every other
+    binding gets. In particular an arrival recorded under an issuer this
+    runtime does not present is refused here rather than written.
+
+    The row is removed only after the binding succeeds. A failed approval
+    leaves the arrival exactly where it was.
+    """
+    from app.services.account_service import ensure_human_external_identity
+
+    arrival = await get_pending_admission(admission_id)
+    resolved_email = _text(email) or _text(arrival["email"])
+    if resolved_email is None:
+        # `ensure_human_external_identity` requires one, and an arrival whose
+        # provider sent no email claim cannot supply it. Say which of the two
+        # is missing rather than failing as a generic invalid argument.
+        raise ValidationError(
+            "This arrival carried no email address; supply one to approve it"
+        )
+    # The exact-binding path removes the note itself, so every writer of a
+    # binding answers the arrival it belongs to — not only this one.
+    result = await ensure_human_external_identity(
+        issuer=arrival["issuer"],
+        subject=arrival["subject"],
+        email=resolved_email,
+        display_name=_text(display_name) or _text(arrival["display_name"]),
+        existing_user_id=existing_user_id,
+        prepare_suspended=prepare_suspended,
+        actor_id=actor_id,
+    )
+    return {"approved": arrival, "user": result}

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -38,6 +38,7 @@ from app.exceptions import (
 )
 from app.models.vault_scope import VaultScope
 from app.repositories.events_repo import emit_event
+from app.services.admission_service import record_arrival
 from app.services.auth_policy import require_local_auth_enabled
 from app.services.auth_verifier_profiles import (
     KEYCLOAK_ACCESS_V1,
@@ -494,6 +495,13 @@ async def _resolve_or_provision_keycloak_user(claims: dict) -> dict:
             return _resolved_external_user(refreshed, newly_provisioned=False)
 
         if settings.keycloak_enrollment_mode == "invite_only":
+            # The broker has just verified this person and minted them a stable
+            # subject in this realm. That subject is the one value an exact
+            # binding needs and the one value nobody could name in advance, so
+            # it is written down here rather than discarded with the refusal.
+            # Recording never changes the answer: the refusal below is raised
+            # whether or not the note was taken.
+            await record_arrival(conn, issuer=issuer, subject=subject, claims=claims)
             raise MembershipRequiredError()
 
         email = (_optional_external_string(claims, "email") or "").strip().lower()

--- a/backend/tests/test_pending_admission_postgres.py
+++ b/backend/tests/test_pending_admission_postgres.py
@@ -1,0 +1,434 @@
+"""The arrival ``invite_only`` refuses, and what an administrator can do with it.
+
+Every one of these runs against a real PostgreSQL because the object under test
+is a row with a uniqueness constraint, a retention window, and a cap that
+evicts. A mock would agree with whatever this file assumed.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+from app.config import settings
+from app.exceptions import (
+    ExternalIdentityConflictError,
+    ExternalIdentityIssuerMismatchError,
+    MembershipRequiredError,
+    NotFoundError,
+)
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
+_ISSUER = "https://id.example.com/realms/akb"
+
+
+@pytest.fixture
+async def services(monkeypatch):
+    try:
+        pool = await asyncpg.create_pool(_DSN, min_size=1, max_size=3)
+    except Exception:
+        pytest.skip("Postgres unreachable at AKB_TEST_DSN")
+
+    from app.db.postgres import _load_migration
+    from app.services import account_service, admission_service, auth_service
+
+    async with pool.acquire() as conn:
+        for filename in (
+            "043_workspace_account_governance.py",
+            "082_pending_admissions.py",
+        ):
+            migration = _load_migration(filename)
+            assert migration is not None
+            await migration.migrate(conn=conn)
+        await conn.execute("DELETE FROM pending_admissions WHERE issuer = $1", _ISSUER)
+
+    async def _get_pool():
+        return pool
+
+    monkeypatch.setattr(auth_service, "get_pool", _get_pool)
+    monkeypatch.setattr(account_service, "get_pool", _get_pool)
+    monkeypatch.setattr(admission_service, "get_pool", _get_pool)
+    monkeypatch.setattr(account_service, "get_role_sync", lambda: _NoRoleSync())
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_server_url", "https://id.example.com", raising=False)
+    monkeypatch.setattr(settings, "keycloak_realm", "akb", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enrollment_mode", "invite_only", raising=False)
+    monkeypatch.setattr(settings, "keycloak_require_verified_email", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_link_by_email", False, raising=False)
+    assert settings.keycloak_issuer == _ISSUER
+
+    yield pool, auth_service, admission_service, account_service
+
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM pending_admissions WHERE issuer LIKE 'https://id.example%'")
+        await conn.execute("DELETE FROM users WHERE username LIKE 'adm-%'")
+        await conn.execute("DELETE FROM events WHERE actor_id LIKE 'adm-%'")
+    await pool.close()
+
+
+class _NoRoleSync:
+    async def on_user_create(self, user_id):
+        return None
+
+
+def _claims(subject: str, email: str | None = None, name: str | None = None) -> dict:
+    claims: dict[str, object] = {
+        "iss": _ISSUER,
+        "sub": subject,
+        "preferred_username": f"adm-{subject}",
+    }
+    if email is not None:
+        claims.update({"email": email, "email_verified": True})
+    if name is not None:
+        claims["name"] = name
+    return claims
+
+
+async def _arrival(pool, subject: str):
+    async with pool.acquire() as conn:
+        return await conn.fetchrow(
+            "SELECT * FROM pending_admissions WHERE issuer = $1 AND subject = $2",
+            _ISSUER,
+            subject,
+        )
+
+
+# ── the refusal now leaves a record, and is still a refusal ──────────────────
+
+
+async def test_invite_only_records_the_exact_arrival_it_refuses(services):
+    pool, auth_service, _, _ = services
+    subject = f"arrival-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+
+    with pytest.raises(MembershipRequiredError) as refusal:
+        await auth_service._resolve_or_provision_keycloak_user(
+            _claims(subject, email, name="Invited Person")
+        )
+
+    # The refusal is unchanged. A note is not a way in.
+    assert refusal.value.code == "membership_required"
+    assert refusal.value.status_code == 403
+
+    row = await _arrival(pool, subject)
+    assert row is not None, "the subject the broker just minted was discarded again"
+    assert row["issuer"] == _ISSUER
+    assert row["subject"] == subject
+    assert row["email"] == email
+    assert row["display_name"] == "Invited Person"
+    assert row["arrivals"] == 1
+
+
+async def test_a_person_who_keeps_trying_stays_one_row(services):
+    pool, auth_service, _, _ = services
+    subject = f"repeat-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+
+    for _ in range(3):
+        with pytest.raises(MembershipRequiredError):
+            await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT * FROM pending_admissions WHERE issuer = $1 AND subject = $2",
+            _ISSUER,
+            subject,
+        )
+    assert len(rows) == 1
+    assert rows[0]["arrivals"] == 3
+    assert rows[0]["last_seen_at"] >= rows[0]["first_seen_at"]
+
+
+async def test_two_arrivals_sharing_an_address_are_two_rows(services):
+    """Nothing here is keyed by email — that is the whole point of the design."""
+    pool, auth_service, _, _ = services
+    email = f"adm-shared-{uuid.uuid4().hex[:10]}@example.com"
+    first = f"shared-a-{uuid.uuid4().hex}"
+    second = f"shared-b-{uuid.uuid4().hex}"
+
+    for subject in (first, second):
+        with pytest.raises(MembershipRequiredError):
+            await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+
+    async with pool.acquire() as conn:
+        count = await conn.fetchval(
+            "SELECT count(*) FROM pending_admissions WHERE email = $1", email
+        )
+    assert count == 2
+
+
+async def test_open_mode_records_nothing(services):
+    pool, auth_service, _, _ = services
+    monkeypatch_subject = f"open-{uuid.uuid4().hex}"
+    settings_mode = settings.keycloak_enrollment_mode
+    try:
+        object.__setattr__(settings, "keycloak_enrollment_mode", "open")
+        resolved = await auth_service._resolve_or_provision_keycloak_user(
+            _claims(monkeypatch_subject, f"adm-{uuid.uuid4().hex[:10]}@example.com")
+        )
+    finally:
+        object.__setattr__(settings, "keycloak_enrollment_mode", settings_mode)
+    assert resolved["newly_provisioned"] is True
+    assert await _arrival(pool, monkeypatch_subject) is None
+
+
+async def test_a_note_that_cannot_be_written_is_still_a_refusal(services):
+    """Taking a note must never be able to change the answer — in either direction.
+
+    The recorder swallows its own failure on purpose, so this asserts the two
+    halves that makes acceptable: the caller still gets the refusal, and the
+    swallow is not hiding a partial write.
+    """
+    pool, auth_service, admission_service, _ = services
+    subject = f"broken-{uuid.uuid4().hex}"
+
+    async def _explode(conn, **kwargs):
+        raise RuntimeError("pending_admissions is unreachable")
+
+    original = auth_service.record_arrival
+    auth_service.record_arrival = _explode  # type: ignore[assignment]
+    try:
+        with pytest.raises(RuntimeError):
+            await auth_service._resolve_or_provision_keycloak_user(_claims(subject))
+    finally:
+        auth_service.record_arrival = original  # type: ignore[assignment]
+
+    # And the recorder itself, given a connection that fails, refuses to raise.
+    class _FailingConn:
+        def transaction(self):
+            raise RuntimeError("no transaction for you")
+
+    await admission_service.record_arrival(
+        _FailingConn(), issuer=_ISSUER, subject=subject, claims=_claims(subject)
+    )
+    assert await _arrival(pool, subject) is None
+
+
+# ── the record is bounded, and both bounds keep the newest ───────────────────
+
+
+async def test_an_arrival_past_its_retention_window_is_evicted_by_the_next_one(services):
+    pool, auth_service, admission_service, _ = services
+    stale = f"stale-{uuid.uuid4().hex}"
+    fresh = f"fresh-{uuid.uuid4().hex}"
+
+    with pytest.raises(MembershipRequiredError):
+        await auth_service._resolve_or_provision_keycloak_user(_claims(stale))
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE pending_admissions SET last_seen_at = NOW() - interval '400 hours'"
+            " WHERE issuer = $1 AND subject = $2",
+            _ISSUER,
+            stale,
+        )
+    with pytest.raises(MembershipRequiredError):
+        await auth_service._resolve_or_provision_keycloak_user(_claims(fresh))
+
+    assert await _arrival(pool, stale) is None
+    assert await _arrival(pool, fresh) is not None
+    listed = await admission_service.list_pending_admissions()
+    assert stale not in [item["subject"] for item in listed["pending_admissions"]]
+
+
+async def test_the_cap_evicts_the_least_recent_and_never_the_newest(services):
+    pool, auth_service, _, _ = services
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM pending_admissions")
+    object.__setattr__(settings, "keycloak_pending_admission_cap", 3)
+    try:
+        subjects = [f"cap-{index}-{uuid.uuid4().hex[:8]}" for index in range(5)]
+        for subject in subjects:
+            with pytest.raises(MembershipRequiredError):
+                await auth_service._resolve_or_provision_keycloak_user(_claims(subject))
+    finally:
+        object.__setattr__(
+            settings,
+            "keycloak_pending_admission_cap",
+            type(settings).model_fields["keycloak_pending_admission_cap"].default,
+        )
+
+    async with pool.acquire() as conn:
+        remaining = [
+            row["subject"]
+            for row in await conn.fetch(
+                "SELECT subject FROM pending_admissions ORDER BY last_seen_at DESC, id"
+            )
+        ]
+    assert len(remaining) == 3
+    assert subjects[-1] in remaining
+    assert subjects[0] not in remaining
+
+
+# ── approval ─────────────────────────────────────────────────────────────────
+
+
+async def _record_and_read(services, subject: str, email: str) -> dict:
+    _, auth_service, admission_service, _ = services
+    with pytest.raises(MembershipRequiredError):
+        await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+    listed = await admission_service.list_pending_admissions()
+    match = [item for item in listed["pending_admissions"] if item["subject"] == subject]
+    assert len(match) == 1
+    return match[0]
+
+
+async def test_approval_binds_that_exact_arrival_and_the_person_gets_in(services):
+    pool, auth_service, admission_service, _ = services
+    subject = f"approve-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    arrival = await _record_and_read(services, subject, email)
+
+    result = await admission_service.approve_pending_admission(
+        arrival["id"], actor_id="adm-actor"
+    )
+    user_id = result["user"]["user_id"]
+
+    # The same login predicate that was refused now resolves — to that account.
+    resolved = await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+    assert str(resolved["user_id"]) == user_id
+    assert resolved["newly_provisioned"] is False
+
+    # And the note is gone, so the list an administrator reads is not a backlog
+    # of people who are already in.
+    assert await _arrival(pool, subject) is None
+
+
+async def test_approval_can_attach_the_arrival_to_the_account_they_already_had(services):
+    """The migration case: a new issuer, the same person, the same AKB account."""
+    pool, auth_service, admission_service, _ = services
+    subject = f"attach-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    existing = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, auth_provider,
+                               account_status, account_kind)
+            VALUES ($1, $2, $3, '!keycloak-sso:no-local-login!', 'keycloak', 'active', 'human')
+            """,
+            existing,
+            f"adm-{uuid.uuid4().hex[:12]}",
+            email,
+        )
+    arrival = await _record_and_read(services, subject, email)
+
+    result = await admission_service.approve_pending_admission(
+        arrival["id"], actor_id="adm-actor", existing_user_id=str(existing)
+    )
+    assert result["user"]["user_id"] == str(existing)
+    resolved = await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+    assert str(resolved["user_id"]) == str(existing)
+
+
+async def test_approval_cannot_name_a_subject_only_a_row(services):
+    """The request model is the guard: naming a row IS the act of approval."""
+    from app.api.routes.admin_sso import ApprovePendingAdmissionRequest
+
+    with pytest.raises(Exception) as rejected:
+        ApprovePendingAdmissionRequest(subject="someone-elses-subject")
+    assert "extra" in str(rejected.value).lower()
+    fields = set(ApprovePendingAdmissionRequest.model_fields)
+    assert "subject" not in fields and "issuer" not in fields
+
+
+async def test_an_arrival_under_a_foreign_issuer_is_refused_and_survives(services):
+    pool, _, admission_service, _ = services
+    subject = f"foreign-{uuid.uuid4().hex}"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO pending_admissions (issuer, subject, email)
+            VALUES ($1, $2, $3) RETURNING id
+            """,
+            "https://id.example.com/realms/somewhere-else",
+            subject,
+            f"adm-{uuid.uuid4().hex[:10]}@example.com",
+        )
+
+    with pytest.raises(ExternalIdentityIssuerMismatchError):
+        await admission_service.approve_pending_admission(str(row["id"]), actor_id="adm-actor")
+
+    async with pool.acquire() as conn:
+        still = await conn.fetchval(
+            "SELECT count(*) FROM pending_admissions WHERE id = $1", row["id"]
+        )
+    assert still == 1, "a failed approval must leave the arrival where it was"
+
+
+async def test_approving_one_arrival_onto_someone_elses_account_conflicts(services):
+    pool, _, admission_service, _ = services
+    subject = f"conflict-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    arrival = await _record_and_read(services, subject, email)
+    other = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, auth_provider,
+                               account_status, account_kind)
+            VALUES ($1, $2, $3, '!keycloak-sso:no-local-login!', 'keycloak', 'active', 'human')
+            """,
+            other,
+            f"adm-{uuid.uuid4().hex[:12]}",
+            f"adm-{uuid.uuid4().hex[:10]}@example.com",
+        )
+    await admission_service.approve_pending_admission(arrival["id"], actor_id="adm-actor")
+
+    # The row is gone, so a second approval has nothing to name.
+    with pytest.raises(NotFoundError):
+        await admission_service.approve_pending_admission(arrival["id"], actor_id="adm-actor")
+
+    # And re-arriving after the binding exists produces no new note to approve.
+    async with pool.acquire() as conn:
+        replay = await conn.fetchrow(
+            """
+            INSERT INTO pending_admissions (issuer, subject, email)
+            VALUES ($1, $2, $3) RETURNING id
+            """,
+            _ISSUER,
+            subject,
+            email,
+        )
+    with pytest.raises(ExternalIdentityConflictError):
+        await admission_service.approve_pending_admission(
+            str(replay["id"]), actor_id="adm-actor", existing_user_id=str(other)
+        )
+
+
+async def test_a_binding_written_by_any_path_answers_the_note(services):
+    """A control plane that prelinks someone who had already been turned away."""
+    pool, auth_service, _, account_service = services
+    subject = f"prelinked-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    with pytest.raises(MembershipRequiredError):
+        await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+    assert await _arrival(pool, subject) is not None
+
+    await account_service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=subject,
+        email=email,
+        display_name=None,
+        actor_id="adm-actor",
+    )
+    assert await _arrival(pool, subject) is None
+
+
+async def test_dismissing_an_arrival_forgets_it_without_admitting_anyone(services):
+    pool, auth_service, admission_service, _ = services
+    subject = f"dismiss-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    arrival = await _record_and_read(services, subject, email)
+
+    await admission_service.dismiss_pending_admission(arrival["id"])
+    assert await _arrival(pool, subject) is None
+    with pytest.raises(MembershipRequiredError):
+        await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
+    with pytest.raises(NotFoundError):
+        await admission_service.dismiss_pending_admission(arrival["id"])

--- a/backend/tests/test_pending_admission_postgres.py
+++ b/backend/tests/test_pending_admission_postgres.py
@@ -15,6 +15,7 @@ import pytest
 
 from app.config import settings
 from app.exceptions import (
+    ExternalIdentityAdoptionNotRequestedError,
     ExternalIdentityConflictError,
     ExternalIdentityIssuerMismatchError,
     MembershipRequiredError,
@@ -265,6 +266,36 @@ async def test_the_cap_evicts_the_least_recent_and_never_the_newest(services):
     assert subjects[0] not in remaining
 
 
+async def test_an_evicted_arrival_comes_back_by_arriving_again(services):
+    """Why eviction is the safe side of the capacity question.
+
+    Refusing to record at capacity would be unrecoverable — one flood and no
+    new arrival could ever be noted until a human pruned, so admission itself
+    would be denied. Eviction loses only what re-arriving restores, and this
+    asserts that it does.
+    """
+    pool, auth_service, _, _ = services
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM pending_admissions")
+    evicted = f"evicted-{uuid.uuid4().hex}"
+    object.__setattr__(settings, "keycloak_pending_admission_cap", 2)
+    try:
+        for subject in (evicted, f"later-a-{uuid.uuid4().hex[:8]}", f"later-b-{uuid.uuid4().hex[:8]}"):
+            with pytest.raises(MembershipRequiredError):
+                await auth_service._resolve_or_provision_keycloak_user(_claims(subject))
+        assert await _arrival(pool, evicted) is None
+
+        with pytest.raises(MembershipRequiredError):
+            await auth_service._resolve_or_provision_keycloak_user(_claims(evicted))
+        assert await _arrival(pool, evicted) is not None
+    finally:
+        object.__setattr__(
+            settings,
+            "keycloak_pending_admission_cap",
+            type(settings).model_fields["keycloak_pending_admission_cap"].default,
+        )
+
+
 # ── approval ─────────────────────────────────────────────────────────────────
 
 
@@ -327,14 +358,91 @@ async def test_approval_can_attach_the_arrival_to_the_account_they_already_had(s
 
 
 async def test_approval_cannot_name_a_subject_only_a_row(services):
-    """The request model is the guard: naming a row IS the act of approval."""
+    """The request model is the guard: naming a row IS the act of approval.
+
+    Asserted as an exact field set rather than as two absences, so a later
+    `issuer` or `subject` cannot appear here without this failing.
+    """
     from app.api.routes.admin_sso import ApprovePendingAdmissionRequest
 
     with pytest.raises(Exception) as rejected:
         ApprovePendingAdmissionRequest(subject="someone-elses-subject")
     assert "extra" in str(rejected.value).lower()
-    fields = set(ApprovePendingAdmissionRequest.model_fields)
-    assert "subject" not in fields and "issuer" not in fields
+    assert set(ApprovePendingAdmissionRequest.model_fields) == {
+        "existing_user_id",
+        "email",
+        "display_name",
+        "prepare_suspended",
+    }
+
+
+async def test_approval_never_picks_an_account_by_address(services):
+    """The address on an arrival is a claim out of the person's own token.
+
+    Letting it select an existing account would make approval an adoption by
+    address at the one step that exists to prevent that. The refusal names the
+    candidate, so an administrator who does mean that account can say so.
+    """
+    pool, _, admission_service, _ = services
+    subject = f"noadopt-{uuid.uuid4().hex}"
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    squatter = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, auth_provider,
+                               account_status, account_kind)
+            VALUES ($1, $2, $3, '!keycloak-sso:no-local-login!', 'keycloak', 'active', 'human')
+            """,
+            squatter,
+            f"adm-{uuid.uuid4().hex[:12]}",
+            email,
+        )
+    arrival = await _record_and_read(services, subject, email)
+
+    with pytest.raises(ExternalIdentityAdoptionNotRequestedError) as refused:
+        await admission_service.approve_pending_admission(
+            arrival["id"], actor_id="adm-actor"
+        )
+    assert refused.value.status_code == 409
+    assert refused.value.details["candidate_user_id"] == str(squatter)
+
+    # The arrival survives, and naming the account deliberately is allowed.
+    assert await _arrival(pool, subject) is not None
+    result = await admission_service.approve_pending_admission(
+        arrival["id"], actor_id="adm-actor", existing_user_id=str(squatter)
+    )
+    assert result["user"]["user_id"] == str(squatter)
+
+
+async def test_the_control_plane_path_still_adopts_an_unbound_address(services):
+    """The default is unchanged: a caller that already identified the person.
+
+    Only approval opts out. Asserting this here keeps the opt-out from being
+    quietly widened into every caller.
+    """
+    pool, _, _, account_service = services
+    email = f"adm-{uuid.uuid4().hex[:10]}@example.com"
+    existing = uuid.uuid4()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, auth_provider,
+                               account_status, account_kind)
+            VALUES ($1, $2, $3, '!keycloak-sso:no-local-login!', 'keycloak', 'active', 'human')
+            """,
+            existing,
+            f"adm-{uuid.uuid4().hex[:12]}",
+            email,
+        )
+    result = await account_service.ensure_human_external_identity(
+        issuer=_ISSUER,
+        subject=f"cp-{uuid.uuid4().hex}",
+        email=email,
+        display_name=None,
+        actor_id="adm-actor",
+    )
+    assert result["user_id"] == str(existing)
 
 
 async def test_an_arrival_under_a_foreign_issuer_is_refused_and_survives(services):

--- a/deploy/keycloak-dev/broker-chain/README.md
+++ b/deploy/keycloak-dev/broker-chain/README.md
@@ -15,6 +15,20 @@ the AKB API audience and still must be rejected. Finally, the provider is
 disabled, the AKB identity binding is rolled back, the operator removes the
 Keycloak prelink/user, and a secret-free JSON receipt is printed.
 
+It also asks a separate question about a differently shaped account. The
+prelink above is an operator's: marked verified, and linked to the upstream
+subject by hand. An account created by member invitation is neither — it is
+enabled, carries no credential and no required action, its address is
+unverified, and nothing is linked to it — so whether the invited person's first
+login through the broker lands on THAT account is a claim about Keycloak's
+first-broker-login rather than about this codebase. The phase creates the
+seeded shape, checks every property of it rather than assuming it, supplies the
+invited person's upstream credential and nothing else, and records which
+account the login landed on, what became of the address's verified flag, and
+every page demanded along the way. It stops at the first page beyond the
+credential rather than answering it, because a step the invited person cannot
+complete is a failure and not a slow success.
+
 It also measures where the authority to mint the product administrator's
 credential actually lives, against the same realm. Three facts in one phase: the
 permanent management account is refused `403` when it tries to reset that

--- a/deploy/keycloak-dev/broker-chain/README.md
+++ b/deploy/keycloak-dev/broker-chain/README.md
@@ -15,19 +15,39 @@ the AKB API audience and still must be rejected. Finally, the provider is
 disabled, the AKB identity binding is rolled back, the operator removes the
 Keycloak prelink/user, and a secret-free JSON receipt is printed.
 
-It also asks a separate question about a differently shaped account. The
-prelink above is an operator's: marked verified, and linked to the upstream
-subject by hand. An account created by member invitation is neither — it is
-enabled, carries no credential and no required action, its address is
-unverified, and nothing is linked to it — so whether the invited person's first
-login through the broker lands on THAT account is a claim about Keycloak's
-first-broker-login rather than about this codebase. The phase creates the
-seeded shape, checks every property of it rather than assuming it, supplies the
-invited person's upstream credential and nothing else, and records which
-account the login landed on, what became of the address's verified flag, and
-every page demanded along the way. It stops at the first page beyond the
-credential rather than answering it, because a step the invited person cannot
-complete is a failure and not a slow success.
+Two further phases are about the people nobody linked by hand, which is
+everyone a workspace admits after it owns its identity provider.
+
+The first asserts where an account seeded ahead of arrival stops its owner.
+Member invitation used to create the realm account before the person arrived,
+deliberately with no credential — a member holding a realm-native password
+keeps it after their organisation revokes the upstream account meant to govern
+them — and left the address unverified on the stated ground that the first
+accepted login would set the flag from the upstream's signed proof. That was a
+claim about Keycloak, so the phase seeds exactly that shape, checks every
+property of it rather than assuming it, supplies the invited person's upstream
+credential and nothing else, and asserts the page they are stopped on:
+confirm-link, on the broker realm, with no token issued and the verified flag
+still false. The seeding ceremony is still in the codebase behind a switch,
+correct only where the platform is itself the upstream, so the next person to
+read that switch finds the measurement rather than the intention.
+
+The second drives the whole admission chain. Nothing is seeded. The invited
+person signs in through the upstream they already have; the broker mints their
+subject; `invite_only` refuses them and the arrival is recorded with that exact
+pair; an administrator approves that row; they sign in again and they are in —
+and the subject is read out of a token this runtime's own verifier accepted,
+not out of an admin read, because the pair an approval binds must be the pair a
+token actually carries. It also proves the two properties the pre-boundary
+workspace migration depends on, because that migration is the same three steps:
+approving with `existing_user_id` keeps the AKB account a person already has,
+with its token still authorizing and its old binding still beside the new one,
+and someone who signs in twice before anyone approves them produces one record
+rather than two.
+
+Together the two are each other's control: same fixture, same run, same
+credential, one page and a token when nothing was seeded and two pages and no
+token when something was.
 
 It also measures where the authority to mint the product administrator's
 credential actually lives, against the same realm. Three facts in one phase: the

--- a/deploy/keycloak-dev/broker-chain/exercise.py
+++ b/deploy/keycloak-dev/broker-chain/exercise.py
@@ -89,6 +89,7 @@ class _FormParser(HTMLParser):
                 "action": values.get("action", ""),
                 "method": (values.get("method") or "get").lower(),
                 "inputs": {},
+                "buttons": [],
             }
         elif tag == "input" and self._form is not None:
             name = values.get("name")
@@ -96,6 +97,15 @@ class _FormParser(HTMLParser):
                 inputs = self._form["inputs"]
                 assert isinstance(inputs, dict)
                 inputs[name] = values.get("value") or ""
+        elif tag == "button" and self._form is not None:
+            # The confirm-link page carries no inputs at all -- its two choices
+            # are submit buttons -- so a parser that reads only inputs sees an
+            # empty form and cannot tell that page from a redirect.
+            name = values.get("name")
+            if name:
+                buttons = self._form["buttons"]
+                assert isinstance(buttons, list)
+                buttons.append(name)
 
     def handle_endtag(self, tag: str) -> None:
         if tag == "form" and self._form is not None:
@@ -825,6 +835,399 @@ async def _assert_continuity(
         raise _fail("fixture_vault_access_continuity_failed")
 
 
+# The account member invitation seeds into a workspace's own realm, reproduced
+# exactly. `_operator_prelink` above is deliberately NOT this shape: it marks
+# the address verified and writes an explicit federated identity link, because
+# it is measuring identity continuity for someone an operator already linked by
+# hand. The invitation ceremony creates neither, and a case that keeps either
+# property proves nothing about invitation -- it proves only that a linked
+# account logs in, which was never in doubt.
+INVITED_EMAIL = "invitee@example.com"
+INVITED_UPSTREAM_USERNAME = "invitee"
+INVITED_UPSTREAM_PASSWORD = "fixture-only-invitee-password"  # pragma: allowlist secret
+
+
+def _seeded_account_payload() -> dict[str, Any]:
+    """The invited person's realm account, field for field.
+
+    Username and email are the same value because Keycloak's first-broker-login
+    detects a collision with an existing account on either key. No credential
+    and no required action, so nothing can sign into it directly. Not marked
+    verified, because verification is a statement about what THIS realm has
+    proved and this realm has proved nothing about this address.
+    """
+    return {
+        "username": INVITED_EMAIL,
+        "email": INVITED_EMAIL,
+        "enabled": True,
+        "emailVerified": False,
+    }
+
+
+def _evidence(code: str, evidence: object) -> RuntimeError:
+    """A failure that says what was on screen, not just that something failed.
+
+    The codes in this fixture are normally enough because the step that raises
+    them is the whole story. This phase is measuring an unproven claim about
+    another system's behaviour, so a bare code would report that the claim is
+    false without reporting what Keycloak actually did instead.
+    """
+    return RuntimeError(f"{code} {json.dumps(evidence, sort_keys=True)}")
+
+
+def _page_shape(response: httpx.Response) -> dict[str, object]:
+    """Name the page a browser is being shown, in fields rather than prose.
+
+    The rendered text is theme markup and inline script; the form fields are
+    the meaning. A username/password pair on the upstream host is the invited
+    person's own credential. The same pair on the broker host is Keycloak
+    demanding that they re-authenticate as the account being linked to -- which
+    for a seeded account means proving a credential that was never created. A
+    `submitAction` button is Keycloak asking which account this login belongs
+    to.
+
+    Nothing recorded here includes the action URL: it carries a single-use
+    session code, and the receipt is secret-free.
+    """
+    parser = _FormParser()
+    parser.feed(response.text)
+    split = urlsplit(str(response.url))
+    fields: set[str] = set()
+    buttons: set[str] = set()
+    for form in parser.forms:
+        inputs = form.get("inputs")
+        if isinstance(inputs, dict):
+            fields.update(key for key in inputs if isinstance(key, str))
+        names = form.get("buttons")
+        if isinstance(names, list):
+            buttons.update(name for name in names if isinstance(name, str))
+    if "submitAction" in buttons:
+        kind = "confirm-link"
+    elif {"username", "password"} <= fields:
+        kind = (
+            "upstream-credential-form"
+            if split.netloc == urlsplit(UPSTREAM).netloc
+            else "existing-account-reauthentication"
+        )
+    elif {"password-new", "password-confirm"} & fields:
+        kind = "forced-credential-change"
+    elif {"firstName", "lastName", "email"} & fields:
+        kind = "review-profile"
+    else:
+        kind = "other"
+    return {
+        "kind": kind,
+        "host": split.netloc,
+        "path": split.path,
+        "fields": sorted(fields),
+        "buttons": sorted(buttons),
+    }
+
+
+async def _invited_broker_login() -> dict[str, object]:
+    """Drive the invited person's login, supplying only what they have.
+
+    An invited person holds exactly one thing: their credential in the
+    workspace's upstream directory. So this supplies exactly that, exactly
+    once, and stops at the next page that asks for anything else -- because
+    "the first accepted login sets the flag" is a claim that there is no next
+    page. Whatever it stops at is the evidence.
+    """
+    verifier, challenge = _pkce()
+    redirect_uri = "https://client.localhost/callback"
+    params = {
+        "client_id": "fixture-browser",
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "openid profile email",
+        "state": secrets.token_urlsafe(24),
+        "nonce": secrets.token_urlsafe(24),
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "kc_idp_hint": "workforce",
+    }
+    pages: list[dict[str, object]] = []
+    code: str | None = None
+    supplied_credential = False
+    async with httpx.AsyncClient(
+        verify=False,
+        follow_redirects=False,
+        timeout=httpx.Timeout(20.0, connect=10.0),
+    ) as client:
+        response = await client.get(
+            f"{BROKER_ISSUER}/protocol/openid-connect/auth",
+            params=params,
+        )
+        for _ in range(30):
+            if response.status_code in {301, 302, 303, 307, 308}:
+                location = response.headers.get("location")
+                if not location:
+                    raise _fail("fixture_invited_authorization_redirect_invalid")
+                target = urljoin(str(response.url), location)
+                if target.startswith(redirect_uri):
+                    query = parse_qs(urlsplit(target).query)
+                    if "error" in query:
+                        return {"pages": pages, "code": None, "rejected": True}
+                    values = query.get("code", [])
+                    if len(values) != 1 or not values[0]:
+                        raise _fail("fixture_invited_authorization_code_missing")
+                    code = values[0]
+                    break
+                response = await client.get(target)
+                continue
+            if response.status_code != 200:
+                raise _fail("fixture_invited_authorization_flow_failed")
+            page = _page_shape(response)
+            pages.append(page)
+            if page["kind"] != "upstream-credential-form" or supplied_credential:
+                break
+            action, data = _login_form(response)
+            data.update(
+                {
+                    "username": INVITED_UPSTREAM_USERNAME,
+                    "password": INVITED_UPSTREAM_PASSWORD,
+                    "login": data.get("login") or "Sign In",
+                }
+            )
+            response = await client.post(action, data=data)
+            supplied_credential = True
+        if code is None:
+            return {"pages": pages, "code": None}
+        token_response = await client.post(
+            f"{BROKER_ISSUER}/protocol/openid-connect/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "fixture-browser",
+                "redirect_uri": redirect_uri,
+                "code": code,
+                "code_verifier": verifier,
+            },
+        )
+    if token_response.status_code != 200:
+        raise _fail("fixture_invited_authorization_code_exchange_failed")
+    tokens = _require_object(token_response.json(), "fixture_invited_token_invalid")
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str):
+        raise _fail("fixture_invited_token_invalid")
+    return {"pages": pages, "code": code, "access_token": access_token}
+
+
+async def _invited_accounts(
+    client: httpx.AsyncClient,
+    *,
+    admin_token: str,
+) -> list[dict[str, Any]]:
+    """Every broker-realm account holding the invited address, with its shape.
+
+    Read by address rather than by id on purpose. The id is what the invitation
+    binds AKB to, so asking Keycloak "which accounts answer to this address"
+    is the only question that can reveal a second one.
+    """
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await client.get(
+        f"{BROKER}/admin/realms/akb/users",
+        params={"email": INVITED_EMAIL, "exact": "true"},
+        headers=headers,
+    )
+    if response.status_code != 200:
+        raise _fail("fixture_invited_account_read_failed")
+    accounts: list[dict[str, Any]] = []
+    for user in _require_objects(response.json(), "fixture_invited_account_read_failed"):
+        subject = user.get("id")
+        if not isinstance(subject, str):
+            raise _fail("fixture_invited_account_read_failed")
+        credentials = await client.get(
+            f"{BROKER}/admin/realms/akb/users/{subject}/credentials",
+            headers=headers,
+        )
+        links = await client.get(
+            f"{BROKER}/admin/realms/akb/users/{subject}/federated-identity",
+            headers=headers,
+        )
+        if credentials.status_code != 200 or links.status_code != 200:
+            raise _fail("fixture_invited_account_read_failed")
+        accounts.append(
+            {
+                "subject": subject,
+                "email_verified": user.get("emailVerified"),
+                "enabled": user.get("enabled"),
+                "required_actions": user.get("requiredActions") or [],
+                "federation_link": user.get("federationLink"),
+                "credential_types": sorted(
+                    str(item.get("type"))
+                    for item in _require_objects(
+                        credentials.json(),
+                        "fixture_invited_account_read_failed",
+                    )
+                ),
+                "federated_identities": sorted(
+                    str(item.get("identityProvider"))
+                    for item in _require_objects(
+                        links.json(),
+                        "fixture_invited_account_read_failed",
+                    )
+                ),
+            }
+        )
+    return accounts
+
+
+async def _prove_invitation_seeded_account_links() -> dict[str, object]:
+    """Does the account invitation seeds actually receive the invited person?
+
+    Everything else about member invitation is settled by construction: the
+    ceremony creates the account, reads its id back, and binds AKB to that id.
+    What is not settled is the step after it, which belongs to Keycloak. The
+    invitation deliberately leaves the seeded account with no credential, no
+    required action, an unverified address, and no federated identity link, on
+    the stated ground that the first accepted login through the broker will
+    find it and set the flag from the upstream's signed proof.
+
+    That is a claim about first-broker-login. This phase supplies the invited
+    person's upstream credential and nothing else, then asks Keycloak three
+    questions whose answers are independent:
+
+      * which account did the login land on -- the seeded one, or a second one
+        Keycloak created, which would leave the AKB binding naming a row nobody
+        ever signs in as;
+      * what became of `emailVerified` on it;
+      * what, if anything, was demanded beyond that credential.
+
+    An account that eventually links after a step the invited person cannot
+    complete is a failure, not a slow success, so the driver stops at the first
+    such step rather than answering it.
+    """
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        upstream_admin = await _admin_token(client, UPSTREAM)
+        created_upstream = await client.post(
+            f"{UPSTREAM}/admin/realms/workforce/users",
+            headers={"Authorization": f"Bearer {upstream_admin}"},
+            json={
+                "username": INVITED_UPSTREAM_USERNAME,
+                "email": INVITED_EMAIL,
+                "emailVerified": True,
+                "enabled": True,
+                "firstName": "Invited",
+                "lastName": "Person",
+                "credentials": [
+                    {
+                        "type": "password",
+                        "value": INVITED_UPSTREAM_PASSWORD,
+                        "temporary": False,
+                    }
+                ],
+            },
+        )
+        if created_upstream.status_code != 201:
+            raise _fail("fixture_invited_upstream_create_failed")
+        upstream_subject = urlsplit(
+            created_upstream.headers.get("location") or ""
+        ).path.rsplit("/", 1)[-1]
+        if not upstream_subject:
+            raise _fail("fixture_invited_upstream_location_invalid")
+
+        broker_admin = await _admin_token(client, BROKER)
+        seeded = await client.post(
+            f"{BROKER}/admin/realms/akb/users",
+            headers={"Authorization": f"Bearer {broker_admin}"},
+            json=_seeded_account_payload(),
+        )
+        if seeded.status_code != 201:
+            raise _fail("fixture_invited_seed_failed")
+        seeded_subject = urlsplit(seeded.headers.get("location") or "").path.rsplit(
+            "/", 1
+        )[-1]
+        if not seeded_subject:
+            raise _fail("fixture_invited_seed_location_invalid")
+
+        # The shape is the precondition, and it is checked rather than assumed.
+        # Every one of these properties is a way for a later pass to be true
+        # for a reason that has nothing to do with invitation: a credential
+        # would let the person answer a re-authentication demand, and a
+        # federated identity link would skip first-broker-login altogether.
+        before = await _invited_accounts(client, admin_token=broker_admin)
+        if [item["subject"] for item in before] != [seeded_subject]:
+            raise _evidence("fixture_seeded_account_not_exact", before)
+        seeded_shape = before[0]
+        if seeded_shape["enabled"] is not True:
+            raise _evidence("fixture_seeded_account_not_enabled", seeded_shape)
+        if seeded_shape["email_verified"] is not False:
+            raise _evidence("fixture_seeded_account_email_verified", seeded_shape)
+        if seeded_shape["credential_types"]:
+            raise _evidence("fixture_seeded_account_carries_credential", seeded_shape)
+        if seeded_shape["required_actions"]:
+            raise _evidence("fixture_seeded_account_has_required_action", seeded_shape)
+        if seeded_shape["federated_identities"] or seeded_shape["federation_link"]:
+            raise _evidence("fixture_seeded_account_is_prelinked", seeded_shape)
+
+    login = await _invited_broker_login()
+    pages = login["pages"]
+    assert isinstance(pages, list)
+    demanded = [page for page in pages if page["kind"] != "upstream-credential-form"]
+    if demanded or len(pages) != 1:
+        raise _evidence(
+            "fixture_invited_login_needs_more_than_the_upstream_credential",
+            pages,
+        )
+    access_token = login.get("access_token")
+    if not isinstance(access_token, str):
+        raise _evidence("fixture_invited_login_produced_no_token", pages)
+
+    # The subject is read out of a token this runtime's own verifier accepted,
+    # not out of an admin read, because the binding written at invitation is
+    # matched against exactly this claim.
+    principal = await verify_keycloak_access_v1(access_token, "api")
+    if principal is None:
+        raise _fail("fixture_invited_token_verification_failed")
+    if principal.claims.get("identity_provider") != "workforce":
+        raise _fail("fixture_invited_token_provider_not_signed")
+    if principal.subject != seeded_subject:
+        raise _evidence(
+            "fixture_invited_login_landed_on_a_second_account",
+            {"seeded": seeded_subject, "signed_in_as": principal.subject},
+        )
+
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        broker_admin = await _admin_token(client, BROKER)
+        after = await _invited_accounts(client, admin_token=broker_admin)
+        if [item["subject"] for item in after] != [seeded_subject]:
+            raise _evidence("fixture_invited_login_created_a_second_account", after)
+        linked_shape = after[0]
+        if linked_shape["federated_identities"] != ["workforce"]:
+            raise _evidence("fixture_invited_login_left_the_account_unlinked", linked_shape)
+        if linked_shape["email_verified"] is not True:
+            raise _evidence(
+                "fixture_invited_login_left_the_address_unproven",
+                linked_shape,
+            )
+        if linked_shape["credential_types"]:
+            raise _evidence("fixture_invited_login_installed_a_credential", linked_shape)
+
+        headers = {"Authorization": f"Bearer {broker_admin}"}
+        removed = await client.delete(
+            f"{BROKER}/admin/realms/akb/users/{seeded_subject}",
+            headers=headers,
+        )
+        if removed.status_code != 204:
+            raise _fail("fixture_invited_seed_remove_failed")
+        upstream_removed = await client.delete(
+            f"{UPSTREAM}/admin/realms/workforce/users/{upstream_subject}",
+            headers={"Authorization": f"Bearer {await _admin_token(client, UPSTREAM)}"},
+        )
+        if upstream_removed.status_code != 204:
+            raise _fail("fixture_invited_upstream_remove_failed")
+        if await _invited_accounts(client, admin_token=broker_admin):
+            raise _fail("fixture_invited_cleanup_not_observed")
+
+    return {
+        "seeded_account": "no-credential-no-required-action-unverified-unlinked",
+        "pages_beyond_the_upstream_credential": 0,
+        "signed_in_as": "the-seeded-account",
+        "email_verified_after_first_login": True,
+        "cleanup": "seed-and-upstream-removed",
+    }
+
+
 async def main() -> None:
     control = KeycloakProviderControl(
         KeycloakAdminConfig(
@@ -956,6 +1359,11 @@ async def main() -> None:
         expect_broker_binding=True,
     )
 
+    # Everything above measures someone an operator linked by hand. This
+    # measures someone an invitation seeded and nobody linked, which is the
+    # only shape member invitation actually produces.
+    invitation = await _prove_invitation_seeded_account_links()
+
     upstream_tokens = await _authorization_code_tokens(
         issuer=UPSTREAM_ISSUER,
         client_id="upstream-probe",
@@ -1021,7 +1429,7 @@ async def main() -> None:
     print(
         json.dumps(
             {
-                "schema_version": 3,
+                "schema_version": 4,
                 "provider_type": enabled.provider_type,
                 "alias": enabled.alias,
                 "configure_state": configured.state,
@@ -1036,6 +1444,7 @@ async def main() -> None:
                 "upstream_token_rejected": True,
                 "rollback": "binding-and-operator-cleanup-verified",
                 "authority_boundary": authority_boundary,
+                "invitation_seeded_account": invitation,
                 "client_secret_exposed": False,
             },
             sort_keys=True,

--- a/deploy/keycloak-dev/broker-chain/exercise.py
+++ b/deploy/keycloak-dev/broker-chain/exercise.py
@@ -18,9 +18,15 @@ import httpx
 import jwt
 
 from app.db import postgres
+from app.exceptions import AKBError
 from app.services import auth_service, keycloak_oidc
 from app.services.access_service import check_vault_access
 from app.services.auth_verifier_profiles import verify_keycloak_access_v1
+from app.services.admission_service import (
+    approve_pending_admission,
+    list_pending_admissions,
+)
+from app.services.role_sync import RoleSync, set_role_sync
 from app.sso.identity_migration import (
     apply_identity_migration,
     inspect_identity_migration,
@@ -690,6 +696,10 @@ async def _operator_remove_prelink(broker_subject: str) -> None:
 async def _seed_akb(upstream_subject: str) -> dict[str, object]:
     await postgres.init_db()
     pool = await postgres.get_pool()
+    # Approving an arrival creates an AKB account, and account creation calls
+    # the process-global RoleSync the way it does in a deployment. Standing it
+    # up here rather than stubbing it keeps the approval path the real one.
+    set_role_sync(RoleSync(pool))
     user_id = uuid.uuid4()
     other_user_id = uuid.uuid4()
     token_id = uuid.uuid4()
@@ -842,23 +852,37 @@ async def _assert_continuity(
 # hand. The invitation ceremony creates neither, and a case that keeps either
 # property proves nothing about invitation -- it proves only that a linked
 # account logs in, which was never in doubt.
+# One address per person, because the broker realm's collision detection is on
+# the address and two people sharing one would make each half's outcome depend
+# on the other's leftovers.
+SEEDED_EMAIL = "seeded-probe@example.com"
+SEEDED_UPSTREAM_USERNAME = "seeded-probe"
+SEEDED_UPSTREAM_PASSWORD = "fixture-only-seeded-probe-password"  # pragma: allowlist secret
 INVITED_EMAIL = "invitee@example.com"
 INVITED_UPSTREAM_USERNAME = "invitee"
 INVITED_UPSTREAM_PASSWORD = "fixture-only-invitee-password"  # pragma: allowlist secret
+MIGRANT_EMAIL = "migrant@example.com"
+MIGRANT_UPSTREAM_USERNAME = "migrant"
+MIGRANT_UPSTREAM_PASSWORD = "fixture-only-migrant-password"  # pragma: allowlist secret
 
 
 def _seeded_account_payload() -> dict[str, Any]:
-    """The invited person's realm account, field for field.
+    """The shape member invitation used to create, field for field.
 
     Username and email are the same value because Keycloak's first-broker-login
     detects a collision with an existing account on either key. No credential
     and no required action, so nothing can sign into it directly. Not marked
     verified, because verification is a statement about what THIS realm has
     proved and this realm has proved nothing about this address.
+
+    Kept, rather than deleted with the ceremony, because the dead end below is
+    the reason the ceremony is switched off. A comment saying "seeding does not
+    work" is not evidence; a phase that seeds and shows where the person stops
+    is.
     """
     return {
-        "username": INVITED_EMAIL,
-        "email": INVITED_EMAIL,
+        "username": SEEDED_EMAIL,
+        "email": SEEDED_EMAIL,
         "enabled": True,
         "emailVerified": False,
     }
@@ -868,9 +892,9 @@ def _evidence(code: str, evidence: object) -> RuntimeError:
     """A failure that says what was on screen, not just that something failed.
 
     The codes in this fixture are normally enough because the step that raises
-    them is the whole story. This phase is measuring an unproven claim about
-    another system's behaviour, so a bare code would report that the claim is
-    false without reporting what Keycloak actually did instead.
+    them is the whole story. These phases measure another system's behaviour,
+    so a bare code would report that an expectation was missed without
+    reporting what Keycloak actually did instead.
     """
     return RuntimeError(f"{code} {json.dumps(evidence, sort_keys=True)}")
 
@@ -879,12 +903,11 @@ def _page_shape(response: httpx.Response) -> dict[str, object]:
     """Name the page a browser is being shown, in fields rather than prose.
 
     The rendered text is theme markup and inline script; the form fields are
-    the meaning. A username/password pair on the upstream host is the invited
-    person's own credential. The same pair on the broker host is Keycloak
-    demanding that they re-authenticate as the account being linked to -- which
-    for a seeded account means proving a credential that was never created. A
-    `submitAction` button is Keycloak asking which account this login belongs
-    to.
+    the meaning. A username/password pair on the upstream host is the person's
+    own credential. The same pair on the broker host is Keycloak demanding that
+    they re-authenticate as the account being linked to -- which for a seeded
+    account means proving a credential that was never created. A `submitAction`
+    button is Keycloak asking which account this login belongs to.
 
     Nothing recorded here includes the action URL: it carries a single-use
     session code, and the receipt is secret-free.
@@ -924,14 +947,14 @@ def _page_shape(response: httpx.Response) -> dict[str, object]:
     }
 
 
-async def _invited_broker_login() -> dict[str, object]:
-    """Drive the invited person's login, supplying only what they have.
+async def _arrive_through_the_broker(username: str, password: str) -> dict[str, object]:
+    """Drive one person's sign-in, supplying only what that person holds.
 
     An invited person holds exactly one thing: their credential in the
     workspace's upstream directory. So this supplies exactly that, exactly
-    once, and stops at the next page that asks for anything else -- because
-    "the first accepted login sets the flag" is a claim that there is no next
-    page. Whatever it stops at is the evidence.
+    once, and stops at the next page that asks for anything else -- because a
+    step they cannot complete is a failure and not a slow success, and which
+    page it is IS the finding.
     """
     verifier, challenge = _pkce()
     redirect_uri = "https://client.localhost/callback"
@@ -962,21 +985,21 @@ async def _invited_broker_login() -> dict[str, object]:
             if response.status_code in {301, 302, 303, 307, 308}:
                 location = response.headers.get("location")
                 if not location:
-                    raise _fail("fixture_invited_authorization_redirect_invalid")
+                    raise _fail("fixture_arrival_redirect_invalid")
                 target = urljoin(str(response.url), location)
                 if target.startswith(redirect_uri):
                     query = parse_qs(urlsplit(target).query)
                     if "error" in query:
-                        return {"pages": pages, "code": None, "rejected": True}
+                        return {"pages": pages, "access_token": None, "rejected": True}
                     values = query.get("code", [])
                     if len(values) != 1 or not values[0]:
-                        raise _fail("fixture_invited_authorization_code_missing")
+                        raise _fail("fixture_arrival_code_missing")
                     code = values[0]
                     break
                 response = await client.get(target)
                 continue
             if response.status_code != 200:
-                raise _fail("fixture_invited_authorization_flow_failed")
+                raise _fail("fixture_arrival_flow_failed")
             page = _page_shape(response)
             pages.append(page)
             if page["kind"] != "upstream-credential-form" or supplied_credential:
@@ -984,15 +1007,15 @@ async def _invited_broker_login() -> dict[str, object]:
             action, data = _login_form(response)
             data.update(
                 {
-                    "username": INVITED_UPSTREAM_USERNAME,
-                    "password": INVITED_UPSTREAM_PASSWORD,
+                    "username": username,
+                    "password": password,
                     "login": data.get("login") or "Sign In",
                 }
             )
             response = await client.post(action, data=data)
             supplied_credential = True
         if code is None:
-            return {"pages": pages, "code": None}
+            return {"pages": pages, "access_token": None}
         token_response = await client.post(
             f"{BROKER_ISSUER}/protocol/openid-connect/token",
             data={
@@ -1004,38 +1027,39 @@ async def _invited_broker_login() -> dict[str, object]:
             },
         )
     if token_response.status_code != 200:
-        raise _fail("fixture_invited_authorization_code_exchange_failed")
-    tokens = _require_object(token_response.json(), "fixture_invited_token_invalid")
+        raise _fail("fixture_arrival_code_exchange_failed")
+    tokens = _require_object(token_response.json(), "fixture_arrival_token_invalid")
     access_token = tokens.get("access_token")
     if not isinstance(access_token, str):
-        raise _fail("fixture_invited_token_invalid")
-    return {"pages": pages, "code": code, "access_token": access_token}
+        raise _fail("fixture_arrival_token_invalid")
+    return {"pages": pages, "access_token": access_token}
 
 
-async def _invited_accounts(
+async def _realm_accounts(
     client: httpx.AsyncClient,
     *,
     admin_token: str,
+    email: str,
 ) -> list[dict[str, Any]]:
-    """Every broker-realm account holding the invited address, with its shape.
+    """Every broker-realm account holding one address, with its shape.
 
-    Read by address rather than by id on purpose. The id is what the invitation
-    binds AKB to, so asking Keycloak "which accounts answer to this address"
-    is the only question that can reveal a second one.
+    Read by address rather than by id on purpose. The id is what a binding
+    names, so asking Keycloak "which accounts answer to this address" is the
+    only question that can reveal a second one.
     """
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await client.get(
         f"{BROKER}/admin/realms/akb/users",
-        params={"email": INVITED_EMAIL, "exact": "true"},
+        params={"email": email, "exact": "true"},
         headers=headers,
     )
     if response.status_code != 200:
-        raise _fail("fixture_invited_account_read_failed")
+        raise _fail("fixture_realm_account_read_failed")
     accounts: list[dict[str, Any]] = []
-    for user in _require_objects(response.json(), "fixture_invited_account_read_failed"):
+    for user in _require_objects(response.json(), "fixture_realm_account_read_failed"):
         subject = user.get("id")
         if not isinstance(subject, str):
-            raise _fail("fixture_invited_account_read_failed")
+            raise _fail("fixture_realm_account_read_failed")
         credentials = await client.get(
             f"{BROKER}/admin/realms/akb/users/{subject}/credentials",
             headers=headers,
@@ -1045,7 +1069,7 @@ async def _invited_accounts(
             headers=headers,
         )
         if credentials.status_code != 200 or links.status_code != 200:
-            raise _fail("fixture_invited_account_read_failed")
+            raise _fail("fixture_realm_account_read_failed")
         accounts.append(
             {
                 "subject": subject,
@@ -1057,14 +1081,14 @@ async def _invited_accounts(
                     str(item.get("type"))
                     for item in _require_objects(
                         credentials.json(),
-                        "fixture_invited_account_read_failed",
+                        "fixture_realm_account_read_failed",
                     )
                 ),
                 "federated_identities": sorted(
                     str(item.get("identityProvider"))
                     for item in _require_objects(
                         links.json(),
-                        "fixture_invited_account_read_failed",
+                        "fixture_realm_account_read_failed",
                     )
                 ),
             }
@@ -1072,60 +1096,90 @@ async def _invited_accounts(
     return accounts
 
 
-async def _prove_invitation_seeded_account_links() -> dict[str, object]:
-    """Does the account invitation seeds actually receive the invited person?
+async def _create_upstream_person(
+    client: httpx.AsyncClient,
+    *,
+    username: str,
+    email: str,
+    password: str,
+) -> str:
+    created = await client.post(
+        f"{UPSTREAM}/admin/realms/workforce/users",
+        headers={"Authorization": f"Bearer {await _admin_token(client, UPSTREAM)}"},
+        json={
+            "username": username,
+            "email": email,
+            "emailVerified": True,
+            "enabled": True,
+            "firstName": "Fixture",
+            "lastName": "Person",
+            "credentials": [
+                {"type": "password", "value": password, "temporary": False}
+            ],
+        },
+    )
+    if created.status_code != 201:
+        raise _fail("fixture_upstream_create_failed")
+    subject = urlsplit(created.headers.get("location") or "").path.rsplit("/", 1)[-1]
+    if not subject:
+        raise _fail("fixture_upstream_location_invalid")
+    return subject
 
-    Everything else about member invitation is settled by construction: the
-    ceremony creates the account, reads its id back, and binds AKB to that id.
-    What is not settled is the step after it, which belongs to Keycloak. The
-    invitation deliberately leaves the seeded account with no credential, no
-    required action, an unverified address, and no federated identity link, on
-    the stated ground that the first accepted login through the broker will
-    find it and set the flag from the upstream's signed proof.
 
-    That is a claim about first-broker-login. This phase supplies the invited
-    person's upstream credential and nothing else, then asks Keycloak three
-    questions whose answers are independent:
+async def _remove_person(
+    client: httpx.AsyncClient,
+    *,
+    upstream_subject: str,
+    broker_subjects: list[str],
+) -> None:
+    broker_admin = await _admin_token(client, BROKER)
+    for subject in broker_subjects:
+        removed = await client.delete(
+            f"{BROKER}/admin/realms/akb/users/{subject}",
+            headers={"Authorization": f"Bearer {broker_admin}"},
+        )
+        if removed.status_code != 204:
+            raise _fail("fixture_broker_account_remove_failed")
+    removed = await client.delete(
+        f"{UPSTREAM}/admin/realms/workforce/users/{upstream_subject}",
+        headers={"Authorization": f"Bearer {await _admin_token(client, UPSTREAM)}"},
+    )
+    if removed.status_code != 204:
+        raise _fail("fixture_upstream_remove_failed")
 
-      * which account did the login land on -- the seeded one, or a second one
-        Keycloak created, which would leave the AKB binding naming a row nobody
-        ever signs in as;
-      * what became of `emailVerified` on it;
-      * what, if anything, was demanded beyond that credential.
 
-    An account that eventually links after a step the invited person cannot
-    complete is a failure, not a slow success, so the driver stops at the first
-    such step rather than answering it.
+async def _prove_seeding_is_a_dead_end() -> dict[str, object]:
+    """Assert where an account seeded ahead of arrival stops its owner.
+
+    Member invitation used to create the account in the workspace realm before
+    the person arrived, deliberately giving it no credential -- because a member
+    holding a realm-native password keeps it after their organisation revokes
+    the upstream account that was supposed to govern them. The stated ground for
+    leaving the address unverified was that the first accepted login through the
+    broker would set the flag from the upstream's signed proof.
+
+    That was a claim about Keycloak, and this is the measurement. It seeds the
+    exact shape, checks every property of it rather than assuming it, supplies
+    the invited person's upstream credential and nothing else, and asserts the
+    page they are stopped on. Keycloak's stock first-broker-login finds the
+    seeded account by address and stops on confirm-link -- "User with email ...
+    already exists" -- and neither branch out of it reaches that account:
+    "Add to existing account" asks for a credential this account has never had,
+    and this deployment has no SMTP for the verify-by-email alternative, while
+    changing the address completes the login onto a SECOND account.
+
+    This is asserted rather than left as a comment because the seeding ceremony
+    is still in the codebase behind a switch, correct only for the case where
+    the platform is itself the upstream. The next person to read that switch
+    should find the measurement, not the intention.
     """
     async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
-        upstream_admin = await _admin_token(client, UPSTREAM)
-        created_upstream = await client.post(
-            f"{UPSTREAM}/admin/realms/workforce/users",
-            headers={"Authorization": f"Bearer {upstream_admin}"},
-            json={
-                "username": INVITED_UPSTREAM_USERNAME,
-                "email": INVITED_EMAIL,
-                "emailVerified": True,
-                "enabled": True,
-                "firstName": "Invited",
-                "lastName": "Person",
-                "credentials": [
-                    {
-                        "type": "password",
-                        "value": INVITED_UPSTREAM_PASSWORD,
-                        "temporary": False,
-                    }
-                ],
-            },
+        upstream_subject = await _create_upstream_person(
+            client,
+            username=SEEDED_UPSTREAM_USERNAME,
+            email=SEEDED_EMAIL,
+            password=SEEDED_UPSTREAM_PASSWORD,
         )
-        if created_upstream.status_code != 201:
-            raise _fail("fixture_invited_upstream_create_failed")
-        upstream_subject = urlsplit(
-            created_upstream.headers.get("location") or ""
-        ).path.rsplit("/", 1)[-1]
-        if not upstream_subject:
-            raise _fail("fixture_invited_upstream_location_invalid")
-
         broker_admin = await _admin_token(client, BROKER)
         seeded = await client.post(
             f"{BROKER}/admin/realms/akb/users",
@@ -1133,98 +1187,360 @@ async def _prove_invitation_seeded_account_links() -> dict[str, object]:
             json=_seeded_account_payload(),
         )
         if seeded.status_code != 201:
-            raise _fail("fixture_invited_seed_failed")
+            raise _fail("fixture_seed_failed")
         seeded_subject = urlsplit(seeded.headers.get("location") or "").path.rsplit(
             "/", 1
         )[-1]
         if not seeded_subject:
-            raise _fail("fixture_invited_seed_location_invalid")
+            raise _fail("fixture_seed_location_invalid")
 
         # The shape is the precondition, and it is checked rather than assumed.
-        # Every one of these properties is a way for a later pass to be true
-        # for a reason that has nothing to do with invitation: a credential
-        # would let the person answer a re-authentication demand, and a
+        # Each property is a way for the dead end to be reached for some other
+        # reason: a credential would let the person answer the demand, and a
         # federated identity link would skip first-broker-login altogether.
-        before = await _invited_accounts(client, admin_token=broker_admin)
+        before = await _realm_accounts(client, admin_token=broker_admin, email=SEEDED_EMAIL)
         if [item["subject"] for item in before] != [seeded_subject]:
             raise _evidence("fixture_seeded_account_not_exact", before)
-        seeded_shape = before[0]
-        if seeded_shape["enabled"] is not True:
-            raise _evidence("fixture_seeded_account_not_enabled", seeded_shape)
-        if seeded_shape["email_verified"] is not False:
-            raise _evidence("fixture_seeded_account_email_verified", seeded_shape)
-        if seeded_shape["credential_types"]:
-            raise _evidence("fixture_seeded_account_carries_credential", seeded_shape)
-        if seeded_shape["required_actions"]:
-            raise _evidence("fixture_seeded_account_has_required_action", seeded_shape)
-        if seeded_shape["federated_identities"] or seeded_shape["federation_link"]:
-            raise _evidence("fixture_seeded_account_is_prelinked", seeded_shape)
+        shape = before[0]
+        if shape["enabled"] is not True:
+            raise _evidence("fixture_seeded_account_not_enabled", shape)
+        if shape["email_verified"] is not False:
+            raise _evidence("fixture_seeded_account_email_verified", shape)
+        if shape["credential_types"]:
+            raise _evidence("fixture_seeded_account_carries_credential", shape)
+        if shape["required_actions"]:
+            raise _evidence("fixture_seeded_account_has_required_action", shape)
+        if shape["federated_identities"] or shape["federation_link"]:
+            raise _evidence("fixture_seeded_account_is_prelinked", shape)
 
-    login = await _invited_broker_login()
-    pages = login["pages"]
+    arrival = await _arrive_through_the_broker(
+        SEEDED_UPSTREAM_USERNAME, SEEDED_UPSTREAM_PASSWORD
+    )
+    pages = arrival["pages"]
     assert isinstance(pages, list)
-    demanded = [page for page in pages if page["kind"] != "upstream-credential-form"]
-    if demanded or len(pages) != 1:
-        raise _evidence(
-            "fixture_invited_login_needs_more_than_the_upstream_credential",
-            pages,
-        )
-    access_token = login.get("access_token")
-    if not isinstance(access_token, str):
-        raise _evidence("fixture_invited_login_produced_no_token", pages)
-
-    # The subject is read out of a token this runtime's own verifier accepted,
-    # not out of an admin read, because the binding written at invitation is
-    # matched against exactly this claim.
-    principal = await verify_keycloak_access_v1(access_token, "api")
-    if principal is None:
-        raise _fail("fixture_invited_token_verification_failed")
-    if principal.claims.get("identity_provider") != "workforce":
-        raise _fail("fixture_invited_token_provider_not_signed")
-    if principal.subject != seeded_subject:
-        raise _evidence(
-            "fixture_invited_login_landed_on_a_second_account",
-            {"seeded": seeded_subject, "signed_in_as": principal.subject},
-        )
+    if arrival["access_token"] is not None:
+        raise _evidence("fixture_seeded_login_was_not_stopped", pages)
+    if len(pages) != 2:
+        raise _evidence("fixture_seeded_login_stopped_somewhere_else", pages)
+    stop = pages[1]
+    if (
+        stop["kind"] != "confirm-link"
+        or stop["host"] != urlsplit(BROKER).netloc
+        or stop["path"] != "/realms/akb/login-actions/first-broker-login"
+    ):
+        raise _evidence("fixture_seeded_login_stopped_somewhere_else", pages)
 
     async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
         broker_admin = await _admin_token(client, BROKER)
-        after = await _invited_accounts(client, admin_token=broker_admin)
+        after = await _realm_accounts(client, admin_token=broker_admin, email=SEEDED_EMAIL)
+        # Stopped means stopped: the flag the claim was about is still false,
+        # nothing was linked, and no second account was created on the way.
         if [item["subject"] for item in after] != [seeded_subject]:
-            raise _evidence("fixture_invited_login_created_a_second_account", after)
-        linked_shape = after[0]
-        if linked_shape["federated_identities"] != ["workforce"]:
-            raise _evidence("fixture_invited_login_left_the_account_unlinked", linked_shape)
-        if linked_shape["email_verified"] is not True:
-            raise _evidence(
-                "fixture_invited_login_left_the_address_unproven",
-                linked_shape,
-            )
-        if linked_shape["credential_types"]:
-            raise _evidence("fixture_invited_login_installed_a_credential", linked_shape)
-
-        headers = {"Authorization": f"Bearer {broker_admin}"}
-        removed = await client.delete(
-            f"{BROKER}/admin/realms/akb/users/{seeded_subject}",
-            headers=headers,
+            raise _evidence("fixture_seeded_login_changed_the_realm", after)
+        if after[0]["email_verified"] is not False or after[0]["federated_identities"]:
+            raise _evidence("fixture_seeded_login_changed_the_account", after[0])
+        await _remove_person(
+            client,
+            upstream_subject=upstream_subject,
+            broker_subjects=[seeded_subject],
         )
-        if removed.status_code != 204:
-            raise _fail("fixture_invited_seed_remove_failed")
-        upstream_removed = await client.delete(
-            f"{UPSTREAM}/admin/realms/workforce/users/{upstream_subject}",
-            headers={"Authorization": f"Bearer {await _admin_token(client, UPSTREAM)}"},
-        )
-        if upstream_removed.status_code != 204:
-            raise _fail("fixture_invited_upstream_remove_failed")
-        if await _invited_accounts(client, admin_token=broker_admin):
-            raise _fail("fixture_invited_cleanup_not_observed")
+        if await _realm_accounts(client, admin_token=broker_admin, email=SEEDED_EMAIL):
+            raise _fail("fixture_seeded_cleanup_not_observed")
 
     return {
         "seeded_account": "no-credential-no-required-action-unverified-unlinked",
+        "stopped_at": "confirm-link",
+        "pages_shown": [str(page["kind"]) for page in pages],
+        "reachable": False,
+        "email_verified_after": False,
+    }
+
+
+async def _recorded_arrivals() -> list[dict[str, Any]]:
+    listed = await list_pending_admissions()
+    admissions = listed.get("pending_admissions")
+    if not isinstance(admissions, list):
+        raise _fail("fixture_pending_admission_list_invalid")
+    return [_require_object(item, "fixture_pending_admission_list_invalid") for item in admissions]
+
+
+async def _admitted_arrival(username: str, password: str) -> tuple[str, str]:
+    """One arrival that AKB refuses, returning the subject and the record id.
+
+    The subject is read out of a token this runtime's own verifier accepted,
+    not out of an admin read, because the pair an approval binds must be the
+    pair a token actually carries.
+    """
+    arrival = await _arrive_through_the_broker(username, password)
+    pages = arrival["pages"]
+    assert isinstance(pages, list)
+    beyond = [page for page in pages if page["kind"] != "upstream-credential-form"]
+    if beyond or len(pages) != 1:
+        raise _evidence("fixture_arrival_needed_more_than_the_upstream_credential", pages)
+    access_token = arrival["access_token"]
+    if not isinstance(access_token, str):
+        raise _evidence("fixture_arrival_produced_no_token", pages)
+    principal = await verify_keycloak_access_v1(access_token, "api")
+    if principal is None:
+        raise _fail("fixture_arrival_token_verification_failed")
+    if principal.claims.get("identity_provider") != "workforce":
+        raise _fail("fixture_arrival_provider_not_signed")
+    if principal.issuer != BROKER_ISSUER:
+        raise _fail("fixture_arrival_issuer_not_the_broker")
+
+    # Refused: the product answers nothing, exactly as before this work.
+    if await auth_service.project_verified_principal(principal) is not None:
+        raise _fail("fixture_arrival_was_admitted_without_approval")
+    # ...and refused for the stated reason. The boundary above answers None to
+    # every rejection there is -- suspended, conflicting, provider disabled --
+    # so "refused" alone would be satisfied by an account that is broken rather
+    # than merely unadmitted, and the phase would report a chain it never ran.
+    # The resolver underneath it is the only place the code is visible from
+    # here; the fixture is not running the HTTP surface that would carry it.
+    try:
+        await auth_service._resolve_or_provision_keycloak_user(  # noqa: SLF001
+            dict(principal.claims)
+        )
+    except AKBError as refusal:
+        if getattr(refusal, "code", None) != "membership_required":
+            raise _evidence(
+                "fixture_arrival_refused_for_another_reason",
+                {"code": getattr(refusal, "code", None)},
+            ) from None
+    else:
+        raise _fail("fixture_arrival_was_admitted_without_approval")
+
+    recorded = [
+        item
+        for item in await _recorded_arrivals()
+        if item.get("subject") == principal.subject
+    ]
+    if len(recorded) != 1:
+        raise _evidence(
+            "fixture_arrival_was_not_recorded",
+            {"subject": principal.subject, "held": len(recorded)},
+        )
+    note = recorded[0]
+    if note.get("issuer") != BROKER_ISSUER:
+        raise _evidence("fixture_arrival_recorded_under_another_issuer", note)
+    admission_id = note.get("id")
+    if not isinstance(admission_id, str):
+        raise _evidence("fixture_arrival_record_has_no_id", note)
+    return principal.subject, admission_id
+
+
+async def _prove_admission_chain(state: dict[str, object]) -> dict[str, object]:
+    """The whole chain, against two real Keycloaks and this runtime's own code.
+
+    Nothing is seeded. The invited person signs in through the upstream they
+    already have; the broker mints their subject; ``invite_only`` refuses them
+    and the arrival is recorded with that exact pair; an administrator approves
+    that row; they sign in again and they are in.
+
+    It also proves the two properties the pre-boundary workspace migration
+    depends on, because that migration is the same three steps: approving with
+    ``existing_user_id`` keeps the AKB account a person already has -- with its
+    token, its owned vault and its writer grant -- and adds a binding beside the
+    one they arrived with rather than replacing it; and a person who signs in
+    twice before anyone approves them produces one record, not two.
+    """
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        invited_upstream = await _create_upstream_person(
+            client,
+            username=INVITED_UPSTREAM_USERNAME,
+            email=INVITED_EMAIL,
+            password=INVITED_UPSTREAM_PASSWORD,
+        )
+        migrant_upstream = await _create_upstream_person(
+            client,
+            username=MIGRANT_UPSTREAM_USERNAME,
+            email=MIGRANT_EMAIL,
+            password=MIGRANT_UPSTREAM_PASSWORD,
+        )
+        broker_admin = await _admin_token(client, BROKER)
+        # The precondition that separates this from the phase above: the realm
+        # holds nothing for either address. Whatever the broker finds, it will
+        # have made itself.
+        for email in (INVITED_EMAIL, MIGRANT_EMAIL):
+            if await _realm_accounts(client, admin_token=broker_admin, email=email):
+                raise _fail("fixture_admission_precondition_realm_not_empty")
+
+    if await _recorded_arrivals():
+        raise _fail("fixture_admission_precondition_records_not_empty")
+
+    # ── the invited person ────────────────────────────────────────────────
+    invited_subject, invited_admission = await _admitted_arrival(
+        INVITED_UPSTREAM_USERNAME, INVITED_UPSTREAM_PASSWORD
+    )
+
+    # A second attempt before anyone approves is the same person knocking
+    # again, not a second arrival: the table is bounded by who, not how often.
+    repeat_subject, repeat_admission = await _admitted_arrival(
+        INVITED_UPSTREAM_USERNAME, INVITED_UPSTREAM_PASSWORD
+    )
+    if (repeat_subject, repeat_admission) != (invited_subject, invited_admission):
+        raise _evidence(
+            "fixture_repeat_arrival_made_a_second_record",
+            {"first": invited_admission, "second": repeat_admission},
+        )
+
+    approved = await approve_pending_admission(
+        invited_admission,
+        actor_id="fixture-product-admin",
+    )
+    invited_user_id = _require_object(
+        approved.get("user"), "fixture_approval_readback_invalid"
+    ).get("user_id")
+    if not isinstance(invited_user_id, str):
+        raise _fail("fixture_approval_readback_invalid")
+
+    # Signing in again is the whole point. Same person, same credential, and
+    # this time the product answers with their account.
+    second = await _arrive_through_the_broker(
+        INVITED_UPSTREAM_USERNAME, INVITED_UPSTREAM_PASSWORD
+    )
+    second_token = second["access_token"]
+    if not isinstance(second_token, str):
+        raise _evidence("fixture_admitted_login_produced_no_token", second["pages"])
+    second_principal = await verify_keycloak_access_v1(second_token, "api")
+    if second_principal is None or second_principal.subject != invited_subject:
+        raise _fail("fixture_admitted_login_landed_elsewhere")
+    admitted = await auth_service.project_verified_principal(second_principal)
+    if admitted is None:
+        raise _fail("fixture_admitted_login_was_refused")
+    if admitted.user_id != invited_user_id:
+        raise _evidence(
+            "fixture_admitted_login_resolved_to_another_account",
+            {"approved": invited_user_id, "signed_in_as": admitted.user_id},
+        )
+    if any(item.get("id") == invited_admission for item in await _recorded_arrivals()):
+        raise _fail("fixture_approved_arrival_is_still_pending")
+
+    # ── the person who already has an account here ────────────────────────
+    # Exactly the migration's shape: someone whose AKB account, token and
+    # bindings predate this workspace owning an identity provider. Their own
+    # account rather than the continuity fixture's, so that what this phase
+    # writes cannot make the rollback assertions below pass or fail.
+    pool = state["pool"]
+    assert hasattr(pool, "acquire")
+    migrant_user_id = uuid.uuid4()
+    migrant_raw_pat, migrant_hash, migrant_prefix = auth_service.generate_pat()
+    async with pool.acquire() as conn:  # type: ignore[union-attr]
+        async with conn.transaction():
+            await conn.execute(
+                """
+                INSERT INTO users (
+                    id, username, email, password_hash, display_name, is_admin,
+                    auth_provider, account_status, account_kind
+                ) VALUES ($1, 'migrant', $2, $3, 'Migrant', false,
+                          'keycloak', 'active', 'human')
+                """,
+                migrant_user_id,
+                MIGRANT_EMAIL,
+                "!keycloak-sso:no-local-login!",  # pragma: allowlist secret
+            )
+            await conn.execute(
+                """
+                INSERT INTO external_identities (
+                    user_id, issuer, subject, username_snapshot, email_snapshot
+                ) VALUES ($1, $2, $3, 'migrant', $4)
+                """,
+                migrant_user_id,
+                UPSTREAM_ISSUER,
+                migrant_upstream,
+                MIGRANT_EMAIL,
+            )
+            await conn.execute(
+                """
+                INSERT INTO tokens (
+                    id, user_id, name, token_hash, token_prefix, scopes, key_class
+                ) VALUES ($1, $2, 'migrant-pat', $3, $4, ARRAY['read'], 'pat')
+                """,
+                uuid.uuid4(),
+                migrant_user_id,
+                migrant_hash,
+                migrant_prefix,
+            )
+
+    migrant_subject, migrant_admission = await _admitted_arrival(
+        MIGRANT_UPSTREAM_USERNAME, MIGRANT_UPSTREAM_PASSWORD
+    )
+    await approve_pending_admission(
+        migrant_admission,
+        actor_id="fixture-product-admin",
+        existing_user_id=str(migrant_user_id),
+    )
+    migrated = await _arrive_through_the_broker(
+        MIGRANT_UPSTREAM_USERNAME, MIGRANT_UPSTREAM_PASSWORD
+    )
+    migrated_token = migrated["access_token"]
+    if not isinstance(migrated_token, str):
+        raise _evidence("fixture_migrated_login_produced_no_token", migrated["pages"])
+    migrated_principal = await verify_keycloak_access_v1(migrated_token, "api")
+    if migrated_principal is None or migrated_principal.subject != migrant_subject:
+        raise _fail("fixture_migrated_login_landed_elsewhere")
+    migrated_user = await auth_service.project_verified_principal(migrated_principal)
+    if migrated_user is None or migrated_user.user_id != str(migrant_user_id):
+        raise _fail("fixture_migrated_login_did_not_keep_the_account")
+
+    # The old binding is still there beside the new one -- that overlap is what
+    # makes the move reversible -- and the token they were already using still
+    # authorizes, which is the half a re-created account would silently lose.
+    async with pool.acquire() as conn:  # type: ignore[union-attr]
+        bindings = await conn.fetch(
+            """
+            SELECT issuer, subject FROM external_identities
+             WHERE user_id = $1 ORDER BY issuer, subject
+            """,
+            migrant_user_id,
+        )
+    if sorted((row["issuer"], row["subject"]) for row in bindings) != sorted(
+        [(BROKER_ISSUER, migrant_subject), (UPSTREAM_ISSUER, migrant_upstream)]
+    ):
+        raise _evidence(
+            "fixture_migrated_bindings_not_both_present",
+            [[row["issuer"], row["subject"]] for row in bindings],
+        )
+    pat_user = await auth_service.resolve_rest_user_authorization(
+        f"Bearer {migrant_raw_pat}"
+    )
+    if pat_user is None or pat_user.user_id != str(migrant_user_id):
+        raise _fail("fixture_migrated_pat_continuity_failed")
+
+    # ── clean up, and prove the cleanup ───────────────────────────────────
+    async with httpx.AsyncClient(verify=False, timeout=20.0) as client:
+        await _remove_person(
+            client,
+            upstream_subject=invited_upstream,
+            broker_subjects=[invited_subject],
+        )
+        await _remove_person(
+            client,
+            upstream_subject=migrant_upstream,
+            broker_subjects=[migrant_subject],
+        )
+        broker_admin = await _admin_token(client, BROKER)
+        for email in (INVITED_EMAIL, MIGRANT_EMAIL):
+            if await _realm_accounts(client, admin_token=broker_admin, email=email):
+                raise _fail("fixture_admission_cleanup_not_observed")
+    if await _recorded_arrivals():
+        raise _fail("fixture_admission_records_not_drained")
+    async with pool.acquire() as conn:  # type: ignore[union-attr]
+        await conn.execute(
+            "DELETE FROM users WHERE id = ANY($1::uuid[])",
+            [uuid.UUID(invited_user_id), migrant_user_id],
+        )
+
+    return {
+        "seeded": "nothing",
         "pages_beyond_the_upstream_credential": 0,
-        "signed_in_as": "the-seeded-account",
-        "email_verified_after_first_login": True,
-        "cleanup": "seed-and-upstream-removed",
+        "refused_before_approval": "membership_required",
+        "arrival_recorded_as": "exact-broker-issuer-and-subject",
+        "repeat_arrival": "one-record",
+        "approved_then_admitted": True,
+        "existing_account_preserved": True,
+        "binding_added_beside_the_old_one": True,
+        "records_drained": True,
     }
 
 
@@ -1359,10 +1675,11 @@ async def main() -> None:
         expect_broker_binding=True,
     )
 
-    # Everything above measures someone an operator linked by hand. This
-    # measures someone an invitation seeded and nobody linked, which is the
-    # only shape member invitation actually produces.
-    invitation = await _prove_invitation_seeded_account_links()
+    # Everything above measures someone an operator linked by hand. These two
+    # measure the people nobody linked: the shape member invitation used to
+    # create, and the shape admission produces.
+    seeding_dead_end = await _prove_seeding_is_a_dead_end()
+    admission = await _prove_admission_chain(state)
 
     upstream_tokens = await _authorization_code_tokens(
         issuer=UPSTREAM_ISSUER,
@@ -1429,7 +1746,7 @@ async def main() -> None:
     print(
         json.dumps(
             {
-                "schema_version": 4,
+                "schema_version": 5,
                 "provider_type": enabled.provider_type,
                 "alias": enabled.alias,
                 "configure_state": configured.state,
@@ -1444,7 +1761,8 @@ async def main() -> None:
                 "upstream_token_rejected": True,
                 "rollback": "binding-and-operator-cleanup-verified",
                 "authority_boundary": authority_boundary,
-                "invitation_seeded_account": invitation,
+                "seeding_dead_end": seeding_dead_end,
+                "admission_chain": admission,
                 "client_secret_exposed": False,
             },
             sort_keys=True,


### PR DESCRIPTION
## The moment that was thrown away

A workspace that owns its identity provider admits people by an exact
`(issuer, subject)` pair, and `invite_only` refuses anyone not already bound.
The subject in that pair is assigned by the workspace's own realm, and it comes
into being at exactly one moment: the person's first arrival through the broker.

That arrival was refused and discarded. `MembershipRequiredError` was raised and
nothing recorded who it was — even though the broker had just verified them,
checked a signed `email_verified` claim, and minted them a stable realm subject.
The one value an exact binding needs was produced and dropped in the same
instant. Every attempt to bind an invited person ahead of time was an attempt to
obtain a value that did not exist yet.

## What changed

The refusal keeps what it refused, and an administrator can approve it.

- `invite_only` still answers `membership_required`, unchanged, and the caller
  still holds nothing. Alongside the refusal it writes `(issuer, subject, email,
  when)` into `pending_admissions`.
- Approval **names a row and nothing else**. The request model has no `issuer`
  and no `subject`, because a caller able to supply one could approve one
  arrival and bind a different one.
- The binding itself is the ordinary exact-binding path, so the issuer guard,
  the conflict rules and the audit trail are the ones every binding already
  gets. An arrival recorded under an issuer this runtime does not present is
  refused rather than written — and the row survives that refusal.
- Writing a binding by **any** path clears the note, so the list an
  administrator reads is not a backlog of people who are already in.

Nothing is keyed by email. The address is stored because an administrator reads
it, never because anything matches on it: two arrivals sharing an address are
two rows.

## Bounds

`(issuer, subject)` is unique, so a person who keeps trying updates one row
rather than adding rows. Retention and a cap both evict least-recent-first and
run with the write, so the table stays bounded without a scheduled job a
deployment could be missing. Both bounds are on the **record** rather than on
the refusal: eviction changes what an administrator can still see, never what a
token may do.

Producing an arrival costs an authenticated session at the upstream identity
provider, so this is not reachable by anyone who merely reaches the login page.
The bounds exist because "unbounded but hard to fill" is still unbounded.

## Taking a note cannot change the answer

The recorder swallows its own failure deliberately — a failure to take a note
must not become a way in, nor a 500 that hides the real answer. Two assertions
make that acceptable rather than invisible: the caller still receives the
refusal, and a recorder handed a connection that fails writes nothing at all.

## Tests

14 new assertions against a real PostgreSQL, because the object under test is a
row with a uniqueness constraint, a retention window and a cap that evicts —
three database facts a mock would agree with rather than test.

Each is proven able to fail for its own reason. Nine minimal mutations were
applied and reverted: removing the record (11 red), recording in `open` mode
(3), re-raising from the recorder (1), dropping retention (1), dropping the cap
(1), letting approval name a subject (1), deleting the row before the bind (1),
not clearing the note on a binding (3), and keying the note by email (2).

The workflow change is separate and unglamorous: the unit job has no database,
so every file needing a DSN self-skips there, and the DB job runs an explicit
list. The enrollment-policy contract and the entire administrative
account-projection surface were in neither list. They reported as passing tests
that never executed.

## Nothing is adopted by address, at the one step that must not

`ensure_human_external_identity` may attach a new identity to an existing
unbound account holding the same address. For a control plane provisioning a
person it has already identified, that is the intended convenience and stays the
default. For approving a recorded arrival it is not: the address there is a
claim out of the person's own token, so letting it select the account makes the
approval an adoption by address.

Approval passes `adopt_unbound_email=False` and gets a `409` that **names** the
candidate account, so an administrator who does mean it can pass it back as
`existing_user_id` — a different act from having it chosen for them. The arrival
survives the refusal.

Found by a second session reviewing the same ground independently; the defect
was in this branch.

## Proven against two real Keycloaks

The last two commits carry the fixture that exercises the whole chain end to end
against a real broker and a real upstream, over a real authorization-code + PKCE
login. Two halves that are each other's control:

- **nothing seeded** — one arrival, zero pages beyond the upstream credential's
  own, `invite_only` answers `membership_required` *and* the exact
  `(issuer, subject)` is recorded, an administrator approves the row, and the
  second sign-in is admitted to that account. Repeat arrivals stay one record;
  approving with `existing_user_id` preserves the account, its token, its vault
  and its grant, and adds the binding beside the old one.
- **an account seeded ahead of arrival** — stopped at a `confirm-link` page the
  invited person cannot answer, unreachable, address still unverified. That is
  asserted rather than left failing, so seeding cannot be reintroduced by
  somebody who reads the switch and not the reason.

Seven mutations reddened it, each for its own reason. One of them is a finding
rather than plumbing: asserting "refused" alone was hollow, because the verified
principal projection answers `None` to *every* rejection — suspended, conflicting,
provider disabled — so a broken account would have satisfied it. The phase now
asserts the code is `membership_required`.
