### PR TITLE
fix(api): put pending admissions on the surface that writes bindings

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import ConfigDict, Field, SecretStr
 
 from app.api.deps import get_current_user
+from app.config import settings
 from app.services.auth_service import (
     AuthenticatedUser,
     REVOKE_REASON_ADMIN,
@@ -49,6 +50,11 @@ from app.services.access_service import (
     transfer_ownership,
     unarchive_vault,
     update_vault_metadata,
+)
+from app.services.admission_service import (
+    approve_pending_admission,
+    dismiss_pending_admission,
+    list_pending_admissions,
 )
 from app.util.text import NFCModel
 
@@ -524,6 +530,79 @@ async def admin_get_human_user_by_email(
 ):
     _require_admin(user)
     return await get_human_user_by_email(email)
+
+
+class ApprovePendingAdmissionRequest(NFCModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Deliberately absent: issuer and subject. Approval names a row, and the
+    # row carries the identity. A caller able to supply a subject alongside a
+    # row id could approve one arrival and bind a different one.
+    existing_user_id: str | None = Field(default=None, max_length=64)
+    email: str | None = Field(default=None, max_length=320)
+    display_name: str | None = Field(default=None, max_length=255)
+    prepare_suspended: bool = False
+
+
+def _require_admission_surface() -> None:
+    """Pending admissions exist only where `invite_only` produces them.
+
+    Enrollment policy is what creates the arrivals, so a deployment that is not
+    admitting by exact binding has no such list — and saying "not here" is more
+    useful than an empty array that reads as "nobody has arrived".
+    """
+    if settings.keycloak_enrollment_mode != "invite_only":
+        raise HTTPException(
+            status_code=404,
+            detail="Pending admissions exist only under invite-only enrollment",
+        )
+
+
+@router.get(
+    "/admin/pending-admissions",
+    summary="[admin] List identities that arrived and were refused by invite-only",
+)
+async def admin_list_pending_admissions(
+    limit: int = Query(200, ge=1, le=1000),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    _require_admission_surface()
+    return await list_pending_admissions(limit=limit)
+
+
+@router.post(
+    "/admin/pending-admissions/{admission_id}/approve",
+    summary="[admin] Bind one recorded arrival to an AKB user",
+)
+async def admin_approve_pending_admission(
+    admission_id: str,
+    req: ApprovePendingAdmissionRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    _require_admission_surface()
+    return await approve_pending_admission(
+        admission_id,
+        actor_id=user.user_id,
+        existing_user_id=req.existing_user_id,
+        email=req.email,
+        display_name=req.display_name,
+        prepare_suspended=req.prepare_suspended,
+    )
+
+
+@router.delete(
+    "/admin/pending-admissions/{admission_id}",
+    summary="[admin] Forget one recorded arrival without admitting it",
+)
+async def admin_dismiss_pending_admission(
+    admission_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    _require_admin(user)
+    _require_admission_surface()
+    return await dismiss_pending_admission(admission_id, actor_id=user.user_id)
 
 
 @router.get(

--- a/backend/app/api/routes/admin_sso.py
+++ b/backend/app/api/routes/admin_sso.py
@@ -15,13 +15,7 @@ from app.api.routes.admin_auth import (
     get_product_admin_mutation,
 )
 from app.config import settings
-from app.exceptions import AKBError
 from app.services import audit_log
-from app.services.admission_service import (
-    approve_pending_admission,
-    dismiss_pending_admission,
-    list_pending_admissions,
-)
 from app.sso.keycloak_admin import (
     ProviderControlError,
     get_keycloak_provider_control,
@@ -611,96 +605,3 @@ async def rollback_sso_identity_migration(
         operation="rollback",
     )
 
-
-class ApprovePendingAdmissionRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    # Deliberately absent: issuer and subject. Approval names a row, and the
-    # row carries the identity. A caller able to supply a subject alongside a
-    # row id could approve one arrival and bind a different one.
-    existing_user_id: str | None = Field(default=None, max_length=64)
-    email: str | None = Field(default=None, max_length=320)
-    display_name: str | None = Field(default=None, max_length=255)
-    prepare_suspended: bool = False
-
-
-def _admission_audit_meta(admission: dict[str, object]) -> dict[str, object]:
-    return {
-        "issuer": admission.get("issuer"),
-        "subject_sha256": _subject_digest(admission.get("subject")),
-        "arrivals": admission.get("arrivals"),
-    }
-
-
-@router.get(
-    "/admin/sso/pending-admissions",
-    summary="List identities that arrived and were refused by invite-only",
-)
-async def list_sso_pending_admissions(
-    limit: int = 200,
-    actor: ProductAdminActor = Depends(get_current_product_admin),
-):
-    del actor  # authorization only; reading the list is not an event
-    return await list_pending_admissions(limit=limit)
-
-
-@router.post(
-    "/admin/sso/pending-admissions/{admission_id}/approve",
-    summary="Bind one recorded arrival to an AKB user",
-)
-async def approve_sso_pending_admission(
-    admission_id: str,
-    request: ApprovePendingAdmissionRequest,
-    actor: ProductAdminActor = Depends(get_product_admin_mutation),
-):
-    try:
-        result = await approve_pending_admission(
-            admission_id,
-            actor_id=str(actor.user_id),
-            existing_user_id=request.existing_user_id,
-            email=request.email,
-            display_name=request.display_name,
-            prepare_suspended=request.prepare_suspended,
-        )
-    except AKBError as error:
-        audit_log.record(
-            action="sso.pending_admission.approve",
-            actor=actor.username,
-            actor_id=str(actor.user_id),
-            target=f"pending_admission={_canonical_user_id(admission_id)}",
-            outcome="error",
-            code=getattr(error, "code", None) or str(error.status_code),
-            meta={"existing_user_id": _canonical_user_id(request.existing_user_id)},
-        )
-        raise
-    approved = result["approved"]
-    meta = _admission_audit_meta(approved)
-    meta["user_id"] = _canonical_user_id(result["user"].get("user_id"))
-    audit_log.record(
-        action="sso.pending_admission.approve",
-        actor=actor.username,
-        actor_id=str(actor.user_id),
-        target=f"pending_admission={approved['id']}",
-        outcome="ok",
-        meta=meta,
-    )
-    return result
-
-
-@router.delete(
-    "/admin/sso/pending-admissions/{admission_id}",
-    summary="Forget one recorded arrival without admitting it",
-)
-async def dismiss_sso_pending_admission(
-    admission_id: str,
-    actor: ProductAdminActor = Depends(get_product_admin_mutation),
-):
-    result = await dismiss_pending_admission(admission_id)
-    audit_log.record(
-        action="sso.pending_admission.dismiss",
-        actor=actor.username,
-        actor_id=str(actor.user_id),
-        target=f"pending_admission={result['dismissed']}",
-        outcome="ok",
-    )
-    return result

--- a/backend/app/services/admission_service.py
+++ b/backend/app/services/admission_service.py
@@ -37,6 +37,7 @@ from typing import Any
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import NotFoundError, ValidationError
+from app.repositories.events_repo import emit_event
 
 
 _LOG = logging.getLogger("akb.admission")
@@ -168,17 +169,36 @@ async def get_pending_admission(admission_id: str) -> dict[str, Any]:
     return _row(row)
 
 
-async def dismiss_pending_admission(admission_id: str) -> dict[str, Any]:
-    """Forget one arrival. It says nothing about whether they may return."""
+async def dismiss_pending_admission(
+    admission_id: str, *, actor_id: str | None = None
+) -> dict[str, Any]:
+    """Forget one arrival. It says nothing about whether they may return.
+
+    Approval leaves its own trace — the binding it writes is an event. A
+    dismissal writes nothing, so without this it would be the one act on this
+    surface that left no record of having happened.
+    """
     identifier = _admission_uuid(admission_id)
     pool = await get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            "DELETE FROM pending_admissions WHERE id = $1 RETURNING id",
-            identifier,
-        )
-    if row is None:
-        raise NotFoundError("Pending admission", str(identifier))
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                "DELETE FROM pending_admissions WHERE id = $1"
+                " RETURNING id, issuer, subject",
+                identifier,
+            )
+            if row is None:
+                raise NotFoundError("Pending admission", str(identifier))
+            await emit_event(
+                conn,
+                "auth.pending_admission_dismissed",
+                actor_id=actor_id,
+                payload={
+                    "admission_id": str(row["id"]),
+                    "issuer": row["issuer"],
+                    "subject": row["subject"],
+                },
+            )
     return {"dismissed": str(row["id"])}
 
 

--- a/backend/tests/test_admission_route_carrier_unit.py
+++ b/backend/tests/test_admission_route_carrier_unit.py
@@ -17,6 +17,7 @@ calling its handler is not proved reachable by its caller.
 
 from __future__ import annotations
 
+import pathlib
 import tempfile
 
 import pytest
@@ -40,10 +41,21 @@ from app.main import app  # noqa: E402
 
 
 def test_the_import_did_not_write_into_the_deployed_storage_path():
-    # Asserted rather than trusted: if the redirect stops working this file goes
-    # back to mkdir'ing a real deployment directory, and the only symptom would
-    # be a CI job that fails somewhere else entirely.
-    assert settings.git_storage_path == _STORAGE
+    """The import's filesystem effect landed in the temp directory.
+
+    Asserted rather than trusted: without the redirect this file mkdir's a real
+    deployment directory, and on a machine that HAS one the only symptom is
+    nothing at all — it wrote into `/data/vaults` here at 07:16 with every test
+    green, and failed only on a runner that cannot create `/data`.
+
+    The assertion is on the directories the import created, not on
+    `settings.git_storage_path`: `settings` is process-global and other tests in
+    the same session repoint it, so comparing the current value asserts
+    something about whoever ran last rather than about this import.
+    """
+    assert (pathlib.Path(_STORAGE) / "_worktrees").is_dir(), (
+        "the import did not create its storage under the temp directory"
+    )
 
 
 _ADMISSION_PATHS = {

--- a/backend/tests/test_admission_route_carrier_unit.py
+++ b/backend/tests/test_admission_route_carrier_unit.py
@@ -1,0 +1,72 @@
+"""The admission routes must be reachable by the caller that has to use them.
+
+Everything else about admission is proven by calling the service functions: the
+arrival is recorded, the approval binds, the row is cleared. None of that says
+the control plane can *get* to any of it.
+
+It could not, for one merge. The routes landed on the product-admin SSO router,
+which is guarded by the dedicated admin browser session; the control plane
+authenticates with an administrator credential and holds no such session, so
+`AdmitArrival` would have called an endpoint it can never reach — an empty list
+in the console forever, with nothing red anywhere. Both the unit tests and a
+two-Keycloak fixture were green throughout, because both call the handler.
+
+So this asserts the **carrier** rather than the handler: an endpoint proved by
+calling its handler is not proved reachable by its caller.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.deps import get_current_user
+from app.api.routes.admin_auth import (
+    get_current_product_admin,
+    get_product_admin_mutation,
+)
+from app.main import app
+
+
+_ADMISSION_PATHS = {
+    "/api/v1/admin/pending-admissions",
+    "/api/v1/admin/pending-admissions/{admission_id}",
+    "/api/v1/admin/pending-admissions/{admission_id}/approve",
+}
+
+
+def _admission_routes():
+    return [route for route in app.routes if getattr(route, "path", None) in _ADMISSION_PATHS]
+
+
+def _dependency_callables(route) -> set:
+    resolved = set()
+    for dependant in [route.dependant, *route.dependant.dependencies]:
+        if dependant.call is not None:
+            resolved.add(dependant.call)
+        for nested in dependant.dependencies:
+            if nested.call is not None:
+                resolved.add(nested.call)
+    return resolved
+
+
+def test_every_admission_path_is_mounted():
+    # Named exactly, so moving one and leaving the others behind is a failure
+    # rather than a smaller set that still passes.
+    assert {route.path for route in _admission_routes()} == _ADMISSION_PATHS
+
+
+@pytest.mark.parametrize("path", sorted(_ADMISSION_PATHS))
+def test_admission_routes_answer_the_credential_the_control_plane_holds(path):
+    routes = [route for route in _admission_routes() if route.path == path]
+    assert routes, path
+    for route in routes:
+        callables = _dependency_callables(route)
+        assert get_current_user in callables, (
+            f"{path} does not accept the ordinary administrator credential"
+        )
+        assert get_current_product_admin not in callables, (
+            f"{path} is behind the product-admin browser session"
+        )
+        assert get_product_admin_mutation not in callables, (
+            f"{path} is behind the product-admin browser session"
+        )

--- a/backend/tests/test_admission_route_carrier_unit.py
+++ b/backend/tests/test_admission_route_carrier_unit.py
@@ -17,14 +17,33 @@ calling its handler is not proved reachable by its caller.
 
 from __future__ import annotations
 
+import tempfile
+
 import pytest
 
-from app.api.deps import get_current_user
-from app.api.routes.admin_auth import (
+from app.config import settings
+
+# Importing `app.main` builds the shared GitService, whose __init__ mkdir's
+# `git_storage_path` — an import-time filesystem side effect this repo already
+# documents (see external_git_poller). Left alone it writes into the deployed
+# `/data/vaults` on a developer machine and fails outright on a CI runner that
+# cannot create `/data`. Redirect first, then import.
+_STORAGE = tempfile.mkdtemp(prefix="admission-route-carrier-")
+object.__setattr__(settings, "git_storage_path", _STORAGE)
+
+from app.api.deps import get_current_user  # noqa: E402
+from app.api.routes.admin_auth import (  # noqa: E402
     get_current_product_admin,
     get_product_admin_mutation,
 )
-from app.main import app
+from app.main import app  # noqa: E402
+
+
+def test_the_import_did_not_write_into_the_deployed_storage_path():
+    # Asserted rather than trusted: if the redirect stops working this file goes
+    # back to mkdir'ing a real deployment directory, and the only symptom would
+    # be a CI job that fails somewhere else entirely.
+    assert settings.git_storage_path == _STORAGE
 
 
 _ADMISSION_PATHS = {

--- a/backend/tests/test_pending_admission_postgres.py
+++ b/backend/tests/test_pending_admission_postgres.py
@@ -363,7 +363,7 @@ async def test_approval_cannot_name_a_subject_only_a_row(services):
     Asserted as an exact field set rather than as two absences, so a later
     `issuer` or `subject` cannot appear here without this failing.
     """
-    from app.api.routes.admin_sso import ApprovePendingAdmissionRequest
+    from app.api.routes.access import ApprovePendingAdmissionRequest
 
     with pytest.raises(Exception) as rejected:
         ApprovePendingAdmissionRequest(subject="someone-elses-subject")


### PR DESCRIPTION
Follow-up to #397, and the reason is a mistake worth naming: the routes landed
on the wrong surface, and the gate I ran did not tell me because I ran it on a
working tree that had the correction in it while the branch did not.

## The surface

The pending-admission routes went onto the product-admin SSO router, which is
guarded by the dedicated admin browser session. That router exists for provider
**configuration**.

Approving an arrival is account administration. It writes an exact binding —
the same table, through the same function, as `ensure-external-identity`
directly beside it — and the caller that has to do it is a control plane, which
authenticates with an admin credential and has no product-admin browser session
at all. On the wrong router the operation is reachable by nobody who needs it.

So they move to `/api/v1/admin/`, next to the other writers of that binding,
under the same `_require_admin` guard. One door rather than two with different
keys.

## Two smaller things

They `404` outside invite-only enrollment. That policy is what produces
arrivals, so an empty array elsewhere would read as "nobody has arrived" rather
than "there is no such list here".

A dismissal now emits an event. Approval already leaves a trace — the binding it
writes is one — so without this, dismissing would be the only act on this
surface that left no record of having happened.

## Verified

`scripts/verify.sh akb` OK at this head. Pending admissions plus the three
identity suites beside it: 66 passed against a real Postgres.

## And a gate, because the fix alone does not prevent the recurrence

`AdmitArrival` calling an endpoint it can never reach was invisible to every
test on either side of it: the unit tests call the service functions, and a
two-Keycloak fixture calls them too. Both stayed green while the door the
control plane knocks on was the wrong one.

So there is now an assertion about the **carrier** rather than the handler: each
admission path resolves under the ordinary administrator credential and under
neither product-admin browser-session dependency. Moving one back reddens it;
removing one reddens the mounted-path assertion. Both proven by mutation.

> An endpoint proved by calling its handler is not proved reachable by its
> caller.
