### PR TITLE
fix(auth): answer a failed SSO sign-in with a page, and name the one refusal that helps

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -28,7 +28,7 @@ from app.services.auth_service import (
     revoke_all_sessions,
     token_has_scope,
     update_profile,
-    project_verified_principal,
+    project_verified_principal_with_reason,
 )
 from app.services.auth_policy import require_local_auth_enabled, sso_browser_session_ready
 from app.services.keycloak_oidc import get_keycloak_oidc
@@ -418,6 +418,35 @@ async def keycloak_login(redirect: str = "/"):
     )
 
 
+# A browser reaches the callback by following a redirect, so whatever it answers
+# IS the page. Raising rendered a serialized error object on a blank white
+# screen — measured, against a deployed workspace: an invited person waiting for
+# approval saw `{"message":"SSO sign-in failed",...}` and nothing else.
+#
+# So the callback answers with the product's own sign-in page and a reason on the
+# query string. `/auth` is fixed here rather than taken from the request, so this
+# cannot become an open redirect.
+#
+# Only the refusals below are named. Naming one tells a caller that this runtime
+# verified their token and what it then decided, which is a disclosure and not a
+# detail: it is defensible for membership, because to be holding such a token
+# they already authenticated at an upstream this workspace's owner registered,
+# and the alternative leaves the one population this flow exists for staring at
+# their credential — the only thing that is fine — instead of telling an
+# administrator they arrived. It is NOT defensible for the rest: whether an
+# account is suspended is a statement about the person, not about a roster, and
+# it stays generic until somebody decides otherwise on purpose.
+_NAMEABLE_SSO_REFUSALS = frozenset({"membership_required"})
+
+
+def _sso_sign_in_failed(reason: str | None = None) -> RedirectResponse:
+    code = reason if reason in _NAMEABLE_SSO_REFUSALS else "sso_failed"
+    return RedirectResponse(
+        f"/auth?sso_error={quote(code, safe='')}",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
 @router.get(
     "/auth/keycloak/callback",
     summary="Complete an ordinary Keycloak SSO browser login",
@@ -432,7 +461,7 @@ async def keycloak_callback(
 ):
     _require_sso_browser_session()
     if error is not None or not code or not state:
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     oidc = get_keycloak_oidc()
     transient = await oidc.consume_browser_state(
         state,
@@ -445,33 +474,33 @@ async def keycloak_callback(
         "code_verifier",
         "nonce",
     }:
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     if transient.get("client_id") != settings.keycloak_client_id:
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     provider_alias = transient.get("provider_alias")
     if not isinstance(provider_alias, str):
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     try:
         validate_alias(provider_alias)
     except ProviderDefinitionError:
-        raise AuthenticationError("SSO sign-in failed") from None
+        return _sso_sign_in_failed()
     redirect_path = _safe_redirect_path(transient.get("redirect_path"))
     verifier = transient.get("code_verifier")
     nonce = transient.get("nonce")
     if not isinstance(verifier, str) or not isinstance(nonce, str):
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     tokens = await oidc.exchange_browser_code(code, verifier)
     access_token = tokens.get("access_token")
     id_token = tokens.get("id_token")
     if tokens.get("token_type") != "Bearer" or not isinstance(access_token, str) or not isinstance(id_token, str):
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     principal = await oidc.verify_access_token(
         access_token,
         settings.api_oauth_audience_effective,
         route_profile="api",
     )
     if principal is None:
-        raise AuthenticationError("SSO sign-in failed")
+        return _sso_sign_in_failed()
     _require_signed_provider(principal.claims, provider_alias)
     id_claims = await oidc.verify_browser_id_token(
         id_token,
@@ -480,9 +509,12 @@ async def keycloak_callback(
         expected_provider_alias=provider_alias,
     )
     _require_signed_provider(id_claims, provider_alias)
-    user = await project_verified_principal(principal)
+    outcome = await project_verified_principal_with_reason(principal)
+    user = outcome.user
     if user is None:
-        raise AuthenticationError("SSO sign-in failed")
+        # The one place the reason is repeated, and only for the refusal the
+        # allowlist above admits.
+        return _sso_sign_in_failed(outcome.refusal_code)
     issued = await create_sso_browser_session(
         user,
         principal,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -581,33 +581,54 @@ async def _resolve_or_provision_keycloak_user(claims: dict) -> dict:
         return _resolved_external_user(row, newly_provisioned=True)
 
 
+@dataclass(frozen=True)
+class ProjectionOutcome:
+    """What the projection boundary decided, and why when it refused.
+
+    The boundary used to answer ``None`` for every rejection there is — no
+    membership, suspended account, provider disabled, conflicting binding — so
+    nothing above it could tell them apart. Callers that only need "in or not"
+    still get exactly that from ``project_verified_principal``; a caller that
+    has to explain itself to a person can ask for the reason.
+
+    ``refusal_code`` is the AKBError code the service layer already raised. It
+    is not a licence to show it: naming a refusal discloses that this runtime
+    verified the token, so each caller decides which reasons it may repeat.
+    """
+
+    user: AuthenticatedUser | None
+    refusal_code: str | None = None
+
+
 async def _project_keycloak_principal(
     principal: VerifiedPrincipal,
-) -> AuthenticatedUser | None:
+) -> ProjectionOutcome:
     """Project a completely verified OIDC identity onto the AKB account path."""
     claims = dict(principal.claims)
     try:
         issuer, subject = _external_identity_key(claims)
         if (issuer, subject) != (principal.issuer, principal.subject):
-            return None
+            return ProjectionOutcome(None, "identity_claims_inconsistent")
         resolved = await _resolve_or_provision_keycloak_user(claims)
     except AKBError as e:
         logging.getLogger("akb.auth").info("Keycloak access token: account projection rejected (%s)", e)
-        return None
+        return ProjectionOutcome(None, getattr(e, "code", None))
 
     if resolved["newly_provisioned"]:
         await get_role_sync().on_user_create(resolved["user_id"])
 
     scope_str = claims["scope"]
     scopes = [scope for scope in scope_str.split(" ") if scope]
-    return AuthenticatedUser(
-        user_id=str(resolved["user_id"]),
-        username=resolved["username"],
-        email=resolved["email"] or "",
-        display_name=resolved["display_name"],
-        is_admin=resolved["is_admin"],
-        auth_method="oauth",
-        oauth_scopes=scopes,
+    return ProjectionOutcome(
+        AuthenticatedUser(
+            user_id=str(resolved["user_id"]),
+            username=resolved["username"],
+            email=resolved["email"] or "",
+            display_name=resolved["display_name"],
+            is_admin=resolved["is_admin"],
+            auth_method="oauth",
+            oauth_scopes=scopes,
+        )
     )
 
 
@@ -663,16 +684,39 @@ async def project_verified_principal(
     fail-closed: a future caller of this boundary is gated unless it
     deliberately asks not to be.
     """
+    outcome = await project_verified_principal_with_reason(
+        principal,
+        for_credential_change=for_credential_change,
+    )
+    return outcome.user
+
+
+async def project_verified_principal_with_reason(
+    principal: VerifiedPrincipal,
+    *,
+    for_credential_change: bool = False,
+) -> ProjectionOutcome:
+    """The same boundary, carrying the reason when it refuses.
+
+    Only the OIDC path reports a reason today, because it is the only one whose
+    refusal a person is waiting on. The others answer with no code, which reads
+    the same as before and keeps a caller from repeating something the service
+    layer never said.
+    """
     if principal.profile_id == LOCAL_SESSION_RS256_V2:
-        return await _project_local_session_principal(
-            principal,
-            for_credential_change=for_credential_change,
+        return ProjectionOutcome(
+            await _project_local_session_principal(
+                principal,
+                for_credential_change=for_credential_change,
+            )
         )
     if principal.profile_id == KEYCLOAK_ACCESS_V1:
         return await _project_keycloak_principal(principal)
     if principal.profile_id == KEYCLOAK_SERVICE_AUTHORITY_V1:
-        return await _project_service_authority_principal(principal)
-    return None
+        return ProjectionOutcome(
+            await _project_service_authority_principal(principal)
+        )
+    return ProjectionOutcome(None)
 
 
 async def resolve_keycloak_access_token(

--- a/backend/tests/test_pending_admission_postgres.py
+++ b/backend/tests/test_pending_admission_postgres.py
@@ -540,3 +540,48 @@ async def test_dismissing_an_arrival_forgets_it_without_admitting_anyone(service
         await auth_service._resolve_or_provision_keycloak_user(_claims(subject, email))
     with pytest.raises(NotFoundError):
         await admission_service.dismiss_pending_admission(arrival["id"])
+
+
+async def test_the_boundary_carries_the_reason_the_service_layer_raised(services):
+    """"Refused" and "refused because they are not a member" are different facts.
+
+    The projection boundary answered None for every rejection there is, so the
+    HTTP layer could not tell them apart and generalised — which is how a person
+    waiting for approval came to be told their token was invalid. The reason is
+    carried now, and this is the test that fails if it stops being.
+    """
+    pool, auth_service, admission_service, _accounts = services
+    from app.services.auth_verifier_profiles import VerifiedPrincipal
+
+    email = "adm-reason@example.com"
+    claims = _claims("subject-reason", email)
+    claims["scope"] = "openid profile email"
+    principal = VerifiedPrincipal(
+        profile_id=auth_service.KEYCLOAK_ACCESS_V1,
+        issuer=_ISSUER,
+        subject="subject-reason",
+        credential_type="bearer",
+        claims=claims,
+        audience="api",
+    )
+
+    outcome = await auth_service.project_verified_principal_with_reason(principal)
+    assert outcome.user is None
+    assert outcome.refusal_code == "membership_required"
+
+    # The same arrival is on the administrator's list, so the reason the
+    # boundary reports and the row they act on are about one event.
+    listed = await admission_service.list_pending_admissions()
+    rows = [r for r in listed["pending_admissions"] if r["subject"] == "subject-reason"]
+    assert len(rows) == 1
+
+    # Admitted, the same principal projects to an account and reports no reason.
+    await admission_service.approve_pending_admission(
+        rows[0]["id"], actor_id="adm-admin"
+    )
+    admitted = await auth_service.project_verified_principal_with_reason(principal)
+    assert admitted.user is not None
+    assert admitted.refusal_code is None
+
+    # And the plain boundary still answers exactly what it always did.
+    assert (await auth_service.project_verified_principal(principal)) is not None

--- a/backend/tests/test_sso_browser_auth_boundary_unit.py
+++ b/backend/tests/test_sso_browser_auth_boundary_unit.py
@@ -11,7 +11,7 @@ import pytest
 from app.api.routes import auth
 from app.config import settings
 from app.exceptions import AuthenticationError
-from app.services.auth_service import AuthenticatedUser
+from app.services.auth_service import AuthenticatedUser, ProjectionOutcome
 from app.services.auth_verifier_profiles import VerifiedPrincipal
 from app.services.keycloak_oidc import BrowserAuthorizationRequest
 from app.services.sso_browser_session_service import (
@@ -244,7 +244,10 @@ async def test_callback_projects_access_token_but_returns_only_opaque_cookies(
 
     async def project(value):
         assert value is principal
-        return user
+        # The boundary carries a reason alongside the account now, so the callback
+        # can tell "not a member" apart from every other refusal. Success carries
+        # none.
+        return ProjectionOutcome(user)
 
     async def create(value, verified, id_claims, tokens):
         captured.update(
@@ -260,7 +263,7 @@ async def test_callback_projects_access_token_but_returns_only_opaque_cookies(
         )
 
     monkeypatch.setattr(auth, "get_keycloak_oidc", lambda: OIDC())
-    monkeypatch.setattr(auth, "project_verified_principal", project)
+    monkeypatch.setattr(auth, "project_verified_principal_with_reason", project)
     monkeypatch.setattr(auth, "create_sso_browser_session", create)
     request = _request(cookie="__Host-akb_sso_oidc_binding=browser-binding-value-that-is-long-enough")
 
@@ -312,12 +315,21 @@ async def test_unbound_or_replayed_callback_fails_before_token_exchange(monkeypa
             raise AssertionError("unbound state must fail before token exchange")
 
     monkeypatch.setattr(auth, "get_keycloak_oidc", lambda: OIDC())
-    with pytest.raises(AuthenticationError, match="sign-in failed"):
-        await auth.keycloak_callback(
-            _request(),
-            code="code-1",
-            state="state-1",
-        )
+    # The point of this case is unchanged and is asserted by OIDC.exchange_browser_code
+    # above: an unbound or replayed state must fail BEFORE the code is exchanged.
+    # What changed is the shape of the failure. The callback is reached by a
+    # browser following a redirect, so raising rendered a serialized error object
+    # as the page; it now answers with the product's sign-in page instead.
+    response = await auth.keycloak_callback(
+        _request(),
+        code="code-1",
+        state="state-1",
+    )
+
+    assert response.status_code == 303
+    # And it says nothing about why. A replayed state is not a person waiting for
+    # admission, and the only named refusal is the one that helps them.
+    assert response.headers["location"] == "/auth?sso_error=sso_failed"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sso_callback_answers_with_a_page_unit.py
+++ b/backend/tests/test_sso_callback_answers_with_a_page_unit.py
@@ -1,0 +1,79 @@
+"""The SSO callback answers a person, not a serializer.
+
+A browser reaches this route by following a redirect, so whatever the route
+returns IS the page. Raising rendered a serialized error object on a blank white
+screen: an invited person waiting for approval, measured against a deployed
+workspace, saw `{"message":"SSO sign-in failed",...}` and nothing else.
+
+Two properties, and the second is a disclosure decision rather than a nicety:
+
+  * every refusal answers with a redirect back to the product's sign-in page;
+  * exactly one refusal is named there. Naming one tells a caller that this
+    runtime verified their token and what it then decided. That is defensible
+    for membership — to hold such a token they already authenticated at an
+    upstream this workspace's owner registered — and it is not defensible for
+    "your account is suspended", which is a statement about the person.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from app.config import settings
+
+_STORAGE = tempfile.mkdtemp(prefix="sso-callback-page-")
+object.__setattr__(settings, "git_storage_path", _STORAGE)
+
+from app.api.routes import auth  # noqa: E402
+
+
+def _location(response) -> str:
+    return response.headers["location"]
+
+
+def test_every_refusal_answers_with_the_sign_in_page():
+    for reason in (None, "", "membership_required", "account_suspended",
+                   "identity_conflict", "external_auth_disabled", "nonsense"):
+        response = auth._sso_sign_in_failed(reason)
+        assert response.status_code == 303, reason
+        assert _location(response).startswith("/auth?sso_error="), reason
+
+
+def test_only_membership_is_named_and_everything_else_is_generic():
+    assert _location(auth._sso_sign_in_failed("membership_required")) == \
+        "/auth?sso_error=membership_required"
+    for reason in ("account_suspended", "identity_conflict", "credential_change_required",
+                   "external_auth_disabled", "permission_denied", None, ""):
+        assert _location(auth._sso_sign_in_failed(reason)) == "/auth?sso_error=sso_failed", reason
+
+
+def test_the_named_set_is_exactly_one_and_it_is_membership():
+    # Written as equality rather than membership so a second reason cannot be
+    # added without this test saying so — the whole point is that adding one is
+    # a decision about disclosure, not a refactor.
+    assert auth._NAMEABLE_SSO_REFUSALS == frozenset({"membership_required"})
+
+
+def test_the_reason_cannot_put_text_on_the_screen():
+    """The query string is an allowlisted code, never an echoed message."""
+    injected = "membership_required</a><script>alert(1)</script>"
+    assert _location(auth._sso_sign_in_failed(injected)) == "/auth?sso_error=sso_failed"
+
+
+def test_the_callback_never_raises_its_refusals():
+    """Nothing in the callback answers a browser with an error body."""
+    import inspect
+
+    source = inspect.getsource(auth.keycloak_callback)
+    assert "raise AuthenticationError" not in source
+    assert source.count("_sso_sign_in_failed") >= 9
+
+
+@pytest.mark.asyncio
+async def test_the_projection_boundary_carries_the_reason_it_already_knew():
+    from app.services.auth_service import ProjectionOutcome
+
+    assert ProjectionOutcome(None).refusal_code is None
+    assert ProjectionOutcome(None, "membership_required").refusal_code == "membership_required"

--- a/frontend/src/pages/__tests__/auth-sso-only.test.tsx
+++ b/frontend/src/pages/__tests__/auth-sso-only.test.tsx
@@ -157,6 +157,48 @@ describe("AuthPage mode gate", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  // The SSO callback is reached by a browser following a redirect, so it cannot
+  // answer with an error body — whatever it returns IS the page. It sends the
+  // person back here with an allowlisted reason code, and this is where that
+  // code has to become a sentence. Measured before the fix: an invited person
+  // waiting for approval saw a serialized error object on a blank white page.
+  it("tells an invited person waiting for approval what is actually happening", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(stagedSsoConfig);
+    window.history.replaceState({}, "", "/auth?sso_error=membership_required");
+
+    renderAuth();
+
+    expect(await screen.findByText(/not a member of this workspace yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/administrator has to admit you/i)).toBeInTheDocument();
+  });
+
+  it("says something generic for every other refusal, and never echoes the code", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(stagedSsoConfig);
+    // The server only ever sends an allowlisted code; the page must still not
+    // put an arbitrary one on screen, because that is what makes the allowlist
+    // the only thing standing between a query string and rendered text.
+    window.history.replaceState({}, "", "/auth?sso_error=<script>alert(1)</script>");
+
+    renderAuth();
+
+    expect(await screen.findByText(/did not complete/i)).toBeInTheDocument();
+    expect(screen.queryByText(/alert\(1\)/)).toBeNull();
+    expect(screen.queryByText(/not a member of this workspace yet/i)).toBeNull();
+  });
+
+  it("says nothing about SSO failures when the person simply arrived", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(stagedSsoConfig);
+    window.history.replaceState({}, "", "/auth");
+
+    renderAuth();
+
+    // `browser_session_ready: false` in this fixture, so the page settles on the
+    // staged-provider notice — enough to know it rendered before asserting absence.
+    await screen.findByText(/SSO browser sign-in is not available yet/i);
+    expect(screen.queryByText(/did not complete/i)).toBeNull();
+    expect(screen.queryByText(/not a member of this workspace yet/i)).toBeNull();
+  });
+
   it("shows setup pending rather than a local fallback when no IdP is enabled", async () => {
     vi.mocked(getAuthConfig).mockResolvedValue({
       ...stagedSsoConfig,

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -40,6 +40,12 @@ export default function AuthPage() {
   const [password, setPassword] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [error, setError] = useState("");
+  // The SSO callback is reached by a browser following a redirect, so it cannot
+  // answer with an error body — whatever it returns IS the page. It sends the
+  // person back here with a reason instead, and this is where that reason
+  // becomes a sentence. Unknown values fall through to the generic line rather
+  // than being echoed, so the query string cannot put text on the screen.
+  const ssoError = new URLSearchParams(window.location.search).get("sso_error") ?? "";
   const [loading, setLoading] = useState(false);
   // Unknown until the versioned public policy is validated. No UI capability
   // is inferred while loading or when the fetch/schema fails.
@@ -231,6 +237,14 @@ export default function AuthPage() {
             {authConfig !== null && !localAuthEnabled && authConfig.available !== true && (
               <Alert variant="destructive">
                 Sign-in is unavailable because authentication configuration could not be verified.
+              </Alert>
+            )}
+
+            {ssoError && (
+              <Alert variant="destructive" id="auth-sso-error">
+                {ssoError === "membership_required"
+                  ? "You signed in, but you are not a member of this workspace yet. An administrator has to admit you — they can see that you arrived."
+                  : "Sign-in through your identity provider did not complete. Try again, and tell your administrator if it keeps happening."}
               </Alert>
             )}
 


### PR DESCRIPTION
Closes #400.

A browser reaches the SSO callback by following a redirect, so whatever that route returns *is* the page. It raised, and the error handler serialised. Measured against a deployed workspace, an invited person waiting for approval saw this on a blank white screen at the callback URL:

```
{"message":"SSO sign-in failed","error":"SSO sign-in failed","code":"permission_denied","detail":"SSO sign-in failed"}
```

That is the one screen every invited person passes through, because the flow requires them to sign in once before anyone can approve them.

## What changes

Every refusal in the callback redirects to the product's own sign-in page with a reason on the query string. The path is fixed in code rather than taken from the request, so this cannot become an open redirect, and the page maps an allowlisted code to a sentence rather than echoing what it was handed.

Exactly one refusal is named, and that is the disclosure decision rather than a nicety. Naming one tells a caller that this runtime verified their token and what it then decided.

- **Defensible for membership.** To be holding such a token they have already authenticated at an upstream this workspace's owner deliberately registered and enabled, so what they learn is one bit about a workspace whose address they already have — something an administrator would tell them if asked. The alternative leaves them looking at their credential, the only thing that is fine, instead of telling an administrator they arrived.
- **Not defensible for the rest.** "Your account is suspended" is a statement about the person rather than about a roster. Everything else stays generic until somebody decides otherwise deliberately, and the test asserts the named set by equality so a second entry cannot pass as a refactor.

Underneath, the projection boundary carries the reason it already knew. It answered nothing at all for every rejection there is — no membership, suspended account, provider disabled, conflicting binding — which is why a single generic answer was the only thing the layer above could give. Callers that only need "in or not" are unchanged.

## Evidence

Nine mutations, each red in its own case: raising again, admitting a second reason to the named set, echoing the reason instead of allowlisting it, removing the banner, printing the code on screen, and the boundary ceasing to carry the reason at all.

That last one is worth naming: the unit tests passed it happily, because they only established that the outcome type *can* hold a code. It took a database-backed test asking for the code end to end to make the mutation red. The gate had the same shape as the defect it was written for.

The repository gate passes, and the neighbouring identity suites pass against a real database.
