### PR TITLE
fix(graph): enforce vault-scoped relation boundaries

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -197,6 +197,11 @@ jobs:
         # collection intentionally skips without Postgres, so keep both files
         # explicit here: otherwise account uniqueness, exact identity FKs,
         # session concurrency, and the 072 upgrade path would never gate CI.
+        #
+        # Edge vault-boundary enforcement is a PostgreSQL trigger contract.
+        # The application tests prove early rejection and filtered reads; this
+        # live test proves a direct SQL writer cannot create a new cross-vault
+        # edge or turn a valid row into one.
         run: >
           pytest
           tests/test_pgvector_ext_bootstrap_e2e.py
@@ -223,6 +228,7 @@ jobs:
           tests/test_admin_auth_postgres.py
           tests/test_sso_identity_migration_postgres.py
           tests/test_pending_admission_postgres.py
+          tests/test_edge_vault_boundary_postgres.py
           tests/test_workspace_external_identity.py
           tests/test_workspace_account_admin_service.py
           tests/test_sso_browser_session_postgres.py

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 367,
         "is_secret": false
       },
       {
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1175,
+        "line_number": 1189,
         "is_secret": false
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1189,
+        "line_number": 1190,
         "is_secret": false
       }
     ],

--- a/backend/app/api/routes/knowledge.py
+++ b/backend/app/api/routes/knowledge.py
@@ -185,7 +185,7 @@ async def delete_relation(
     relation: RelationType | None = Query(
         None,
         description="Relation type to remove (one of the link vocabulary); "
-        "omit to remove all edges between the two",
+        "omit to remove all explicit edges between the two",
     ),
     user: AuthenticatedUser = Depends(get_current_user),
 ):

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -591,7 +591,7 @@ CREATE INDEX IF NOT EXISTS idx_vault_migrations_vault_applied
 
 -- ============================================================
 -- Edges (unified cross-type relation graph via URI scheme)
--- Replaces document-only 'relations' for cross-type connections.
+-- Replaces document-only 'relations' for cross-type, same-vault connections.
 -- URI format: akb://{vault}/doc/{path}
 --             akb://{vault}/table/{name}
 --             akb://{vault}/file/{id}

--- a/backend/app/db/migrations/083_edge_vault_boundary.py
+++ b/backend/app/db/migrations/083_edge_vault_boundary.py
@@ -1,0 +1,100 @@
+"""Enforce one-vault ownership for knowledge-graph edges.
+
+The graph service treats a vault as one authorization and lifecycle boundary.
+Both endpoint URI authorities must therefore match ``edges.vault_id``. Existing
+cross-vault rows are retained for an operator-reviewed cleanup and hidden by
+read-side filtering; the trigger prevents new rows and valid-to-invalid updates.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger("akb.migration.083")
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION akb_enforce_edge_vault_boundary()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            SET search_path = pg_catalog, public
+            AS $$
+            DECLARE
+                owner_name TEXT;
+                source_name TEXT;
+                target_name TEXT;
+                old_source_name TEXT;
+                old_target_name TEXT;
+                new_is_valid BOOLEAN;
+                old_is_valid BOOLEAN := FALSE;
+            BEGIN
+                SELECT name INTO owner_name FROM public.vaults WHERE id = NEW.vault_id;
+                source_name := split_part(substr(NEW.source_uri, 7), '/', 1);
+                target_name := split_part(substr(NEW.target_uri, 7), '/', 1);
+                new_is_valid :=
+                    starts_with(NEW.source_uri, 'akb://')
+                    AND starts_with(NEW.target_uri, 'akb://')
+                    AND source_name = owner_name
+                    AND target_name = owner_name;
+
+                IF new_is_valid THEN
+                    RETURN NEW;
+                END IF;
+
+                -- A rollout may encounter a legacy invalid row while moving a
+                -- document. Let an already-invalid row remain invalid so an
+                -- unrelated lifecycle write is not blocked; read paths hide it
+                -- and the operator audit below identifies it for cleanup.
+                IF TG_OP = 'UPDATE' AND NEW.vault_id = OLD.vault_id THEN
+                    old_source_name := split_part(substr(OLD.source_uri, 7), '/', 1);
+                    old_target_name := split_part(substr(OLD.target_uri, 7), '/', 1);
+                    old_is_valid :=
+                        starts_with(OLD.source_uri, 'akb://')
+                        AND starts_with(OLD.target_uri, 'akb://')
+                        AND old_source_name = owner_name
+                        AND old_target_name = owner_name;
+                    IF NOT old_is_valid
+                       AND source_name = old_source_name
+                       AND target_name = old_target_name THEN
+                        RETURN NEW;
+                    END IF;
+                END IF;
+
+                RAISE EXCEPTION USING
+                    ERRCODE = '23514',
+                    MESSAGE = 'edge endpoints must belong to the owning vault';
+            END;
+            $$
+            """
+        )
+        await conn.execute("DROP TRIGGER IF EXISTS trg_edges_vault_boundary ON edges")
+        await conn.execute(
+            """
+            CREATE TRIGGER trg_edges_vault_boundary
+            BEFORE INSERT OR UPDATE OF vault_id, source_uri, target_uri
+            ON edges
+            FOR EACH ROW
+            EXECUTE FUNCTION akb_enforce_edge_vault_boundary()
+            """
+        )
+
+        legacy_count = await conn.fetchval(
+            """
+            SELECT count(*)
+            FROM edges e
+            JOIN vaults v ON v.id = e.vault_id
+            WHERE NOT starts_with(e.source_uri, 'akb://' || v.name || '/')
+               OR NOT starts_with(e.target_uri, 'akb://' || v.name || '/')
+            """
+        )
+
+    if legacy_count:
+        logger.warning(
+            "Detected %d legacy edge row(s) outside their owning vault; "
+            "reader projections exclude them until operator-reviewed cleanup",
+            legacy_count,
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -305,6 +305,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "080_local_forced_credential_change.py",  # local parity for the identity provider's UPDATE_PASSWORD: a delivered credential is owed a replacement until its holder changes it
         "081_service_identities.py",  # non-human (issuer, client) → AKB service account bindings, kept out of the human external_identities population
         "082_pending_admissions.py",  # the arrival invite_only refuses, kept so an administrator can approve that exact identity instead of guessing a subject in advance
+        "083_edge_vault_boundary.py",  # graph edges are vault-local: owner/source/target authorities agree; legacy rows stay hidden pending reviewed cleanup
     ):
         if filename in applied:
             continue

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -57,6 +57,7 @@ class RelationItem(KnowledgeResponse):
     relation: ReadRelationType
     uri: str
     resource_type: ResourceType
+    kind: EdgeKind
     name: str | None = None
 
 

--- a/backend/app/openapi_contract.py
+++ b/backend/app/openapi_contract.py
@@ -542,7 +542,7 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
         },
         "AkbRelation": {
             "type": "object",
-            "required": ["direction", "relation", "uri", "resource_type"],
+            "required": ["direction", "relation", "uri", "resource_type", "kind"],
             "properties": {
                 "direction": {"type": "string", "enum": ["incoming", "outgoing"]},
                 "relation": {
@@ -559,6 +559,7 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
                 },
                 "uri": {"type": "string"},
                 "resource_type": {"type": "string", "enum": ["doc", "table", "file"]},
+                "kind": {"type": "string", "enum": ["implicit", "explicit"]},
                 "name": _nullable_string(),
             },
             "additionalProperties": {"$ref": "#/components/schemas/AkbJsonValue"},

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -24,6 +24,7 @@ from app.repositories.events_repo import emit_event
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services.account_markers import is_retired_recovery_admin_password
 from app.services.account_service import presented_issuer_or_none
+from app.services.edge_boundary import edge_scope_sql, vault_uri_prefix
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
 from app.services.write_lane import run_compensation, run_git_write
@@ -776,7 +777,12 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
         # Authoritative collection total — depth-safe, unlike a client-side
         # browse(depth=2) count which silently undercounts deeper nesting.
         _q("SELECT COUNT(*) FROM collections WHERE vault_id = $1", vid),
-        _q("SELECT COUNT(*) FROM edges WHERE vault_id = $1", vid),
+        _q(
+            "SELECT COUNT(*) FROM edges WHERE "
+            + edge_scope_sql(vault_param=1, prefix_param=2),
+            vid,
+            vault_uri_prefix(vault_name),
+        ),
         _r(
             "SELECT updated_at, created_by FROM documents WHERE vault_id = $1 "
             "ORDER BY updated_at DESC LIMIT 1",

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -55,6 +55,8 @@ free-form this section. Agents read it as context, not a hard schema.)
 
 ## Relation rules
 
+- Structured relations stay inside this vault. For a cross-vault citation,
+  use an ordinary Markdown link; it remains content and is not a graph edge.
 - depends_on — one resource cannot be understood without another
 - implements — code/spec realizes a designed behavior
 - references — background citation
@@ -138,7 +140,11 @@ from app.services.index_service import (
     delete_document_chunks,
     delete_vault_chunks,
 )
-from app.services.kg_service import delete_document_relations, store_document_relations
+from app.services.kg_service import (
+    delete_document_relations,
+    store_document_relations,
+    validate_new_structured_relation_refs,
+)
 from app.services.resource_hash import HASH_ALGORITHM, compute_text_content_hash
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
@@ -599,6 +605,12 @@ class DocumentService:
         explicit_slug, now, normalized_collection, doc_repo, coll_repo, conn,
         allow_unavailable_asset_refs=False,
     ) -> DocumentPutResponse:
+        # Structured graph relations are vault-local. Validate before any Git
+        # write or target lookup; ordinary cross-vault Markdown links remain
+        # valid body content and are intentionally handled separately.
+        validate_new_structured_relation_refs(req.vault, req.depends_on)
+        validate_new_structured_relation_refs(req.vault, req.related_to)
+
         # Resolve the final path under the (vault, base_path) advisory lock,
         # which serializes writers racing on the same base slug. If the clean
         # path is free, use it (predictable, human-readable). If taken: a
@@ -1021,6 +1033,22 @@ class DocumentService:
             raise ConflictError(
                 f"content_hash moved: expected {req.expected_content_hash}, "
                 f"actual {current_hash}"
+            )
+
+        # Preserve pre-existing cross-vault metadata as inert legacy content so
+        # unrelated edits still work, but reject any newly introduced value
+        # before the Git commit. Re-extraction below removes any legacy edge.
+        if req.depends_on is not None:
+            validate_new_structured_relation_refs(
+                vault,
+                req.depends_on,
+                existing_refs=ensure_list(current_fm.get("depends_on", [])),
+            )
+        if req.related_to is not None:
+            validate_new_structured_relation_refs(
+                vault,
+                req.related_to,
+                existing_refs=ensure_list(current_fm.get("related_to", [])),
             )
 
         # Merge updates

--- a/backend/app/services/edge_boundary.py
+++ b/backend/app/services/edge_boundary.py
@@ -1,0 +1,60 @@
+"""Shared knowledge-graph vault-boundary primitives.
+
+An edge belongs to exactly one vault. Application reads therefore scope both
+the owning ``vault_id`` and the authority embedded in each endpoint URI. Keep
+that predicate centralized so a new projection cannot accidentally count or
+display a legacy cross-vault row.
+"""
+
+from __future__ import annotations
+
+from app.services.uri_service import parse_uri
+
+
+LINKABLE_RESOURCE_TYPES = ("doc", "table", "file")
+
+
+def vault_uri_prefix(vault: str) -> str:
+    """Return the unambiguous URI prefix for resources in ``vault``."""
+    return f"akb://{vault}/"
+
+
+def edge_scope_sql(
+    *,
+    alias: str = "",
+    vault_param: int,
+    prefix_param: int,
+) -> str:
+    """Return the SQL predicate for a reader-visible edge.
+
+    Parameter numbers are explicit because callers compose the predicate into
+    queries with different leading arguments. Values remain bound parameters;
+    only trusted column aliases and integer placeholders are interpolated.
+    """
+    column = f"{alias}." if alias else ""
+    return (
+        f"{column}vault_id = ${vault_param} "
+        f"AND starts_with({column}source_uri, ${prefix_param}) "
+        f"AND starts_with({column}target_uri, ${prefix_param})"
+    )
+
+
+def uri_is_in_vault(uri: str, vault: str) -> bool:
+    """Return whether ``uri`` is a linkable resource owned by ``vault``."""
+    parsed = parse_uri(uri)
+    return bool(
+        parsed
+        and parsed.vault == vault
+        and parsed.kind in LINKABLE_RESOURCE_TYPES
+        and parsed.identifier is not None
+    )
+
+
+def invalid_edge_predicate(*, edge_alias: str = "e", vault_alias: str = "v") -> str:
+    """Return the aggregate audit predicate for an out-of-boundary edge."""
+    return (
+        f"NOT starts_with({edge_alias}.source_uri, "
+        f"'akb://' || {vault_alias}.name || '/') "
+        f"OR NOT starts_with({edge_alias}.target_uri, "
+        f"'akb://' || {vault_alias}.name || '/')"
+    )

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -20,9 +20,16 @@ import uuid
 from itertools import zip_longest
 from typing import Literal, get_args
 
+from app.exceptions import ValidationError
 from app.db.postgres import get_pool
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services.asset_service import ASSET_URL_PREFIX
+from app.services.edge_boundary import (
+    LINKABLE_RESOURCE_TYPES,
+    edge_scope_sql,
+    uri_is_in_vault,
+    vault_uri_prefix,
+)
 from app.services.uri_service import parse_uri, doc_uri, table_uri, file_uri
 from app.util.errors import (
     err,
@@ -58,6 +65,31 @@ LinkRelationType = Literal[
     "derived_from",
 ]
 LINK_RELATION_TYPES: tuple[str, ...] = get_args(LinkRelationType)
+
+
+def validate_new_structured_relation_refs(
+    vault: str,
+    refs: list[str],
+    *,
+    existing_refs: list[str] | None = None,
+) -> None:
+    """Reject newly introduced structured references outside ``vault``.
+
+    Existing values are accepted so an unrelated edit does not make a legacy
+    document unwritable. They are inert in the graph because extraction skips
+    cross-vault targets. New values fail before Git or PostgreSQL mutation and
+    before any target-vault catalog lookup, so target existence is not exposed.
+    """
+    existing = set(existing_refs or [])
+    for ref in refs:
+        if ref in existing:
+            continue
+        parsed = parse_uri(ref)
+        if parsed is not None and parsed.vault != vault:
+            raise ValidationError(
+                "Structured relations must stay within the document's vault; "
+                "use an ordinary Markdown link for a cross-vault reference."
+            )
 
 # Matches markdown links and image destinations. Relative images can represent
 # document-to-document references in imported Markdown; generated editor asset
@@ -274,24 +306,31 @@ async def link_resources(
         return err(f"Invalid source URI: {source_uri}", code=INVALID_URI)
     if not target_parsed:
         return err(f"Invalid target URI: {target_uri}", code=INVALID_URI)
-    _LINKABLE = ("doc", "table", "file")
-    if source_parsed.kind not in _LINKABLE:
+    if source_parsed.kind not in LINKABLE_RESOURCE_TYPES:
         return err(
             f"Cannot link from a {source_parsed.kind} URI ({source_uri}). "
-            f"Linkable kinds: {_LINKABLE}.",
+            f"Linkable kinds: {LINKABLE_RESOURCE_TYPES}.",
             code=INVALID_ARGUMENT,
         )
-    if target_parsed.kind not in _LINKABLE:
+    if target_parsed.kind not in LINKABLE_RESOURCE_TYPES:
         return err(
             f"Cannot link to a {target_parsed.kind} URI ({target_uri}). "
-            f"Linkable kinds: {_LINKABLE}.",
+            f"Linkable kinds: {LINKABLE_RESOURCE_TYPES}.",
             code=INVALID_ARGUMENT,
         )
 
-    source_vault_name = source_parsed.vault
+    # Enforce the boundary before any vault or resource lookup. The requested
+    # graph owner, source authority, and target authority must all agree; this
+    # also prevents a direct service caller from assigning a valid edge to an
+    # unrelated vault container.
+    if not source_parsed.vault == target_parsed.vault == vault_name:
+        return err(
+            "source and target must belong to the requested vault",
+            code=INVALID_ARGUMENT,
+        )
+
     source_type = source_parsed.kind
     source_id = source_parsed.identifier
-    target_vault_name = target_parsed.vault
     target_type = target_parsed.kind
     target_id = target_parsed.identifier
 
@@ -323,17 +362,6 @@ async def link_resources(
                 return err(f"Vault not found: {vault_name}", code=NOT_FOUND)
             vault_id = vault["id"]
 
-            source_vault = await conn.fetchrow(
-                "SELECT id FROM vaults WHERE name = $1", source_vault_name,
-            )
-            if not source_vault:
-                return err(f"Source vault not found: {source_vault_name}", code=NOT_FOUND)
-            target_vault = await conn.fetchrow(
-                "SELECT id FROM vaults WHERE name = $1", target_vault_name,
-            )
-            if not target_vault:
-                return err(f"Target vault not found: {target_vault_name}", code=NOT_FOUND)
-
             # Acquire the same path advisory lock the doc write paths use so
             # akb_link serialises with akb_delete / akb_update on either
             # endpoint. Doc endpoints only — table/file lifecycle is keyed by
@@ -342,20 +370,20 @@ async def link_resources(
             from app.repositories.document_repo import acquire_path_lock
             doc_endpoints: list[tuple[uuid.UUID, str]] = []
             if source_type == "doc":
-                doc_endpoints.append((source_vault["id"], source_id))
+                doc_endpoints.append((vault_id, source_id))
             if target_type == "doc":
-                doc_endpoints.append((target_vault["id"], target_id))
+                doc_endpoints.append((vault_id, target_id))
             for vid, ident in sorted(
                 doc_endpoints, key=lambda x: (str(x[0]), x[1]),
             ):
                 await acquire_path_lock(conn, vid, ident)
 
             if not await _resource_exists(
-                conn, source_vault["id"], source_type, source_id,
+                conn, vault_id, source_type, source_id,
             ):
                 return err(f"Source resource not found: {source_uri}", code=NOT_FOUND)
             if not await _resource_exists(
-                conn, target_vault["id"], target_type, target_id,
+                conn, vault_id, target_type, target_id,
             ):
                 return err(f"Target resource not found: {target_uri}", code=NOT_FOUND)
 
@@ -380,7 +408,7 @@ async def unlink_resources(
     target_uri: str,
     relation_type: str | None = None,
     *,
-    vault_id: uuid.UUID | None = None,
+    vault_id: uuid.UUID,
 ) -> dict:
     """Remove an edge between two resources.
 
@@ -413,6 +441,11 @@ async def unlink_resources(
         return err(f"Invalid source URI: {source_uri}", code=INVALID_URI)
     if not tgt_parsed:
         return err(f"Invalid target URI: {target_uri}", code=INVALID_URI)
+    if src_parsed.vault != tgt_parsed.vault:
+        return err(
+            "source and target must belong to the same vault",
+            code=INVALID_ARGUMENT,
+        )
     src_canon = canonicalize_resource_uri(src_parsed)
     tgt_canon = canonicalize_resource_uri(tgt_parsed)
     if src_canon is None:
@@ -432,14 +465,26 @@ async def unlink_resources(
 
     pool = await get_pool()
     async with pool.acquire() as conn:
+        owner_vault = await conn.fetchval(
+            "SELECT name FROM vaults WHERE id = $1", vault_id,
+        )
+        if owner_vault is None:
+            return err("Vault not found", code=NOT_FOUND)
+        if owner_vault != src_parsed.vault:
+            return err(
+                "source and target must belong to the authorized vault",
+                code=INVALID_ARGUMENT,
+            )
         params: list = [source_uri, target_uri]
-        where = "source_uri = $1 AND target_uri = $2"
+        # Implicit edges are owned by document metadata/body extraction. They
+        # must be removed by editing that source content, not by the explicit
+        # relation API (which would only make them reappear on the next save).
+        where = "source_uri = $1 AND target_uri = $2 AND kind = 'explicit'"
         if relation_type:
             where += " AND relation_type = $3"
             params.append(relation_type)
-        if vault_id is not None:
-            where += f" AND vault_id = ${len(params) + 1}"
-            params.append(vault_id)
+        where += f" AND vault_id = ${len(params) + 1}"
+        params.append(vault_id)
         result = await conn.execute(
             f"DELETE FROM edges WHERE {where}", *params,
         )
@@ -461,78 +506,87 @@ async def get_resource_relations(
 ) -> list[dict]:
     """Get direct (1-hop) relations for any resource.
 
-    `vault_id` scopes both the edge fetch and the name resolution to a
-    single vault. Cross-vault edges (an edge whose endpoint URI lives in
-    another vault) are returned only as opaque URIs — the endpoint name
-    is NOT resolved unless the resource also exists in this vault. This
-    is the security boundary: a caller authorized for vault A cannot
-    learn the title/description/filename of a doc/table/file in vault B
-    even if A holds an edge pointing at B.
+    ``vault_id`` and both endpoint URI authorities must identify ``vault``.
+    Legacy cross-vault rows are omitted completely: neither their raw URI nor
+    their contribution to a count is part of the reader-visible graph.
     """
+    if not uri_is_in_vault(resource_uri, vault):
+        return []
+
     pool = await get_pool()
     results = []
     uris_to_resolve: list[tuple[str, str]] = []
+    prefix = vault_uri_prefix(vault)
+    scoped = edge_scope_sql(alias="e", vault_param=2, prefix_param=3)
 
     async with pool.acquire() as conn:
         if direction in ("outgoing", "both"):
-            base_params: list = [resource_uri, vault_id]
+            base_params: list = [resource_uri, vault_id, prefix]
             if relation_type:
                 rows = await conn.fetch(
-                    """
-                    SELECT e.relation_type, e.target_uri, e.target_type
+                    f"""
+                    SELECT e.relation_type, e.target_uri, e.target_type, e.kind
                     FROM edges e
-                    WHERE e.source_uri = $1 AND e.vault_id = $2 AND e.relation_type = $3
+                    WHERE e.source_uri = $1 AND {scoped} AND e.relation_type = $4
                     """,
                     *base_params, relation_type,
                 )
             else:
                 rows = await conn.fetch(
-                    """
-                    SELECT e.relation_type, e.target_uri, e.target_type
+                    f"""
+                    SELECT e.relation_type, e.target_uri, e.target_type, e.kind
                     FROM edges e
-                    WHERE e.source_uri = $1 AND e.vault_id = $2
+                    WHERE e.source_uri = $1 AND {scoped}
                     """,
                     *base_params,
                 )
             for r in rows:
+                if not uri_is_in_vault(r["target_uri"], vault):
+                    continue
                 results.append({
                     "direction": "outgoing",
                     "relation": r["relation_type"],
                     "uri": r["target_uri"],
                     "resource_type": r["target_type"],
+                    "kind": r["kind"],
                 })
                 uris_to_resolve.append((r["target_uri"], r["target_type"]))
 
         if direction in ("incoming", "both"):
-            base_params = [resource_uri, vault_id]
+            base_params = [resource_uri, vault_id, prefix]
             if relation_type:
                 rows = await conn.fetch(
-                    """
-                    SELECT e.relation_type, e.source_uri, e.source_type
+                    f"""
+                    SELECT e.relation_type, e.source_uri, e.source_type, e.kind
                     FROM edges e
-                    WHERE e.target_uri = $1 AND e.vault_id = $2 AND e.relation_type = $3
+                    WHERE e.target_uri = $1 AND {scoped} AND e.relation_type = $4
                     """,
                     *base_params, relation_type,
                 )
             else:
                 rows = await conn.fetch(
-                    """
-                    SELECT e.relation_type, e.source_uri, e.source_type
+                    f"""
+                    SELECT e.relation_type, e.source_uri, e.source_type, e.kind
                     FROM edges e
-                    WHERE e.target_uri = $1 AND e.vault_id = $2
+                    WHERE e.target_uri = $1 AND {scoped}
                     """,
                     *base_params,
                 )
             for r in rows:
+                if not uri_is_in_vault(r["source_uri"], vault):
+                    continue
                 results.append({
                     "direction": "incoming",
                     "relation": r["relation_type"],
                     "uri": r["source_uri"],
                     "resource_type": r["source_type"],
+                    "kind": r["kind"],
                 })
                 uris_to_resolve.append((r["source_uri"], r["source_type"]))
 
-        names = await _batch_resolve_names(conn, uris_to_resolve, vault_id=vault_id)
+        names = await _batch_resolve_names(
+            conn, uris_to_resolve, vault_id=vault_id, vault_name=vault,
+        )
         for entry in results:
             name = names.get(entry["uri"])
             if name:
@@ -575,6 +629,8 @@ async def get_graph(
     """
     if not resource_uri:
         return await get_overview(vault, vault_id=vault_id, top_k=limit)
+    if not uri_is_in_vault(resource_uri, vault):
+        return {"nodes": [], "edges": []}
 
     pool = await get_pool()
     nodes: dict[str, dict] = {}
@@ -708,17 +764,23 @@ async def get_overview(
                 return empty
             vault_id = vault_row["id"]
 
+        prefix = vault_uri_prefix(vault)
+        scoped = edge_scope_sql(vault_param=1, prefix_param=2)
+
         totals = await conn.fetchrow(
-            """
-            WITH endpoints AS (
-                SELECT source_uri AS uri FROM edges WHERE vault_id = $1
+            f"""
+            WITH scoped_edges AS (
+                SELECT * FROM edges WHERE {scoped}
+            ),
+            endpoints AS (
+                SELECT source_uri AS uri FROM scoped_edges
                 UNION ALL
-                SELECT target_uri FROM edges WHERE vault_id = $1
+                SELECT target_uri FROM scoped_edges
             )
-            SELECT (SELECT count(*) FROM edges WHERE vault_id = $1) AS edges_total,
+            SELECT (SELECT count(*) FROM scoped_edges) AS edges_total,
                    (SELECT count(DISTINCT uri) FROM endpoints) AS nodes_total
             """,
-            vault_id,
+            vault_id, prefix,
         )
         nodes_total = totals["nodes_total"] if totals else 0
         edges_total = totals["edges_total"] if totals else 0
@@ -736,19 +798,22 @@ async def get_overview(
         # max(rtype) just picks that single value. The `uri` tie-break makes the
         # cut deterministic when several nodes share the boundary degree.
         top_rows = await conn.fetch(
-            """
-            WITH endpoints AS (
-                SELECT source_uri AS uri, source_type AS rtype FROM edges WHERE vault_id = $1
+            f"""
+            WITH scoped_edges AS (
+                SELECT * FROM edges WHERE {scoped}
+            ),
+            endpoints AS (
+                SELECT source_uri AS uri, source_type AS rtype FROM scoped_edges
                 UNION ALL
-                SELECT target_uri, target_type FROM edges WHERE vault_id = $1
+                SELECT target_uri, target_type FROM scoped_edges
             )
             SELECT uri, max(rtype) AS rtype, count(*) AS degree
             FROM endpoints
             GROUP BY uri
             ORDER BY degree DESC, uri
-            LIMIT $2
+            LIMIT $3
             """,
-            vault_id, top_k,
+            vault_id, prefix, top_k,
         )
 
         nodes: dict[str, dict] = {}
@@ -767,14 +832,14 @@ async def get_overview(
             # top-K set — so the overview never paints a dangling stub to a
             # node it didn't include.
             edge_rows = await conn.fetch(
-                """
+                f"""
                 SELECT source_uri, target_uri, relation_type, kind
                 FROM edges
-                WHERE vault_id = $1
-                  AND source_uri = ANY($2::text[])
-                  AND target_uri = ANY($2::text[])
+                WHERE {scoped}
+                  AND source_uri = ANY($3::text[])
+                  AND target_uri = ANY($3::text[])
                 """,
-                vault_id, top_uris,
+                vault_id, prefix, top_uris,
             )
             for r in edge_rows:
                 edge_list.append({
@@ -785,7 +850,8 @@ async def get_overview(
                 })
 
         names = await _batch_resolve_names(
-            conn, [(u, n["resource_type"]) for u, n in nodes.items()], vault_id=vault_id
+            conn, [(u, n["resource_type"]) for u, n in nodes.items()],
+            vault_id=vault_id, vault_name=vault,
         )
         for uri, node in nodes.items():
             node["name"] = names.get(uri) or uri
@@ -807,9 +873,9 @@ async def get_overview(
             file_ids: set[str] = set()
             if nodes_total:
                 conn_rows = await conn.fetch(
-                    "SELECT source_uri AS uri FROM edges WHERE vault_id = $1 "
-                    "UNION ALL SELECT target_uri FROM edges WHERE vault_id = $1",
-                    vault_id,
+                    f"SELECT source_uri AS uri FROM edges WHERE {scoped} "
+                    f"UNION ALL SELECT target_uri FROM edges WHERE {scoped}",
+                    vault_id, prefix,
                 )
                 for r in conn_rows:
                     p = parse_uri(r["uri"])
@@ -886,31 +952,37 @@ async def get_health(
                 return {"hubs": [], "orphans": {"count": 0, "sample": []}}
             vault_id = vault_row["id"]
 
+        prefix = vault_uri_prefix(vault)
+        scoped = edge_scope_sql(vault_param=1, prefix_param=2)
+
         hub_rows = await conn.fetch(
-            """
-            WITH endpoints AS (
-                SELECT source_uri AS uri, source_type AS rtype FROM edges WHERE vault_id = $1
+            f"""
+            WITH scoped_edges AS (
+                SELECT * FROM edges WHERE {scoped}
+            ),
+            endpoints AS (
+                SELECT source_uri AS uri, source_type AS rtype FROM scoped_edges
                 UNION ALL
-                SELECT target_uri, target_type FROM edges WHERE vault_id = $1
+                SELECT target_uri, target_type FROM scoped_edges
             )
             SELECT uri, max(rtype) AS rtype, count(*) AS degree
             FROM endpoints
             GROUP BY uri
-            HAVING count(*) >= $2
+            HAVING count(*) >= $3
             ORDER BY degree DESC, uri
-            LIMIT $3
+            LIMIT $4
             """,
-            vault_id, hub_threshold, limit,
+            vault_id, prefix, hub_threshold, limit,
         )
 
         # Every URI that appears on either end of an edge → "connected".
         connected_rows = await conn.fetch(
-            """
-            SELECT source_uri AS uri FROM edges WHERE vault_id = $1
+            f"""
+            SELECT source_uri AS uri FROM edges WHERE {scoped}
             UNION
-            SELECT target_uri FROM edges WHERE vault_id = $1
+            SELECT target_uri FROM edges WHERE {scoped}
             """,
-            vault_id,
+            vault_id, prefix,
         )
         connected = {r["uri"] for r in connected_rows}
 
@@ -936,7 +1008,8 @@ async def get_health(
         hubs: list[dict] = []
         if hub_rows:
             hub_names = await _batch_resolve_names(
-                conn, [(r["uri"], r["rtype"]) for r in hub_rows], vault_id=vault_id
+                conn, [(r["uri"], r["rtype"]) for r in hub_rows],
+                vault_id=vault_id, vault_name=vault,
             )
             hubs = [
                 {
@@ -1000,15 +1073,13 @@ async def _batch_resolve_names(
     conn, uris: list[tuple[str, str]],
     *,
     vault_id: uuid.UUID,
+    vault_name: str,
 ) -> dict[str, str]:
     """Resolve multiple URIs to display names in batch (3 queries max, not N).
 
-    Scoped to `vault_id`. URIs whose underlying resource lives in a
-    different vault won't get a resolved title/description/name —
-    they fall back to the identifier from the URI itself. This is a
-    privacy boundary: callers authorized for one vault shouldn't learn
-    the human-readable names of resources in another vault, even if
-    they can see the raw URI through a cross-vault edge.
+    Scoped to both ``vault_id`` and ``vault_name``. A URI from another vault is
+    ignored rather than receiving an identifier fallback; callers must not be
+    able to project even the raw foreign endpoint through this helper.
     """
     if not uris:
         return {}
@@ -1023,7 +1094,7 @@ async def _batch_resolve_names(
 
     for uri, rtype in uris:
         parsed = parse_uri(uri)
-        if not parsed:
+        if not parsed or parsed.vault != vault_name:
             continue
         identifier = parsed.identifier
         if identifier is None:
@@ -1139,19 +1210,16 @@ async def _store_edge(
                 target_ref, parsed.kind,
             )
             return False
-        target_type = parsed.kind
-        ident = parsed.identifier or ""
-        # Resolve the target's vault (edges may cross vaults) so existence
-        # is checked against the right catalog.
-        target_vault_id = await conn.fetchval(
-            "SELECT id FROM vaults WHERE name = $1", parsed.vault,
-        )
-        if target_vault_id is None:
+        if parsed.vault != vault_name:
+            # Cross-vault Markdown links remain authored content, but are not
+            # graph edges. Rejecting before any vault lookup also prevents the
+            # extraction result from revealing whether the target exists.
             logger.debug(
-                "Skipping edge to %r: target vault %r not found",
-                target_ref, parsed.vault,
+                "Skipping cross-vault implicit edge from vault %r", vault_name,
             )
             return False
+        target_type = parsed.kind
+        ident = parsed.identifier or ""
         # Validate the target EXISTS before storing — via the SAME
         # `_resource_exists` primitive the explicit akb_link path uses, so
         # the two link paths validate identically (they differ only in
@@ -1161,7 +1229,7 @@ async def _store_edge(
         # the path (`…/x.md|Label`), or a forward reference to a doc never
         # created. The extraction path used to skip this check, which is how
         # the malformed targets got persisted.
-        if not await _resource_exists(conn, target_vault_id, parsed.kind, ident):
+        if not await _resource_exists(conn, vault_id, parsed.kind, ident):
             logger.debug(
                 "Skipping edge to nonexistent %s %r", parsed.kind, target_ref,
             )
@@ -1253,17 +1321,17 @@ async def _bfs_collect(
 ) -> None:
     """BFS traversal from a starting resource URI, scoped to one vault.
 
-    Both edge fetches gate on `edges.vault_id` so the traversal cannot
-    follow cross-vault links into vaults the caller wasn't authorized
-    on. Endpoints whose URI lives in another vault still appear as
-    leaf nodes (with the URI as the only signal) but are never used as
-    seeds for the next BFS layer's name resolution.
+    Edge ownership and both endpoint URI authorities must match the requested
+    vault. A legacy cross-vault edge therefore contributes no node, row, or
+    traversal seed.
     """
     queue = [start_uri]
     visited: set[str] = set()
     # Track emitted edges so an edge A→B doesn't appear twice when both
     # A and B are processed in the same BFS wave.
     emitted: set[tuple[str, str, str]] = set()
+    prefix = vault_uri_prefix(vault_name)
+    scoped = edge_scope_sql(vault_param=2, prefix_param=3)
 
     for current_depth in range(depth + 1):
         if not queue or len(nodes) >= limit:
@@ -1277,14 +1345,24 @@ async def _bfs_collect(
 
         outgoing = await conn.fetch(
             "SELECT source_uri, target_uri, target_type, relation_type, kind "
-            "FROM edges WHERE source_uri = ANY($1::text[]) AND vault_id = $2",
-            unvisited, vault_id,
+            f"FROM edges WHERE source_uri = ANY($1::text[]) AND {scoped}",
+            unvisited, vault_id, prefix,
         )
         incoming = await conn.fetch(
             "SELECT source_uri, source_type, target_uri, relation_type, kind "
-            "FROM edges WHERE target_uri = ANY($1::text[]) AND vault_id = $2",
-            unvisited, vault_id,
+            f"FROM edges WHERE target_uri = ANY($1::text[]) AND {scoped}",
+            unvisited, vault_id, prefix,
         )
+        outgoing = [
+            row for row in outgoing
+            if uri_is_in_vault(row["source_uri"], vault_name)
+            and uri_is_in_vault(row["target_uri"], vault_name)
+        ]
+        incoming = [
+            row for row in incoming
+            if uri_is_in_vault(row["source_uri"], vault_name)
+            and uri_is_in_vault(row["target_uri"], vault_name)
+        ]
 
         # Index edges by source/target for quick lookup
         out_by_uri: dict[str, list] = {}
@@ -1350,7 +1428,9 @@ async def _bfs_collect(
     edges[:] = [e for e in edges if e["source"] in nodes and e["target"] in nodes]
 
     uris_to_resolve = [(uri, n["resource_type"]) for uri, n in nodes.items()]
-    names = await _batch_resolve_names(conn, uris_to_resolve, vault_id=vault_id)
+    names = await _batch_resolve_names(
+        conn, uris_to_resolve, vault_id=vault_id, vault_name=vault_name,
+    )
     for uri, node in nodes.items():
         node["name"] = names.get(uri) or uri
 

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -44,6 +44,7 @@ from app.services.document_service import (
     validate_vault_name,
 )
 from app.services.m1_pg_body_store import M1PgBodyStore
+from app.services.kg_service import validate_new_structured_relation_refs
 from app.services.native_revision_service import (
     Failpoint,
     NativeRevisionService,
@@ -307,6 +308,8 @@ class NativeDocumentService(DocumentService):
         del allow_unavailable_asset_refs
         if req.status not in DOC_STATUSES:
             raise ValidationError(f"status must be one of {list(DOC_STATUSES)}, got {req.status!r}")
+        validate_new_structured_relation_refs(req.vault, req.depends_on)
+        validate_new_structured_relation_refs(req.vault, req.related_to)
         skill_policy.check_put(
             normalize_collection_path(req.collection), req.type,
             internal=skill_internal,
@@ -451,6 +454,18 @@ class NativeDocumentService(DocumentService):
             previous_hash = _body_content_hash(current_body)
             if req.expected_content_hash and req.expected_content_hash != previous_hash:
                 raise ConflictError(f"content_hash moved: expected {req.expected_content_hash}, actual {previous_hash}")
+            if req.depends_on is not None:
+                validate_new_structured_relation_refs(
+                    vault,
+                    req.depends_on,
+                    existing_refs=ensure_list(frontmatter.get("depends_on", [])),
+                )
+            if req.related_to is not None:
+                validate_new_structured_relation_refs(
+                    vault,
+                    req.related_to,
+                    existing_refs=ensure_list(frontmatter.get("related_to", [])),
+                )
             if req.title:
                 frontmatter["title"] = req.title
             if req.type:

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -495,7 +495,7 @@ akb_graph(uri="akb://eng/doc/specs/api.md", hops=2)
 ## Provenance
 ```
 akb_provenance(uri="akb://eng/doc/specs/api.md")
-→ who created it, when, all relations (including cross-type)
+→ who created it, when, and visible same-vault relations (including cross-type)
 ```""",
 
     # ── Workflows ─────────────────────────────────────────────
@@ -1164,12 +1164,13 @@ Pass either `vault` (full vault graph) or `uri` (graph anchored on one resource)
 ```
 akb_graph(vault="eng")                                            # Full vault graph
 akb_graph(uri="akb://eng/table/experiments", hops=2)              # From a table
-akb_graph(uri="akb://eng/doc/specs/api.md", depth=3)              # 3-hop from doc
+akb_graph(uri="akb://eng/doc/specs/api.md", hops=3)               # 3-hop from doc
 ```""",
 
     "akb_provenance": """# akb_provenance — Document Provenance
 
-Shows who created a document, when, and all its relations (including cross-type).
+Shows who created a document, when, and its visible same-vault relations
+(including cross-type).
 
 ## Parameters
 | Param | Required | Description |

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -46,7 +46,8 @@ Every resource has a URI: `akb://{vault}/{type}/{id}`
 - `akb://eng/table/experiments` → table
 - `akb://eng/file/abc123-def456` → file
 
-Use these URIs with `akb_link` and `akb_relations` to connect any resource to any other.
+Use these URIs with `akb_link` and `akb_relations` to connect resources within
+the same vault. Cross-vault citations stay ordinary Markdown links.
 
 ## Workflows — drill down with `akb_help(topic="...")`
 
@@ -435,6 +436,11 @@ Browse results include the `uri` field for each resource.
 
 ## Creating Links
 
+Structured relations are vault-local: every source and target below must use
+the same vault. To cite content in another vault, keep the `akb://` URI as an
+ordinary Markdown link. AKB preserves that authored link but does not query the
+target or add it to either vault's graph.
+
 **Explicit (any resource type):**
 ```
 akb_link(
@@ -467,7 +473,7 @@ akb_unlink(
 
 akb_unlink(
   source="akb://eng/doc/specs/api.md",
-  target="akb://eng/table/api-endpoints")  # removes ALL relations between them
+  target="akb://eng/table/api-endpoints")  # removes all explicit relations between them
 ```
 
 ## Querying Relations
@@ -475,11 +481,15 @@ akb_unlink(
 akb_relations(uri="akb://eng/doc/specs/api.md")
 akb_relations(uri="akb://eng/table/experiments", direction="incoming")
 ```
+Each returned row has `kind="explicit"` for an `akb_link` edge or
+`kind="implicit"` when it is managed by document metadata/body content.
+Remove explicit rows with `akb_unlink`; edit the source document to remove an
+implicit row.
 
 ## Graph View
 ```
 akb_graph(vault="eng")                           # Full vault graph (all types)
-akb_graph(uri="akb://eng/doc/specs/api.md", depth=2)
+akb_graph(uri="akb://eng/doc/specs/api.md", hops=2)
 ```
 
 ## Provenance
@@ -534,7 +544,7 @@ result = akb_put(vault="eng", collection="decisions", title="API Redesign",
 ### Step 4: Verify the graph
 ```
 akb_relations(uri="akb://eng/doc/specs/experiment-design.md")
-akb_graph(uri="akb://eng/doc/specs/experiment-design.md", depth=2)
+akb_graph(uri="akb://eng/doc/specs/experiment-design.md", hops=2)
 ```
 
 ### Step 5: Remove a link if needed
@@ -666,8 +676,8 @@ akb_help(topic="link-resources")    # Workflow guide
 | tags | | ["auth", "api"] |
 | domain | | engineering, product, ops, legal, etc. |
 | summary | | Brief summary (auto-generated if omitted) |
-| depends_on | | ["akb://vault/doc/path"] — URIs of prerequisite documents |
-| related_to | | ["akb://vault/doc/path"] — URIs of related documents |
+| depends_on | | Same-vault URIs of prerequisite documents |
+| related_to | | Same-vault URIs of related documents |
 
 ## Examples
 
@@ -732,8 +742,8 @@ body**. Never pass only a newly uploaded image or another partial fragment as
 | status | | draft (default), active, archived |
 | tags | | New tag list (replaces existing) |
 | summary | | New summary |
-| depends_on | | Update dependency list (akb:// URIs) |
-| related_to | | Update related list (akb:// URIs) |
+| depends_on | | Update same-vault dependency list (akb:// URIs) |
+| related_to | | Update same-vault related list (akb:// URIs) |
 | message | | Git commit message |
 | expected_commit | | Reject if the document moved since it was read |
 | expected_content_hash | | Reject if the current body changed since it was read |
@@ -1130,7 +1140,11 @@ Requires writer role. All edges referencing this document are automatically clea
 ```
 akb_relations(uri="akb://eng/doc/specs/api.md")
 akb_relations(uri="akb://eng/table/experiments", direction="incoming")
-```""",
+```
+
+Every returned row includes `kind`: `explicit` rows are removable with
+`akb_unlink`; `implicit` rows must be removed by editing the document metadata
+or Markdown link that generated them. Relations never cross vaults.""",
 
     "akb_graph": """# akb_graph — Knowledge Graph (Cross-Type)
 
@@ -1141,7 +1155,7 @@ Shows nodes (documents, tables, files) and edges (all relation types).
 |-------|----------|-------------|
 | vault | | Vault name (use for full-vault graph) |
 | uri | | Center node AKB URI (use to anchor on a specific resource) |
-| depth | | BFS traversal depth (1-5, default 2) |
+| hops | | BFS traversal radius (1-5, default 2) |
 | limit | | Max nodes (1-200, default 50) |
 
 Pass either `vault` (full vault graph) or `uri` (graph anchored on one resource).
@@ -1149,7 +1163,7 @@ Pass either `vault` (full vault graph) or `uri` (graph anchored on one resource)
 ## Examples
 ```
 akb_graph(vault="eng")                                            # Full vault graph
-akb_graph(uri="akb://eng/table/experiments", depth=2)             # From a table
+akb_graph(uri="akb://eng/table/experiments", hops=2)              # From a table
 akb_graph(uri="akb://eng/doc/specs/api.md", depth=3)              # 3-hop from doc
 ```""",
 
@@ -1803,6 +1817,8 @@ akb_link(
     "akb_unlink": """# akb_unlink — Remove a Relation
 
 The vault is inferred from the URIs — no separate `vault` arg.
+Both URIs must be in that same vault. This command removes explicit
+`akb_link` edges only; edit the source document to remove an implicit edge.
 
 ## Parameters
 | Param | Required | Description |
@@ -1820,7 +1836,7 @@ akb_unlink(
 
 akb_unlink(
   source="akb://eng/doc/specs/api.md",
-  target="akb://eng/table/endpoints")  # removes ALL relations
+  target="akb://eng/table/endpoints")  # removes all explicit relations
 ```""",
 
     # ── Vault skill ───────────────────────────────────────────

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -158,8 +158,8 @@ TOOLS = [
                 "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags for classification"},
                 "domain": {"type": "string", "description": "Domain: engineering, product, ops, legal, etc."},
                 "summary": {"type": "string", "description": "Brief summary (auto-generated if omitted)"},
-                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "akb:// URIs this depends on"},
-                "related_to": {"type": "array", "items": {"type": "string"}, "description": "akb:// URIs of related resources"},
+                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Same-vault akb:// URIs this depends on. Use an ordinary Markdown link for a cross-vault reference."},
+                "related_to": {"type": "array", "items": {"type": "string"}, "description": "Same-vault akb:// URIs of related resources. Use an ordinary Markdown link for a cross-vault reference."},
             },
             # `vault` + `collection` are required-via-handler rather than
             # required-in-schema — passing `parent` instead also satisfies.
@@ -199,8 +199,8 @@ TOOLS = [
                 "status": {"type": "string", "enum": ["draft", "active", "archived"]},
                 "tags": {"type": "array", "items": {"type": "string"}},
                 "summary": {"type": "string"},
-                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Update dependency list (akb:// URIs)"},
-                "related_to": {"type": "array", "items": {"type": "string"}, "description": "Update related list (akb:// URIs)"},
+                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault dependency list (akb:// URIs)"},
+                "related_to": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault related list (akb:// URIs)"},
                 "message": {"type": "string", "description": "Commit message describing the change"},
                 "expected_commit": {
                     "type": "string",
@@ -549,7 +549,8 @@ TOOLS = [
         name="akb_relations",
         description=(
             "Get relations for any resource (document, table, or file). "
-            "Shows cross-type connections: doc→table, doc→file, table→file, etc."
+            "Shows same-vault cross-type connections: doc→table, doc→file, table→file, etc. "
+            "Each row identifies whether it is an explicit link or implicit document-derived edge."
         ),
         inputSchema={
             "type": "object",
@@ -592,7 +593,7 @@ TOOLS = [
         name="akb_link",
         description=(
             "Create a relation between any two resources (documents, tables, files). "
-            "Source and target are AKB URIs. "
+            "Source and target are AKB URIs in the same vault. "
             f"Relation types: {_REL_LIST}. "
             "Example: link a design doc to its data table, or attach a diagram file to a spec."
         ),
@@ -613,8 +614,9 @@ TOOLS = [
     Tool(
         name="akb_unlink",
         description=(
-            "Remove a relation between two resources. "
-            "If relation type is omitted, removes ALL relations between the two resources."
+            "Remove an explicit same-vault relation between two resources. "
+            "Implicit relations are removed by editing their source document. "
+            "If relation type is omitted, removes all explicit relations between the two resources."
         ),
         inputSchema={
             "type": "object",
@@ -623,7 +625,7 @@ TOOLS = [
                 "target": {"type": "string", "description": "Target resource URI"},
                 "relation": {
                     "type": "string",
-                    "description": f"Specific relation type to remove, one of: {_REL_LIST} (omit to remove all)",
+                    "description": f"Specific explicit relation type to remove, one of: {_REL_LIST} (omit to remove all explicit relations)",
                     "enum": _REL_ENUM,
                 },
             },

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -199,8 +199,8 @@ TOOLS = [
                 "status": {"type": "string", "enum": ["draft", "active", "archived"]},
                 "tags": {"type": "array", "items": {"type": "string"}},
                 "summary": {"type": "string"},
-                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault dependency list (akb:// URIs)"},
-                "related_to": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault related list (akb:// URIs)"},
+                "depends_on": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault dependency list (akb:// URIs). Use an ordinary Markdown link in content for a cross-vault reference."},
+                "related_to": {"type": "array", "items": {"type": "string"}, "description": "Update the same-vault related list (akb:// URIs). Use an ordinary Markdown link in content for a cross-vault reference."},
                 "message": {"type": "string", "description": "Commit message describing the change"},
                 "expected_commit": {
                     "type": "string",
@@ -565,7 +565,7 @@ TOOLS = [
     Tool(
         name="akb_graph",
         description=(
-            "Get a knowledge graph — nodes (documents, tables, files) and edges (relations). "
+            "Get a same-vault knowledge graph — nodes (documents, tables, files) and edges (relations). "
             "Provide `uri` to get a subgraph centered on any resource with BFS traversal. "
             "Provide `vault` (without uri) to get the full vault graph."
         ),
@@ -634,7 +634,10 @@ TOOLS = [
     ),
     Tool(
         name="akb_provenance",
-        description="Get provenance for a document — who created it, when, which entities were extracted.",
+        description=(
+            "Get provenance for a document — who created it, when, which entities were "
+            "extracted, and its visible same-vault relations."
+        ),
         inputSchema={
             "type": "object",
             "properties": {

--- a/backend/scripts/audit_edge_vault_boundary.py
+++ b/backend/scripts/audit_edge_vault_boundary.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Audit or remove graph edges outside their owning vault.
+
+The default mode is read-only and reports aggregate counts only. Full resource
+URIs are intentionally not printed because vault and path names may be
+sensitive. Cleanup is explicit, confirmation-gated, transactional, and
+idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+
+# Operators run this file directly from ``backend/`` (and the container does
+# the same), which otherwise places only ``scripts/`` on Python's import path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.db.postgres import close_pool, get_pool
+from app.services.edge_boundary import invalid_edge_predicate
+
+
+_CONFIRMATION = "DELETE_CROSS_VAULT_EDGES"
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Report knowledge-graph edges outside their owning vault",
+    )
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete every reported row in one transaction",
+    )
+    parser.add_argument(
+        "--confirm",
+        help=f"Required with --delete; must equal {_CONFIRMATION!r}",
+    )
+    return parser
+
+
+async def _audit(*, delete: bool) -> dict:
+    pool = await get_pool()
+    invalid = invalid_edge_predicate()
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=not delete):
+            rows = await conn.fetch(
+                f"""
+                SELECT e.kind, e.relation_type, count(*) AS count
+                FROM edges e
+                JOIN vaults v ON v.id = e.vault_id
+                WHERE {invalid}
+                GROUP BY e.kind, e.relation_type
+                ORDER BY e.kind, e.relation_type
+                """
+            )
+            groups = [
+                {
+                    "kind": row["kind"],
+                    "relation_type": row["relation_type"],
+                    "count": row["count"],
+                }
+                for row in rows
+            ]
+            total = sum(group["count"] for group in groups)
+            deleted = 0
+            if delete and total:
+                result = await conn.execute(
+                    f"""
+                    DELETE FROM edges e
+                    USING vaults v
+                    WHERE v.id = e.vault_id
+                      AND ({invalid})
+                    """
+                )
+                deleted = int(result.rsplit(" ", 1)[-1])
+    return {"invalid_edges": total, "groups": groups, "deleted": deleted}
+
+
+async def _main() -> int:
+    args = _parser().parse_args()
+    if args.delete and args.confirm != _CONFIRMATION:
+        raise SystemExit(
+            f"--delete requires --confirm {_CONFIRMATION}"
+        )
+    try:
+        print(json.dumps(await _audit(delete=args.delete), sort_keys=True))
+    finally:
+        await close_pool()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/backend/tests/test_admin_ownership_semantics_unit.py
+++ b/backend/tests/test_admin_ownership_semantics_unit.py
@@ -165,6 +165,10 @@ async def test_owner_initiated_transfer_succeeds_when_row_matches(
 class _VaultInfoConn(_FakeConn):
     """Extends the transfer fake with the vault_info fan-out queries."""
 
+    def __init__(self, *, vault_owner: uuid.UUID):
+        super().__init__(vault_owner=vault_owner)
+        self.fetchval_calls: list[tuple[str, tuple]] = []
+
     async def fetchrow(self, query: str, *args):
         if "SELECT * FROM vaults" in query:
             return {
@@ -183,6 +187,7 @@ class _VaultInfoConn(_FakeConn):
         raise AssertionError(f"unexpected fetchrow: {query}")
 
     async def fetchval(self, query: str, *args):
+        self.fetchval_calls.append((" ".join(query.split()), args))
         return 0
 
 
@@ -234,3 +239,20 @@ async def test_vault_info_keeps_owner_role_for_the_literal_owner(
     info = await access_service.get_vault_info(str(OWNER_ID), "fixture-vault")
 
     assert info["role"] == "owner"
+
+
+async def test_vault_info_edge_count_uses_the_reader_visible_boundary(
+    monkeypatch, vault_info_env
+):
+    _grant_reader_access(monkeypatch, role="reader", role_source="member")
+
+    await access_service.get_vault_info(str(OWNER_ID), "fixture-vault")
+
+    query, args = next(
+        (query, args)
+        for query, args in vault_info_env.fetchval_calls
+        if "FROM edges" in query
+    )
+    assert "starts_with(source_uri, $2)" in query
+    assert "starts_with(target_uri, $2)" in query
+    assert args == (VAULT_ID, "akb://fixture-vault/")

--- a/backend/tests/test_edge_vault_boundary_postgres.py
+++ b/backend/tests/test_edge_vault_boundary_postgres.py
@@ -1,0 +1,102 @@
+"""Live PostgreSQL backstop for the one-vault edge invariant."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+@pytest.fixture
+async def connection():
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    from app.db.postgres import _load_migration
+
+    migration = _load_migration("083_edge_vault_boundary.py")
+    assert migration is not None
+    await migration.migrate(conn)
+
+    names = [
+        f"edge-boundary-a-{uuid.uuid4().hex[:10]}",
+        f"edge-boundary-b-{uuid.uuid4().hex[:10]}",
+    ]
+    ids = [
+        await conn.fetchval(
+            "INSERT INTO vaults(name, git_path) VALUES($1, $2) RETURNING id",
+            name,
+            f"/tmp/{name}.git",
+        )
+        for name in names
+    ]
+    try:
+        yield conn, names, ids
+    finally:
+        await conn.execute("DELETE FROM vaults WHERE id = ANY($1::uuid[])", ids)
+        await conn.close()
+
+
+async def _insert_edge(conn, vault_id, source: str, target: str) -> uuid.UUID:
+    return await conn.fetchval(
+        """
+        INSERT INTO edges(
+            vault_id, source_uri, target_uri, relation_type,
+            source_type, target_type, kind
+        )
+        VALUES($1, $2, $3, 'related_to', 'doc', 'doc', 'explicit')
+        RETURNING id
+        """,
+        vault_id,
+        source,
+        target,
+    )
+
+
+async def test_trigger_accepts_same_vault_and_rejects_cross_vault(connection):
+    conn, names, ids = connection
+    first, second = names
+    valid_source = f"akb://{first}/doc/a.md"
+    valid_target = f"akb://{first}/doc/b.md"
+
+    edge_id = await _insert_edge(conn, ids[0], valid_source, valid_target)
+    assert edge_id is not None
+
+    with pytest.raises(asyncpg.CheckViolationError, match="owning vault"):
+        await _insert_edge(
+            conn,
+            ids[0],
+            valid_source,
+            f"akb://{second}/doc/private.md",
+        )
+
+
+async def test_trigger_rejects_owner_mismatch_and_valid_to_invalid_update(connection):
+    conn, names, ids = connection
+    first, second = names
+    source = f"akb://{first}/doc/a.md"
+    target = f"akb://{first}/doc/b.md"
+
+    with pytest.raises(asyncpg.CheckViolationError, match="owning vault"):
+        await _insert_edge(conn, ids[1], source, target)
+
+    edge_id = await _insert_edge(conn, ids[0], source, target)
+    with pytest.raises(asyncpg.CheckViolationError, match="owning vault"):
+        await conn.execute(
+            "UPDATE edges SET target_uri = $2 WHERE id = $1",
+            edge_id,
+            f"akb://{second}/doc/private.md",
+        )

--- a/backend/tests/test_kg_vault_boundary_unit.py
+++ b/backend/tests/test_kg_vault_boundary_unit.py
@@ -1,0 +1,262 @@
+"""Vault-boundary regression tests for structured and projected relations."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services import kg_service
+
+
+VAULT = "alpha"
+OTHER = "beta"
+VAULT_ID = uuid.uuid4()
+SOURCE = f"akb://{VAULT}/coll/specs/doc/a.md"
+TARGET = f"akb://{VAULT}/coll/specs/doc/b.md"
+FOREIGN = f"akb://{OTHER}/coll/private/doc/hidden.md"
+
+
+class _Acquire:
+    def __init__(self, conn) -> None:
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Pool:
+    def __init__(self, conn) -> None:
+        self.conn = conn
+
+    def acquire(self):
+        return _Acquire(self.conn)
+
+
+def test_new_structured_cross_vault_ref_is_rejected_without_target_lookup():
+    with pytest.raises(ValidationError, match="ordinary Markdown link"):
+        kg_service.validate_new_structured_relation_refs(VAULT, [FOREIGN])
+
+
+def test_existing_cross_vault_ref_remains_editable_but_inert():
+    kg_service.validate_new_structured_relation_refs(
+        VAULT,
+        [FOREIGN],
+        existing_refs=[FOREIGN],
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_cross_vault_and_owner_mismatch_fail_before_pool(monkeypatch):
+    async def _unexpected_pool():
+        raise AssertionError("boundary rejection must not open PostgreSQL")
+
+    monkeypatch.setattr(kg_service, "get_pool", _unexpected_pool)
+
+    cross = await kg_service.link_resources(VAULT, SOURCE, FOREIGN, "related_to")
+    owner_mismatch = await kg_service.link_resources(OTHER, SOURCE, TARGET, "related_to")
+
+    assert cross["code"] == "invalid_argument"
+    assert owner_mismatch["code"] == "invalid_argument"
+
+
+@pytest.mark.asyncio
+async def test_unlink_removes_explicit_edges_only(monkeypatch):
+    observed: dict[str, object] = {}
+
+    class _Connection:
+        async def fetchval(self, _query: str, *_args):
+            return VAULT
+
+        async def execute(self, query: str, *args):
+            observed["query"] = query
+            observed["args"] = args
+            return "DELETE 0"
+
+    async def _pool():
+        return _Pool(_Connection())
+
+    monkeypatch.setattr(kg_service, "get_pool", _pool)
+    result = await kg_service.unlink_resources(
+        SOURCE,
+        TARGET,
+        relation_type="related_to",
+        vault_id=VAULT_ID,
+    )
+
+    assert result["unlinked"] == 0
+    assert "kind = 'explicit'" in str(observed["query"])
+
+
+@pytest.mark.asyncio
+async def test_implicit_cross_vault_link_skips_before_catalog_or_insert():
+    class _NoLookupConnection:
+        async def fetchval(self, *_args):
+            raise AssertionError("cross-vault extraction must not query a catalog")
+
+        async def execute(self, *_args):
+            raise AssertionError("cross-vault extraction must not insert an edge")
+
+    stored = await kg_service._store_edge(
+        _NoLookupConnection(),
+        VAULT_ID,
+        VAULT,
+        SOURCE,
+        "doc",
+        FOREIGN,
+        "links_to",
+    )
+
+    assert stored is False
+
+
+@pytest.mark.asyncio
+async def test_relation_projection_omits_foreign_uri_and_exposes_edge_kind(monkeypatch):
+    edge_queries: list[str] = []
+
+    class _Connection:
+        async def fetch(self, query: str, *_args):
+            if "FROM edges e" in query:
+                edge_queries.append(query)
+                if "e.source_uri = $1" in query:
+                    return [
+                        {
+                            "relation_type": "references",
+                            "target_uri": TARGET,
+                            "target_type": "doc",
+                            "kind": "explicit",
+                        },
+                        {
+                            "relation_type": "related_to",
+                            "target_uri": FOREIGN,
+                            "target_type": "doc",
+                            "kind": "implicit",
+                        },
+                    ]
+                return []
+            if "FROM documents" in query:
+                return [{"path": "specs/b.md", "title": "Visible target"}]
+            return []
+
+    conn = _Connection()
+
+    async def _pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(kg_service, "get_pool", _pool)
+    rows = await kg_service.get_resource_relations(
+        VAULT,
+        SOURCE,
+        vault_id=VAULT_ID,
+    )
+
+    assert rows == [
+        {
+            "direction": "outgoing",
+            "relation": "references",
+            "uri": TARGET,
+            "resource_type": "doc",
+            "kind": "explicit",
+            "name": "Visible target",
+        }
+    ]
+    assert edge_queries
+    assert all("starts_with(e.source_uri" in query for query in edge_queries)
+    assert all("starts_with(e.target_uri" in query for query in edge_queries)
+
+
+@pytest.mark.asyncio
+async def test_bfs_never_materializes_foreign_endpoint():
+    edge_queries: list[str] = []
+
+    class _Connection:
+        async def fetch(self, query: str, args, *_rest):
+            if "FROM edges" in query:
+                edge_queries.append(query)
+                if "source_uri = ANY" in query and SOURCE in args:
+                    return [
+                        {
+                            "source_uri": SOURCE,
+                            "target_uri": TARGET,
+                            "target_type": "doc",
+                            "relation_type": "references",
+                            "kind": "explicit",
+                        },
+                        {
+                            "source_uri": SOURCE,
+                            "target_uri": FOREIGN,
+                            "target_type": "doc",
+                            "relation_type": "related_to",
+                            "kind": "implicit",
+                        },
+                    ]
+                return []
+            if "FROM documents" in query:
+                return [
+                    {"path": "specs/a.md", "title": "A"},
+                    {"path": "specs/b.md", "title": "B"},
+                ]
+            return []
+
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+    await kg_service._bfs_collect(
+        _Connection(),
+        VAULT_ID,
+        VAULT,
+        SOURCE,
+        1,
+        20,
+        nodes,
+        edges,
+    )
+
+    assert FOREIGN not in nodes
+    assert all(FOREIGN not in (edge["source"], edge["target"]) for edge in edges)
+    assert edge_queries
+    assert all("starts_with(source_uri" in query for query in edge_queries)
+    assert all("starts_with(target_uri" in query for query in edge_queries)
+
+
+@pytest.mark.asyncio
+async def test_overview_and_health_scope_counts_to_both_uri_authorities(monkeypatch):
+    observed: list[tuple[str, tuple]] = []
+
+    class _Connection:
+        async def fetchrow(self, query: str, *args):
+            observed.append((query, args))
+            return {"edges_total": 0, "nodes_total": 0}
+
+        async def fetch(self, query: str, *args):
+            observed.append((query, args))
+            return []
+
+    conn = _Connection()
+
+    async def _pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(kg_service, "get_pool", _pool)
+
+    overview = await kg_service.get_overview(
+        VAULT,
+        vault_id=VAULT_ID,
+        include_orphans=False,
+    )
+    health = await kg_service.get_health(VAULT, vault_id=VAULT_ID)
+
+    assert overview["edges_total"] == 0
+    assert health == {"hubs": [], "orphans": {"count": 0, "sample": []}}
+    scoped_queries = [query for query, _args in observed if "FROM edges" in query]
+    assert scoped_queries
+    assert all("starts_with(source_uri" in query for query in scoped_queries)
+    assert all("starts_with(target_uri" in query for query in scoped_queries)
+    assert all(
+        f"akb://{VAULT}/" in args
+        for query, args in observed
+        if "FROM edges" in query
+    )

--- a/backend/tests/test_mcp_prose_tool_closure_unit.py
+++ b/backend/tests/test_mcp_prose_tool_closure_unit.py
@@ -214,6 +214,21 @@ def test_inline_image_guidance_is_safe_and_matches_bounded_lifecycle() -> None:
     assert unsafe_example not in put_image
 
 
+def test_relation_help_matches_the_vault_boundary_and_graph_schema() -> None:
+    topics = _help_topics()
+
+    graph = topics["akb_graph"]
+    assert "depth=" not in graph
+    assert "hops=3" in graph
+
+    provenance = topics["akb_provenance"].lower()
+    assert "visible same-vault relations" in provenance
+
+    relations = topics["akb_relations"].lower()
+    assert "relations never cross vaults" in relations
+    assert "explicit" in relations and "implicit" in relations
+
+
 def test_help_root_table_topics_are_real_help_topics() -> None:
     """Every drill-down topic the root help table points at exists as a key.
 

--- a/backend/tests/test_mcp_tool_validation_unit.py
+++ b/backend/tests/test_mcp_tool_validation_unit.py
@@ -82,3 +82,23 @@ def test_tools_and_handlers_are_in_sync():
         f"@_h handlers in server.py but not in TOOLS list: "
         f"{sorted(missing_tool)}"
     )
+
+
+def test_relation_tool_descriptions_match_the_vault_boundary():
+    tools = {tool.name: tool for tool in TOOLS}
+
+    for tool_name in ("akb_put", "akb_update"):
+        properties = tools[tool_name].inputSchema["properties"]
+        for field in ("depends_on", "related_to"):
+            description = properties[field]["description"].lower()
+            assert "same-vault" in description
+            assert "ordinary markdown link" in description
+            assert "cross-vault" in description
+
+    assert "same-vault knowledge graph" in tools["akb_graph"].description.lower()
+    assert "visible same-vault relations" in tools["akb_provenance"].description.lower()
+
+    relations = tools["akb_relations"].description.lower()
+    assert "explicit" in relations and "implicit" in relations
+    unlink = tools["akb_unlink"].description.lower()
+    assert "explicit" in unlink and "implicit" in unlink

--- a/backend/tests/test_relations_rest_e2e.sh
+++ b/backend/tests/test_relations_rest_e2e.sh
@@ -208,13 +208,13 @@ CODE=$(rdel_code "$PAT1" "$COLL_URI" "$URI_B" "references")
 CODE=$(rdel_code "$PAT1" "$URI_A" "$URI_B" "bogus_rel")
 [ "$CODE" = "422" ] && pass "unlink with bad relation enum → 422" || fail "DELETE bad relation" "got $CODE"
 
-# relation omitted → remove ALL edges between the two
+# relation omitted → remove all explicit edges between the two
 rpost "$PAT1" "{\"source\":\"$URI_A\",\"target\":\"$URI_B\",\"relation\":\"references\"}" >/dev/null
 rpost "$PAT1" "{\"source\":\"$URI_A\",\"target\":\"$URI_B\",\"relation\":\"related_to\"}" >/dev/null
 BEFORE=$(rel_count "$PAT1" "$URI_A")
 rdel "$PAT1" "$URI_A" "$URI_B" >/dev/null   # no relation → wipe both
 AFTER=$(rel_count "$PAT1" "$URI_A")
-[ "$BEFORE" = "2" ] && [ "$AFTER" = "0" ] && pass "unlink w/o relation removes all edges (2→0)" || fail "unlink-all" "before=$BEFORE after=$AFTER"
+[ "$BEFORE" = "2" ] && [ "$AFTER" = "0" ] && pass "unlink w/o relation removes all explicit edges (2→0)" || fail "unlink-all" "before=$BEFORE after=$AFTER"
 
 # ── 4. Canonicalization parity (link/unlink resolve URIs identically) ─
 # link_resources canonicalizes on write; unlink_resources must too, or a

--- a/backend/tests/test_relations_rest_unit.py
+++ b/backend/tests/test_relations_rest_unit.py
@@ -151,6 +151,24 @@ def test_get_links_to_filter_is_allowed(client, monkeypatch):
     assert r.json() == {"kind": "relations", "uri": DOC_A, "relations": []}
 
 
+def test_get_relation_exposes_implicit_or_explicit_ownership(client, monkeypatch):
+    async def _relations(*_a, **_kwargs):
+        return [{
+            "direction": "outgoing",
+            "relation": "links_to",
+            "uri": DOC_B,
+            "resource_type": "doc",
+            "kind": "implicit",
+            "name": "B",
+        }]
+
+    monkeypatch.setattr(knowledge, "get_resource_relations", _relations)
+    response = client.get("/api/v1/relations", params={"uri": DOC_A})
+
+    assert response.status_code == 200
+    assert response.json()["relations"][0]["kind"] == "implicit"
+
+
 # ── _bridge_service_error unit behaviour (dict guard + unmapped code) ─
 
 def test_bridge_unmapped_code_falls_back_to_400_and_logs(caplog):

--- a/frontend/src/components/relations/__tests__/relation-row-utils.test.ts
+++ b/frontend/src/components/relations/__tests__/relation-row-utils.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { edgeFor, hrefFor } from "@/components/relations/relation-row-utils";
+import { edgeFor, hrefFor, relationIsInVault } from "@/components/relations/relation-row-utils";
 import type { RelationRow } from "@/lib/api";
 
 const SRC = "akb://v1/coll/notes/doc/alpha.md";
 
 function row(partial: Partial<RelationRow> & { uri: string }): RelationRow {
-  return { direction: "outgoing", relation: "references", ...partial };
+  return { direction: "outgoing", relation: "references", kind: "explicit", ...partial };
 }
 
 describe("edgeFor", () => {
@@ -29,6 +29,14 @@ describe("edgeFor", () => {
     // Defensive: the type is required, but a stray value must not invert the edge.
     const r = { direction: "both", relation: "references", uri: other } as unknown as RelationRow;
     expect(edgeFor(r, SRC)).toEqual({ source: SRC, target: other });
+  });
+});
+
+describe("relationIsInVault", () => {
+  it("accepts only a parseable endpoint in the requested vault", () => {
+    expect(relationIsInVault(row({ uri: "akb://v1/coll/notes/doc/a.md" }), "v1")).toBe(true);
+    expect(relationIsInVault(row({ uri: "akb://v2/coll/private/doc/a.md" }), "v1")).toBe(false);
+    expect(relationIsInVault(row({ uri: "not-an-akb-uri" }), "v1")).toBe(false);
   });
 });
 

--- a/frontend/src/components/relations/__tests__/relations-panel.test.tsx
+++ b/frontend/src/components/relations/__tests__/relations-panel.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RelationsPanel } from "@/components/relations/relations-panel";
+import type { RelationRow } from "@/lib/api";
+
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    createRelation: vi.fn(),
+    deleteRelation: vi.fn(),
+  };
+});
+
+const explicit: RelationRow = {
+  direction: "outgoing",
+  relation: "related_to",
+  uri: "akb://alpha/coll/specs/doc/b.md",
+  resource_type: "doc",
+  kind: "explicit",
+  name: "Visible relation",
+};
+
+const implicit: RelationRow = {
+  direction: "outgoing",
+  relation: "links_to",
+  uri: "akb://alpha/coll/specs/doc/c.md",
+  resource_type: "doc",
+  kind: "implicit",
+  name: "Managed relation",
+};
+
+function renderPanel(relations: RelationRow[], canWrite: boolean) {
+  return render(
+    <MemoryRouter>
+      <RelationsPanel
+        vault="alpha"
+        sourceUri="akb://alpha/coll/specs/doc/a.md"
+        relations={relations}
+        relationsError={false}
+        canWrite={canWrite}
+        graphHref="/vault/alpha/graph"
+        onReload={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("RelationsPanel authority and source ownership", () => {
+  it("does not render mutation controls for a reader", () => {
+    renderPanel([explicit], false);
+
+    expect(screen.getByText("Visible relation", { exact: false })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove relation/ })).not.toBeInTheDocument();
+  });
+
+  it("allows a writer to remove only explicit relations", () => {
+    renderPanel([explicit, implicit], true);
+
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Remove relation/ })).toHaveLength(1);
+    expect(screen.getByLabelText("Managed by document content")).toBeInTheDocument();
+  });
+
+  it("omits a foreign endpoint from labels and relation counts", () => {
+    renderPanel(
+      [{ ...explicit, uri: "akb://beta/coll/private/doc/hidden.md", name: "Hidden" }],
+      true,
+    );
+
+    expect(screen.getByText("0 relations")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/relations/relation-row-utils.ts
+++ b/frontend/src/components/relations/relation-row-utils.ts
@@ -5,6 +5,11 @@ import { parseUri } from "@/lib/uri";
 // branchy bits (edge direction, URI routing) are unit-testable. A relation row
 // from GET /relations carries only the "other side" (`uri`) plus a `direction`.
 
+/** Fail-closed visibility check shared by the panel and its outer count badge. */
+export function relationIsInVault(row: RelationRow, vault: string): boolean {
+  return parseUri(row.uri)?.vault === vault;
+}
+
 /**
  * Rebuild the (source, target) pair the unlink endpoint wants, from this
  * document's vantage point. An outgoing edge has this doc as the source; an

--- a/frontend/src/components/relations/relations-panel.tsx
+++ b/frontend/src/components/relations/relations-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { GitGraph, Link2, Loader2, Plus, Unlink } from "lucide-react";
+import { FileText, GitGraph, Link2, Loader2, Plus, Unlink } from "lucide-react";
 import {
   RELATION_TYPES,
   type RelationType,
@@ -9,7 +9,7 @@ import {
   deleteRelation,
 } from "@/lib/api";
 import { parseUri } from "@/lib/uri";
-import { edgeFor, hrefFor } from "@/components/relations/relation-row-utils";
+import { edgeFor, hrefFor, relationIsInVault } from "@/components/relations/relation-row-utils";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { SelectMenu } from "@/components/ui/select-menu";
@@ -49,6 +49,7 @@ interface RelationsPanelProps {
   sourceUri: string;
   relations: RelationRow[];
   relationsError: boolean;
+  canWrite: boolean;
   graphHref: string;
   onReload: () => void;
 }
@@ -58,34 +59,43 @@ export function RelationsPanel({
   sourceUri,
   relations,
   relationsError,
+  canWrite,
   graphHref,
   onReload,
 }: RelationsPanelProps) {
   const [addOpen, setAddOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<RelationRow | null>(null);
+  // The backend is authoritative, but fail closed during mixed-version
+  // rollouts: a foreign or malformed endpoint must not become a label, route,
+  // or count merely because an older response included it.
+  const visibleRelations = relations.filter((row) => relationIsInVault(row, vault));
 
   return (
     <div className="flex h-full flex-col">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="coord">{relations.length} relation{relations.length === 1 ? "" : "s"}</span>
-        <Button variant="ghost" size="sm" onClick={() => setAddOpen(true)}>
-          <Plus className="h-3.5 w-3.5" aria-hidden />
-          Add
-        </Button>
+        <span className="coord">
+          {visibleRelations.length} relation{visibleRelations.length === 1 ? "" : "s"}
+        </span>
+        {canWrite && (
+          <Button variant="ghost" size="sm" onClick={() => setAddOpen(true)}>
+            <Plus className="h-3.5 w-3.5" aria-hidden />
+            Add
+          </Button>
+        )}
       </div>
 
       {relationsError ? (
         <Alert variant="destructive">Failed to load relations.</Alert>
-      ) : relations.length === 0 ? (
+      ) : visibleRelations.length === 0 ? (
         <div className="coord">No relations yet.</div>
       ) : (
         <ol className="space-y-0.5 font-mono text-[11px] leading-[1.9]">
-          {relations.map((r) => {
+          {visibleRelations.map((r) => {
             const label = r.name || parseUri(r.uri)?.id || r.uri;
             const relColor = RELATION_COLOR[r.relation] || "text-foreground-muted";
-            // `links_to` is auto-derived from markdown — re-created on save, so
-            // unlinking it is meaningless. Hide its delete affordance.
-            const deletable = r.relation !== "links_to";
+            // Only explicit rows are owned by the relation API. Implicit rows
+            // come from frontmatter/body content and would reappear on save.
+            const deletable = canWrite && r.kind === "explicit";
             return (
               <li key={`${r.direction}:${r.relation}:${r.uri}`} className="group flex items-center gap-1">
                 <Link
@@ -98,6 +108,15 @@ export function RelationsPanel({
                     {label}
                   </TooltipText>
                 </Link>
+                {r.kind === "implicit" && (
+                  <span
+                    aria-label="Managed by document content"
+                    title="Managed by document metadata or Markdown content"
+                    className="shrink-0 rounded-[var(--radius-sm)] p-1 text-foreground-muted"
+                  >
+                    <FileText className="h-3 w-3" aria-hidden />
+                  </span>
+                )}
                 {deletable && (
                   <button
                     type="button"
@@ -121,13 +140,15 @@ export function RelationsPanel({
         <GitGraph className="h-3 w-3" aria-hidden /> Open in graph →
       </Link>
 
-      <AddRelationDialog
-        open={addOpen}
-        onOpenChange={setAddOpen}
-        vault={vault}
-        sourceUri={sourceUri}
-        onCreated={onReload}
-      />
+      {canWrite && (
+        <AddRelationDialog
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          vault={vault}
+          sourceUri={sourceUri}
+          onCreated={onReload}
+        />
+      )}
 
       <ConfirmDialog
         open={pendingDelete !== null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1313,6 +1313,7 @@ export interface RelationRow {
   relation: string;
   uri: string;          // the "other" side
   resource_type?: string;
+  kind: "implicit" | "explicit";
   name?: string;
 }
 export const getRelations = (vault: string, docPath: string) => {

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -144,6 +144,33 @@ describe("DocumentPage view toggle", () => {
     );
   });
 
+  it("does not include a foreign endpoint in the outer relation count", async () => {
+    getRelationsMock.mockResolvedValue({
+      relations: [
+        {
+          direction: "outgoing",
+          relation: "references",
+          uri: "akb://v/coll/notes/doc/local.md",
+          resource_type: "doc",
+          kind: "explicit",
+        },
+        {
+          direction: "outgoing",
+          relation: "references",
+          uri: "akb://private/coll/notes/doc/hidden.md",
+          resource_type: "doc",
+          kind: "explicit",
+        },
+      ],
+    });
+
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    const relationsTab = await screen.findByRole("tab", { name: /^Relations/ });
+    expect(relationsTab).toHaveTextContent(/^Relations1$/);
+    expect(relationsTab).not.toHaveTextContent("2");
+  });
+
   it("?view=raw renders the raw markdown inside <pre>", async () => {
     renderAt("/vault/v/doc/notes%2Fhello.md?view=raw");
     const pre = await screen.findByTestId("doc-raw");

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -44,6 +44,7 @@ import { PublishOptionsDialog } from "@/components/publish-options-dialog";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import { RelationsPanel } from "@/components/relations/relations-panel";
+import { relationIsInVault } from "@/components/relations/relation-row-utils";
 
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
 // (Rendered / Raw) stays cheap.
@@ -94,6 +95,10 @@ export default function DocumentPage() {
   const isDirty = editingContent !== originalContent;
   const hasUnsavedWork = isDirty || uploadingImage;
   const docId = id ? decodeURIComponent(id) : "";
+  const visibleRelationCount = useMemo(
+    () => relations.filter((row) => name && relationIsInVault(row, name)).length,
+    [name, relations],
+  );
 
   const applyView = (next: DocView) => {
     const p = new URLSearchParams(searchParams);
@@ -754,8 +759,8 @@ export default function DocumentPage() {
             </TabsTrigger>
             <TabsTrigger value="relations" className="flex-1 min-w-0 gap-1 px-2">
               Relations
-              {relations.length > 0 && (
-                <span className="coord tabular-nums">{relations.length}</span>
+              {visibleRelationCount > 0 && (
+                <span className="coord tabular-nums">{visibleRelationCount}</span>
               )}
             </TabsTrigger>
             <TabsTrigger value="history" className="flex-1 min-w-0 gap-1 px-2">
@@ -782,6 +787,7 @@ export default function DocumentPage() {
               sourceUri={doc.path ? docUri(name!, doc.path) : ""}
               relations={relations}
               relationsError={relationsError}
+              canWrite={canEdit}
               graphHref={`/vault/${name}/graph${doc.path ? `?entry=${encodeURIComponent(doc.path)}` : ""}`}
               onReload={reloadRelations}
             />
@@ -889,18 +895,6 @@ function FrontmatterCard({ doc }: { doc: any }) {
     rows.push([
       "Tags",
       <span className="text-info break-words">{doc.tags.map((t: string) => `#${t}`).join(" ")}</span>,
-    ]);
-  }
-  if (doc.depends_on?.length) {
-    rows.push([
-      "Depends on",
-      <span className="text-foreground-muted break-words">{doc.depends_on.join(", ")}</span>,
-    ]);
-  }
-  if (doc.related_to?.length) {
-    rows.push([
-      "Related to",
-      <span className="text-foreground-muted break-words">{doc.related_to.join(", ")}</span>,
     ]);
   }
   if (doc.is_public) {

--- a/frontend/src/stories/components-resource-viewers.stories.tsx
+++ b/frontend/src/stories/components-resource-viewers.stories.tsx
@@ -80,6 +80,7 @@ const relations: RelationRow[] = [
   {
     direction: "outgoing",
     relation: "depends_on",
+    kind: "explicit",
     uri: "akb://akb/doc/runbooks/deploy.md",
     resource_type: "document",
     name: "runbooks/deploy.md",
@@ -87,6 +88,7 @@ const relations: RelationRow[] = [
   {
     direction: "incoming",
     relation: "implements",
+    kind: "explicit",
     uri: "akb://akb/doc/decisions/storybook-rollout.md",
     resource_type: "document",
     name: "decisions/storybook-rollout.md",
@@ -94,6 +96,7 @@ const relations: RelationRow[] = [
   {
     direction: "outgoing",
     relation: "links_to",
+    kind: "implicit",
     uri: "akb://akb/file/f-123",
     resource_type: "file",
     name: "figures/storybook.png",
@@ -258,6 +261,7 @@ export const RelationsLinked: Story = {
             sourceUri="akb://akb/doc/overview/storybook.md"
             relations={relations}
             relationsError={false}
+            canWrite
             graphHref="/vault/akb/graph?uri=akb%3A%2F%2Fakb%2Fdoc%2Foverview%2Fstorybook.md"
             onReload={() => {}}
           />
@@ -284,6 +288,7 @@ export const RelationsEmptyAndError: Story = {
               sourceUri="akb://akb/doc/overview/empty.md"
               relations={[]}
               relationsError={false}
+              canWrite
               graphHref="/vault/akb/graph"
               onReload={() => {}}
             />
@@ -297,6 +302,7 @@ export const RelationsEmptyAndError: Story = {
               sourceUri="akb://akb/doc/overview/error.md"
               relations={[]}
               relationsError
+              canWrite
               graphHref="/vault/akb/graph"
               onReload={() => {}}
             />


### PR DESCRIPTION
## Summary

- keep structured knowledge-graph relations within a single vault across document writes, REST, and MCP operations
- centralize reader-visible edge scoping for relation lists, graph projections, health metrics, provenance, and vault counts
- add a PostgreSQL backstop and an aggregate audit utility for rows that predate the invariant
- expose relation ownership (`explicit` or `implicit`) and align the document UI with write capability and source ownership
- align MCP tool schemas and help examples with the same-vault relation model

## Behavior

- same-vault explicit relations continue to support document, table, and file endpoints
- newly introduced cross-vault structured references are rejected before document mutation or target lookup
- existing cross-vault metadata remains editable as inert document content during rollout
- cross-vault Markdown citations remain in the authored document but do not become graph edges
- only explicit relations can be removed through the relation API; implicit relations are managed by their source document
- legacy out-of-boundary rows are excluded from reader projections and can be reviewed with the audit command before optional cleanup
- MCP guidance consistently uses `hops` for graph traversal and identifies visible relations as same-vault

## Validation

- `bash scripts/check.sh`
- `pytest tests/test_kg_vault_boundary_unit.py tests/test_relations_rest_unit.py tests/test_admin_ownership_semantics_unit.py`
- `pytest tests/test_mcp_tool_validation_unit.py tests/test_mcp_prose_tool_closure_unit.py tests/test_kg_vault_boundary_unit.py`
- `REQUIRE_REAL_PG=1 pytest tests/test_edge_vault_boundary_postgres.py`
- frontend unit suite: 68 files, 501 tests

## Rollout

Migration 083 installs the database trigger without deleting existing rows. Deployments can run `python scripts/audit_edge_vault_boundary.py` to review aggregate counts and use the confirmation-gated cleanup mode only after operator review.
