### PR TITLE
admin/users: say which issuer an account is bound under

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -51,6 +51,7 @@ from app.services.access_service import (
     unarchive_vault,
     update_vault_metadata,
 )
+from app.services.account_service import presented_issuer_or_none
 from app.services.admission_service import (
     approve_pending_admission,
     dismiss_pending_admission,
@@ -397,8 +398,17 @@ async def admin_remove_vault_write_grant(
 
 @router.get("/admin/users", summary="[admin] List every user with stats")
 async def admin_list_users(user: AuthenticatedUser = Depends(get_current_user)):
+    """Every account, plus the issuer this runtime presents.
+
+    The issuer is reported rather than left for the caller to derive. A control
+    plane that computed it a second way would be a second answer to a question
+    that must have one, and the runtime is the side that actually presents it.
+    """
     _require_admin(user)
-    return {"users": await list_all_users_admin()}
+    return {
+        "users": await list_all_users_admin(),
+        "presented_issuer": presented_issuer_or_none(),
+    }
 
 
 @router.post(

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -23,6 +23,7 @@ from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services.account_markers import is_retired_recovery_admin_password
+from app.services.account_service import presented_issuer_or_none
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
 from app.services.write_lane import run_compensation, run_git_write
@@ -1022,14 +1023,27 @@ async def search_users(query: str | None = None, limit: int = 20) -> list[dict]:
 
 
 async def list_all_users_admin() -> list[dict]:
-    """Admin-only: list every user with vault counts. Caller must gate on is_admin."""
+    """Admin-only: list every user with vault counts. Caller must gate on is_admin.
+
+    Each account also carries the issuers it is bound under, and whether one of
+    them is the issuer this runtime presents. A control plane that has moved a
+    workspace to its own realm cannot answer that from a bare "has an external
+    identity": after the move every stale account still answers yes, which is
+    exactly how a member who cannot sign in reads as ready.
+    """
+    presented = presented_issuer_or_none()
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             """
             SELECT u.id, u.username, u.display_name, u.email, u.is_admin,
                    u.auth_provider, u.account_status, u.account_kind, u.created_at,
-                   (SELECT COUNT(*) FROM vaults v WHERE v.owner_id = u.id) AS owned_vaults
+                   (SELECT COUNT(*) FROM vaults v WHERE v.owner_id = u.id) AS owned_vaults,
+                   COALESCE((
+                       SELECT ARRAY_AGG(DISTINCT e.issuer ORDER BY e.issuer)
+                         FROM external_identities e
+                        WHERE e.user_id = u.id
+                   ), ARRAY[]::text[]) AS identity_issuers
             FROM users u
             ORDER BY u.created_at
             """
@@ -1046,6 +1060,12 @@ async def list_all_users_admin() -> list[dict]:
             "account_kind": r["account_kind"],
             "created_at": r["created_at"].isoformat(),
             "owned_vaults": r["owned_vaults"],
+            "identity_issuers": list(r["identity_issuers"]),
+            # None, not False, when this runtime presents no issuer — see
+            # `presented_issuer_or_none`.
+            "bound_to_presented_issuer": (
+                None if presented is None else presented in r["identity_issuers"]
+            ),
         }
         for r in rows
     ]

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -51,12 +51,29 @@ def _presented_issuer(issuer: str) -> str:
     it locks the account out of the only credential it has.
     """
 
-    if settings.require_auth_mode() != "sso" or not settings.keycloak_enabled:
+    expected = presented_issuer_or_none()
+    if expected is None:
         raise ExternalAuthDisabledError()
-    expected = settings.keycloak_issuer
     if issuer != expected:
         raise ExternalIdentityIssuerMismatchError(expected)
     return issuer
+
+
+def presented_issuer_or_none() -> str | None:
+    """The issuer this runtime stamps on the tokens it will accept, or None.
+
+    ``_presented_issuer`` is the write-path guard built on this. Read paths need
+    the same answer without the refusal: a control plane asking "is this account
+    bound to the issuer you present" is not attempting a write, and it must be
+    able to tell "no" from "the question does not apply here".
+
+    None is not "some other issuer" — in local mode this runtime presents none
+    at all, and a caller that reads that as a mismatch would mark every account
+    stale. The absence has to travel as absence.
+    """
+    if settings.require_auth_mode() != "sso" or not settings.keycloak_enabled:
+        return None
+    return settings.keycloak_issuer
 
 
 _HUMAN_SENTINEL_HASH = "!keycloak-sso:no-local-login!"

--- a/backend/tests/test_admin_users_binding_issuer_postgres.py
+++ b/backend/tests/test_admin_users_binding_issuer_postgres.py
@@ -1,0 +1,187 @@
+"""PostgreSQL contract: the account listing says WHICH issuer an account is bound under.
+
+A control plane that has moved a workspace to its own realm needs to tell, for
+each person, whether the binding they already have is the one this runtime will
+accept. `has_external_identity` cannot answer that: it says a binding exists,
+not that it is the right one, and after an issuer move every stale account still
+answers true. That gap is what makes a migrated member show as ready while being
+unable to sign in.
+
+The runtime is the authority on what it presents, so it answers rather than
+handing out parts for a caller to recombine — an issuer derived a second way
+somewhere else would be a second answer to a question that must have one.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+_PRESENTED = "https://auth-team1.example.invalid/realms/akb"
+_LEFT_BEHIND = "https://shared.example.invalid/realms/akb-platform"
+
+
+@pytest.fixture
+async def listing(monkeypatch):
+    try:
+        admin = await asyncpg.connect(_DSN, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail("REQUIRE_REAL_PG=1 but Postgres is not reachable at AKB_TEST_DSN")
+        pytest.skip("Postgres unreachable at AKB_TEST_DSN")
+
+    schema = "admin_users_binding_issuer_" + uuid.uuid4().hex
+    await admin.execute(f'CREATE SCHEMA "{schema}"')
+    pool = await asyncpg.create_pool(
+        _DSN, min_size=1, max_size=4, server_settings={"search_path": schema}
+    )
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE users (
+                    id UUID PRIMARY KEY,
+                    username TEXT NOT NULL UNIQUE,
+                    email TEXT NOT NULL UNIQUE,
+                    display_name TEXT,
+                    is_admin BOOLEAN NOT NULL DEFAULT false,
+                    auth_provider TEXT NOT NULL,
+                    account_status TEXT NOT NULL,
+                    account_kind TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+                CREATE TABLE external_identities (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    issuer TEXT NOT NULL,
+                    subject TEXT NOT NULL,
+                    username_snapshot TEXT,
+                    email_snapshot TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE (issuer, subject)
+                );
+                CREATE TABLE vaults (
+                    id UUID PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    owner_id UUID REFERENCES users(id)
+                );
+                """
+            )
+
+        from app.services import access_service
+
+        async def _get_pool():
+            return pool
+
+        monkeypatch.setattr(access_service, "get_pool", _get_pool)
+        yield pool, access_service
+    finally:
+        await pool.close()
+        await admin.execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await admin.close()
+
+
+async def _seed(pool) -> dict[str, uuid.UUID]:
+    ids = {name: uuid.uuid4() for name in ("carried", "left_behind", "unbound", "service")}
+    async with pool.acquire() as conn:
+        for name, user_id in ids.items():
+            await conn.execute(
+                """
+                INSERT INTO users (id, username, email, display_name, is_admin,
+                                   auth_provider, account_status, account_kind)
+                VALUES ($1, $2, $3, $2, false, $4, 'active', $5)
+                """,
+                user_id, name, f"{name}@example.invalid",
+                "keycloak" if name != "service" else "service",
+                "service" if name == "service" else "human",
+            )
+        await conn.execute(
+            "INSERT INTO external_identities (user_id, issuer, subject) VALUES ($1,$2,'s1')",
+            ids["carried"], _PRESENTED,
+        )
+        await conn.execute(
+            "INSERT INTO external_identities (user_id, issuer, subject) VALUES ($1,$2,'s2')",
+            ids["left_behind"], _LEFT_BEHIND,
+        )
+    return ids
+
+
+def _by_username(users: list[dict]) -> dict[str, dict]:
+    return {u["username"]: u for u in users}
+
+
+async def test_listing_distinguishes_a_carried_binding_from_one_left_behind(
+    listing, monkeypatch
+):
+    pool, access_service = listing
+    await _seed(pool)
+    monkeypatch.setattr(access_service, "presented_issuer_or_none", lambda: _PRESENTED)
+
+    users = _by_username(await access_service.list_all_users_admin())
+
+    assert users["carried"]["identity_issuers"] == [_PRESENTED]
+    assert users["carried"]["bound_to_presented_issuer"] is True
+
+    # The whole point: this account HAS a binding, and `has_external_identity`
+    # would say so. It is bound to the issuer the workspace left.
+    assert users["left_behind"]["identity_issuers"] == [_LEFT_BEHIND]
+    assert users["left_behind"]["bound_to_presented_issuer"] is False
+
+    assert users["unbound"]["identity_issuers"] == []
+    assert users["unbound"]["bound_to_presented_issuer"] is False
+
+
+async def test_a_runtime_that_presents_no_issuer_answers_unknown_not_false(
+    listing, monkeypatch
+):
+    """Local mode has no issuer, so "is this binding stale" has no answer here.
+
+    `False` would be a lie shaped exactly like the defect this field exists to
+    remove — every account would read as needing to sign in again. The absence
+    has to travel as absence.
+    """
+    pool, access_service = listing
+    await _seed(pool)
+    monkeypatch.setattr(access_service, "presented_issuer_or_none", lambda: None)
+
+    users = _by_username(await access_service.list_all_users_admin())
+
+    assert users["carried"]["bound_to_presented_issuer"] is None
+    assert users["left_behind"]["bound_to_presented_issuer"] is None
+    # The issuers themselves are still reported: they are facts about the rows,
+    # not about what this runtime accepts.
+    assert users["left_behind"]["identity_issuers"] == [_LEFT_BEHIND]
+
+
+async def test_the_route_reports_the_issuer_this_runtime_presents(monkeypatch):
+    """The caller must not have to derive the issuer to compare against."""
+    from app.api.routes import access
+    from app.services.auth_service import AuthenticatedUser
+
+    monkeypatch.setattr(access, "presented_issuer_or_none", lambda: _PRESENTED)
+
+    async def _users() -> list[dict]:
+        return [{"username": "carried", "bound_to_presented_issuer": True}]
+
+    monkeypatch.setattr(access, "list_all_users_admin", _users)
+    result = await access.admin_list_users(
+        AuthenticatedUser(
+            user_id=str(uuid.uuid4()), username="platform-bot",
+            email="platform-bot@workspace.local", display_name=None,
+            is_admin=True, auth_method="pat", account_kind="service",
+            key_class="service",
+        )
+    )
+
+    assert result["presented_issuer"] == _PRESENTED
+    assert result["users"][0]["bound_to_presented_issuer"] is True


### PR DESCRIPTION
The account listing can say that an account has an external identity. It cannot say **which** issuer that identity is under — and after a workspace moves to its own realm, that is the only question worth asking.

Every account left bound to the issuer the workspace departed still answers `has_external_identity: true`. A control plane reading that field concludes the person is fine, and shows them as ready, while they are in fact unable to sign in: their binding is under an issuer this runtime no longer presents, and `invite_only` matches the exact pair.

## What changes

`GET /api/v1/admin/users` now returns, per account:

- `identity_issuers` — the issuers it is bound under
- `bound_to_presented_issuer` — whether one of them is the issuer this runtime presents

and, once at the response level, `presented_issuer`.

The issuer is reported rather than left for the caller to derive. This runtime is the side that actually presents it, and an issuer computed a second way somewhere else would be a second answer to a question that must have one.

## Absence travels as absence

Where this runtime presents no issuer at all — local mode, or Keycloak disabled — `bound_to_presented_issuer` is `null`, not `false`.

`false` there would be a lie shaped exactly like the defect this field exists to remove: every account would read as needing to sign in again. A caller must be able to tell "no" from "the question does not apply here".

`presented_issuer_or_none()` is that absence, and the existing write-path guard (`_presented_issuer`) is rebuilt on top of it, so the read path and the write path read one answer rather than two.

## Verification

A PostgreSQL-backed test seeds four accounts — one bound under the presented issuer, one bound under an issuer left behind, one unbound, one service — and asserts the listing distinguishes them. A second test asserts the local-mode answer is absence. A third asserts the route reports the presented issuer.

Two mutations confirm the assertions are not vacuous:

| mutation | result |
|---|---|
| answer `false` instead of absence in local mode | the absence test alone turns red |
| always return an empty issuer list | the distinguishing test turns red |

Repo gate green (`scripts/check.sh`: mypy 3.14, ruff, bandit, eslint/tsc, packed-SDK proof, vitest 496/496, detect-secrets).

Backend suite: 2776 passed, 55 failed, 37 skipped. Every failure is in four git-suite files, and a negative control on a pristine checkout of the base commit produces the same 52 failures in those files. The suite names the cause itself — `assert _installed_git_version() >= (2, 37, 0)` against a host running git 2.34.1. Nothing in the failing set touches this change.
