### PR TITLE
feat: add MCP E2E capability profiles

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "backend/scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 87
+        "line_number": 100
       }
     ],
     "backend/scripts/ci/dependency-compose.yaml": [
@@ -201,28 +201,28 @@
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 63
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 796
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "7bd173a7d5330a38f4e220b20348085e38bf232b",
         "is_verified": false,
-        "line_number": 762
+        "line_number": 1132
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "ea67b3a75dccf0e8c1d6058e060151a3c5ed90a8",
         "is_verified": false,
-        "line_number": 764
+        "line_number": 1134
       }
     ],
     "backend/tests/bench/sparse_shape_bench.py": [
@@ -270,7 +270,7 @@
         "filename": "backend/tests/test_e2e_runtime_unit.py",
         "hashed_secret": "e4b2fc073450eb73ac13305ba129b049865f69e2",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 125
       }
     ],
     "backend/tests/test_publications_e2e.sh": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-20T07:14:53Z"
+  "generated_at": "2026-08-21T08:17:29Z"
 }

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -79,6 +79,19 @@ The supervisor has two modes:
   the foreground until SIGINT/SIGTERM. The fixture's `POST /reset` performs a
   safe empty reset and waits for backend readiness again.
 
+Each invocation also selects one explicit capability profile. The default
+`tool-only` profile starts only the HTTP backend, PAT fixture, and shared
+fixture control app. `transport-proxy` adds a clean install of the checkout's
+`akb-mcp` package into the private runtime root and starts its real executable
+over stdin/stdout. `oidc-resource-server` adds an ephemeral RSA issuer/JWKS
+fixture with deterministic token variants. `transport-oidc` composes both.
+`keycloak-overlay` is intentionally rejected with
+`blocked_runtime_config`; browser SSO and the real Keycloak service remain a
+specialist overlay. Add a capability explicitly with repeatable
+`--capability stdio` / `--capability oidc` (or use `--profile`). Optional
+processes are never started for `tool-only`, and an unavailable selected
+capability is a hard failure rather than a skip.
+
 The ready descriptor is the only line written to stdout by the supervisor.
 Operational logs go to stderr and the private runtime log directory. Its
 shape is schema v2:
@@ -89,10 +102,27 @@ shape is schema v2:
 
 Credential values are read only from the named environment variables and are
 never put in the descriptor, argv, or runtime logs. The only supported
-scenario is `empty`; callers must pass `--scenario empty` when mapping a
-runtime command. Both `gate` and `serve` require
+scenarios are `empty`, `app-installation-lifecycle`, `app-release-rollout`,
+and `app-control-plane`; callers must pass the selected scenario when mapping
+a runtime command. Both `gate` and `serve` require
 `AKB_E2E_USERNAME` and `AKB_E2E_PASSWORD` to be present before the supervisor
 starts; the runtime does not generate or persist those values.
+
+For a selected transport profile the supervisor mints one candidate-bound PAT
+in memory, passes it to the real proxy only as the `AKB_PAT` child environment
+value, and exposes only the configured PAT environment-name in descriptor and
+discovery. The private discovery `runtime` object records the exact source
+revision, backend/proxy artifact versions, protocol revision, transport,
+selected capabilities, tool-case coordinates, fixture reset, and whether the
+stdio initialize/tools-list/read probes crossed the process boundary. The
+OIDC discovery object exposes issuer/JWKS/token coordinates and variant names,
+never an access token or signing key.
+
+`gate` runs the existing curated HTTP suite runner for every profile. A
+transport profile additionally runs the existing proxy contract/reconnect
+tests after the clean install and observes `tools/list` plus a read-only
+`tools/call` through the real child process. Provisioning failures and live
+product-assertion failures are emitted as separate gate events.
 
 For a direct local gate, use the uv-managed Python environment to generate
 per-run values and export them without placing a credential value in the

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -153,10 +153,12 @@ to the descriptor, logs, argv, or committed files.
 contain runtime lifecycle logic. On a clean Ubuntu 24.04 host it:
 
 1. verifies the base image and installs `curl`/CA certificates as needed;
-2. installs and starts Docker Engine plus Compose v2 idempotently;
-3. installs/verifies `uv` and Python 3.14 under the private runtime root;
-4. runs `uv sync --locked --extra dev --project backend`; and
-5. `exec`s the same Python supervisor in `gate` or `serve` mode.
+2. installs the Ubuntu archive's `nodejs`/`npm` packages and verifies both
+   executables before any selected stdio profile is validated;
+3. installs and starts Docker Engine plus Compose v2 idempotently;
+4. installs/verifies `uv` and Python 3.14 under the private runtime root;
+5. runs `uv sync --locked --extra dev --project backend`; and
+6. `exec`s the same Python supervisor in `gate` or `serve` mode.
 
 Package, network, Docker, uv, and Python failures are provisioning failures
 and stop immediately with an actionable stderr message. The bootstrap does

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -5,7 +5,9 @@ The runtime owns only the test infrastructure around AKB:
 * Compose manages the pinned PostgreSQL/pgvector and MinIO dependencies.
 * Uvicorn runs the embedding stub and backend as host processes.
 * A small in-process fixture control app exposes health, discovery, and the
-  project-neutral ``empty`` reset.
+  bounded scenario reset.
+* Optional profiles add the clean stdio proxy consumer and/or a lightweight
+  OIDC Resource Server fixture without changing the schema-v2 descriptor.
 
 The process deliberately keeps all runtime state outside the checkout.  It
 prints one machine-readable descriptor to stdout after readiness; operational
@@ -29,12 +31,13 @@ import shlex
 import shutil
 import signal
 import socket
+import subprocess
 import sys
 import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -43,10 +46,12 @@ from e2e_gate_observability import (
     shell_exit_code,
 )
 from fixture_control import create_app
+from oidc_fixture import OIDCFixture
 
 
 LOGGER = logging.getLogger("akb.e2e_runtime")
 SCHEMA_VERSION = 2
+PROTOCOL_REVISION = "2025-06-18"
 Scenario = Literal[
     "empty",
     "app-installation-lifecycle",
@@ -61,16 +66,110 @@ DEFAULT_EMBED_PORT = 8888
 DEFAULT_FIXTURE_PORT = 8889
 DEFAULT_COMPOSE_PROJECT = "akb-e2e"
 DEFAULT_TIMEOUT_SECONDS = 180.0
+DEFAULT_PROFILE = "tool-only"
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityProfile:
+    """One explicit, fail-closed runtime capability selection."""
+
+    name: str
+    capabilities: frozenset[str]
+
+    @property
+    def needs_stdio(self) -> bool:
+        return "stdio" in self.capabilities
+
+    @property
+    def needs_oidc(self) -> bool:
+        return "oidc" in self.capabilities
+
+    @property
+    def needs_keycloak_overlay(self) -> bool:
+        return "keycloak" in self.capabilities
+
+
+_PROFILE_CAPABILITIES: dict[str, frozenset[str]] = {
+    "tool-only": frozenset({"http", "pat"}),
+    "transport-proxy": frozenset({"http", "pat", "stdio"}),
+    "oidc-resource-server": frozenset({"http", "pat", "oidc"}),
+    "transport-oidc": frozenset({"http", "pat", "stdio", "oidc"}),
+    # The common runtime never starts Keycloak.  Selecting this profile is an
+    # explicit request for the specialist overlay and therefore fails closed
+    # unless the orchestrator supplies that separate runtime.
+    "keycloak-overlay": frozenset({"http", "pat", "keycloak"}),
+}
+_CAPABILITY_ALIASES = {
+    "http": "http",
+    "pat": "pat",
+    "stdio": "stdio",
+    "oidc": "oidc",
+    "keycloak": "keycloak",
+}
+
+
+def _canonical_capabilities(values: Sequence[str]) -> frozenset[str]:
+    selected: set[str] = set()
+    for raw in values:
+        for token in re.split(r"[,+]", raw.strip().lower().replace("_", "-").replace("/", "-")):
+            if not token:
+                continue
+            capability = _CAPABILITY_ALIASES.get(token)
+            if capability is None:
+                raise ValueError(f"unknown runtime capability: {raw}")
+            selected.add(capability)
+    # Every supported MCP profile is rooted in the same HTTP/PAT fixture.  A
+    # caller selecting only a transport capability still gets the complete
+    # base rather than an accidental unauthenticated or HTTP-less runtime.
+    selected.update({"http", "pat"})
+    return frozenset(selected)
+
+
+def select_capability_profile(
+    profile: str = DEFAULT_PROFILE,
+    capabilities: Sequence[str] = (),
+) -> CapabilityProfile:
+    """Resolve one profile name plus optional capability additions."""
+
+    normalized = profile.strip().lower()
+
+    if normalized not in _PROFILE_CAPABILITIES:
+        raise ValueError(f"unknown runtime capability profile: {profile}")
+    selected = set(_PROFILE_CAPABILITIES[normalized])
+    if capabilities:
+        selected.update(_canonical_capabilities(capabilities))
+    resolved = frozenset(selected)
+    canonical_name = next(
+        (name for name, values in _PROFILE_CAPABILITIES.items() if values == resolved),
+        "custom-" + "-".join(sorted(resolved)),
+    )
+    return CapabilityProfile(canonical_name, resolved)
 
 
 class ProvisioningFailure(RuntimeError):
     """A dependency, process, or fixture precondition failed."""
 
 
+class BlockedRuntimeConfig(ProvisioningFailure):
+    """A requested capability cannot be provided by this runtime."""
+
+    code = "blocked_runtime_config"
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(f"{self.code}: {detail}")
+
+
+class ProductAssertionFailure(RuntimeError):
+    """A live profile assertion failed after provisioning succeeded."""
+
+    code = "product_assertion_failed"
+
+
 @dataclasses.dataclass(frozen=True)
 class CredentialNames:
     username_env: str = DEFAULT_USERNAME_ENV
     password_env: str = DEFAULT_PASSWORD_ENV
+    pat_env: str = "AKB_E2E_PAT"
 
     def values(self) -> tuple[str, str]:
         username = os.environ.get(self.username_env, "")
@@ -99,6 +198,12 @@ class RuntimeConfig:
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
     credentials: CredentialNames = dataclasses.field(default_factory=CredentialNames)
     scenario: Scenario = SCENARIO
+    profile: str = DEFAULT_PROFILE
+    capabilities: tuple[str, ...] = ()
+
+    @property
+    def capability_profile(self) -> CapabilityProfile:
+        return select_capability_profile(self.profile, self.capabilities)
 
     @property
     def backend_dir(self) -> Path:
@@ -128,11 +233,21 @@ class RuntimeConfig:
     def logs_dir(self) -> Path:
         return self.runtime_root / "logs"
 
+    @property
+    def proxy_package_dir(self) -> Path:
+        return self.checkout / "packages" / "akb-mcp-client"
+
+    @property
+    def proxy_consumer_dir(self) -> Path:
+        return self.runtime_root / "node-consumer"
+
 
 @dataclasses.dataclass
 class ManagedProcess:
     process: asyncio.subprocess.Process
     process_group: bool = True
+    stdin: asyncio.StreamWriter | None = None
+    stdout: asyncio.StreamReader | None = None
 
 
 def prepare_private_runtime_root(root: Path) -> tuple[Path, Path, Path, Path]:
@@ -161,6 +276,32 @@ def _write_private_text(path: Path, value: str) -> None:
 
 def _http_get(url: str, timeout: float = 2.0) -> tuple[int, bytes]:
     request = Request(url, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return response.status, response.read()
+    except HTTPError as exc:
+        return exc.code, exc.read()
+    except (URLError, OSError):
+        return 0, b""
+
+
+def _http_json(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict[str, object] | None = None,
+    authorization: str | None = None,
+    timeout: float = 10.0,
+) -> tuple[int, bytes]:
+    """Small JSON client used for runtime-owned credential provisioning."""
+
+    payload = json.dumps(body, separators=(",", ":")).encode("utf-8") if body is not None else None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    if authorization:
+        headers["Authorization"] = authorization
+    request = Request(url, data=payload, headers=headers, method=method)
     try:
         with urlopen(request, timeout=timeout) as response:
             return response.status, response.read()
@@ -215,6 +356,7 @@ async def terminate_process(
 class E2ERuntime:
     def __init__(self, config: RuntimeConfig) -> None:
         self.config = config
+        self.profile = config.capability_profile
         self._children: dict[str, ManagedProcess] = {}
         self._active_command: asyncio.subprocess.Process | None = None
         self._fixture_server: Any | None = None
@@ -233,6 +375,22 @@ class E2ERuntime:
         self._fixture_private_values: tuple[str, ...] = ()
         self._fixture_private_marker = ""
         self._fixture_controls: dict[str, object] = {}
+        self._pat_value = ""
+        self._candidate_revision: str | None = None
+        self._proxy_version: str | None = None
+        self._stdio_initialize_observed = False
+        self._stdio_tools_list_observed = False
+        self._stdio_read_call_observed = False
+        self._stdio_next_id = 2
+        self.oidc_fixture: OIDCFixture | None = (
+            OIDCFixture(
+                origin=config.fixture_origin,
+                realm="runtime",
+                audience=f"{config.app_origin}/mcp",
+            )
+            if self.profile.needs_oidc
+            else None
+        )
 
         self._compose_log = self.config.logs_dir / "compose.log"
 
@@ -244,6 +402,129 @@ class E2ERuntime:
     @property
     def scenario(self) -> Scenario:
         return self.config.scenario
+
+    @property
+    def selected_capabilities(self) -> tuple[str, ...]:
+        return tuple(sorted(self.profile.capabilities))
+
+    def _source_revision(self) -> str:
+        if self._candidate_revision is not None:
+            return self._candidate_revision
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(self.config.checkout), "rev-parse", "HEAD"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            completed = None
+        revision = completed.stdout.strip() if completed and completed.returncode == 0 else "unknown"
+        self._candidate_revision = revision
+        return revision
+
+    def _artifact_version(self, package_dir: Path, *, default: str = "unknown") -> str:
+        package_file = package_dir / "package.json"
+        try:
+            parsed = json.loads(package_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return default
+        version = parsed.get("version")
+        return version if isinstance(version, str) and version else default
+
+    def _backend_version(self) -> str:
+        try:
+            text = (self.config.backend_dir / "pyproject.toml").read_text(encoding="utf-8")
+        except OSError:
+            return "unknown"
+        match = re.search(r"(?m)^version\s*=\s*[\"']([^\"']+)[\"']", text)
+        return match.group(1) if match else "unknown"
+
+    def runtime_evidence(self) -> dict[str, object]:
+        """Return source-bound, credential-free evidence coordinates."""
+
+        fixture_namespace = self._fixture_catalog.get("namespace")
+        fixture: dict[str, object] = {
+            "scenario": self.config.scenario,
+            "reset": {
+                "method": "POST",
+                "url": f"{self.config.fixture_origin}/reset",
+                "body": {"scenario": self.config.scenario},
+            },
+        }
+        if isinstance(fixture_namespace, str):
+            fixture["namespace"] = fixture_namespace
+        evidence: dict[str, object] = {
+            "source_revision": self._source_revision(),
+            "backend_artifact_version": self._backend_version(),
+            "protocol_revision": PROTOCOL_REVISION,
+            "transport": ["http", "stdio"] if self.profile.needs_stdio else ["http"],
+            "selected_capabilities": list(self.selected_capabilities),
+            "tool_cases": {
+                "read": "akb_list_vaults",
+                "write": "akb_put",
+                "destructive": "akb_delete",
+                "comparison": "same candidate, fixture, origin and credential",
+            },
+            "origin": {
+                "backend": self.config.app_origin,
+                "fixture": self.config.fixture_origin,
+            },
+            "credential_env": {
+                "username": self.config.credentials.username_env,
+                "password": self.config.credentials.password_env,
+                "pat": self.config.credentials.pat_env,
+            },
+            "pat": {
+                "credential_env": self.config.credentials.pat_env,
+                "mint": {
+                    "service": "app",
+                    "method": "POST",
+                    "path": "/api/v1/auth/tokens",
+                    "body_fields": ["name", "scopes", "vault_scope"],
+                    "auth": "login_session",
+                },
+                "cases": {
+                    "valid": {"authorization": "credential_env"},
+                    "unauthenticated": {"authorization": "omitted"},
+                    "read_only": {"scope": "akb:vault:read"},
+                    "write": {"scope": "akb:vault:write"},
+                    "destructive": {"scope": "akb:vault:admin"},
+                },
+            },
+            "fixture": fixture,
+            "failure_stages": ["provisioning", "product_assertion"],
+        }
+        if self.profile.needs_stdio:
+            if self._proxy_version is None:
+                self._proxy_version = self._artifact_version(self.config.proxy_package_dir)
+            evidence["proxy_artifact_version"] = self._proxy_version
+            evidence["stdio"] = {
+                "package": "akb-mcp",
+                "executable": "akb-mcp",
+                "consumer_root": str(self.config.proxy_consumer_dir),
+                "environment": {
+                    "AKB_MCP_URL": f"{self.config.app_origin}/mcp/",
+                    "AKB_PAT": self.config.credentials.pat_env,
+                },
+                "initialize_observed": self._stdio_initialize_observed,
+                "tools_list_observed": getattr(self, "_stdio_tools_list_observed", False),
+                "read_call_observed": getattr(self, "_stdio_read_call_observed", False),
+            }
+        if self.oidc_fixture is not None:
+            oidc_evidence = self.oidc_fixture.discovery()
+            oidc_evidence["resource_metadata"] = {
+                "method": "GET",
+                "url": f"{self.config.app_origin}/.well-known/oauth-protected-resource",
+            }
+            oidc_evidence["challenge"] = {
+                "method": "POST",
+                "url": f"{self.config.app_origin}/mcp/",
+                "authorization": "omitted",
+            }
+            evidence["oidc"] = oidc_evidence
+        return evidence
 
     def fixture_health(self) -> dict[str, object]:
         return {
@@ -287,6 +568,9 @@ class E2ERuntime:
                 "path": "/log-observation",
             }
         }
+        catalog["runtime"] = self.runtime_evidence()
+        if self.oidc_fixture is not None:
+            catalog["oidc"] = self.oidc_fixture.discovery()
         if self.config.scenario in {"app-release-rollout", "app-control-plane"}:
             installations = catalog.get("installations", [])
             targets: list[dict[str, str]] = []
@@ -670,7 +954,7 @@ class E2ERuntime:
             return
 
     def descriptor(self) -> dict[str, object]:
-        return {
+        descriptor: dict[str, object] = {
             "schema_version": SCHEMA_VERSION,
             "status": "ready",
             "scenario": self.config.scenario,
@@ -710,21 +994,93 @@ class E2ERuntime:
                 "login_path": "/api/v1/auth/login",
             },
         }
+        # Keep the legacy default descriptor byte-for-byte compatible.  A
+        # selected non-default profile advertises its added capabilities using
+        # the same schema-v2 service map rather than a parallel MCP descriptor.
+        if self.profile.name != DEFAULT_PROFILE or self.config.capabilities:
+            descriptor["profile"] = self.profile.name
+            descriptor["capabilities"] = list(self.selected_capabilities)
+            descriptor["evidence"] = self.runtime_evidence()
+        if self.profile.needs_stdio:
+            services = descriptor["services"]
+            assert isinstance(services, dict)
+            services["stdio"] = {
+                "origin": self.config.app_origin,
+                "transport": "stdio",
+                "package": "akb-mcp",
+                "executable": "akb-mcp",
+                "consumer_root": str(self.config.proxy_consumer_dir),
+                "environment": {
+                    "AKB_MCP_URL": f"{self.config.app_origin}/mcp/",
+                    "AKB_PAT": self.config.credentials.pat_env,
+                },
+            }
+            credentials = descriptor["credentials"]
+            assert isinstance(credentials, dict)
+            credentials["pat_env"] = self.config.credentials.pat_env
+        if self.oidc_fixture is not None:
+            services = descriptor["services"]
+            assert isinstance(services, dict)
+            app_service = services["app"]
+            assert isinstance(app_service, dict)
+            app_service["oauth_metadata"] = {
+                "method": "GET",
+                "url": f"{self.config.app_origin}/.well-known/oauth-protected-resource",
+            }
+            app_service["oauth_challenge"] = {
+                "method": "POST",
+                "url": f"{self.config.app_origin}/mcp/",
+                "authorization": "omitted",
+            }
+            services["oidc"] = {
+                "origin": self.config.fixture_origin,
+                "health": {"method": "GET", "url": self.oidc_fixture.health_uri},
+                "discovery": {"method": "GET", "url": self.oidc_fixture.metadata_uri},
+                "jwks": {"method": "GET", "url": self.oidc_fixture.jwks_uri},
+                "token": {
+                    "method": "POST",
+                    "url": self.oidc_fixture.token_uri,
+                    "body": {"variant": "valid"},
+                },
+            }
+        return descriptor
 
     def _validate_checkout(self) -> None:
         if not self.config.checkout.is_dir():
             raise ProvisioningFailure(f"checkout does not exist: {self.config.checkout}")
-        required = (
+        required: tuple[Path, ...] = (
             self.config.backend_dir / "uv.lock",
             self.config.backend_dir / "pyproject.toml",
             self.config.backend_dir / "scripts" / "ci" / "embed_stub.py",
             self.config.backend_dir / "scripts" / "ci" / "e2e_suite_runner.py",
         )
+        if self.profile.needs_stdio:
+            required += (
+                self.config.proxy_package_dir / "package.json",
+                self.config.proxy_package_dir / "bin" / "akb-mcp.mjs",
+            )
         missing = [str(path) for path in required if not path.is_file()]
         if missing:
             raise ProvisioningFailure("checkout is missing runtime inputs")
         if self.config.checkout == self.config.runtime_root or self.config.checkout in self.config.runtime_root.parents:
             raise ProvisioningFailure("runtime root must be outside the checkout")
+
+    def _validate_profile(self) -> None:
+        if self.profile.needs_keycloak_overlay:
+            raise BlockedRuntimeConfig(
+                "the common runtime does not start Keycloak; use the specialist SSO/IdP overlay"
+            )
+        if self.profile.needs_stdio:
+            missing = [name for name in ("node", "npm") if shutil.which(name) is None]
+            if missing:
+                raise BlockedRuntimeConfig(
+                    "stdio capability requires the installed Node consumer toolchain: "
+                    + ", ".join(missing)
+                )
+            if not self.config.proxy_package_dir.is_dir():
+                raise BlockedRuntimeConfig("stdio capability requires packages/akb-mcp-client")
+        if self.profile.needs_oidc and self.oidc_fixture is None:
+            raise BlockedRuntimeConfig("OIDC capability was selected without its fixture")
 
     def _write_config(self) -> None:
         import yaml
@@ -755,6 +1111,20 @@ class E2ERuntime:
             "s3_public_url": "http://127.0.0.1:9000",
             "s3_bucket": "akb-files",
         }
+        if self.oidc_fixture is not None:
+            app_config.update(
+                {
+                    "keycloak_enabled": True,
+                    "mcp_oauth_enabled": True,
+                    "keycloak_server_url": self.oidc_fixture.origin,
+                    "keycloak_internal_url": self.oidc_fixture.origin,
+                    "keycloak_realm": self.oidc_fixture.realm,
+                    "keycloak_client_id": "runtime-mcp-client",
+                    "mcp_oauth_audience": self.oidc_fixture.audience,
+                    "keycloak_enrollment_mode": "open",
+                    "keycloak_require_verified_email": True,
+                }
+            )
         secret_config = {
             "db_password": "akb",
             "system_hmac_secret": secrets.token_urlsafe(48),
@@ -772,7 +1142,7 @@ class E2ERuntime:
             yaml.safe_dump(secret_config, sort_keys=False),
         )
 
-    def _child_environment(self) -> dict[str, str]:
+    def _child_environment(self, overrides: dict[str, str] | None = None) -> dict[str, str]:
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
         env["PYTHONFAULTHANDLER"] = "1"
@@ -793,6 +1163,8 @@ class E2ERuntime:
             )
         env.setdefault("AKB_PG_USER", "akb")
         env.setdefault("AKB_PG_DB", "akb")
+        if overrides:
+            env.update(overrides)
         return env
 
     def _compose_command(self, *arguments: str) -> list[str]:
@@ -896,10 +1268,46 @@ class E2ERuntime:
             )
             self._children[name] = ManagedProcess(process)
 
+    async def _spawn_interactive_process(
+        self,
+        name: str,
+        command: list[str],
+        log_name: str,
+        *,
+        environment: dict[str, str],
+    ) -> ManagedProcess:
+        """Start a real stdio boundary while keeping stderr in private logs."""
+
+        if name in self._children:
+            raise ProvisioningFailure(f"process already running: {name}")
+        log_path = self.config.logs_dir / log_name
+        with log_path.open("ab", buffering=0) as handle:
+            os.chmod(log_path, 0o600)
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(self.config.runtime_root),
+                env=self._child_environment(environment),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=handle,
+                start_new_session=True,
+            )
+        managed = ManagedProcess(
+            process,
+            stdin=process.stdin,
+            stdout=process.stdout,
+        )
+        self._children[name] = managed
+        return managed
+
     async def _stop_named_process(self, name: str) -> None:
         managed = self._children.pop(name, None)
         if managed is None:
             return
+        if managed.stdin is not None:
+            managed.stdin.close()
+            with contextlib.suppress(Exception):
+                await managed.stdin.wait_closed()
         await terminate_process(managed.process, process_group=managed.process_group)
 
     async def _start_dependencies(self) -> None:
@@ -977,6 +1385,209 @@ class E2ERuntime:
             f"{self.config.app_origin}/readyz",
             self._ready_response,
         )
+
+    async def _mint_runtime_pat(self) -> None:
+        """Mint one candidate-bound PAT without ever putting it in argv/logs."""
+
+        username, password = self.config.credentials.values()
+        status, body = await asyncio.to_thread(
+            _http_json,
+            f"{self.config.app_origin}/api/v1/auth/login",
+            method="POST",
+            body={"username": username, "password": password},
+        )
+        if status != 200:
+            raise ProvisioningFailure("runtime PAT login failed")
+        try:
+            login_payload = json.loads(body)
+            session_token = login_payload["token"]
+            if not isinstance(session_token, str) or not session_token:
+                raise ValueError
+        except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+            raise ProvisioningFailure("runtime PAT login returned an invalid response") from None
+        # The session bearer is only an in-memory provisioning intermediate;
+        # include it in the private-value redaction set before the token mint
+        # request so a driver or child log can never echo it through discovery.
+        self._fixture_private_values = (*self._fixture_private_values, session_token)
+
+        status, body = await asyncio.to_thread(
+            _http_json,
+            f"{self.config.app_origin}/api/v1/auth/tokens",
+            method="POST",
+            authorization=f"Bearer {session_token}",
+            body={"name": "runtime-mcp"},
+        )
+        if status != 200:
+            raise ProvisioningFailure("runtime PAT mint failed")
+        try:
+            token_payload = json.loads(body)
+            token = token_payload["token"]
+            if not isinstance(token, str) or not token.startswith("akb_"):
+                raise ValueError
+        except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+            raise ProvisioningFailure("runtime PAT mint returned an invalid response") from None
+        self._pat_value = token
+        self._fixture_private_values = (*self._fixture_private_values, token)
+
+    async def _install_stdio_proxy(self) -> Path:
+        """Install the checkout package into the private clean Node consumer."""
+
+        consumer = self.config.proxy_consumer_dir
+        consumer.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(consumer, 0o700)
+        try:
+            await self._run_logged_command(
+                [
+                    "npm",
+                    "install",
+                    "--prefix",
+                    str(consumer),
+                    "--no-save",
+                    "--package-lock=false",
+                    "--ignore-scripts",
+                    "--no-audit",
+                    "--no-fund",
+                    str(self.config.proxy_package_dir),
+                ],
+                log_path=self.config.logs_dir / "stdio-install.log",
+            )
+        except ProvisioningFailure as exc:
+            raise BlockedRuntimeConfig("clean Node consumer installation failed") from exc
+        executable = consumer / "node_modules" / ".bin" / "akb-mcp"
+        if not executable.is_file():
+            executable = consumer / "node_modules" / "akb-mcp" / "bin" / "akb-mcp.mjs"
+        if not executable.is_file():
+            raise BlockedRuntimeConfig("installed akb-mcp package did not expose its bin")
+        self._proxy_version = self._artifact_version(self.config.proxy_package_dir)
+        return executable
+
+    async def _start_stdio_proxy(self) -> None:
+        if not self._pat_value:
+            raise BlockedRuntimeConfig("stdio capability requires a runtime PAT")
+        executable = await self._install_stdio_proxy()
+        node = shutil.which("node")
+        if node is None:
+            raise BlockedRuntimeConfig("stdio capability requires node")
+        managed = await self._spawn_interactive_process(
+            "stdio",
+            [node, str(executable)],
+            "stdio-proxy.log",
+            environment={
+                "AKB_MCP_URL": f"{self.config.app_origin}/mcp/",
+                "AKB_PAT": self._pat_value,
+            },
+        )
+        if managed.stdin is None or managed.stdout is None:
+            raise BlockedRuntimeConfig("stdio proxy did not expose stdin/stdout pipes")
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_REVISION,
+                "capabilities": {},
+                "clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
+            },
+        }
+        managed.stdin.write((json.dumps(initialize, separators=(",", ":")) + "\n").encode())
+        await managed.stdin.drain()
+        try:
+            for _ in range(8):
+                line = await asyncio.wait_for(managed.stdout.readline(), timeout=10)
+                if not line:
+                    break
+                response = json.loads(line)
+                if not isinstance(response, dict):
+                    continue
+                if response.get("id") != 1:
+                    continue
+                if "error" in response:
+                    raise ValueError
+                self._stdio_initialize_observed = True
+                initialized = {
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized",
+                    "params": {},
+                }
+                managed.stdin.write((json.dumps(initialized, separators=(",", ":")) + "\n").encode())
+                await managed.stdin.drain()
+                return
+        except (asyncio.TimeoutError, ValueError, json.JSONDecodeError):
+            pass
+        await self._stop_named_process("stdio")
+        raise BlockedRuntimeConfig("stdio proxy initialize did not cross the process boundary")
+
+    async def _stdio_response(self, expected_id: int) -> dict[str, object]:
+        managed = self._children.get("stdio")
+        if managed is None or managed.stdout is None:
+            raise ProductAssertionFailure("stdio process is unavailable")
+        for _ in range(32):
+            try:
+                line = await asyncio.wait_for(managed.stdout.readline(), timeout=20)
+            except asyncio.TimeoutError:
+                raise ProductAssertionFailure("stdio response timed out") from None
+            if not line:
+                raise ProductAssertionFailure("stdio process closed its output")
+            try:
+                response = json.loads(line)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                # A non-JSON line is not a valid protocol response.  Do not
+                # copy it into an error because it could contain credentials.
+                continue
+            if isinstance(response, dict) and response.get("id") == expected_id:
+                return response
+        raise ProductAssertionFailure("stdio response id was not observed")
+
+    async def _stdio_request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        managed = self._children.get("stdio")
+        if managed is None or managed.stdin is None:
+            raise ProductAssertionFailure("stdio process is unavailable")
+        request_id = self._stdio_next_id
+        self._stdio_next_id += 1
+        message: dict[str, object] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
+        if params is not None:
+            message["params"] = params
+        managed.stdin.write((json.dumps(message, separators=(",", ":")) + "\n").encode())
+        await managed.stdin.drain()
+        return await self._stdio_response(request_id)
+
+    async def _probe_stdio_behavior(self) -> None:
+        """Observe the installed proxy at the protocol boundary.
+
+        This is intentionally a small read-only product assertion.  The
+        curated HTTP suites remain responsible for write/destructive side
+        effects; the discovery evidence advertises the same tool cases for a
+        source-blind transport comparison.
+        """
+
+        if not self.profile.needs_stdio:
+            return
+        response = await self._stdio_request("tools/list", {})
+        result = response.get("result")
+        if not isinstance(result, dict) or not isinstance(result.get("tools"), list):
+            raise ProductAssertionFailure("stdio tools/list returned an invalid result")
+        names = {
+            item.get("name")
+            for item in result["tools"]
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        required = {"akb_list_vaults", "akb_put", "akb_delete_vault"}
+        if not required.issubset(names):
+            raise ProductAssertionFailure("stdio tools/list omitted a required tool")
+        self._stdio_tools_list_observed = True
+
+        read_response = await self._stdio_request(
+            "tools/call",
+            {"name": "akb_list_vaults", "arguments": {}},
+        )
+        read_result = read_response.get("result")
+        if not isinstance(read_result, dict) or "error" in read_response:
+            raise ProductAssertionFailure("stdio read tool call was not accepted")
+        self._stdio_read_call_observed = True
 
     @staticmethod
     def _ready_response(status: int, body: bytes) -> bool:
@@ -2379,6 +2990,7 @@ class E2ERuntime:
         await self._stop_named_process("backend")
         await self._seed_external_credential()
         await self._start_backend()
+        await self._mint_runtime_pat()
 
     async def _start_fixture_control(self) -> None:
         import uvicorn
@@ -2407,6 +3019,7 @@ class E2ERuntime:
 
     async def prepare(self) -> None:
         self._validate_checkout()
+        self._validate_profile()
         prepare_private_runtime_root(self.config.runtime_root)
         self._write_config()
         self.config.logs_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -2414,6 +3027,8 @@ class E2ERuntime:
         await self._start_fixture_control()
         await self._start_embed_stub()
         await self._bootstrap_backend_and_seed()
+        if self.profile.needs_stdio:
+            await self._start_stdio_proxy()
         self._prepared = True
 
     async def reset_scenario(self) -> None:
@@ -2424,6 +3039,11 @@ class E2ERuntime:
             self._resetting = True
             try:
                 self._fixture_controls.clear()
+                await self._stop_named_process("stdio")
+                self._stdio_initialize_observed = False
+                self._stdio_tools_list_observed = False
+                self._stdio_read_call_observed = False
+                self._stdio_next_id = 2
                 await self._stop_named_process("backend")
                 await self._stop_named_process("embed")
                 await self._compose("down", "--volumes", "--remove-orphans", check=False)
@@ -2434,6 +3054,8 @@ class E2ERuntime:
                 await self._start_dependencies()
                 await self._start_embed_stub()
                 await self._bootstrap_backend_and_seed()
+                if self.profile.needs_stdio:
+                    await self._start_stdio_proxy()
             finally:
                 self._resetting = False
 
@@ -2493,8 +3115,39 @@ class E2ERuntime:
                 "process": "supervisor",
                 "suite_runner": str(suite_path),
                 "gate_log": str(log_path),
+                "stage": "product_assertion",
+                "profile": self.profile.name,
+                "capabilities": list(self.selected_capabilities),
+                "source_revision": self._source_revision(),
             },
         )
+
+        if self.profile.needs_stdio:
+            await self._probe_stdio_behavior()
+            emit_gate_event(
+                {
+                    "event": "stdio_contract_start",
+                    "process": "supervisor",
+                    "stage": "product_assertion",
+                    "profile": self.profile.name,
+                }
+            )
+            try:
+                await self._run_logged_command(
+                    ["npm", "test", "--prefix", str(self.config.proxy_package_dir)],
+                    log_path=self.config.logs_dir / "stdio-contract.log",
+                )
+            except ProvisioningFailure as exc:
+                raise ProductAssertionFailure("stdio contract/reconnect tests failed") from exc
+            emit_gate_event(
+                {
+                    "event": "stdio_contract_complete",
+                    "process": "supervisor",
+                    "stage": "product_assertion",
+                    "profile": self.profile.name,
+                    "returncode": 0,
+                }
+            )
 
         child_env = self._child_environment()
         with log_path.open("ab", buffering=0) as handle:
@@ -2564,6 +3217,7 @@ class E2ERuntime:
             await terminate_process(self._suite_process.process)
             self._suite_process = None
         await self._stop_fixture_control()
+        await self._stop_named_process("stdio")
         await self._stop_named_process("backend")
         await self._stop_named_process("embed")
         with contextlib.suppress(Exception):
@@ -2577,13 +3231,36 @@ class E2ERuntime:
             # Validate before any process/resource is created.  The values are
             # intentionally read only for presence and later hashing; they are
             # never copied into a descriptor, command line, or log message.
+            self._validate_profile()
             self.config.credentials.values()
             await self.prepare()
             print(json.dumps(self.descriptor(), separators=(",", ":"), ensure_ascii=False), flush=True)
             if self.config.mode == "gate":
                 return await self._run_gate()
             return await self._serve_foreground()
+        except ProductAssertionFailure as exc:
+            emit_gate_event(
+                {
+                    "event": "product_assertion_failed",
+                    "process": "supervisor",
+                    "code": ProductAssertionFailure.code,
+                    "stage": "product_assertion",
+                    "profile": self.profile.name,
+                }
+            )
+            LOGGER.error("E2E product assertion failed: %s", str(exc))
+            return 1
         except ProvisioningFailure as exc:
+            if isinstance(exc, BlockedRuntimeConfig):
+                emit_gate_event(
+                    {
+                        "event": "runtime_blocked",
+                        "process": "supervisor",
+                        "code": BlockedRuntimeConfig.code,
+                        "stage": "provisioning",
+                        "profile": self.profile.name,
+                    }
+                )
             LOGGER.error("E2E runtime provisioning failed: %s", str(exc))
             return 1
         except Exception:
@@ -2619,6 +3296,21 @@ def _parse_args(argv: list[str] | None = None) -> RuntimeConfig:
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--username-env", default=DEFAULT_USERNAME_ENV)
     parser.add_argument("--password-env", default=DEFAULT_PASSWORD_ENV)
+    parser.add_argument("--pat-env", default="AKB_E2E_PAT")
+    parser.add_argument(
+        "--profile",
+        default=DEFAULT_PROFILE,
+        help=(
+            "capability profile: tool-only, transport-proxy, "
+            "oidc-resource-server, transport-oidc, or keycloak-overlay"
+        ),
+    )
+    parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        help="optional capability addition (stdio, oidc, or keycloak); repeatable",
+    )
     parser.add_argument(
         "--scenario",
         choices=(
@@ -2630,6 +3322,11 @@ def _parse_args(argv: list[str] | None = None) -> RuntimeConfig:
         default=SCENARIO,
     )
     args = parser.parse_args(argv)
+
+    try:
+        select_capability_profile(args.profile, args.capability)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     checkout = args.checkout.expanduser().resolve()
     runtime_root = (
@@ -2649,8 +3346,10 @@ def _parse_args(argv: list[str] | None = None) -> RuntimeConfig:
         embed_port=args.embed_port,
         fixture_port=args.fixture_port,
         timeout_seconds=args.timeout_seconds,
-        credentials=CredentialNames(args.username_env, args.password_env),
+        credentials=CredentialNames(args.username_env, args.password_env, args.pat_env),
         scenario=args.scenario,
+        profile=args.profile,
+        capabilities=tuple(args.capability),
     )
 
 

--- a/backend/scripts/ci/fixture_control.py
+++ b/backend/scripts/ci/fixture_control.py
@@ -64,6 +64,16 @@ def create_app(runtime: FixtureRuntime) -> FastAPI:
         openapi_url="/openapi.json",
     )
 
+    # The lightweight OIDC Resource Server fixture is an optional capability
+    # of the same in-process control service.  Keeping it absent from the app
+    # when the profile does not select OIDC makes tool-only startup cheap and
+    # prevents an accidental Keycloak/issuer dependency.
+    oidc_fixture = getattr(runtime, "oidc_fixture", None)
+    if oidc_fixture is not None:
+        register = getattr(oidc_fixture, "register", None)
+        if callable(register):
+            register(app)
+
     @app.get("/health")
     async def health() -> dict[str, object]:
         return runtime.fixture_health()

--- a/backend/scripts/ci/oidc_fixture.py
+++ b/backend/scripts/ci/oidc_fixture.py
@@ -1,0 +1,212 @@
+"""Small, deterministic OIDC Resource Server fixture for the E2E runtime.
+
+The fixture deliberately implements only the authority surface that AKB's
+Resource Server verifier consumes: an ephemeral RSA key, the realm JWKS
+endpoint, discovery metadata, and bounded token variants.  It does not model
+authorization, browser login, consent, or a Keycloak-compatible server.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+
+OIDC_TOKEN_VARIANTS: tuple[str, ...] = (
+    "valid",
+    "wrong_issuer",
+    "wrong_audience",
+    "expired",
+    "wrong_algorithm",
+    "wrong_key_id",
+    "insufficient_scope",
+)
+
+
+def _base64url(value: int) -> str:
+    width = max(1, (value.bit_length() + 7) // 8)
+    return base64.urlsafe_b64encode(value.to_bytes(width, "big")).rstrip(b"=").decode("ascii")
+
+
+class TokenRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    variant: str = Field(min_length=1, max_length=64)
+
+
+@dataclass(slots=True)
+class OIDCFixture:
+    """In-process OIDC fixture bound to one runtime origin and candidate."""
+
+    origin: str
+    realm: str
+    audience: str
+    subject: str = "runtime-oidc-subject"
+    username: str = "runtime-oidc-user"
+    email: str = "runtime-oidc-user@example.invalid"
+    _private_key: Any = field(init=False, repr=False)
+    _key_id: str = field(init=False, repr=False)
+    _jwk: dict[str, str] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._key_id = f"runtime-{uuid.uuid4().hex[:12]}"
+        self._jwk = self._make_jwk()
+
+    @property
+    def issuer(self) -> str:
+        return f"{self.origin.rstrip('/')}/realms/{self.realm}"
+
+    @property
+    def jwks_uri(self) -> str:
+        return f"{self.issuer}/protocol/openid-connect/certs"
+
+    @property
+    def token_uri(self) -> str:
+        return f"{self.origin.rstrip('/')}/oidc/token"
+
+    @property
+    def metadata_uri(self) -> str:
+        return f"{self.origin.rstrip('/')}/.well-known/openid-configuration"
+
+    @property
+    def health_uri(self) -> str:
+        return f"{self.origin.rstrip('/')}/oidc/health"
+
+    def _make_jwk(self) -> dict[str, str]:
+        public = self._private_key.public_key().public_numbers()
+        return {
+            "kty": "RSA",
+            "use": "sig",
+            "alg": "RS256",
+            "kid": self._key_id,
+            "n": _base64url(public.n),
+            "e": _base64url(public.e),
+        }
+
+    def discovery(self) -> dict[str, object]:
+        """Return only coordinates and variant names, never token material."""
+
+        return {
+            "issuer": self.issuer,
+            "jwks": {"method": "GET", "url": self.jwks_uri},
+            "token_variants": list(OIDC_TOKEN_VARIANTS),
+            "token": {"method": "POST", "url": self.token_uri, "body": {"variant": "valid"}},
+            "metadata": {"method": "GET", "url": self.metadata_uri},
+            "health": {"method": "GET", "url": self.health_uri},
+            "scope_cases": {
+                "read": "akb:vault:read",
+                "write": "akb:vault:write",
+            },
+            # These are verifier-boundary cases, not Authorization Server
+            # flows.  The common fixture intentionally exposes coordinates so
+            # a source-blind consumer can reproduce an absent/malformed
+            # bearer and a scope rejection without learning any secret.
+            "challenge_cases": {
+                "metadata": {
+                    "method": "GET",
+                    "url": self.metadata_uri,
+                },
+                "missing_authorization": {"authorization": "omitted"},
+                "malformed_bearer": {"authorization": "Bearer <malformed>"},
+                "insufficient_scope": {"token_variant": "insufficient_scope"},
+            },
+        }
+
+    def jwks(self) -> dict[str, list[dict[str, str]]]:
+        return {"keys": [dict(self._jwk)]}
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "issuer": self.issuer,
+            "jwks_uri": self.jwks_uri,
+            "token_endpoint": self.token_uri,
+            "response_types_supported": [],
+            "grant_types_supported": [],
+            "authorization_endpoint": None,
+            "scopes_supported": ["akb:vault:read", "akb:vault:write"],
+        }
+
+    def _claims(self, variant: str) -> dict[str, object]:
+        now = int(time.time())
+        claims: dict[str, object] = {
+            "iss": self.issuer,
+            "aud": self.audience,
+            "sub": self.subject,
+            "iat": now,
+            "exp": now + 300,
+            "jti": hashlib.sha256(f"{self.subject}:{variant}:{now // 300}".encode()).hexdigest(),
+            "typ": "Bearer",
+            "azp": "runtime-mcp-client",
+            "sid": "runtime-mcp-session",
+            "scope": "akb:vault:read akb:vault:write",
+            "preferred_username": self.username,
+            "email": self.email,
+            "email_verified": True,
+        }
+        if variant == "wrong_issuer":
+            claims["iss"] = f"{self.origin.rstrip('/')}/realms/other"
+        elif variant == "wrong_audience":
+            claims["aud"] = f"{self.origin.rstrip('/')}/wrong-audience"
+        elif variant == "expired":
+            claims["exp"] = now - 10
+        elif variant == "insufficient_scope":
+            claims["scope"] = "akb:vault:read"
+        return claims
+
+    def mint(self, variant: str) -> str:
+        if variant not in OIDC_TOKEN_VARIANTS:
+            raise ValueError(f"unknown OIDC token variant: {variant}")
+        claims = self._claims(variant)
+        if variant == "wrong_algorithm":
+            # The verifier rejects this before consulting the JWKS.  The
+            # signing secret is fixture-local and is never returned.
+            return jwt.encode(
+                claims,
+                "runtime-oidc-invalid-algorithm-key-material-0123456789abcdef",  # pragma: allowlist secret
+                algorithm="HS256",
+            )
+        headers = {"kid": self._key_id, "typ": "JWT", "alg": "RS256"}
+        if variant == "wrong_key_id":
+            headers["kid"] = "runtime-unknown-key"
+        return jwt.encode(claims, self._private_key, algorithm="RS256", headers=headers)
+
+    def register(self, app: FastAPI) -> None:
+        """Mount the fixture endpoints on the runtime's existing control app."""
+
+        @app.get("/oidc/health", include_in_schema=True)
+        async def oidc_health() -> dict[str, object]:
+            return {"status": "ready", "issuer": self.issuer, "jwks_key_count": 1}
+
+        @app.get("/.well-known/openid-configuration", include_in_schema=True)
+        async def oidc_metadata() -> dict[str, object]:
+            return self.metadata()
+
+        @app.get(f"/realms/{self.realm}/protocol/openid-connect/certs", include_in_schema=True)
+        async def oidc_jwks() -> dict[str, list[dict[str, str]]]:
+            return self.jwks()
+
+        @app.post("/oidc/token", include_in_schema=True)
+        async def oidc_token(request: TokenRequest) -> dict[str, object]:
+            try:
+                token = self.mint(request.variant)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="unknown OIDC token variant") from exc
+            return {
+                "access_token": token,
+                "token_type": "Bearer",
+                "expires_in": 300,
+                "scope": self._claims(request.variant)["scope"],
+            }
+
+
+__all__ = ["OIDCFixture", "OIDC_TOKEN_VARIANTS"]

--- a/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 DEFAULT_CHECKOUT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 MODE="${1:-}"
 [ "$MODE" = "gate" ] || [ "$MODE" = "serve" ] \
-  || die "usage: $0 {gate|serve} [--scenario empty|app-installation-lifecycle|app-release-rollout] [--checkout PATH] [--runtime-root PATH] [supervisor options]"
+  || die "usage: $0 {gate|serve} [--profile tool-only|transport-proxy|oidc-resource-server|transport-oidc] [--capability stdio|oidc] [--scenario empty|app-installation-lifecycle|app-release-rollout|app-control-plane] [--checkout PATH] [--runtime-root PATH] [supervisor options]"
 shift
 
 CHECKOUT="${AKB_CHECKOUT:-$DEFAULT_CHECKOUT}"

--- a/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -81,6 +81,22 @@ source /etc/os-release 2>/dev/null || die "cannot inspect /etc/os-release"
 "${SUDO[@]}" apt-get install -y curl ca-certificates \
   || die "curl/CA package installation failed"
 
+# The transport profiles execute the repository's real zero-dependency Node
+# consumer after this host layer completes.  Use the Ubuntu 24.04 archive
+# rather than an unpinned third-party installer so a clean VM gets the same
+# package-managed node/npm toolchain as the rest of its base image.
+"${SUDO[@]}" apt-get install -y nodejs npm \
+  || die "Node.js/npm package installation failed"
+command -v node >/dev/null 2>&1 \
+  || die "Node.js executable is unavailable after package installation"
+command -v npm >/dev/null 2>&1 \
+  || die "npm executable is unavailable after package installation"
+NODE_VERSION=$(node --version) \
+  || die "Node.js version check failed"
+NPM_VERSION=$(npm --version) \
+  || die "npm version check failed"
+echo "Node.js ${NODE_VERSION}, npm ${NPM_VERSION} ready" >&2
+
 if ! command -v docker >/dev/null 2>&1; then
   "${SUDO[@]}" apt-get install -y docker.io \
     || die "Docker Engine package installation failed"

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -1011,6 +1011,10 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     assert "exec 3>&1 1>&2" in text
     assert "--scenario empty" in text
     assert "app-installation-lifecycle" in text
+    assert 'apt-get install -y nodejs npm' in text
+    assert 'command -v node' in text
+    assert 'command -v npm' in text
+    assert "Node.js/npm package installation failed" in text
     assert "uv sync --locked" in text
     assert "exec 1>&3 3>&-" in text
     assert stat.S_IMODE(BOOTSTRAP.stat().st_mode) & stat.S_IXUSR

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -18,13 +18,16 @@ CI_DIR = Path(__file__).resolve().parent.parent / "scripts" / "ci"
 sys.path.insert(0, str(CI_DIR))
 
 from e2e_runtime import (  # noqa: E402
+    BlockedRuntimeConfig,
+    CapabilityProfile,
     CredentialNames,
     E2ERuntime,
     ManagedProcess,
     RuntimeConfig,
     _parse_args,
-    terminate_process,
     prepare_private_runtime_root,
+    select_capability_profile,
+    terminate_process,
 )
 from e2e_gate_observability import (  # noqa: E402
     EVENT_PREFIX,
@@ -1011,3 +1014,91 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     assert "uv sync --locked" in text
     assert "exec 1>&3 3>&-" in text
     assert stat.S_IMODE(BOOTSTRAP.stat().st_mode) & stat.S_IXUSR
+
+
+def test_capability_profiles_are_explicit_and_composable():
+    assert select_capability_profile("tool-only") == CapabilityProfile(
+        "tool-only", frozenset({"http", "pat"})
+    )
+    assert select_capability_profile("transport-proxy").needs_stdio
+    assert select_capability_profile("oidc-resource-server").needs_oidc
+    combined = select_capability_profile("tool-only", ("stdio", "oidc"))
+    assert combined.name == "transport-oidc"
+    assert combined.capabilities == frozenset({"http", "pat", "stdio", "oidc"})
+
+
+def test_tool_only_does_not_advertise_optional_processes(tmp_path):
+    runtime = E2ERuntime(make_config(tmp_path))
+    descriptor = runtime.descriptor()
+    assert set(descriptor["services"]) == {"app", "fixture"}
+    assert "profile" not in descriptor
+    discovery = runtime.fixture_discovery()
+    assert discovery["runtime"]["selected_capabilities"] == ["http", "pat"]
+    assert "stdio" not in discovery["runtime"]
+    assert "oidc" not in discovery["runtime"]
+
+
+def test_transport_profile_exposes_real_proxy_boundary_without_secret(tmp_path):
+    runtime = E2ERuntime(
+        dataclasses.replace(make_config(tmp_path), profile="transport-proxy")
+    )
+    runtime._pat_value = "akb_runtime_secret"  # pragma: allowlist secret
+    descriptor = runtime.descriptor()
+    assert descriptor["services"]["stdio"]["transport"] == "stdio"
+    assert descriptor["credentials"]["pat_env"] == "AKB_E2E_PAT"
+    serialized = json.dumps(descriptor)
+    assert "akb_runtime_secret" not in serialized
+    assert "AKB_E2E_PAT" in serialized
+    assert descriptor["evidence"]["transport"] == ["http", "stdio"]
+
+
+@pytest.mark.asyncio
+async def test_oidc_profile_serves_jwks_metadata_and_deterministic_variants(tmp_path):
+    runtime = E2ERuntime(
+        dataclasses.replace(make_config(tmp_path), profile="oidc-resource-server")
+    )
+    app = create_app(runtime)
+    jwks_path = runtime.oidc_fixture.jwks_uri.removeprefix(runtime.config.fixture_origin)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url=runtime.config.fixture_origin
+    ) as client:
+        health = await client.get("/oidc/health")
+        metadata = await client.get("/.well-known/openid-configuration")
+        jwks = await client.get(jwks_path)
+        token = await client.post("/oidc/token", json={"variant": "valid"})
+        bad = await client.post("/oidc/token", json={"variant": "wrong_issuer"})
+    assert health.status_code == 200
+    assert metadata.json()["issuer"] == runtime.oidc_fixture.issuer
+    assert jwks.json()["keys"][0]["alg"] == "RS256"
+    assert token.status_code == 200 and token.json()["token_type"] == "Bearer"
+    assert bad.status_code == 200 and bad.json()["access_token"] != token.json()["access_token"]
+    assert metadata.json()["scopes_supported"] == ["akb:vault:read", "akb:vault:write"]
+    assert set(runtime.oidc_fixture.discovery()["token_variants"]) == {
+        "valid",
+        "wrong_issuer",
+        "wrong_audience",
+        "expired",
+        "wrong_algorithm",
+        "wrong_key_id",
+        "insufficient_scope",
+    }
+    assert "challenge_cases" in runtime.oidc_fixture.discovery()
+    assert "access_token" not in json.dumps(runtime.fixture_discovery())
+
+
+def test_optional_capabilities_fail_closed_without_silent_skip(tmp_path, monkeypatch):
+    runtime = E2ERuntime(
+        dataclasses.replace(make_config(tmp_path), profile="keycloak-overlay")
+    )
+    with pytest.raises(BlockedRuntimeConfig, match="blocked_runtime_config"):
+        runtime._validate_profile()
+
+    transport = E2ERuntime(
+        dataclasses.replace(make_config(tmp_path), profile="transport-proxy")
+    )
+    monkeypatch.setattr(
+        "e2e_runtime.shutil.which",
+        lambda name: None if name == "node" else "/usr/bin/npm",
+    )
+    with pytest.raises(BlockedRuntimeConfig, match="stdio capability"):
+        transport._validate_profile()

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.2 — strict MCP protocol boundary
+
+The stdio proxy now rejects an `initialize` request that names an unsupported
+MCP protocol revision instead of echoing that revision as a successful
+handshake. The response identifies the single supported revision so a caller
+can retry explicitly; no fallback or downgrade path is introduced.
+
 ## 2.2.1 — vault guide preflight for proxy-local tools
 
 Proxy-local file and image tools now participate in the same vault-guide

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -370,7 +370,7 @@ const FILE_CONTENT_TOOLS = new Set(["akb_put", "akb_update"]);
 // local `initialize` response, so it must not silently drift on a proxy
 // behaviour change. There is no import of package.json here to keep lib/
 // zero-dependency and load-safe across Node versions.
-const PROXY_VERSION = "2.2.1";
+const PROXY_VERSION = "2.2.2";
 const VAULT_SKILL_PREFLIGHT_CAPABILITY =
   "io.dnotitia.akb/vault-skill-preflight";
 const PROXY_INSTRUCTIONS =
@@ -573,14 +573,28 @@ export class AKBProxy {
     // regardless of whether the backend is reachable right now. If the VPN
     // is down at startup, the server still registers; tools recover once
     // connectivity returns (see the monitor + tools/list_changed path).
+    const requestedProtocol =
+      params && typeof params.protocolVersion === "string" && params.protocolVersion;
+    if (requestedProtocol && requestedProtocol !== MCP_PROTOCOL_VERSION) {
+      // Never claim success by echoing a protocol revision this proxy does
+      // not implement.  A client can retry with the explicit supported
+      // revision; there is no fallback or downgrade path here.
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32602,
+          message: "Unsupported protocol version",
+          data: { supported: [MCP_PROTOCOL_VERSION] },
+        },
+      };
+    }
     this._clientInitParams = params || null;
     this._initialized = true;
     // Kick off the backend session + tool prefetch in the background.
     this._startBackendMonitor();
 
-    const protocolVersion =
-      (params && typeof params.protocolVersion === "string" && params.protocolVersion) ||
-      MCP_PROTOCOL_VERSION;
+    const protocolVersion = requestedProtocol || MCP_PROTOCOL_VERSION;
     return {
       jsonrpc: "2.0",
       id,

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {

--- a/packages/akb-mcp-client/test/reconnect.test.mjs
+++ b/packages/akb-mcp-client/test/reconnect.test.mjs
@@ -73,6 +73,20 @@ itAsync("initialize falls back to a default protocol version when omitted", asyn
   assert.match(res.result.protocolVersion, /^\d{4}-\d{2}-\d{2}$/);
 });
 
+itAsync("initialize rejects an unsupported protocol version instead of echoing it", async () => {
+  const proxy = newProxy();
+  proxy._startBackendMonitor = () => {};
+  const res = await proxy._initialize(1, {
+    protocolVersion: "2099-01-01",
+    capabilities: {},
+  });
+
+  assert.equal(res.error.code, -32602);
+  assert.deepEqual(res.error.data.supported, ["2025-06-18"]);
+  assert.equal(res.result, undefined);
+  assert.equal(proxy._initialized, false);
+});
+
 itAsync("backend initialize negotiates vault-guide preflight without dropping client capabilities", async () => {
   const proxy = newProxy();
   const original = {


### PR DESCRIPTION
## Summary
- extend the repository-owned E2E runtime with explicit tool-only, transport/proxy, OIDC and specialist profile boundaries
- add deterministic fixture discovery, readiness, reset and redacted evidence paths
- enforce MCP proxy protocol-version boundaries and add reconnect coverage

## Issue
- AKB-179 — Shared HTTP and stdio validation runtime for MCP tool development

## Validation
- exact candidate HEAD: cbe95b9b6575ec4ffa4bd9edb54222abc8e44bd8
- focused pytest: 68 passed
- ruff, mypy, manifest check and bash scripts/check.sh: passed
- MCP client contract/reconnect tests: passed
- mapped mcp-e2e Crabbox gate on apple-vm: 802 passed, 0 failed
- independent mcp_behavior validation: all applicable readiness, discovery, reset, redaction and auth-boundary clauses passed
- hosted CI: backend unit tests, static analysis, shell e2e and pgvector e2e all passed

The pull request has been merged.