### PR TITLE
Treat document suffix references as literal values

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -229,4 +229,5 @@ jobs:
           tests/test_sso_session_epoch_upgrade_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
+          tests/test_kg_document_ref_postgres.py
           -v --tb=short

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -31,6 +31,7 @@ from app.util.errors import (
     NOT_FOUND,
     SELF_LINK,
 )
+from app.util.text import like_escape
 
 logger = logging.getLogger("akb.graph")
 
@@ -1213,12 +1214,13 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
     the URI cutover):
       1. UUID — `id = $2`
       2. Exact path — `path = $2`
-      3. Trailing-segment match — `path LIKE '%/' || $2` (e.g. ref
-         `api.md` matches `notes/api.md` iff there is exactly one such
-         doc; the unique constraint on `(vault_id, path)` does NOT
-         dedupe across collections, so this can still return one of
-         several matches — but the suffix is anchored at `/`, so
-         `api.md` cannot match `funapi.md`).
+      3. Trailing-segment match — `path LIKE '%/' || $2` with the
+         reference escaped as a literal pattern (e.g. ref `api.md`
+         matches `notes/api.md` iff there is exactly one such doc; the
+         unique constraint on `(vault_id, path)` does NOT dedupe across
+         collections, so this can still return one of several matches —
+         but the suffix is anchored at `/`, so `api.md` cannot match
+         `funapi.md`).
     """
     ref = normalize_document_link_ref(ref)
 
@@ -1235,8 +1237,8 @@ async def _resolve_doc_ref(conn, vault_id: uuid.UUID, ref: str) -> uuid.UUID | N
     # Trailing-segment match: `api.md` ↔ `notes/api.md`. Anchored at
     # `/` so it can't match arbitrary substrings.
     row = await conn.fetchrow(
-        "SELECT id FROM documents WHERE vault_id = $1 AND path LIKE '%/' || $2",
-        vault_id, ref,
+        "SELECT id FROM documents WHERE vault_id = $1 AND path LIKE '%/' || $2 ESCAPE '\\'",
+        vault_id, like_escape(ref),
     )
     if row:
         return row["id"]

--- a/backend/tests/test_kg_document_ref_postgres.py
+++ b/backend/tests/test_kg_document_ref_postgres.py
@@ -1,0 +1,141 @@
+"""Real-PostgreSQL regressions for literal document suffix lookup."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from app.services.kg_service import _resolve_doc_ref
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@pytest_asyncio.fixture
+async def pool():
+    if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    pool = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=4)
+    async with pool.acquire() as conn:
+        await conn.execute((_BACKEND / "app" / "db" / "init.sql").read_text())
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+@pytest_asyncio.fixture
+async def vault_id(pool):
+    name = f"_test_kg_document_ref_{uuid.uuid4().hex[:8]}"
+    async with pool.acquire() as conn:
+        vault_id = await conn.fetchval(
+            "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+            name,
+            f"/tmp/{name}.git",
+        )
+    try:
+        yield vault_id
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+
+
+async def _insert_document(conn, vault_id: uuid.UUID, path: str) -> uuid.UUID:
+    document_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO documents (id, vault_id, path, title)
+        VALUES ($1, $2, $3, $4)
+        """,
+        document_id,
+        vault_id,
+        path,
+        path,
+    )
+    return document_id
+
+
+@pytest.mark.parametrize(
+    ("target_path", "ref", "near_path"),
+    [
+        pytest.param(
+            "literal/trailing" + "\\",
+            "trailing" + "\\",
+            "literal/trailingx",
+            id="trailing-backslash",
+        ),
+        pytest.param(
+            "literal/100%",
+            "100%",
+            "literal/100x",
+            id="percent",
+        ),
+        pytest.param(
+            "literal/under_score",
+            "under_score",
+            "literal/underXscore",
+            id="underscore",
+        ),
+    ],
+)
+async def test_non_uri_suffix_reference_is_literal(
+    pool,
+    vault_id: uuid.UUID,
+    target_path: str,
+    ref: str,
+    near_path: str,
+):
+    async with pool.acquire() as conn:
+        # Insert the wildcard near-miss first so an unescaped LIKE pattern
+        # would return the wrong row instead of the requested document.
+        near_id = await _insert_document(conn, vault_id, near_path)
+        target_id = await _insert_document(conn, vault_id, target_path)
+
+        resolved = await _resolve_doc_ref(conn, vault_id, ref)
+
+    assert resolved == target_id
+    assert resolved != near_id
+
+
+async def test_suffix_reference_keeps_exact_suffix_and_near_miss_behavior(
+    pool,
+    vault_id: uuid.UUID,
+):
+    async with pool.acquire() as conn:
+        near_id = await _insert_document(conn, vault_id, "nested/funapi.md")
+        exact_id = await _insert_document(conn, vault_id, "nested/api.md")
+
+        assert await _resolve_doc_ref(conn, vault_id, "api.md") == exact_id
+        assert await _resolve_doc_ref(conn, vault_id, "api.md") != near_id
+        assert await _resolve_doc_ref(conn, vault_id, "pi.md") is None
+
+
+async def test_exact_path_precedes_suffix_fallback(pool, vault_id: uuid.UUID):
+    async with pool.acquire() as conn:
+        exact_id = await _insert_document(conn, vault_id, "api.md")
+        await _insert_document(conn, vault_id, "nested/api.md")
+
+        assert await _resolve_doc_ref(conn, vault_id, "api.md") == exact_id

--- a/backend/tests/test_kg_document_ref_postgres.py
+++ b/backend/tests/test_kg_document_ref_postgres.py
@@ -10,7 +10,7 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-from app.services.kg_service import _resolve_doc_ref
+from app.services.kg_service import _resolve_doc_ref, store_document_relations
 
 
 pytestmark = pytest.mark.asyncio
@@ -109,11 +109,14 @@ async def test_non_uri_suffix_reference_is_literal(
     near_path: str,
 ):
     async with pool.acquire() as conn:
-        # Insert the wildcard near-miss first so an unescaped LIKE pattern
-        # would return the wrong row instead of the requested document.
+        # With only the wildcard-shaped near miss present, an unescaped LIKE
+        # pattern returns the wrong row.  Assert absence before adding the
+        # literal target so the regression never depends on PostgreSQL row
+        # order when both rows match the old predicate.
         near_id = await _insert_document(conn, vault_id, near_path)
-        target_id = await _insert_document(conn, vault_id, target_path)
+        assert await _resolve_doc_ref(conn, vault_id, ref) is None
 
+        target_id = await _insert_document(conn, vault_id, target_path)
         resolved = await _resolve_doc_ref(conn, vault_id, ref)
 
     assert resolved == target_id
@@ -139,3 +142,22 @@ async def test_exact_path_precedes_suffix_fallback(pool, vault_id: uuid.UUID):
         await _insert_document(conn, vault_id, "nested/api.md")
 
         assert await _resolve_doc_ref(conn, vault_id, "api.md") == exact_id
+
+
+async def test_relation_refresh_ignores_unresolved_trailing_backslash(
+    pool,
+    vault_id: uuid.UUID,
+):
+    async with pool.acquire() as conn:
+        stored = await store_document_relations(
+            conn,
+            vault_id,
+            "literal-references",
+            "source.md",
+            [],
+            [],
+            [],
+            "See [[missing" + "\\" + "]]",
+        )
+
+    assert stored == 0


### PR DESCRIPTION
## Summary

- Escape non-URI document references before the trailing-segment LIKE lookup and declare the PostgreSQL escape character explicitly.
- Preserve the existing UUID and exact-path lookup behavior.
- Add deterministic real-PostgreSQL coverage for percent, underscore, trailing backslash, exact suffixes, near misses, and relation refresh.
- Run the new regression in the database-backed CI job.

## Validation

- 2,284 unit tests passed; 590 database-dependent tests skipped in the standard no-PostgreSQL run.
- 23 focused KG tests passed against PostgreSQL 16, including 6 database-backed regressions.
- Ruff passed for the full backend tree.
- Independent exact-head review reported no findings.

Fixes #405
