### PR TITLE
fix(search): prevent repeated BM25 corpus rebuilds

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -233,6 +233,7 @@ jobs:
           tests/test_workspace_account_admin_service.py
           tests/test_sso_browser_session_postgres.py
           tests/test_sso_session_epoch_upgrade_postgres.py
+          tests/test_bm25_corpus_revision_postgres.py
           tests/test_tool_usage_e2e.py
           tests/test_table_if_not_exists_e2e.py
           tests/test_kg_document_ref_postgres.py

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3556
+        "line_number": 3572
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-21T08:17:29Z"
+  "generated_at": "2026-08-24T07:47:42Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,22 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Fixed repeated production-scale BM25 rebuilds and bounded rebuild memory
+
+The BM25 refresher no longer compares all non-null chunks with the smaller set
+of chunks that produce at least one Kiwi token. That population mismatch made a
+stable corpus look permanently stale and repeatedly retokenized roughly 960k
+chunks. A PostgreSQL sequence now records only BM25-relevant chunk mutations;
+the startup and periodic refresh paths share that revision gate, so a stable
+worker restart performs no full scan while inserts, deletes, content changes,
+tokenizer changes, and sequence restores remain detectable.
+
+Full rebuilds now aggregate document frequency in a PostgreSQL temporary table
+one input batch at a time and bypass the process-local token LRU. Backend Python
+memory is therefore bounded by batch size instead of growing with the entire
+corpus vocabulary. Kubernetes' existing API/worker split and explicit Kiwi
+worker limits remain the cgroup isolation boundary.
+
 ### Made vault-guide write preflight concurrency-safe
 
 MCP clients can negotiate vault-guide preflight version 2. The server now

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1084,13 +1084,12 @@ class Settings(BaseModel):
     bm25_k1: float = 1.5
     bm25_b: float = 0.75
     # How often to recompute `bm25_stats(total_docs, avgdl)` + per-term
-    # df from the live chunks corpus. The recompute also runs once at
-    # startup, so this controls the steady-state cadence. recompute_stats
-    # tokenizes every chunk and gets expensive on large corpora; the
-    # refresher skips ticks when the chunk count hasn't moved (see
-    # `_should_recompute` in sparse_encoder), so an aggressive interval
-    # is cheap when nothing's changing. 6 h matches the slow drift of
-    # avgdl/df on a steady-state corpus.
+    # df from the live chunks corpus. Startup and steady-state ticks share a
+    # tokenizer/corpus-revision gate, so a stable process restart does not
+    # retokenize the corpus. `recompute_stats` is expensive on large corpora;
+    # source INSERT/DELETE/content changes advance a DB sequence and the
+    # refresher batches that drift. 6 h matches the slow drift of avgdl/df on
+    # a steady-state corpus.
     bm25_recompute_interval_secs: int = 21600
 
     # Periodic PG-RBAC reconcile cadence. Lifecycle hooks emit role

--- a/backend/app/db/migrations/084_bm25_corpus_revision.py
+++ b/backend/app/db/migrations/084_bm25_corpus_revision.py
@@ -23,6 +23,25 @@ logger = logging.getLogger("akb.migration.084")
 
 
 async def migrate(conn) -> None:
+    # A supported historical-bootstrap fixture records migration 005 as
+    # applied while intentionally omitting its optional derived-index tables.
+    # Do not make an unrelated auth-schema upgrade recreate (or depend on)
+    # that subsystem.  Fresh/current databases have both tables because 005
+    # runs before this migration.
+    bm25_tables_available = bool(
+        await conn.fetchval(
+            """
+            SELECT to_regclass('public.chunks') IS NOT NULL
+               AND to_regclass('public.bm25_stats') IS NOT NULL
+            """
+        )
+    )
+    if not bm25_tables_available:
+        logger.info(
+            "Migration 084: optional BM25 corpus tables are unavailable; skipping"
+        )
+        return
+
     sequence_existed = bool(
         await conn.fetchval(
             "SELECT to_regclass('public.bm25_corpus_revision_seq') IS NOT NULL"

--- a/backend/app/db/migrations/084_bm25_corpus_revision.py
+++ b/backend/app/db/migrations/084_bm25_corpus_revision.py
@@ -1,0 +1,108 @@
+"""Track BM25 source-corpus mutations without rescanning ``chunks``.
+
+The old refresher compared ``COUNT(chunks)`` with ``bm25_stats.total_docs``.
+Those values describe different populations: the former includes every source
+chunk, while the latter includes only chunks that retain at least one token
+after Kiwi/tag/stop-word filtering.  A stable corpus can therefore look dirty
+forever and trigger a full retokenization on every cadence.
+
+``bm25_corpus_revision_seq`` is a cheap, monotonic invalidation clock.  Row
+triggers advance it only for changes that can affect BM25 (insert, delete, or
+content update); indexing-state updates do not touch it.  Sequences are used
+instead of a singleton counter row so concurrent chunk writers do not serialize
+on one hot tuple.  Gaps after rolled-back writes are harmless: at worst they
+cause a conservative extra refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger("akb.migration.084")
+
+
+async def migrate(conn) -> None:
+    sequence_existed = bool(
+        await conn.fetchval(
+            "SELECT to_regclass('public.bm25_corpus_revision_seq') IS NOT NULL"
+        )
+    )
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE SEQUENCE IF NOT EXISTS bm25_corpus_revision_seq AS BIGINT;
+
+            ALTER TABLE bm25_stats
+                ADD COLUMN IF NOT EXISTS source_revision BIGINT NOT NULL DEFAULT 0,
+                ADD COLUMN IF NOT EXISTS source_chunk_count BIGINT NOT NULL DEFAULT 0;
+
+            CREATE OR REPLACE FUNCTION akb_bump_bm25_corpus_revision()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            SET search_path = pg_catalog, public
+            AS $$
+            BEGIN
+                PERFORM pg_catalog.nextval(
+                    'public.bm25_corpus_revision_seq'::regclass
+                );
+                -- AFTER-trigger return values are ignored.  Returning NULL
+                -- also works for TRUNCATE, where neither row record exists.
+                RETURN NULL;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS trg_chunks_bm25_revision_insert_delete ON chunks;
+            CREATE TRIGGER trg_chunks_bm25_revision_insert_delete
+            AFTER INSERT OR DELETE ON chunks
+            FOR EACH ROW
+            EXECUTE FUNCTION akb_bump_bm25_corpus_revision();
+
+            DROP TRIGGER IF EXISTS trg_chunks_bm25_revision_content_update ON chunks;
+            CREATE TRIGGER trg_chunks_bm25_revision_content_update
+            AFTER UPDATE OF content ON chunks
+            FOR EACH ROW
+            WHEN (OLD.content IS DISTINCT FROM NEW.content)
+            EXECUTE FUNCTION akb_bump_bm25_corpus_revision();
+
+            DROP TRIGGER IF EXISTS trg_chunks_bm25_revision_truncate ON chunks;
+            CREATE TRIGGER trg_chunks_bm25_revision_truncate
+            AFTER TRUNCATE ON chunks
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION akb_bump_bm25_corpus_revision();
+            """
+        )
+
+        # Establish a no-scan baseline only when introducing the sequence.
+        # Existing non-zero tokenizer metadata proves that this database has
+        # completed at least one recompute already; trust that snapshot instead
+        # of forcing a production-sized corpus through Kiwi during rollout.
+        if not sequence_existed:
+            chunk_count = int(
+                await conn.fetchval("SELECT COUNT(*) FROM chunks") or 0
+            )
+            if chunk_count:
+                await conn.fetchval(
+                    "SELECT setval('bm25_corpus_revision_seq', $1, true)",
+                    chunk_count,
+                )
+                revision = chunk_count
+            else:
+                await conn.fetchval(
+                    "SELECT setval('bm25_corpus_revision_seq', 1, false)"
+                )
+                revision = 0
+
+            await conn.execute(
+                """
+                UPDATE bm25_stats
+                   SET source_revision = $1,
+                       source_chunk_count = $2
+                 WHERE tokenizer_version <> '0'
+                """,
+                revision,
+                chunk_count,
+            )
+
+    logger.info("Migration 084 added BM25 corpus revision tracking")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -306,6 +306,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "081_service_identities.py",  # non-human (issuer, client) → AKB service account bindings, kept out of the human external_identities population
         "082_pending_admissions.py",  # the arrival invite_only refuses, kept so an administrator can approve that exact identity instead of guessing a subject in advance
         "083_edge_vault_boundary.py",  # graph edges are vault-local: owner/source/target authorities agree; legacy rows stay hidden pending reviewed cleanup
+        "084_bm25_corpus_revision.py",  # mutation revision replaces mismatched chunk-count/eligible-doc BM25 refresh gate
     ):
         if filename in applied:
             continue

--- a/backend/app/services/sparse_encoder.py
+++ b/backend/app/services/sparse_encoder.py
@@ -332,6 +332,22 @@ async def tokenize(text: str) -> list[str]:
     return tokens
 
 
+async def _tokenize_uncached(text: str) -> list[str]:
+    """Tokenize without retaining source text/results in the API-process LRU.
+
+    Corpus recomputation walks every chunk exactly once, so caching those rows
+    has no reuse value and leaves the last 2,048 potentially-large chunks live
+    in the worker RSS.  Query/document encoding keeps using :func:`tokenize`.
+    """
+    if not text:
+        return []
+    pool = _tokenizer_pool
+    if pool is not None:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, _tokenize_sync, text)
+    return await asyncio.to_thread(_tokenize_sync, text)
+
+
 # ── Vocab management (append-only) ────────────────────────────────
 
 
@@ -570,8 +586,11 @@ _BM25_RECOMPUTE_LOCK_KEY = 987654321
 async def recompute_stats(batch_size: int = 500) -> dict:
     """Rebuild df (per term) and (total_docs, avgdl). Safe to run repeatedly.
 
-    Streams chunks in keyset-paginated batches to keep memory bounded even
-    on large corpora.
+    Streams chunks in keyset-paginated batches and accumulates document
+    frequency in a PostgreSQL temporary table.  The old process-global
+    ``Counter`` retained every unique term until the end of the scan, so the
+    function described itself as bounded while backend RSS still grew with
+    corpus vocabulary.  Only one batch's terms now live in Python memory.
 
     Held under a session-scoped PG advisory lock for the duration of the
     scan AND write. Without this, two replicas would each spend minutes
@@ -601,9 +620,27 @@ async def recompute_stats(batch_size: int = 500) -> dict:
                 "skipped": True,
             }
         try:
+            # Capture the invalidation boundary before the scan.  Chunk writes
+            # that commit while we are walking the corpus advance the sequence
+            # past this value, so a later tick will conservatively revisit them
+            # even if READ COMMITTED happened to expose some of those rows.
+            source_revision = await _current_corpus_revision(lock_conn)
+            source_chunk_count = 0
             total_docs = 0
             total_length = 0
-            df_counts: Counter[str] = Counter()
+
+            # The advisory lock guarantees a single recompute globally, but a
+            # cancelled prior call can leave its temp table on this pooled
+            # session.  Recreate it explicitly before accumulating this run.
+            await lock_conn.execute("DROP TABLE IF EXISTS bm25_recompute_df")
+            await lock_conn.execute(
+                """
+                CREATE TEMPORARY TABLE bm25_recompute_df (
+                    term TEXT PRIMARY KEY,
+                    df BIGINT NOT NULL
+                ) ON COMMIT PRESERVE ROWS
+                """
+            )
 
             last_id = None
             while True:
@@ -621,46 +658,65 @@ async def recompute_stats(batch_size: int = 500) -> dict:
                     )
                 if not rows:
                     break
+                batch_df_counts: Counter[str] = Counter()
                 for r in rows:
                     last_id = r["id"]
-                    toks = await tokenize(r["content"] or "")
+                    source_chunk_count += 1
+                    toks = await _tokenize_uncached(r["content"] or "")
                     if not toks:
                         continue
                     total_docs += 1
                     total_length += len(toks)
                     for term in set(toks):
-                        df_counts[term] += 1
+                        batch_df_counts[term] += 1
+
+                if batch_df_counts:
+                    terms, counts = zip(*batch_df_counts.items())
+                    await lock_conn.execute(
+                        """
+                        INSERT INTO bm25_recompute_df AS aggregate (term, df)
+                        SELECT * FROM unnest($1::text[], $2::bigint[])
+                        ON CONFLICT (term) DO UPDATE
+                            SET df = aggregate.df + EXCLUDED.df
+                        """,
+                        list(terms),
+                        list(counts),
+                    )
 
             avgdl = (total_length / total_docs) if total_docs else 0.0
+            vocab_count = int(
+                await lock_conn.fetchval(
+                    "SELECT COUNT(*) FROM bm25_recompute_df"
+                ) or 0
+            )
 
             async with lock_conn.transaction():
-                # Ensure all encountered terms have vocab ids. Assign in one batch.
-                if df_counts:
+                # Ensure all encountered terms have stable vocab ids.  Reading
+                # directly from the temp aggregate avoids materialising the
+                # corpus vocabulary in Python a second time.
+                if vocab_count:
                     await lock_conn.execute(
                         """
                         INSERT INTO bm25_vocab (term, term_id)
-                        SELECT t, nextval('bm25_term_id_seq')
-                          FROM unnest($1::text[]) AS t
+                        SELECT term, nextval('bm25_term_id_seq')
+                          FROM bm25_recompute_df
+                         ORDER BY term
                         ON CONFLICT (term) DO NOTHING
-                        """,
-                        list(df_counts.keys()),
+                        """
                     )
 
-                # Two-step reset: (1) zero every row, (2) set counts for present
-                # terms from a single unnest. Replaces a full-table UPDATE + N
-                # executemany (one round-trip per term) with exactly two queries.
+                # Two-step reset preserves append-only term ids while making
+                # terms absent from the current corpus explicitly zero.
                 await lock_conn.execute("UPDATE bm25_vocab SET df = 0, updated_at = NOW()")
-                if df_counts:
-                    terms, counts = zip(*df_counts.items())
+                if vocab_count:
                     await lock_conn.execute(
                         """
                         UPDATE bm25_vocab v
-                           SET df = c.cnt,
+                           SET df = c.df,
                                updated_at = NOW()
-                          FROM unnest($1::text[], $2::bigint[]) AS c(term, cnt)
+                          FROM bm25_recompute_df c
                          WHERE v.term = c.term
-                        """,
-                        list(terms), list(counts),
+                        """
                     )
 
                 await lock_conn.execute(
@@ -670,22 +726,35 @@ async def recompute_stats(batch_size: int = 500) -> dict:
                            avgdl = $2,
                            tokenizer_name = $3,
                            tokenizer_version = $4,
+                           source_revision = $5,
+                           source_chunk_count = $6,
                            updated_at = NOW()
                      WHERE id = 1
                     """,
                     total_docs, avgdl, tname, tver,
+                    source_revision, source_chunk_count,
                 )
 
             _invalidate_stats_cache()
-            logger.info("BM25 stats recomputed: total_docs=%d avgdl=%.2f vocab_size=%d",
-                        total_docs, avgdl, len(df_counts))
+            logger.info(
+                "BM25 stats recomputed: source_chunks=%d total_docs=%d "
+                "avgdl=%.2f vocab_size=%d source_revision=%d",
+                source_chunk_count,
+                total_docs,
+                avgdl,
+                vocab_count,
+                source_revision,
+            )
             return {
                 "total_docs": total_docs,
                 "avgdl": avgdl,
-                "vocab_size": len(df_counts),
+                "vocab_size": vocab_count,
                 "tokenizer": f"{tname}@{tver}",
+                "source_revision": source_revision,
+                "source_chunk_count": source_chunk_count,
             }
         finally:
+            await lock_conn.execute("DROP TABLE IF EXISTS bm25_recompute_df")
             await lock_conn.execute(
                 "SELECT pg_advisory_unlock($1)", _BM25_RECOMPUTE_LOCK_KEY
             )
@@ -708,25 +777,94 @@ async def vocab_size() -> int:
 # stuck at zero, then on a fixed cadence so a long-running deploy
 # stays in sync as docs are added/removed/updated.
 
-# Skip a tick when the indexable chunk count hasn't moved by this many
-# rows since the last recompute. Tokenizing a 600k-row corpus through
-# Kiwi is minutes of CPU, so an unconditional cadence wastes work on a
-# steady-state vault.
+# Skip a tick until this many source-corpus mutations have accumulated since
+# the last recompute.  The mutation sequence tracks inserts, deletes, and
+# content changes without conflating raw source chunks with token-bearing BM25
+# documents (the old count comparison did exactly that).
 _BM25_RECOMPUTE_DELTA_THRESHOLD = 50
 
 
+async def _current_corpus_revision(conn) -> int:
+    """Return the sequence's logical revision (zero before first mutation)."""
+    row = await conn.fetchrow(
+        "SELECT last_value, is_called FROM bm25_corpus_revision_seq"
+    )
+    if not row or not row["is_called"]:
+        return 0
+    return int(row["last_value"])
+
+
+def _state_requires_recompute(
+    row,
+    current_revision: int,
+    *,
+    live_chunk_count: int | None = None,
+) -> bool:
+    """Pure refresh decision shared by the periodic and startup gates.
+
+    ``live_chunk_count`` is intentionally optional.  A steady-state tick needs
+    only the O(1) sequence read; the full COUNT is a fallback for a small
+    revision delta so a one-statement TRUNCATE is still detected.
+    """
+    if not row:
+        return True
+    if (
+        row["tokenizer_name"] != "kiwi"
+        or row["tokenizer_version"] != _kiwi_version
+    ):
+        return True
+
+    stored_revision = int(row["source_revision"] or 0)
+    if current_revision < stored_revision:
+        # A restored/reset sequence must never make stale stats look current.
+        return True
+    delta = current_revision - stored_revision
+    if delta == 0:
+        return False
+    if delta >= _BM25_RECOMPUTE_DELTA_THRESHOLD:
+        return True
+
+    source_chunk_count = int(row["source_chunk_count"] or 0)
+    if source_chunk_count < _BM25_RECOMPUTE_DELTA_THRESHOLD:
+        # Small corpora are cheap and need useful IDF immediately rather than
+        # waiting until they happen to accumulate fifty mutations.
+        return True
+    if live_chunk_count is not None:
+        return (
+            abs(live_chunk_count - source_chunk_count)
+            >= _BM25_RECOMPUTE_DELTA_THRESHOLD
+        )
+    return False
+
+
 async def _should_recompute() -> bool:
-    """True if the chunk count has drifted enough from the stored
-    `total_docs` to warrant a fresh recompute. Cheap COUNT(*) probe."""
+    """True when tokenizer identity or source-corpus revision is stale."""
     pool = await get_pool()
     async with pool.acquire() as conn:
-        live = await conn.fetchval(
-            "SELECT COUNT(*) FROM chunks WHERE content IS NOT NULL"
+        row = await conn.fetchrow(
+            """
+            SELECT source_revision, source_chunk_count,
+                   tokenizer_name, tokenizer_version
+              FROM bm25_stats
+             WHERE id = 1
+            """
         )
-        stored = await conn.fetchval(
-            "SELECT total_docs FROM bm25_stats WHERE id = 1"
-        )
-    return abs(int(live or 0) - int(stored or 0)) >= _BM25_RECOMPUTE_DELTA_THRESHOLD
+        current_revision = await _current_corpus_revision(conn)
+        if _state_requires_recompute(row, current_revision):
+            return True
+
+        # A sub-threshold revision delta normally waits for more changes.  The
+        # only exception is a large set-based mutation represented by one
+        # revision (notably TRUNCATE), detected by this conditional count.
+        stored_revision = int(row["source_revision"] or 0) if row else 0
+        if current_revision != stored_revision:
+            live = int(await conn.fetchval("SELECT COUNT(*) FROM chunks") or 0)
+            return _state_requires_recompute(
+                row,
+                current_revision,
+                live_chunk_count=live,
+            )
+    return False
 
 
 async def _refresh_tick() -> int:
@@ -741,46 +879,24 @@ async def _refresh_tick() -> int:
 from app.services._backfill import BackfillRunner  # noqa: E402
 
 _refresher = BackfillRunner("bm25_stats_refresher", _refresh_tick, idle_secs=1)
-_bootstrap_task: asyncio.Task | None = None
 
 
 def start_stats_refresher(interval_secs: int = 1800) -> None:
     """Launch the periodic stats refresher. Idempotent.
 
-    Always fires `recompute_stats` once at startup (bypassing the delta
-    gate) so a fresh install isn't stuck at total_docs=0; subsequent
-    ticks honour the gate.
+    ``BackfillRunner`` executes one tick immediately before its first sleep, so
+    the startup path naturally uses the same tokenizer/revision gate as every
+    periodic tick.  A fresh or tokenizer-changed database recomputes promptly,
+    while restarting a stable 960k-chunk deployment performs no corpus scan.
     """
-    global _bootstrap_task
     if _refresher.is_running():
         return
     _refresher.configure_idle_secs(interval_secs)
-    # Bootstrap: force one recompute on startup regardless of delta so
-    # a brand-new DB doesn't have to wait `interval_secs` for usable
-    # sparse weights. Wrapped in a task so startup isn't blocked.
-    _bootstrap_task = asyncio.create_task(
-        _bootstrap_recompute(), name="bm25_stats_bootstrap",
-    )
     _refresher.start()
-
-
-async def _bootstrap_recompute() -> None:
-    try:
-        await recompute_stats()
-    except Exception as e:  # noqa: BLE001
-        logger.warning("BM25 bootstrap recompute failed: %s", e)
 
 
 async def stop_stats_refresher() -> None:
     """Signal stop and await the runner. Safe to call when not started."""
-    global _bootstrap_task
-    task, _bootstrap_task = _bootstrap_task, None
-    if task is not None and not task.done():
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
     if _refresher is not None:
         await _refresher.stop()
 
@@ -792,23 +908,34 @@ async def stats_snapshot() -> dict:
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT total_docs, avgdl, tokenizer_name, tokenizer_version, updated_at
+            SELECT total_docs, avgdl, tokenizer_name, tokenizer_version,
+                   source_revision, source_chunk_count, updated_at
               FROM bm25_stats WHERE id = 1
             """
         )
         vocab = await conn.fetchval("SELECT COUNT(*) FROM bm25_vocab")
+        current_revision = await _current_corpus_revision(conn)
     if not row:
         return {
             "total_docs": 0, "avgdl": 0.0,
             "tokenizer": "kiwi@0",
             "vocab_size": int(vocab or 0),
+            "source_chunk_count": 0,
+            "source_revision": 0,
+            "current_revision": current_revision,
+            "pending_changes": current_revision,
             "last_recomputed_at": None,
         }
+    source_revision = int(row["source_revision"] or 0)
     return {
         "total_docs": int(row["total_docs"] or 0),
         "avgdl": float(row["avgdl"] or 0.0),
         "tokenizer": f"{row['tokenizer_name']}@{row['tokenizer_version']}",
         "vocab_size": int(vocab or 0),
+        "source_chunk_count": int(row["source_chunk_count"] or 0),
+        "source_revision": source_revision,
+        "current_revision": current_revision,
+        "pending_changes": max(0, current_revision - source_revision),
         "last_recomputed_at": (
             row["updated_at"].isoformat() if row["updated_at"] else None
         ),

--- a/backend/tests/test_bm25_corpus_revision_postgres.py
+++ b/backend/tests/test_bm25_corpus_revision_postgres.py
@@ -24,6 +24,22 @@ async def _revision(conn) -> int:
     return int(row["last_value"]) if row["is_called"] else 0
 
 
+async def test_migration_skips_optional_bm25_tables_when_not_materialized():
+    from app.db.postgres import _load_migration
+
+    class HistoricalBootstrapConnection:
+        async def fetchval(self, query, *args):
+            assert "to_regclass('public.bm25_stats')" in query
+            return False
+
+        def transaction(self):
+            raise AssertionError("a skipped migration must not start DDL")
+
+    migration = _load_migration("084_bm25_corpus_revision.py")
+    assert migration is not None
+    await migration.migrate(HistoricalBootstrapConnection())
+
+
 @pytest.fixture
 async def connection():
     try:

--- a/backend/tests/test_bm25_corpus_revision_postgres.py
+++ b/backend/tests/test_bm25_corpus_revision_postgres.py
@@ -1,0 +1,136 @@
+"""Live PostgreSQL backstop for BM25 corpus invalidation tracking."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import asynccontextmanager
+
+import asyncpg
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+async def _revision(conn) -> int:
+    row = await conn.fetchrow(
+        "SELECT last_value, is_called FROM bm25_corpus_revision_seq"
+    )
+    return int(row["last_value"]) if row["is_called"] else 0
+
+
+@pytest.fixture
+async def connection():
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2.0)
+    except (OSError, asyncpg.PostgresError):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"REQUIRE_REAL_PG=1 but Postgres is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    from app.db.postgres import _load_migration
+
+    # ``init.sql`` intentionally leaves historical derived-index tables to
+    # migration 005.  Make this focused test self-contained on a fresh schema.
+    if not await conn.fetchval("SELECT to_regclass('public.bm25_stats')"):
+        bm25_base = _load_migration("005_qdrant_index.py")
+        assert bm25_base is not None
+        await bm25_base.migrate(conn)
+    migration = _load_migration("084_bm25_corpus_revision.py")
+    assert migration is not None
+    await migration.migrate(conn)
+
+    vault_name = f"bm25-revision-{uuid.uuid4().hex[:10]}"
+    vault_id = await conn.fetchval(
+        "INSERT INTO vaults(name, git_path) VALUES($1, $2) RETURNING id",
+        vault_name,
+        f"/tmp/{vault_name}.git",
+    )
+    try:
+        yield conn, vault_id
+    finally:
+        await conn.execute("DELETE FROM vaults WHERE id = $1", vault_id)
+        await conn.close()
+
+
+async def test_only_bm25_relevant_chunk_mutations_advance_revision(connection):
+    conn, vault_id = connection
+    chunk_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    before = await _revision(conn)
+
+    await conn.execute(
+        """
+        INSERT INTO chunks(
+            id, source_type, source_id, vault_id,
+            section_path, content, chunk_index
+        ) VALUES($1, 'document', $2, $3, '', 'alpha', 0)
+        """,
+        chunk_id,
+        source_id,
+        vault_id,
+    )
+    assert await _revision(conn) == before + 1
+
+    # Worker claim/index bookkeeping cannot invalidate corpus statistics.
+    await conn.execute(
+        "UPDATE chunks SET vector_retry_count = vector_retry_count + 1 WHERE id = $1",
+        chunk_id,
+    )
+    assert await _revision(conn) == before + 1
+
+    await conn.execute(
+        "UPDATE chunks SET content = 'beta' WHERE id = $1",
+        chunk_id,
+    )
+    assert await _revision(conn) == before + 2
+
+    await conn.execute("DELETE FROM chunks WHERE id = $1", chunk_id)
+    assert await _revision(conn) == before + 3
+
+
+async def test_recompute_uses_source_revision_not_token_bearing_doc_count(
+    connection,
+    monkeypatch,
+):
+    from app.services import sparse_encoder
+
+    conn, vault_id = connection
+    source_id = uuid.uuid4()
+    for index, content in enumerate(("alpha", "베타", "")):
+        await conn.execute(
+            """
+            INSERT INTO chunks(
+                id, source_type, source_id, vault_id,
+                section_path, content, chunk_index
+            ) VALUES($1, 'document', $2, $3, '', $4, $5)
+            """,
+            uuid.uuid4(),
+            source_id,
+            vault_id,
+            content,
+            index,
+        )
+
+    class SingleConnectionPool:
+        def acquire(self):
+            @asynccontextmanager
+            async def acquired():
+                yield conn
+
+            return acquired()
+
+    async def get_single_pool():
+        return SingleConnectionPool()
+
+    monkeypatch.setattr(sparse_encoder, "get_pool", get_single_pool)
+    result = await sparse_encoder.recompute_stats(batch_size=2)
+
+    assert result["source_chunk_count"] == 3
+    assert result["total_docs"] == 2
+    assert not await sparse_encoder._should_recompute()

--- a/backend/tests/test_sparse_encoder.py
+++ b/backend/tests/test_sparse_encoder.py
@@ -2,7 +2,11 @@ import asyncio
 
 import pytest
 
-from app.services.sparse_encoder import _english_token_variants
+from app.services.sparse_encoder import (
+    _BM25_RECOMPUTE_DELTA_THRESHOLD,
+    _english_token_variants,
+    _state_requires_recompute,
+)
 
 
 def test_english_token_variants_keep_original_and_match_past_tense():
@@ -40,6 +44,53 @@ def test_english_token_variants_stem_plural_once_no_es_s_overlap():
     assert "studie" not in studies
 
 
+def _stats_row(**overrides):
+    from app.services import sparse_encoder
+
+    row = {
+        "source_revision": 10_000,
+        "source_chunk_count": 960_000,
+        "tokenizer_name": "kiwi",
+        "tokenizer_version": sparse_encoder._kiwi_version,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_refresh_gate_ignores_token_bearing_doc_count_mismatch():
+    # The old gate compared 960k raw chunks with ~954k token-bearing docs and
+    # rebuilt forever. total_docs is deliberately absent from the new decision.
+    assert not _state_requires_recompute(_stats_row(), 10_000)
+
+
+def test_refresh_gate_detects_same_count_content_replacements():
+    assert _state_requires_recompute(
+        _stats_row(),
+        10_000 + _BM25_RECOMPUTE_DELTA_THRESHOLD,
+    )
+
+
+def test_refresh_gate_updates_small_corpus_without_waiting_for_fifty_changes():
+    assert _state_requires_recompute(
+        _stats_row(source_chunk_count=12),
+        10_001,
+    )
+
+
+def test_refresh_gate_uses_conditional_count_for_set_based_truncate():
+    row = _stats_row()
+    assert not _state_requires_recompute(row, 10_001)
+    assert _state_requires_recompute(row, 10_001, live_chunk_count=0)
+
+
+def test_refresh_gate_fails_safe_on_tokenizer_change_or_sequence_restore():
+    assert _state_requires_recompute(
+        _stats_row(tokenizer_version="old"),
+        10_000,
+    )
+    assert _state_requires_recompute(_stats_row(), 9_999)
+
+
 @pytest.mark.asyncio
 async def test_stats_refresher_start_is_idempotent_and_keeps_one_health_runner(
     monkeypatch,
@@ -52,11 +103,7 @@ async def test_stats_refresher_start_is_idempotent_and_keeps_one_health_runner(
     async def no_work() -> int:
         return 0
 
-    async def bootstrap() -> None:
-        await asyncio.sleep(0)
-
     monkeypatch.setattr(sparse_encoder._refresher, "_process_once", no_work)
-    monkeypatch.setattr(sparse_encoder, "_bootstrap_recompute", bootstrap)
     before = sum(
         item["name"] == "bm25_stats_refresher" for item in runner_snapshots()
     )


### PR DESCRIPTION
## Summary

- replace the BM25 refresher's mismatched chunk-count gate with a persistent corpus mutation revision
- make startup use the same revision/tokenizer gate as periodic refreshes instead of forcing a full scan
- bound backend Python memory during full recomputes by aggregating document frequency in a PostgreSQL temporary table
- expose source/current revisions and pending changes in the BM25 health snapshot

## Problem

The previous refresh decision compared two different populations:

```text
COUNT(chunks WHERE content IS NOT NULL)
vs.
bm25_stats.total_docs
```

The first value counts every source chunk. `total_docs` counts only chunks that retain at least one term after Kiwi tokenization, POS filtering, and stop-word removal. On a large stable corpus, tokenless chunks can keep that difference permanently above the 50-row threshold, so every cadence retokenizes the full corpus.

Two additional paths amplified the cost:

1. worker startup bypassed the delta gate and always launched a full recompute;
2. the process-wide DF `Counter` retained every unique corpus term until the scan completed, so Python RSS grew with vocabulary cardinality despite paginated chunk reads.

## Design

### Corpus revision

Migration 084 adds a monotonic `bm25_corpus_revision_seq` and records the last completed scan boundary in `bm25_stats.source_revision`.

Triggers advance the sequence only for BM25-relevant mutations:

- chunk insert
- chunk delete
- actual `content` changes
- truncate

Vector indexing claim/retry bookkeeping does not advance it. A sequence is used instead of a singleton counter row so concurrent chunk writers do not serialize on one hot tuple. Sequence gaps caused by rolled-back writes are conservative: they may cause an extra refresh but cannot hide stale stats.

Existing databases with initialized tokenizer metadata receive a no-scan baseline during migration. Fresh/uninitialized databases still recompute on the first runner tick.

### Refresh decision

The startup and periodic paths now share one gate. A recompute runs when:

- tokenizer identity changed;
- the revision was restored/reset behind the stored boundary;
- at least 50 corpus mutations accumulated;
- a small corpus changed; or
- a set-based mutation such as `TRUNCATE` causes a large source-count change.

Same-count content replacements are now detectable, while a stable process restart performs only the O(1) revision read.

### Bounded recompute memory

Full recomputes aggregate one batch at a time into a session-local PostgreSQL temporary table. The final vocab insert and DF update read directly from that table, avoiding whole-vocabulary Python lists and counters. Corpus scans also bypass the normal token LRU because those one-shot results have no reuse value.

The scan captures its source revision before reading. Mutations committed during the scan remain ahead of the stored boundary and are conservatively picked up by a later tick.

## Compatibility and operations

- migration 084 is additive
- BM25 term IDs remain append-only and stable
- vector-store schemas and weight conventions are unchanged
- no Kubernetes manifest or deployment changes are included
- existing initialized deployments do not pay an immediate migration-time corpus rebuild
- `/health` adds `source_chunk_count`, `source_revision`, `current_revision`, and `pending_changes` under `vector_store.bm25`

`source_chunk_count` and `total_docs` are intentionally allowed to differ: they describe source chunks and token-bearing BM25 documents respectively.

## Validation

Real PostgreSQL 16 + Kiwi integration coverage verifies that:

- insert/content-update/delete advance the revision;
- vector retry bookkeeping does not;
- a corpus with 3 source chunks and 2 token-bearing documents is current immediately after recompute;
- the temporary-table recompute path completes successfully.

```text
uv run pytest -q
2334 passed, 618 skipped, 0 failed

AKB_TEST_DSN=... REQUIRE_REAL_PG=1 uv run pytest -q tests/test_bm25_corpus_revision_postgres.py
2 passed

uv run ruff check .
All checks passed!

git diff --check
clean
```

The PostgreSQL integration tests used an ephemeral `pgvector/pgvector:pg16` container. No Kubernetes deployment was performed.
