### PR TITLE
fix(auth): expose broker logout callback

### DIFF
--- a/backend/app/sso/models.py
+++ b/backend/app/sso/models.py
@@ -36,6 +36,7 @@ class ProviderReadback:
     client_id: str | None
     client_secret_configured: bool
     redirect_uri: str
+    post_logout_redirect_uri: str
     supports_logout: bool
     supports_identity_migration: bool
 
@@ -51,6 +52,7 @@ class ProviderReadback:
             "client_id": self.client_id,
             "client_secret_configured": self.client_secret_configured,
             "redirect_uri": self.redirect_uri,
+            "post_logout_redirect_uri": self.post_logout_redirect_uri,
             "capabilities": {
                 "supports_logout": self.supports_logout,
                 "supports_identity_migration": self.supports_identity_migration,

--- a/backend/app/sso/providers/keycloak_oidc.py
+++ b/backend/app/sso/providers/keycloak_oidc.py
@@ -407,6 +407,7 @@ def readback(
         client_id=client_id,
         client_secret_configured=secret_configured,
         redirect_uri=redirect_uri,
+        post_logout_redirect_uri=f"{redirect_uri}/logout_response",
         supports_logout=True,
         # This capability means AKB can verify an operator-created exact
         # Keycloak prelink and atomically add the broker identity to one

--- a/backend/tests/test_admin_sso_routes_unit.py
+++ b/backend/tests/test_admin_sso_routes_unit.py
@@ -56,6 +56,9 @@ def _provider(
         client_id="akb-broker",
         client_secret_configured=True,
         redirect_uri=("https://auth.akb.example.com/realms/akb/broker/workforce/endpoint"),
+        post_logout_redirect_uri=(
+            "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint/logout_response"
+        ),
         supports_logout=True,
         supports_identity_migration=True,
     )

--- a/backend/tests/test_auth_config_shape_unit.py
+++ b/backend/tests/test_auth_config_shape_unit.py
@@ -25,6 +25,9 @@ def _provider(alias: str, state: str) -> ProviderReadback:
         client_id="akb-broker",
         client_secret_configured=True,
         redirect_uri=(f"https://auth.akb.example.com/realms/akb/broker/{alias}/endpoint"),
+        post_logout_redirect_uri=(
+            f"https://auth.akb.example.com/realms/akb/broker/{alias}/endpoint/logout_response"
+        ),
         supports_logout=True,
         supports_identity_migration=True,
     )

--- a/backend/tests/test_sso_browser_auth_boundary_unit.py
+++ b/backend/tests/test_sso_browser_auth_boundary_unit.py
@@ -68,6 +68,9 @@ def _provider(alias: str = "workforce", state: str = "enabled") -> ProviderReadb
         client_id="akb-broker",
         client_secret_configured=True,
         redirect_uri=("https://id.example/realms/akb/broker/workforce/endpoint"),
+        post_logout_redirect_uri=(
+            "https://id.example/realms/akb/broker/workforce/endpoint/logout_response"
+        ),
         supports_logout=True,
         supports_identity_migration=True,
     )

--- a/backend/tests/test_sso_provider_contract_unit.py
+++ b/backend/tests/test_sso_provider_contract_unit.py
@@ -235,6 +235,9 @@ def test_readback_recognizes_only_exact_disabled_and_enabled_profiles():
     assert enabled.redirect_uri == (
         "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint"
     )
+    assert enabled.post_logout_redirect_uri == (
+        "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint/logout_response"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary: expose the exact Keycloak broker post-logout callback beside the login redirect without changing provider-control authorization or mutations. Validation: 91 focused tests and Ruff green; an opposite logout-response suffix mutation proved the assertion red.