### PR TITLE
fix(revisions): order a Resource's history by its chain, not by the legacy clock

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -210,6 +210,7 @@ jobs:
           tests/test_migration_058_publication_identity_unit.py
           tests/test_index_order_unit.py
           tests/concurrency/test_alter_unique_race_unit.py
+          tests/test_native_revision_reconcile_pg.py
           tests/concurrency/test_native_ledger_b_core.py
           tests/concurrency/test_native_derived_pipeline.py
           tests/test_m1_file_measurement_pg.py

--- a/backend/app/repositories/native_revision_repo.py
+++ b/backend/app/repositories/native_revision_repo.py
@@ -708,15 +708,50 @@ class NativeRevisionRepository:
         limit: int = 100,
         conn: asyncpg.Connection | None = None,
     ) -> list[dict]:
+        """Return the head's lineage, newest first.
+
+        A Resource's history is a parent chain, not a timestamp sort.
+        ``occurred_at`` cannot stand in for that order: the reconcile path
+        copies it from the legacy Git commit, and Git commit times are whole
+        seconds, so two Revisions of one Resource routinely carry the *same*
+        instant.  Ordering by ``occurred_at DESC, revision_id DESC`` then
+        decided the tie on ``revision_id`` — a content address with no
+        chronology in it — and returned the ``create`` as the newest event
+        ahead of the ``move`` that descends from it, on 4 of 10 runs of the
+        same fixture (akb#399).
+
+        Walking up from ``native_resources.head_revision_id`` is causal by
+        construction: a Revision can never precede its own parent, and each
+        step is a primary-key lookup bounded by ``limit``, so the walk reads
+        exactly as many rows as it returns.
+
+        This is the head's lineage specifically.  A Revision that is not
+        reachable from the current head is not part of how this Resource got
+        to its current state, and is not history.
+        """
         sql = """
-            SELECT revision_id, resource_id, parent_revision_id, action,
-                   path_at_revision AS path, path_from, path_to,
-                   payload_manifest_id, message, subject, summary, actor,
-                   occurred_at
-              FROM native_revisions
-             WHERE resource_id = $1
-             ORDER BY occurred_at DESC, revision_id DESC
-             LIMIT $2
+            WITH RECURSIVE lineage AS (
+                SELECT head.revision_id, head.parent_revision_id, 0 AS distance
+                  FROM native_revisions head
+                  JOIN native_resources resource
+                    ON resource.resource_id = head.resource_id
+                   AND resource.head_revision_id = head.revision_id
+                 WHERE head.resource_id = $1
+                UNION ALL
+                SELECT parent.revision_id, parent.parent_revision_id, child.distance + 1
+                  FROM native_revisions parent
+                  JOIN lineage child ON parent.revision_id = child.parent_revision_id
+                 WHERE parent.resource_id = $1
+                   AND child.distance + 1 < $2
+            )
+            SELECT r.revision_id, r.resource_id, r.parent_revision_id, r.action,
+                   r.path_at_revision AS path, r.path_from, r.path_to,
+                   r.payload_manifest_id, r.message, r.subject, r.summary, r.actor,
+                   r.occurred_at
+              FROM native_revisions r
+              JOIN lineage l ON l.revision_id = r.revision_id
+             WHERE r.resource_id = $1
+             ORDER BY l.distance
         """
         if conn is not None:
             rows = await conn.fetch(sql, resource_id, limit)

--- a/backend/tests/test_native_revision_reconcile_pg.py
+++ b/backend/tests/test_native_revision_reconcile_pg.py
@@ -21,6 +21,7 @@ from app.services.native_revision_backfill import (
     NativeRevisionBackfill,
 )
 from app.repositories.native_revision_migration_repo import NativeRevisionMigrationRepository
+from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.native_revision_reconcile import (
     NativeRevisionReconcile,
     ReconcileIntegrityError,
@@ -36,6 +37,30 @@ _DSN = os.environ.get(
     "AKB_TEST_DSN",
     "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
 )
+
+# Revisions of one Resource are a parent chain, and the chain is the order.
+# ``occurred_at`` is not: reconcile copies it from the legacy Git commit, Git
+# commit times are whole seconds, and a fixture that commits twice inside one
+# second gives both Revisions the *same* instant.  Sorting on
+# ``occurred_at, revision_id`` then let the 40-hex content address decide, which
+# is why this file's move assertion flipped on an unchanged tree (akb#399).
+_LINEAGE_ORDERED_REVISIONS = """
+    WITH RECURSIVE lineage AS (
+        SELECT revision_id, parent_revision_id, 0 AS depth
+          FROM native_revisions
+         WHERE resource_id = $1 AND parent_revision_id IS NULL
+        UNION ALL
+        SELECT child.revision_id, child.parent_revision_id, parent.depth + 1
+          FROM native_revisions child
+          JOIN lineage parent ON child.parent_revision_id = parent.revision_id
+         WHERE child.resource_id = $1
+    )
+    SELECT r.revision_id, r.parent_revision_id, r.action, r.path_from, r.path_to
+      FROM native_revisions r
+      JOIN lineage l ON l.revision_id = r.revision_id
+     WHERE r.resource_id = $1
+     ORDER BY l.depth
+"""
 
 
 async def _reachable() -> bool:
@@ -413,12 +438,7 @@ async def test_update_then_final_move_collapses_to_one_move_and_binds_suffix(tmp
         assert result.items[0].action == "move"
         async with pool.acquire() as conn:
             revisions = await conn.fetch(
-                """
-                SELECT revision_id, parent_revision_id, action, path_from, path_to
-                  FROM native_revisions
-                 WHERE resource_id = $1
-                 ORDER BY occurred_at, revision_id
-                """,
+                _LINEAGE_ORDERED_REVISIONS,
                 fixture["document_id"],
             )
             mappings = await conn.fetch(
@@ -452,6 +472,78 @@ async def test_update_then_final_move_collapses_to_one_move_and_binds_suffix(tmp
         assert mappings[-1]["native_revision_id"] == revisions[-1]["revision_id"]
         assert alias["old_path"] == "doc.md"
         assert alias["created_revision_id"] == revisions[-1]["revision_id"]
+
+
+async def _reconciled_head_and_history(pool, tmp_path, monkeypatch, *, make_at: str, advance_at: str):
+    """Build the reconcile fixture with the legacy clock pinned.
+
+    ``GIT_AUTHOR_DATE``/``GIT_COMMITTER_DATE`` are what a legacy vault's commit
+    times actually are to us — reconcile copies them into ``occurred_at``
+    verbatim — so pinning them here builds the real state through the real
+    writer instead of forging rows the immutability trigger rightly refuses.
+    """
+    for name in ("GIT_AUTHOR_DATE", "GIT_COMMITTER_DATE"):
+        monkeypatch.setenv(name, make_at)
+    fixture = await _make_fixture(pool, tmp_path)
+    for name in ("GIT_AUTHOR_DATE", "GIT_COMMITTER_DATE"):
+        monkeypatch.setenv(name, advance_at)
+    fixture = await _advance_fixture(fixture, move=True)
+
+    service = NativeRevisionReconcile(pool, git=fixture["git"], bridge=fixture["bridge"])
+    await service.reconcile(
+        namespace_id=fixture["namespace_id"],
+        fixed_ref=fixture["fixed_r2"],
+    )
+    resource_id = fixture["document_id"]
+    async with pool.acquire() as conn:
+        head_revision_id = await conn.fetchval(
+            "SELECT head_revision_id FROM native_resources WHERE resource_id = $1",
+            resource_id,
+        )
+        instants = await conn.fetchval(
+            "SELECT count(DISTINCT occurred_at) FROM native_revisions WHERE resource_id = $1",
+            resource_id,
+        )
+    history = await NativeRevisionRepository(pool).list_history(resource_id=resource_id)
+    return head_revision_id, instants, history
+
+
+def _assert_history_is_the_chain(head_revision_id, history):
+    assert [row["action"] for row in history] == ["move", "create"]
+    assert history[0]["revision_id"] == head_revision_id
+    assert history[1]["revision_id"] == history[0]["parent_revision_id"]
+
+
+async def test_history_is_the_chain_when_two_revisions_share_one_second(tmp_path, monkeypatch):
+    """Git commit times are whole seconds, so one instant can hold both Revisions.
+
+    The fixture already reaches this state on roughly 4 runs in 10 by committing
+    twice inside the same second; pinning the legacy clock makes it every run.
+    ``occurred_at`` then carries no order, and whatever breaks the tie decides
+    what the caller is told is newest.
+
+    Sorting on ``revision_id`` gets that right half the time by luck, so the
+    loop below keeps building fixtures until it has the half it gets wrong — a
+    head whose content address sorts *below* its own parent's.  Asserting
+    against a case that only shows up on a coin flip is how this file came to
+    have a test that flipped on an unchanged tree (akb#399).
+    """
+    async with _fresh_schema(tmp_path) as pool:
+        instant = "2026-01-02T03:04:05+00:00"
+        for _ in range(24):
+            head_revision_id, instants, history = await _reconciled_head_and_history(
+                pool, tmp_path, monkeypatch, make_at=instant, advance_at=instant
+            )
+            assert instants == 1, "the pinned legacy clock did not collapse to one instant"
+            parent_revision_id = next(
+                row["revision_id"] for row in history if row["revision_id"] != head_revision_id
+            )
+            if head_revision_id < parent_revision_id:
+                break
+        else:
+            pytest.fail("could not build a head whose content address sorts below its parent's")
+
+        _assert_history_is_the_chain(head_revision_id, history)
 
 
 async def test_move_then_update_collapses_to_move_and_resolves_suffix_mappings(tmp_path):

--- a/backend/tests/test_native_revision_reconcile_pg.py
+++ b/backend/tests/test_native_revision_reconcile_pg.py
@@ -88,6 +88,11 @@ def _load(filename: str):
 @asynccontextmanager
 async def _fresh_schema(tmp_path: Path):
     if not await _reachable():
+        # The DB-free unit job has nothing on the default DSN, so skipping there
+        # is correct. On the live-PG gate it is not: a skip and a pass read the
+        # same, and every assertion in this file is about what PostgreSQL stores.
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"the real-PG gate requires a reachable Postgres at {_DSN}")
         pytest.skip(f"Postgres not reachable at {_DSN}")
 
     name = f"akb_c9_reconcile_{uuid.uuid4().hex[:12]}"


### PR DESCRIPTION
Closes #399.

The test was not unstable. It was reporting a real ordering defect, and it
reported it half the time because the defect is a coin flip.

## What is actually wrong

`NativeRevisionRepository.list_history` ordered a Resource's history with:

```sql
ORDER BY occurred_at DESC, revision_id DESC
```

Reconcile copies `occurred_at` straight from the legacy Git commit
(`document.lineage[-1].committed_at`), and Git commit times are whole seconds.
A fixture that commits twice inside one second gives both Revisions the **same
instant**, so the sort falls entirely to `revision_id` — a 40-hex content
address with no chronology in it, and one that varies per run because it is
derived from run-random ids.

Measured against the reconcile fixture, PostgreSQL 16.14 / Python 3.14.0rc3 /
pytest 9.0.3:

```
list_history newest revision, 10 runs of the same fixture
  move    6      correct
  create  4      the create returned as the newest event, ahead of the
                 move whose parent_revision_id is that very create
```

`test_update_then_final_move_collapses_to_one_move_and_binds_suffix` queried the
table the same way and asserted `revisions[-1]["action"] == "move"`, so it flipped
for the same reason: **8 red / 20 runs** on an unchanged tree.

## The fix

Walk up from `native_resources.head_revision_id`. A Resource's history is a
parent chain, and the chain is the order:

- causal by construction — a Revision can never precede its own parent, whatever
  timestamp it carries;
- each step is a primary-key lookup bounded by `limit`, so the walk reads exactly
  as many rows as it returns rather than sorting the whole table;
- it says what history means: the lineage that produced the current head.

The test now reads the chain too, and its assertions are unchanged.

## New regression test

`test_history_is_the_chain_when_two_revisions_share_one_second` pins
`GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` so both commits land on one instant. That
builds the real state through the real writer — `native_revisions` rows are
immutable by trigger, and forging the state with an `UPDATE` produces a test that
fails before it reaches its own assertion.

A `revision_id` tiebreak still gets the tie right half the time by luck, so the
test keeps building fixtures until it holds the half it gets wrong — a head whose
content address sorts *below* its parent's. Asserting against a case that only
appears on a coin flip is how the original flake got here.

## Verification

```
mutation   revert the ordering        new test red 6/6
           restore                    new test green 6/6
flaky test after the change           0 red / 25 runs
           second database            0 red / 15 runs
suites     reconcile + shadow reader + activity routes + native ledger B
                                      132 passed
gate       scripts/check.sh           ruff clean · mypy 325 files, no issues ·
                                      bandit · eslint 0 errors · vitest 50 + 501
                                      passed · detect-secrets clean
```

## Two things this does not do

**The unconfirmed second suspect in the issue.**
`tests/concurrency/test_ensure_collection_race_unit.py` ran **14/14 green** here.
That neither confirms nor refutes the load sensitivity the issue records as
unmeasured; it is one more environment, not a verdict. Note it needs the `vector`
extension — on a stock `postgres:16` image it fails 12/12 for a missing extension,
which is not a flake and should not be counted as one.

**Two local-only failures — not a repo defect.**
`tests/test_m1_file_measurement_pg.py::test_reference_document_and_native_text_file_deduplicate_per_placement`
and `::test_namespace_placement_observation_counts_both_placements` fail with
`M1 measurement namespace cannot mix payload placements` in the environment these
measurements were taken in, with this branch's changes reverted as well as
applied. **They pass in CI on this branch**, where the measurement database is
created fresh for the run — so this is a difference in how the measurement
database was provisioned locally, not something wrong in the repository. Recorded
so the negative control is not mistaken for a finding about `main`.

## The file was never in front of a check

Worth its own commit, because it is why an unstable test could sit here:

- `scripts/check.sh` runs no backend pytest at all.
- CI's DB-free unit job runs `pytest tests/ -k 'not _e2e'` with no
  `AKB_TEST_DSN`, and this file self-skips — **12 skipped of 13**.
- CI's live-PG job runs an explicit file list, and
  `tests/test_native_revision_reconcile_pg.py` is not on it.

So neither job has ever executed an assertion in this file, and the new
regression test would have inherited that. The second commit adds the file to
the live-PG list and gives `_fresh_schema` the fail-closed guard
`test_m1_file_measurement_pg.py` already carries, so that under
`REQUIRE_REAL_PG=1` an unreachable Postgres fails rather than skipping. The
workflow's own comments give the reason: off that list, a file skips in both
jobs and becomes a gate that never fires.

```
no DSN + REQUIRE_REAL_PG=1     12 skipped -> 12 failed
with DSN                       13 passed
neither                        1 passed, 12 skipped (DB-free job unchanged)
```
