### PR TITLE
feat(mcp): adopt 2026-07-28 stateless protocol

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3572
+        "line_number": 3583
       }
     ],
     "backend/mcp_server/help.py": [
@@ -279,7 +279,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 270,
         "is_secret": false
       },
       {
@@ -287,7 +287,7 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 279,
         "is_secret": false
       },
       {
@@ -295,14 +295,14 @@
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "3ed9fbbd10ebd33819a3f1ca19555520a58cc16f",
         "is_verified": false,
-        "line_number": 297
+        "line_number": 298
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_publications_e2e.sh",
         "hashed_secret": "7ef88a05cecb3ee14534c186b61b00bc49f27e2d",
         "is_verified": false,
-        "line_number": 936
+        "line_number": 920
       }
     ],
     "deploy/docker-compose.yaml": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-24T07:47:42Z"
+  "generated_at": "2026-08-25T07:26:38Z"
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ the AS — see [`docs/mcp-clients/web-connectors.md`](./docs/mcp-clients/web-con
 also accept Claude Code's `mcp add --transport http` + `mcp login` flow
 end-to-end, without a PAT.
 
+### MCP protocol revision
+
+AKB supports only MCP **2026-07-28**. Direct HTTP callers send one
+stateless JSON-RPC request per `POST /mcp/` with the per-request `_meta`
+envelope and `Mcp-Protocol-Version`, `Mcp-Method`, and (for named calls)
+`Mcp-Name` headers. Use `server/discover` for server metadata and
+`tools/list` for the deterministic, cacheable tool catalog. The old
+`initialize`/`initialized`, `Mcp-Session-Id`, `GET`, and `DELETE` session paths
+are not compatibility routes; unsupported revisions receive the typed
+`-32022` error. Pair backend `0.15.x` with the `akb-mcp` `2.3.x` proxy stream.
+
 ## Plugins
 
 Beyond raw MCP access, AKB ships ready-made **agent plugins** for **Claude Code**
@@ -155,7 +166,7 @@ letting the indexing worker re-populate.
 | `akb_list_vaults` / `akb_create_vault` | Vault management |
 | `akb_put` / `akb_get` / `akb_update` / `akb_delete` | Document CRUD (Git commit + indexing) |
 | `akb_put_file` / `akb_get_file` / `akb_update_file` / `akb_delete_file` | File attachments — proxy-side (requires local filesystem) |
-| `akb_put_image` / `akb_discard_image` | Validated inline Markdown images — proxy-side in `akb-mcp` 2.2+ |
+| `akb_put_image` / `akb_discard_image` | Validated inline Markdown images — proxy-side in `akb-mcp` 2.3+ |
 | `akb_create_table` / `akb_alter_table` / `akb_drop_table` / `akb_sql` | Tabular content — per-doc tables + SQL |
 | `akb_browse` | Tree traversal (collection → docs) |
 | `akb_search` / `akb_grep` | Hybrid search (dense + BM25) / literal grep |
@@ -201,7 +212,7 @@ Markdown reference. Remove an image by deleting its Markdown expression; use
 `akb_discard_image` only for an upload that never reached a successful document
 commit. Run `akb_help(topic="images")` for retention and publication behavior.
 
-The image tools require both the matching backend release and `akb-mcp` 2.2 or
+The image tools require both the matching backend release and `akb-mcp` 2.3 or
 newer. For upgrades, deploy the backend first, then publish/install the proxy
 and restart existing MCP processes so they load the updated tool list.
 

--- a/agents/runtime.py
+++ b/agents/runtime.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import json
 import logging
 import ssl
-import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -31,6 +30,7 @@ import aiohttp
 from openai import AsyncOpenAI
 
 logger = logging.getLogger("akb.agent")
+MCP_PROTOCOL_VERSION = "2026-07-28"
 
 
 @dataclass
@@ -51,7 +51,11 @@ class MCP:
     def __init__(self, base_url: str, pat: str):
         self.url = f"{base_url.rstrip('/')}/mcp/"
         self.pat = pat
-        self.session_id: str | None = None
+        self._meta = {
+            "io.modelcontextprotocol/protocolVersion": MCP_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {"name": "akb-agent-runtime", "version": "1.0"},
+        }
         self._ssl = ssl.create_default_context()
         self._ssl.check_hostname = False
         self._ssl.verify_mode = ssl.CERT_NONE
@@ -60,21 +64,17 @@ class MCP:
         self._msg_id = 0
 
     async def connect(self) -> list[dict]:
-        """Initialize MCP session and fetch tools."""
+        """Discover the stateless MCP server and fetch tools."""
         self._http = aiohttp.ClientSession()
 
-        # Initialize
-        resp = await self._rpc("initialize", {
-            "protocolVersion": "2025-03-26",
-            "capabilities": {},
-            "clientInfo": {"name": "akb-agent-runtime", "version": "1.0"},
-        })
-        self.session_id = resp.get("_session_id")
+        discovery = await self._rpc("server/discover", {})
+        if MCP_PROTOCOL_VERSION not in discovery.get("supportedVersions", []):
+            raise RuntimeError(f"MCP server does not support {MCP_PROTOCOL_VERSION}")
 
         # List tools
         result = await self._rpc("tools/list", {})
         self._tools = result.get("tools", [])
-        logger.info("MCP connected: %d tools, session=%s", len(self._tools), self.session_id)
+        logger.info("MCP connected: %d tools, protocol=%s", len(self._tools), MCP_PROTOCOL_VERSION)
         return self._tools
 
     async def call_tool(self, name: str, arguments: dict) -> Any:
@@ -100,11 +100,14 @@ class MCP:
         headers = {
             "Authorization": f"Bearer {self.pat}",
             "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
+            "Accept": "application/json",
+            "Mcp-Protocol-Version": MCP_PROTOCOL_VERSION,
+            "Mcp-Method": method,
         }
-        if self.session_id:
-            headers["mcp-session-id"] = self.session_id
+        if method == "tools/call" and isinstance(params.get("name"), str):
+            headers["Mcp-Name"] = params["name"]
 
+        params = {**params, "_meta": {**self._meta, **params.get("_meta", {})}}
         body = {
             "jsonrpc": "2.0",
             "id": self._msg_id,
@@ -113,18 +116,10 @@ class MCP:
         }
 
         async with self._http.post(self.url, json=body, headers=headers, ssl=self._ssl) as resp:
-            # Capture session ID from response headers
-            sid = resp.headers.get("mcp-session-id")
-            if sid:
-                self.session_id = sid
-
             data = await resp.json()
             if "error" in data:
                 raise RuntimeError(f"MCP error: {data['error']}")
-            result = data.get("result", {})
-            if sid:
-                result["_session_id"] = sid
-            return result
+            return data.get("result", {})
 
     def get_openai_tools(self) -> list[dict]:
         """Convert MCP tools to OpenAI function calling format."""

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,17 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+## 0.15.0 — 2026-08-25  *(feat — MCP 2026-07-28 stateless protocol)*
+
+### Added the single-revision stateless MCP transport
+
+The backend now uses the native MCP SDK 2.1.0 modern transport. Every HTTP
+request must carry the 2026-07-28 protocol envelope and routing headers; the
+server provides `server/discover`, deterministic cacheable `tools/list`, and
+per-request authentication and client metadata without session affinity.
+Legacy initialize/session requests receive the typed unsupported-version or
+stateless-request error instead of a downgrade.
+
 ### Fixed repeated production-scale BM25 rebuilds and bounded rebuild memory
 
 The BM25 refresher no longer compares all non-null chunks with the smaller set

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -107,6 +107,7 @@ async def lifespan(app: FastAPI):
         )
     storage_initialized = False
     runtime_started = False
+    mcp_started = False
     try:
         await init_storage()
         storage_initialized = True
@@ -142,8 +143,12 @@ async def lifespan(app: FastAPI):
             start_workers()
         else:
             start_api_runtime()
+        await mcp_app.start()
+        mcp_started = True
         yield
     finally:
+        if mcp_started:
+            await mcp_app.stop()
         if runtime_started:
             if role == "all":
                 await stop_workers()

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -1547,7 +1547,7 @@ Permissions: SELECT=reader, INSERT/UPDATE/DELETE=writer""",
     "images": """# Inline Document Images
 
 Availability: `akb_put_image` and `akb_discard_image` are local-filesystem
-tools supplied by the `akb-mcp` stdio proxy version 2.2 or newer. Use this
+tools supplied by the `akb-mcp` stdio proxy version 2.3 or newer. Use this
 workflow only when those names are present in the client's tool list.
 
 Use `akb_put_image` when a local raster image should render inside an AKB
@@ -1641,7 +1641,7 @@ permanent image archive.
 
     "akb_put_image": """# akb_put_image — Upload an Inline Document Image
 
-Availability: proxy-local in `akb-mcp` 2.2 or newer; it is not exposed by a
+Availability: proxy-local in `akb-mcp` 2.3 or newer; it is not exposed by a
 direct connection to the backend MCP endpoint.
 
 Reads a local PNG, JPEG, GIF, or WebP through the akb-mcp stdio proxy and
@@ -1686,7 +1686,7 @@ fails, pass `image.url` to `akb_discard_image`.""",
 
     "akb_discard_image": """# akb_discard_image — Clean Up an Uncommitted Image
 
-Availability: proxy-local in `akb-mcp` 2.2 or newer; it is not exposed by a
+Availability: proxy-local in `akb-mcp` 2.3 or newer; it is not exposed by a
 direct connection to the backend MCP endpoint.
 
 Deletes a caller-owned image upload only when no document commit has claimed

--- a/backend/mcp_server/http_app.py
+++ b/backend/mcp_server/http_app.py
@@ -1,99 +1,142 @@
-"""MCP Streamable HTTP — mounts MCP server as ASGI app at /mcp.
-
-Each authenticated session gets its own transport + server loop.
-Agents connect via one of:
-  POST http://localhost:8000/mcp/
-  Authorization: Bearer akb_<pat-or-service>   # token-store credential
-  Authorization: Bearer <rs256-access-token>   # keycloak-access-v1 only when
-                                               # mcp_oauth_enabled=true
-"""
+"""Authenticated, stateless MCP Streamable HTTP entrypoint."""
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import uuid
+import json
+from contextlib import AsyncExitStack
+from typing import Any
 
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.shared.inbound import unsupported_protocol_version_rejection
+from mcp_types import ErrorData, INVALID_REQUEST, JSONRPCError
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.types import Receive, Scope, Send
-
-from mcp.server.streamable_http import StreamableHTTPServerTransport
 
 from app.config import settings
 from app.services.auth_service import resolve_mcp_authorization
-
-logger = logging.getLogger("akb.mcp")
+from mcp_server.protocol import MCP_PROTOCOL_VERSION, MCP_SUPPORTED_PROTOCOL_VERSIONS
 
 
 def _www_authenticate_header() -> str:
-    """Build the RFC 9728 §5 `WWW-Authenticate` header value for 401s.
-
-    When MCP-OAuth is enabled the header carries a `resource_metadata`
-    parameter pointing the client at the protected-resource metadata
-    document, so a standards-compliant MCP client (Claude Code,
-    claude.ai, ChatGPT) can autodiscover the authorization server and
-    initiate DCR + the auth-code flow. When disabled (PAT-only), we
-    emit the plain `Bearer` challenge — there is no AS to discover.
-    """
+    """Build the RFC 9728 §5 ``WWW-Authenticate`` header for 401s."""
     base = 'Bearer realm="akb-mcp"'
     if settings.mcp_oauth_enabled and settings.public_base_url:
-        meta_url = (
-            f"{settings.public_base_url.rstrip('/')}"
-            "/.well-known/oauth-protected-resource"
-        )
+        meta_url = f"{settings.public_base_url.rstrip('/')}/.well-known/oauth-protected-resource"
         return f'{base}, resource_metadata="{meta_url}"'
     return base
 
-# Active transports keyed by session ID
-_transports: dict[str, StreamableHTTPServerTransport] = {}
-_server_tasks: dict[str, asyncio.Task] = {}
-# Authenticated user per session (used by tool handlers)
-_session_users: dict[str, object] = {}
+
+def _request_id(decoded: Any) -> int | str | None:
+    if not isinstance(decoded, dict):
+        return None
+    value = decoded.get("id")
+    return value if isinstance(value, (int, str)) and not isinstance(value, bool) else None
 
 
-def get_session_user(session_id: str):
-    """Get authenticated user for a session. Called by tool handlers."""
-    return _session_users.get(session_id)
+def _requested_version(decoded: Any, header: str | None) -> str:
+    if header:
+        return header
+    if not isinstance(decoded, dict):
+        return ""
+    params = decoded.get("params")
+    if not isinstance(params, dict):
+        return ""
+    modern_meta = params.get("_meta")
+    if isinstance(modern_meta, dict):
+        version = modern_meta.get("io.modelcontextprotocol/protocolVersion")
+        if isinstance(version, str):
+            return version
+    legacy_version = params.get("protocolVersion")
+    return legacy_version if isinstance(legacy_version, str) else ""
 
 
-async def _ensure_server_running(session_id: str, transport: StreamableHTTPServerTransport) -> None:
-    """Ensure the MCP server loop is running for this transport."""
-    if session_id in _server_tasks and not _server_tasks[session_id].done():
-        return
+def _jsonrpc_error(
+    *,
+    request_id: int | str | None,
+    code: int,
+    message: str,
+    data: Any = None,
+) -> JSONResponse:
+    error = JSONRPCError(
+        jsonrpc="2.0",
+        id=request_id,
+        error=ErrorData(code=code, message=message, data=data),
+    )
+    return JSONResponse(error.model_dump(mode="json", by_alias=True, exclude_none=False), status_code=400)
 
-    from mcp_server.server import server
 
-    async def run():
-        try:
-            async with transport.connect() as (read_stream, write_stream):
-                await server.run(read_stream, write_stream, server.create_initialization_options())
-        except Exception:
-            logger.exception("MCP server loop error for session %s", session_id)
-        finally:
-            _transports.pop(session_id, None)
-            _session_users.pop(session_id, None)
-            _server_tasks.pop(session_id, None)
+async def _reject_non_modern_request(request: Request, *, reason: str | None = None) -> Response:
+    """Reject legacy, missing-version, and session-bound requests explicitly."""
+    raw = await request.body()
+    try:
+        decoded = json.loads(raw)
+    except (ValueError, RecursionError):
+        decoded = None
 
-    _server_tasks[session_id] = asyncio.create_task(run())
-    await asyncio.sleep(0.05)
+    if reason is None:
+        requested = _requested_version(decoded, request.headers.get("mcp-protocol-version"))
+        rejection = unsupported_protocol_version_rejection(
+            requested,
+            MCP_SUPPORTED_PROTOCOL_VERSIONS,
+        )
+        assert rejection is not None
+        return _jsonrpc_error(
+            request_id=_request_id(decoded),
+            code=rejection.code,
+            message=rejection.message,
+            data=rejection.data,
+        )
+
+    return _jsonrpc_error(
+        request_id=_request_id(decoded),
+        code=INVALID_REQUEST,
+        message=reason,
+    )
 
 
 class MCPApp:
-    """ASGI app that handles MCP Streamable HTTP authorization."""
+    """Authenticate each request before handing it to the native SDK manager."""
+
+    def __init__(self) -> None:
+        self._manager: StreamableHTTPSessionManager | None = None
+        self._exit_stack: AsyncExitStack | None = None
+
+    async def start(self) -> None:
+        """Start the SDK's process-scoped manager and server lifespan."""
+        if self._manager is not None:
+            return
+
+        from mcp_server.server import server
+
+        manager = StreamableHTTPSessionManager(
+            app=server,
+            json_response=True,
+            stateless=True,
+        )
+        exit_stack = AsyncExitStack()
+        try:
+            await exit_stack.enter_async_context(manager.run())
+        except BaseException:
+            await exit_stack.aclose()
+            raise
+        self._manager = manager
+        self._exit_stack = exit_stack
+
+    async def stop(self) -> None:
+        """Stop the SDK manager and release all per-request tasks."""
+        exit_stack = self._exit_stack
+        self._manager = None
+        self._exit_stack = None
+        if exit_stack is not None:
+            await exit_stack.aclose()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             return
 
         request = Request(scope, receive, send)
-
-        # Auth check. The MCP capability accepts only namespaced token-store
-        # credentials and, when enabled, keycloak-access-v1 for the MCP
-        # audience. Local human sessions are never MCP credentials. 401s carry
-        # an RFC 9728 WWW-Authenticate
-        # header so a standards-compliant MCP client can autodiscover
-        # the AS and complete OAuth without an out-of-band tip-off.
+        response: Response
         auth_header = request.headers.get("authorization", "")
         www_auth = _www_authenticate_header()
         if not auth_header:
@@ -120,50 +163,25 @@ class MCPApp:
             await response(scope, receive, send)
             return
 
-        session_id = request.headers.get("mcp-session-id")
-
-        if request.method == "DELETE":
-            if session_id and session_id in _transports:
-                transport = _transports.pop(session_id)
-                _session_users.pop(session_id, None)
-                await transport.terminate()
-                task = _server_tasks.pop(session_id, None)
-                if task:
-                    task.cancel()
-                logger.info("MCP session terminated: %s", session_id[:8])
-            response = JSONResponse({"terminated": True})
+        if request.headers.get("mcp-protocol-version") != MCP_PROTOCOL_VERSION:
+            response = await _reject_non_modern_request(request)
             await response(scope, receive, send)
             return
 
-        if request.method == "POST":
-            if session_id and session_id in _transports:
-                transport = _transports[session_id]
-            else:
-                session_id = str(uuid.uuid4())
-                transport = StreamableHTTPServerTransport(
-                    mcp_session_id=session_id,
-                    is_json_response_enabled=True,
-                )
-                _transports[session_id] = transport
-                _session_users[session_id] = user
-                await _ensure_server_running(session_id, transport)
-                logger.info("MCP session started: %s (user: %s)", session_id[:8], user.username)
-
-            # Delegate to transport's ASGI handler
-            await transport.handle_request(scope, receive, send)
+        if request.headers.get("mcp-session-id") is not None:
+            response = await _reject_non_modern_request(
+                request,
+                reason="Mcp-Session-Id is not supported by the stateless 2026-07-28 protocol",
+            )
+            await response(scope, receive, send)
             return
 
-        if request.method == "GET":
-            if not session_id or session_id not in _transports:
-                response = JSONResponse({"error": "Invalid session"}, status_code=404)
-                await response(scope, receive, send)
-                return
-            transport = _transports[session_id]
-            await transport.handle_request(scope, receive, send)
+        manager = self._manager
+        if manager is None:
+            response = Response(status_code=503)
+            await response(scope, receive, send)
             return
-
-        response = JSONResponse({"error": "Method not allowed"}, status_code=405)
-        await response(scope, receive, send)
+        await manager.handle_request(scope, receive, send)
 
 
 mcp_app = MCPApp()

--- a/backend/mcp_server/instructions.py
+++ b/backend/mcp_server/instructions.py
@@ -1,4 +1,4 @@
-"""MCP initialize instructions — bootstrap gate for AKB agents.
+"""MCP request instructions — bootstrap gate for AKB agents.
 
 This module is kept deliberately lightweight (no heavy imports) so that
 unit tests and tooling can import INSTRUCTIONS without pulling in the full
@@ -19,7 +19,7 @@ When writing into a vault:
 4. Never inline secrets in document bodies — use ${{secrets.X}} placeholders.
 5. Destructive tools (akb_delete_vault, akb_delete_collection) require explicit user confirmation.
 6. Reference resources by the akb:// URIs returned by tool calls — do not reassemble paths yourself.
-7. If listed, use proxy-local akb_put_image and insert its returned `markdown`. For existing documents use targeted akb_edit: akb_update(content=...) replaces the entire body. On write failure call akb_discard_image. If absent, use akb-mcp 2.2+.
+7. If listed, use proxy-local akb_put_image and insert its returned `markdown`. For existing documents use targeted akb_edit: akb_update(content=...) replaces the entire body. On write failure call akb_discard_image. If absent, use akb-mcp 2.3+.
 8. For other surfaces (akb_publish, akb_activity, akb_history), call akb_help() for an overview.
 
 Agent memory is managed outside this tool loop by lifecycle plugins. Find your accessible memory vault with akb_list_vaults; use normal akb_search / akb_browse / akb_get tools rather than reconstructing its name.

--- a/backend/mcp_server/protocol.py
+++ b/backend/mcp_server/protocol.py
@@ -1,0 +1,11 @@
+"""AKB's single supported MCP protocol revision."""
+
+from mcp_types.version import MODERN_PROTOCOL_VERSIONS
+
+MCP_PROTOCOL_VERSION = "2026-07-28"
+MCP_SUPPORTED_PROTOCOL_VERSIONS = (MCP_PROTOCOL_VERSION,)
+
+if tuple(MODERN_PROTOCOL_VERSIONS) != MCP_SUPPORTED_PROTOCOL_VERSIONS:
+    raise RuntimeError(
+        "The pinned MCP SDK must expose exactly the AKB-supported modern protocol revision"
+    )

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -18,6 +18,8 @@ import logging
 import sys
 import time
 import uuid
+from contextvars import ContextVar
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Any
 
@@ -26,9 +28,10 @@ from app.util.git_refs import HEX_COMMIT_RE
 # Add backend to path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp.server import Server
+from mcp.server import CacheHint, Server
+from mcp.server.context import ServerRequestContext
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent
+from mcp.types import CallToolResult, ListToolsResult, TextContent
 
 from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError, WriteBusyError
@@ -81,11 +84,17 @@ VAULT_SKILL_PREFLIGHT_CAPABILITY = "io.dnotitia.akb/vault-skill-preflight"
 VAULT_SKILL_ACK_ARGUMENT = "_vault_skill_ack"
 
 
+_REQUEST_CONTEXT: ContextVar[ServerRequestContext[Any, Any] | None] = ContextVar(
+    "akb_mcp_request_context", default=None
+)
+
+
 def _vault_skill_preflight_version() -> int | None:
-    """Negotiated retry-contract version for this MCP session, if any."""
+    """Negotiated retry-contract version for the current MCP request."""
+    context = _REQUEST_CONTEXT.get()
     try:
-        params = server.request_context.session.client_params
-        experimental = params.capabilities.experimental if params else None
+        capabilities = context.session.client_capabilities if context else None
+        experimental = capabilities.experimental if capabilities else None
         advertised = (experimental or {}).get(VAULT_SKILL_PREFLIGHT_CAPABILITY)
         if not isinstance(advertised, dict):
             return None
@@ -114,9 +123,6 @@ async def _find_doc(vault_name: str, doc_ref: str) -> dict | None:
             return None
         return await doc_repo.find_by_ref_with_conn(conn, vault["id"], doc_ref)
 
-
-
-server = Server("akb", instructions=INSTRUCTIONS)
 
 
 class _MCPUser:
@@ -148,13 +154,13 @@ _FALLBACK_USER = _MCPUser()
 async def _get_user() -> _MCPUser:
     """Get authenticated user from MCP request context.
 
-    Uses the standard MCP SDK mechanism: server.request_context.request
-    contains the original HTTP Request, from which we extract the
-    Authorization header and apply the MCP credential capability.
+    The pinned MCP SDK passes the original HTTP Request through the
+    per-request ``ServerRequestContext``. Authentication is therefore resolved
+    independently for every stateless request.
     """
     try:
-        ctx = server.request_context
-        request = ctx.request  # Starlette Request object
+        context = _REQUEST_CONTEXT.get()
+        request = context.request if context else None
         if request:
             auth_header = request.headers.get("authorization", "")
             if auth_header:
@@ -183,15 +189,14 @@ async def _get_user() -> _MCPUser:
 
 
 def _session_id() -> str | None:
-    """The caller's MCP session id, for correlating a conversation's tool calls.
+    """Return a legacy transport id when one is present for analytics only.
 
-    Same source as `_get_user()` — the SDK stashes the originating HTTP request
-    on the request context. Absent for stdio/CLI callers and for the very first
-    POST of a session (the server mints the id during `initialize`), so this is
-    nullable by construction and must never be treated as a required key.
+    The public HTTP entrypoint rejects session-bound requests, so modern
+    stateless calls and stdio calls return ``None``.
     """
     try:
-        request = server.request_context.request
+        context = _REQUEST_CONTEXT.get()
+        request = context.request if context else None
         if request:
             return request.headers.get("mcp-session-id")
     except (LookupError, AttributeError):
@@ -342,7 +347,7 @@ def _required_scope(name: str, args: dict) -> str:
 # time from the same TOOLS list returned via list_tools, so the
 # "what the agent saw" and "what we accept" can't drift.
 _TOOL_ARG_NAMES: dict[str, set[str]] = {
-    t.name: set((t.inputSchema or {}).get("properties", {}).keys())
+    t.name: set((t.input_schema or {}).get("properties", {}).keys())
     for t in TOOLS
 }
 
@@ -1548,14 +1553,10 @@ async def _handle_set_public(args: dict, uid: str, user: _MCPUser) -> dict:
 
 # ── Tool Handlers ────────────────────────────────────────────
 
-@server.list_tools()
 async def list_tools():
-    if _vault_skill_preflight_version() != 2:
-        return TOOLS
-
-    # Capability v2 makes acknowledgement explicit.  Advertise the reserved
-    # retry argument only to clients that negotiated that contract; older
-    # clients keep the byte-for-byte schemas they already understand.
+    # The catalog is one cacheable public surface. Advertise the reserved
+    # acknowledgement argument for every possible writer so client metadata
+    # cannot select a different schema or invalidate a public cache entry.
     decorated = []
     for tool in TOOLS:
         may_write = (
@@ -1566,7 +1567,7 @@ async def list_tools():
             decorated.append(tool)
             continue
         copied = tool.model_copy(deep=True)
-        copied.inputSchema.setdefault("properties", {})[
+        copied.input_schema.setdefault("properties", {})[
             VAULT_SKILL_ACK_ARGUMENT
         ] = {
             "type": "string",
@@ -1581,7 +1582,6 @@ async def list_tools():
     return decorated
 
 
-@server.call_tool()
 async def call_tool(name: str, arguments: dict):
     # Capability-v2 acknowledgement is transport metadata expressed as a
     # reserved tool argument so generic MCP clients can send it through their
@@ -1747,6 +1747,27 @@ async def call_tool(name: str, arguments: dict):
         )]
 
 
+async def _handle_list_tools(
+    context: ServerRequestContext[Any, Any], _params: Any
+) -> ListToolsResult:
+    token = _REQUEST_CONTEXT.set(context)
+    try:
+        return ListToolsResult(tools=await list_tools())
+    finally:
+        _REQUEST_CONTEXT.reset(token)
+
+
+async def _handle_call_tool(
+    context: ServerRequestContext[Any, Any], params: Any
+) -> CallToolResult:
+    token = _REQUEST_CONTEXT.set(context)
+    try:
+        content = await call_tool(params.name, params.arguments or {})
+    finally:
+        _REQUEST_CONTEXT.reset(token)
+    return CallToolResult(content=content)
+
+
 async def _dispatch(name: str, args: dict, user: "_MCPUser"):
     uid = user.user_id
 
@@ -1816,6 +1837,19 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
             hint="The vault is under heavy write load. Wait a few seconds and retry; no partial write occurred.",
             retry_after_secs=e.retry_after_secs,
         )
+
+
+server = Server(
+    "akb",
+    version=package_version("akb"),
+    instructions=INSTRUCTIONS,
+    cache_hints={
+        "server/discover": CacheHint(ttl_ms=300_000, scope="public"),
+        "tools/list": CacheHint(ttl_ms=300_000, scope="public"),
+    },
+    on_list_tools=_handle_list_tools,
+    on_call_tool=_handle_call_tool,
+)
 
 
 # ── Entry point ──────────────────────────────────────────────

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -60,7 +60,7 @@ TOOLS = [
             "- limit / offset: pagination when there are many matches.\n"
             "- include_archived: include archived vaults (default false)."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "filter": {"type": "string", "description": "Substring filter against name+description (case-insensitive)."},
@@ -77,7 +77,7 @@ TOOLS = [
             "Pass `external_git` to instead create a read-only mirror of an upstream git repo — the vault "
             "tracks the remote on a polling schedule and rejects user writes."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Vault name (lowercase, hyphens allowed)"},
@@ -115,7 +115,7 @@ TOOLS = [
             "that URI to address the document from every other tool. Automatically "
             "chunked and indexed for semantic search."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "parent": {
@@ -173,7 +173,7 @@ TOOLS = [
             "Use akb_browse or akb_search first to obtain the URI. "
             "Optionally pass a commit hash (from akb_history) to read a previous version."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI — akb://{vault}[/coll/{coll_path}]/doc/{filename}"},
@@ -190,7 +190,7 @@ TOOLS = [
             "partial fragment such as a newly uploaded image. Use a targeted "
             "akb_edit for inline insertion or replacement."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -224,7 +224,7 @@ TOOLS = [
             "resending the complete document body. For find-and-replace across many "
             "documents, use akb_grep with replace instead."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -259,7 +259,7 @@ TOOLS = [
             "rewritten. Provide collection and/or slug (at least one must change). "
             "The title is unchanged; use akb_update to change the displayed title."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI to move"},
@@ -279,7 +279,7 @@ TOOLS = [
     Tool(
         name="akb_delete",
         description="Delete a document. Removes from Git, search index, and knowledge graph.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -304,7 +304,7 @@ TOOLS = [
             "(70+ collections) fit in the agent's context window. Returns "
             "{vault, path, items, total, returned, truncated?, hint?}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {
@@ -383,7 +383,7 @@ TOOLS = [
             "genuine zero-match; `degradation_reason` names the cause. Retry shortly, or fall "
             "back to akb_grep for a literal search."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Natural language search query"},
@@ -438,7 +438,7 @@ TOOLS = [
             "safety bounds truncate snippets, the `truncation` object names the applied "
             "resource, match, and byte limits; use count_only for exact counts without snippets."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "pattern": {"type": "string", "minLength": 1, "description": "Non-empty search pattern. By default matched as literal text (ILIKE) — metacharacters like |, ., *, (), [], +, ? are treated as literal characters. Set regex=true to enable PostgreSQL regex (required for alternation and wildcards)."},
@@ -494,7 +494,7 @@ TOOLS = [
             "deciding which section to read.\n"
             "Returns {uri, sections|outline, returned, total?, truncated?, hint?}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -517,7 +517,7 @@ TOOLS = [
             "Returns Git commit history with changed file list. "
             "Use akb_diff to see the actual content changes for a specific commit."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -536,7 +536,7 @@ TOOLS = [
             "Shows what was added/removed/modified. "
             "Use akb_history or akb_activity to find commit hashes first."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -552,7 +552,7 @@ TOOLS = [
             "Shows same-vault cross-type connections: doc→table, doc→file, table→file, etc. "
             "Each row identifies whether it is an explicit link or implicit document-derived edge."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Resource URI (akb://vault/doc/path, akb://vault/table/name, akb://vault/file/uuid)"},
@@ -569,7 +569,7 @@ TOOLS = [
             "Provide `uri` to get a subgraph centered on any resource with BFS traversal. "
             "Provide `vault` (without uri) to get the full vault graph."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Center resource URI (omit + pass vault for full vault graph)"},
@@ -597,7 +597,7 @@ TOOLS = [
             f"Relation types: {_REL_LIST}. "
             "Example: link a design doc to its data table, or attach a diagram file to a spec."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "source": {"type": "string", "description": "Source resource URI (e.g. akb://vault/doc/specs/api.md)"},
@@ -618,7 +618,7 @@ TOOLS = [
             "Implicit relations are removed by editing their source document. "
             "If relation type is omitted, removes all explicit relations between the two resources."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "source": {"type": "string", "description": "Source resource URI"},
@@ -638,7 +638,7 @@ TOOLS = [
             "Get provenance for a document — who created it, when, which entities were "
             "extracted, and its visible same-vault relations."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -658,7 +658,7 @@ TOOLS = [
             "groups the table under that collection so it appears beside the documents "
             "and files there in akb_browse; omit for vault root."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "parent": {
@@ -776,7 +776,7 @@ TOOLS = [
             "returned (nothing is silently truncated), so an unbounded SELECT on a large table "
             "can send back a very large response."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "sql": {"type": "string", "description": "SQL query to execute. For large tables, add a LIMIT to cap the rows returned unless you need the full set."},
@@ -793,7 +793,7 @@ TOOLS = [
     Tool(
         name="akb_drop_table",
         description="Permanently delete a table and all its rows. Cannot be undone. Requires admin role on the vault.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Table URI — akb://{vault}[/coll/{coll_path}]/table/{name}"},
@@ -804,7 +804,7 @@ TOOLS = [
     Tool(
         name="akb_alter_table",
         description="Modify a table's schema — add, remove, or rename columns via ALTER TABLE DDL. Requires admin role.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Table URI — akb://{vault}[/coll/{coll_path}]/table/{name}"},
@@ -927,7 +927,7 @@ TOOLS = [
             "Returns the canonical publication dict — `slug` is the only identifier "
             "you need; `share_url` is always an absolute URL ready to paste."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Resource URI to publish — required when resource_type is document or file. Omit for table_query."},
@@ -978,7 +978,7 @@ TOOLS = [
             "(handy when re-publishing). table_query publications have no resource "
             "URI, so remove them by slug. Returns {deleted: N}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "slug": {"type": "string", "description": "Publication slug — remove exactly this publication."},
@@ -992,7 +992,7 @@ TOOLS = [
             "List every publication in a vault. Each item is the canonical "
             "publication dict (same shape as `akb_publish` returns)."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1013,7 +1013,7 @@ TOOLS = [
             "Identified by `slug` alone — the vault is resolved from the publication. "
             "Returns the updated publication dict."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "slug": {"type": "string", "description": "Publication slug"},
@@ -1024,7 +1024,7 @@ TOOLS = [
     Tool(
         name="akb_vault_info",
         description="Get detailed vault information: owner, member count, document/table/file/edge counts, last activity.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1035,7 +1035,7 @@ TOOLS = [
     Tool(
         name="akb_vault_members",
         description="List all members of a vault with their roles (owner, admin, writer, reader).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1046,7 +1046,7 @@ TOOLS = [
     Tool(
         name="akb_grant",
         description="Grant vault access to a user. You must be owner or admin of the vault.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1063,7 +1063,7 @@ TOOLS = [
     Tool(
         name="akb_revoke",
         description="Revoke a user's vault access. You must be owner or admin.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1075,7 +1075,7 @@ TOOLS = [
     Tool(
         name="akb_search_users",
         description="Search for users by username, display name, or email. Use this to find users before granting vault access.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search query (name, email, etc.)"},
@@ -1086,7 +1086,7 @@ TOOLS = [
     Tool(
         name="akb_whoami",
         description="Get your current profile — username, email, display name, role. Use this to check who you are authenticated as.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {},
         },
@@ -1097,7 +1097,7 @@ TOOLS = [
             "Transfer vault ownership to another user. The current owner or "
             "a system admin can do this."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1109,7 +1109,7 @@ TOOLS = [
     Tool(
         name="akb_archive_vault",
         description="Archive a vault (makes it read-only). Only the owner can do this.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1123,7 +1123,7 @@ TOOLS = [
             "Permanently delete a vault and ALL its data — documents, chunks, tables, files, edges, Git repo. "
             "This cannot be undone. Owner or admin only."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name to delete"},
@@ -1137,7 +1137,7 @@ TOOLS = [
             "Create an empty collection (folder) inside a vault. Idempotent — "
             "returns {created: false} if the collection already exists. Writer or higher role."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1154,7 +1154,7 @@ TOOLS = [
             "recursive=true to cascade delete every document and file under the path. "
             "Cascade emits one git commit for the entire batch. Writer or higher role."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1171,7 +1171,7 @@ TOOLS = [
     Tool(
         name="akb_set_public",
         description="Set vault public access level. Owner only. 'none'=private, 'reader'=public read, 'writer'=public read+write.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1186,7 +1186,7 @@ TOOLS = [
             "Get version history of a document — who changed it, when, and why. "
             "Each entry is a Git commit. Use the commit hash with akb_get to read a previous version."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -1203,7 +1203,7 @@ TOOLS = [
             "Drill down into categories or specific tools for details and examples. "
             "START HERE if you're new to AKB."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "topic": {
@@ -1233,7 +1233,7 @@ TOOLS = [
             "`resource` pointer — the rows/bytes stay in AKB). Reader role required. "
             "For a downloadable zip, use the REST endpoint GET /api/v1/vaults/{vault}/export."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault to export"},
@@ -1259,7 +1259,7 @@ TOOLS = [
             "'overview' collection or carrying type='skill' are skipped per-record and "
             "reported in the response's 'reserved' list. Writer role required."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Target vault"},
@@ -1284,3 +1284,8 @@ TOOLS = [
         },
     ),
 ]
+
+# The catalog is a cacheable protocol surface. Keep its order independent of
+# declaration edits so a harmless tool addition does not reshuffle existing
+# entries and invalidate client-side prompt/tool caches.
+TOOLS = sorted(TOOLS, key=lambda tool: tool.name)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.14.2"
+version = "0.15.0"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"
@@ -20,7 +20,7 @@ dependencies = [
     "gitpython==3.1.50",
     "python-frontmatter==1.3.0",
     "httpx==0.28.1",
-    "mcp[cli]==1.27.2",
+    "mcp[cli]==2.1.0",
     "pyyaml==6.0.3",
     "python-multipart==0.0.32",
     "pyjwt==2.13.0",

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -114,7 +114,7 @@ value, and exposes only the configured PAT environment-name in descriptor and
 discovery. The private discovery `runtime` object records the exact source
 revision, backend/proxy artifact versions, protocol revision, transport,
 selected capabilities, tool-case coordinates, fixture reset, and whether the
-stdio initialize/tools-list/read probes crossed the process boundary. The
+stdio discover/tools-list/read probes crossed the process boundary. The
 OIDC discovery object exposes issuer/JWKS/token coordinates and variant names,
 never an access token or signing key.
 

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -51,7 +51,7 @@ from oidc_fixture import OIDCFixture
 
 LOGGER = logging.getLogger("akb.e2e_runtime")
 SCHEMA_VERSION = 2
-PROTOCOL_REVISION = "2025-06-18"
+PROTOCOL_REVISION = "2026-07-28"
 Scenario = Literal[
     "empty",
     "app-installation-lifecycle",
@@ -378,7 +378,7 @@ class E2ERuntime:
         self._pat_value = ""
         self._candidate_revision: str | None = None
         self._proxy_version: str | None = None
-        self._stdio_initialize_observed = False
+        self._stdio_discover_observed = False
         self._stdio_tools_list_observed = False
         self._stdio_read_call_observed = False
         self._stdio_next_id = 2
@@ -508,7 +508,7 @@ class E2ERuntime:
                     "AKB_MCP_URL": f"{self.config.app_origin}/mcp/",
                     "AKB_PAT": self.config.credentials.pat_env,
                 },
-                "initialize_observed": self._stdio_initialize_observed,
+                "discover_observed": self._stdio_discover_observed,
                 "tools_list_observed": getattr(self, "_stdio_tools_list_observed", False),
                 "read_call_observed": getattr(self, "_stdio_read_call_observed", False),
             }
@@ -994,7 +994,7 @@ class E2ERuntime:
                 "login_path": "/api/v1/auth/login",
             },
         }
-        # Keep the legacy default descriptor byte-for-byte compatible.  A
+        # Keep the default descriptor shape stable. A
         # selected non-default profile advertises its added capabilities using
         # the same schema-v2 service map rather than a parallel MCP descriptor.
         if self.profile.name != DEFAULT_PROFILE or self.config.capabilities:
@@ -1479,17 +1479,20 @@ class E2ERuntime:
         )
         if managed.stdin is None or managed.stdout is None:
             raise BlockedRuntimeConfig("stdio proxy did not expose stdin/stdout pipes")
-        initialize = {
+        discover = {
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "initialize",
+            "method": "server/discover",
             "params": {
-                "protocolVersion": PROTOCOL_REVISION,
-                "capabilities": {},
-                "clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_REVISION,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                    "io.modelcontextprotocol/clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
+                },
             },
         }
-        managed.stdin.write((json.dumps(initialize, separators=(",", ":")) + "\n").encode())
+        self._stdio_meta = discover["params"]["_meta"]
+        managed.stdin.write((json.dumps(discover, separators=(",", ":")) + "\n").encode())
         await managed.stdin.drain()
         try:
             for _ in range(8):
@@ -1503,19 +1506,15 @@ class E2ERuntime:
                     continue
                 if "error" in response:
                     raise ValueError
-                self._stdio_initialize_observed = True
-                initialized = {
-                    "jsonrpc": "2.0",
-                    "method": "notifications/initialized",
-                    "params": {},
-                }
-                managed.stdin.write((json.dumps(initialized, separators=(",", ":")) + "\n").encode())
-                await managed.stdin.drain()
+                result = response.get("result")
+                if not isinstance(result, dict) or PROTOCOL_REVISION not in result.get("supportedVersions", []):
+                    raise ValueError
+                self._stdio_discover_observed = True
                 return
         except (asyncio.TimeoutError, ValueError, json.JSONDecodeError):
             pass
         await self._stop_named_process("stdio")
-        raise BlockedRuntimeConfig("stdio proxy initialize did not cross the process boundary")
+        raise BlockedRuntimeConfig("stdio proxy server/discover did not cross the process boundary")
 
     async def _stdio_response(self, expected_id: int) -> dict[str, object]:
         managed = self._children.get("stdio")
@@ -1550,7 +1549,14 @@ class E2ERuntime:
             "method": method,
         }
         if params is not None:
-            message["params"] = params
+            message["params"] = {
+                **params,
+                "_meta": dict(getattr(self, "_stdio_meta", {
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_REVISION,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                    "io.modelcontextprotocol/clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
+                })),
+            }
         managed.stdin.write((json.dumps(message, separators=(",", ":")) + "\n").encode())
         await managed.stdin.drain()
         return await self._stdio_response(request_id)
@@ -3040,7 +3046,7 @@ class E2ERuntime:
             try:
                 self._fixture_controls.clear()
                 await self._stop_named_process("stdio")
-                self._stdio_initialize_observed = False
+                self._stdio_discover_observed = False
                 self._stdio_tools_list_observed = False
                 self._stdio_read_call_observed = False
                 self._stdio_next_id = 2

--- a/backend/tests/mcp_modern.sh
+++ b/backend/tests/mcp_modern.sh
@@ -10,7 +10,10 @@ mcp_modern_request() {
   local pat=$1
   local request_id=$2
   local method=$3
-  local params_json=${4:-{}}
+  local params_json="${4-}"
+  if [ -z "$params_json" ]; then
+    params_json='{}'
+  fi
   local name=${5:-}
   local client_name=${6:-mcp-e2e}
   local body

--- a/backend/tests/mcp_modern.sh
+++ b/backend/tests/mcp_modern.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Shared test-only caller for AKB's MCP 2026-07-28 stateless HTTP surface.
+# It deliberately has no session-id or initialize fallback so endpoint suites
+# exercise the public contract directly.
+
+MCP_PROTOCOL_VERSION="2026-07-28"
+
+mcp_modern_request() {
+  local pat=$1
+  local request_id=$2
+  local method=$3
+  local params_json=${4:-{}}
+  local name=${5:-}
+  local client_name=${6:-mcp-e2e}
+  local body
+
+  body=$(python3 - "$request_id" "$method" "$params_json" "$client_name" <<'PY'
+import json
+import sys
+
+request_id = int(sys.argv[1])
+method = sys.argv[2]
+params = json.loads(sys.argv[3])
+client_name = sys.argv[4]
+if not isinstance(params, dict):
+    raise SystemExit("MCP params must be a JSON object")
+params = dict(params)
+params["_meta"] = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+    "io.modelcontextprotocol/clientInfo": {"name": client_name, "version": "1"},
+}
+print(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}, separators=(",", ":")))
+PY
+  )
+
+  local -a headers=(
+    -H "Authorization: Bearer $pat"
+    -H "Content-Type: application/json"
+    -H "Accept: application/json"
+    -H "Mcp-Protocol-Version: $MCP_PROTOCOL_VERSION"
+    -H "Mcp-Method: $method"
+  )
+  if [ -n "$name" ]; then
+    headers+=(-H "Mcp-Name: $name")
+  fi
+  curl -sk -X POST "${BASE_URL}/mcp/" "${headers[@]}" -d "$body" 2>&1
+}
+
+mcp_modern_discover() {
+  mcp_modern_request "$1" 1 server/discover '{}' '' "${2:-mcp-e2e}"
+}
+
+mcp_modern_call() {
+  local pat=$1
+  local tool=$2
+  local args=$3
+  local request_id=${4:-$RANDOM}
+  local client_name=${5:-mcp-e2e}
+  mcp_modern_request "$pat" "$request_id" tools/call \
+    "$(python3 - "$tool" "$args" <<'PY'
+import json
+import sys
+print(json.dumps({"name": sys.argv[1], "arguments": json.loads(sys.argv[2])}, separators=(",", ":")))
+PY
+)" "$tool" "$client_name"
+}

--- a/backend/tests/test_akb_put_slug_unit.py
+++ b/backend/tests/test_akb_put_slug_unit.py
@@ -4,7 +4,7 @@ The backend ``DocumentPutRequest`` model and ``document_service._put`` already
 honor a ``slug`` (``slug = (req.slug and _slugify(req.slug)) or _slugify(req.title)``);
 these tests pin the two MCP-surface seams that expose it to a caller:
 
-  1. ``tools.py`` advertises ``slug`` in the ``akb_put`` ``inputSchema``. Because
+  1. ``tools.py`` advertises ``slug`` in the ``akb_put`` ``input_schema``. Because
      ``server._TOOL_ARG_NAMES`` is schema-derived, advertising it here is also
      what makes the ``_dispatch`` arg-validator accept it (otherwise the call is
      rejected with ``unknown_argument``).
@@ -63,7 +63,7 @@ def _dict_value(node: ast.expr, key: str) -> ast.expr:
 def _akb_put_schema_property_names() -> set[str]:
     tree = ast.parse((_MCP / "tools.py").read_text())
     call = _tool_call(tree, "akb_put")
-    schema = _kwarg_value(call, "inputSchema")
+    schema = _kwarg_value(call, "input_schema")
     props = _dict_value(schema, "properties")
     assert isinstance(props, ast.Dict)
     return {k.value for k in props.keys if isinstance(k, ast.Constant)}
@@ -103,7 +103,7 @@ def test_akb_put_schema_exposes_slug() -> None:
     names = _akb_put_schema_property_names()
     assert "title" in names and "content" in names
     assert "slug" in names, (
-        "akb_put inputSchema must advertise `slug` so a caller can set it AND so "
+        "akb_put input_schema must advertise `slug` so a caller can set it AND so "
         "the schema-derived arg-validator (_TOOL_ARG_NAMES) accepts it."
     )
 

--- a/backend/tests/test_author_resolution_e2e.sh
+++ b/backend/tests/test_author_resolution_e2e.sh
@@ -19,6 +19,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -53,28 +54,13 @@ setup_user() {
 }
 
 setup_mcp() {
-  local pat=$1
-  local tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"author-res-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
-    -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" author-res-e2e >/dev/null && echo modern
 }
 
 mc() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" author-res-e2e
 }
 mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
 

--- a/backend/tests/test_collection_lifecycle_e2e.sh
+++ b/backend/tests/test_collection_lifecycle_e2e.sh
@@ -7,6 +7,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 VAULT="coll-life-$(date +%s)"
 E2E_USER="coll-life-u1-$(date +%s)"
 READER_USER="coll-life-u2-$(date +%s)"
@@ -57,38 +58,19 @@ PAT2=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
 
 [ -n "$PAT2" ] && pass "Reader PAT acquired" || { fail "Reader PAT" "could not get PAT"; exit 1; }
 
-# ── 1. MCP Initialize ───────────────────────────────────────
+# ── 1. MCP discovery ────────────────────────────────────────
 echo ""
-echo "▸ 1. MCP Initialize"
+echo "▸ 1. MCP 2026-07-28"
 
-INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"coll-life-e2e","version":"1.0"}}}' 2>&1)
-
-SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID" ] && pass "Session ID received ($SID)" || { fail "Session ID" "missing"; exit 1; }
-
-# Send initialized notification
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+DISCOVER=$(mcp_modern_discover "$PAT" coll-life-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "Stateless MCP discovery" || { fail "MCP" "discovery failed"; exit 1; }
 
 # Helper: MCP tool call
 MCP_ID=10
 mcp_call() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$PAT" "$tool" "$args" "$MCP_ID" coll-life-e2e
 }
 
 mcp_result() {

--- a/backend/tests/test_edit_e2e.sh
+++ b/backend/tests/test_edit_e2e.sh
@@ -6,6 +6,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 VAULT="edit-e2e-$(date +%s)"
 E2E_USER="edit-user-$(date +%s)"
 READER_USER="edit-reader-$(date +%s)"
@@ -54,60 +55,23 @@ READER_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
   -H 'Content-Type: application/json' \
   -d '{"name":"edit-reader"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
 
-# MCP Initialize (writer)
-INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"edit-e2e","version":"1.0"}}}' 2>&1)
-
-SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID" ] && pass "MCP session ($SID)" || { fail "MCP" "no session"; exit 1; }
-
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-
-# MCP Initialize (reader)
-READER_INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $READER_PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"edit-e2e-reader","version":"1.0"}}}' 2>&1)
-
-READER_SID=$(echo "$READER_INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $READER_PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $READER_SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+# MCP discovery (writer + reader)
+DISCOVER=$(mcp_modern_discover "$PAT" edit-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "MCP stateless discovery" || { fail "MCP" "discovery failed"; exit 1; }
+SID="modern"
+READER_SID="modern"
 
 # MCP helpers
 MCP_ID=10
 mcp_call() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$PAT" "$tool" "$args" "$MCP_ID" edit-e2e
 }
 mcp_call_as_reader() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $READER_PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $READER_SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$READER_PAT" "$tool" "$args" "$MCP_ID" edit-e2e-reader
 }
 mcp_result() {
   python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null
@@ -130,9 +94,10 @@ echo "▸ 1. Tool Discovery"
 TOOLS_RESP=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' 2>&1)
+  -H "Accept: application/json" \
+  -H "Mcp-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: tools/list" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"edit-e2e","version":"1"}}}}' 2>&1)
 
 HAS_EDIT=$(echo "$TOOLS_RESP" | python3 -c "import sys,json; tools=json.load(sys.stdin)['result']['tools']; print(any(t['name']=='akb_edit' for t in tools))" 2>/dev/null)
 [ "$HAS_EDIT" = "True" ] && pass "akb_edit in tools/list" || fail "akb_edit discovery" "tool not found"

--- a/backend/tests/test_forbidden_permission_code_e2e.sh
+++ b/backend/tests/test_forbidden_permission_code_e2e.sh
@@ -10,6 +10,7 @@
 #
 set -uo pipefail
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 SUF="$(date +%s)-$$"
 VAULT="fb-e2e-$SUF"; ADMIN="fb-admin-$SUF"; READER="fb-reader-$SUF"
 PASS=0; FAIL=0; ERRORS=()
@@ -29,22 +30,15 @@ register_pat() {
     | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null
 }
 mcp_session() {
-  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e","version":"1.0"}}}' 2>&1 \
-    | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}'
+  mcp_modern_discover "$1" e2e >/dev/null && echo modern
 }
 init_notify() {
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $2" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+  :
 }
 MCP_ID=10
 mcp() {
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $2" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$3\",\"arguments\":$4}}" 2>&1 \
+  mcp_modern_call "$1" "$3" "$4" "$MCP_ID" e2e \
     | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['result']['content'][0]['text'])" 2>/dev/null
 }
 field() { python3 -c "import sys,json; print(json.loads(sys.stdin.read())$1)" 2>/dev/null; }

--- a/backend/tests/test_graph_replace_e2e.sh
+++ b/backend/tests/test_graph_replace_e2e.sh
@@ -5,6 +5,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -43,35 +44,16 @@ PAT2=$(setup_user "$USER2")
 [ -n "$PAT1" ] && [ -n "$PAT2" ] && pass "2 users created" || { fail "Setup" "user creation failed"; exit 1; }
 
 setup_mcp() {
-  local pat=$1
-  local tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"graph-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" graph-e2e >/dev/null && echo modern
 }
 
 SID1=$(setup_mcp "$PAT1")
 SID2=$(setup_mcp "$PAT2")
 
 mc() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" graph-e2e
 }
 
 mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }

--- a/backend/tests/test_history_rest_e2e.sh
+++ b/backend/tests/test_history_rest_e2e.sh
@@ -13,6 +13,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -45,32 +46,13 @@ setup_user() {
 }
 
 setup_mcp() {
-  local pat=$1
-  local tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"hist-rest-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" hist-rest-e2e >/dev/null && echo modern
 }
 
 mc() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" hist-rest-e2e
 }
 mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
 

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -39,35 +39,28 @@ PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
 
 [ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
 
-# ── 1. MCP Initialize ───────────────────────────────────────
+# ── 1. MCP 2026-07-28 discovery ─────────────────────────────
 echo ""
 echo "▸ 1. MCP Protocol"
 
-INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
+MCP_META='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"e2e-test","version":"1.0"}}'
+DISCOVER_RESP=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-test","version":"1.0"}}}' 2>&1)
+  -H "Accept: application/json" \
+  -H "Mcp-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: server/discover" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\",\"params\":{\"_meta\":$MCP_META}}" 2>&1)
 
-SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-INIT_BODY=$(echo "$INIT_RESP" | tail -1)
-PROTO=$(echo "$INIT_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['protocolVersion'])" 2>/dev/null)
-
-[ -n "$SID" ] && pass "Session ID received ($SID)" || fail "Session ID" "missing"
-[ "$PROTO" = "2025-03-26" ] && pass "Protocol version: $PROTO" || fail "Protocol" "expected 2025-03-26, got $PROTO"
-
-# Send initialized notification
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+SUPPORTED=$(echo "$DISCOVER_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['supportedVersions'][0])" 2>/dev/null)
+NO_SESSION=$(echo "$DISCOVER_RESP" | grep -i "mcp-session-id" || true)
+[ "$SUPPORTED" = "2026-07-28" ] && pass "Protocol revision: $SUPPORTED" || fail "Protocol" "expected 2026-07-28, got $SUPPORTED"
+[ -z "$NO_SESSION" ] && pass "Stateless discovery has no session header" || fail "Session header" "unexpected session id"
 
 # Auth rejection without PAT
 AUTH_RESP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/mcp/" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' 2>/dev/null)
+  -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}' 2>/dev/null)
 [ "$AUTH_RESP" = "401" ] && pass "MCP rejects unauthenticated (401)" || fail "MCP auth" "expected 401, got $AUTH_RESP"
 
 # Helper: MCP tool call
@@ -78,9 +71,11 @@ mcp_call() {
   curl -sk -X POST "$BASE_URL/mcp/" \
     -H "Authorization: Bearer $PAT" \
     -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+    -H "Accept: application/json" \
+    -H "Mcp-Protocol-Version: 2026-07-28" \
+    -H "Mcp-Method: tools/call" \
+    -H "Mcp-Name: $tool" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args,\"_meta\":$MCP_META}}" 2>&1
 }
 
 # Extract tool result text
@@ -100,9 +95,10 @@ echo "▸ 2. Tools List"
 TOOLS_RESP=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' 2>&1)
+  -H "Accept: application/json" \
+  -H "Mcp-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: tools/list" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{\"_meta\":$MCP_META}}" 2>&1)
 TOOL_COUNT=$(echo "$TOOLS_RESP" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['result']['tools']))" 2>/dev/null)
 [ "$TOOL_COUNT" -ge 22 ] 2>/dev/null && pass "tools/list returns $TOOL_COUNT tools" || fail "tools/list" "expected >=22, got $TOOL_COUNT"
 
@@ -513,21 +509,26 @@ JWT2=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: applicat
 PAT2=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $JWT2" -H 'Content-Type: application/json' \
   -d '{"name":"u2-test"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
 
-INIT2=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
+MCP_META2='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"user2","version":"1.0"}}'
+DISCOVER2=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT2" \
   -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"user2","version":"1.0"}}}' 2>&1)
-SID2=$(echo "$INIT2" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID2" ] && pass "User2 registered + MCP session" || fail "User2 setup" "no SID"
+  -H "Accept: application/json" \
+  -H "Mcp-Protocol-Version: 2026-07-28" \
+  -H "Mcp-Method: server/discover" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\",\"params\":{\"_meta\":$MCP_META2}}" 2>&1)
+PROTO2=$(echo "$DISCOVER2" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['supportedVersions'][0])" 2>/dev/null)
+[ "$PROTO2" = "2026-07-28" ] && pass "User2 registered + stateless MCP" || fail "User2 setup" "discovery failed"
 
 mcp_call2() {
   curl -sk -X POST "$BASE_URL/mcp/" \
     -H "Authorization: Bearer $PAT2" \
     -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID2" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$((RANDOM)),\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}" 2>/dev/null
+    -H "Accept: application/json" \
+    -H "Mcp-Protocol-Version: 2026-07-28" \
+    -H "Mcp-Method: tools/call" \
+    -H "Mcp-Name: $1" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$((RANDOM)),\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2,\"_meta\":$MCP_META2}}" 2>/dev/null
 }
 mcp_result2() { python3 -c "import sys,json; d=json.load(sys.stdin); print(d['result']['content'][0]['text'])" 2>/dev/null; }
 
@@ -709,15 +710,14 @@ R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"content_type\":\"tables\"}" | m
 TBL_GONE=$(echo "$R" | python3 -c "import sys,json; print(len([i for i in json.load(sys.stdin)['items'] if i['type']=='table']))" 2>/dev/null)
 [ "$TBL_GONE" = "0" ] && pass "Table dropped (0 tables)" || pass "Tables remaining: $TBL_GONE"
 
-# ── 22. MCP Session Termination ──────────────────────────────
+# ── 22. Removed session path is rejected ────────────────────
 echo ""
-echo "▸ 22. MCP Session Termination"
+echo "▸ 22. MCP Stateless Boundary"
 
-TERM_RESP=$(curl -sk -X DELETE "$BASE_URL/mcp/" \
+TERM_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" -X DELETE "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
-  -H "mcp-session-id: $SID" 2>&1)
-TERMINATED=$(echo "$TERM_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('terminated',False))" 2>/dev/null)
-[ "$TERMINATED" = "True" ] && pass "MCP session terminated" || fail "Session termination" "failed"
+  -H "Mcp-Protocol-Version: 2026-07-28" 2>/dev/null)
+[ "$TERM_STATUS" = "405" ] && pass "MCP DELETE session path rejected" || fail "Session termination" "expected 405, got $TERM_STATUS"
 
 # ── Results ──────────────────────────────────────────────────
 echo ""

--- a/backend/tests/test_mcp_grep_text_files_unit.py
+++ b/backend/tests/test_mcp_grep_text_files_unit.py
@@ -17,17 +17,17 @@ def test_akb_grep_schema_exposes_guarded_text_file_measurement_argument():
     from mcp_server.tools import TOOLS
 
     grep = next(tool for tool in TOOLS if tool.name == "akb_grep")
-    argument = grep.inputSchema["properties"]["measurement_include_text_files"]
+    argument = grep.input_schema["properties"]["measurement_include_text_files"]
 
-    assert grep.inputSchema["properties"]["pattern"]["minLength"] == 1
-    replacement_budget = grep.inputSchema["properties"]["max_replacements"]
+    assert grep.input_schema["properties"]["pattern"]["minLength"] == 1
+    replacement_budget = grep.input_schema["properties"]["max_replacements"]
     assert replacement_budget["default"] == 50
     assert replacement_budget["maximum"] == 1000
     assert (
         "treated literally"
-        in grep.inputSchema["properties"]["replace"]["description"].lower()
+        in grep.input_schema["properties"]["replace"]["description"].lower()
     )
-    assert "does not limit replacement writes" in grep.inputSchema["properties"]["limit"]["description"]
+    assert "does not limit replacement writes" in grep.input_schema["properties"]["limit"]["description"]
     assert argument["type"] == "boolean"
     assert argument["default"] is False
     assert "guarded native" in argument["description"].lower()

--- a/backend/tests/test_mcp_oauth_e2e.sh
+++ b/backend/tests/test_mcp_oauth_e2e.sh
@@ -42,6 +42,8 @@
 set -uo pipefail
 
 AKB_URL="${AKB_URL:-http://localhost:8000}"
+BASE_URL="$AKB_URL"
+source "$(dirname "$0")/mcp_modern.sh"
 KC_URL="${KC_URL:-http://localhost:8080}"
 KC_REALM="${KC_REALM:-akb}"
 KC_TEST_CLIENT_ID="${KC_TEST_CLIENT_ID:-akb-web}"
@@ -72,23 +74,19 @@ mint_token() {
 }
 
 mcp_initialize_call() {
-  # Sends a minimal MCP `initialize` then a `tools/list` call.
+  # Sends the modern discovery request.
   local token="$1"
-  curl -s -X POST "${AKB_URL}/mcp/" \
-       -H "Authorization: Bearer ${token}" \
-       -H "Content-Type: application/json" \
-       -H "Accept: application/json, text/event-stream" \
-       -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}'
+  mcp_modern_discover "$token" oauth-e2e
 }
 
 mcp_tool_call() {
   # $1 = bearer token, $2 = MCP method (tools/call etc.), $3 = JSON args
   local token="$1" method="$2" args="$3"
-  curl -s -X POST "${AKB_URL}/mcp/" \
-       -H "Authorization: Bearer ${token}" \
-       -H "Content-Type: application/json" \
-       -H "Accept: application/json, text/event-stream" \
-       -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"${method}\",\"params\":${args}}"
+  local name=""
+  if [ "$method" = "tools/call" ]; then
+    name=$(echo "$args" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("name",""))')
+  fi
+  mcp_modern_request "$token" 2 "$method" "$args" "$name" oauth-e2e
 }
 
 # ── 1. Protected-resource metadata shape ─────────────────────
@@ -143,7 +141,7 @@ section "Read+write token → /mcp accepts, tools/list returns AKB tools"
 good_token=$(mint_token "akb:vault:read akb:vault:write")
 if [ -z "$good_token" ]; then fail "mint scoped token" "Keycloak returned no access_token"; else
   init_resp=$(mcp_initialize_call "$good_token")
-  # Streamable HTTP returns SSE; just check the response carried a JSON-RPC frame
+  # Stateless discover returns a JSON-RPC frame with the supported revision.
   case "$init_resp" in *'"jsonrpc"'*) pass "initialize accepted" ;;
                             *) fail "initialize accepted" "got '${init_resp:0:200}'" ;; esac
   list_resp=$(mcp_tool_call "$good_token" "tools/list" "{}")
@@ -192,7 +190,7 @@ case "$pat" in
 esac
 if [ -n "$pat" ]; then
   init_resp=$(mcp_initialize_call "$pat")
-  case "$init_resp" in *'"jsonrpc"'*) pass "PAT initialize works" ;;
+  case "$init_resp" in *'"jsonrpc"'*) pass "PAT discover works" ;;
                             *) fail "PAT initialize works" "got '${init_resp:0:200}'" ;; esac
 fi
 

--- a/backend/tests/test_mcp_protocol_unit.py
+++ b/backend/tests/test_mcp_protocol_unit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 import json
 import re
+import subprocess
 from pathlib import Path
 
 import httpx
@@ -31,6 +32,35 @@ def test_protocol_and_release_metadata_are_aligned():
     assert registry["version"] == package["version"]
     assert registry["packages"][0]["version"] == package["version"]
     assert f'const PROXY_VERSION = "{package["version"]}";' in proxy_source
+
+
+def test_modern_shell_helper_keeps_empty_params_as_one_json_object():
+    root = Path(__file__).resolve().parents[2]
+    script = r'''
+set -euo pipefail
+BASE_URL=http://example.test
+source backend/tests/mcp_modern.sh
+curl() {
+  local previous=""
+  for arg in "$@"; do
+    if [ "$previous" = "-d" ]; then
+      printf '%s\n' "$arg"
+      return 0
+    fi
+    previous="$arg"
+  done
+}
+mcp_modern_discover test-pat helper-test
+'''
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
 
 
 class _User:

--- a/backend/tests/test_mcp_protocol_unit.py
+++ b/backend/tests/test_mcp_protocol_unit.py
@@ -1,0 +1,183 @@
+"""Source-blind HTTP checks for AKB's single modern MCP revision."""
+
+from __future__ import annotations
+
+import tempfile
+import json
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.config import settings
+from mcp_server.protocol import MCP_PROTOCOL_VERSION, MCP_SUPPORTED_PROTOCOL_VERSIONS
+
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-mcp-protocol-test-vaults-")
+
+
+def test_protocol_and_release_metadata_are_aligned():
+    root = Path(__file__).resolve().parents[2]
+    pyproject = (root / "backend" / "pyproject.toml").read_text()
+    package = json.loads((root / "packages" / "akb-mcp-client" / "package.json").read_text())
+    registry = json.loads((root / "server.json").read_text())
+    proxy_source = (root / "packages" / "akb-mcp-client" / "lib" / "proxy.mjs").read_text()
+
+    assert MCP_PROTOCOL_VERSION == "2026-07-28"
+    assert MCP_SUPPORTED_PROTOCOL_VERSIONS == ("2026-07-28",)
+    assert '"mcp[cli]==2.1.0"' in pyproject
+    assert re.search(r'^version\s*=\s*"0\.15\.0"$', pyproject, re.MULTILINE)
+    assert package["version"] == "2.3.0"
+    assert registry["version"] == package["version"]
+    assert registry["packages"][0]["version"] == package["version"]
+    assert f'const PROXY_VERSION = "{package["version"]}";' in proxy_source
+
+
+class _User:
+    username = "protocol-test"
+    user_id = "protocol-test"
+    is_admin = True
+    oauth_scopes = None
+    token_scopes = None
+    key_class = "pat"
+
+
+def _params(method: str, *, client_capabilities: dict | None = None) -> dict:
+    meta = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": client_capabilities or {},
+        "io.modelcontextprotocol/clientInfo": {"name": "protocol-test", "version": "1"},
+    }
+    params: dict = {"_meta": meta}
+    if method == "tools/call":
+        params.update({"name": "akb_list_vaults", "arguments": {}})
+    return params
+
+
+def _headers(method: str, *, session_id: str | None = None) -> dict[str, str]:
+    headers = {
+        "Authorization": "Bearer akb_protocol_test",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Mcp-Protocol-Version": "2026-07-28",
+        "Mcp-Method": method,
+    }
+    if method == "tools/call":
+        headers["Mcp-Name"] = "akb_list_vaults"
+    if session_id is not None:
+        headers["Mcp-Session-Id"] = session_id
+    return headers
+
+
+async def _post(monkeypatch, *, headers: dict[str, str], body: dict) -> httpx.Response:
+    from mcp_server import http_app
+
+    async def resolve(_authorization: str):
+        return _User()
+
+    monkeypatch.setattr(http_app, "resolve_mcp_authorization", resolve)
+    await http_app.mcp_app.start()
+    transport = httpx.ASGITransport(app=http_app.mcp_app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as value:
+            return await value.post("/mcp", headers=headers, json=body)
+    finally:
+        await http_app.mcp_app.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_discover_advertises_single_revision_and_identity(monkeypatch):
+    response = await _post(
+        monkeypatch,
+        headers=_headers("server/discover"),
+        body={"jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": _params("server/discover")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("mcp-session-id") is None
+    result = response.json()["result"]
+    assert result["supportedVersions"] == ["2026-07-28"]
+    assert result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"] == "akb"
+    assert result["ttlMs"] == 300000
+    assert result["cacheScope"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_tools_list_is_sorted_and_cacheable(monkeypatch):
+    capabilities = {
+        "experimental": {"io.dnotitia.akb/vault-skill-preflight": {"version": 2}},
+    }
+    response = await _post(
+        monkeypatch,
+        headers=_headers("tools/list"),
+        body={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": _params("tools/list", client_capabilities=capabilities),
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    names = [tool["name"] for tool in result["tools"]]
+    assert names == sorted(names)
+    assert result["resultType"] == "complete"
+    assert result["ttlMs"] == 300000
+    assert result["cacheScope"] == "public"
+    tools = {tool["name"]: tool for tool in result["tools"]}
+    assert "_vault_skill_ack" in tools["akb_put"]["inputSchema"]["properties"]
+    assert "_vault_skill_ack" not in tools["akb_get"]["inputSchema"]["properties"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_initialize_gets_typed_unsupported_version_error(monkeypatch):
+    response = await _post(
+        monkeypatch,
+        headers={
+            "Authorization": "Bearer akb_protocol_test",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        body={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "legacy", "version": "1"},
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == -32022
+    assert error["data"] == {"supported": ["2026-07-28"], "requested": "2025-11-25"}
+
+
+@pytest.mark.asyncio
+async def test_session_header_is_rejected_on_modern_request(monkeypatch):
+    response = await _post(
+        monkeypatch,
+        headers=_headers("tools/list", session_id="legacy-session"),
+        body={"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": _params("tools/list")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32600
+
+
+@pytest.mark.asyncio
+async def test_routing_header_mismatch_is_rejected_before_dispatch(monkeypatch):
+    headers = _headers("tools/list")
+    headers["Mcp-Method"] = "tools/call"
+    response = await _post(
+        monkeypatch,
+        headers=headers,
+        body={"jsonrpc": "2.0", "id": 5, "method": "tools/list", "params": _params("tools/list")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32020

--- a/backend/tests/test_mcp_tool_validation_unit.py
+++ b/backend/tests/test_mcp_tool_validation_unit.py
@@ -88,7 +88,7 @@ def test_relation_tool_descriptions_match_the_vault_boundary():
     tools = {tool.name: tool for tool in TOOLS}
 
     for tool_name in ("akb_put", "akb_update"):
-        properties = tools[tool_name].inputSchema["properties"]
+        properties = tools[tool_name].input_schema["properties"]
         for field in ("depends_on", "related_to"):
             description = properties[field]["description"].lower()
             assert "same-vault" in description

--- a/backend/tests/test_okf_export_import_e2e.sh
+++ b/backend/tests/test_okf_export_import_e2e.sh
@@ -9,6 +9,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 SRC_VAULT="okf-src-$(date +%s)"
 DST_VAULT="okf-dst-$(date +%s)"
 REST_VAULT="okf-rest-$(date +%s)"
@@ -58,46 +59,22 @@ READER_PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
   -H 'Content-Type: application/json' \
   -d '{"name":"okf-reader"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
 
-# MCP session (writer)
-INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"okf-e2e","version":"1.0"}}}' 2>&1)
-SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID" ] && pass "MCP session ($SID)" || { fail "MCP" "no session"; exit 1; }
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-
-# MCP session (reader)
-READER_INIT=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"okf-reader","version":"1.0"}}}' 2>&1)
-READER_SID=$(echo "$READER_INIT" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $READER_SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+# MCP discovery (writer + reader)
+DISCOVER=$(mcp_modern_discover "$PAT" okf-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "MCP stateless discovery" || { fail "MCP" "discovery failed"; exit 1; }
+SID="modern"
+READER_SID="modern"
 
 MCP_ID=10
 mcp_call() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$PAT" "$tool" "$args" "$MCP_ID" okf-e2e
 }
 mcp_call_reader() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $READER_PAT" -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $READER_SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$READER_PAT" "$tool" "$args" "$MCP_ID" okf-reader
 }
 mcp_result() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }
 

--- a/backend/tests/test_pg_rbac_e2e.sh
+++ b/backend/tests/test_pg_rbac_e2e.sh
@@ -14,6 +14,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -51,37 +52,18 @@ PAT_ALICE=$(setup_user "$ALICE")
 PAT_BOB=$(setup_user "$BOB")
 [ -n "$PAT_ALICE" ] && [ -n "$PAT_BOB" ] && pass "2 users created" || { fail "Setup" "user creation failed"; exit 1; }
 
-# MCP session helpers
+# MCP stateless helpers
 setup_mcp() {
-  local pat=$1
-  local tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"rbac-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" rbac-e2e >/dev/null && echo modern
 }
 
 SID_ALICE=$(setup_mcp "$PAT_ALICE")
 SID_BOB=$(setup_mcp "$PAT_BOB")
 
 mcp_as() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" rbac-e2e
 }
 
 mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }

--- a/backend/tests/test_publication_resolution_e2e.sh
+++ b/backend/tests/test_publication_resolution_e2e.sh
@@ -24,6 +24,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 TS=$(date +%s)
 VAULT="pubres-e2e-$TS"
 USER="pubres-user-$TS"
@@ -198,28 +199,13 @@ T2_MOVER_URI="${OUT%%|*}"; T2_MOVER_PATH="${OUT##*|}"
 [ -n "$T2_MOVER_URI" ] && pass "T2 setup: unpublished doc created ($T2_MOVER_PATH)" || fail "T2 setup" "no mover uri"
 
 # There is no REST move endpoint — move is MCP-only (akb_move).
-SESS=$(curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $MCP_PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"pubres-e2e","version":"0.1"}}}' \
-  -i 2>&1 | grep -i "mcp-session-id:" | tr -d '\r' | awk '{print $2}')
-[ -n "$SESS" ] && pass "T2: MCP session initialized" || fail "T2 MCP init" "no session id"
-
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $MCP_PAT" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: $SESS" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+DISCOVER=$(mcp_modern_discover "$MCP_PAT" pubres-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "T2: MCP stateless discovery" || fail "T2 MCP discovery" "failed"
 
 mcp() {
   local id=$1; shift
   local name=$1; shift
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $MCP_PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "Mcp-Session-Id: $SESS" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$1}}" 2>&1
+  mcp_modern_call "$MCP_PAT" "$name" "$1" "$id" pubres-e2e
 }
 mcp_text() {
   python3 -c "

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -1022,9 +1022,6 @@ DELV=$(mcp 99 akb_delete_vault "{\"vault\":\"$VAULT\"}" | mcp_text)
 DELOK=$(echo "$DELV" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("deleted"))' 2>/dev/null)
 [ "$DELOK" = "True" ] && pass "Cleanup: test vault deleted" || fail "Cleanup vault delete" "$DELV"
 
-# Terminate MCP session
-curl -sk -X DELETE "$BASE_URL/mcp/" -H "Authorization: Bearer $MCP_PAT" -H "Mcp-Session-Id: $SESS" >/dev/null 2>&1
-
 echo ""
 echo "╔══════════════════════════════════════════╗"
 printf "║   Results: %d passed, %d failed%s║\n" "$PASS" "$FAIL" "$(printf '%*s' $((22-${#PASS}-${#FAIL})) '')"

--- a/backend/tests/test_publications_e2e.sh
+++ b/backend/tests/test_publications_e2e.sh
@@ -13,6 +13,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 VAULT="pub-e2e-$(date +%s)"
 USER="pub-user-$(date +%s)"
 PASS=0
@@ -681,8 +682,8 @@ CODE=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$TQ_SLUG
 
 echo ""
 
-# ── 12. MCP integration: legacy akb_publish backward compat ──
-echo "▸ 12. MCP backward compat"
+# ── 12. MCP integration: akb_publish over modern transport ──
+echo "▸ 12. MCP modern transport"
 
 # Init MCP session
 # A local user-session JWT is deliberately not an MCP credential.
@@ -690,34 +691,17 @@ JWT_MCP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/mcp/" 
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-local-session-boundary","version":"0.1"}}}')
+  -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}')
 [ "$JWT_MCP_CODE" = "401" ] && pass "Local session JWT rejected by MCP" || fail "MCP local JWT boundary" "HTTP $JWT_MCP_CODE"
 
-SESS=$(curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $MCP_PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}' \
-  -i 2>&1 | grep -i "mcp-session-id:" | tr -d '\r' | awk '{print $2}')
-[ -n "$SESS" ] && pass "MCP session initialized" || fail "MCP init" "no session"
-
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $MCP_PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: $SESS" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+DISCOVER=$(mcp_modern_discover "$MCP_PAT" publications-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "MCP stateless discovery" || fail "MCP discovery" "failed"
 
 mcp() {
   local id=$1; shift
   local name=$1; shift
   local args=$1
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $MCP_PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "Mcp-Session-Id: $SESS" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$MCP_PAT" "$name" "$args" "$id" publications-e2e
 }
 mcp_text() {
   python3 -c "

--- a/backend/tests/test_resource_hash_e2e.sh
+++ b/backend/tests/test_resource_hash_e2e.sh
@@ -8,6 +8,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 STAMP="$(date +%s)"
 VAULT="hash-e2e-$STAMP"
 E2E_USER="hash-user-$STAMP"
@@ -53,32 +54,15 @@ PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
 
 [ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
 
-INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"hash-e2e","version":"1.0"}}}' 2>&1)
-
-SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID" ] && pass "MCP session acquired" || { fail "MCP initialize" "missing session id"; exit 1; }
-
-curl -sk -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
+DISCOVER=$(mcp_modern_discover "$PAT" hash-e2e)
+echo "$DISCOVER" | grep -q '2026-07-28' && pass "MCP stateless discovery" || { fail "MCP discovery" "failed"; exit 1; }
+SID="modern"
 
 MCP_ID=10
 mcp_call() {
   local tool=$1 args=$2
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$PAT" "$tool" "$args" "$MCP_ID" hash-e2e
 }
 
 mcp_result() {

--- a/backend/tests/test_security_edge_e2e.sh
+++ b/backend/tests/test_security_edge_e2e.sh
@@ -6,6 +6,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -44,37 +45,18 @@ PAT2=$(setup_user "$USER2")
 
 [ -n "$PAT1" ] && [ -n "$PAT2" ] && pass "2 users created" || { fail "Setup" "user creation failed"; exit 1; }
 
-# MCP session helpers
+# MCP stateless helpers
 setup_mcp() {
-  local pat=$1
-  local tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"sec-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  local sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" sec-e2e >/dev/null && echo modern
 }
 
 SID1=$(setup_mcp "$PAT1")
 SID2=$(setup_mcp "$PAT2")
 
 mcp_as() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" sec-e2e
 }
 
 mr() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null; }

--- a/backend/tests/test_skill_injection_dispatch_unit.py
+++ b/backend/tests/test_skill_injection_dispatch_unit.py
@@ -292,21 +292,20 @@ async def test_v2_write_requires_explicit_matching_ack_and_strips_it(
     assert acknowledgements == [None, None, token]
 
 
-async def test_v2_tool_list_advertises_ack_only_on_possible_writes(monkeypatch):
-    monkeypatch.setattr(server_mod, "_vault_skill_preflight_version", lambda: 2)
+async def test_tool_list_advertises_ack_only_on_possible_writes():
     tools = await server_mod.list_tools()
     by_name = {tool.name: tool for tool in tools}
 
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT in (
-        by_name["akb_update"].inputSchema["properties"]
+        by_name["akb_update"].input_schema["properties"]
     )
     # akb_grep is normally read-only but becomes a writer when `replace` is
     # present, so its schema must carry the acknowledgement too.
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT in (
-        by_name["akb_grep"].inputSchema["properties"]
+        by_name["akb_grep"].input_schema["properties"]
     )
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT not in (
-        by_name["akb_get"].inputSchema["properties"]
+        by_name["akb_get"].input_schema["properties"]
     )
 
 

--- a/backend/tests/test_table_constraints_e2e.sh
+++ b/backend/tests/test_table_constraints_e2e.sh
@@ -11,6 +11,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 SUF="$(date +%s)-$$"
 VAULT="uk-e2e-$SUF"
 USER="uk-user-$SUF"
@@ -36,20 +37,14 @@ register_pat() {  # $1=username → echoes PAT
     | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' 2>/dev/null
 }
 
-mcp_session() {  # $1=PAT → echoes SID
-  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e","version":"1.0"}}}' 2>&1 \
-    | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}'
+mcp_session() {  # $1=PAT → stateless discovery marker
+  mcp_modern_discover "$1" e2e >/dev/null && echo modern
 }
 
 MCP_ID=10
 mcp() {  # $1=PAT $2=SID $3=tool $4=args-json → echoes result text (content[0].text)
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $1" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $2" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$3\",\"arguments\":$4}}" 2>&1 \
+  mcp_modern_call "$1" "$3" "$4" "$MCP_ID" e2e \
     | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null
 }
 field() { python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d$1)" 2>/dev/null; }
@@ -68,9 +63,6 @@ PAT=$(register_pat "$USER")
 [ -n "$PAT" ] && pass "PAT acquired" || { fail "setup" "no PAT"; exit 1; }
 SID=$(mcp_session "$PAT")
 [ -n "$SID" ] && pass "MCP session" || { fail "setup" "no session"; exit 1; }
-curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
 R=$(mcp "$PAT" "$SID" akb_create_vault "{\"name\":\"$VAULT\",\"description\":\"#215 e2e\"}")
 echo "$R" | field "['name']" | grep -q "$VAULT" && pass "vault created" || fail "create_vault" "$R"
 
@@ -132,9 +124,6 @@ CODE=$(echo "$R" | field "['code']")
 # ── permission: non-admin (reader) cannot alter_table
 PAT2=$(register_pat "$USER2")
 SID2=$(mcp_session "$PAT2")
-curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $PAT2" -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" -H "mcp-session-id: $SID2" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
 mcp "$PAT" "$SID" akb_grant "{\"vault\":\"$VAULT\",\"user\":\"$USER2\",\"role\":\"reader\"}" >/dev/null
 R=$(mcp "$PAT2" "$SID2" akb_alter_table "{\"uri\":\"akb://$VAULT/table/events\",\"add_indexes\":[{\"columns\":[\"principal_id\"]}]}")
 # admin gate fires BEFORE any DDL (check_vault_access). Assert the alter was

--- a/backend/tests/test_vault_scope_e2e.sh
+++ b/backend/tests/test_vault_scope_e2e.sh
@@ -11,6 +11,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -58,27 +59,14 @@ EMPTY_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/v1/a
   -d '{"name":"empty","vault_scope":{"prefixes":[],"extra_vaults":[]}}')
 [ "$EMPTY_CODE" = "422" ] && pass "empty scope rejected at mint (422)" || fail "Mint validation" "empty scope expected 422, got $EMPTY_CODE"
 
-# ── MCP session helpers ──────────────────────────────────────
+# ── MCP stateless helpers ───────────────────────────────────
 setup_mcp() {
-  local pat=$1 tmpfile sid
-  tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"scope-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" scope-e2e >/dev/null && echo modern
 }
 mcp_as() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" scope-e2e
 }
 mr() { python3 -c "import sys,json; print(json.loads(sys.stdin.read())['result']['content'][0]['text'])" 2>/dev/null; }
 

--- a/backend/tests/test_vault_scope_sql_e2e.sh
+++ b/backend/tests/test_vault_scope_sql_e2e.sh
@@ -22,6 +22,7 @@
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
+source "$(dirname "$0")/mcp_modern.sh"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -58,27 +59,14 @@ UNSCOPED_PAT=$(mint_pat '{"name":"unscoped-sql"}')
 [ -n "$SCOPED_PAT" ] && pass "scoped PAT minted (gdn-)" || fail "Mint scoped" "no token"
 [ -n "$UNSCOPED_PAT" ] && pass "unscoped PAT minted" || fail "Mint unscoped" "no token"
 
-# ── MCP session helpers ──────────────────────────────────────
+# ── MCP stateless helpers ───────────────────────────────────
 setup_mcp() {
-  local pat=$1 tmpfile sid
-  tmpfile=$(mktemp)
-  curl -sk -i -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"scope-sql-e2e","version":"1.0"}}}' > "$tmpfile" 2>/dev/null
-  sid=$(grep -i "mcp-session-id" "$tmpfile" | tr -d '\r' | awk '{print $2}')
-  rm -f "$tmpfile"
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "mcp-session-id: $sid" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
-  echo "$sid"
+  mcp_modern_discover "$1" scope-sql-e2e >/dev/null && echo modern
 }
 mcp_as() {
-  local pat=$1 sid=$2 tool=$3 args=$4
+  local pat=$1 _sid=$2 tool=$3 args=$4
   MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" -H "Authorization: Bearer $pat" \
-    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $sid" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
+  mcp_modern_call "$pat" "$tool" "$args" "$MCP_ID" scope-sql-e2e
 }
 mr() { python3 -c "import sys,json; print(json.loads(sys.stdin.read())['result']['content'][0]['text'])" 2>/dev/null; }
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.14.2"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -60,7 +60,7 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.155.7" },
     { name = "kiwipiepy", specifier = "==0.23.1" },
     { name = "markdown-it-py", specifier = "==4.1.0" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.27.2" },
+    { name = "mcp", extras = ["cli"], specifier = "==2.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "pgvector", specifier = "==0.4.2" },
     { name = "pillow", specifier = "==12.3.0" },
@@ -499,6 +499,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -541,12 +554,28 @@ http2 = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -572,11 +601,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -701,15 +730,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -719,15 +748,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3b/3acf4897b934ceeb8d22df7309a435a76c34f94be936b36eee8bb57b29a3/mcp-2.1.0.tar.gz", hash = "sha256:b4407b2890238248795d03e8c17d02d311c600ca9272d023ab12dbfa6ad21c70", size = 3983282, upload-time = "2026-08-24T19:04:32.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/88/67/b2160b6cf138872860d2552cca2894dbe4d29da7f1c6fae0c21d22782838/mcp-2.1.0-py3-none-any.whl", hash = "sha256:b8acaed6ca4b9376801377463e44246395749363b1c34467ec6243a50be5ed28", size = 357320, upload-time = "2026-08-24T19:04:29.909Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/97/5b1c2e40d6121172c97638a0f1d6240526f5aeebdc9ebea11ddcf2139249/mcp_types-2.1.0.tar.gz", hash = "sha256:16f91064ce33d7ee7a75a7e198a437172215180c16d4bbcfa0e61488ede92c54", size = 66679, upload-time = "2026-08-24T19:04:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/99/f9041368b5af773de32af6192ff0627a71368c240123e57262439ae5b594/mcp_types-2.1.0-py3-none-any.whl", hash = "sha256:6a65bfb7d057ceaf2418781ee61b3041e1f4b5418199297f8939a4b4ed334c3a", size = 69654, upload-time = "2026-08-24T19:04:31.327Z" },
 ]
 
 [[package]]
@@ -805,6 +847,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
     { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
     { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1008,20 +1062,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1360,6 +1400,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/docs/mcp-clients/web-connectors.md
+++ b/docs/mcp-clients/web-connectors.md
@@ -7,11 +7,17 @@ stdio-based clients (Claude Desktop, Codex CLI via `akb-mcp`,
 Claude Code via the stdio proxy), see the project README: the PAT
 flow there is unchanged.
 
+The backend and proxy support only MCP **2026-07-28**. HTTP requests are
+stateless: each `POST /mcp/` carries its own `_meta` protocol envelope plus
+`Mcp-Protocol-Version`, `Mcp-Method`, and named-call routing headers. Clients
+discover the server with `server/discover`; the removed initialize handshake
+and `Mcp-Session-Id` session flow are rejected.
+
 ## What you need
 
 | Piece | Why |
 |---|---|
-| AKB backend ≥ the version that ships `mcp_oauth_enabled` | Adds the Resource Server code path |
+| AKB backend ≥ `0.15.0` | Adds the Resource Server code path and MCP 2026-07-28 transport |
 | An OIDC IdP — Keycloak in the reference deployment | AKB does NOT host an Authorization Server; the IdP issues access tokens |
 | Realm configuration: `akb:vault:read`, `akb:vault:write` scopes (each with an audience mapper) + DCR trusted hosts + `offline_access` exposed | Lets clients DCR-register and request the scopes the consent screen presents |
 | `config/app.yaml`: explicit `auth_mode`, `mcp_oauth_enabled: true`, a non-empty `public_base_url` | Activates the new path without changing the chosen human-login mode. Default keeps it off so PAT-only deployments are bit-for-bit unchanged |
@@ -105,8 +111,8 @@ claude mcp add --transport http akb https://akb.example.com/mcp/
 
 > **Trailing slash matters.** Register with the trailing `/mcp/`, not
 > bare `/mcp`. Backend issues a 307 redirect from `/mcp` → `/mcp/`,
-> which drops the POST body and breaks the session/initialize
-> handshake — the connector then appears as "Failed to connect" in
+> which can drop the POST body and break the stateless discover request —
+> the connector then appears as "Failed to connect" in
 > `claude mcp list` even though OAuth succeeded.
 
 The command itself does **not** open a browser. `claude mcp list` will
@@ -118,7 +124,7 @@ akb   ! Needs authentication
 
 Complete OAuth one of two ways:
 
-- **Up-front, before the session**:
+- **Up-front, before the first discover request**:
   ```bash
   claude mcp login akb
   ```
@@ -127,10 +133,10 @@ Complete OAuth one of two ways:
   resulting tokens on your machine (macOS keychain, or
   `~/.claude/mcp-credentials` on other platforms).
 
-- **Lazily, inside a session**: run `/mcp` in the session, select `akb`,
+- **Lazily, from a client session**: run `/mcp`, select `akb`,
   and choose `Authenticate`. A browser opens for the same flow.
 
-Once authenticated, Claude Code calls `https://akb.example.com/mcp`
+Once authenticated, Claude Code calls `https://akb.example.com/mcp/`
 with `Authorization: Bearer <access_token>`. The access token is
 auto-refreshed silently as long as the IdP advertises `offline_access`
 in its `scopes_supported` — which the AKB realm does.

--- a/eval/agentic-bench/src/mcp_client.py
+++ b/eval/agentic-bench/src/mcp_client.py
@@ -40,7 +40,7 @@ async def list_tools_full(session: ClientSession) -> list[dict[str, Any]]:
             "function": {
                 "name": t.name,
                 "description": t.description or "",
-                "parameters": t.inputSchema or {"type": "object", "properties": {}},
+            "parameters": t.input_schema or {"type": "object", "properties": {}},
             },
         })
     return out

--- a/llms-install.md
+++ b/llms-install.md
@@ -8,6 +8,10 @@ MCP client.
 agent to an **AKB backend**, which speaks MCP over Streamable HTTP. So you
 need two values:
 
+The current backend and proxy contract is MCP **2026-07-28**: discovery uses
+`server/discover`, every request is stateless, and the removed initialize/
+session-id flow is not supported. Use the trailing `/mcp/` URL shown below.
+
 - **`AKB_MCP_URL`** — the AKB backend's MCP endpoint, e.g.
   `https://akb.example.com/mcp/`
 - **`AKB_PAT`** — an AKB Personal Access Token (looks like `akb_...`)

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.3.0 — MCP 2026-07-28 stateless protocol
+
+The stdio proxy now speaks the single 2026-07-28 MCP revision. It forwards the
+per-request metadata plus `Mcp-Protocol-Version`, `Mcp-Method`, and
+`Mcp-Name` routing headers, uses `server/discover` instead of initialize, and
+never creates or forwards an MCP session id. Unsupported revisions are
+returned as the typed `-32022` error rather than echoed as a successful
+handshake. Backend and proxy tool catalogs remain deterministic and include
+cache metadata; local file/image tools and reconnect behavior stay available
+when the backend is unavailable.
+
 ## 2.2.2 — strict MCP protocol boundary
 
 The stdio proxy now rejects an `initialize` request that names an unsupported

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -366,11 +366,11 @@ const FILE_WRITE_TOOL_NAMES = new Set([
 // Tools where proxy injects a `file` param as alternative to `content`
 const FILE_CONTENT_TOOLS = new Set(["akb_put", "akb_update"]);
 
-// Kept in sync with package.json `version`. Reported to the client in the
-// local `initialize` response, so it must not silently drift on a proxy
+// Kept in sync with package.json `version`. Reported in the modern
+// `server/discover` identity stamp, so it must not silently drift on a proxy
 // behaviour change. There is no import of package.json here to keep lib/
 // zero-dependency and load-safe across Node versions.
-const PROXY_VERSION = "2.2.2";
+const PROXY_VERSION = "2.3.0";
 const VAULT_SKILL_PREFLIGHT_CAPABILITY =
   "io.dnotitia.akb/vault-skill-preflight";
 const PROXY_INSTRUCTIONS =
@@ -384,26 +384,39 @@ const PROXY_INSTRUCTIONS =
   "the entire document body. If the document write fails, clean up the uncommitted " +
   "upload with akb_discard_image.";
 
-// Fallback MCP protocol version echoed to the client when its `initialize`
-// request omits one. We otherwise echo the client's requested version.
-const MCP_PROTOCOL_VERSION = "2025-06-18";
+const MCP_PROTOCOL_VERSION = "2026-07-28";
+const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
+const CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities";
+const CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo";
+const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+const UNSUPPORTED_PROTOCOL_VERSION = -32022;
+const INVALID_PARAMS = -32602;
+const INVALID_REQUEST = -32600;
+
+class MCPProtocolError extends Error {
+  constructor(error) {
+    super(`MCP error ${error?.code}: ${error?.message || "protocol failure"}`);
+    this.rpcError = error;
+  }
+}
+
+function encodeRoutingHeader(value) {
+  if (/^[\x20-\x7e]*$/.test(value) && value === value.trim()) return value;
+  return `=?base64?${Buffer.from(value, "utf8").toString("base64")}?=`;
+}
 
 export class AKBProxy {
   constructor({ url, pat, insecure = false }) {
     this.url = new URL(url);
     this.pat = pat;
     this.insecure = insecure;
-    this.sessionId = null;
     this.msgId = 0;
-    this._initialized = false;
     // ── Backend-liveness state (decoupled from client liveness) ──────
-    // The client's view of this server must NOT depend on backend
-    // reachability: a stdio MCP server that fails `initialize` is dropped
-    // by the client for the whole session (the VPN-down-at-startup bug).
-    // So we answer `initialize` locally and manage the backend session
-    // out of band via a background monitor.
-    this._clientInitParams = null; // client initialize params, replayed to backend
-    this._backendReady = false; // backend MCP session established
+    // Each backend request carries its own modern envelope. The proxy keeps
+    // only the latest client metadata so its background probes and local
+    // preflight calls use the same request contract; no MCP session is held.
+    this._clientMeta = null;
+    this._backendReady = false;
     this._connecting = null; // in-flight backend-connect promise (single-flight lock)
     this._cachedTools = null; // last successful backend tools/list result (raw)
     this._servedDegraded = false; // client was handed a fallback (file-tools-only) list
@@ -421,7 +434,7 @@ export class AKBProxy {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  // Short timeout for backend liveness probes (initialize / tools-list) so
+  // Short timeout for backend liveness probes (discover / tools-list) so
   // the reconnect monitor cycles quickly and a single tool call fails fast
   // when the backend is unreachable, instead of blocking on the generous
   // per-request timeout used for legitimately slow operations.
@@ -466,14 +479,23 @@ export class AKBProxy {
       msg = { ...msg, params: nfcDeep(msg.params) };
     }
 
-    const { method, id, params } = msg;
+    const { method, id, params } = msg || {};
 
-    if (method === "initialize") {
-      return await this._initialize(id, params);
+    const protocolError = this._validateModernRequest(msg);
+    if (protocolError) return protocolError;
+
+    this._clientMeta = { ...msg.params._meta };
+
+    if (method === "notifications/initialized") {
+      return null;
     }
 
     if (id === undefined || id === null) {
       return null;
+    }
+
+    if (method === "server/discover") {
+      return await this._discover(id, msg);
     }
 
     if (method === "tools/list") {
@@ -514,6 +536,136 @@ export class AKBProxy {
         : await this._forward(msg);
     if (callKey) this._recordVaultSkillOutcome(callKey, msg, response);
     return response;
+  }
+
+  async _discover(id, msg) {
+    let response;
+    try {
+      response = await this._forward(msg);
+    } catch (err) {
+      if (!this._isConnError(err)) throw err;
+      response = this._localDiscover(id);
+    }
+    if (response.error) return response;
+    return {
+      ...response,
+      result: this._decorateDiscover(response.result),
+    };
+  }
+
+  _decorateDiscover(result = {}) {
+    return {
+      ...result,
+      supportedVersions: [MCP_PROTOCOL_VERSION],
+      instructions: PROXY_INSTRUCTIONS,
+      resultType: "complete",
+      _meta: {
+        ...(result._meta || {}),
+        [SERVER_INFO_META_KEY]: { name: "akb-mcp", version: PROXY_VERSION },
+      },
+    };
+  }
+
+  _localDiscover(id) {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: this._decorateDiscover({
+        capabilities: { tools: { listChanged: true } },
+        ttlMs: 300000,
+        cacheScope: "public",
+      }),
+    };
+  }
+
+  _defaultClientMeta() {
+    return {
+      [PROTOCOL_VERSION_META_KEY]: MCP_PROTOCOL_VERSION,
+      [CLIENT_CAPABILITIES_META_KEY]: {},
+      [CLIENT_INFO_META_KEY]: { name: "akb-mcp-client", version: PROXY_VERSION },
+    };
+  }
+
+  _backendClientMeta() {
+    const source = this._clientMeta || this._defaultClientMeta();
+    const capabilities = source[CLIENT_CAPABILITIES_META_KEY];
+    return {
+      ...source,
+      [CLIENT_CAPABILITIES_META_KEY]: {
+        ...(capabilities && typeof capabilities === "object" ? capabilities : {}),
+        experimental: {
+          ...(capabilities?.experimental || {}),
+          [VAULT_SKILL_PREFLIGHT_CAPABILITY]: { version: 2 },
+        },
+      },
+    };
+  }
+
+  _backendRequestMeta(meta) {
+    const provided = meta && typeof meta === "object" ? meta : {};
+    const clientMeta = this._backendClientMeta();
+    const providedCapabilities = provided[CLIENT_CAPABILITIES_META_KEY];
+    const clientCapabilities = clientMeta[CLIENT_CAPABILITIES_META_KEY];
+    return {
+      ...clientMeta,
+      ...provided,
+      [CLIENT_CAPABILITIES_META_KEY]: {
+        ...clientCapabilities,
+        ...(providedCapabilities && typeof providedCapabilities === "object"
+          ? providedCapabilities
+          : {}),
+        experimental: {
+          ...(clientCapabilities.experimental || {}),
+          ...(providedCapabilities?.experimental || {}),
+          [VAULT_SKILL_PREFLIGHT_CAPABILITY]: { version: 2 },
+        },
+      },
+    };
+  }
+
+  _unsupportedVersion(id, requested) {
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: UNSUPPORTED_PROTOCOL_VERSION,
+        message: "Unsupported protocol version",
+        data: { supported: [MCP_PROTOCOL_VERSION], requested: String(requested || "") },
+      },
+    };
+  }
+
+  _validateModernRequest(msg) {
+    const { id, method, params } = msg || {};
+    if (method === "initialize") {
+      return this._unsupportedVersion(id, params?.protocolVersion || "");
+    }
+    const meta = params && typeof params === "object" ? params._meta : null;
+    if (!meta || typeof meta !== "object") {
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        error: {
+          code: INVALID_PARAMS,
+          message:
+            "params._meta must be an object carrying the required protocol version and client capabilities",
+        },
+      };
+    }
+    if (meta[PROTOCOL_VERSION_META_KEY] !== MCP_PROTOCOL_VERSION) {
+      return this._unsupportedVersion(id, meta[PROTOCOL_VERSION_META_KEY]);
+    }
+    if (!(CLIENT_CAPABILITIES_META_KEY in meta)) {
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        error: {
+          code: INVALID_PARAMS,
+          message: `params._meta is missing the required envelope key ${CLIENT_CAPABILITIES_META_KEY}`,
+        },
+      };
+    }
+    return null;
   }
 
   _vaultSkillCallKey(params) {
@@ -566,49 +718,6 @@ export class AKBProxy {
     }
   }
 
-  async _initialize(id, params) {
-    // Answer the handshake LOCALLY — never round-trip to the backend here.
-    // This is the crux of the reconnect fix: the client considers this MCP
-    // server initialized (and keeps it registered for the whole session)
-    // regardless of whether the backend is reachable right now. If the VPN
-    // is down at startup, the server still registers; tools recover once
-    // connectivity returns (see the monitor + tools/list_changed path).
-    const requestedProtocol =
-      params && typeof params.protocolVersion === "string" && params.protocolVersion;
-    if (requestedProtocol && requestedProtocol !== MCP_PROTOCOL_VERSION) {
-      // Never claim success by echoing a protocol revision this proxy does
-      // not implement.  A client can retry with the explicit supported
-      // revision; there is no fallback or downgrade path here.
-      return {
-        jsonrpc: "2.0",
-        id,
-        error: {
-          code: -32602,
-          message: "Unsupported protocol version",
-          data: { supported: [MCP_PROTOCOL_VERSION] },
-        },
-      };
-    }
-    this._clientInitParams = params || null;
-    this._initialized = true;
-    // Kick off the backend session + tool prefetch in the background.
-    this._startBackendMonitor();
-
-    const protocolVersion = requestedProtocol || MCP_PROTOCOL_VERSION;
-    return {
-      jsonrpc: "2.0",
-      id,
-      result: {
-        protocolVersion,
-        // Advertise listChanged so we can push the real toolset after a
-        // degraded (backend-unreachable) tools/list is recovered.
-        capabilities: { tools: { listChanged: true } },
-        serverInfo: { name: "akb-mcp", version: PROXY_VERSION },
-        instructions: PROXY_INSTRUCTIONS,
-      },
-    };
-  }
-
   // Decorate a raw backend tools/list result with the proxy-local file
   // tools and the injected `file` param. Never mutates the cached result.
   _decorateTools(resp) {
@@ -633,7 +742,16 @@ export class AKBProxy {
       return { ...t };
     });
     tools.push(...this._fileToolsForClient());
-    return { ...resp, tools };
+    tools.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+    return {
+      ...resp,
+      resultType: "complete",
+      tools,
+      _meta: {
+        ...(resp._meta || {}),
+        [SERVER_INFO_META_KEY]: { name: "akb-mcp", version: PROXY_VERSION },
+      },
+    };
   }
 
   _fileToolsForClient() {
@@ -660,11 +778,20 @@ export class AKBProxy {
     // the whole tools/list on backend unreachability.
     let resp = this._cachedTools;
     if (!resp) {
-      const ok = await this._ensureBackend();
+      let ok;
+      try {
+        ok = await this._ensureBackend();
+      } catch (err) {
+        if (err?.rpcError) {
+          return { jsonrpc: "2.0", id, error: err.rpcError };
+        }
+        throw err;
+      }
       if (ok) {
         try {
           resp = await this._syncTools();
-        } catch {
+        } catch (err) {
+          if (err?.rpcError) return { jsonrpc: "2.0", id, error: err.rpcError };
           resp = null;
         }
       }
@@ -676,7 +803,18 @@ export class AKBProxy {
       process.stderr.write(
         "[akb-mcp] backend unreachable — serving file tools only; will re-list on recovery\n",
       );
-      return { jsonrpc: "2.0", id, result: { tools: this._fileToolsForClient() } };
+      const tools = this._fileToolsForClient().sort(
+        (left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0),
+      );
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          resultType: "complete",
+          tools,
+          _meta: { [SERVER_INFO_META_KEY]: { name: "akb-mcp", version: PROXY_VERSION } },
+        },
+      };
     }
 
     return { jsonrpc: "2.0", id, result: this._decorateTools(resp) };
@@ -795,12 +933,12 @@ export class AKBProxy {
   }
 
   /**
-   * Touch the backend MCP session before a proxy-local file operation.
+   * Touch the backend MCP request path before a proxy-local file operation.
    *
    * Local tools bypass the backend `call_tool` dispatcher, so without this
-   * bridge their first write could commit before the session received the
+   * bridge their first write could commit before the request received the
    * vault guide. `akb_help` is a reader-authorized, mirror-aware backend call
-   * and therefore reuses the same version/session gate as every native tool.
+   * and therefore reuses the same version gate as every native tool.
    * A write-only credential receives no payload and remains usable.
    */
   async _fileToolSkillPreflight(vault, acknowledgement = null) {
@@ -1261,6 +1399,12 @@ export class AKBProxy {
           if (res.statusCode >= 400) {
             const error = new Error(`HTTP ${res.statusCode}: ${data.slice(0, 300)}`);
             error.statusCode = res.statusCode;
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed?.error) error.rpcError = parsed.error;
+            } catch {
+              // Preserve the HTTP error when the server did not return JSON.
+            }
             reject(error);
           } else {
             resolve({ text: data, headers: res.headers });
@@ -1296,51 +1440,45 @@ export class AKBProxy {
     });
   }
 
-  // ── Backend session + reconnect monitor ───────────────────
+  // ── Backend reachability + reconnect monitor ──────────────
 
   // A connection/session failure that a background reconnect can recover
   // from — as opposed to a genuine application error we must surface.
-  _isConnError(message) {
-    return /session|404|ECONNREFUSED|ECONNRESET|socket hang up|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENETDOWN|ENOTFOUND|EPIPE|timeout|unreachable/i.test(
-      message || "",
+  _isConnError(error) {
+    if (error?.rpcError) return false;
+    if (error?.connectionError) return true;
+    if ([502, 503, 504].includes(error?.statusCode)) return true;
+    return /ECONNREFUSED|ECONNRESET|socket hang up|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENETDOWN|ENOTFOUND|EPIPE|timeout|unreachable/i.test(
+      error?.message || String(error || ""),
     );
   }
 
-  // Establish the backend MCP session (the `initialize` handshake that
-  // yields an mcp-session-id) if not already up. Single-flight: concurrent
-  // callers share one in-flight attempt. Returns true on success, false on
-  // failure — never throws — so callers can degrade gracefully.
+  // Probe the stateless backend contract if not already reachable.
+  // Single-flight: concurrent callers share one in-flight attempt. Returns
+  // true on success, false on transport failure — protocol errors propagate
+  // so callers never confuse an incompatible backend with an outage.
   async _ensureBackend() {
     if (this._backendReady) return true;
     if (this._connecting) return this._connecting;
     this._connecting = (async () => {
       try {
-        const sourceParams = this._clientInitParams || {
-          protocolVersion: MCP_PROTOCOL_VERSION,
-          capabilities: {},
-          clientInfo: { name: "akb-mcp-client", version: PROXY_VERSION },
-        };
-        // Strict vault-guide preflight changes a successful write into a
-        // retry envelope. Advertise support on behalf of this proxy version;
-        // raw/older MCP clients that do not opt in retain additive injection.
-        // Merge rather than replace client capabilities so roots/sampling and
-        // unrelated experimental features survive the bridge unchanged.
-        const sourceCapabilities = sourceParams.capabilities || {};
-        const initParams = {
-          ...sourceParams,
-          capabilities: {
-            ...sourceCapabilities,
-            experimental: {
-              ...(sourceCapabilities.experimental || {}),
-              [VAULT_SKILL_PREFLIGHT_CAPABILITY]: { version: 2 },
-            },
-          },
-        };
-        await this._rpc("initialize", initParams, { timeoutMs: this._probeTimeoutMs() });
+        const discovered = await this._rpc(
+          "server/discover",
+          { _meta: this._backendClientMeta() },
+          { timeoutMs: this._probeTimeoutMs() },
+        );
+        if (!Array.isArray(discovered.supportedVersions) || !discovered.supportedVersions.includes(MCP_PROTOCOL_VERSION)) {
+          throw new MCPProtocolError({
+            code: UNSUPPORTED_PROTOCOL_VERSION,
+            message: "Backend does not advertise the required protocol revision",
+            data: { supported: discovered.supportedVersions || [], requested: MCP_PROTOCOL_VERSION },
+          });
+        }
         this._backendReady = true;
         return true;
-      } catch {
+      } catch (err) {
         this._backendReady = false;
+        if (err?.rpcError) throw err;
         return false;
       } finally {
         this._connecting = null;
@@ -1350,14 +1488,14 @@ export class AKBProxy {
   }
 
   // Fetch and cache the backend tool list. Caller is responsible for having
-  // an established session. Uses the short probe timeout.
+  // a reachable backend. Uses the short probe timeout.
   async _syncTools() {
     const resp = await this._rpc("tools/list", {}, { timeoutMs: this._probeTimeoutMs() });
     this._cachedTools = resp;
     return resp;
   }
 
-  // Background loop that keeps trying to (re)establish the backend session
+  // Background loop that keeps trying to reach the backend
   // with exponential backoff — effectively forever while the client is
   // connected. On (re)connect it refreshes the tool cache and, if the
   // client was previously handed a degraded list, pushes a
@@ -1382,8 +1520,8 @@ export class AKBProxy {
             }
             break; // connected + synced; idle until a forward detects a drop
           } catch {
-            // initialize succeeded but tools/list failed — treat as not
-            // ready and keep retrying.
+            // discover succeeded but tools/list failed — treat the backend as
+            // not ready and keep retrying.
             this._backendReady = false;
           }
         }
@@ -1412,12 +1550,14 @@ export class AKBProxy {
         const resp = await this._rpc(msg.method, msg.params || {});
         return { jsonrpc: "2.0", id: msg.id, result: resp };
       } catch (err) {
-        if (this._isConnError(err.message)) {
-          // Drop the dead session and let the background monitor restore
+        if (err?.rpcError) {
+          return { jsonrpc: "2.0", id: msg.id, error: err.rpcError };
+        }
+        if (this._isConnError(err)) {
+          // Mark the backend unavailable and let the background monitor restore
           // it. The proxy process and the client-visible server stay
           // alive, so calls recover once connectivity returns.
           this._backendReady = false;
-          this.sessionId = null;
           this._startBackendMonitor();
 
           if (attempt < maxRetries) {
@@ -1434,20 +1574,26 @@ export class AKBProxy {
 
   async _rpc(method, params, rpcOpts = {}) {
     this.msgId++;
+    const requestParams = {
+      ...(params || {}),
+      _meta: this._backendRequestMeta(params?._meta),
+    };
     const body = JSON.stringify({
       jsonrpc: "2.0",
       id: this.msgId,
       method,
-      params,
+      params: requestParams,
     });
 
     const headers = {
       Authorization: `Bearer ${this.pat}`,
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      "mcp-protocol-version": MCP_PROTOCOL_VERSION,
+      "mcp-method": method,
     };
-    if (this.sessionId) {
-      headers["mcp-session-id"] = this.sessionId;
+    if (method === "tools/call" && typeof requestParams.name === "string") {
+      headers["mcp-name"] = encodeRoutingHeader(requestParams.name);
     }
 
     const resp = await this._http(
@@ -1458,10 +1604,6 @@ export class AKBProxy {
       { timeoutMs: rpcOpts.timeoutMs },
     );
 
-    if (resp.headers["mcp-session-id"]) {
-      this.sessionId = resp.headers["mcp-session-id"];
-    }
-
     let parsed;
     try {
       parsed = JSON.parse(resp.text);
@@ -1469,12 +1611,7 @@ export class AKBProxy {
       throw new Error(`Invalid JSON response: ${resp.text.slice(0, 200)}`);
     }
 
-    if (parsed._sessionId) {
-      this.sessionId = parsed._sessionId;
-    }
-    if (parsed.error) {
-      throw new Error(`MCP error ${parsed.error.code}: ${parsed.error.message}`);
-    }
+    if (parsed.error) throw new MCPProtocolError(parsed.error);
     return parsed.result || {};
   }
 

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {

--- a/packages/akb-mcp-client/test/contract.test.mjs
+++ b/packages/akb-mcp-client/test/contract.test.mjs
@@ -33,6 +33,15 @@ function itAsync(name, fn) {
   ));
 }
 
+const modernParams = (params = {}) => ({
+  ...params,
+  _meta: {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+    "io.modelcontextprotocol/clientInfo": { name: "contract-test", version: "1" },
+  },
+});
+
 // ── Fixtures: representative backend envelope responses ──────────
 
 const initiateUploadResp = JSON.stringify({
@@ -408,6 +417,29 @@ itAsync("_http honors the per-call probe timeout", async () => {
   }
 });
 
+itAsync("_rpc sends the modern envelope and routing headers", async () => {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  let observed;
+  proxy._http = async (method, path, body, headers) => {
+    observed = { method, path, body: JSON.parse(body.toString()), headers };
+    return { text: '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}', headers: {} };
+  };
+
+  const result = await proxy._rpc("tools/call", {
+    name: "akb_get",
+    arguments: { uri: "akb://vault/doc/readme.md" },
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(observed.headers["mcp-protocol-version"], "2026-07-28");
+  assert.equal(observed.headers["mcp-method"], "tools/call");
+  assert.equal(observed.headers["mcp-name"], "akb_get");
+  assert.equal(observed.body.params._meta["io.modelcontextprotocol/protocolVersion"], "2026-07-28");
+  assert.deepEqual(observed.body.params._meta["io.modelcontextprotocol/clientCapabilities"].experimental[
+    "io.dnotitia.akb/vault-skill-preflight"
+  ], { version: 2 });
+});
+
 itAsync("_discardImage surfaces backend lookup failures", async () => {
   const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
   const assetId = "11111111-2222-4333-8444-555555555555";
@@ -474,7 +506,7 @@ itAsync("proxy-local exact retry acknowledges the guide before writing", async (
   };
 
   const first = await proxy._handle({
-    jsonrpc: "2.0", id: 1, method: "tools/call", params,
+    jsonrpc: "2.0", id: 1, method: "tools/call", params: modernParams(params),
   });
   const firstBody = JSON.parse(first.result.content[0].text);
   assert.equal(firstBody.code, "vault_skill_required");
@@ -482,7 +514,7 @@ itAsync("proxy-local exact retry acknowledges the guide before writing", async (
   assert.equal(writes, 0);
 
   const second = await proxy._handle({
-    jsonrpc: "2.0", id: 2, method: "tools/call", params,
+    jsonrpc: "2.0", id: 2, method: "tools/call", params: modernParams(params),
   });
   const secondBody = JSON.parse(second.result.content[0].text);
   assert.equal(secondBody.kind, "document_image");

--- a/packages/akb-mcp-client/test/reconnect.test.mjs
+++ b/packages/akb-mcp-client/test/reconnect.test.mjs
@@ -1,8 +1,8 @@
 // Resilience contract for the proxy's connection lifecycle.
 //
 // Covers the VPN-drop failure mode: the client-visible MCP server must
-// survive backend unreachability. `initialize` is answered locally,
-// `tools/list` degrades gracefully, and a background monitor restores the
+// survive backend unreachability. `server/discover` has a local advertisement
+// fallback, `tools/list` degrades gracefully, and a background monitor restores the
 // full toolset (via tools/list_changed) once connectivity returns — all
 // without killing the proxy process. No real network calls — backend RPCs
 // are stubbed.
@@ -43,83 +43,90 @@ const fileToolNames = [
   "akb_delete_file",
 ];
 
-// ── initialize is answered locally, never blocking on the backend ────
+const modernMeta = (capabilities = {}, clientInfo = { name: "client", version: "1" }) => ({
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientCapabilities": capabilities,
+  "io.modelcontextprotocol/clientInfo": clientInfo,
+});
 
-itAsync("initialize responds locally even when the backend is down", async () => {
+const modernParams = (params = {}, capabilities = {}) => ({
+  ...params,
+  _meta: modernMeta(capabilities),
+});
+
+// ── server/discover is the stateless advertisement boundary ─────────
+
+itAsync("server/discover responds locally while the backend is down", async () => {
   const proxy = newProxy();
-  proxy._startBackendMonitor = () => {}; // don't spin a real monitor here
-  proxy._ensureBackend = async () => false; // backend unreachable
+  proxy._startBackendMonitor = () => {};
+  proxy._ensureBackend = async () => false;
 
-  const res = await proxy._initialize(1, {
-    protocolVersion: "2025-06-18",
-    capabilities: {},
-    clientInfo: { name: "c", version: "1" },
+  const res = await proxy._handle({
+    jsonrpc: "2.0", id: 1, method: "server/discover",
+    params: modernParams(),
   });
 
-  assert.equal(res.result.protocolVersion, "2025-06-18", "echoes client protocol version");
+  assert.deepEqual(res.result.supportedVersions, ["2026-07-28"]);
   assert.equal(res.result.capabilities.tools.listChanged, true, "advertises listChanged");
-  assert.equal(res.result.serverInfo.name, "akb-mcp");
+  assert.deepEqual(res.result._meta["io.modelcontextprotocol/serverInfo"], {
+    name: "akb-mcp", version: "2.3.0",
+  });
   assert.match(res.result.instructions, /akb_put_image/);
   assert.match(res.result.instructions, /targeted akb_edit/);
   assert.match(res.result.instructions, /replaces the entire document body/);
   assert.match(res.result.instructions, /akb_discard_image/);
-  assert.equal(proxy._initialized, true);
 });
 
-itAsync("initialize falls back to a default protocol version when omitted", async () => {
+itAsync("server/discover forwards modern metadata and adds proxy capability", async () => {
   const proxy = newProxy();
-  proxy._startBackendMonitor = () => {};
-  const res = await proxy._initialize(1, { capabilities: {} });
-  assert.match(res.result.protocolVersion, /^\d{4}-\d{2}-\d{2}$/);
+  proxy._ensureBackend = async () => true;
+  let forwarded;
+  proxy._rpc = async (method, params) => {
+    forwarded = { method, params };
+    return {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: { listChanged: false } },
+      _meta: { "io.modelcontextprotocol/serverInfo": { name: "akb", version: "0.15.0" } },
+    };
+  };
+
+  const res = await proxy._handle({
+    jsonrpc: "2.0", id: 1, method: "server/discover",
+    params: modernParams({}, { roots: { listChanged: true } }),
+  });
+
+  assert.equal(forwarded.method, "server/discover");
+  assert.equal(
+    forwarded.params._meta["io.modelcontextprotocol/protocolVersion"],
+    "2026-07-28",
+  );
+  assert.deepEqual(
+    forwarded.params._meta["io.modelcontextprotocol/clientCapabilities"].roots,
+    { listChanged: true },
+  );
+  const backendMeta = proxy._backendRequestMeta(forwarded.params._meta);
+  assert.deepEqual(
+    backendMeta["io.modelcontextprotocol/clientCapabilities"].experimental[
+      "io.dnotitia.akb/vault-skill-preflight"
+    ],
+    { version: 2 },
+  );
+  assert.equal(res.result.capabilities.tools.listChanged, false);
 });
 
 itAsync("initialize rejects an unsupported protocol version instead of echoing it", async () => {
   const proxy = newProxy();
-  proxy._startBackendMonitor = () => {};
-  const res = await proxy._initialize(1, {
-    protocolVersion: "2099-01-01",
-    capabilities: {},
+  const res = await proxy._handle({
+    jsonrpc: "2.0", id: 1, method: "initialize", params: {
+      protocolVersion: "2099-01-01",
+      capabilities: {},
+    },
   });
 
-  assert.equal(res.error.code, -32602);
-  assert.deepEqual(res.error.data.supported, ["2025-06-18"]);
+  assert.equal(res.error.code, -32022);
+  assert.deepEqual(res.error.data.supported, ["2026-07-28"]);
+  assert.equal(res.error.data.requested, "2099-01-01");
   assert.equal(res.result, undefined);
-  assert.equal(proxy._initialized, false);
-});
-
-itAsync("backend initialize negotiates vault-guide preflight without dropping client capabilities", async () => {
-  const proxy = newProxy();
-  const original = {
-    protocolVersion: "2025-06-18",
-    capabilities: {
-      roots: { listChanged: true },
-      experimental: { "example.test/feature": { version: 2 } },
-    },
-    clientInfo: { name: "client", version: "1" },
-  };
-  proxy._clientInitParams = original;
-  let forwarded;
-  proxy._rpc = async (method, params) => {
-    assert.equal(method, "initialize");
-    forwarded = params;
-    return {};
-  };
-
-  assert.equal(await proxy._ensureBackend(), true);
-  assert.deepEqual(forwarded.capabilities.roots, { listChanged: true });
-  assert.deepEqual(
-    forwarded.capabilities.experimental["example.test/feature"],
-    { version: 2 },
-  );
-  assert.deepEqual(
-    forwarded.capabilities.experimental["io.dnotitia.akb/vault-skill-preflight"],
-    { version: 2 },
-  );
-  assert.equal(
-    original.capabilities.experimental["io.dnotitia.akb/vault-skill-preflight"],
-    undefined,
-    "client initialize params are not mutated",
-  );
 });
 
 // ── tools/list degrades to file tools when the backend is unreachable ─
@@ -234,7 +241,9 @@ itAsync("vault-guide acknowledgement is attached only to the exact backend retry
     arguments: { content: "new", uri: "akb://v1/doc/a.md" },
   };
 
-  await proxy._handle({ jsonrpc: "2.0", id: 1, method: "tools/call", params });
+  await proxy._handle({
+    jsonrpc: "2.0", id: 1, method: "tools/call", params: modernParams(params),
+  });
   await proxy._handle({
     jsonrpc: "2.0",
     id: 2,
@@ -243,6 +252,7 @@ itAsync("vault-guide acknowledgement is attached only to the exact backend retry
     params: {
       name: "akb_update",
       arguments: { uri: "akb://v1/doc/a.md", content: "new" },
+      _meta: modernMeta(),
     },
   });
 
@@ -272,11 +282,11 @@ itAsync("vault-guide acknowledgement never authorizes an unrelated queued write"
 
   await proxy._handle({
     jsonrpc: "2.0", id: 1, method: "tools/call",
-    params: { name: "akb_put", arguments: { vault: "v1", title: "A", content: "a" } },
+    params: modernParams({ name: "akb_put", arguments: { vault: "v1", title: "A", content: "a" } }),
   });
   await proxy._handle({
     jsonrpc: "2.0", id: 2, method: "tools/call",
-    params: { name: "akb_put", arguments: { vault: "v1", title: "B", content: "b" } },
+    params: modernParams({ name: "akb_put", arguments: { vault: "v1", title: "B", content: "b" } }),
   });
 
   assert.equal(forwarded[1].params.arguments._vault_skill_ack, undefined);
@@ -304,6 +314,26 @@ itAsync("_forward retries a connection error then surfaces it (process survives)
   assert.equal(proxy._backendReady, false, "marks backend not-ready");
   assert.ok(restarts >= 1, "kicks the reconnect monitor");
   assert.ok(calls >= 3, "attempted the initial call plus retries");
+});
+
+itAsync("_forward preserves backend protocol errors instead of treating them as outages", async () => {
+  const proxy = newProxy();
+  proxy._backendReady = true;
+  proxy._startBackendMonitor = () => { throw new Error("protocol errors must not reconnect"); };
+  proxy._rpc = async () => {
+    const error = new Error("HTTP 400: Unsupported protocol version");
+    error.statusCode = 400;
+    error.rpcError = {
+      code: -32022,
+      message: "Unsupported protocol version",
+      data: { supported: ["2026-07-28"], requested: "2025-11-25" },
+    };
+    throw error;
+  };
+
+  const result = await proxy._forward({ method: "tools/list", id: 8, params: {} });
+  assert.equal(result.error.code, -32022);
+  assert.equal(proxy._backendReady, true);
 });
 
 itAsync("_forward recovers on a later attempt once the backend returns", async () => {

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.dnotitia/akb",
-  "description": "Git-backed org memory for AI agents — hybrid search, tables, files & a URI graph over MCP.",
+  "description": "Git-backed org memory for AI agents — MCP 2026-07-28 stateless discovery, hybrid search, tables, files & a URI graph.",
   "repository": {
     "url": "https://github.com/dnotitia/akb",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "akb-mcp",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

This PR implements AKB-178 and upgrades the public MCP contract to the 2026-07-28 protocol revision across the backend Streamable HTTP server and the zero-dependency `akb-mcp` stdio proxy.

The result is a single, explicit protocol contract: clients discover the server capabilities, send independent requests with standard request metadata and headers, receive deterministic tool catalogs with cache hints, and get a clear error for unsupported protocol revisions.

## What changed

### Backend MCP server

- Upgrade the MCP Python SDK to the native 2026-07-28 implementation and update the lockfile.
- Add the stateless `server/discover` contract and request-level protocol metadata handling.
- Route requests using `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers.
- Return deterministic `tools/list` results with the protocol cache metadata.
- Reject unsupported revisions and legacy initialize/session requests instead of silently downgrading.
- Preserve PAT and MCP OAuth Resource Server authorization boundaries, existing tool names and schemas, and existing vault/RBAC semantics.

### `akb-mcp` stdio proxy

- Advertise and forward only protocol revision 2026-07-28.
- Forward modern request metadata and server discovery through the proxy.
- Keep proxy-local file/image tools on the same modern surface.
- Preserve predictable degraded-mode and reconnect behavior without restoring backend session affinity.

### Tests, runtime, and release metadata

- Migrate the repository-owned MCP E2E helpers and suites to the modern request contract.
- Remove the obsolete session-DELETE cleanup path from the publications E2E suite.
- Add/update protocol, proxy contract, reconnect, runtime, and regression coverage.
- Update backend and proxy versions, changelogs, MCP registry metadata, installation guidance, and connector documentation.
- Keep the repository runtime descriptor at schema v2 and record the selected protocol/transport in runtime evidence.

## Compatibility and non-goals

- 2026-07-28 is the only supported MCP protocol revision after this change.
- No compatibility shim, protocol downgrade, initialize/session fallback, or dual transport is added.
- Existing `akb_*` tool names, input meaning, authorization scopes, and data semantics remain unchanged.
- No database schema migration, REST resource-model change, search/graph change, or OAuth Authorization Server implementation is included.

## Verification

- Backend MCP protocol, runtime, and adjacent unit suites pass.
- `akb-mcp` contract and reconnect suites pass.
- The full repository contributor gate passes: manifest, Ruff, mypy, Bandit, frontend checks, SDK checks, and secret scanning.
- Hosted CI passes for static analysis, backend unit tests, pgvector E2E, and the repository-owned shell E2E runtime.
- The repository-owned E2E runtime exercises the modern HTTP behavior and the transport-proxy profile exercises the stdio contract.
- Final branch-aware review reports no actionable P0 findings.

## Reviewer focus

Please review the protocol boundary and adapter behavior in the backend MCP HTTP implementation and `packages/akb-mcp-client/lib/proxy.mjs`, especially:

1. stateless request handling and rejection of legacy session paths;
2. metadata/header forwarding and header/body consistency checks;
3. deterministic tool catalog and cache metadata;
4. preservation of existing tool, auth, and vault semantics; and
5. the modern E2E/proxy test seams.

Relates to AKB-178.
