### PR TITLE
feat(users): return the canonical id from user search

### DIFF
--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -1002,13 +1002,30 @@ async def transfer_ownership(owner_id: str, vault_name: str, new_owner_username:
 # ── User search ──────────────────────────────────────────────
 
 async def search_users(query: str | None = None, limit: int = 20) -> list[dict]:
-    """Search users by username or display_name."""
+    """Search users by username or display_name.
+
+    Carries the canonical ``id`` alongside the display fields.
+
+    The id is what a caller needs to record a person durably: a username can be
+    renamed, so anything keyed on one silently detaches when it is. Every client
+    that stores a reference to a Workspace member — an authorization surface, a
+    membership list, an assignment — has to hold the id, and until now the only
+    way to obtain one was ``/admin/users``, which requires system admin. That
+    left an ordinary authenticated caller with no way at all to name a person
+    durably, and pushed clients toward either a broad admin credential or a
+    username they would have to hope never changes.
+
+    This does not widen who can see whom: the endpoint already returns
+    ``username``, ``display_name`` and ``email`` to any authenticated caller,
+    and an opaque uuid discloses strictly less than the email beside it. What
+    changes is only that the identifier those three describe is now nameable.
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
         if query:
             rows = await conn.fetch(
                 """
-                SELECT username, display_name, email
+                SELECT id, username, display_name, email
                 FROM users
                 WHERE username ILIKE $1 OR display_name ILIKE $1 OR email ILIKE $1
                 ORDER BY username
@@ -1018,12 +1035,17 @@ async def search_users(query: str | None = None, limit: int = 20) -> list[dict]:
             )
         else:
             rows = await conn.fetch(
-                "SELECT username, display_name, email FROM users ORDER BY username LIMIT $1",
+                "SELECT id, username, display_name, email FROM users ORDER BY username LIMIT $1",
                 limit,
             )
 
     return [
-        {"username": r["username"], "display_name": r["display_name"], "email": r["email"]}
+        {
+            "id": str(r["id"]),
+            "username": r["username"],
+            "display_name": r["display_name"],
+            "email": r["email"],
+        }
         for r in rows
     ]
 

--- a/backend/tests/test_user_search_unit.py
+++ b/backend/tests/test_user_search_unit.py
@@ -1,0 +1,101 @@
+"""Unit tests for access_service.search_users.
+
+These pin the one thing a caller cannot get anywhere else without system-admin
+rights: the canonical ``id``. A username can be renamed, so a client that stores
+one has a reference that silently detaches; the id is what makes a recorded
+reference to a person durable, and until it was projected here the only source
+was ``/admin/users``.
+
+No live DB — the pool is patched, so what is asserted is the projection and the
+statement, which is where the id can go missing.
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services import access_service
+
+
+def _patch_pool(monkeypatch, *, fetch_rows):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=fetch_rows)
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = _acquire
+    monkeypatch.setattr(
+        "app.services.access_service.get_pool", AsyncMock(return_value=pool)
+    )
+    return conn
+
+
+def _row(username: str, *, uid: uuid.UUID | None = None) -> dict:
+    return {
+        "id": uid or uuid.uuid4(),
+        "username": username,
+        "display_name": username.title(),
+        "email": f"{username}@example.invalid",
+    }
+
+
+async def test_search_projects_the_canonical_id(monkeypatch):
+    uid = uuid.uuid4()
+    _patch_pool(monkeypatch, fetch_rows=[_row("minji", uid=uid)])
+
+    out = await access_service.search_users("min")
+
+    assert out == [
+        {
+            "id": str(uid),
+            "username": "minji",
+            "display_name": "Minji",
+            "email": "minji@example.invalid",
+        }
+    ]
+
+
+async def test_id_is_a_string_not_a_uuid_object(monkeypatch):
+    # asyncpg hands back a uuid.UUID, which is not JSON-serialisable. Returning
+    # it unconverted fails at the response encoder rather than here, far from
+    # the cause.
+    _patch_pool(monkeypatch, fetch_rows=[_row("minji")])
+
+    out = await access_service.search_users()
+
+    assert isinstance(out[0]["id"], str)
+    uuid.UUID(out[0]["id"])  # parses, so it is the id and not a repr
+
+
+async def test_both_query_branches_select_the_id(monkeypatch):
+    # Two statements, and only one of them runs per call — so a projection added
+    # to the searched branch alone would look right in every test that passes a
+    # query and be missing for every caller that does not.
+    conn = _patch_pool(monkeypatch, fetch_rows=[_row("minji")])
+
+    await access_service.search_users("min")
+    searched = conn.fetch.await_args_list[-1].args[0]
+
+    await access_service.search_users()
+    unsearched = conn.fetch.await_args_list[-1].args[0]
+
+    assert "SELECT id, username, display_name, email" in " ".join(searched.split())
+    assert "SELECT id, username, display_name, email" in " ".join(unsearched.split())
+
+
+async def test_empty_result_stays_empty(monkeypatch):
+    _patch_pool(monkeypatch, fetch_rows=[])
+    assert await access_service.search_users("nobody") == []
+
+
+async def test_limit_is_passed_through_unchanged(monkeypatch):
+    conn = _patch_pool(monkeypatch, fetch_rows=[])
+
+    await access_service.search_users("min", limit=7)
+    assert conn.fetch.await_args_list[-1].args[2] == 7
+
+    await access_service.search_users(limit=7)
+    assert conn.fetch.await_args_list[-1].args[1] == 7


### PR DESCRIPTION
`GET /api/v1/users/search` returns `username`, `display_name` and `email`. All
three describe a person; none of them names one durably.

A username can be renamed, so any client that stores one holds a reference that
silently detaches the moment it changes — and nothing signals that it has. The
identifier that survives a rename is the canonical `id`, and until now the only
endpoint that projected it was `/admin/users`, behind a system-admin gate.

So an ordinary authenticated caller had exactly one id available to it — its own,
from `/auth/me`. Any client that needed to record a reference to somebody else
was pushed toward either a broad admin credential or a username it would have to
hope never changed. Both are worse than the one field this adds.

## This widens nothing about who can see whom

The endpoint already returns username, display name and email to any
authenticated caller. An opaque uuid discloses strictly less than the email
beside it. What changes is only that the person those three fields describe is
now nameable.

## Details worth noting

- **Both query branches project it** — the searched one and the unsearched
  listing. A projection added to one alone looks correct in every test that
  passes a query and is missing for every caller that does not.
- **The id is stringified at the boundary.** asyncpg hands back a `uuid.UUID`;
  returning it unconverted fails at the response encoder rather than here, far
  from the cause.

## Verification

- `scripts/check.sh` — exit 0.
- `tests/test_user_search_unit.py` — **5 passed**. Covers both branches, the
  string conversion, the empty result and the limit pass-through. The pool is
  patched, so no database is required.
- Mutation controls: dropping the id from the unsearched branch alone fails
  `test_both_query_branches_select_the_id`; returning the raw `uuid.UUID` fails
  two cases.
- Neighbouring suites `test_user_directory_unit.py` and
  `test_admin_users_binding_issuer_postgres.py` pass. The latter skips two
  Postgres-backed cases with `Postgres unreachable at AKB_TEST_DSN` — unrelated
  to this change, and skipping before it.

Not verified: the response shape on a deployed instance. This change is not
built or deployed anywhere yet, so the evidence above is the unit projection and
the repository gate, not a live response.
