### PR TITLE
feat(access): keep independent grant bases apart

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -38,6 +38,7 @@ from app.services.access_service import (
     delete_user_account,
     delete_vault,
     get_vault_info,
+    explain_vault_access,
     grant_access,
     list_accessible_vaults,
     list_all_users_admin,
@@ -70,10 +71,23 @@ router = APIRouter()
 class GrantRequest(NFCModel):
     user: str
     role: str  # reader, writer, admin
+    # The basis on which the role is held. Omit it and the grant is `direct`,
+    # which is what every grant was before bases could coexist. A rule-driven
+    # grantor names its own key so it can later withdraw its own reason without
+    # deleting anybody else's.
+    source_key: str | None = None
+    # Monotonic per (vault, user, source). A retry carrying a revision no newer
+    # than the stored one is a no-op rather than an overwrite.
+    revision: int | None = None
 
 
 class RevokeRequest(NFCModel):
     user: str
+    # Omit it and the person is out of the vault — every basis goes, which is
+    # what this endpoint has always meant. Name one and only that basis is
+    # withdrawn, so the user may be downgraded rather than removed.
+    source_key: str | None = None
+    revision: int | None = None
 
 
 class TransferRequest(NFCModel):
@@ -227,12 +241,28 @@ async def vault_members(vault: str, user: AuthenticatedUser = Depends(get_curren
 
 @router.post("/vaults/{vault}/grant", summary="Grant vault access to a user")
 async def grant(vault: str, req: GrantRequest, user: AuthenticatedUser = Depends(get_current_user)):
-    return await grant_access(user.user_id, vault, req.user, req.role)
+    kwargs = {} if req.source_key is None else {"source_key": req.source_key}
+    return await grant_access(
+        user.user_id, vault, req.user, req.role, revision=req.revision, **kwargs,
+    )
 
 
 @router.post("/vaults/{vault}/revoke", summary="Revoke vault access from a user")
 async def revoke(vault: str, req: RevokeRequest, user: AuthenticatedUser = Depends(get_current_user)):
-    return await revoke_access(user.user_id, vault, req.user)
+    return await revoke_access(
+        user.user_id, vault, req.user,
+        source_key=req.source_key, revision=req.revision,
+    )
+
+
+@router.get(
+    "/vaults/{vault}/access/{username}",
+    summary="Explain why a user holds the role they hold on a vault",
+)
+async def explain_access(
+    vault: str, username: str, user: AuthenticatedUser = Depends(get_current_user),
+):
+    return await explain_vault_access(user.user_id, vault, username)
 
 
 @router.post("/vaults/{vault}/transfer", summary="Transfer vault ownership")

--- a/backend/app/db/init.sql
+++ b/backend/app/db/init.sql
@@ -405,6 +405,32 @@ CREATE TABLE IF NOT EXISTS vault_access (
 CREATE INDEX IF NOT EXISTS idx_vault_access_user ON vault_access(user_id);
 CREATE INDEX IF NOT EXISTS idx_vault_access_vault ON vault_access(vault_id);
 
+-- Why a (vault, user) pair has the role vault_access holds. One row per
+-- independent basis; vault_access above is the materialization of the strongest
+-- of them, recomputed in the same transaction as the write that changed one.
+-- 'direct' is the basis every human grant carries. Ownership, public_access,
+-- system administration and the vault write policy are decided on separate
+-- branches of check_vault_access and are deliberately not contributions.
+CREATE TABLE IF NOT EXISTS vault_access_contributions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    source_key TEXT NOT NULL,  -- 'direct', or an opaque '<namespace>:<id>'
+    granted_by UUID REFERENCES users(id),
+    revision BIGINT NOT NULL DEFAULT 1,  -- monotonic per (vault, user, source)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (vault_id, user_id, source_key),
+    CONSTRAINT vault_access_contributions_role_check
+        CHECK (role IN ('reader', 'writer', 'admin')),
+    CONSTRAINT vault_access_contributions_source_key_check
+        CHECK (
+            length(source_key) BETWEEN 1 AND 255
+            AND source_key !~ '[[:space:]]'
+        )
+);
+
 -- ============================================================
 -- Collections (L1 - directory-level metadata cache)
 -- ============================================================

--- a/backend/app/db/migrations/085_vault_access_contributions.py
+++ b/backend/app/db/migrations/085_vault_access_contributions.py
@@ -1,0 +1,124 @@
+"""Source-keyed grant contributions behind the effective ``vault_access`` row.
+
+``vault_access`` stores the result of a grant, not the grant: one row per
+(vault, user), and ``grant_access`` overwrites ``role`` on conflict. That is
+correct while every grant is one person acting on another — there is only ever
+one reason then — and it stops being correct the moment a second, automated
+grantor exists, because its revoke deletes access that was never its to remove.
+
+This migration adds the place a reason can live. It changes no effective role:
+every existing row is backfilled as exactly one contribution with source key
+``direct``, preserving ``role``, ``granted_by`` and ``created_at``. The derived
+value therefore equals the stored value for every pair, and every reader — REST,
+``akb_sql``, search, grep, revision visibility, and the PostgreSQL role
+membership ``role_sync`` reconciles out of ``vault_access`` — sees exactly what
+it saw before. The check at the end is what proves that rather than assuming it.
+
+Ownership, ``public_access``, system administration and the vault write policy
+stay outside this table: ``check_vault_access`` decides them on separate
+branches and reports them through ``role_source``. ``role`` therefore admits
+``admin`` — which ``transfer_ownership`` writes for a former owner — and never
+``owner``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger("akb.migration.085")
+
+
+async def migrate(conn) -> None:
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS vault_access_contributions (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                vault_id UUID NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                role TEXT NOT NULL,
+                -- 'direct', or an opaque '<namespace>:<id>' the grantor owns.
+                -- AKB validates the shape and never interprets the value; the
+                -- moment it does, it has imported the grantor's concept.
+                source_key TEXT NOT NULL,
+                granted_by UUID REFERENCES users(id),
+                -- Monotonic per (vault, user, source). A retrying automated
+                -- grantor carrying an older revision than the stored one is a
+                -- no-op rather than an overwrite.
+                revision BIGINT NOT NULL DEFAULT 1,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE (vault_id, user_id, source_key),
+                CONSTRAINT vault_access_contributions_role_check
+                    CHECK (role IN ('reader', 'writer', 'admin')),
+                CONSTRAINT vault_access_contributions_source_key_check
+                    CHECK (
+                        length(source_key) BETWEEN 1 AND 255
+                        AND source_key !~ '[[:space:]]'
+                    )
+            )
+            """
+        )
+
+        backfilled = await conn.fetchval(
+            """
+            WITH inserted AS (
+                INSERT INTO vault_access_contributions
+                    (vault_id, user_id, role, source_key, granted_by,
+                     revision, created_at, updated_at)
+                SELECT va.vault_id, va.user_id, va.role, 'direct', va.granted_by,
+                       1, va.created_at, va.created_at
+                FROM vault_access va
+                WHERE va.role IN ('reader', 'writer', 'admin')
+                ON CONFLICT (vault_id, user_id, source_key) DO NOTHING
+                RETURNING 1
+            )
+            SELECT count(*) FROM inserted
+            """
+        )
+
+        # A row whose role is outside the contribution vocabulary cannot be
+        # represented, so it is reported rather than dropped or coerced: an
+        # 'owner' row in vault_access would mean ownership had leaked into the
+        # member plane, which is a different defect than this migration's.
+        unrepresentable = await conn.fetchval(
+            "SELECT count(*) FROM vault_access WHERE role NOT IN ('reader', 'writer', 'admin')"
+        )
+
+        # The claim this migration rests on: derived == stored, everywhere.
+        divergent = await conn.fetchval(
+            """
+            SELECT count(*)
+            FROM vault_access va
+            LEFT JOIN LATERAL (
+                SELECT c.role
+                FROM vault_access_contributions c
+                WHERE c.vault_id = va.vault_id AND c.user_id = va.user_id
+                ORDER BY CASE c.role
+                             WHEN 'admin' THEN 3 WHEN 'writer' THEN 2
+                             WHEN 'reader' THEN 1 ELSE 0 END DESC
+                LIMIT 1
+            ) derived ON TRUE
+            WHERE va.role IN ('reader', 'writer', 'admin')
+              AND derived.role IS DISTINCT FROM va.role
+            """
+        )
+        if divergent:
+            raise RuntimeError(
+                f"vault_access_contributions backfill left {divergent} pair(s) whose "
+                "derived effective role differs from the stored one; refusing to "
+                "commit a migration that moves access"
+            )
+
+    logger.info(
+        "vault_access_contributions: backfilled %d direct contribution(s); "
+        "derived effective role matches the stored one for every pair",
+        backfilled or 0,
+    )
+    if unrepresentable:
+        logger.warning(
+            "%d vault_access row(s) carry a role outside (reader, writer, admin) and "
+            "have no contribution; ownership belongs on vaults.owner_id, not here",
+            unrepresentable,
+        )

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -307,6 +307,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "082_pending_admissions.py",  # the arrival invite_only refuses, kept so an administrator can approve that exact identity instead of guessing a subject in advance
         "083_edge_vault_boundary.py",  # graph edges are vault-local: owner/source/target authorities agree; legacy rows stay hidden pending reviewed cleanup
         "084_bm25_corpus_revision.py",  # mutation revision replaces mismatched chunk-count/eligible-doc BM25 refresh gate
+        "085_vault_access_contributions.py",  # why a pair holds the role it holds: independent grant bases behind the effective vault_access row, backfilled as 'direct' so nothing moves
     ):
         if filename in applied:
             continue

--- a/backend/app/services/access_contributions.py
+++ b/backend/app/services/access_contributions.py
@@ -1,0 +1,351 @@
+"""Why a (vault, user) pair holds the role it holds.
+
+``vault_access`` stores the *result* of a grant, not the grant. One row per
+pair, and ``grant_access`` overwrites ``role`` on conflict. That is correct
+while every grant is one person acting on another — there is only ever one
+reason then — and it stops being correct the moment a second, automated
+grantor exists:
+
+    1. a person holds ``reader`` on V, granted directly;
+    2. an automated grantor applies ``writer`` for everyone in some set the
+       person belongs to; the row becomes ``writer`` and the direct ``reader``
+       no longer exists anywhere;
+    3. the person leaves the set, the grantor revokes, and the row is deleted.
+
+Nobody revoked the access held in step 1, and after step 2 no query could have
+prevented step 3. This module holds the reasons so that it can.
+
+``vault_access`` stays the materialized effective row and is recomputed here
+inside the caller's transaction, so every reader keeps working unchanged — REST,
+``akb_sql``, search, grep, revision visibility, and the PostgreSQL role
+membership ``role_sync`` reconciles out of ``vault_access``.
+
+Deliberately outside this plane: ownership, ``public_access``, system
+administration and the vault write policy. ``check_vault_access`` decides those
+on separate branches and reports them through ``role_source``; folding them in
+would create states the model cannot express ("revoke the ownership
+contribution" is not a sentence) and would put break-glass behind a derivation.
+
+AKB validates the *shape* of a source key and never interprets its value. The
+moment it interprets one it has imported the grantor's concept, and the whole
+point is that AKB need not know what anybody's rule is — only to keep
+independent bases apart.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Iterable
+
+
+# The one role ordering. `access_service` imports it from here so the
+# derivation below and every comparison in the codebase read the same table.
+ROLE_HIERARCHY = {"owner": 4, "admin": 3, "writer": 2, "reader": 1}
+
+#: The basis every human grant carries, and the default for callers that do not
+#: name one — which is every caller that existed before contributions did.
+DIRECT_SOURCE_KEY = "direct"
+
+#: `owner` is not among them: ownership lives on `vaults.owner_id`, and the only
+#: `admin` this plane writes for a former owner comes from `transfer_ownership`.
+CONTRIBUTION_ROLES = frozenset({"reader", "writer", "admin"})
+
+_SOURCE_KEY_MAX = 255
+_SOURCE_KEY_FORBIDDEN = re.compile(r"\s")
+
+
+class InvalidSourceKey(ValueError):
+    """The source key is not a shape AKB will store."""
+
+
+def role_level(role: str | None) -> int:
+    return ROLE_HIERARCHY.get(role or "", 0)
+
+
+def effective_role(roles: Iterable[str | None]) -> str | None:
+    """The strongest currently applicable role, or None if there is no basis.
+
+    This is the derivation. It is one function on purpose: negative
+    contributions, expiry, a coarser or finer grain and a different subject
+    shape all reduce to "the union is computed differently", and each of them
+    should be a change here rather than a sweep across call sites.
+    """
+    best: str | None = None
+    for role in roles:
+        if role_level(role) > role_level(best):
+            best = role
+    return best
+
+
+def validate_source_key(source_key: str) -> str:
+    """Shape only — never meaning.
+
+    A registry of permitted namespaces would only stop two independent grantors
+    choosing the same key, which is an operator configuration concern, and it
+    can be added later as a validation without changing the row shape.
+    """
+    if not isinstance(source_key, str) or not source_key:
+        raise InvalidSourceKey("source key must be a non-empty string")
+    if len(source_key) > _SOURCE_KEY_MAX:
+        raise InvalidSourceKey(
+            f"source key exceeds {_SOURCE_KEY_MAX} characters"
+        )
+    if _SOURCE_KEY_FORBIDDEN.search(source_key):
+        raise InvalidSourceKey("source key must not contain whitespace")
+    return source_key
+
+
+@dataclass(frozen=True)
+class ContributionOutcome:
+    """What one contribution write did, and what it did to the pair.
+
+    `applied` is False when a stale revision made the write a no-op. The two
+    effective roles are what an event subscriber needs: "the writer
+    contribution was removed" and "this user is no longer a writer" are
+    different facts once bases can coexist, and only the pair of values
+    separates them.
+    """
+
+    applied: bool
+    effective_role: str | None
+    previous_effective_role: str | None
+    contribution_role: str | None
+
+    @property
+    def effective_role_changed(self) -> bool:
+        return self.effective_role != self.previous_effective_role
+
+
+async def _lock_vault(conn, vault_id) -> None:
+    """Serialize recompute for this vault.
+
+    The vault row is the lock `grant_access`/`revoke_access` already take, and
+    re-acquiring it inside their transaction is a no-op. Locking the pair's
+    contribution rows instead would not serialize against a concurrent INSERT
+    of a *new* basis for the same pair — there is no row yet to lock.
+    """
+    await conn.fetchval("SELECT id FROM vaults WHERE id = $1 FOR UPDATE", vault_id)
+
+
+async def current_effective_role(conn, vault_id, user_id) -> str | None:
+    """The stored effective role for a pair, as `vault_access` holds it."""
+    return await conn.fetchval(
+        "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+        vault_id, user_id,
+    )
+
+
+async def list_contributions(conn, vault_id, user_id) -> list[dict]:
+    """Every basis on which this pair currently holds access."""
+    rows = await conn.fetch(
+        """
+        SELECT c.source_key, c.role, c.revision, c.granted_by,
+               c.created_at, c.updated_at, u.username AS granted_by_username
+        FROM vault_access_contributions c
+        LEFT JOIN users u ON u.id = c.granted_by
+        WHERE c.vault_id = $1 AND c.user_id = $2
+        ORDER BY c.source_key
+        """,
+        vault_id, user_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def _materialize(conn, vault_id, user_id) -> str | None:
+    """Recompute `vault_access` from the pair's contributions.
+
+    Runs in the caller's transaction. `created_at` is deliberately left alone on
+    conflict: it means "since when does this pair have any access at all", and
+    letting it follow the winning contribution would move a member's `since`
+    backwards whenever a contribution is removed.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT role, granted_by
+        FROM vault_access_contributions
+        WHERE vault_id = $1 AND user_id = $2
+        """,
+        vault_id, user_id,
+    )
+    effective = effective_role(r["role"] for r in rows)
+    if effective is None:
+        await conn.execute(
+            "DELETE FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            vault_id, user_id,
+        )
+        return None
+
+    # Attribution follows the basis that won, which is the honest answer to
+    # "who gave this person this role".
+    granted_by = next(
+        (r["granted_by"] for r in rows if r["role"] == effective), None,
+    )
+    await conn.execute(
+        """
+        INSERT INTO vault_access (id, vault_id, user_id, role, granted_by)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (vault_id, user_id)
+        DO UPDATE SET role = $4, granted_by = $5
+        """,
+        uuid.uuid4(), vault_id, user_id, effective, granted_by,
+    )
+    return effective
+
+
+async def apply_contribution(
+    conn,
+    vault_id,
+    user_id,
+    role: str,
+    *,
+    source_key: str = DIRECT_SOURCE_KEY,
+    granted_by=None,
+    revision: int | None = None,
+) -> ContributionOutcome:
+    """Record one basis for a pair and recompute the effective role.
+
+    `revision` is what makes a retrying automated grantor safe: a write carrying
+    a revision no newer than the stored one changes nothing. Callers that do not
+    track a revision — every caller that existed before contributions did — pass
+    None and get the next one.
+    """
+    if role not in CONTRIBUTION_ROLES:
+        raise ValueError(
+            f"invalid contribution role: {role!r}. Use: "
+            + ", ".join(sorted(CONTRIBUTION_ROLES))
+        )
+    validate_source_key(source_key)
+
+    await _lock_vault(conn, vault_id)
+    previous_effective = await current_effective_role(conn, vault_id, user_id)
+    stored = await conn.fetchrow(
+        """
+        SELECT role, revision FROM vault_access_contributions
+        WHERE vault_id = $1 AND user_id = $2 AND source_key = $3
+        """,
+        vault_id, user_id, source_key,
+    )
+
+    if revision is None:
+        next_revision = (stored["revision"] if stored else 0) + 1
+    elif stored is not None and revision <= stored["revision"]:
+        # Replay. Not an error: a grantor retrying after a lost response is
+        # doing the right thing, and the stored state is already newer.
+        return ContributionOutcome(
+            applied=False,
+            effective_role=previous_effective,
+            previous_effective_role=previous_effective,
+            contribution_role=stored["role"],
+        )
+    else:
+        next_revision = revision
+
+    await conn.execute(
+        """
+        INSERT INTO vault_access_contributions
+            (id, vault_id, user_id, role, source_key, granted_by, revision)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (vault_id, user_id, source_key)
+        DO UPDATE SET role = $4, granted_by = $6, revision = $7, updated_at = NOW()
+        """,
+        uuid.uuid4(), vault_id, user_id, role, source_key, granted_by, next_revision,
+    )
+    effective = await _materialize(conn, vault_id, user_id)
+    return ContributionOutcome(
+        applied=True,
+        effective_role=effective,
+        previous_effective_role=previous_effective,
+        contribution_role=role,
+    )
+
+
+async def remove_contribution(
+    conn,
+    vault_id,
+    user_id,
+    *,
+    source_key: str = DIRECT_SOURCE_KEY,
+    revision: int | None = None,
+) -> ContributionOutcome:
+    """Remove one basis and recompute.
+
+    If other bases remain the user is **downgraded**; only the last removal
+    deletes the `vault_access` row. So a caller must not read a successful
+    removal as "this user can no longer reach this vault" — `effective_role`
+    on the outcome is the fact, and it may be unchanged.
+    """
+    validate_source_key(source_key)
+
+    await _lock_vault(conn, vault_id)
+    previous_effective = await current_effective_role(conn, vault_id, user_id)
+    stored = await conn.fetchrow(
+        """
+        SELECT role, revision FROM vault_access_contributions
+        WHERE vault_id = $1 AND user_id = $2 AND source_key = $3
+        """,
+        vault_id, user_id, source_key,
+    )
+    if stored is None:
+        # Nothing to remove on this basis. The pair may still hold access on
+        # another, so the effective role is reported rather than assumed gone.
+        return ContributionOutcome(
+            applied=False,
+            effective_role=previous_effective,
+            previous_effective_role=previous_effective,
+            contribution_role=None,
+        )
+    if revision is not None and revision <= stored["revision"]:
+        return ContributionOutcome(
+            applied=False,
+            effective_role=previous_effective,
+            previous_effective_role=previous_effective,
+            contribution_role=stored["role"],
+        )
+
+    await conn.execute(
+        """
+        DELETE FROM vault_access_contributions
+        WHERE vault_id = $1 AND user_id = $2 AND source_key = $3
+        """,
+        vault_id, user_id, source_key,
+    )
+    effective = await _materialize(conn, vault_id, user_id)
+    return ContributionOutcome(
+        applied=True,
+        effective_role=effective,
+        previous_effective_role=previous_effective,
+        contribution_role=None,
+    )
+
+
+async def remove_all_contributions(conn, vault_id, user_id) -> ContributionOutcome:
+    """Remove every basis for a pair — what an administrator's revoke means.
+
+    An explicit human revoke is not "withdraw my own contribution"; it is "this
+    person should not be in this vault". Leaving an automated grantor's basis
+    behind would make the revoke silently ineffective, and the grantors that
+    write those bases treat their rule as a floor precisely so this decision
+    stands.
+    """
+    await _lock_vault(conn, vault_id)
+    previous_effective = await current_effective_role(conn, vault_id, user_id)
+    removed = await conn.fetchval(
+        """
+        WITH deleted AS (
+            DELETE FROM vault_access_contributions
+            WHERE vault_id = $1 AND user_id = $2
+            RETURNING 1
+        )
+        SELECT count(*) FROM deleted
+        """,
+        vault_id, user_id,
+    )
+    effective = await _materialize(conn, vault_id, user_id)
+    return ContributionOutcome(
+        applied=bool(removed) or previous_effective is not None,
+        effective_role=effective,
+        previous_effective_role=previous_effective,
+        contribution_role=None,
+    )

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -22,6 +22,17 @@ from app.models.vault_scope import VaultScope, current_token_uuid, current_vault
 from app.repositories import vault_write_policy_repo as write_policy_repo
 from app.repositories.events_repo import emit_event
 from app.repositories.vault_files_repo import confirmed_file_predicate
+from app.services.access_contributions import (
+    DIRECT_SOURCE_KEY,
+    ROLE_HIERARCHY,
+    InvalidSourceKey,
+    apply_contribution,
+    effective_role,
+    list_contributions,
+    remove_all_contributions,
+    remove_contribution,
+    validate_source_key,
+)
 from app.services.account_markers import is_retired_recovery_admin_password
 from app.services.account_service import presented_issuer_or_none
 from app.services.edge_boundary import edge_scope_sql, vault_uri_prefix
@@ -32,7 +43,6 @@ from app.util.errors import NOT_FOUND, err
 
 logger = logging.getLogger("akb.access")
 
-ROLE_HIERARCHY = {"owner": 4, "admin": 3, "writer": 2, "reader": 1}
 VALID_ROLES = set(ROLE_HIERARCHY.keys())
 VALID_PUBLIC_ACCESS = {"none", "reader", "writer"}
 
@@ -493,10 +503,25 @@ async def get_user_role(user_id: str, vault_name: str) -> str | None:
 
 async def grant_access(
     granter_id: str, vault_name: str, target_username: str, role: str,
+    *, source_key: str = DIRECT_SOURCE_KEY, revision: int | None = None,
 ) -> dict:
-    """Grant vault access to a user. Granter must be owner or admin."""
+    """Grant vault access to a user. Granter must be owner or admin.
+
+    `source_key` names the basis on which the role is held. It defaults to
+    `direct`, so a caller that does not name one keeps its exact previous
+    behaviour. A rule-driven grantor names its own key and can then withdraw
+    that basis later without touching anybody else's — which is the only way an
+    automated revoke stops deleting access that was never its to remove.
+
+    The returned `role` is the requested one; `effective_role` is what the user
+    now holds, which is higher when a stronger basis already exists.
+    """
     if role not in VALID_ROLES or role == "owner":
         raise ForbiddenError(f"Invalid role: {role}. Use: reader, writer, admin")
+    try:
+        source_key = validate_source_key(source_key)
+    except InvalidSourceKey as e:
+        raise ValidationError(str(e)) from e
 
     # Verify granter has permission BEFORE the mutation transaction. The
     # actual mutation re-acquires a FOR UPDATE row lock on the vault to
@@ -535,34 +560,78 @@ async def grant_access(
             )
             if not target:
                 raise NotFoundError("User", target_username)
-            await conn.execute(
-                """
-                INSERT INTO vault_access (id, vault_id, user_id, role, granted_by)
-                VALUES ($1, $2, $3, $4, $5)
-                ON CONFLICT (vault_id, user_id)
-                DO UPDATE SET role = $4, granted_by = $5
-                """,
-                uuid.uuid4(), vault["id"], target["id"], role, granter_uid,
+            outcome = await apply_contribution(
+                conn, vault["id"], target["id"], role,
+                source_key=source_key, granted_by=granter_uid, revision=revision,
             )
+            # "the writer basis was recorded" and "this user is now a writer"
+            # are different facts once bases can coexist, and only both
+            # effective roles separate them. A subscriber that reads `role`
+            # alone would act on a change that did not happen.
             await emit_event(
                 conn, "access.grant",
                 vault_id=vault["id"],
                 resource_uri=vault_uri(vault_name),
                 actor_id=str(granter_uid),
-                payload={"vault": vault_name, "user": target_username, "role": role},
+                payload={
+                    "vault": vault_name,
+                    "user": target_username,
+                    "role": role,
+                    "source_key": source_key,
+                    "effective_role": outcome.effective_role,
+                    "previous_effective_role": outcome.previous_effective_role,
+                    "applied": outcome.applied,
+                },
             )
 
     # PG-native RBAC: GRANT akb_vault_<vid>_<role> TO akb_user_<uid>.
     # Best-effort — reconciler covers drift.
-    await get_role_sync().on_grant(vault["id"], target["id"], role)
+    #
+    # The EFFECTIVE role, not the requested one: granting `reader` to somebody a
+    # rule already made a `writer` must not demote them in PostgreSQL, or the
+    # database layer would disagree with every application read.
+    if outcome.effective_role is not None:
+        await get_role_sync().on_grant(
+            vault["id"], target["id"], outcome.effective_role,
+        )
 
     logger.info("Granted %s role to %s on vault %s", role, target_username, vault_name)
-    return {"vault": vault_name, "user": target_username, "role": role, "granted": True}
+    return {
+        "vault": vault_name,
+        "user": target_username,
+        "role": role,
+        "source_key": source_key,
+        "effective_role": outcome.effective_role,
+        # False for a replay: the stored basis was already newer, so nothing
+        # moved. `granted` stays True because the requested state holds.
+        "applied": outcome.applied,
+        "granted": True,
+    }
 
 
-async def revoke_access(revoker_id: str, vault_name: str, target_username: str) -> dict:
-    """Revoke vault access from a user. Revoker must be owner or admin."""
+async def revoke_access(
+    revoker_id: str, vault_name: str, target_username: str,
+    *, source_key: str | None = None, revision: int | None = None,
+) -> dict:
+    """Revoke vault access from a user. Revoker must be owner or admin.
+
+    With no `source_key` this keeps meaning exactly what it has always meant:
+    the person is out of the vault, so every basis goes. Removing only the
+    `direct` one would leave an administrator's revoke silently ineffective
+    against a rule-driven basis — the button would report success and the person
+    would keep the access.
+
+    With a `source_key` only that basis is withdrawn, which is what a rule-driven
+    grantor does when its rule stops applying. Other bases survive, so the user
+    may be *downgraded* rather than removed, and `revoked` alone does not mean
+    they can no longer reach the vault. `effective_role` is the fact.
+    """
     await check_vault_access(revoker_id, vault_name, required_role="admin")
+    if source_key is not None:
+        try:
+            source_key = validate_source_key(source_key)
+        except InvalidSourceKey as e:
+            raise ValidationError(str(e)) from e
 
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -598,23 +667,51 @@ async def revoke_access(revoker_id: str, vault_name: str, target_username: str) 
                 raise ForbiddenError(
                     "Cannot revoke owner's access. Use transfer_ownership instead."
                 )
-            await conn.execute(
-                "DELETE FROM vault_access WHERE vault_id = $1 AND user_id = $2",
-                vault["id"], target["id"],
-            )
+            if source_key is None:
+                outcome = await remove_all_contributions(
+                    conn, vault["id"], target["id"],
+                )
+            else:
+                outcome = await remove_contribution(
+                    conn, vault["id"], target["id"],
+                    source_key=source_key, revision=revision,
+                )
+            # `source_key: null` means every basis went — an administrator
+            # removing the person, not a rule withdrawing its own reason.
             await emit_event(
                 conn, "access.revoke",
                 vault_id=vault["id"],
                 resource_uri=vault_uri(vault_name),
                 actor_id=str(revoker_uid),
-                payload={"vault": vault_name, "user": target_username},
+                payload={
+                    "vault": vault_name,
+                    "user": target_username,
+                    "source_key": source_key,
+                    "effective_role": outcome.effective_role,
+                    "previous_effective_role": outcome.previous_effective_role,
+                    "applied": outcome.applied,
+                },
             )
 
-    # PG-native RBAC: REVOKE all vault group memberships from akb_user_<uid>.
-    await get_role_sync().on_revoke(vault["id"], target["id"])
+    # PG-native RBAC. A surviving basis is a DOWNGRADE, not a removal: revoking
+    # all memberships there while the catalog still holds `reader` would take
+    # away in the database what the application still grants.
+    if outcome.effective_role is None:
+        await get_role_sync().on_revoke(vault["id"], target["id"])
+    else:
+        await get_role_sync().on_grant(
+            vault["id"], target["id"], outcome.effective_role,
+        )
 
     logger.info("Revoked access for %s on vault %s", target_username, vault_name)
-    return {"vault": vault_name, "user": target_username, "revoked": True}
+    return {
+        "vault": vault_name,
+        "user": target_username,
+        "source_key": source_key,
+        "effective_role": outcome.effective_role,
+        "applied": outcome.applied,
+        "revoked": True,
+    }
 
 
 # ── Vault members ────────────────────────────────────────────
@@ -662,6 +759,85 @@ async def list_vault_members(user_id: str, vault_name: str) -> list[dict]:
 
 
 # ── User-accessible vaults ──────────────────────────────────
+
+async def explain_vault_access(
+    actor_id: str, vault_name: str, target_username: str,
+) -> dict:
+    """Why this user holds the role they hold on this vault.
+
+    `list_vault_members` answers *who*, and it answers it incompletely: it
+    returns the owner plus one member row each, so a user reachable through
+    `public_access`, system administration or a write-policy bypass is simply
+    not in the list. That already reads as the audience when it is not, and it
+    gets worse once a member's role has a reason the list cannot show.
+
+    Two planes, kept apart on purpose. `contributions` are the bases behind the
+    member row; everything under `non_member_paths` is decided on a separate
+    branch of `check_vault_access` and is not a contribution — "revoke the
+    ownership contribution" is not a sentence.
+
+    Explaining somebody else requires `admin`, because the answer can be "they
+    are a system administrator". Explaining yourself requires `reader`.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        target = await conn.fetchrow(
+            "SELECT id, username FROM users WHERE username = $1", target_username,
+        )
+        if not target:
+            raise NotFoundError("User", target_username)
+
+    explaining_self = str(target["id"]) == str(actor_id)
+    await check_vault_access(
+        actor_id, vault_name,
+        required_role="reader" if explaining_self else "admin",
+    )
+
+    async with pool.acquire() as conn:
+        vault = await conn.fetchrow(
+            "SELECT id, name, owner_id, status, public_access FROM vaults WHERE name = $1",
+            vault_name,
+        )
+        if not vault:
+            raise NotFoundError("Vault", vault_name)
+        contributions = await list_contributions(conn, vault["id"], target["id"])
+        stored_role = await conn.fetchval(
+            "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+            vault["id"], target["id"],
+        )
+        is_admin = await conn.fetchval(
+            "SELECT is_admin FROM users WHERE id = $1", target["id"],
+        )
+        policy = await write_policy_repo.get_policy(vault["id"], conn=conn)
+
+    derived = effective_role(c["role"] for c in contributions)
+    return {
+        "vault": vault_name,
+        "user": target["username"],
+        # What the member plane says, and what it is derived from. They are
+        # reported separately rather than as one number: if they ever disagree
+        # the recompute is broken, and collapsing them would hide exactly that.
+        "effective_role": stored_role,
+        "derived_role": derived,
+        "contributions": [
+            {
+                "source_key": c["source_key"],
+                "role": c["role"],
+                "revision": c["revision"],
+                "granted_by": c["granted_by_username"],
+                "since": c["created_at"].isoformat() if c["created_at"] else None,
+                "updated_at": c["updated_at"].isoformat() if c["updated_at"] else None,
+            }
+            for c in contributions
+        ],
+        "non_member_paths": {
+            "owner": vault["owner_id"] == target["id"],
+            "system_admin": bool(is_admin),
+            "public_access": vault["public_access"] or "none",
+            "write_policy_managed_by": policy["managed_by"] if policy else None,
+        },
+    }
+
 
 async def list_accessible_vaults(user_id: str) -> list[dict]:
     """List all vaults the user has access to, with their role."""
@@ -961,18 +1137,17 @@ async def transfer_ownership(owner_id: str, vault_name: str, new_owner_username:
                 "UPDATE vaults SET owner_id = $1 WHERE id = $2",
                 new_owner["id"], vault["id"],
             )
-            await conn.execute(
-                """
-                INSERT INTO vault_access (id, vault_id, user_id, role, granted_by)
-                VALUES ($1, $2, $3, 'admin', $4)
-                ON CONFLICT (vault_id, user_id) DO UPDATE SET role = 'admin'
-                """,
-                uuid.uuid4(), vault["id"], vault["owner_id"], new_owner["id"],
+            # The former owner keeps `admin`, on the `direct` basis: this is one
+            # person handing a vault to another, which is exactly what `direct`
+            # means. The new owner leaves the member plane entirely — every
+            # basis, because ownership is decided on `vaults.owner_id` and a
+            # leftover member row would be a second, weaker answer to the same
+            # question.
+            await apply_contribution(
+                conn, vault["id"], vault["owner_id"], "admin",
+                source_key=DIRECT_SOURCE_KEY, granted_by=new_owner["id"],
             )
-            await conn.execute(
-                "DELETE FROM vault_access WHERE vault_id = $1 AND user_id = $2",
-                vault["id"], new_owner["id"],
-            )
+            await remove_all_contributions(conn, vault["id"], new_owner["id"])
             await emit_event(
                 conn, "access.transfer_ownership",
                 vault_id=vault["id"],
@@ -1842,8 +2017,12 @@ async def delete_user_account(user_id: str) -> dict:
     async with pool.acquire() as conn:
         # Detach residual references rather than deleting the artifacts
         await conn.execute("UPDATE vault_access SET granted_by = NULL WHERE granted_by = $1", uid)
+        await conn.execute(
+            "UPDATE vault_access_contributions SET granted_by = NULL WHERE granted_by = $1",
+            uid,
+        )
         await conn.execute("UPDATE publications SET created_by = NULL WHERE created_by = $1", uid)
-        # CASCADE handles tokens + vault_access.user_id
+        # CASCADE handles tokens + vault_access.user_id + the bases behind it
         await conn.execute("DELETE FROM users WHERE id = $1", uid)
 
     # PG-native RBAC: drop akb_user_<uid>. Owned vault group roles

--- a/backend/tests/test_access_contributions_postgres.py
+++ b/backend/tests/test_access_contributions_postgres.py
@@ -1,0 +1,712 @@
+"""The seven acceptance gates for source-keyed grant contributions.
+
+Written before the implementation and expected to be red at `6db98bf`, which is
+the point: gate 1 is impossible to satisfy against a single-row `vault_access`,
+and a gate that cannot fail proves nothing.
+
+Live PostgreSQL, because every claim here is about SQL semantics — a row that
+survives, a role that is derived rather than stored, a stale write that is a
+no-op. A fake connection would be asserting the test's own model.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.exceptions import ForbiddenError, ValidationError
+from app.services import access_service
+from app.services import access_contributions as contrib
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text()
+_MIGRATION_085 = (
+    _BACKEND / "app" / "db" / "migrations" / "085_vault_access_contributions.py"
+)
+_MIGRATIONS_DIR = _BACKEND / "app" / "db" / "migrations"
+
+
+def _registered_migrations() -> list[Path]:
+    """Every migration, in the order `postgres.py` registers them.
+
+    Reading the registry rather than listing the directory keeps this database
+    the same shape as a real one: `check_vault_access` reads the vault write
+    policy and `emit_event` writes the outbox, and neither table is in
+    `init.sql`. Picking migrations by hand is how a test database quietly stops
+    resembling the thing under test.
+    """
+    registry = (_BACKEND / "app" / "db" / "postgres.py").read_text()
+    names = re.findall(r'"(\d{3}_[a-z0-9_]+\.py)"', registry)
+    seen: set[str] = set()
+    ordered: list[Path] = []
+    for name in names:
+        if name in seen:
+            continue
+        seen.add(name)
+        ordered.append(_MIGRATIONS_DIR / name)
+    assert ordered, "no migrations found in the registry"
+    assert ordered[-1].name == _MIGRATION_085.name, (
+        "085 must be the last registered migration for this test to be measuring "
+        f"the current head; registry ends at {ordered[-1].name}"
+    )
+    return ordered
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:15432/akb",  # pragma: allowlist secret
+)
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _can_connect() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+@asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect():
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"Required PostgreSQL is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_contrib_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(_INIT_SQL)
+            for path in _registered_migrations():
+                await _load_migration(path).migrate(conn=conn)
+        yield pool
+    finally:
+        await pool.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+class _RecordingRoleSync:
+    """What the PG-native layer was told to do, so gate 5 can read it back."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def on_grant(self, vault_id, user_id, scope):
+        self.calls.append(("grant", str(vault_id), str(user_id), scope))
+
+    async def on_revoke(self, vault_id, user_id):
+        self.calls.append(("revoke", str(vault_id), str(user_id)))
+
+
+@pytest.fixture
+async def env(monkeypatch):
+    async with _fresh_database() as pool:
+        role_sync = _RecordingRoleSync()
+        monkeypatch.setattr(access_service, "get_pool", lambda: pool)
+        monkeypatch.setattr(access_service, "get_role_sync", lambda: role_sync)
+        yield _Env(pool, role_sync)
+
+
+class _Env:
+    def __init__(self, pool, role_sync):
+        self.pool = pool
+        self.role_sync = role_sync
+
+    async def user(self, label: str, *, is_admin: bool = False) -> uuid.UUID:
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                INSERT INTO users (username, email, password_hash, is_admin)
+                VALUES ($1, $2, 'fixture', $3) RETURNING id
+                """,
+                label, f"{label}@example.invalid", is_admin,
+            )
+
+    async def vault(self, name: str, owner_id: uuid.UUID) -> uuid.UUID:
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                "INSERT INTO vaults (name, git_path, owner_id) VALUES ($1, $2, $3) RETURNING id",
+                name, f"/tmp/{name}.git", owner_id,
+            )
+
+    async def stored_role(self, vault_id, user_id) -> str | None:
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                "SELECT role FROM vault_access WHERE vault_id = $1 AND user_id = $2",
+                vault_id, user_id,
+            )
+
+    async def bases(self, vault_id, user_id) -> dict[str, str]:
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT source_key, role FROM vault_access_contributions
+                WHERE vault_id = $1 AND user_id = $2
+                """,
+                vault_id, user_id,
+            )
+        return {r["source_key"]: r["role"] for r in rows}
+
+
+async def _fixture(env, label: str):
+    """An owner, a vault they own, an admin who may grant, and a member."""
+    suffix = uuid.uuid4().hex[:8]
+    owner = await env.user(f"{label}-owner-{suffix}")
+    member = await env.user(f"{label}-member-{suffix}")
+    granter = await env.user(f"{label}-granter-{suffix}", is_admin=True)
+    name = f"{label}-{suffix}"
+    vault_id = await env.vault(name, owner)
+    return name, vault_id, owner, member, granter
+
+
+# ── Gate 1 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_1_independent_bases_survive_each_other(env):
+    """direct reader + source writer → writer; the source leaves → reader.
+
+    NOT no access. This is the whole proposal: at `6db98bf` step two overwrote
+    the direct reader and step three deleted the row, so the person lost access
+    nobody revoked.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "gate1")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    assert await env.stored_role(vault_id, member) == "reader"
+
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+    assert await env.stored_role(vault_id, member) == "writer"
+
+    result = await access_service.revoke_access(
+        str(granter), name, member_name, source_key="team:alpha",
+    )
+    assert result["effective_role"] == "reader"
+    assert await env.stored_role(vault_id, member) == "reader"
+    assert await env.bases(vault_id, member) == {"direct": "reader"}
+
+
+# ── Gate 2 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_2_the_last_removal_removes_the_row(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "gate2")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+    result = await access_service.revoke_access(
+        str(granter), name, member_name, source_key="team:alpha",
+    )
+    assert result["effective_role"] is None
+    assert await env.stored_role(vault_id, member) is None
+    assert await env.bases(vault_id, member) == {}
+
+
+# ── Gate 3 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_3_two_automated_sources_do_not_erase_each_other(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "gate3")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+    await access_service.grant_access(
+        str(granter), name, member_name, "reader", source_key="policy:derived",
+    )
+    assert await env.stored_role(vault_id, member) == "writer"
+
+    await access_service.revoke_access(
+        str(granter), name, member_name, source_key="team:alpha",
+    )
+    assert await env.stored_role(vault_id, member) == "reader"
+    assert await env.bases(vault_id, member) == {"policy:derived": "reader"}
+
+
+# ── Gate 4 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_4_a_stale_revision_changes_nothing(env):
+    """A grantor retrying after a lost response must not undo a newer write."""
+    name, vault_id, owner, member, granter = await _fixture(env, "gate4")
+
+    async with env.pool.acquire() as conn:
+        await contrib.apply_contribution(
+            conn, vault_id, member, "reader",
+            source_key="team:alpha", granted_by=granter, revision=5,
+        )
+        await contrib.apply_contribution(
+            conn, vault_id, member, "writer",
+            source_key="team:alpha", granted_by=granter, revision=9,
+        )
+        replay = await contrib.apply_contribution(
+            conn, vault_id, member, "reader",
+            source_key="team:alpha", granted_by=granter, revision=5,
+        )
+
+    assert replay.applied is False
+    assert replay.effective_role == "writer"
+    assert await env.stored_role(vault_id, member) == "writer"
+
+    async with env.pool.acquire() as conn:
+        stale_removal = await contrib.remove_contribution(
+            conn, vault_id, member, source_key="team:alpha", revision=5,
+        )
+    assert stale_removal.applied is False
+    assert await env.stored_role(vault_id, member) == "writer"
+
+
+# ── Gate 5 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_5_every_read_surface_agrees_after_a_downgrade(env):
+    """The materialized row is the single answer, and the PG-native layer is
+    told the EFFECTIVE role rather than the one the caller asked for.
+
+    The predicates below are the ones the readers actually run: `search_service`
+    and `m1_native_grep_service` test membership through `vault_access`, and
+    `role_sync` reconciles PostgreSQL group membership from exactly
+    `SELECT vault_id, user_id, role FROM vault_access`.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "gate5")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(
+        str(granter), name, member_name, "admin", source_key="team:alpha",
+    )
+    env.role_sync.calls.clear()
+
+    await access_service.revoke_access(
+        str(granter), name, member_name, source_key="team:alpha",
+    )
+
+    async with env.pool.acquire() as conn:
+        # what a search sees
+        visible = await conn.fetchval(
+            "SELECT count(*) FROM vaults v WHERE v.id IN "
+            "(SELECT vault_id FROM vault_access WHERE user_id = $1)",
+            member,
+        )
+        # what grep sees
+        greppable = await conn.fetchval(
+            "SELECT count(*) FROM vaults v WHERE EXISTS ("
+            "SELECT 1 FROM vault_access va WHERE va.vault_id = v.id AND va.user_id = $1)",
+            member,
+        )
+        # what role_sync reconciles from
+        reconciled = await conn.fetch(
+            "SELECT vault_id, user_id, role FROM vault_access WHERE user_id = $1",
+            member,
+        )
+        derived = await contrib.list_contributions(conn, vault_id, member)
+
+    assert visible == 1
+    assert greppable == 1
+    assert [r["role"] for r in reconciled] == ["reader"]
+    assert contrib.effective_role(c["role"] for c in derived) == "reader"
+
+    # A surviving basis is a downgrade, not a removal: revoking every PG-native
+    # membership here would take away in the database what the catalog grants.
+    assert env.role_sync.calls == [("grant", str(vault_id), str(member), "reader")]
+
+
+async def test_gate_5_the_pg_layer_is_never_told_to_demote_below_effective(env):
+    """Granting `reader` to somebody a rule already made `admin` must not
+    demote them in PostgreSQL."""
+    name, vault_id, owner, member, granter = await _fixture(env, "gate5b")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(
+        str(granter), name, member_name, "admin", source_key="team:alpha",
+    )
+    env.role_sync.calls.clear()
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+
+    assert await env.stored_role(vault_id, member) == "admin"
+    assert env.role_sync.calls == [("grant", str(vault_id), str(member), "admin")]
+
+
+# ── Gate 6 ────────────────────────────────────────────────────────────
+
+
+async def test_gate_6_a_source_key_grants_no_authority_of_its_own(env):
+    """A source key is a label on a grant, not a new authority axis."""
+    name, vault_id, owner, member, granter = await _fixture(env, "gate6")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    outsider = await env.user(f"gate6-outsider-{uuid.uuid4().hex[:8]}")
+
+    with pytest.raises(ForbiddenError):
+        await access_service.grant_access(
+            str(outsider), name, member_name, "writer", source_key="team:alpha",
+        )
+    assert await env.bases(vault_id, member) == {}
+
+    # A reader cannot promote themselves through a source key either.
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    with pytest.raises(ForbiddenError):
+        await access_service.grant_access(
+            str(member), name, member_name, "admin", source_key="team:alpha",
+        )
+    assert await env.stored_role(vault_id, member) == "reader"
+
+
+async def test_gate_6_ownership_is_not_a_contribution(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "gate6b")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    with pytest.raises(ForbiddenError):
+        await access_service.grant_access(
+            str(granter), name, member_name, "owner", source_key="team:alpha",
+        )
+    async with env.pool.acquire() as conn:
+        with pytest.raises(ValueError):
+            await contrib.apply_contribution(
+                conn, vault_id, member, "owner", source_key="team:alpha",
+            )
+
+
+# ── The administrator's revoke ────────────────────────────────────────
+
+
+async def test_an_administrators_revoke_removes_every_basis(env):
+    """Without a source key, revoke keeps meaning what it has always meant.
+
+    Removing only the `direct` basis would let the button report success while
+    the person kept the access a rule gave them.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "adminrevoke")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+    result = await access_service.revoke_access(str(granter), name, member_name)
+
+    assert result["effective_role"] is None
+    assert await env.stored_role(vault_id, member) is None
+    assert await env.bases(vault_id, member) == {}
+    assert ("revoke", str(vault_id), str(member)) in env.role_sync.calls
+
+
+# ── Source key shape ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["", "team alpha", "a" * 256, "team\talpha"])
+async def test_a_source_key_is_validated_for_shape_only(env, bad):
+    name, vault_id, owner, member, granter = await _fixture(env, "shape")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    with pytest.raises(ValidationError):
+        await access_service.grant_access(
+            str(granter), name, member_name, "writer", source_key=bad,
+        )
+    # And a key AKB has no opinion about is accepted, because it must not have one.
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer",
+        source_key="anything:the-grantor-owns/42",
+    )
+    assert await env.stored_role(vault_id, member) == "writer"
+
+
+# ── The backfill (C3) ─────────────────────────────────────────────────
+
+
+async def test_the_backfill_moves_no_effective_role(env):
+    """An existing database gains a basis per row and loses nothing.
+
+    Simulated faithfully: drop the table a fresh `init.sql` creates, seed rows
+    the way a pre-contribution AKB would have, then run the migration.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "backfill")
+    second = await env.user(f"backfill-second-{uuid.uuid4().hex[:8]}")
+
+    async with env.pool.acquire() as conn:
+        await conn.execute("DROP TABLE vault_access_contributions")
+        for user_id, role in ((member, "reader"), (second, "admin")):
+            await conn.execute(
+                """
+                INSERT INTO vault_access (vault_id, user_id, role, granted_by)
+                VALUES ($1, $2, $3, $4)
+                """,
+                vault_id, user_id, role, granter,
+            )
+        before = {
+            r["user_id"]: r["role"]
+            for r in await conn.fetch(
+                "SELECT user_id, role FROM vault_access WHERE vault_id = $1", vault_id,
+            )
+        }
+
+        await _load_migration(_MIGRATION_085).migrate(conn=conn)
+
+        after = {
+            r["user_id"]: r["role"]
+            for r in await conn.fetch(
+                "SELECT user_id, role FROM vault_access WHERE vault_id = $1", vault_id,
+            )
+        }
+        bases = await conn.fetch(
+            """
+            SELECT user_id, source_key, role, granted_by
+            FROM vault_access_contributions WHERE vault_id = $1
+            """,
+            vault_id,
+        )
+
+    assert after == before
+    assert {(b["source_key"], b["role"]) for b in bases} == {
+        ("direct", "reader"), ("direct", "admin"),
+    }
+    assert all(b["granted_by"] == granter for b in bases)
+
+
+async def test_the_backfill_refuses_to_commit_a_migration_that_moves_access(env):
+    """The migration's own check, proved by making the thing it checks true.
+
+    A rerun over a pair whose stored role drifted away from its basis is the
+    realistic case: `ON CONFLICT DO NOTHING` leaves the older basis in place, so
+    the derived value and the stored one disagree. Committing there would change
+    somebody's access inside a migration that promises to change none.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "backfillguard")
+
+    async with env.pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO vault_access (vault_id, user_id, role) VALUES ($1, $2, 'reader')",
+            vault_id, member,
+        )
+        await conn.execute(
+            """
+            INSERT INTO vault_access_contributions
+                (vault_id, user_id, role, source_key) VALUES ($1, $2, 'reader', 'direct')
+            """,
+            vault_id, member,
+        )
+        # The stored row drifts away from the basis behind it.
+        await conn.execute(
+            "UPDATE vault_access SET role = 'writer' WHERE vault_id = $1 AND user_id = $2",
+            vault_id, member,
+        )
+        with pytest.raises(RuntimeError, match="refusing to commit"):
+            await _load_migration(_MIGRATION_085).migrate(conn=conn)
+
+
+# ── The event payload (C4) ────────────────────────────────────────────
+
+
+async def _events(env, vault_id, kind: str) -> list[dict]:
+    import json
+    async with env.pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT payload FROM events WHERE vault_id = $1 AND kind = $2 "
+            "ORDER BY id",
+            vault_id, kind,
+        )
+    return [
+        json.loads(r["payload"]) if isinstance(r["payload"], str) else r["payload"]
+        for r in rows
+    ]
+
+
+async def test_the_grant_event_names_the_basis_and_both_effective_roles(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "eventgrant")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+
+    first, second = await _events(env, vault_id, "access.grant")
+    assert first["source_key"] == "direct"
+    assert (first["previous_effective_role"], first["effective_role"]) == (None, "reader")
+    assert second["source_key"] == "team:alpha"
+    assert (second["previous_effective_role"], second["effective_role"]) == (
+        "reader", "writer",
+    )
+
+
+async def test_the_revoke_event_separates_a_downgrade_from_a_removal(env):
+    """A subscriber reading only "revoked" cannot tell these two apart."""
+    name, vault_id, owner, member, granter = await _fixture(env, "eventrevoke")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+    await access_service.revoke_access(
+        str(granter), name, member_name, source_key="team:alpha",
+    )
+    await access_service.revoke_access(str(granter), name, member_name)
+
+    downgrade, removal = await _events(env, vault_id, "access.revoke")
+    assert downgrade["source_key"] == "team:alpha"
+    assert (downgrade["previous_effective_role"], downgrade["effective_role"]) == (
+        "writer", "reader",
+    )
+    # No source key: every basis went, and the payload says so with a null.
+    assert removal["source_key"] is None
+    assert (removal["previous_effective_role"], removal["effective_role"]) == (
+        "reader", None,
+    )
+
+
+# ── The explanation surface (C5) ──────────────────────────────────────
+
+
+async def test_the_explanation_lists_every_basis_behind_the_role(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "explain")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(
+        str(granter), name, member_name, "writer", source_key="team:alpha",
+    )
+
+    explained = await access_service.explain_vault_access(
+        str(granter), name, member_name,
+    )
+    assert explained["effective_role"] == "writer"
+    assert explained["derived_role"] == "writer"
+    assert {(c["source_key"], c["role"]) for c in explained["contributions"]} == {
+        ("direct", "reader"), ("team:alpha", "writer"),
+    }
+    assert explained["non_member_paths"] == {
+        "owner": False,
+        "system_admin": False,
+        "public_access": "none",
+        "write_policy_managed_by": None,
+    }
+
+
+async def test_the_explanation_shows_the_paths_the_member_list_never_had(env):
+    """A user reachable only through `public_access` is in no member list."""
+    name, vault_id, owner, member, granter = await _fixture(env, "explainpaths")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    async with env.pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE vaults SET public_access = 'reader' WHERE id = $1", vault_id,
+        )
+
+    explained = await access_service.explain_vault_access(
+        str(granter), name, member_name,
+    )
+    assert explained["contributions"] == []
+    assert explained["effective_role"] is None
+    assert explained["non_member_paths"]["public_access"] == "reader"
+
+    owner_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", owner,
+    )
+    owner_view = await access_service.explain_vault_access(
+        str(granter), name, owner_name,
+    )
+    assert owner_view["non_member_paths"]["owner"] is True
+    assert owner_view["contributions"] == []
+
+
+async def test_explaining_somebody_else_requires_admin_but_yourself_does_not(env):
+    name, vault_id, owner, member, granter = await _fixture(env, "explainauthz")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    other = await env.user(f"explainauthz-other-{uuid.uuid4().hex[:8]}")
+    other_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", other,
+    )
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+    await access_service.grant_access(str(granter), name, other_name, "reader")
+
+    mine = await access_service.explain_vault_access(str(member), name, member_name)
+    assert mine["effective_role"] == "reader"
+
+    with pytest.raises(ForbiddenError):
+        await access_service.explain_vault_access(str(member), name, other_name)
+
+
+async def test_the_explanation_reports_a_recompute_that_fell_behind(env):
+    """The two roles are separate fields because they can disagree.
+
+    A materialized effective row can drift; a derived one cannot. That is the
+    honest advantage of deriving at read time, and reporting one number here
+    would hide exactly the failure the materialization introduces — so the
+    explanation shows both, and a stale row is visible instead of authoritative.
+    """
+    name, vault_id, owner, member, granter = await _fixture(env, "explaindrift")
+    member_name = await env.pool.fetchval(
+        "SELECT username FROM users WHERE id = $1", member,
+    )
+    await access_service.grant_access(str(granter), name, member_name, "reader")
+
+    async with env.pool.acquire() as conn:
+        # A basis written without the recompute that belongs with it — what a
+        # broken write path would leave behind.
+        await conn.execute(
+            """
+            INSERT INTO vault_access_contributions
+                (vault_id, user_id, role, source_key) VALUES ($1, $2, 'admin', 'team:alpha')
+            """,
+            vault_id, member,
+        )
+
+    explained = await access_service.explain_vault_access(
+        str(granter), name, member_name,
+    )
+    assert explained["effective_role"] == "reader"
+    assert explained["derived_role"] == "admin"

--- a/backend/tests/test_admin_ownership_semantics_unit.py
+++ b/backend/tests/test_admin_ownership_semantics_unit.py
@@ -37,16 +37,56 @@ class _FakeTransaction:
 
 
 class _FakeConn:
-    """Answers the exact queries transfer_ownership runs, records writes."""
+    """Answers the exact queries transfer_ownership runs, records writes.
+
+    The member row is now derived from the bases behind it, so the fake keeps
+    both planes rather than only recording statements: the transfer's outcome —
+    the former owner demoted to `admin`, the new owner out of the member plane —
+    is a property of what the recompute produces, and a fake that swallowed the
+    contribution writes would assert nothing about it.
+    """
 
     def __init__(self, *, vault_owner: uuid.UUID):
         self.vault_owner = vault_owner
         self.executed: list[tuple[str, tuple]] = []
+        # (vault_id, user_id, source_key) -> role
+        self.contributions: dict[tuple, str] = {}
+        # (vault_id, user_id) -> role
+        self.access: dict[tuple, str] = {}
 
     def transaction(self):
         return _FakeTransaction()
 
+    async def fetchval(self, query: str, *args):
+        q = " ".join(query.split())
+        if q.startswith("SELECT id FROM vaults"):
+            return VAULT_ID
+        if q.startswith("SELECT role FROM vault_access WHERE"):
+            return self.access.get((args[0], args[1]))
+        if "DELETE FROM vault_access_contributions" in q:
+            gone = [
+                k for k in self.contributions
+                if k[0] == args[0] and k[1] == args[1]
+            ]
+            for key in gone:
+                del self.contributions[key]
+            return len(gone)
+        raise AssertionError(f"unexpected fetchval: {q}")
+
+    async def fetch(self, query: str, *args):
+        q = " ".join(query.split())
+        if "FROM vault_access_contributions" in q:
+            return [
+                {"role": role, "granted_by": None}
+                for (vault_id, user_id, _), role in self.contributions.items()
+                if vault_id == args[0] and user_id == args[1]
+            ]
+        raise AssertionError(f"unexpected fetch: {q}")
+
     async def fetchrow(self, query: str, *args):
+        if "FROM vault_access_contributions" in query:
+            role = self.contributions.get((args[0], args[1], args[2]))
+            return None if role is None else {"role": role, "revision": 1}
         if "FROM vaults" in query:
             return {"id": VAULT_ID, "owner_id": self.vault_owner}
         if "FROM users" in query:
@@ -54,7 +94,14 @@ class _FakeConn:
         raise AssertionError(f"unexpected fetchrow: {query}")
 
     async def execute(self, query: str, *args):
-        self.executed.append((" ".join(query.split()), args))
+        q = " ".join(query.split())
+        self.executed.append((q, args))
+        if q.startswith("INSERT INTO vault_access_contributions"):
+            self.contributions[(args[1], args[2], args[4])] = args[3]
+        elif q.startswith("INSERT INTO vault_access "):
+            self.access[(args[1], args[2])] = args[3]
+        elif q.startswith("DELETE FROM vault_access WHERE"):
+            self.access.pop((args[0], args[1]), None)
 
 
 class _FakeAcquire:
@@ -134,6 +181,11 @@ async def test_admin_initiated_transfer_succeeds_for_unowned_vault(
     assert (VAULT_ID, OWNER_ID, "admin") in role_sync.grants
     assert (VAULT_ID, NEW_OWNER_ID, "admin") in role_sync.grants
     assert events == ["access.transfer_ownership"]
+    # One person handing a vault to another is a `direct` basis, and the new
+    # owner leaves the member plane entirely — ownership is decided on
+    # vaults.owner_id, and a leftover member row is a second, weaker answer.
+    assert conn.contributions == {(VAULT_ID, OWNER_ID, "direct"): "admin"}
+    assert conn.access == {(VAULT_ID, OWNER_ID): "admin"}
 
 
 async def test_owner_initiated_transfer_still_detects_lost_race(


### PR DESCRIPTION
Implements the direction settled in #407: `vault_access` stays the
materialized effective row, and the reasons behind it live in a new
`vault_access_contributions` table, recomputed in the same transaction as
the write that changed one.

### The defect

`vault_access` stores the result of a grant, not the grant. One row per
(vault, user), and `grant_access` overwrites `role` on conflict. That is
correct while every grant is one person acting on another — there is only
ever one reason then — and it stops being correct the moment a second,
automated grantor exists:

1. a person holds `reader` on V, granted directly;
2. an automated grantor applies `writer` for everyone in some set they
   belong to; the row becomes `writer` and the direct `reader` no longer
   exists anywhere;
3. they leave the set, the grantor revokes, and the row is deleted.

Nobody revoked the access from step 1, and after step 2 no query could
have prevented step 3.

### What changes, and what deliberately does not

`access_contributions.py` holds one derivation function and the write
helpers. `vault_access` keeps its shape, so every reader is untouched:
search, grep, revision visibility, and the PostgreSQL group membership
`role_sync` reconciles out of it. `role_sync.py` has no diff.

Grant and revoke take an optional source key defaulting to `direct`, so
every existing caller keeps its exact behaviour. Every existing row
backfills as one `direct` contribution preserving `role`, `granted_by`
and `created_at` — and migration 085 refuses to commit if any pair's
derived role differs from its stored one, rather than trusting that it
does not.

Ownership, `public_access`, system administration and the vault write
policy stay outside the plane; `check_vault_access` decides them on
separate branches.

### Two refinements the implementation forced

**An administrator's revoke removes every basis.** §4.3 of the proposal,
read literally, also described the no-source-key revoke — which would
mean an administrator revoking somebody who also holds a rule-driven
basis gets a success while the person keeps the access. Those are two
operations; the one without a source key keeps meaning what it has always
meant.

**The PostgreSQL layer is told the effective role, not the requested
one**, in both directions. Granting `reader` to somebody a rule already
made a `writer` must not demote them in the database, and a surviving
basis after a revoke is a downgrade rather than a removal.

### Also here

- `GET /vaults/{vault}/access/{username}` answers *why* — the bases plus
  the non-member paths that never appeared in `list_vault_members` at
  all. It reports the stored and derived roles as separate fields, so a
  recompute that fell behind is visible rather than authoritative.
- Access events carry the basis and the effective role before and after.
  "The writer basis was removed" and "this user is no longer a writer"
  are different facts once bases can coexist, and only both values
  separate them.

### Verification

The seven gates from #407, plus the migration and explanation cases: 21
tests against live PostgreSQL. Each was verified to turn red when the
guard it names is removed — 18 mutations, 18 red.

`scripts/check.sh` exits 0. The backend suite is 2937 passed / 7 failed;
a pristine `origin/main` checkout under the same runner is 2916 passed /
the same 7 (`test_ensure_collection_race_unit`,
`test_external_git_capability` — pre-existing and unrelated).
