### PR TITLE
fix(frontend): support legacy hybrid auth contract

### DIFF
--- a/frontend/src/components/__tests__/layout-auth-gate.test.tsx
+++ b/frontend/src/components/__tests__/layout-auth-gate.test.tsx
@@ -86,6 +86,29 @@ describe("Layout — auth gate", () => {
     expect(screen.queryByTestId("home")).toBeNull();
   });
 
+  it("requires a Bearer token before entering through legacy hybrid mode", async () => {
+    vi.mocked(api.getAuthConfig).mockResolvedValue({
+      available: true,
+      schema_version: 1,
+      auth_mode: "hybrid",
+      local_auth: { enabled: true },
+      keycloak: { enabled: true, browser_session_ready: false },
+      providers: [{
+        provider_type: "legacy-keycloak-oidc",
+        alias: "legacy-keycloak",
+        display_name: "SSO",
+        login_url: "/api/v1/auth/keycloak/login",
+      }],
+      mcp_oauth: { enabled: true },
+    });
+    vi.mocked(api.getToken).mockReturnValue(null);
+
+    renderAt("/");
+
+    expect(await screen.findByTestId("auth-page")).toBeTruthy();
+    expect(api.getMe).not.toHaveBeenCalled();
+  });
+
   it("renders the outlet only after the local token is verified", async () => {
     vi.mocked(api.getToken).mockReturnValue("fake-jwt");
     renderAt("/");

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -56,7 +56,8 @@ export function Layout() {
       if (
         config.available !== true ||
         config.auth_mode === null ||
-        (config.auth_mode === "local" && !getToken())
+        ((config.auth_mode === "local" || config.auth_mode === "hybrid") &&
+          !getToken())
       ) {
         if (!cancelled) setSession({ status: "unauthenticated", user: null });
         return;

--- a/frontend/src/lib/__tests__/auth-config.test.ts
+++ b/frontend/src/lib/__tests__/auth-config.test.ts
@@ -33,6 +33,17 @@ const stagedSso = {
   mcp_oauth: { enabled: false },
 };
 
+const legacyHybrid = {
+  local_auth: { enabled: true },
+  keycloak: {
+    enabled: true,
+    enrollment_mode: "open",
+    login_url: "/api/v1/auth/keycloak/login",
+    sso_only: false,
+  },
+  mcp_oauth: { enabled: true },
+};
+
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -61,6 +72,50 @@ describe("getAuthConfig v2", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(ready)));
 
     expect(await getAuthConfig()).toEqual({ available: true, ...ready });
+  });
+
+  it("adapts only the exact legacy hybrid payload to Bearer-backed compatibility mode", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(legacyHybrid)));
+
+    expect(await getAuthConfig()).toEqual({
+      available: true,
+      schema_version: 1,
+      auth_mode: "hybrid",
+      local_auth: { enabled: true },
+      keycloak: { enabled: true, browser_session_ready: false },
+      providers: [{
+        provider_type: "legacy-keycloak-oidc",
+        alias: "legacy-keycloak",
+        display_name: "SSO",
+        login_url: "/api/v1/auth/keycloak/login",
+      }],
+      mcp_oauth: { enabled: true },
+    });
+  });
+
+  it.each([
+    ["external Keycloak URL", {
+      ...legacyHybrid,
+      keycloak: { ...legacyHybrid.keycloak, login_url: "https://id.example/login" },
+    }],
+    ["extra root capability", { ...legacyHybrid, debug: true }],
+    ["unknown enrollment policy", {
+      ...legacyHybrid,
+      keycloak: { ...legacyHybrid.keycloak, enrollment_mode: "anything" },
+    }],
+    ["SSO-only without Keycloak", {
+      ...legacyHybrid,
+      keycloak: {
+        ...legacyHybrid.keycloak,
+        enabled: false,
+        login_url: null,
+        sso_only: true,
+      },
+    }],
+  ])("fails closed for legacy payload with %s", async (_name, body) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response(body)));
+
+    expect(await getAuthConfig()).toEqual(AUTH_CONFIG_UNAVAILABLE);
   });
 
   it.each([

--- a/frontend/src/lib/__tests__/auth-transport.test.ts
+++ b/frontend/src/lib/__tests__/auth-transport.test.ts
@@ -9,6 +9,7 @@ import {
   getMe,
   getToken,
   logoutOrdinarySession,
+  markLegacySsoSession,
   setToken,
 } from "../api";
 
@@ -36,6 +37,17 @@ const ssoConfig = {
   mcp_oauth: { enabled: true },
 };
 
+const legacyHybridConfig = {
+  local_auth: { enabled: true },
+  keycloak: {
+    enabled: true,
+    enrollment_mode: "open",
+    login_url: "/api/v1/auth/keycloak/login",
+    sso_only: false,
+  },
+  mcp_oauth: { enabled: true },
+};
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -56,6 +68,7 @@ describe("ordinary browser auth transport", () => {
     configureAuthTransport(null);
     setToken(null);
     localStorage.clear();
+    sessionStorage.clear();
     document.cookie = "akb_dev_sso_csrf=; Max-Age=0; Path=/";
   });
 
@@ -77,6 +90,22 @@ describe("ordinary browser auth transport", () => {
     expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/v1/auth/me");
     expect((fetchMock.mock.calls[1]?.[1] as RequestInit).credentials).toBe("same-origin");
     expect(headersAt(fetchMock, 1).get("Authorization")).toBe("Bearer local-session-jwt");
+    expect(headersAt(fetchMock, 1).has("X-AKB-CSRF")).toBe(false);
+  });
+
+  it("uses the Bearer carrier for an adapted legacy hybrid session", async () => {
+    setToken("legacy-session-jwt");
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(legacyHybridConfig))
+      .mockResolvedValueOnce(jsonResponse({ username: "alice" }));
+
+    const config = await getAuthConfig();
+    await getMe({ redirectOnUnauthorized: false });
+
+    expect(config.auth_mode).toBe("hybrid");
+    expect(headersAt(fetchMock, 1).get("Authorization")).toBe(
+      "Bearer legacy-session-jwt",
+    );
     expect(headersAt(fetchMock, 1).has("X-AKB-CSRF")).toBe(false);
   });
 
@@ -202,6 +231,22 @@ describe("ordinary browser auth transport", () => {
     });
 
     expect(getToken()).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ends an adapted legacy SSO session through its same-origin logout route", async () => {
+    configureAuthTransport("local");
+    setToken("legacy-sso-jwt");
+    markLegacySsoSession("legacy-id-token");
+
+    await expect(logoutOrdinarySession()).resolves.toEqual({
+      mode: "sso",
+      logout_url:
+        "/api/v1/auth/keycloak/logout?id_token_hint=legacy-id-token",
+    });
+
+    expect(getToken()).toBeNull();
+    expect(sessionStorage.getItem("akb_legacy_sso")).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,12 +1,15 @@
 const API_BASE = "/api/v1";
 
 export type AuthMode = "local" | "sso";
+export type PublicAuthMode = AuthMode | "hybrid";
 
 let _token: string | null = null;
 let _authMode: AuthMode | null = null;
 let _authSessionGeneration = 0;
 const SAFE_AUTH_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const LOCAL_TOKEN_STORAGE_KEY = "akb_token";
+const LEGACY_SSO_SESSION_KEY = "akb_legacy_sso";
+const LEGACY_SSO_ID_TOKEN_KEY = "akb_legacy_kc_id_token";
 
 const PRIVATE_ASSET_CACHE_MAX_ENTRIES = 32;
 const PRIVATE_ASSET_CACHE_MAX_BYTES = 64 * 1024 * 1024;
@@ -58,6 +61,54 @@ export function setToken(t: string | null) {
   }
   _token = t;
   writeStoredToken(t);
+}
+
+/**
+ * Temporary compatibility marker for the pre-browser-session Keycloak flow.
+ * The legacy backend exchanges a one-time callback code for the same Bearer
+ * JWT used by local login, so transport remains `local`; this marker exists
+ * only to choose the matching RP-initiated logout route. Session storage keeps
+ * the optional Keycloak hint scoped to the tab that completed the redirect.
+ */
+export function markLegacySsoSession(idToken?: unknown) {
+  try {
+    sessionStorage.setItem(LEGACY_SSO_SESSION_KEY, "1");
+    if (
+      typeof idToken === "string" &&
+      idToken.length > 0 &&
+      idToken.length <= 16_384 &&
+      !hasControlCharacters(idToken)
+    ) {
+      sessionStorage.setItem(LEGACY_SSO_ID_TOKEN_KEY, idToken);
+    } else {
+      sessionStorage.removeItem(LEGACY_SSO_ID_TOKEN_KEY);
+    }
+  } catch {
+    // The Bearer session remains usable when storage is blocked; only the
+    // seamless Keycloak logout hint is lost.
+  }
+}
+
+export function clearLegacySsoSession() {
+  try {
+    sessionStorage.removeItem(LEGACY_SSO_SESSION_KEY);
+    sessionStorage.removeItem(LEGACY_SSO_ID_TOKEN_KEY);
+  } catch {
+    // Best effort; the AKB Bearer token is cleared independently.
+  }
+}
+
+function legacySsoLogoutUrl(): string | null {
+  try {
+    if (sessionStorage.getItem(LEGACY_SSO_SESSION_KEY) !== "1") return null;
+    const hint = sessionStorage.getItem(LEGACY_SSO_ID_TOKEN_KEY);
+    const search = new URLSearchParams();
+    if (hint) search.set("id_token_hint", hint);
+    const query = search.toString();
+    return `${API_BASE}/auth/keycloak/logout${query ? `?${query}` : ""}`;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -190,6 +241,7 @@ function withAuthCarrier(headers: HeadersInit | undefined, method: string): Head
 function expireUnauthorizedSession(redirect: boolean) {
   if (_authMode === "local" || getToken() !== null) {
     setToken(null);
+    clearLegacySsoSession();
   } else {
     _authSessionGeneration += 1;
     clearPrivateAssetCache();
@@ -328,8 +380,8 @@ export interface AuthProviderOption {
 
 export interface AuthConfig {
   available: boolean;
-  schema_version: 2 | null;
-  auth_mode: AuthMode | null;
+  schema_version: 1 | 2 | null;
+  auth_mode: PublicAuthMode | null;
   local_auth: { enabled: boolean };
   keycloak: {
     enabled: boolean;
@@ -375,7 +427,7 @@ function hasControlCharacters(value: string): boolean {
   });
 }
 
-export function parseAuthConfig(value: unknown): AuthConfig {
+function parseV2AuthConfig(value: unknown): AuthConfig | null {
   const root = record(value);
   const localAuth = record(root?.local_auth);
   const keycloak = record(root?.keycloak);
@@ -400,14 +452,14 @@ export function parseAuthConfig(value: unknown): AuthConfig {
     (keycloak.browser_session_ready && !keycloak.enabled) ||
     (mode === "local" && providerValues.length !== 0)
   ) {
-    return AUTH_CONFIG_UNAVAILABLE;
+    return null;
   }
   const aliases = new Set<string>();
   const providers: AuthProviderOption[] = [];
   for (const value of providerValues) {
     const provider = record(value);
     if (!hasExactKeys(provider, ["provider_type", "alias", "display_name", "login_url"])) {
-      return AUTH_CONFIG_UNAVAILABLE;
+      return null;
     }
     const providerType = provider.provider_type;
     const alias = provider.alias;
@@ -427,7 +479,7 @@ export function parseAuthConfig(value: unknown): AuthConfig {
       (!keycloak.browser_session_ready && loginUrl !== null) ||
       (keycloak.browser_session_ready && loginUrl !== `/api/v1/auth/sso/${alias}/login`)
     ) {
-      return AUTH_CONFIG_UNAVAILABLE;
+      return null;
     }
     aliases.add(alias);
     providers.push({
@@ -451,6 +503,73 @@ export function parseAuthConfig(value: unknown): AuthConfig {
   };
 }
 
+/**
+ * Exact adapter for the last unversioned hybrid contract shipped before the
+ * server-custodied SSO transition. Do not broaden this parser: unknown legacy
+ * shapes must continue to fail closed instead of being guessed into policy.
+ */
+function parseLegacyHybridAuthConfig(value: unknown): AuthConfig | null {
+  const root = record(value);
+  const localAuth = record(root?.local_auth);
+  const keycloak = record(root?.keycloak);
+  const mcpOauth = record(root?.mcp_oauth);
+  const keycloakEnabled = keycloak?.enabled;
+  const loginUrl = keycloak?.login_url;
+  const ssoOnly = keycloak?.sso_only;
+  const enrollmentMode = keycloak?.enrollment_mode;
+  if (
+    !hasExactKeys(root, ["local_auth", "keycloak", "mcp_oauth"]) ||
+    !hasExactKeys(localAuth, ["enabled"]) ||
+    !hasExactKeys(keycloak, ["enabled", "enrollment_mode", "login_url", "sso_only"]) ||
+    !hasExactKeys(mcpOauth, ["enabled"]) ||
+    typeof localAuth.enabled !== "boolean" ||
+    typeof keycloakEnabled !== "boolean" ||
+    typeof ssoOnly !== "boolean" ||
+    !["open", "invite_only", "disabled"].includes(String(enrollmentMode)) ||
+    typeof mcpOauth.enabled !== "boolean" ||
+    loginUrl !== (keycloakEnabled ? "/api/v1/auth/keycloak/login" : null) ||
+    (ssoOnly && !keycloakEnabled)
+  ) {
+    return null;
+  }
+
+  // `sso_only` was a server-owned presentation policy. Its recovery escape is
+  // intentionally not revived: when set, the compatibility client exposes no
+  // local form even if the old payload also reports local_auth.enabled=true.
+  const localEnabled = localAuth.enabled && !ssoOnly;
+  if (!localEnabled && !keycloakEnabled) return null;
+
+  return {
+    available: true,
+    schema_version: 1,
+    auth_mode: keycloakEnabled ? "hybrid" : "local",
+    local_auth: { enabled: localEnabled },
+    keycloak: {
+      enabled: keycloakEnabled,
+      // Legacy Keycloak exchanges into a Bearer JWT. It is intentionally not
+      // represented as the v2 HttpOnly browser-session transport.
+      browser_session_ready: false,
+    },
+    providers: keycloakEnabled
+      ? [{
+          provider_type: "legacy-keycloak-oidc",
+          alias: "legacy-keycloak",
+          display_name: "SSO",
+          login_url: "/api/v1/auth/keycloak/login",
+        }]
+      : [],
+    mcp_oauth: { enabled: mcpOauth.enabled },
+  };
+}
+
+export function parseAuthConfig(value: unknown): AuthConfig {
+  return (
+    parseV2AuthConfig(value) ??
+    parseLegacyHybridAuthConfig(value) ??
+    AUTH_CONFIG_UNAVAILABLE
+  );
+}
+
 /** Versioned public capabilities. Any transport/schema error is deny-all. */
 export async function getAuthConfig(): Promise<AuthConfig> {
   try {
@@ -458,7 +577,7 @@ export async function getAuthConfig(): Promise<AuthConfig> {
     if (!response.ok) return AUTH_CONFIG_UNAVAILABLE;
     const config = parseAuthConfig(await response.json());
     if (config.available && config.auth_mode !== null) {
-      configureAuthTransport(config.auth_mode);
+      configureAuthTransport(config.auth_mode === "hybrid" ? "local" : config.auth_mode);
     }
     return config;
   } catch {
@@ -890,8 +1009,12 @@ export interface OrdinaryLogoutResult {
 export async function logoutOrdinarySession(): Promise<OrdinaryLogoutResult> {
   const mode = _authMode === "sso" ? "sso" : "local";
   if (mode === "local") {
+    const legacyLogout = legacySsoLogoutUrl();
     setToken(null);
-    return { mode, logout_url: "/auth" };
+    clearLegacySsoSession();
+    return legacyLogout
+      ? { mode: "sso", logout_url: legacyLogout }
+      : { mode, logout_url: "/auth" };
   }
   const response = await authenticatedFetch(
     `${API_BASE}/auth/logout`,
@@ -927,6 +1050,14 @@ export async function logoutOrdinarySession(): Promise<OrdinaryLogoutResult> {
   clearPrivateAssetCache();
   return { mode, logout_url: navigation.href };
 }
+
+/** Redeem the legacy one-time Keycloak callback code for an AKB Bearer JWT. */
+export const keycloakExchange = (code: string) =>
+  fetch(`${API_BASE}/auth/keycloak/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+  }).then(parseAuthResponse);
 
 export const createPAT = (name: string, scopes?: string[], expires_days?: number) =>
   api<any>("/auth/tokens", { method: "POST", body: JSON.stringify({ name, scopes, expires_days }) });

--- a/frontend/src/pages/__tests__/auth-callback-fail-closed.test.tsx
+++ b/frontend/src/pages/__tests__/auth-callback-fail-closed.test.tsx
@@ -1,9 +1,63 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
+import {
+  getAuthConfig,
+  keycloakExchange,
+  markLegacySsoSession,
+  setToken,
+} from "@/lib/api";
 import AuthCallbackPage from "../auth-callback";
 
+vi.mock("@/lib/api", () => ({
+  getAuthConfig: vi.fn(),
+  keycloakExchange: vi.fn(),
+  markLegacySsoSession: vi.fn(),
+  setToken: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const v2Config = {
+  available: true,
+  schema_version: 2 as const,
+  auth_mode: "sso" as const,
+  local_auth: { enabled: false },
+  keycloak: { enabled: true, browser_session_ready: true },
+  providers: [],
+  mcp_oauth: { enabled: true },
+};
+
+const legacyHybridConfig = {
+  available: true,
+  schema_version: 1 as const,
+  auth_mode: "hybrid" as const,
+  local_auth: { enabled: true },
+  keycloak: { enabled: true, browser_session_ready: false },
+  providers: [{
+    provider_type: "legacy-keycloak-oidc",
+    alias: "legacy-keycloak",
+    display_name: "SSO",
+    login_url: "/api/v1/auth/keycloak/login",
+  }],
+  mcp_oauth: { enabled: true },
+};
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/auth/callback?code=legacy-code");
+  vi.mocked(getAuthConfig).mockReset();
+  vi.mocked(keycloakExchange).mockReset();
+  vi.mocked(markLegacySsoSession).mockReset();
+  vi.mocked(setToken).mockReset();
+  navigate.mockReset();
+});
 
 afterEach(() => {
   cleanup();
@@ -12,10 +66,8 @@ afterEach(() => {
 });
 
 describe("AuthCallbackPage", () => {
-  it("never exchanges or stores a browser credential", () => {
-    const fetchMock = vi.fn();
-    const storageWrite = vi.spyOn(Storage.prototype, "setItem");
-    vi.stubGlobal("fetch", fetchMock);
+  it("keeps the browser exchange retired for current v2 SSO", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(v2Config);
 
     render(
       <MemoryRouter initialEntries={["/auth/callback?code=legacy-code"]}>
@@ -23,8 +75,61 @@ describe("AuthCallbackPage", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: /Legacy SSO callback retired/i })).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(storageWrite).not.toHaveBeenCalled();
+    expect(
+      await screen.findByRole("heading", {
+        name: /Legacy SSO callback retired/i,
+      }),
+    ).toBeInTheDocument();
+    expect(keycloakExchange).not.toHaveBeenCalled();
+    expect(setToken).not.toHaveBeenCalled();
+  });
+
+  it("exchanges a one-time code only for the validated legacy hybrid contract", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/auth/callback?code=legacy-code&redirect=%2Fvault%2Fdemo",
+    );
+    vi.mocked(getAuthConfig).mockResolvedValue(legacyHybridConfig);
+    vi.mocked(keycloakExchange).mockResolvedValue({
+      token: "legacy-akb-jwt",
+      kc_id_token: "legacy-keycloak-id-token",
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Completing sign-in/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(keycloakExchange).toHaveBeenCalledWith("legacy-code");
+      expect(setToken).toHaveBeenCalledWith("legacy-akb-jwt");
+      expect(markLegacySsoSession).toHaveBeenCalledWith(
+        "legacy-keycloak-id-token",
+      );
+      expect(navigate).toHaveBeenCalledWith("/vault/demo", { replace: true });
+    });
+  });
+
+  it("rejects a malformed legacy exchange without storing a credential", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(legacyHybridConfig);
+    vi.mocked(keycloakExchange).mockResolvedValue({ token: "" });
+
+    render(
+      <MemoryRouter>
+        <AuthCallbackPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith(
+        "/auth?sso_error=exchange_failed",
+        { replace: true },
+      );
+    });
+    expect(setToken).not.toHaveBeenCalled();
+    expect(markLegacySsoSession).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
+++ b/frontend/src/pages/__tests__/auth-form-submit-and-error.test.tsx
@@ -23,6 +23,7 @@ import { authLogin, authRegister, getMe, getToken, setToken } from "@/lib/api";
 vi.mock("@/lib/api", () => ({
   authLogin: vi.fn(),
   authRegister: vi.fn(),
+  clearLegacySsoSession: vi.fn(),
   setToken: vi.fn(),
   // null → not signed in, so AuthPage's authed-guard doesn't redirect on mount.
   getToken: vi.fn(() => null),

--- a/frontend/src/pages/__tests__/auth-sso-only.test.tsx
+++ b/frontend/src/pages/__tests__/auth-sso-only.test.tsx
@@ -63,6 +63,24 @@ const stagedSsoConfig = {
   mcp_oauth: { enabled: false },
 };
 
+const legacyHybridConfig = {
+  available: true,
+  schema_version: 1 as const,
+  auth_mode: "hybrid" as const,
+  local_auth: { enabled: true },
+  keycloak: {
+    enabled: true,
+    browser_session_ready: false,
+  },
+  providers: [{
+    provider_type: "legacy-keycloak-oidc",
+    alias: "legacy-keycloak",
+    display_name: "SSO",
+    login_url: "/api/v1/auth/keycloak/login",
+  }],
+  mcp_oauth: { enabled: true },
+};
+
 function renderAuth() {
   return render(
     <MemoryRouter>
@@ -92,6 +110,18 @@ describe("AuthPage mode gate", () => {
     expect(screen.getByRole("tab", { name: /Register/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Forgot password/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /SSO/i })).toBeNull();
+  });
+
+  it("renders local and Keycloak choices together for the adapted legacy contract", async () => {
+    vi.mocked(getAuthConfig).mockResolvedValue(legacyHybridConfig);
+
+    renderAuth();
+
+    expect(await screen.findByLabelText(/Username/i)).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Register/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Sign in with SSO$/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders no local or unusable SSO controls while browser custody is staged", async () => {

--- a/frontend/src/pages/auth-callback.tsx
+++ b/frontend/src/pages/auth-callback.tsx
@@ -1,13 +1,116 @@
-import { Link } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, Loader2 } from "lucide-react";
 import { Logo } from "@/components/logo";
+import {
+  getAuthConfig,
+  keycloakExchange,
+  markLegacySsoSession,
+  setToken,
+} from "@/lib/api";
 
 /**
- * Retired client-side callback. Ordinary SSO now completes on the fixed
- * server callback and redirects with only an opaque AKB cookie. This route
- * never redeems a code, stores a credential, or marks an SSO identity.
+ * Compatibility callback for the exact pre-v2 Keycloak contract. Current v2
+ * SSO still completes on the fixed server callback and never redeems a code in
+ * the browser; only a validated schema_version=1 hybrid policy can enter the
+ * temporary exchange branch below.
  */
 export default function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const ran = useRef(false);
+  const [state, setState] = useState<"checking" | "retired">("checking");
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    let cancelled = false;
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const rawRedirect = params.get("redirect") || "/";
+    let redirect = "/";
+    try {
+      const candidate = new URL(rawRedirect, window.location.origin);
+      if (candidate.origin === window.location.origin) {
+        redirect = candidate.pathname + candidate.search + candidate.hash;
+      }
+    } catch {
+      // Malformed or cross-origin targets return home.
+    }
+
+    void (async () => {
+      const config = await getAuthConfig();
+      if (cancelled) return;
+      if (
+        config.available !== true ||
+        config.schema_version !== 1 ||
+        config.auth_mode !== "hybrid" ||
+        !config.keycloak.enabled
+      ) {
+        setState("retired");
+        return;
+      }
+      if (!code) {
+        navigate("/auth?sso_error=missing_code", { replace: true });
+        return;
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const timeout = new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error("timeout")), 15_000);
+        });
+        const result = await Promise.race([keycloakExchange(code), timeout]);
+        if (cancelled) return;
+        const token = result?.token;
+        const idToken = result?.kc_id_token;
+        const tokenHasControlCharacters =
+          typeof token === "string" &&
+          Array.from(token).some((character) => {
+            const codePoint = character.charCodeAt(0);
+            return codePoint < 0x20 || codePoint === 0x7f;
+          });
+        if (
+          result?.error ||
+          typeof token !== "string" ||
+          token.length === 0 ||
+          token.length > 16_384 ||
+          tokenHasControlCharacters ||
+          (idToken !== undefined && typeof idToken !== "string")
+        ) {
+          navigate("/auth?sso_error=exchange_failed", { replace: true });
+          return;
+        }
+        setToken(token);
+        markLegacySsoSession(idToken);
+        navigate(redirect, { replace: true });
+      } catch (caught) {
+        const reason = caught instanceof Error && caught.message === "timeout"
+          ? "timeout"
+          : "exchange_failed";
+        if (!cancelled) {
+          navigate(`/auth?sso_error=${reason}`, { replace: true });
+        }
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate]);
+
+  if (state === "checking") {
+    return (
+      <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
+        <div className="flex flex-col items-center gap-4 text-sm text-foreground-muted" role="status" aria-live="polite">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden />
+          <span>Completing sign-in…</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background text-foreground p-6">
       <div className="hero-glow w-full max-w-md mx-auto fade-up flex flex-col items-center gap-8 text-center">

--- a/frontend/src/pages/auth-forgot.tsx
+++ b/frontend/src/pages/auth-forgot.tsx
@@ -10,7 +10,7 @@ export default function AuthForgotPage() {
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const localPasswordHelp =
     authConfig?.available === true &&
-    authConfig.auth_mode === "local" &&
+    (authConfig.auth_mode === "local" || authConfig.auth_mode === "hybrid") &&
     authConfig.local_auth.enabled;
   // This route sits outside the Layout auth gate — bounce signed-in users home.
   useEffect(() => {

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Database, Boxes, GitBranch } from "lucide-react";
 import {
   authLogin,
   authRegister,
+  clearLegacySsoSession,
   getAuthConfig,
   getMe,
   getToken,
@@ -53,15 +54,16 @@ export default function AuthPage() {
   const next = safeNext(new URLSearchParams(window.location.search).get("next"));
   const localAuthEnabled =
     authConfig?.available === true &&
-    authConfig.auth_mode === "local" &&
+    (authConfig.auth_mode === "local" || authConfig.auth_mode === "hybrid") &&
     authConfig.local_auth.enabled;
   const ssoConfigEnabled =
     authConfig?.available === true &&
-    authConfig.auth_mode === "sso" &&
+    (authConfig.auth_mode === "sso" || authConfig.auth_mode === "hybrid") &&
     authConfig.keycloak.enabled;
   const ssoProviders = ssoConfigEnabled ? authConfig.providers : [];
   const usableSsoProviders =
-    ssoConfigEnabled && authConfig.keycloak.browser_session_ready
+    ssoConfigEnabled &&
+    (authConfig.schema_version === 1 || authConfig.keycloak.browser_session_ready)
       ? ssoProviders.filter((provider) => provider.login_url !== null)
       : [];
 
@@ -134,6 +136,7 @@ export default function AuthPage() {
         return;
       }
       setToken(r.token);
+      clearLegacySsoSession();
       try {
         if ("PasswordCredential" in window) {
           const cred = new PasswordCredential({ id: username, password });
@@ -261,7 +264,12 @@ export default function AuthPage() {
             )}
 
             {usableSsoProviders.length > 0 && (
-              <div className="space-y-3">
+              <div
+                className={cn(
+                  "space-y-3",
+                  localAuthEnabled && "mt-6 border-t border-border pt-6",
+                )}
+              >
                 {usableSsoProviders.map((provider) => (
                   <Button
                     key={provider.alias}

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -161,7 +161,7 @@ export default function SettingsPage() {
       : "profile";
   const localPasswordEnabled =
     authConfig?.available === true &&
-    authConfig.auth_mode === "local" &&
+    (authConfig.auth_mode === "local" || authConfig.auth_mode === "hybrid") &&
     authConfig.local_auth.enabled;
   const mcpOauthEnabled =
     authConfig?.available === true && authConfig.mcp_oauth.enabled;


### PR DESCRIPTION
## Summary

- add a fail-closed adapter for the exact unversioned local + Keycloak auth configuration currently served by legacy AKB backends
- keep local sign-in and legacy Keycloak SSO available together while preserving the strict v2 local/SSO contract
- restore the legacy one-time callback exchange and matching Keycloak logout only for validated schema-v1 compatibility sessions
- keep new v2 SSO cookie-only and reject unknown or broadened legacy payloads

## Compatibility boundary

- frontend-only change; no backend endpoint or deployment change
- accepts only the observed same-origin `/api/v1/auth/keycloak/*` contract
- unknown keys, contradictory states, external login URLs, and unsupported enrollment modes remain unavailable
- intended as a temporary migration bridge until the production backend serves schema v2

## Verification

- `npm run design:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test` (83 files, 592 tests)
- `npm run build`
- targeted auth regression suite (6 files, 69 tests)