### PR TITLE
fix(frontend): preserve document drafts across file picker focus

### DIFF
--- a/frontend/src/components/__tests__/asset-image.test.tsx
+++ b/frontend/src/components/__tests__/asset-image.test.tsx
@@ -74,6 +74,25 @@ describe("AssetImage", () => {
     await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith("blob:private-image"));
   });
 
+  it("uses paragraph-safe loading markup for protected markdown images", () => {
+    apiMocks.getAssetBlob.mockReturnValue(new Promise(() => {}));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <MarkdownRender
+        markdown={`![Architecture diagram](${ASSET_URL})`}
+        assetContext={{ mode: "authenticated", vault: "team" }}
+      />,
+    );
+
+    const loading = screen.getByRole("status", {
+      name: "Loading image: Architecture diagram",
+    });
+    expect(loading.tagName).toBe("SPAN");
+    expect(loading.closest("p")).not.toBeNull();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
   it("shows an unavailable state when a live private request is aborted", async () => {
     apiMocks.getAssetBlob.mockRejectedValue(new DOMException("Aborted", "AbortError"));
 

--- a/frontend/src/components/__tests__/layout-auth-gate.test.tsx
+++ b/frontend/src/components/__tests__/layout-auth-gate.test.tsx
@@ -239,6 +239,7 @@ describe("Layout — auth gate", () => {
       mcp_oauth: { enabled: true },
     });
     vi.mocked(api.getToken).mockReturnValue(null);
+    let resolveForeground: ((user: api.CurrentUser) => void) | undefined;
     vi.mocked(api.getMe)
       .mockResolvedValueOnce({
         user_id: "user-1",
@@ -249,26 +250,33 @@ describe("Layout — auth gate", () => {
         auth_method: "browser_session",
         key_class: null,
       })
-      .mockResolvedValueOnce({
-        user_id: "user-2",
-        username: "bob",
-        email: "bob@example.com",
-        display_name: "Bob",
-        is_admin: false,
-        auth_method: "browser_session",
-        key_class: null,
-      });
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveForeground = resolve;
+      }));
     const queryClient = new QueryClient();
     queryClient.setQueryData(["private", "alice"], { secret: true });
 
     renderAt("/", queryClient);
-    expect(await screen.findByTestId("home")).toBeTruthy();
+    const mountedWorkspace = await screen.findByTestId("home");
 
     window.dispatchEvent(new Event("focus"));
 
     expect(await screen.findByText("Verifying session…")).toBeTruthy();
+    expect(screen.getByTestId("home")).toBe(mountedWorkspace);
+    resolveForeground?.({
+      user_id: "user-2",
+      username: "bob",
+      email: "bob@example.com",
+      display_name: "Bob",
+      is_admin: false,
+      auth_method: "browser_session",
+      key_class: null,
+    });
     await waitFor(() => expect(api.getMe).toHaveBeenCalledTimes(2));
-    expect(await screen.findByTestId("home")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByText("Verifying session…")).toBeNull();
+    });
+    expect(screen.getByTestId("home")).toBe(mountedWorkspace);
     expect(queryClient.getQueryData(["private", "alice"])).toBeUndefined();
     expect(api.clearPrivateAssetCache).toHaveBeenCalled();
   });

--- a/frontend/src/components/asset-image.tsx
+++ b/frontend/src/components/asset-image.tsx
@@ -140,7 +140,7 @@ export function AssetImage({
 
   if (isPrivateAsset && !currentLoadState?.blobUrl && !currentLoadState?.failed) {
     return (
-      <div
+      <span
         role="status"
         aria-label={alt ? `Loading image: ${alt}` : "Loading image"}
         className={cn(
@@ -150,13 +150,13 @@ export function AssetImage({
       >
         <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
         Loading image…
-      </div>
+      </span>
     );
   }
 
   if (currentLoadState?.failed || imageFailed || !resolvedSrc) {
     return (
-      <div
+      <span
         role="img"
         aria-label={alt ? `Image unavailable: ${alt}` : "Image unavailable"}
         className={cn(
@@ -166,7 +166,7 @@ export function AssetImage({
       >
         <ImageOff className="h-4 w-4" aria-hidden />
         Image unavailable
-      </div>
+      </span>
     );
   }
 

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -154,7 +154,7 @@ export function Layout() {
     return () => root.classList.remove("vault-workspace-scroll-lock");
   }, [viewportLocked]);
 
-  if (session.status === "checking" || revalidating) {
+  if (session.status === "checking") {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
         <div className="coord" role="status" aria-live="polite">
@@ -179,7 +179,16 @@ export function Layout() {
     : "min-h-screen flex flex-col bg-background text-foreground";
 
   return (
-    <div className={rootClass}>
+    <div className={rootClass} aria-busy={revalidating || undefined}>
+      {revalidating && (
+        <div
+          className="fixed inset-0 z-[var(--z-toast)] flex items-center justify-center bg-background/95 backdrop-blur-sm"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="coord">Verifying session…</div>
+        </div>
+      )}
       {/* Skip link — first focusable element; jumps keyboard/SR users past the
           header chrome to the page content on every route. */}
       <a


### PR DESCRIPTION
## Summary

- keep the authenticated workspace mounted while foreground identity revalidation is pending, so returning from a native file picker cannot destroy the document composer and its draft
- retain the existing full-screen session-verification shield and fail-closed logout/cache clearing behavior without unmounting route state
- render private-image loading and failure placeholders with paragraph-safe markup to avoid `p > div` hydration warnings in rendered documents
- strengthen regression coverage for mounted workspace identity and protected Markdown image markup

## Root cause

Closing a native image picker focuses the browser window. Layout treated every foreground session revalidation as an initial auth gate and replaced the entire authenticated tree with a verification screen. That unmounted VaultShell and DocumentCreateDialog even though the dialog itself correctly ignored Radix close requests.

## Local end-to-end verification

- created a temporary local user and Vault
- opened New document and entered title, collection, and body text
- selected a real PNG through the file chooser
- confirmed the image rendered in the editor and the modal stayed open
- created the document and verified its collection path and Git-backed document route
- opened the generated document in a fresh tab and confirmed title, body text, and private asset image all rendered with no console errors
- deleted the temporary account, Vault, document, and uploaded asset after verification

## Automated verification

- `npm run design:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test` (83 files, 593 tests)
- `npm run build`
- focused image/composer regression suite (4 files, 48 tests)